### PR TITLE
feat(slash): /<alias> model switching via DIRECT_ALIASES/MODEL_ALIASES

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9397,19 +9397,29 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             _cprint("    (session only — add --global to persist)")
 
-        # Surface structured side-effect metadata so a parent process can
-        # mirror the model switch without re-deriving whether the typed
-        # command was an alias. ``raw_args`` is what the user actually
-        # typed after /model (preserved verbatim); ``target`` is the
-        # resolved model name. ``side_effect`` is always ``"model_switch"``
-        # because /model is the only canonical command that mutates the
-        # live model.
+        # Surface structured resolved-result metadata so the parent TUI
+        # process can mirror the live session without re-deriving any
+        # alias or re-reading the parent's profile-scoped provider
+        # config. The worker (this process) ran inside the session's
+        # ``profile_home`` scope, so these resolved values reflect that
+        # profile's provider / model resolution.
+        #
+        # SECURITY: never include credentials (``api_key``, tokens,
+        # ``Authorization``). The parent re-resolves credentials by
+        # entering the session's ``profile_home`` scope.
+        scope_value = (
+            "once" if one_turn
+            else ("global" if persist_global else "session")
+        )
         self._last_slash_metadata = {
-            "canonical": "model",
-            "raw_args": raw_args,
-            "args": model_input,
-            "target": result.new_model if result is not None else model_input,
             "side_effect": "model_switch",
+            "canonical": "model",
+            "scope": scope_value,
+            "resolved_model": str(result.new_model or ""),
+            "resolved_provider": str(result.target_provider or ""),
+            "base_url": str(result.base_url or "") or None,
+            "api_mode": str(result.api_mode or "") or None,
+            "raw_args": raw_args,
         }
 
     def _handle_codex_runtime(self, cmd_original: str) -> None:

--- a/cli.py
+++ b/cli.py
@@ -9397,6 +9397,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         else:
             _cprint("    (session only — add --global to persist)")
 
+        # Surface structured side-effect metadata so a parent process can
+        # mirror the model switch without re-deriving whether the typed
+        # command was an alias. ``raw_args`` is what the user actually
+        # typed after /model (preserved verbatim); ``target`` is the
+        # resolved model name. ``side_effect`` is always ``"model_switch"``
+        # because /model is the only canonical command that mutates the
+        # live model.
+        self._last_slash_metadata = {
+            "canonical": "model",
+            "raw_args": raw_args,
+            "args": model_input,
+            "target": result.new_model if result is not None else model_input,
+            "side_effect": "model_switch",
+        }
+
     def _handle_codex_runtime(self, cmd_original: str) -> None:
         """Handle /codex-runtime — toggle the codex app-server runtime opt-in.
 
@@ -9570,6 +9585,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Lowercase only for dispatch matching; preserve original case for arguments
         cmd_lower = command.lower().strip()
         cmd_original = command.strip()
+
+        # Reset side-effect metadata for the next command. Each ``process_command``
+        # invocation produces its own metadata snapshot; stale snapshots from a
+        # previous turn must NOT leak into the parent process's mirror decision.
+        self._last_slash_metadata = None
 
         # Resolve aliases via central registry so adding an alias is a one-line
         # change in hermes_cli/commands.py instead of touching every dispatch site.

--- a/cli.py
+++ b/cli.py
@@ -10211,6 +10211,29 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 from hermes_cli.commands import COMMANDS
                 typed_base = cmd_lower.split()[0]
                 all_known = set(COMMANDS) | set(skill_commands) | set(skill_bundles)
+                # Model-alias shortcut: /<alias> -> /model <alias>. Done BEFORE
+                # prefix-matching so a typed alias like /ds-flash expands to
+                # /model ds-flash (and then to the resolved provider/model),
+                # instead of being misclassified as an unknown /d token.
+                # Mirrors the gateway's behaviour and reuses the same alias
+                # dictionaries. Done AFTER built-in / quick / plugin / skill
+                # checks above so a registered command with the same name
+                # always wins.
+                try:
+                    from hermes_cli.model_switch import (
+                        _ensure_direct_aliases,
+                        DIRECT_ALIASES,
+                        MODEL_ALIASES,
+                    )
+
+                    _ensure_direct_aliases()
+                    _alias_key = typed_base.lstrip("/").strip().lower()
+                    if _alias_key in DIRECT_ALIASES or _alias_key in MODEL_ALIASES:
+                        remainder = cmd_original[len(typed_base):].strip()
+                        aliased = f"/model {_alias_key} {remainder}".strip()
+                        return self.process_command(aliased)
+                except ImportError:
+                    pass
                 matches = [c for c in all_known if c.startswith(typed_base)]
                 if len(matches) > 1:
                     # Prefer an exact match (typed the full command name)

--- a/cli.py
+++ b/cli.py
@@ -3204,6 +3204,11 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         cmd_lower = command.lower().strip()  # lowercase only for matching; args keep their case
         cmd_original = command.strip()
 
+        # Reset side-effect metadata for the next command. Each ``process_command``
+        # invocation produces its own metadata snapshot; a stale snapshot from a previous
+        # turn must NOT leak into the parent process's mirror decision.
+        self._last_slash_metadata = None
+
         # Aliases resolve via the central registry (hermes_cli/commands.py).
         from hermes_cli.commands import resolve_command as _resolve_cmd
         _base_word = cmd_lower.split()[0].lstrip("/")
@@ -3356,6 +3361,27 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         """Unique-prefix expansion against built-in COMMANDS + skill commands/bundles (agrees with tab-completion)."""
         from hermes_cli.commands import COMMANDS
         typed_base = cmd_lower.split()[0]
+        # Model-alias shortcut: /<alias> -> /model <alias>. Done BEFORE prefix-matching so
+        # a typed alias like /ds-flash expands to /model ds-flash (and then to the resolved
+        # provider/model), instead of being misclassified as an unknown /d token. Mirrors
+        # the gateway's behaviour and reuses the same alias dictionaries. Reached only
+        # after built-in / quick / plugin / bundle / skill dispatch, so a registered
+        # command with the same name always wins.
+        try:
+            from hermes_cli.model_switch import (
+                _ensure_direct_aliases,
+                DIRECT_ALIASES,
+                MODEL_ALIASES,
+            )
+
+            _ensure_direct_aliases()
+            _alias_key = typed_base.lstrip("/").strip().lower()
+            if _alias_key in DIRECT_ALIASES or _alias_key in MODEL_ALIASES:
+                remainder = cmd_original[len(typed_base):].strip()
+                aliased = f"/model {_alias_key} {remainder}".strip()
+                return self.process_command(aliased)
+        except ImportError:
+            pass
         all_known = set(COMMANDS) | set(skill_commands) | set(skill_bundles)
         matches = [c for c in all_known if c.startswith(typed_base)]
         if len(matches) > 1:

--- a/gateway/_model_alias_normalize.py
+++ b/gateway/_model_alias_normalize.py
@@ -1,0 +1,145 @@
+"""Narrow helper that turns a typed ``/<alias>`` slash command into the
+canonical ``/model <alias>`` form so the rest of the gateway can dispatch
+it through its existing model CommandDef, busy-path, access-control gate,
+and ``command:model`` hook without any per-call duplication.
+
+The function is pure with respect to the gateway:
+
+* No handler is called.
+* No session state is mutated.
+* The caller-supplied ``self`` reference is never touched.
+* No attribute is attached to the inbound event.
+
+Priority Order (Fail Closed):
+1. resolve_command() -> built-in / canonical command
+2. quick commands
+3. get_plugin_command_handler(name.replace("_", "-")) -> plugin command
+4. resolve_bundle_command_key(name) -> skill bundle
+5. resolve_skill_command_key(name) -> active skill
+6. unavailable_skill_fn(name) -> disabled / optional skill
+
+If any resolver raises an exception during checking, the helper FAILS CLOSED:
+it logs a sanitized debug message and returns the original unchanged event.
+"""
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Callable, Optional
+
+from gateway.platforms.base import MessageEvent
+from hermes_cli.commands import resolve_command as _resolve_cmd
+from hermes_cli.model_switch import (
+    DIRECT_ALIASES,
+    MODEL_ALIASES,
+    _ensure_direct_aliases,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _typed_command(text: Optional[str]) -> Optional[str]:
+    if not text:
+        return None
+    raw = text.strip()
+    if not raw.startswith("/"):
+        return None
+    head = raw[1:].split(None, 1)
+    if not head:
+        return None
+    return head[0].strip().lower() or None
+
+
+def is_name_occupied(
+    name: str,
+    *,
+    config: object = None,
+    unavailable_skill_fn: Optional[Callable[[str], Optional[str]]] = None,
+) -> bool:
+    """Return True if ``name`` is already claimed by a higher-priority
+    built-in, quick command, plugin, skill bundle, active skill, or
+    unavailable skill.
+
+    Raises Exception if any underlying lookup fails unexpectedly, allowing
+    the caller to fail-closed.
+    """
+    if not name:
+        return True
+
+    # 1. Built-in command
+    if _resolve_cmd(name) is not None:
+        return True
+
+    # 2. Quick command
+    qc: object = {}
+    if isinstance(config, dict):
+        qc = config.get("quick_commands", {}) or {}
+    else:
+        qc = getattr(config, "quick_commands", {}) or {}
+    if isinstance(qc, dict) and name in qc:
+        return True
+
+    # 3. Plugin command
+    from hermes_cli.plugins import get_plugin_command_handler
+    if get_plugin_command_handler(name.replace("_", "-")) is not None:
+        return True
+
+    # 4. Skill bundle
+    from agent.skill_bundles import resolve_bundle_command_key
+    if resolve_bundle_command_key(name) is not None:
+        return True
+
+    # 5. Active skill
+    from agent.skill_commands import resolve_skill_command_key
+    if resolve_skill_command_key(name) is not None:
+        return True
+
+    # 6. Known-but-disabled or uninstalled skill
+    if unavailable_skill_fn is not None:
+        if unavailable_skill_fn(name):
+            return True
+
+    return False
+
+
+def canonicalize_event_for_model_alias(
+    event: MessageEvent,
+    *,
+    config: object = None,
+    unavailable_skill_fn: Optional[Callable[[str], Optional[str]]] = None,
+) -> MessageEvent:
+    """Return either the original event (no rewrite) or a ``dataclasses``
+    clone whose ``text`` is the canonical ``/model <alias> <args>`` form.
+
+    The helper bails out (returning ``event`` unchanged) when:
+    * the typed name is not a known model alias;
+    * the typed name is occupied by a higher-priority command;
+    * any resolver raises an unexpected Exception (Fail-Closed).
+    """
+    name = _typed_command(getattr(event, "text", None))
+    if name is None:
+        return event
+
+    _ensure_direct_aliases()
+    if name not in DIRECT_ALIASES and name not in MODEL_ALIASES:
+        return event
+
+    try:
+        if is_name_occupied(name, config=config, unavailable_skill_fn=unavailable_skill_fn):
+            return event
+    except Exception as err:
+        logger.debug(
+            "Model alias helper failed closed on command check '%s': %s",
+            name,
+            type(err).__name__,
+        )
+        return event
+
+    # Build the canonical ``/model <alias> <args>`` text.
+    raw = (getattr(event, "text", "") or "").lstrip()
+    parts = raw.split(None, 1)
+    args = parts[1].strip() if len(parts) > 1 else ""
+    new_text = f"/model {name} {args}".strip()
+    if new_text == raw.strip():
+        return event
+    return dataclasses.replace(event, text=new_text)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13746,7 +13746,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Record rate limit so subsequent messages are silently ignored
                     pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
-        
+
+        # Model-alias shortcut: turn /<alias> into /model <alias> before the
+        # pending-update / pending-clarify / slash-confirm intercepts, so
+        # /sonnet and /model sonnet behave identically when the user has a
+        # detached update process waiting for an answer (or a clarifying
+        # question). Done via dataclasses.replace so the original event is
+        # untouched (no hidden alias attribute) and we never re-enter
+        # _handle_message (no duplicate pre_gateway_dispatch / auth /
+        # inbound-activity side effects). Higher-priority command names
+        # (built-in / quick / plugin / skill / bundle / disabled skill)
+        # always win — the helper bails out when the name is occupied.
+        from gateway._model_alias_normalize import (
+            canonicalize_event_for_model_alias,
+        )
+        event = canonicalize_event_for_model_alias(
+            event,
+            config=getattr(self, "config", None),
+            unavailable_skill_fn=_check_unavailable_skill,
+        )
+
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher
         # forwarded it to the user; now the user's reply goes back via
@@ -14289,6 +14308,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if not new_command:
                         continue
                     new_args = str(hook_result.get("raw_args", "")).strip()
+                    rewritten_event = dataclasses.replace(
+                        event, text=f"/{new_command} {new_args}".strip()
+                    )
+                    from gateway._model_alias_normalize import (
+                        canonicalize_event_for_model_alias,
+                    )
+                    norm_event = canonicalize_event_for_model_alias(
+                        rewritten_event,
+                        config=getattr(self, "config", None),
+                        unavailable_skill_fn=_check_unavailable_skill,
+                    )
+                    if norm_event is not rewritten_event:
+                        event = norm_event
+                        command = "model"
+                        _cmd_def = _resolve_cmd(command)
+                        canonical = "model"
+                        break
                     event.text = f"/{new_command} {new_args}".strip()
                     command = event.get_command()
                     _cmd_def = _resolve_cmd(command) if command else None

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -668,6 +668,23 @@ class GatewayInboundMixin:
         target_command = target.lstrip("/")
         return target_command.split()[0] if target_command else target_command
 
+    def _hm_canonicalize_model_alias_event(self, event: "MessageEvent") -> "MessageEvent":
+        """Rewrite a typed ``/<model-alias>`` into the canonical ``/model <alias>`` form.
+
+        Returns the ORIGINAL event when the typed name is not a configured model alias
+        (``DIRECT_ALIASES`` from ``config.yaml model_aliases:`` / built-in ``MODEL_ALIASES``),
+        or when a higher-priority name (built-in / quick / plugin / skill bundle / active
+        skill / disabled skill) already claims it — those always win. Resolver failures fail
+        CLOSED: the event comes back unchanged and the typed text is delivered as-is.
+        """
+        from gateway._model_alias_normalize import canonicalize_event_for_model_alias
+        from gateway.run import _check_unavailable_skill
+        return canonicalize_event_for_model_alias(
+            event,
+            config=getattr(self, "config", None),
+            unavailable_skill_fn=_check_unavailable_skill,
+        )
+
     async def _hm_command_hooks(
         self, event: "MessageEvent", source: SessionSource, _quick_key: str, command: str, canonical: str
     ) -> Tuple[bool, Optional[str], Optional[str]]:
@@ -712,6 +729,13 @@ class GatewayInboundMixin:
                 new_command = str(hook_result.get("command_name", "")).strip().lstrip("/")
                 if new_command:
                     event.text = f"/{new_command} {str(hook_result.get('raw_args', '')).strip()}".strip()
+                    # A hook may rewrite to a model alias (/sonnet): hand the caller the
+                    # canonical command name so dispatch, the access gate and the model
+                    # side-effect mirror all see the command that actually runs.
+                    _alias_norm = self._hm_canonicalize_model_alias_event(event)
+                    if _alias_norm is not event:
+                        event.text = _alias_norm.text
+                        return False, None, "model"
                     return False, None, event.get_command()
         return False, None, None
 
@@ -1192,6 +1216,17 @@ class GatewayInboundMixin:
         # — Discord interaction passthrough builds its own MessageEvent and
         # calls handle_message directly, so a teardown on the relay's inbound
         # handler left those turns muted.
+
+        # Model-alias shortcut: turn /<alias> into /model <alias> before the
+        # pending-update / pending-clarify / slash-confirm / estop intercepts, so
+        # /sonnet and /model sonnet behave identically when a detached update process
+        # is waiting for an answer (or a clarifying question is pending). Done via
+        # dataclasses.replace so the original event is left untouched (no hidden alias
+        # attribute) and we never re-enter _handle_message — no duplicate
+        # pre_gateway_dispatch / auth / inbound-activity side effects. Higher-priority
+        # command names (built-in / quick / plugin / skill / bundle / disabled skill)
+        # always win — the helper bails out when the name is occupied.
+        event = self._hm_canonicalize_model_alias_event(event)
 
         _paused_notice = self._hm_estop_gate(event, source, is_internal)
         if _paused_notice is not None:

--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -181,6 +181,23 @@ def _commit_model_switch(
     if not one_turn:
         HermesCLI._persist_model_switch_to_session(cli, result)
 
+    # Surface structured resolved-result metadata so a parent TUI process can mirror the
+    # live session without re-deriving any alias or re-reading this profile's provider
+    # config. The worker (this process) ran inside the session's ``profile_home`` scope,
+    # so these resolved values reflect that profile's provider / model resolution.
+    #
+    # SECURITY: never include credentials (``api_key``, tokens, ``Authorization``). The
+    # parent re-resolves credentials by entering the session's ``profile_home`` scope.
+    cli._last_slash_metadata = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "once" if one_turn else ("global" if persist_global else "session"),
+        "resolved_model": str(getattr(result, "new_model", "") or ""),
+        "resolved_provider": str(getattr(result, "target_provider", "") or ""),
+        "base_url": str(getattr(result, "base_url", "") or "") or None,
+        "api_mode": str(getattr(result, "api_mode", "") or "") or None,
+    }
+
 
 def _persist_global_switch(cli, result) -> None:
     """Write the switched route to config.yaml (--global). base_url/api_mode are freshly resolved

--- a/tests/cli/test_model_alias_slash_dispatch.py
+++ b/tests/cli/test_model_alias_slash_dispatch.py
@@ -1,0 +1,107 @@
+"""Tests for CLI model-alias slash dispatch (/<alias> -> /model <alias>).
+
+Regression coverage for PR #59606's CLI side. The /<alias> shortcut must
+behave like /model <alias> for the actual switch but never shadow a
+higher-priority command (built-in / plugin / skill / quick-command) that
+happens to share the name.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli import HermesCLI
+
+
+def _make_cli() -> HermesCLI:
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {}
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj.conversation_history = []
+    cli_obj.session_id = None
+    cli_obj._pending_input = MagicMock()
+    return cli_obj
+
+
+class TestModelAliasSlashDispatch:
+    """Confirm that typing /<alias> dispatches to _handle_model_switch with
+    the canonical /model command, not with the raw alias name."""
+
+    def test_alias_dispatches_via_model_handler(self):
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_handle_model_switch") as mock_switch:
+            cli_obj.process_command("/sonnet")
+        # /sonnet must reach the model handler with a /model-canonical command
+        mock_switch.assert_called_once()
+        called_with = mock_switch.call_args[0][0]
+        assert called_with.lower().startswith("/model"), (
+            f"alias /sonnet must be canonicalised to /model before dispatch, "
+            f"got {called_with!r}"
+        )
+        assert "sonnet" in called_with.lower()
+
+    def test_alias_with_extra_args_preserves_them(self):
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_handle_model_switch") as mock_switch:
+            cli_obj.process_command("/sonnet --provider openrouter")
+        mock_switch.assert_called_once()
+        called_with = mock_switch.call_args[0][0]
+        assert "sonnet" in called_with.lower()
+        assert "--provider openrouter" in called_with.lower()
+
+    def test_unknown_command_behavior_unchanged(self):
+        """An unknown slash command that is NOT a model alias must still
+        print the 'Unknown command' notice and NOT call _handle_model_switch."""
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_handle_model_switch") as mock_switch, \
+             patch("cli._cprint") as mock_cprint:
+            cli_obj.process_command("/xyzzy-not-an-alias-987")
+        mock_switch.assert_not_called()
+        # The unknown-command notice path prints via _cprint; just confirm
+        # the model handler was not invoked.
+        assert mock_switch.call_count == 0
+
+
+class TestModelAliasPriority:
+    """Alias resolution must NOT shadow built-ins, plugins, skills, or
+    user-defined quick_commands. If a higher-priority handler matches the
+    typed name, the alias branch must not fire."""
+
+    def test_alias_does_not_shadow_built_in(self):
+        """/help is a built-in; even if 'help' were an alias, the built-in
+        branch must win."""
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "show_help") as mock_help, \
+             patch.object(cli_obj, "_handle_model_switch") as mock_switch:
+            cli_obj.process_command("/help")
+        mock_help.assert_called_once()
+        mock_switch.assert_not_called()
+
+    def test_alias_does_not_shadow_quick_command(self):
+        """If the operator defines a quick_command named 'sonnet', that
+        command wins over the model alias."""
+        cli_obj = _make_cli()
+        cli_obj.config = {
+            "quick_commands": {
+                "sonnet": {
+                    "type": "alias",
+                    "target": "help",
+                }
+            }
+        }
+        with patch.object(cli_obj, "show_help") as mock_help, \
+             patch.object(cli_obj, "_handle_model_switch") as mock_switch:
+            cli_obj.process_command("/sonnet")
+        # quick_command target=/help routes to /help
+        mock_help.assert_called_once()
+        mock_switch.assert_not_called()
+
+    def test_unknown_command_does_not_invoke_model_handler(self):
+        """Guard against accidental alias-table expansion swallowing unknown
+        commands: a totally fabricated alias must not match."""
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_handle_model_switch") as mock_switch:
+            cli_obj.process_command("/xyzzy-not-an-alias-987")
+        mock_switch.assert_not_called()

--- a/tests/gateway/test_model_alias_non_recursive.py
+++ b/tests/gateway/test_model_alias_non_recursive.py
@@ -1,0 +1,812 @@
+"""Strict behaviour tests for the non-recursive alias dispatcher.
+
+Verifies the eight invariants the user-supplied gate demands:
+
+1. pre_gateway_dispatch fires exactly once.
+2. ``_is_user_authorized`` fires exactly once.
+3. ``_scale_to_zero_note_real_inbound`` fires exactly once.
+4. ``event`` never gains a ``_original_command`` (or any alias marker).
+5. ``/sonnet`` and ``/model sonnet`` behave identically while a session
+   is running (busy-path, access gate, dispatch result).
+6. ``/sonnet`` is NOT treated as a raw text interrupt/queue/steer when
+   a session is running.
+7. Higher-priority command names always win (built-in, quick, plugin,
+   bundle, active skill, unavailable skill).
+8. Hook rewrite target itself being an alias folds into /model form
+   with arguments preserved.
+9. Hook rewrite target being a normal command keeps upstream semantics.
+10. ``/sonnet`` and ``/model sonnet`` access / hook / handler traces are
+    identical (semantic equivalence).
+11. / 12. Sequential AND concurrent events share no alias state — the
+    helper is a pure function of the input event text.
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway._model_alias_normalize import (
+    canonicalize_event_for_model_alias,
+)
+from gateway.platforms.base import MessageEvent, MessageType
+from hermes_cli.model_switch import (
+    DIRECT_ALIASES,
+    MODEL_ALIASES,
+)
+
+
+# ----------------------------------------------------------------------
+# Test scaffolding
+# ----------------------------------------------------------------------
+
+
+class _StubSource:
+    """Minimal SessionSource replacement — only fields touched by the
+    alias path. Built via object.__new__ to mirror the bare-runner pattern
+    used by other gateway tests (see tests/gateway/conftest.py)."""
+
+    def __init__(self, platform_value="discord", user_id="anyone", chat_type="dm"):
+        self.platform = MagicMock()
+        self.platform.value = platform_value
+        self.user_id = user_id
+        self.user_name = "Stub User"
+        self.chat_id = "chat-1"
+        self.chat_type = chat_type
+        self.profile = "default"
+        self.adapter_name = platform_value
+        self.channel_context = None
+        self.internal = False
+        self.metadata = {}
+        self.timestamp = None
+
+
+def _event(text: str, *, source: _StubSource | None = None) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source or _StubSource(),
+    )
+
+
+def _runner(
+    *,
+    platform_extra: dict | None = None,
+    busy: bool = False,
+    session_id: str = "chat-1",
+):
+    """Build a bare GatewayRunner via object.__new__ so we never invoke
+    the real __init__ (which spawns workers, timers, plugin discovery,
+    etc.). Each helper we want to observe is then attached explicitly.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    cfg: dict = {}
+    if platform_extra:
+        cfg[platform_extra.setdefault("__platform_key__", "discord")] = platform_extra
+    runner.config = cfg
+    runner.console = MagicMock()
+    runner.session_store = None
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._agent_heartbeat_tasks = {}
+    runner._session_run_generation = {}
+    runner._session_run_generation_lock = MagicMock()
+    runner._session_locks = {}
+    runner._session_locks_guard = MagicMock()
+    runner._pairing_store = {}
+    runner._draining = False
+    runner._lobby_reminder_last_sent = {}
+    runner._busy_input_mode = "interrupt"
+    runner.hooks = MagicMock()
+    runner.hooks.emit_collect = AsyncMock(return_value=[])
+    runner._adapter_for_source = MagicMock(return_value=None)
+    runner._claim_active_session_slot = MagicMock(return_value=(None, None))
+    runner._session_state = MagicMock(return_value=MagicMock())
+    runner._peek_session_state = MagicMock(return_value=None)
+    runner._persist_active_agents = MagicMock()
+    runner._begin_session_run_generation = MagicMock(return_value=0)
+    runner._invalidate_session_run_generation = MagicMock()
+    runner._release_running_agent_state = MagicMock()
+    runner._evict_cached_agent = MagicMock()
+    runner._adapter_for_source = MagicMock(return_value=None)
+    runner._session_key_for_source = MagicMock(return_value=session_id)
+    runner._is_session_running = MagicMock(return_value=busy)
+    runner._is_user_authorized = MagicMock(return_value=True)
+    runner._scale_to_zero_note_real_inbound = MagicMock()
+    runner._invoke_hook = MagicMock(return_value=[])
+    runner._handle_model_command = AsyncMock(return_value="model-handled")
+    runner._handle_status_command = AsyncMock(return_value="status-handled")
+    runner._handle_context_command = AsyncMock(return_value="context-handled")
+    runner._dispatch_busy_slash_command = AsyncMock(return_value="busy-handled")
+    runner._check_slash_access = MagicMock(return_value=None)
+    runner._pending_event_audio_paths = MagicMock(return_value=[])
+    runner._prepare_clarify_reply_text = AsyncMock(return_value="")
+    runner._handle_message_with_agent = AsyncMock(return_value="agent-handled")
+    runner._is_telegram_topic_root_lobby = MagicMock(return_value=False)
+    runner._should_send_telegram_lobby_reminder = MagicMock(return_value=False)
+    runner._telegram_topic_root_lobby_message = MagicMock(return_value="")
+    runner._telegram_topic_root_new_message = MagicMock(return_value="")
+    runner._peek_pending_update_prompt_state = MagicMock(return_value=None)
+    runner._status_action_gerund = MagicMock(return_value="shutting down")
+    runner._hermes_home_override = None
+    return runner
+
+
+# ----------------------------------------------------------------------
+# 1–4: Single-entry invariants
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_gateway_dispatch_fires_once():
+    """``pre_gateway_dispatch`` MUST fire exactly once for a typed
+    ``/sonnet`` even though the helper rewrites the event to
+    ``/model sonnet``."""
+    runner = _runner()
+
+    with patch(
+        "hermes_cli.lifecycle.invoke_hook",
+        return_value=[],
+    ) as invoke, patch.object(
+        runner, "_handle_model_command", AsyncMock(return_value="model-handled")
+    ):
+        result = await runner._handle_message(_event("/sonnet"))
+
+    assert invoke.call_count == 1, (
+        f"pre_gateway_dispatch fired {invoke.call_count} times for one "
+        f"typed alias; expected exactly 1 (no _handle_message recursion)."
+    )
+    assert result == "model-handled"
+
+
+@pytest.mark.asyncio
+async def test_user_authorization_fires_once():
+    runner = _runner()
+
+    with patch(
+        "hermes_cli.lifecycle.invoke_hook",
+        return_value=[],
+    ):
+        await runner._handle_message(_event("/sonnet"))
+
+    assert runner._is_user_authorized.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_inbound_activity_note_fires_once():
+    runner = _runner()
+
+    with patch(
+        "hermes_cli.lifecycle.invoke_hook",
+        return_value=[],
+    ):
+        await runner._handle_message(_event("/sonnet"))
+
+    assert runner._scale_to_zero_note_real_inbound.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_event_has_no_alias_marker():
+    """The dispatcher must never attach ``_original_command`` (or any
+    other alias sentinel) to the inbound event."""
+    runner = _runner()
+    src = _StubSource()
+    inbound = _event("/sonnet", source=src)
+
+    with patch(
+        "hermes_cli.lifecycle.invoke_hook",
+        return_value=[],
+    ):
+        await runner._handle_message(inbound)
+
+    for forbidden in (
+        "_original_command",
+        "_alias_name",
+        "_alias_rewrite",
+        "_pre_rewrite_text",
+    ):
+        assert not hasattr(inbound, forbidden) or getattr(inbound, forbidden, None) is None, (
+            f"event acquired a hidden alias marker {forbidden!r}; "
+            f"the dispatcher must be stateless."
+        )
+    # Inbound text unchanged — the gateway only ever produces a local
+    # dataclasses.replace clone that never escapes the function scope.
+    assert inbound.text == "/sonnet"
+
+
+# ----------------------------------------------------------------------
+# 5. / 6. busy-path equivalence
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_busy_path_dispatch_identical_to_typed_model():
+    """While an agent is running, ``/sonnet`` must reach
+    ``_dispatch_busy_slash_command`` exactly once with a model-shape
+    event — same as a typed ``/model sonnet``."""
+    runner = _runner(busy=True)
+    src = _StubSource()
+
+    with patch(
+        "hermes_cli.lifecycle.invoke_hook",
+        return_value=[],
+    ):
+        await runner._handle_message(_event("/sonnet", source=src))
+
+    runner._dispatch_busy_slash_command.assert_awaited_once()
+    cmd_def = runner._dispatch_busy_slash_command.await_args.args[1]
+    assert cmd_def.name == "model", (
+        f"busy-path cmd_def must be the model CommandDef for alias dispatch, "
+        f"got {cmd_def.name!r}"
+    )
+    busy_event = runner._dispatch_busy_slash_command.await_args.args[0]
+    assert busy_event.text.lower().startswith("/model sonnet"), (
+        f"busy-path event must be canonical /model sonnet, "
+        f"got {busy_event.text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_alias_not_treated_as_text_interrupt_under_busy_path():
+    """While busy, the dispatcher must NOT treat ``/sonnet`` as plain
+    text and route it through the interrupt/queue/steer logic."""
+    runner = _runner(busy=True)
+    # If alias were treated as text, _handle_message_with_agent would be
+    # invoked (the fallthrough for unrecognised / plain text). If the
+    # alias is correctly routed to the model CommandDef's busy policy,
+    # _dispatch_busy_slash_command handles it instead.
+    with patch(
+        "hermes_cli.lifecycle.invoke_hook",
+        return_value=[],
+    ):
+        await runner._handle_message(_event("/sonnet"))
+
+    runner._handle_message_with_agent.assert_not_awaited()
+    runner._dispatch_busy_slash_command.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_busy_path_access_checked_via_canonical_model():
+    """Access control for an alias under busy-path must use the model's
+    canonical name, never the raw alias."""
+    runner = _runner(busy=True)
+
+    with patch(
+        "hermes_cli.lifecycle.invoke_hook",
+        return_value=[],
+    ):
+        await runner._handle_message(_event("/sonnet"))
+
+    # _check_slash_access on the busy-path runs at the very top, before
+    # the canonicalising helper (status / context are intentionally
+    # pre-gated). Aliases aren't status/context, so they reach the
+    # busy-path dispatcher which then runs access control. We assert
+    # the busy dispatch was invoked and observed the model name.
+    cmd_def = runner._dispatch_busy_slash_command.await_args.args[1]
+    assert cmd_def.name == "model"
+
+
+# ----------------------------------------------------------------------
+# 7. Higher-priority command names always win
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_built_in_command_wins_over_alias():
+    """A built-in that happens to share the alias name must dispatch
+    via its built-in handler, not via the alias shortcut."""
+    from hermes_cli.commands import resolve_command
+
+    # Pre-condition: ``help`` is a built-in. We don't have a registered
+    # alias named ``help`` in DIRECT_ALIASES / MODEL_ALIASES by default,
+    # so the test asserts via the helper directly with a name we KNOW
+    # is occupied.
+    assert resolve_command("help") is not None
+    src = _StubSource()
+    ev = _event("/help", source=src)
+    out = canonicalize_event_for_model_alias(ev, config={})
+    assert out.text == "/help", (
+        f"built-in /help must NOT be rewritten as a model alias; "
+        f"got {out.text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_quick_command_wins_over_alias():
+    """A user-defined quick_command named like an alias must still win."""
+    cfg = {"quick_commands": {"sonnet": {"type": "exec", "command": "echo hi"}}}
+    ev = _event("/sonnet")
+    out = canonicalize_event_for_model_alias(ev, config=cfg)
+    assert out.text == "/sonnet", (
+        f"quick_command /sonnet must NOT be rewritten; got {out.text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_alias_helper_returns_unchanged_for_unknown_name():
+    """A name that is neither an alias nor any registered command must
+    pass through untouched so the upstream ``unknown command`` warning
+    path can fire."""
+    ev = _event("/xyzzy-no-such-alias-987")
+    out = canonicalize_event_for_model_alias(ev, config={})
+    assert out is ev, (
+        "helper must return the exact input event when no rewrite applies"
+    )
+    assert out.text == "/xyzzy-no-such-alias-987"
+
+
+@pytest.mark.asyncio
+async def test_unavailable_skill_blocks_alias():
+    """If a known-but-disabled skill happens to share an alias name,
+    the skill's unavailability message must surface — the alias
+    shortcut must NOT fire."""
+    from gateway._model_alias_normalize import canonicalize_event_for_model_alias
+
+    # Force the helper to recognise ``disabled-alias`` as an alias.
+    DIRECT_ALIASES["disabled-alias"] = DIRECT_ALIASES.get(
+        "sonnet", MagicMock()
+    )  # may fail if sonnet absent; tolerated — see alias-or-skip below
+
+    def _stub_unavailable(name):
+        if name == "help":
+            return "The **help** skill is disabled for this platform."
+        return None
+
+    # Use a known alias that the helper will recognise. Here we pick
+    # the canonical test alias by checking the dict.
+    if "sonnet" in DIRECT_ALIASES or "sonnet" in MODEL_ALIASES:
+        ev = _event("/sonnet")
+        out = canonicalize_event_for_model_alias(
+            ev,
+            config={},
+            unavailable_skill_fn=_stub_unavailable,
+        )
+        # ``sonnet`` isn't a disabled skill name; alias wins.
+        assert out.text.startswith("/model sonnet"), (
+            f"alias should fire when no skill occupies the name; "
+            f"got {out.text!r}"
+        )
+
+    # Now confirm that a name which IS occupied by ``unavailable`` is
+    # never rewritten (even if we manually inject it as an alias).
+    DIRECT_ALIASES["help"] = MagicMock()
+    try:
+        ev = _event("/help")
+        out = canonicalize_event_for_model_alias(
+            ev,
+            config={},
+            unavailable_skill_fn=_stub_unavailable,
+        )
+        assert out.text == "/help", (
+            f"unavailable skill /help must NOT be rewritten; got {out.text!r}"
+        )
+    finally:
+        DIRECT_ALIASES.pop("help", None)
+        DIRECT_ALIASES.pop("disabled-alias", None)
+
+
+# ----------------------------------------------------------------------
+# 8. / 9. Hook rewrite behaviour
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hook_rewrite_to_alias_folds_into_model():
+    """A hook returning ``decision='rewrite'`` with a target that IS a
+    model alias must fold into ``/model <alias> <args>`` so the
+    eventual handler still receives the model namespace."""
+    runner = _runner()
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[
+            {
+                "decision": "rewrite",
+                "command_name": "opus",
+                "raw_args": "--provider openrouter",
+            }
+        ]
+    )
+
+    with patch(
+        "hermes_cli.lifecycle.invoke_hook",
+        return_value=[],
+    ):
+        await runner._handle_message(_event("/sonnet"))
+
+    runner._handle_model_command.assert_awaited_once()
+    event_arg = runner._handle_model_command.await_args.args[0]
+    assert event_arg.text == "/model opus --provider openrouter", (
+        f"alias-rewrite target must fold into /model <alias> form, "
+        f"got {event_arg.text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_hook_rewrite_to_normal_command_keeps_upstream_semantics():
+    """A hook rewriting to a normal (non-alias) command must follow the
+    canonical upstream rewrite path — the access gate fires once on the
+    ORIGINAL canonical command (``command:model`` for the alias) and the
+    rewritten target is dispatched as a regular built-in (no re-fire of
+    the hook on the rewritten command, no recursion into _handle_message).
+
+    This matches the documented upstream behaviour in ``gateway/run.py``
+    where the rewrite branch ``break``s out of the hook loop and then
+    falls through to the canonical ``if canonical == "..."`` ladder.
+    """
+    runner = _runner()
+    runner._handle_help_command = AsyncMock(return_value="help-handled")
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[
+            {"decision": "rewrite", "command_name": "help", "raw_args": ""}
+        ]
+    )
+
+    with patch(
+        "hermes_cli.lifecycle.invoke_hook",
+        return_value=[],
+    ):
+        result = await runner._handle_message(_event("/sonnet"))
+
+    # Hook fired exactly once (on the alias's canonical ``command:model``),
+    # then the dispatcher routed the rewritten ``/help`` to the built-in
+    # handler. The upstream semantics forbid re-firing the hook on the
+    # rewrite target or re-entering _handle_message.
+    assert runner.hooks.emit_collect.await_count == 1
+    assert runner.hooks.emit_collect.await_args.args[0] == "command:model"
+    runner._handle_help_command.assert_awaited_once()
+    runner._handle_model_command.assert_not_awaited()
+    assert result == "help-handled"
+
+
+# ----------------------------------------------------------------------
+# 10. Direct /sonnet vs /model sonnet semantic equivalence
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_direct_model_command_and_alias_share_access_hook_handler():
+    """A typed ``/sonnet`` and a typed ``/model sonnet`` must produce
+    the same number of access checks, the same hook name(s), and the
+    same handler invocation — only the input text differs."""
+    captured = []
+
+    runner_alias = _runner()
+    runner_direct = _runner()
+
+    # Capture every emit_collect invocation.
+    captured_alias: list = []
+    captured_direct: list = []
+
+    async def _alias_emit(name, ctx):
+        captured_alias.append((name, dict(ctx)))
+        return []
+
+    async def _direct_emit(name, ctx):
+        captured_direct.append((name, dict(ctx)))
+        return []
+
+    runner_alias.hooks.emit_collect = _alias_emit
+    runner_direct.hooks.emit_collect = _direct_emit
+
+    with patch("hermes_cli.lifecycle.invoke_hook", return_value=[]):
+        await runner_alias._handle_message(_event("/sonnet"))
+        await runner_direct._handle_message(_event("/model sonnet"))
+
+    # Both must fire exactly one command:model hook with the same
+    # canonical name.
+    assert len(captured_alias) == 1
+    assert len(captured_direct) == 1
+    assert captured_alias[0][0] == "command:model"
+    assert captured_direct[0][0] == "command:model"
+    assert captured_alias[0][1]["command"] == "model"
+    assert captured_direct[0][1]["command"] == "model"
+
+    # Both must reach _handle_model_command exactly once.
+    runner_alias._handle_model_command.assert_awaited_once()
+    runner_direct._handle_model_command.assert_awaited_once()
+
+
+# ----------------------------------------------------------------------
+# 11. / 12. Sequential + concurrent messages share no alias state
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sequential_messages_do_not_leak_alias_state():
+    """Two sequential alias messages must each rewrite independently;
+    a rewrite from message #1 must NOT bleed into message #2's text or
+    flag any session/global/self state."""
+    runner = _runner()
+
+    with patch("hermes_cli.lifecycle.invoke_hook", return_value=[]):
+        await runner._handle_message(_event("/sonnet"))
+        await runner._handle_message(_event("/opus"))
+
+    assert runner._handle_model_command.await_count == 2
+    first_text = runner._handle_model_command.await_args_list[0].args[0].text
+    second_text = runner._handle_model_command.await_args_list[1].args[0].text
+    assert "sonnet" in first_text.lower()
+    assert "opus" in second_text.lower()
+    # No event should have an alias marker.
+    assert not hasattr(runner, "_alias_pending") or not runner._alias_pending
+    assert not hasattr(runner, "_alias_last_rewrite")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_messages_do_not_leak_alias_state():
+    """Two concurrent alias messages must each rewrite independently
+    and reach the model handler with their own (unique) target."""
+    runner = _runner()
+
+    async def _emit(name, ctx):
+        return []
+
+    runner.hooks.emit_collect = _emit
+
+    with patch("hermes_cli.lifecycle.invoke_hook", return_value=[]):
+        await asyncio.gather(
+            runner._handle_message(_event("/sonnet")),
+            runner._handle_message(_event("/opus")),
+        )
+
+    assert runner._handle_model_command.await_count == 2
+    texts = sorted(
+        call.args[0].text.lower() for call in runner._handle_model_command.await_args_list
+    )
+    # Each call's rewritten text is independent.
+    assert any("sonnet" in t for t in texts)
+    assert any("opus" in t for t in texts)
+
+
+# ----------------------------------------------------------------------
+# Pending Update Interception & Equivalence
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pending_update_alias_bypasses_and_equals_typed_model(tmp_path):
+    """When update_prompt_pending=True, /sonnet must bypass prompt interception
+    and match /model sonnet identically without writing to .update_response."""
+    runner = _runner()
+
+    # Create a mock session state with update_prompt_pending = True
+    session_state = MagicMock()
+    session_state.persistent.update_prompt_pending = True
+    session_state.turn.agent = None
+    session_state.turn.started_ts = 0
+    runner._peek_session_state = MagicMock(return_value=session_state)
+
+    # Temporary home directory for .update_response / .update_prompt.json
+    home_dir = tmp_path / "hermes_home"
+    home_dir.mkdir()
+    prompt_file = home_dir / ".update_prompt.json"
+    prompt_file.write_text('{"prompt": "Update?"}', encoding="utf-8")
+    resp_file = home_dir / ".update_response"
+
+    with patch("gateway.run._hermes_home", home_dir), patch(
+        "hermes_cli.lifecycle.invoke_hook", return_value=[]
+    ):
+        result_alias = await runner._handle_message(_event("/sonnet"))
+
+    # Response file must NOT contain "/sonnet" (it was not swallowed as raw reply)
+    if resp_file.exists():
+        assert resp_file.read_text(encoding="utf-8") == ""
+
+    runner._handle_model_command.assert_awaited_once()
+    assert result_alias == "model-handled"
+
+
+@pytest.mark.asyncio
+async def test_pending_update_consumes_plain_text(tmp_path):
+    """Plain text responses during pending update MUST still be consumed."""
+    runner = _runner()
+
+    session_state = MagicMock()
+    session_state.persistent.update_prompt_pending = True
+    session_state.turn.agent = None
+    session_state.turn.started_ts = 0
+    runner._peek_session_state = MagicMock(return_value=session_state)
+
+    home_dir = tmp_path / "hermes_home"
+    home_dir.mkdir()
+    prompt_file = home_dir / ".update_prompt.json"
+    prompt_file.write_text('{"prompt": "Update?"}', encoding="utf-8")
+    resp_file = home_dir / ".update_response"
+
+    with patch("gateway.run._hermes_home", home_dir), patch(
+        "hermes_cli.lifecycle.invoke_hook", return_value=[]
+    ):
+        result = await runner._handle_message(_event("yes, please update"))
+
+    assert resp_file.exists()
+    assert resp_file.read_text(encoding="utf-8") == "yes, please update"
+    assert "Sent `yes, please update`" in result
+
+
+# ----------------------------------------------------------------------
+# 10 Strict Priority Conflict & Fail-Closed Tests
+# ----------------------------------------------------------------------
+
+
+def test_priority_1_plugin_wins_over_alias():
+    """1. plugin name with model alias -> plugin wins, no handler called."""
+    plugin_handler = MagicMock()
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        return_value=plugin_handler,
+    ):
+        ev = _event("/sonnet")
+        out = canonicalize_event_for_model_alias(ev)
+        assert out is ev, "Plugin name must occupy alias and prevent rewrite"
+        plugin_handler.assert_not_called()
+
+
+def test_priority_2_bundle_wins_over_alias():
+    """2. bundle name with model alias -> bundle wins, no builder called."""
+    bundle_key = "some_bundle"
+    with patch(
+        "agent.skill_bundles.resolve_bundle_command_key",
+        return_value=bundle_key,
+    ), patch("hermes_cli.plugins.get_plugin_command_handler", return_value=None):
+        ev = _event("/sonnet")
+        out = canonicalize_event_for_model_alias(ev)
+        assert out is ev, "Bundle name must occupy alias and prevent rewrite"
+
+
+def test_priority_3_active_skill_wins_over_alias():
+    """3. active skill name with model alias -> skill wins, no invocation built."""
+    skill_key = "some_skill"
+    with patch(
+        "agent.skill_commands.resolve_skill_command_key",
+        return_value=skill_key,
+    ), patch(
+        "agent.skill_bundles.resolve_bundle_command_key", return_value=None
+    ), patch("hermes_cli.plugins.get_plugin_command_handler", return_value=None):
+        ev = _event("/sonnet")
+        out = canonicalize_event_for_model_alias(ev)
+        assert out is ev, "Active skill name must occupy alias and prevent rewrite"
+
+
+def test_priority_4_unavailable_skill_guidance_wins_over_alias():
+    """4. unavailable skill name with model alias -> unavailable wins."""
+    def _stub_unavailable(name):
+        return "The **sonnet** skill is disabled."
+
+    with patch(
+        "agent.skill_commands.resolve_skill_command_key", return_value=None
+    ), patch(
+        "agent.skill_bundles.resolve_bundle_command_key", return_value=None
+    ), patch("hermes_cli.plugins.get_plugin_command_handler", return_value=None):
+        ev = _event("/sonnet")
+        out = canonicalize_event_for_model_alias(
+            ev, unavailable_skill_fn=_stub_unavailable
+        )
+        assert out is ev, "Unavailable skill must block model alias rewrite"
+
+
+def test_priority_5_quick_command_wins_over_alias():
+    """5. quick command with model alias -> quick command wins."""
+    cfg = {"quick_commands": {"sonnet": {"type": "exec", "command": "echo 1"}}}
+    ev = _event("/sonnet")
+    out = canonicalize_event_for_model_alias(ev, config=cfg)
+    assert out is ev, "Quick command must occupy alias and prevent rewrite"
+
+
+def test_priority_6_builtin_wins_over_alias():
+    """6. built-in with model alias -> built-in wins."""
+    with patch(
+        "gateway._model_alias_normalize._resolve_cmd", return_value=MagicMock()
+    ):
+        ev = _event("/sonnet")
+        out = canonicalize_event_for_model_alias(ev)
+        assert out is ev, "Built-in command must occupy alias and prevent rewrite"
+
+
+def test_priority_7_resolver_exception_fails_closed():
+    """7. plugin/bundle/skill resolver exception -> fail closed (returns raw event)."""
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        side_effect=RuntimeError("DB corrupt"),
+    ):
+        ev = _event("/sonnet")
+        out = canonicalize_event_for_model_alias(ev)
+        assert out is ev, "Exception in lookup must fail closed and return unrewritten event"
+
+
+@pytest.mark.asyncio
+async def test_priority_8_hook_rewrite_to_occupied_plugin_does_not_fold():
+    """8. Hook rewrite to an occupied plugin -> does not fold to /model."""
+    runner = _runner()
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[
+            {
+                "decision": "rewrite",
+                "command_name": "sonnet",
+                "raw_args": "--foo",
+            }
+        ]
+    )
+    plugin_handler = AsyncMock(return_value="plugin-handled")
+
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        return_value=plugin_handler,
+    ), patch(
+        "hermes_cli.lifecycle.invoke_hook", return_value=[]
+    ):
+        result = await runner._handle_message(_event("/model_switch_cmd"))
+
+    # Because sonnet is an occupied plugin, it must NOT fold into /model sonnet
+    runner._handle_model_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_priority_9_hook_rewrite_to_unoccupied_alias_folds():
+    """9. Hook rewrite to un-occupied model alias -> folds to /model and preserves args."""
+    runner = _runner()
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[
+            {
+                "decision": "rewrite",
+                "command_name": "opus",
+                "raw_args": "--temperature 0.5",
+            }
+        ]
+    )
+
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler", return_value=None
+    ), patch(
+        "agent.skill_bundles.resolve_bundle_command_key", return_value=None
+    ), patch(
+        "agent.skill_commands.resolve_skill_command_key", return_value=None
+    ), patch(
+        "hermes_cli.lifecycle.invoke_hook", return_value=[]
+    ):
+        await runner._handle_message(_event("/sonnet"))
+
+    runner._handle_model_command.assert_awaited_once()
+    event_arg = runner._handle_model_command.await_args.args[0]
+    assert event_arg.text == "/model opus --temperature 0.5"
+
+
+def test_priority_10_cli_and_gateway_share_priority_order():
+    """10. CLI and Gateway share identical priority resolution via helper."""
+    ev = _event("/sonnet")
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler", return_value=None
+    ), patch(
+        "agent.skill_bundles.resolve_bundle_command_key", return_value=None
+    ), patch(
+        "agent.skill_commands.resolve_skill_command_key", return_value=None
+    ):
+        out_gateway = canonicalize_event_for_model_alias(ev)
+        assert out_gateway.text == "/model sonnet"
+
+
+# ----------------------------------------------------------------------
+# Helper purity invariant (separate from the runner-level tests).
+# ----------------------------------------------------------------------
+
+
+def test_helper_is_pure_and_returns_new_event():
+    """The helper must return a brand-new dataclass instance (never
+    mutate the input) and never raise on edge cases."""
+    a = _event("/sonnet")
+    b = canonicalize_event_for_model_alias(a, config={})
+    assert b is not a, (
+        "helper must return a fresh dataclasses.replace clone when rewriting"
+    )
+    assert a.text == "/sonnet", "original event text must be unchanged"
+
+    # Edge case: no leading slash, no text, control characters.
+    c = _event("plain text")
+    d = canonicalize_event_for_model_alias(c, config={})
+    assert d is c
+
+    e = _event("")
+    f = canonicalize_event_for_model_alias(e, config={})
+    assert f is e

--- a/tests/gateway/test_model_alias_slash_dispatch.py
+++ b/tests/gateway/test_model_alias_slash_dispatch.py
@@ -1,0 +1,481 @@
+"""Regression coverage for PR #59606 — /<alias> must enter the canonical
+/model dispatch path on the gateway, not bypass per-platform slash access
+control or the ``command:model`` hook.
+
+Drives the real ``GatewayRunner._handle_message`` path with a stub
+session store. Uses the same ``object.__new__`` runner construction
+pattern as test_slash_access_dispatch.py so we exercise the real alias
+branch and hook site, not a re-implementation in the test.
+
+Coverage:
+  - /sonnet (a real MODEL_ALIASES entry) is dispatched as /model sonnet
+  - The per-platform slash access-control gate fires for /sonnet under
+    the same policy as /model.
+  - The ``command:model`` hook fires for /sonnet with canonical
+    command="model" and raw_command="sonnet".
+  - A non-admin denied of /model is also denied of /sonnet; an admin
+    bypasses both.
+  - Hook deny decision short-circuits the switch.
+  - /sonnet does NOT pre-empt a user-defined quick_command named sonnet.
+  - Unknown /<x> still gets the unknown-command notice when x is not an
+    alias.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source(
+    *,
+    platform: Platform = Platform.DISCORD,
+    user_id: str = "user1",
+    chat_type: str = "dm",
+    chat_id: str = "c1",
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name=f"name-{user_id}",
+        chat_type=chat_type,
+    )
+
+
+def _make_event(text: str, source: SessionSource) -> MessageEvent:
+    return MessageEvent(text=text, source=source, message_id="m1")
+
+
+def _make_runner(*, platform_extra: dict | None = None,
+                 platform: Platform = Platform.DISCORD):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            platform: PlatformConfig(
+                enabled=True,
+                token="***",
+                extra=platform_extra or {},
+            )
+        }
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {platform: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    runner.session_store = MagicMock()
+    session_entry = SessionEntry(
+        session_key="agent:main:discord:dm:c1",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=platform,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._session_run_generation = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_sources = {}
+    runner._session_db = MagicMock()
+    runner._session_db.get_session_title.return_value = None
+    runner._session_db.get_session.return_value = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    # The real _handle_model_command needs heavy gateway plumbing; tests
+    # stub it so we can assert dispatch happened without actually
+    # mutating the live model state.
+    runner._handle_model_command = AsyncMock(return_value="model-handled")
+    return runner
+
+
+# -----------------------------------------------------------------------
+# 1. Alias routes through the same /model handler a typed /model uses.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_routes_through_handle_model_command():
+    """Typing /sonnet must invoke _handle_model_command exactly as
+    typing /model sonnet would."""
+    runner = _make_runner(platform_extra={})  # no admin gating
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+    assert result == "model-handled"
+    runner._handle_model_command.assert_awaited_once()
+    # The event passed to _handle_model_command must be the rewritten
+    # /model sonnet so the handler's own arg parsing matches a typed
+    # /model sonnet path.
+    event_arg = runner._handle_model_command.await_args.args[0]
+    assert event_arg.text.lower().startswith("/model"), (
+        f"alias /sonnet must be rewritten to /model sonnet before "
+        f"reaching the handler, got event.text={event_arg.text!r}"
+    )
+    assert "sonnet" in event_arg.text.lower()
+
+
+# -----------------------------------------------------------------------
+# 2. Per-platform slash access-control gate fires for /<alias>.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_denied_for_non_admin_when_model_not_allowed():
+    """Non-admin who can't run /model must also be denied /sonnet — the
+    alias must NOT bypass the access-control gate."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["status"],  # /model is NOT listed
+        }
+    )
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="999"))
+    )
+    assert result is not None
+    assert "⛔" in result
+    assert "model is admin-only here" in result
+    # /sonnet was denied → _handle_model_command never fired
+    runner._handle_model_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_alias_allowed_for_non_admin_when_model_allowed():
+    """When /model IS in user_allowed_commands, /sonnet must be allowed
+    too (alias and canonical are indistinguishable from the gate's POV)."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["status", "model"],
+        }
+    )
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="999"))
+    )
+    assert result == "model-handled"
+    runner._handle_model_command.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_alias_admin_bypasses_gate():
+    """An admin can switch models via /sonnet the same way they can via
+    /model sonnet."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": [],
+        }
+    )
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="111"))
+    )
+    assert result == "model-handled"
+    runner._handle_model_command.assert_awaited_once()
+
+
+# -----------------------------------------------------------------------
+# 3. command:model hook fires for /<alias> with canonical name.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_fires_command_model_hook():
+    """hooks.emit_collect('command:model', ...) must be called when an
+    alias is dispatched, so handlers can't tell /sonnet from /model sonnet.
+    """
+    runner = _make_runner(platform_extra={})
+    # Capture the actual call args to assert on hook context shape.
+    captured: list[tuple] = []
+
+    async def _capture_emit(name, ctx):
+        captured.append((name, ctx))
+        return []
+
+    runner.hooks.emit_collect = _capture_emit
+
+    await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+
+    hook_names = [name for name, _ in captured]
+    assert "command:model" in hook_names, (
+        f"command:model hook must fire for /sonnet, "
+        f"got hook names: {hook_names}"
+    )
+    # Find the command:model hook call and verify context shape
+    model_hook = next(
+        ctx for name, ctx in captured if name == "command:model"
+    )
+    # Hook fires after the alias rewrite, so the canonical command is
+    # ``model`` and ``raw_command`` matches the rewritten /model form
+    # (hooks observe post-rewrite state, mirroring the canonical /model
+    # rewrite contract). The gateway never attaches an alias marker to
+    # the event itself, so handlers that want to distinguish a typed
+    # /<alias> from a typed /model <alias> must rely on this single
+    # rewrite — both inputs collapse to ``raw_command == "model"``.
+    assert model_hook["command"] == "model"
+    assert model_hook["raw_command"] == "model"
+
+
+@pytest.mark.asyncio
+async def test_alias_hook_deny_blocks_switch():
+    """A hook that returns decision='deny' for command:model must block
+    the alias dispatch the same way it blocks /model sonnet."""
+    runner = _make_runner(platform_extra={})
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[{"decision": "deny", "message": "blocked-by-test"}]
+    )
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+    assert result == "blocked-by-test"
+    runner._handle_model_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_alias_hook_handled_short_circuits():
+    """A hook returning decision='handled' must stop the switch without
+    calling _handle_model_command."""
+    runner = _make_runner(platform_extra={})
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[{"decision": "handled", "message": "handled-by-test"}]
+    )
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+    assert result == "handled-by-test"
+    runner._handle_model_command.assert_not_awaited()
+
+
+# -----------------------------------------------------------------------
+# 4. Priority preservation — alias must NOT pre-empt higher-priority commands.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_does_not_shadow_quick_command(monkeypatch):
+    """If a user defines a quick_command named sonnet, that command wins
+    over the model alias (preserves existing priority rules).
+
+    We avoid exercising the actual subprocess sink (printf/sh) and
+    instead stub the lower-level ``asyncio.create_subprocess_shell``
+    so the test runs cross-platform — only the dispatch priority
+    matters here, not shell semantics.
+    """
+    import asyncio as _asyncio
+
+    runner = _make_runner(platform_extra={})
+    runner.config.quick_commands = {
+        "sonnet": {"type": "exec", "command": "echo quick-wins"}
+    }
+
+    class _FakeProc:
+        async def communicate(self):
+            return (b"quick-wins", b"")
+
+    async def _fake_shell(*_args, **_kwargs):
+        return _FakeProc()
+
+    monkeypatch.setattr(_asyncio, "create_subprocess_shell", _fake_shell)
+
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+    assert result == "quick-wins"
+    runner._handle_model_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_alias_does_not_shadow_running_agent_fastpath():
+    """When an agent is running and a fast-path-eligible command is
+    typed under an alias name, the fast-path semantics must be
+    preserved (alias only intercepts unknown commands, not built-ins)."""
+    runner = _make_runner(platform_extra={})
+    # /restart is a fast-path command — its alias 'r' (if any) would win
+    # via _resolve_cmd. The alias check only runs for unrecognized
+    # commands, so /restart never enters the alias branch.
+    runner._handle_restart_command = AsyncMock(return_value="restart-handled")
+    src = _make_source(user_id="anyone")
+    sk = build_session_key(src)
+    runner._running_agents[sk] = MagicMock()
+    runner._running_agents_ts[sk] = 0  # not stale
+    result = await runner._handle_message(_make_event("/restart", src))
+    assert result == "restart-handled"
+    runner._handle_model_command.assert_not_awaited()
+
+
+# -----------------------------------------------------------------------
+# 5. Unknown command behavior unchanged.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_still_warns_when_not_alias():
+    """A typed /<x> where x is neither a built-in, plugin, skill, nor
+    a model alias must still hit the unknown-command warning."""
+    runner = _make_runner(platform_extra={})
+    # /xyzzy-nope is not in COMMAND_REGISTRY, not a plugin, not a skill,
+    # not a model alias.
+    result = await runner._handle_message(
+        _make_event("/xyzzy-nope", _make_source(user_id="anyone"))
+    )
+    assert result is not None
+    assert "Unknown command" in result
+    runner._handle_model_command.assert_not_awaited()
+
+
+# -----------------------------------------------------------------------
+# 6. Edge case — alias with extra args.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_with_provider_flag_dispatches_with_args():
+    """Typing /sonnet --provider foo must reach _handle_model_command
+    with the rewritten event including both the alias name and the
+    --provider flag, so the handler's flag parsing works identically to
+    /model sonnet --provider foo."""
+    runner = _make_runner(platform_extra={})
+    await runner._handle_message(
+        _make_event("/sonnet --provider openrouter", _make_source(user_id="anyone"))
+    )
+    runner._handle_model_command.assert_awaited_once()
+    event_arg = runner._handle_model_command.await_args.args[0]
+    assert event_arg.text.lower().startswith("/model")
+    assert "sonnet" in event_arg.text.lower()
+    assert "--provider openrouter" in event_arg.text.lower()
+
+
+# -----------------------------------------------------------------------
+# 7. command:model hook rewrite decision — must mirror canonical /model
+#    rewrite protocol field-for-field.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_hook_rewrite_routes_to_handle_model_command():
+    """A hook returning decision='rewrite' with command_name and raw_args
+    must rewrite event.text, re-resolve command/canonical, and then
+    dispatch to _handle_model_command with the rewritten args. This
+    mirrors the canonical /model rewrite branch at gateway/run.py:9456
+    (and the test_unknown_command.py::test_command_hook_rewrite_routes_to_plugin
+    contract) so alias and /model have the same command:model hook
+    lifecycle.
+    """
+    runner = _make_runner(platform_extra={})
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[
+            {
+                "decision": "rewrite",
+                "command_name": "opus",  # alias-style rewrite within model namespace
+                "raw_args": "--provider openrouter",
+            }
+        ]
+    )
+
+    await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+
+    # Hook fires once on the canonical ``command:model`` (the cold-path
+    # fallback already canonicalised /sonnet → /model sonnet, so this is
+    # NOT a re-fire — it matches the canonical /model rewrite contract
+    # (one decision per turn).
+    runner.hooks.emit_collect.assert_awaited_once()
+    hook_name = runner.hooks.emit_collect.await_args.args[0]
+    assert hook_name == "command:model"
+
+    # The rewrite target was itself a model alias (``opus``), so the
+    # dispatcher folds it into the canonical ``/model opus <args>`` form
+    # so the eventual handler still receives a target. Without this fold
+    # the event would dispatch to an unknown ``/opus`` handler and lose
+    # the model semantics.
+    runner._handle_model_command.assert_awaited_once()
+    event_arg = runner._handle_model_command.await_args.args[0]
+    assert event_arg.text.lower().startswith("/model opus"), (
+        f"alias-rewrite target must fold into /model <alias> form, "
+        f"got event_arg.text={event_arg.text!r}"
+    )
+    assert "--provider openrouter" in event_arg.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_alias_hook_rewrite_with_empty_command_is_noop():
+    """If the rewrite decision returns an empty command_name, the alias
+    dispatcher treats it as a no-op (continue), exactly like the canonical
+    branch at gateway/run.py:9458-9460."""
+    runner = _make_runner(platform_extra={})
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[{"decision": "rewrite", "command_name": "", "raw_args": "ignored"}]
+    )
+
+    await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+
+    # Empty command_name → continue → fall through to dispatch with the
+    # alias's pre-rewrite event.text (still /model sonnet).
+    runner._handle_model_command.assert_awaited_once()
+    event_arg = runner._handle_model_command.await_args.args[0]
+    assert event_arg.text.lower().startswith("/model")
+    assert "sonnet" in event_arg.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_alias_hook_rewrite_strips_leading_slash_from_command_name():
+    """The rewrite protocol (canonical run.py:9457-9459) strips any leading
+    slash from command_name before concatenating. Alias must do the same."""
+    runner = _make_runner(platform_extra={})
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[
+            {
+                "decision": "rewrite",
+                "command_name": "/opus",  # leading slash must be stripped
+                "raw_args": "",
+            }
+        ]
+    )
+
+    await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+
+    runner._handle_model_command.assert_awaited_once()
+    event_arg = runner._handle_model_command.await_args.args[0]
+    # Leading-slash stripped by the rewrite protocol; ``opus`` is a model
+    # alias so the dispatcher folds it into ``/model opus`` (no double
+    # slash, and the handler still receives the canonical /model shape).
+    assert event_arg.text == "/model opus", (
+        f"alias-rewrite target must fold into /model <alias> form, "
+        f"got event_arg.text={event_arg.text!r}"
+    )

--- a/tests/gateway/test_model_alias_slash_dispatch.py
+++ b/tests/gateway/test_model_alias_slash_dispatch.py
@@ -1,0 +1,530 @@
+"""Regression coverage for PR #59606 — /<alias> must enter the canonical
+/model dispatch path on the gateway, not bypass per-platform slash access
+control or the ``command:model`` hook.
+
+Drives the real ``GatewayRunner._handle_message`` path with a stub
+session store. Uses the same ``object.__new__`` runner construction
+pattern as test_slash_access_dispatch.py so we exercise the real alias
+branch and hook site, not a re-implementation in the test.
+
+Coverage:
+  - /sonnet (a real MODEL_ALIASES entry) is dispatched as /model sonnet
+  - The per-platform slash access-control gate fires for /sonnet under
+    the same policy as /model.
+  - The ``command:model`` hook fires for /sonnet with canonical
+    command="model" and raw_command="sonnet".
+  - A non-admin denied of /model is also denied of /sonnet; an admin
+    bypasses both.
+  - Hook deny decision short-circuits the switch.
+  - /sonnet does NOT pre-empt a user-defined quick_command named sonnet.
+  - Unknown /<x> still gets the unknown-command notice when x is not an
+    alias.
+"""
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source(
+    *,
+    platform: Platform = Platform.DISCORD,
+    user_id: str = "user1",
+    chat_type: str = "dm",
+    chat_id: str = "c1",
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name=f"name-{user_id}",
+        chat_type=chat_type,
+    )
+
+
+def _make_event(text: str, source: SessionSource) -> MessageEvent:
+    return MessageEvent(text=text, source=source, message_id="m1")
+
+
+def _make_runner(*, platform_extra: dict | None = None,
+                 platform: Platform = Platform.DISCORD):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            platform: PlatformConfig(
+                enabled=True,
+                token="***",
+                extra=platform_extra or {},
+            )
+        }
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {platform: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    runner.session_store = MagicMock()
+    session_entry = SessionEntry(
+        session_key="agent:main:discord:dm:c1",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=platform,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._session_run_generation = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_sources = {}
+    runner._session_db = MagicMock()
+    runner._session_db.get_session_title.return_value = None
+    runner._session_db.get_session.return_value = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    # The real _handle_model_command needs heavy gateway plumbing; tests
+    # stub it so we can assert dispatch happened without actually
+    # mutating the live model state.
+    runner._handle_model_command = AsyncMock(return_value="model-handled")
+    return runner
+
+
+# -----------------------------------------------------------------------
+# 1. Alias routes through the same /model handler a typed /model uses.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_routes_through_handle_model_command():
+    """Typing /sonnet must invoke _handle_model_command exactly as
+    typing /model sonnet would."""
+    runner = _make_runner(platform_extra={})  # no admin gating
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+    assert result == "model-handled"
+    runner._handle_model_command.assert_awaited_once()
+    # The event passed to _handle_model_command must be the rewritten
+    # /model sonnet so the handler's own arg parsing matches a typed
+    # /model sonnet path.
+    event_arg = runner._handle_model_command.await_args.args[0]
+    assert event_arg.text.lower().startswith("/model"), (
+        f"alias /sonnet must be rewritten to /model sonnet before "
+        f"reaching the handler, got event.text={event_arg.text!r}"
+    )
+    assert "sonnet" in event_arg.text.lower()
+
+
+# -----------------------------------------------------------------------
+# 2. Per-platform slash access-control gate fires for /<alias>.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_denied_for_non_admin_when_model_not_allowed():
+    """Non-admin who can't run /model must also be denied /sonnet — the
+    alias must NOT bypass the access-control gate."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["status"],  # /model is NOT listed
+        }
+    )
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="999"))
+    )
+    assert result is not None
+    assert "⛔" in result
+    assert "model is admin-only here" in result
+    # /sonnet was denied → _handle_model_command never fired
+    runner._handle_model_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_alias_allowed_for_non_admin_when_model_allowed():
+    """When /model IS in user_allowed_commands, /sonnet must be allowed
+    too (alias and canonical are indistinguishable from the gate's POV)."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["status", "model"],
+        }
+    )
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="999"))
+    )
+    assert result == "model-handled"
+    runner._handle_model_command.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_alias_admin_bypasses_gate():
+    """An admin can switch models via /sonnet the same way they can via
+    /model sonnet."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": [],
+        }
+    )
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="111"))
+    )
+    assert result == "model-handled"
+    runner._handle_model_command.assert_awaited_once()
+
+
+# -----------------------------------------------------------------------
+# 3. command:model hook fires for /<alias> with canonical name.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_fires_command_model_hook():
+    """hooks.emit_collect('command:model', ...) must be called when an
+    alias is dispatched, so handlers can't tell /sonnet from /model sonnet.
+    """
+    runner = _make_runner(platform_extra={})
+    # Capture the actual call args to assert on hook context shape.
+    captured: list[tuple] = []
+
+    async def _capture_emit(name, ctx):
+        captured.append((name, ctx))
+        return []
+
+    runner.hooks.emit_collect = _capture_emit
+
+    await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+
+    hook_names = [name for name, _ in captured]
+    assert "command:model" in hook_names, (
+        f"command:model hook must fire for /sonnet, "
+        f"got hook names: {hook_names}"
+    )
+    # Find the command:model hook call and verify context shape
+    model_hook = next(
+        ctx for name, ctx in captured if name == "command:model"
+    )
+    # Hook fires after the alias rewrite, so the canonical command is
+    # ``model`` and ``raw_command`` matches the rewritten /model form
+    # (hooks observe post-rewrite state, mirroring the canonical /model
+    # rewrite contract). The gateway never attaches an alias marker to
+    # the event itself, so handlers that want to distinguish a typed
+    # /<alias> from a typed /model <alias> must rely on this single
+    # rewrite — both inputs collapse to ``raw_command == "model"``.
+    assert model_hook["command"] == "model"
+    assert model_hook["raw_command"] == "model"
+
+
+@pytest.mark.asyncio
+async def test_alias_hook_deny_blocks_switch():
+    """A hook that returns decision='deny' for command:model must block
+    the alias dispatch the same way it blocks /model sonnet."""
+    runner = _make_runner(platform_extra={})
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[{"decision": "deny", "message": "blocked-by-test"}]
+    )
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+    assert result == "blocked-by-test"
+    runner._handle_model_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_alias_hook_handled_short_circuits():
+    """A hook returning decision='handled' must stop the switch without
+    calling _handle_model_command."""
+    runner = _make_runner(platform_extra={})
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[{"decision": "handled", "message": "handled-by-test"}]
+    )
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+    assert result == "handled-by-test"
+    runner._handle_model_command.assert_not_awaited()
+
+
+# -----------------------------------------------------------------------
+# 4. Priority preservation — alias must NOT pre-empt higher-priority commands.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_does_not_shadow_quick_command(monkeypatch):
+    """If a user defines a quick_command named sonnet, that command wins
+    over the model alias (preserves existing priority rules).
+
+    We avoid exercising the actual subprocess sink (printf/sh) and
+    instead stub the lower-level ``asyncio.create_subprocess_shell``
+    so the test runs cross-platform — only the dispatch priority
+    matters here, not shell semantics.
+    """
+    import asyncio as _asyncio
+
+    runner = _make_runner(platform_extra={})
+    runner.config.quick_commands = {
+        "sonnet": {"type": "exec", "command": "echo quick-wins"}
+    }
+
+    class _FakeProc:
+        async def communicate(self):
+            return (b"quick-wins", b"")
+
+    async def _fake_shell(*_args, **_kwargs):
+        return _FakeProc()
+
+    monkeypatch.setattr(_asyncio, "create_subprocess_shell", _fake_shell)
+
+    result = await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+    assert result == "quick-wins"
+    runner._handle_model_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_alias_does_not_shadow_running_agent_fastpath():
+    """When an agent is running and a fast-path-eligible command is
+    typed under an alias name, the fast-path semantics must be
+    preserved (alias only intercepts unknown commands, not built-ins)."""
+    runner = _make_runner(platform_extra={})
+    # /restart is a fast-path command — its alias 'r' (if any) would win
+    # via _resolve_cmd. The alias check only runs for unrecognized
+    # commands, so /restart never enters the alias branch.
+    runner._handle_restart_command = AsyncMock(return_value="restart-handled")
+    src = _make_source(user_id="anyone")
+    sk = build_session_key(src)
+    runner._running_agents[sk] = MagicMock()
+    runner._running_agents_ts[sk] = 0  # not stale
+    result = await runner._handle_message(_make_event("/restart", src))
+    assert result == "restart-handled"
+    runner._handle_model_command.assert_not_awaited()
+
+
+# -----------------------------------------------------------------------
+# 5. Unknown command behavior unchanged.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_still_warns_when_not_alias():
+    """A typed /<x> where x is neither a built-in, plugin, skill, nor
+    a model alias must still hit the unknown-command warning."""
+    runner = _make_runner(platform_extra={})
+    # /xyzzy-nope is not in COMMAND_REGISTRY, not a plugin, not a skill,
+    # not a model alias.
+    result = await runner._handle_message(
+        _make_event("/xyzzy-nope", _make_source(user_id="anyone"))
+    )
+    assert result is not None
+    assert "Unknown command" in result
+    runner._handle_model_command.assert_not_awaited()
+
+
+# -----------------------------------------------------------------------
+# 6. Edge case — alias with extra args.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_with_provider_flag_dispatches_with_args():
+    """Typing /sonnet --provider foo must reach _handle_model_command
+    with the rewritten event including both the alias name and the
+    --provider flag, so the handler's flag parsing works identically to
+    /model sonnet --provider foo."""
+    runner = _make_runner(platform_extra={})
+    await runner._handle_message(
+        _make_event("/sonnet --provider openrouter", _make_source(user_id="anyone"))
+    )
+    runner._handle_model_command.assert_awaited_once()
+    event_arg = runner._handle_model_command.await_args.args[0]
+    assert event_arg.text.lower().startswith("/model")
+    assert "sonnet" in event_arg.text.lower()
+    assert "--provider openrouter" in event_arg.text.lower()
+
+
+# -----------------------------------------------------------------------
+# 7. command:model hook rewrite decision — must mirror canonical /model
+#    rewrite protocol field-for-field.
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alias_hook_rewrite_routes_to_handle_model_command():
+    """A hook returning decision='rewrite' with command_name and raw_args
+    must rewrite event.text, re-resolve command/canonical, and then
+    dispatch to _handle_model_command with the rewritten args. This
+    mirrors the canonical /model rewrite branch at gateway/run.py:9456
+    (and the test_unknown_command.py::test_command_hook_rewrite_routes_to_plugin
+    contract) so alias and /model have the same command:model hook
+    lifecycle.
+    """
+    runner = _make_runner(platform_extra={})
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[
+            {
+                "decision": "rewrite",
+                "command_name": "opus",  # alias-style rewrite within model namespace
+                "raw_args": "--provider openrouter",
+            }
+        ]
+    )
+
+    await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+
+    # Hook fires once on the canonical ``command:model`` (the cold-path
+    # fallback already canonicalised /sonnet → /model sonnet, so this is
+    # NOT a re-fire — it matches the canonical /model rewrite contract
+    # (one decision per turn).
+    runner.hooks.emit_collect.assert_awaited_once()
+    hook_name = runner.hooks.emit_collect.await_args.args[0]
+    assert hook_name == "command:model"
+
+    # The rewrite target was itself a model alias (``opus``), so the
+    # dispatcher folds it into the canonical ``/model opus <args>`` form
+    # so the eventual handler still receives a target. Without this fold
+    # the event would dispatch to an unknown ``/opus`` handler and lose
+    # the model semantics.
+    runner._handle_model_command.assert_awaited_once()
+    event_arg = runner._handle_model_command.await_args.args[0]
+    assert event_arg.text.lower().startswith("/model opus"), (
+        f"alias-rewrite target must fold into /model <alias> form, "
+        f"got event_arg.text={event_arg.text!r}"
+    )
+    assert "--provider openrouter" in event_arg.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_alias_hook_rewrite_with_empty_command_is_noop():
+    """If the rewrite decision returns an empty command_name, the alias
+    dispatcher treats it as a no-op (continue), exactly like the canonical
+    branch at gateway/run.py:9458-9460."""
+    runner = _make_runner(platform_extra={})
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[{"decision": "rewrite", "command_name": "", "raw_args": "ignored"}]
+    )
+
+    await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+
+    # Empty command_name → continue → fall through to dispatch with the
+    # alias's pre-rewrite event.text (still /model sonnet).
+    runner._handle_model_command.assert_awaited_once()
+    event_arg = runner._handle_model_command.await_args.args[0]
+    assert event_arg.text.lower().startswith("/model")
+    assert "sonnet" in event_arg.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_alias_hook_rewrite_strips_leading_slash_from_command_name():
+    """The rewrite protocol (canonical run.py:9457-9459) strips any leading
+    slash from command_name before concatenating. Alias must do the same."""
+    runner = _make_runner(platform_extra={})
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[
+            {
+                "decision": "rewrite",
+                "command_name": "/opus",  # leading slash must be stripped
+                "raw_args": "",
+            }
+        ]
+    )
+
+    await runner._handle_message(
+        _make_event("/sonnet", _make_source(user_id="anyone"))
+    )
+
+    runner._handle_model_command.assert_awaited_once()
+    event_arg = runner._handle_model_command.await_args.args[0]
+    # Leading-slash stripped by the rewrite protocol; ``opus`` is a model
+    # alias so the dispatcher folds it into ``/model opus`` (no double
+    # slash, and the handler still receives the canonical /model shape).
+    assert event_arg.text == "/model opus", (
+        f"alias-rewrite target must fold into /model <alias> form, "
+        f"got event_arg.text={event_arg.text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_estop_pause_interaction_with_model_alias():
+    """Verify emergency stop (`hermes pause`) interaction with model aliases:
+    1. /model sonnet and /sonnet are both allowed through while paused (recognized command);
+    2. Regular non-command messages are blocked by estop notice;
+    3. Unknown slash commands (/unknown_alias_123) are blocked by estop notice;
+    4. Internal events bypass estop pause completely.
+    """
+    runner = _make_runner(platform_extra={})
+
+    with patch("agent.estop.paused_reply", return_value="⏸ Paused by estop"):
+        # 1a. /model sonnet -> recognized command "model" -> allowed
+        res_model = await runner._handle_message(
+            _make_event("/model sonnet", _make_source(user_id="anyone"))
+        )
+        assert res_model != "⏸ Paused by estop"
+        runner._handle_model_command.assert_awaited()
+
+        runner._handle_model_command.reset_mock()
+
+        # 1b. /sonnet -> canonicalized to /model sonnet -> recognized command "model" -> allowed identically
+        res_alias = await runner._handle_message(
+            _make_event("/sonnet", _make_source(user_id="anyone"))
+        )
+        assert res_alias != "⏸ Paused by estop"
+        runner._handle_model_command.assert_awaited_once()
+
+        runner._handle_model_command.reset_mock()
+
+        # 2. Regular non-command message -> blocked by estop notice
+        res_text = await runner._handle_message(
+            _make_event("hello world", _make_source(user_id="anyone"))
+        )
+        assert res_text == "⏸ Paused by estop"
+
+        # 3. Unknown slash command -> not canonicalized, not recognized -> blocked by estop
+        res_unknown = await runner._handle_message(
+            _make_event("/unknown_command_xyz123", _make_source(user_id="anyone"))
+        )
+        assert res_unknown == "⏸ Paused by estop"
+
+        # 4. Internal event -> event.internal=True -> bypasses estop pause completely
+        internal_event = _make_event("hello internal", _make_source(user_id="anyone"))
+        internal_event.internal = True
+        res_internal = await runner._handle_message(internal_event)
+        assert res_internal != "⏸ Paused by estop"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -18927,6 +18927,12 @@ def test_slash_exec_concurrent_first_use_spawns_single_worker(monkeypatch):
         def run(self, cmd):
             return f"ran {cmd}"
 
+        # slash.exec consumes the worker's resolved side-effect metadata, so the
+        # double must serve the same protocol as _SlashWorker (no model side
+        # effect here → meta is None).
+        def run_with_meta(self, cmd):
+            return f"ran {cmd}", None
+
         def close(self):
             pass
 

--- a/tests/tui_gateway/test_model_alias_canonical_mirror.py
+++ b/tests/tui_gateway/test_model_alias_canonical_mirror.py
@@ -107,10 +107,40 @@ def _install_worker(session_entry, worker):
     session_entry["slash_worker"] = worker
 
 
+@pytest.fixture()
+def patched_runtime_provider(monkeypatch):
+    """Replace ``hermes_cli.runtime_provider.resolve_runtime_provider`` with a
+    stub that returns a deterministic runtime dict, so the mirror path can run
+    end-to-end against fake providers without trying to actually reach an LLM.
+    """
+    def fake_resolve(
+        requested=None,
+        target_model=None,
+        explicit_base_url=None,
+        **_kwargs,
+    ):
+        return {
+            "provider": requested or "",
+            "api_mode": "chat_completions",
+            "base_url": explicit_base_url or "",
+            "api_key": "fake-key",
+            "source": "test-stub",
+            "requested_provider": requested or "",
+        }
+
+    import hermes_cli.runtime_provider as _rp_module
+    _rp_module.resolve_runtime_provider = fake_resolve
+    monkeypatch.setattr(
+        _rp_module,
+        "resolve_runtime_provider",
+        fake_resolve,
+    )
+
+
 # ── Scenario 1: Multi-profile A vs B resolution & provider/model ─────
 
 
-def test_multi_profile_resolved_model_mirror(server, hermes_home):
+def test_multi_profile_resolved_model_mirror(server, hermes_home, patched_runtime_provider):
     """Profile A maps /foo -> provider-a/model-a.
     Profile B maps /foo -> provider-b/model-b.
     Executing /foo in B session mirrors provider-b/model-b on B's live agent.
@@ -180,7 +210,7 @@ def test_multi_profile_resolved_model_mirror(server, hermes_home):
 # ── Scenario 2: Concurrent profile interleaving without env tampering ────
 
 
-def test_concurrent_profile_cross_talk_isolation(server, hermes_home):
+def test_concurrent_profile_cross_talk_isolation(server, hermes_home, patched_runtime_provider):
     """Execute Profile A and Profile B mirrors concurrently using a barrier
     to force interleaving. Verify os.environ["HERMES_HOME"] is NEVER modified,
     context overrides remain isolated, and both sessions end up in correct state.
@@ -351,7 +381,7 @@ def test_once_full_lifecycle_restore(server, session_with_agent):
 # ── Scenario 4: Custom provider & No credentials in metadata ────────────
 
 
-def test_custom_provider_metadata_has_no_secrets(server, session_with_agent, hermes_home):
+def test_custom_provider_metadata_has_no_secrets(server, session_with_agent, hermes_home, patched_runtime_provider):
     """Ensure worker metadata contains no api_key/tokens, and custom provider resolves."""
     sid, _, sess, agent = session_with_agent
 
@@ -389,7 +419,7 @@ def test_custom_provider_metadata_has_no_secrets(server, session_with_agent, her
 # ── Scenario 5: --session, --once, --global scope behavior ───────────────
 
 
-def test_scope_session_once_global_behavior(server, session_with_agent, hermes_home):
+def test_scope_session_once_global_behavior(server, session_with_agent, hermes_home, patched_runtime_provider):
     """Test --session, --once, and --global metadata scope handling."""
     sid, _, sess, agent = session_with_agent
     prof_dir = hermes_home / "scope_prof"
@@ -544,3 +574,424 @@ def test_builtin_plugin_skill_collision_no_model_mirror(server, session_with_age
     # Live agent unchanged
     assert agent.model == initial_model
     assert "model_override" not in sess
+
+
+# ── Profile scope fail-closed tests ───────────────────────────────
+
+
+def _session_with_profile(server, profile_home: Path):
+    """Build a session dict wired with a real MagicMock agent."""
+    sid = f"sid-{profile_home.name}"
+    fake_agent = MagicMock(
+        spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model"]
+    )
+    fake_agent.model = "initial-model"
+    fake_agent.provider = "initial-provider"
+    fake_agent.base_url = "https://initial.api"
+    fake_agent.api_key = "secret-key"
+    fake_agent.api_mode = "chat_completions"
+
+    def fake_switch(new_model="", new_provider="", **kw):
+        fake_agent.model = new_model
+        fake_agent.provider = new_provider
+        if base_url:
+            fake_agent.base_url = base_url
+
+    fake_agent.switch_model = MagicMock(side_effect=fake_switch)
+
+    sess = {
+        "session_key": f"k-{profile_home.name}",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+        "agent": fake_agent,
+        "profile_home": str(profile_home),
+    }
+    server._sessions[sid] = sess
+    return sid, sess, fake_agent
+
+
+def test_fail_closed_home_scope_raises(server, hermes_home):
+    """``set_hermes_home_override`` raises -> mirror aborts BEFORE any
+    provider resolution, agent mutation, or model_override write."""
+    prof_dir = hermes_home / "prof_home_fail"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sid, sess, agent = _session_with_profile(server, prof_dir)
+
+    import hermes_constants
+    real_set = hermes_constants.set_hermes_home_override
+
+    def broken_set(path):
+        raise RuntimeError("scope setup failed")
+
+    hermes_constants.set_hermes_home_override = broken_set
+
+    meta = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-x",
+        "resolved_provider": "provider-x",
+        "raw_args": "x",
+    }
+
+    try:
+        warning = server._mirror_resolved_model_switch(sid, sess, meta)
+    finally:
+        hermes_constants.set_hermes_home_override = real_set
+
+    assert "mirror aborted" in warning
+    # Agent untouched
+    assert agent.model == "initial-model"
+    assert agent.provider == "initial-provider"
+    # No session mutation
+    assert "model_override" not in sess
+    # config.yaml not created on profile_home
+    assert not (prof_dir / "config.yaml").exists()
+
+
+def test_fail_closed_secret_scope_raises(server, hermes_home):
+    """``set_secret_scope`` raises AFTER home_token was established —
+    home_token must be reset (no ContextVar leak) and mirror aborts."""
+    prof_dir = hermes_home / "prof_secret_fail"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sid, sess, agent = _session_with_profile(server, prof_dir)
+
+    # Track that home override was set and reset
+    home_set_calls = []
+
+    real_set = None
+    real_reset = None
+    import hermes_constants
+
+    try:
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    except ImportError:
+        pytest.skip("hermes_constants unavailable")
+
+    real_set = set_hermes_home_override
+    real_reset = reset_hermes_home_override
+
+    def tracked_set(path):
+        tok = real_set(path)
+        home_set_calls.append(("set", tok))
+        return tok
+
+    def tracked_reset(tok):
+        home_set_calls.append(("reset", tok))
+        return real_reset(tok)
+
+    hermes_constants.set_hermes_home_override = tracked_set
+    hermes_constants.reset_hermes_home_override = tracked_reset
+
+    # Force set_secret_scope to raise
+    import agent.secret_scope as ss_module
+
+    def broken_set_scope(scope):
+        raise RuntimeError("secret scope setup failed")
+
+    original_set_secret_scope = ss_module.set_secret_scope
+    ss_module.set_secret_scope = broken_set_scope
+
+    try:
+        meta = {
+            "side_effect": "model_switch",
+            "canonical": "model",
+            "scope": "session",
+            "resolved_model": "model-x",
+            "resolved_provider": "provider-x",
+            "raw_args": "x",
+        }
+
+        warning = server._mirror_resolved_model_switch(sid, sess, meta)
+    finally:
+        ss_module.set_secret_scope = original_set_secret_scope
+        hermes_constants.set_hermes_home_override = real_set
+        hermes_constants.reset_hermes_home_override = real_reset
+
+    assert "mirror aborted" in warning
+    # home_token was set then reset by ExitStack
+    ops = [op for op, _ in home_set_calls]
+    assert ops.count("set") >= 1
+    assert ops.count("reset") >= 1
+    # Agent untouched, no session mutation
+    assert agent.model == "initial-model"
+    assert "model_override" not in sess
+
+
+def test_fail_closed_provider_resolution_raises(server, hermes_home, monkeypatch):
+    """``resolve_runtime_provider`` raises -> both scope tokens are reset."""
+    prof_dir = hermes_home / "prof_resolve_fail"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sid, sess, agent = _session_with_profile(server, prof_dir)
+
+    import hermes_cli.runtime_provider as rp
+    monkeypatch.setattr(rp, "resolve_runtime_provider",
+                       lambda *a, **k: (_ for _ in ()).throw(RuntimeError("resolve broken")))
+
+    meta = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-x",
+        "resolved_provider": "provider-x",
+        "raw_args": "x",
+    }
+
+    warning = server._mirror_resolved_model_switch(sid, sess, meta)
+
+    assert "provider resolution failed" in warning
+    assert agent.model == "initial-model"
+    assert "model_override" not in sess
+
+
+def test_fail_closed_agent_apply_raises(server, hermes_home, patched_runtime_provider):
+    """``agent.switch_model`` raises during apply -> scope tokens are reset."""
+    prof_dir = hermes_home / "prof_apply_fail"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sid, sess, agent = _session_with_profile(server, prof_dir)
+
+    # Force switch_model to raise on apply
+    def broken_switch(**kw):
+        raise RuntimeError("agent switch failed")
+    agent.switch_model = MagicMock(side_effect=broken_switch)
+
+    meta = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-x",
+        "resolved_provider": "provider-x",
+        "raw_args": "x",
+    }
+
+    warning = server._mirror_resolved_model_switch(sid, sess, meta)
+
+    assert "model mirror failed" in warning
+    # Agent.switch_model did get called (and raised) but agent.model stays initial
+    assert agent.model == "initial-model"
+    # session was not mutated
+    assert "model_override" not in sess
+
+
+def test_fail_closed_secret_scope_init_raises(server, hermes_home):
+    """``build_profile_secret_scope`` raises (during init, before set_secret_scope)
+    — home_token already established; both attempts handled and tokens reset."""
+    prof_dir = hermes_home / "prof_build_secret_fail"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sid, sess, agent = _session_with_profile(server, prof_dir)
+
+    import hermes_constants
+    import agent.secret_scope as ss_module
+
+    home_resets = []
+
+    real_set = hermes_constants.set_hermes_home_override
+    real_reset = hermes_constants.reset_hermes_home_override
+
+    def tracked_reset(tok):
+        home_resets.append(tok)
+        return real_reset(tok)
+
+    hermes_constants.set_hermes_home_override = real_set
+    hermes_constants.reset_hermes_home_override = tracked_reset
+
+    def broken_build(path):
+        raise RuntimeError("build profile secret scope failed")
+
+    real_build = ss_module.build_profile_secret_scope
+    ss_module.build_profile_secret_scope = broken_build
+
+    try:
+        meta = {
+            "side_effect": "model_switch",
+            "canonical": "model",
+            "scope": "session",
+            "resolved_model": "model-x",
+            "resolved_provider": "provider-x",
+            "raw_args": "x",
+        }
+        warning = server._mirror_resolved_model_switch(sid, sess, meta)
+    finally:
+        ss_module.build_profile_secret_scope = real_build
+        hermes_constants.set_hermes_home_override = real_set
+        hermes_constants.reset_hermes_home_override = real_reset
+
+    assert "mirror aborted" in warning
+    # Agent untouched, no session mutation
+    assert agent.model == "initial-model"
+    assert "model_override" not in sess
+
+
+# ── Real production --once lifecycle integration ─────────────────────
+
+
+def _once_lifecycle_setup(server, hermes_home, patched_runtime_provider):
+    """Prepare a session with all prerequisites for prompt.submit production chain.
+
+    Returns: (sid, sess, agent)
+    """
+    prof_dir = hermes_home / "prof_lifecycle"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+
+    sid = "sid-once-life"
+    agent = MagicMock(
+        spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model", "run_conversation"]
+    )
+    agent.model = "orig-model"
+    agent.provider = "orig-provider"
+    agent.base_url = "https://orig.api"
+    agent.api_key = "orig-key"
+    agent.api_mode = "chat_completions"
+
+    def fake_switch(new_model="", new_provider="", api_key="", base_url="", api_mode=""):
+        agent.model = new_model
+        agent.provider = new_provider
+        if base_url:
+            agent.base_url = base_url
+
+    agent.switch_model = MagicMock(side_effect=fake_switch)
+
+    sess = {
+        "session_key": "k-once-life",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+        "agent": agent,
+        "profile_home": str(prof_dir),
+        # Mark session as not running so prompt.submit runs _run_prompt_submit
+        "agent_ready": threading.Event(),
+    }
+    sess["agent_ready"].set()
+    server._sessions[sid] = sess
+
+    # Worker reports once metadata
+    meta_once = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "once",
+        "resolved_model": "model-once-temp",
+        "resolved_provider": "prov-once-temp",
+        "raw_args": "temp-model --once",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta_once))
+
+    # Phase A: slash.exec applies once via production mirror path
+    res = server._methods["slash.exec"](1, {"command": "/temp-model --once", "session_id": sid})
+    assert "result" in res
+
+    return sid, sess, agent
+
+
+def _wait_turn_threads(sess, timeout=120):
+    """Join both daemon turn threads: the ``prompt.submit``
+    ``run_after_agent_ready`` wrapper and the inner ``_run_prompt_submit``
+    ``run()`` thread that ``_run_prompt_submit`` stores back into
+    ``session["_run_thread"]`` when it starts the real turn body."""
+    first = sess.get("_run_thread")
+    if first is not None:
+        first.join(timeout=timeout)
+    inner = sess.get("_run_thread")
+    if inner is not None and inner is not first:
+        inner.join(timeout=timeout)
+
+
+def test_once_real_turn_chain_success_restores(server, hermes_home, patched_runtime_provider):
+    """Real production turn chain restores --once after successful turn."""
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    # Phase 2: live agent temp model after mirror
+    assert agent.model == "model-once-temp"
+    assert sess["one_turn_model_restore"] is not None
+
+    # Mock agent.run_conversation to return successfully without real LLM
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+    # Phase 3: real prompt.submit -> _run_prompt_submit -> turn-finally -> restore
+    res = server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    assert "result" in res
+
+    # Wait for daemon _run_thread to finish
+    _wait_turn_threads(sess)
+
+    # Phase 4: agent restored to original
+    assert agent.model == "orig-model"
+    assert agent.provider == "orig-provider"
+    # Phase 5: once snapshot consumed by the production turn finally
+    assert "one_turn_model_restore" not in sess
+    # model_override scope remains "once" (production keeps it; the
+    # consumed snapshot is what drives the restore)
+    mo = sess.get("model_override", {})
+    assert mo.get("scope") == "once"
+
+
+def test_once_real_turn_chain_error_restores(server, hermes_home, patched_runtime_provider):
+    """Real production turn chain restores --once even if turn raises."""
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    assert agent.model == "model-once-temp"
+
+    # Mock agent.run_conversation to raise an exception
+    def failing_run(*args, **kwargs):
+        raise RuntimeError("model provider rate-limit")
+    agent.run_conversation = MagicMock(side_effect=failing_run)
+
+    # Submit prompt through production chain
+    server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+
+    _wait_turn_threads(sess)
+
+    # Agent restored despite turn error
+    assert agent.model == "orig-model"
+    assert agent.provider == "orig-provider"
+    # Once snapshot consumed
+    assert "one_turn_model_restore" not in sess
+
+
+def test_once_real_turn_chain_interrupt_restores(server, hermes_home, patched_runtime_provider):
+    """Real production turn chain restores --once when session is interrupted."""
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    assert agent.model == "model-once-temp"
+
+    # Mock agent.run_conversation to honor interrupt flag and abort
+    def interruptible_run(*args, **kwargs):
+        # Read interrupt flag under lock to mimic real agent behavior
+        with sess["history_lock"]:
+            cancelled = bool(sess.get("_turn_cancel_requested"))
+        if cancelled:
+            raise RuntimeError("turn interrupted")
+        # Otherwise block; interrupt will set the flag
+        import time as _t
+        for _ in range(50):
+            with sess["history_lock"]:
+                if sess.get("_turn_cancel_requested"):
+                    raise RuntimeError("turn interrupted")
+            _t.sleep(0.1)
+        return {"messages": []}
+
+    agent.run_conversation = MagicMock(side_effect=interruptible_run)
+
+    # Submit prompt through production chain
+    server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+
+    # Set interrupt flag immediately
+    import time as _t
+    _t.sleep(0.2)
+    with sess["history_lock"]:
+        sess["_turn_cancel_requested"] = True
+
+    _wait_turn_threads(sess)
+
+    # Agent restored despite interrupt
+    assert agent.model == "orig-model"
+    assert "one_turn_model_restore" not in sess

--- a/tests/tui_gateway/test_model_alias_canonical_mirror.py
+++ b/tests/tui_gateway/test_model_alias_canonical_mirror.py
@@ -13,14 +13,23 @@ MUST consume this resolved metadata directly via
 MUST NOT consult the parent process's alias cache, and MUST NOT transmit
 or receive credentials in metadata.
 
-These tests assert final live agent state (``agent.model``, ``agent.provider``),
-``session["model_override"]``, scope behavior, multi-profile isolation,
-failure/rollback safety, and metadata sanitization.
+These tests assert:
+  1. Multi-profile resolution isolation and agent state.
+  2. True concurrent interleaving execution without process-global environment tampering.
+  3. Closed 7-phase --once model switch lifecycle and restore.
+  4. Custom provider resolution without credential transmission.
+  5. Session, once, and global scope behavior (verifying config writes stay within profile home).
+  6. Worker failure / cancellation safety.
+  7. Parent apply failure rollback.
+  8. Consecutive command metadata resetting and collision immunity.
 """
 from __future__ import annotations
 
+import asyncio
 import importlib
+import os
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -57,12 +66,14 @@ def session_with_agent(server):
     sid = "sid-resolved-mirror"
     session_key = "tui-resolved-mirror"
 
-    fake_agent = MagicMock()
+    fake_agent = MagicMock(spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model"])
     fake_agent.model = "initial-model"
     fake_agent.provider = "initial-provider"
     fake_agent.base_url = "https://initial.api"
+    fake_agent.api_key = "secret-key"
+    fake_agent.api_mode = "chat_completions"
 
-    def fake_switch(new_model, new_provider, api_key="", base_url="", api_mode=""):
+    def fake_switch(new_model="", new_provider="", api_key="", base_url="", api_mode=""):
         fake_agent.model = new_model
         fake_agent.provider = new_provider
         if base_url:
@@ -96,10 +107,10 @@ def _install_worker(session_entry, worker):
     session_entry["slash_worker"] = worker
 
 
-# ── Scenario 1 & 3: Multi-profile A vs B resolution & provider/model ─────
+# ── Scenario 1: Multi-profile A vs B resolution & provider/model ─────
 
 
-def test_multi_profile_resolved_model_mirror(server, hermes_home, monkeypatch):
+def test_multi_profile_resolved_model_mirror(server, hermes_home):
     """Profile A maps /foo -> provider-a/model-a.
     Profile B maps /foo -> provider-b/model-b.
     Executing /foo in B session mirrors provider-b/model-b on B's live agent.
@@ -166,14 +177,22 @@ def test_multi_profile_resolved_model_mirror(server, hermes_home, monkeypatch):
     assert agent_a.provider == "old-provider"
 
 
-# ── Scenario 2: Sequential execution A then B does not contaminate ──────
+# ── Scenario 2: Concurrent profile interleaving without env tampering ────
 
 
-def test_sequential_execution_profile_isolation(server, hermes_home):
-    """Execute session A (/foo -> provider-a/model-a), then session B (/foo -> provider-b/model-b).
-    Assert both sessions end up with their respective profile's resolved provider/model.
+def test_concurrent_profile_cross_talk_isolation(server, hermes_home):
+    """Execute Profile A and Profile B mirrors concurrently using a barrier
+    to force interleaving. Verify os.environ["HERMES_HOME"] is NEVER modified,
+    context overrides remain isolated, and both sessions end up in correct state.
     """
-    sid_a = "sid-seq-a"
+    initial_env_home = os.environ.get("HERMES_HOME")
+
+    prof_a_dir = hermes_home / "prof_conc_a"
+    prof_b_dir = hermes_home / "prof_conc_b"
+    prof_a_dir.mkdir(parents=True, exist_ok=True)
+    prof_b_dir.mkdir(parents=True, exist_ok=True)
+
+    sid_a = "sid-conc-a"
     agent_a = MagicMock()
     agent_a.model = "init"
     agent_a.provider = "init"
@@ -183,15 +202,14 @@ def test_sequential_execution_profile_isolation(server, hermes_home):
     agent_a.switch_model = switch_a
 
     sess_a = {
-        "session_key": "k-seq-a",
+        "session_key": "k-conc-a",
         "history": [],
         "history_lock": threading.Lock(),
         "agent": agent_a,
-        "profile_home": str(hermes_home / "prof_a"),
+        "profile_home": str(prof_a_dir),
     }
-    server._sessions[sid_a] = sess_a
 
-    sid_b = "sid-seq-b"
+    sid_b = "sid-conc-b"
     agent_b = MagicMock()
     agent_b.model = "init"
     agent_b.provider = "init"
@@ -201,51 +219,133 @@ def test_sequential_execution_profile_isolation(server, hermes_home):
     agent_b.switch_model = switch_b
 
     sess_b = {
-        "session_key": "k-seq-b",
+        "session_key": "k-conc-b",
         "history": [],
         "history_lock": threading.Lock(),
         "agent": agent_b,
-        "profile_home": str(hermes_home / "prof_b"),
+        "profile_home": str(prof_b_dir),
     }
-    server._sessions[sid_b] = sess_b
 
     meta_a = {
         "side_effect": "model_switch",
         "canonical": "model",
-        "scope": "session",
+        "scope": "global",
         "resolved_model": "model-a",
         "resolved_provider": "provider-a",
-        "base_url": None,
-        "api_mode": None,
         "raw_args": "foo",
     }
     meta_b = {
         "side_effect": "model_switch",
         "canonical": "model",
-        "scope": "session",
+        "scope": "global",
         "resolved_model": "model-b",
         "resolved_provider": "provider-b",
-        "base_url": None,
-        "api_mode": None,
         "raw_args": "foo",
     }
 
-    _install_worker(sess_a, _make_worker_double(slash_meta=meta_a))
-    _install_worker(sess_b, _make_worker_double(slash_meta=meta_b))
+    barrier = threading.Barrier(2)
 
-    # Execute A first
-    server._methods["slash.exec"](1, {"command": "/foo", "session_id": sid_a})
+    def run_mirror_a():
+        # Inject barrier inside resolution path
+        orig_res = server._mirror_resolved_model_switch
+        barrier.wait(timeout=5)
+        res = orig_res(sid_a, sess_a, meta_a)
+        # Assert process-global environment was NEVER mutated
+        assert os.environ.get("HERMES_HOME") == initial_env_home
+        return res
+
+    def run_mirror_b():
+        orig_res = server._mirror_resolved_model_switch
+        barrier.wait(timeout=5)
+        res = orig_res(sid_b, sess_b, meta_b)
+        assert os.environ.get("HERMES_HOME") == initial_env_home
+        return res
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        fut_a = executor.submit(run_mirror_a)
+        fut_b = executor.submit(run_mirror_b)
+        fut_a.result()
+        fut_b.result()
+
+    # Verify final agent models
     assert agent_a.model == "model-a"
     assert agent_a.provider == "provider-a"
-
-    # Execute B second
-    server._methods["slash.exec"](2, {"command": "/foo", "session_id": sid_b})
     assert agent_b.model == "model-b"
     assert agent_b.provider == "provider-b"
 
-    # Re-verify A was not overwritten by B
-    assert agent_a.model == "model-a"
-    assert agent_a.provider == "provider-a"
+    # Verify configs persisted to respective profile homes without clobbering
+    cfg_a = (prof_a_dir / "config.yaml").read_text(encoding="utf-8")
+    cfg_b = (prof_b_dir / "config.yaml").read_text(encoding="utf-8")
+    assert "model-a" in cfg_a
+    assert "model-b" in cfg_b
+
+    # Final env assertion
+    assert os.environ.get("HERMES_HOME") == initial_env_home
+
+
+# ── Scenario 3: Closed --once 7-phase lifecycle and restore ───────────────
+
+
+def test_once_full_lifecycle_restore(server, session_with_agent):
+    """Complete 7-phase validation for --once model switch:
+    Phase 1: Worker returns once metadata.
+    Phase 2: Live agent switches to target model.
+    Phase 3: Turn 1 executes using target model.
+    Phase 4: Turn 1 completes and restores previous provider/model.
+    Phase 5: Session model_override once state and restore_snapshot cleared.
+    Phase 6: Turn 2 continues using original model.
+    Phase 7: Failure or cancellation paths leave no pending restore state.
+    """
+    sid, _, sess, agent = session_with_agent
+
+    orig_model = agent.model
+    orig_provider = agent.provider
+
+    # Phase 1: Worker returns once metadata
+    meta_once = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "once",
+        "resolved_model": "model-temp-once",
+        "resolved_provider": "prov-once",
+        "raw_args": "temp-model --once",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta_once))
+
+    # Phase 2: Parent mirrors slash exec
+    res = server._methods["slash.exec"](1, {"command": "/temp-model --once", "session_id": sid})
+    assert "result" in res
+
+    # Live agent switched to temp once model
+    assert agent.model == "model-temp-once"
+    assert agent.provider == "prov-once"
+    assert sess["model_override"]["scope"] == "once"
+    assert sess.get("one_turn_model_restore") is not None
+
+    # Phase 3: Assistant turn 1 executes with temp model
+    assert agent.model == "model-temp-once"
+
+    # Phase 4 & 5: Turn 1 finishes -> restore agent model runtime
+    restore_snap = sess.pop("one_turn_model_restore", None)
+    assert restore_snap is not None
+    server._restore_agent_model_runtime(agent, restore_snap)
+    sess["model_override"].pop("restore_snapshot", None)
+    sess.pop("model_override", None)
+
+    # Restored to original model and provider
+    assert agent.model == orig_model
+    assert agent.provider == orig_provider
+
+    # Phase 6: Turn 2 executes with original model
+    assert agent.model == orig_model
+    assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
+
+    # Phase 7: Failure/cancellation leaves no pending restore state
+    _install_worker(sess, _make_worker_double(slash_meta=None, output="Cancelled"))
+    server._methods["slash.exec"](2, {"command": "/bad-cmd", "session_id": sid})
+    assert agent.model == orig_model
+    assert "one_turn_model_restore" not in sess
 
 
 # ── Scenario 4: Custom provider & No credentials in metadata ────────────
@@ -296,7 +396,21 @@ def test_scope_session_once_global_behavior(server, session_with_agent, hermes_h
     prof_dir.mkdir(parents=True, exist_ok=True)
     sess["profile_home"] = str(prof_dir)
 
-    # 1. Once scope
+    # 1. Session scope
+    meta_sess = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-sess",
+        "resolved_provider": "prov-sess",
+        "raw_args": "sess-model --session",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta_sess))
+    server._methods["slash.exec"](1, {"command": "/sess-model --session", "session_id": sid})
+    assert agent.model == "model-sess"
+    assert sess["model_override"]["scope"] == "session"
+
+    # 2. Once scope
     meta_once = {
         "side_effect": "model_switch",
         "canonical": "model",
@@ -306,11 +420,11 @@ def test_scope_session_once_global_behavior(server, session_with_agent, hermes_h
         "raw_args": "once-model --once",
     }
     _install_worker(sess, _make_worker_double(slash_meta=meta_once))
-    server._methods["slash.exec"](1, {"command": "/once-model --once", "session_id": sid})
+    server._methods["slash.exec"](2, {"command": "/once-model --once", "session_id": sid})
     assert agent.model == "model-once"
     assert sess["model_override"]["scope"] == "once"
 
-    # 2. Global scope
+    # 3. Global scope
     meta_global = {
         "side_effect": "model_switch",
         "canonical": "model",
@@ -320,11 +434,11 @@ def test_scope_session_once_global_behavior(server, session_with_agent, hermes_h
         "raw_args": "global-model --global",
     }
     _install_worker(sess, _make_worker_double(slash_meta=meta_global))
-    server._methods["slash.exec"](2, {"command": "/global-model --global", "session_id": sid})
+    server._methods["slash.exec"](3, {"command": "/global-model --global", "session_id": sid})
     assert agent.model == "model-global"
     assert sess["model_override"]["scope"] == "global"
 
-    # Check that global persisted to config.yaml under prof_dir
+    # Check that global persisted ONLY to config.yaml under prof_dir
     config_file = prof_dir / "config.yaml"
     assert config_file.exists()
     content = config_file.read_text(encoding="utf-8")
@@ -352,7 +466,34 @@ def test_worker_failure_does_not_mirror(server, session_with_agent):
     assert "model_override" not in sess
 
 
-# ── Scenario 7: Consecutive commands reset metadata ─────────────────────
+# ── Scenario 7: Parent apply failure rollback ────────────────────────────
+
+
+def test_parent_apply_failure_rollback(server, session_with_agent):
+    """If agent.switch_model fails on the parent, _mirror_resolved_model_switch
+    returns a warning message and does not corrupt session state.
+    """
+    sid, _, sess, agent = session_with_agent
+
+    agent.switch_model = MagicMock(side_effect=RuntimeError("connection refused"))
+
+    meta = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "broken-model",
+        "resolved_provider": "broken-prov",
+        "raw_args": "broken",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta))
+
+    res = server._methods["slash.exec"](1, {"command": "/broken", "session_id": sid})
+    assert "result" in res
+    assert "warning" in res["result"]
+    assert "model mirror failed" in res["result"]["warning"]
+
+
+# ── Scenario 8: Consecutive commands reset metadata & collision safety ───
 
 
 def test_consecutive_commands_metadata_reset(server, session_with_agent):
@@ -385,11 +526,8 @@ def test_consecutive_commands_metadata_reset(server, session_with_agent):
     server._mirror_slash_side_effects = fake_mirror
 
     server._methods["slash.exec"](2, {"command": "/help", "session_id": sid})
-    # Agent remains model-turn-1, no second call to switch_model
+    # Agent remains model-turn-1
     assert agent.model == "model-turn-1"
-
-
-# ── Scenario 8: Built-in / plugin / skill collision still no model mirror ─
 
 
 def test_builtin_plugin_skill_collision_no_model_mirror(server, session_with_agent):

--- a/tests/tui_gateway/test_model_alias_canonical_mirror.py
+++ b/tests/tui_gateway/test_model_alias_canonical_mirror.py
@@ -1,26 +1,21 @@
-"""Tests for the TUI slash worker canonical-side-effect mirror contract.
+"""Tests for the TUI slash worker resolved-model mirror contract.
 
 The TUI slash worker (``tui_gateway.slash_worker``) runs inside the
 session's ``profile_home`` scope and resolves the typed command against
-the real built-in / quick / plugin / bundle / skill / model alias
-registry. It then writes a structured ``meta`` JSON field describing
-what it actually did.
+its profile-scoped provider / model / alias registry. When a model
+switch succeeds, it emits structured metadata containing ONLY resolved,
+non-sensitive fields (``side_effect="model_switch"``, ``resolved_model``,
+``resolved_provider``, ``scope``, ``base_url``, ``api_mode``, ``raw_args``).
 
-The parent ``slash.exec`` handler (``tui_gateway.methods_tools``) MUST
-base the live-session mirror decision ONLY on that ``meta`` field. It
-must NOT re-derive whether the typed token is in a global alias cache.
-Re-deriving breaks two things at once:
+The parent process (``tui_gateway.methods_tools`` / ``tui_gateway.server``)
+MUST consume this resolved metadata directly via
+``_mirror_resolved_model_switch``. It MUST NOT re-parse ``raw_args``,
+MUST NOT consult the parent process's alias cache, and MUST NOT transmit
+or receive credentials in metadata.
 
-1. A built-in / quick / plugin / bundle / skill command whose typed
-   name also exists as a model alias (e.g. ``/version`` while
-   ``version`` is configured as a model alias). The worker actually
-   ran the built-in; the mirror must NOT switch the live model.
-
-2. Profile A and Profile B with the same alias name mapped to
-   different models. The parent must read the worker's profile-scoped
-   metadata, not the parent's global alias cache.
-
-These tests exercise both bugs and pin the contract for every layer.
+These tests assert final live agent state (``agent.model``, ``agent.provider``),
+``session["model_override"]``, scope behavior, multi-profile isolation,
+failure/rollback safety, and metadata sanitization.
 """
 from __future__ import annotations
 
@@ -58,9 +53,23 @@ def server(hermes_home):
 
 
 @pytest.fixture()
-def session(server):
-    sid = "sid-mirror-canonical"
-    session_key = "tui-mirror-canonical"
+def session_with_agent(server):
+    sid = "sid-resolved-mirror"
+    session_key = "tui-resolved-mirror"
+
+    fake_agent = MagicMock()
+    fake_agent.model = "initial-model"
+    fake_agent.provider = "initial-provider"
+    fake_agent.base_url = "https://initial.api"
+
+    def fake_switch(new_model, new_provider, api_key="", base_url="", api_mode=""):
+        fake_agent.model = new_model
+        fake_agent.provider = new_provider
+        if base_url:
+            fake_agent.base_url = base_url
+
+    fake_agent.switch_model = MagicMock(side_effect=fake_switch)
+
     s = {
         "session_key": session_key,
         "history": [],
@@ -69,16 +78,13 @@ def session(server):
         "running": False,
         "attached_images": [],
         "cols": 120,
+        "agent": fake_agent,
     }
     server._sessions[sid] = s
-    return sid, session_key, s
+    return sid, session_key, s, fake_agent
 
 
 def _make_worker_double(slash_meta=None, output=""):
-    """Return a worker double whose ``run_with_meta`` returns
-    ``(output, slash_meta)`` — the structured metadata the real
-    slash worker emits inside the session's profile scope.
-    """
     w = MagicMock()
     w.run = MagicMock(return_value=output)
     w.run_with_meta = MagicMock(return_value=(output, slash_meta))
@@ -90,511 +96,313 @@ def _install_worker(session_entry, worker):
     session_entry["slash_worker"] = worker
 
 
-def _capturing_mirror():
-    """Return ``(fake_mirror_fn, captured_list)`` for capturing mirror calls."""
-    captured = []
-
-    def fake_mirror(sid, sess, cmd):
-        captured.append(cmd)
-        return ""
-
-    return fake_mirror, captured
+# ── Scenario 1 & 3: Multi-profile A vs B resolution & provider/model ─────
 
 
-# ── 1. /version vs alias `version` ────────────────────────────────────
-
-
-def test_builtin_version_with_alias_version_does_not_mirror_model(
-    server, session, monkeypatch
-):
-    """When ``version`` is configured as a model alias, the worker
-    actually resolves the built-in ``version`` command and reports
-    ``side_effect=None`` (no model switch). The parent must NOT call
-    ``_apply_model_switch`` and must NOT change the live session's
-    model.
+def test_multi_profile_resolved_model_mirror(server, hermes_home, monkeypatch):
+    """Profile A maps /foo -> provider-a/model-a.
+    Profile B maps /foo -> provider-b/model-b.
+    Executing /foo in B session mirrors provider-b/model-b on B's live agent.
     """
-    sid, _, sess = session
-    fake_mirror, captured = _capturing_mirror()
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+    sid_a = "sid-prof-a"
+    agent_a = MagicMock()
+    agent_a.model = "old-model"
+    agent_a.provider = "old-provider"
+    def switch_a(new_model="", new_provider="", **kw):
+        agent_a.model = new_model
+        agent_a.provider = new_provider
+    agent_a.switch_model = switch_a
 
-    # Force the worker's reported metadata to be what the real worker
-    # would have set when it ran built-in ``version``: meta is None.
-    worker = _make_worker_double(slash_meta=None)
-    _install_worker(sess, worker)
-
-    server._methods["slash.exec"](1, {"command": "/version", "session_id": sid})
-
-    # The mirror still gets called (so other built-in side effects can
-    # fire), but the command is /version verbatim — NOT /model version.
-    assert len(captured) == 1
-    assert captured[0].lower() == "/version"
-    worker.run_with_meta.assert_called_with("/version")
-
-
-# ── 2. alias vs quick command ──────────────────────────────────────────
-
-
-def test_alias_collision_with_quick_command_does_not_mirror_model(
-    server, session, monkeypatch
-):
-    """A quick command named like a model alias must win; the worker
-    reports ``meta=None`` and the parent must NOT switch models.
-    """
-    sid, _, sess = session
-    fake_mirror, captured = _capturing_mirror()
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-
-    worker = _make_worker_double(slash_meta=None)
-    _install_worker(sess, worker)
-
-    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
-
-    assert len(captured) == 1
-    assert captured[0].lower() == "/sonnet"
-
-
-# ── 3. alias vs plugin command ──────────────────────────────────────────
-
-
-def test_alias_collision_with_plugin_does_not_mirror_model(
-    server, session, monkeypatch
-):
-    """A plugin command named like a model alias must win."""
-    sid, _, sess = session
-    fake_mirror, captured = _capturing_mirror()
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-
-    worker = _make_worker_double(slash_meta=None)
-    _install_worker(sess, worker)
-
-    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
-
-    assert len(captured) == 1
-    assert captured[0].lower() == "/sonnet"
-
-
-# ── 4. alias vs skill bundle ──────────────────────────────────────────
-
-
-def test_alias_collision_with_bundle_does_not_mirror_model(
-    server, session, monkeypatch
-):
-    """A skill bundle command named like a model alias must win."""
-    sid, _, sess = session
-    fake_mirror, captured = _capturing_mirror()
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-
-    worker = _make_worker_double(slash_meta=None)
-    _install_worker(sess, worker)
-
-    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
-
-    assert len(captured) == 1
-    assert captured[0].lower() == "/sonnet"
-
-
-# ── 5. alias vs active skill ──────────────────────────────────────────
-
-
-def test_alias_collision_with_active_skill_does_not_mirror_model(
-    server, session, monkeypatch
-):
-    """An active skill command named like a model alias must win."""
-    sid, _, sess = session
-    fake_mirror, captured = _capturing_mirror()
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-
-    worker = _make_worker_double(slash_meta=None)
-    _install_worker(sess, worker)
-
-    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
-
-    assert len(captured) == 1
-    assert captured[0].lower() == "/sonnet"
-
-
-# ── 6. /sonnet (real alias) is canonicalized by worker ────────────────
-
-
-def test_real_alias_sonnet_does_mirror_via_worker_meta(
-    server, session, monkeypatch
-):
-    """When the worker reports ``side_effect == "model_switch"`` with
-    ``canonical == "model"``, the parent must re-emit the model switch
-    via ``_mirror_slash_side_effects`` exactly once.
-    """
-    sid, _, sess = session
-    fake_mirror, captured = _capturing_mirror()
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-
-    meta = {
-        "canonical": "model",
-        "raw_args": "sonnet",
-        "args": "sonnet",
-        "target": "anthropic/claude-sonnet",
-        "side_effect": "model_switch",
-    }
-    worker = _make_worker_double(slash_meta=meta)
-    _install_worker(sess, worker)
-
-    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
-
-    assert len(captured) == 1
-    cmd = captured[0].lower()
-    assert cmd.startswith("/model")
-    assert "sonnet" in cmd
-    worker.run_with_meta.assert_called_with("/sonnet")
-
-
-# ── 7. Multi-profile: only the worker's profile-scoped meta matters ───
-
-
-def test_multi_profile_meta_only_worker_resolves_alias(
-    server, session, monkeypatch
-):
-    """The parent must NOT inspect any cross-profile alias cache. The
-    decision comes purely from the structured metadata the worker
-    returned.
-
-    Profile A's worker resolves ``/foo`` to a built-in (meta=None).
-    Profile B's worker resolves ``/foo`` to ``model_switch`` (meta=...).
-    Two independent sessions, two independent mirror outcomes.
-    """
-    fake_mirror_a, captured_a = _capturing_mirror()
-    fake_mirror_b, captured_b = _capturing_mirror()
-
-    # Two sessions on different profile homes.
-    sid_a, _, sess_a = session
-
-    sid_b = "sid-profile-b"
-    sess_b = {
-        "session_key": "tui-profile-b",
+    sess_a = {
+        "session_key": "k-a",
         "history": [],
         "history_lock": threading.Lock(),
-        "history_version": 0,
-        "running": False,
-        "attached_images": [],
-        "cols": 120,
+        "agent": agent_a,
+        "profile_home": str(hermes_home / "prof_a"),
+    }
+    server._sessions[sid_a] = sess_a
+
+    sid_b = "sid-prof-b"
+    agent_b = MagicMock()
+    agent_b.model = "old-model"
+    agent_b.provider = "old-provider"
+    def switch_b(new_model="", new_provider="", **kw):
+        agent_b.model = new_model
+        agent_b.provider = new_provider
+    agent_b.switch_model = switch_b
+
+    sess_b = {
+        "session_key": "k-b",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "agent": agent_b,
+        "profile_home": str(hermes_home / "prof_b"),
     }
     server._sessions[sid_b] = sess_b
 
-    # Profile A: built-in /foo (e.g. a future addon)
-    worker_a = _make_worker_double(slash_meta=None)
-    _install_worker(sess_a, worker_a)
-
-    # Profile B: /foo is a model alias to "gpt-5"
     meta_b = {
-        "canonical": "model",
-        "raw_args": "foo",
-        "args": "foo",
-        "target": "gpt-5",
         "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-b",
+        "resolved_provider": "provider-b",
+        "base_url": "https://b.api",
+        "api_mode": "chat_completions",
+        "raw_args": "foo",
     }
-    worker_b = _make_worker_double(slash_meta=meta_b)
-    _install_worker(sess_b, worker_b)
+    _install_worker(sess_b, _make_worker_double(slash_meta=meta_b))
 
-    # Patch each session's mirror capture independently. Because the
-    # session dict carries its own ``agent``, we route the mirror
-    # through the existing ``_mirror_slash_side_effects`` name, but
-    # capture per-session using a wrapping closure that filters on sid.
-    def route_mirror(sid_arg, sess_arg, cmd):
-        if sid_arg == sid_a:
-            return fake_mirror_a(sid_arg, sess_arg, cmd)
-        if sid_arg == sid_b:
-            return fake_mirror_b(sid_arg, sess_arg, cmd)
-        return ""
+    res = server._methods["slash.exec"](1, {"command": "/foo", "session_id": sid_b})
+    assert "result" in res
 
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", route_mirror)
+    # Assert live agent in session B is updated to provider-b / model-b
+    assert agent_b.model == "model-b"
+    assert agent_b.provider == "provider-b"
+    assert sess_b["model_override"]["model"] == "model-b"
+    assert sess_b["model_override"]["provider"] == "provider-b"
 
-    # Profile A: /foo
-    server._methods["slash.exec"](1, {"command": "/foo", "session_id": sid_a})
-    # Profile B: /foo (different profile's worker)
-    server._methods["slash.exec"](1, {"command": "/foo", "session_id": sid_b})
-
-    # Profile A: built-in, mirror sees /foo verbatim
-    assert len(captured_a) == 1
-    assert captured_a[0].lower() == "/foo"
-
-    # Profile B: model, mirror sees /model foo
-    assert len(captured_b) == 1
-    cmd_b = captured_b[0].lower()
-    assert cmd_b.startswith("/model")
-    assert "foo" in cmd_b
+    # Profile A must remain untouched
+    assert agent_a.model == "old-model"
+    assert agent_a.provider == "old-provider"
 
 
-# ── 8. Multi-profile with same alias name, different targets ──────────
+# ── Scenario 2: Sequential execution A then B does not contaminate ──────
 
 
-def test_multi_profile_same_alias_different_targets_isolated(
-    server, session, monkeypatch
-):
-    """Profile A maps ``/foo`` -> model X. Profile B maps ``/foo`` ->
-    model Y. The two live sessions must NOT contaminate each other.
-    The mirror decision is entirely derived from the worker's
-    profile-scoped metadata.
+def test_sequential_execution_profile_isolation(server, hermes_home):
+    """Execute session A (/foo -> provider-a/model-a), then session B (/foo -> provider-b/model-b).
+    Assert both sessions end up with their respective profile's resolved provider/model.
     """
-    sid_a, _, sess_a = session
+    sid_a = "sid-seq-a"
+    agent_a = MagicMock()
+    agent_a.model = "init"
+    agent_a.provider = "init"
+    def switch_a(new_model="", new_provider="", **kw):
+        agent_a.model = new_model
+        agent_a.provider = new_provider
+    agent_a.switch_model = switch_a
 
-    sid_b = "sid-different-models"
-    sess_b = {
-        "session_key": "tui-different-models",
+    sess_a = {
+        "session_key": "k-seq-a",
         "history": [],
         "history_lock": threading.Lock(),
-        "history_version": 0,
-        "running": False,
-        "attached_images": [],
-        "cols": 120,
+        "agent": agent_a,
+        "profile_home": str(hermes_home / "prof_a"),
+    }
+    server._sessions[sid_a] = sess_a
+
+    sid_b = "sid-seq-b"
+    agent_b = MagicMock()
+    agent_b.model = "init"
+    agent_b.provider = "init"
+    def switch_b(new_model="", new_provider="", **kw):
+        agent_b.model = new_model
+        agent_b.provider = new_provider
+    agent_b.switch_model = switch_b
+
+    sess_b = {
+        "session_key": "k-seq-b",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "agent": agent_b,
+        "profile_home": str(hermes_home / "prof_b"),
     }
     server._sessions[sid_b] = sess_b
-
-    captured_a, captured_b = [], []
-
-    def route_mirror(sid_arg, sess_arg, cmd):
-        if sid_arg == sid_a:
-            captured_a.append(cmd)
-        else:
-            captured_b.append(cmd)
-        return ""
-
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", route_mirror)
 
     meta_a = {
-        "canonical": "model",
-        "raw_args": "foo",
-        "args": "foo",
-        "target": "model-x",
         "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-a",
+        "resolved_provider": "provider-a",
+        "base_url": None,
+        "api_mode": None,
+        "raw_args": "foo",
     }
     meta_b = {
-        "canonical": "model",
-        "raw_args": "foo",
-        "args": "foo",
-        "target": "model-y",
         "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-b",
+        "resolved_provider": "provider-b",
+        "base_url": None,
+        "api_mode": None,
+        "raw_args": "foo",
     }
+
     _install_worker(sess_a, _make_worker_double(slash_meta=meta_a))
     _install_worker(sess_b, _make_worker_double(slash_meta=meta_b))
 
+    # Execute A first
     server._methods["slash.exec"](1, {"command": "/foo", "session_id": sid_a})
-    server._methods["slash.exec"](1, {"command": "/foo", "session_id": sid_b})
+    assert agent_a.model == "model-a"
+    assert agent_a.provider == "provider-a"
 
-    # Both sessions get model switches; the targets differ only in
-    # resolution, which is the worker's concern. The parent's mirror
-    # contract is: re-emit ``/model foo`` because the worker said so.
-    # No global cache leak must propagate one session's meta into the
-    # other — and indeed it cannot, because the dict lookup of
-    # ``slash_worker`` per session is local.
-    assert len(captured_a) == 1
-    assert captured_a[0].lower().startswith("/model")
-    assert len(captured_b) == 1
-    assert captured_b[0].lower().startswith("/model")
+    # Execute B second
+    server._methods["slash.exec"](2, {"command": "/foo", "session_id": sid_b})
+    assert agent_b.model == "model-b"
+    assert agent_b.provider == "provider-b"
 
-
-# ── 9. Sequential calls do not leak state across sessions ─────────────
+    # Re-verify A was not overwritten by B
+    assert agent_a.model == "model-a"
+    assert agent_a.provider == "provider-a"
 
 
-def test_sequential_calls_do_not_leak_across_sessions(
-    server, session, monkeypatch
-):
-    """A second slash.exec on session B after session A's model switch
-    must not re-trigger A's switch. State is local to each session's
-    worker metadata snapshot.
-    """
-    sid_a, _, sess_a = session
-    sid_b = "sid-sequential"
-    sess_b = {
-        "session_key": "tui-sequential",
-        "history": [],
-        "history_lock": threading.Lock(),
-        "history_version": 0,
-        "running": False,
-        "attached_images": [],
-        "cols": 120,
-    }
-    server._sessions[sid_b] = sess_b
+# ── Scenario 4: Custom provider & No credentials in metadata ────────────
 
-    captured_a, captured_b = [], []
 
-    def route_mirror(sid_arg, sess_arg, cmd):
-        if sid_arg == sid_a:
-            captured_a.append(cmd)
-        else:
-            captured_b.append(cmd)
-        return ""
+def test_custom_provider_metadata_has_no_secrets(server, session_with_agent, hermes_home):
+    """Ensure worker metadata contains no api_key/tokens, and custom provider resolves."""
+    sid, _, sess, agent = session_with_agent
 
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", route_mirror)
+    prof_dir = hermes_home / "custom_prof"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sess["profile_home"] = str(prof_dir)
 
-    # Profile A: first a model switch, then a non-model built-in.
-    meta_a_switch = {
-        "canonical": "model",
-        "raw_args": "sonnet",
-        "args": "sonnet",
-        "target": "sonnet",
+    meta_custom = {
         "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "my-custom-model",
+        "resolved_provider": "my-custom-provider",
+        "base_url": "https://custom.endpoint/v1",
+        "api_mode": "chat_completions",
+        "raw_args": "custom-alias",
     }
-    worker_a = _make_worker_double()
-    worker_a.run_with_meta = MagicMock(
-        side_effect=[("ok", meta_a_switch), ("ok", None)]
-    )
-    _install_worker(sess_a, worker_a)
 
-    # Profile B: only built-in.
-    worker_b = _make_worker_double(slash_meta=None)
-    _install_worker(sess_b, worker_b)
+    # Assert security constraint: metadata dict does not have api_key, token, or secret
+    assert "api_key" not in meta_custom
+    assert "token" not in meta_custom
+    assert "secret" not in meta_custom
 
-    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid_a})
-    server._methods["slash.exec"](1, {"command": "/version", "session_id": sid_a})
-    server._methods["slash.exec"](1, {"command": "/personality", "session_id": sid_b})
+    _install_worker(sess, _make_worker_double(slash_meta=meta_custom))
 
-    assert len(captured_a) == 2
-    # First call: model switch mirror
-    assert captured_a[0].lower().startswith("/model")
-    # Second call: built-in (worker said meta=None)
-    assert captured_a[1].lower() == "/version"
+    res = server._methods["slash.exec"](1, {"command": "/custom-alias", "session_id": sid})
+    assert "result" in res
 
-    assert len(captured_b) == 1
-    assert captured_b[0].lower() == "/personality"
+    # Live agent updated
+    assert agent.model == "my-custom-model"
+    assert agent.provider == "my-custom-provider"
+    assert agent.base_url == "https://custom.endpoint/v1"
 
 
-# ── 10. Worker reports non-model canonical; parent does not switch ──
+# ── Scenario 5: --session, --once, --global scope behavior ───────────────
 
 
-def test_worker_reports_builtin_canonical_does_not_mirror_model(
-    server, session, monkeypatch
-):
-    """If the worker explicitly reports ``canonical="version"`` and
-    ``side_effect != "model_switch"``, the parent must not perform a
-    model switch even if the typed token happens to be a model alias.
+def test_scope_session_once_global_behavior(server, session_with_agent, hermes_home):
+    """Test --session, --once, and --global metadata scope handling."""
+    sid, _, sess, agent = session_with_agent
+    prof_dir = hermes_home / "scope_prof"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sess["profile_home"] = str(prof_dir)
+
+    # 1. Once scope
+    meta_once = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "once",
+        "resolved_model": "model-once",
+        "resolved_provider": "prov-once",
+        "raw_args": "once-model --once",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta_once))
+    server._methods["slash.exec"](1, {"command": "/once-model --once", "session_id": sid})
+    assert agent.model == "model-once"
+    assert sess["model_override"]["scope"] == "once"
+
+    # 2. Global scope
+    meta_global = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "global",
+        "resolved_model": "model-global",
+        "resolved_provider": "prov-global",
+        "raw_args": "global-model --global",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta_global))
+    server._methods["slash.exec"](2, {"command": "/global-model --global", "session_id": sid})
+    assert agent.model == "model-global"
+    assert sess["model_override"]["scope"] == "global"
+
+    # Check that global persisted to config.yaml under prof_dir
+    config_file = prof_dir / "config.yaml"
+    assert config_file.exists()
+    content = config_file.read_text(encoding="utf-8")
+    assert "model-global" in content
+
+
+# ── Scenario 6: Worker failure / rollback does NOT mirror ───────────────
+
+
+def test_worker_failure_does_not_mirror(server, session_with_agent):
+    """When the worker fails or returns meta=None, live agent is NOT modified."""
+    sid, _, sess, agent = session_with_agent
+
+    initial_model = agent.model
+    initial_provider = agent.provider
+
+    # Worker returns meta=None (failed execution or no model switch produced)
+    _install_worker(sess, _make_worker_double(slash_meta=None, output="Error: invalid model"))
+
+    server._methods["slash.exec"](1, {"command": "/invalid-model", "session_id": sid})
+
+    # Live agent must remain on initial state
+    assert agent.model == initial_model
+    assert agent.provider == initial_provider
+    assert "model_override" not in sess
+
+
+# ── Scenario 7: Consecutive commands reset metadata ─────────────────────
+
+
+def test_consecutive_commands_metadata_reset(server, session_with_agent):
+    """First command switches model; second command (non-model) returns meta=None.
+    The second command must NOT re-apply the previous model switch metadata.
     """
-    sid, _, sess = session
-    fake_mirror, captured = _capturing_mirror()
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+    sid, _, sess, agent = session_with_agent
 
-    meta = {
-        "canonical": "version",
-        "raw_args": "",
-        "args": "",
-        "target": None,
-        "side_effect": None,
+    # Turn 1: model switch
+    meta_1 = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-turn-1",
+        "resolved_provider": "prov-1",
+        "raw_args": "turn-1",
     }
-    worker = _make_worker_double(slash_meta=meta)
+    worker = _make_worker_double()
+    worker.run_with_meta = MagicMock(side_effect=[
+        ("Switched", meta_1),
+        ("Help output", None),
+    ])
     _install_worker(sess, worker)
+
+    server._methods["slash.exec"](1, {"command": "/turn-1", "session_id": sid})
+    assert agent.model == "model-turn-1"
+
+    # Turn 2: non-model command (meta=None)
+    fake_mirror = MagicMock(return_value="")
+    server._mirror_slash_side_effects = fake_mirror
+
+    server._methods["slash.exec"](2, {"command": "/help", "session_id": sid})
+    # Agent remains model-turn-1, no second call to switch_model
+    assert agent.model == "model-turn-1"
+
+
+# ── Scenario 8: Built-in / plugin / skill collision still no model mirror ─
+
+
+def test_builtin_plugin_skill_collision_no_model_mirror(server, session_with_agent):
+    """When token matches a built-in or plugin, worker resolves meta=None and no model switch happens."""
+    sid, _, sess, agent = session_with_agent
+
+    initial_model = agent.model
+
+    # Worker reports meta=None for built-in /version or plugin /foo
+    _install_worker(sess, _make_worker_double(slash_meta=None, output="Version 1.0"))
 
     server._methods["slash.exec"](1, {"command": "/version", "session_id": sid})
 
-    assert len(captured) == 1
-    cmd = captured[0].lower()
-    assert cmd == "/version"
-    assert not cmd.startswith("/model")
-
-
-# ── Guarantee: parent never re-imports DIRECT_ALIASES / MODEL_ALIASES ─
-
-
-def test_parent_does_not_import_global_alias_cache(
-    server, session, monkeypatch
-):
-    """Hard guarantee that the TUI mirror call site is NOT consulting
-    the global alias registry. The contract is: trust the worker's
-    profile-scoped meta. We force the parent's attempted import to
-    blow up if it ever re-introduces a global alias cache lookup.
-    """
-    import builtins
-
-    original_import = builtins.__import__
-
-    def guarded_import(name, *args, **kwargs):
-        # Allow the canonical helper under gateway/_model_alias_normalize
-        # to keep being importable (the helper is the only sanctioned
-        # resolver). The forbidden paths are direct reads of the live
-        # alias caches from the TUI mirror call site.
-        if name in {
-            "hermes_cli.model_switch",
-        } and any(
-            mod in (kwargs.get("globals", {}) or {}).get("__name__", "")
-            for mod in ["tui_gateway.methods_tools", "tui_gateway.server"]
-        ):
-            raise ImportError(
-                "TUI mirror is forbidden from importing the global alias cache"
-            )
-        return original_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", guarded_import)
-
-    sid, _, sess = session
-    fake_mirror, captured = _capturing_mirror()
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-
-    # Worker says built-in (meta=None): no switch.
-    worker = _make_worker_double(slash_meta=None)
-    _install_worker(sess, worker)
-
-    server._methods["slash.exec"](1, {"command": "/version", "session_id": sid})
-
-    assert len(captured) == 1
-    assert captured[0].lower() == "/version"
-
-
-# ── Direct protocol test: /<alias> from worker reports model_switch ──
-
-
-def test_alias_meta_says_model_switch_and_preserves_args(
-    server, session, monkeypatch
-):
-    """When the worker reports ``side_effect="model_switch"`` with
-    extra raw args (e.g. ``/sonnet --provider openrouter``), the
-    parent's mirror command must include those args verbatim.
-    """
-    sid, _, sess = session
-    fake_mirror, captured = _capturing_mirror()
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-
-    meta = {
-        "canonical": "model",
-        "raw_args": "sonnet --provider openrouter",
-        "args": "sonnet --provider openrouter",
-        "target": "anthropic/claude-sonnet",
-        "side_effect": "model_switch",
-    }
-    worker = _make_worker_double(slash_meta=meta)
-    _install_worker(sess, worker)
-
-    server._methods["slash.exec"](
-        1, {"command": "/sonnet --provider openrouter", "session_id": sid}
-    )
-
-    assert len(captured) == 1
-    cmd = captured[0].lower()
-    assert cmd.startswith("/model")
-    assert "sonnet" in cmd
-    assert "--provider openrouter" in cmd
-
-
-# ── SlashWorker.run_with_meta passes through meta unchanged ───────────
-
-
-def test_slash_worker_run_with_meta_returns_meta(server, monkeypatch):
-    """Contract on _SlashWorker.run_with_meta: must return the worker's
-    metadata dict verbatim, not a derived / re-derived one.
-    """
-    worker = server._SlashWorker.__new__(server._SlashWorker)
-    worker._lock = threading.Lock()
-    worker._seq = 0
-    import queue
-
-    captured_meta = {"canonical": "model", "side_effect": "model_switch"}
-
-    worker.proc = MagicMock()
-    worker.proc.poll = MagicMock(return_value=None)
-    worker._drain_stdout = lambda: None
-    worker._drain_stderr = lambda: None
-    worker.stdout_queue = queue.Queue()
-    worker.stdout_queue.put(
-        {"id": 1, "ok": True, "output": "ok", "meta": captured_meta}
-    )
-    worker.proc.stdin = MagicMock()
-    worker.stderr_tail = []
-
-    output, meta = worker.run_with_meta("/model sonnet")
-    assert output == "ok"
-    assert meta is captured_meta
+    # Live agent unchanged
+    assert agent.model == initial_model
+    assert "model_override" not in sess

--- a/tests/tui_gateway/test_model_alias_canonical_mirror.py
+++ b/tests/tui_gateway/test_model_alias_canonical_mirror.py
@@ -1,0 +1,600 @@
+"""Tests for the TUI slash worker canonical-side-effect mirror contract.
+
+The TUI slash worker (``tui_gateway.slash_worker``) runs inside the
+session's ``profile_home`` scope and resolves the typed command against
+the real built-in / quick / plugin / bundle / skill / model alias
+registry. It then writes a structured ``meta`` JSON field describing
+what it actually did.
+
+The parent ``slash.exec`` handler (``tui_gateway.methods_tools``) MUST
+base the live-session mirror decision ONLY on that ``meta`` field. It
+must NOT re-derive whether the typed token is in a global alias cache.
+Re-deriving breaks two things at once:
+
+1. A built-in / quick / plugin / bundle / skill command whose typed
+   name also exists as a model alias (e.g. ``/version`` while
+   ``version`` is configured as a model alias). The worker actually
+   ran the built-in; the mirror must NOT switch the live model.
+
+2. Profile A and Profile B with the same alias name mapped to
+   different models. The parent must read the worker's profile-scoped
+   metadata, not the parent's global alias cache.
+
+These tests exercise both bugs and pin the contract for every layer.
+"""
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+@pytest.fixture()
+def session(server):
+    sid = "sid-mirror-canonical"
+    session_key = "tui-mirror-canonical"
+    s = {
+        "session_key": session_key,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+    }
+    server._sessions[sid] = s
+    return sid, session_key, s
+
+
+def _make_worker_double(slash_meta=None, output=""):
+    """Return a worker double whose ``run_with_meta`` returns
+    ``(output, slash_meta)`` — the structured metadata the real
+    slash worker emits inside the session's profile scope.
+    """
+    w = MagicMock()
+    w.run = MagicMock(return_value=output)
+    w.run_with_meta = MagicMock(return_value=(output, slash_meta))
+    w.close = MagicMock()
+    return w
+
+
+def _install_worker(session_entry, worker):
+    session_entry["slash_worker"] = worker
+
+
+def _capturing_mirror():
+    """Return ``(fake_mirror_fn, captured_list)`` for capturing mirror calls."""
+    captured = []
+
+    def fake_mirror(sid, sess, cmd):
+        captured.append(cmd)
+        return ""
+
+    return fake_mirror, captured
+
+
+# ── 1. /version vs alias `version` ────────────────────────────────────
+
+
+def test_builtin_version_with_alias_version_does_not_mirror_model(
+    server, session, monkeypatch
+):
+    """When ``version`` is configured as a model alias, the worker
+    actually resolves the built-in ``version`` command and reports
+    ``side_effect=None`` (no model switch). The parent must NOT call
+    ``_apply_model_switch`` and must NOT change the live session's
+    model.
+    """
+    sid, _, sess = session
+    fake_mirror, captured = _capturing_mirror()
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+
+    # Force the worker's reported metadata to be what the real worker
+    # would have set when it ran built-in ``version``: meta is None.
+    worker = _make_worker_double(slash_meta=None)
+    _install_worker(sess, worker)
+
+    server._methods["slash.exec"](1, {"command": "/version", "session_id": sid})
+
+    # The mirror still gets called (so other built-in side effects can
+    # fire), but the command is /version verbatim — NOT /model version.
+    assert len(captured) == 1
+    assert captured[0].lower() == "/version"
+    worker.run_with_meta.assert_called_with("/version")
+
+
+# ── 2. alias vs quick command ──────────────────────────────────────────
+
+
+def test_alias_collision_with_quick_command_does_not_mirror_model(
+    server, session, monkeypatch
+):
+    """A quick command named like a model alias must win; the worker
+    reports ``meta=None`` and the parent must NOT switch models.
+    """
+    sid, _, sess = session
+    fake_mirror, captured = _capturing_mirror()
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+
+    worker = _make_worker_double(slash_meta=None)
+    _install_worker(sess, worker)
+
+    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
+
+    assert len(captured) == 1
+    assert captured[0].lower() == "/sonnet"
+
+
+# ── 3. alias vs plugin command ──────────────────────────────────────────
+
+
+def test_alias_collision_with_plugin_does_not_mirror_model(
+    server, session, monkeypatch
+):
+    """A plugin command named like a model alias must win."""
+    sid, _, sess = session
+    fake_mirror, captured = _capturing_mirror()
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+
+    worker = _make_worker_double(slash_meta=None)
+    _install_worker(sess, worker)
+
+    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
+
+    assert len(captured) == 1
+    assert captured[0].lower() == "/sonnet"
+
+
+# ── 4. alias vs skill bundle ──────────────────────────────────────────
+
+
+def test_alias_collision_with_bundle_does_not_mirror_model(
+    server, session, monkeypatch
+):
+    """A skill bundle command named like a model alias must win."""
+    sid, _, sess = session
+    fake_mirror, captured = _capturing_mirror()
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+
+    worker = _make_worker_double(slash_meta=None)
+    _install_worker(sess, worker)
+
+    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
+
+    assert len(captured) == 1
+    assert captured[0].lower() == "/sonnet"
+
+
+# ── 5. alias vs active skill ──────────────────────────────────────────
+
+
+def test_alias_collision_with_active_skill_does_not_mirror_model(
+    server, session, monkeypatch
+):
+    """An active skill command named like a model alias must win."""
+    sid, _, sess = session
+    fake_mirror, captured = _capturing_mirror()
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+
+    worker = _make_worker_double(slash_meta=None)
+    _install_worker(sess, worker)
+
+    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
+
+    assert len(captured) == 1
+    assert captured[0].lower() == "/sonnet"
+
+
+# ── 6. /sonnet (real alias) is canonicalized by worker ────────────────
+
+
+def test_real_alias_sonnet_does_mirror_via_worker_meta(
+    server, session, monkeypatch
+):
+    """When the worker reports ``side_effect == "model_switch"`` with
+    ``canonical == "model"``, the parent must re-emit the model switch
+    via ``_mirror_slash_side_effects`` exactly once.
+    """
+    sid, _, sess = session
+    fake_mirror, captured = _capturing_mirror()
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+
+    meta = {
+        "canonical": "model",
+        "raw_args": "sonnet",
+        "args": "sonnet",
+        "target": "anthropic/claude-sonnet",
+        "side_effect": "model_switch",
+    }
+    worker = _make_worker_double(slash_meta=meta)
+    _install_worker(sess, worker)
+
+    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
+
+    assert len(captured) == 1
+    cmd = captured[0].lower()
+    assert cmd.startswith("/model")
+    assert "sonnet" in cmd
+    worker.run_with_meta.assert_called_with("/sonnet")
+
+
+# ── 7. Multi-profile: only the worker's profile-scoped meta matters ───
+
+
+def test_multi_profile_meta_only_worker_resolves_alias(
+    server, session, monkeypatch
+):
+    """The parent must NOT inspect any cross-profile alias cache. The
+    decision comes purely from the structured metadata the worker
+    returned.
+
+    Profile A's worker resolves ``/foo`` to a built-in (meta=None).
+    Profile B's worker resolves ``/foo`` to ``model_switch`` (meta=...).
+    Two independent sessions, two independent mirror outcomes.
+    """
+    fake_mirror_a, captured_a = _capturing_mirror()
+    fake_mirror_b, captured_b = _capturing_mirror()
+
+    # Two sessions on different profile homes.
+    sid_a, _, sess_a = session
+
+    sid_b = "sid-profile-b"
+    sess_b = {
+        "session_key": "tui-profile-b",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+    }
+    server._sessions[sid_b] = sess_b
+
+    # Profile A: built-in /foo (e.g. a future addon)
+    worker_a = _make_worker_double(slash_meta=None)
+    _install_worker(sess_a, worker_a)
+
+    # Profile B: /foo is a model alias to "gpt-5"
+    meta_b = {
+        "canonical": "model",
+        "raw_args": "foo",
+        "args": "foo",
+        "target": "gpt-5",
+        "side_effect": "model_switch",
+    }
+    worker_b = _make_worker_double(slash_meta=meta_b)
+    _install_worker(sess_b, worker_b)
+
+    # Patch each session's mirror capture independently. Because the
+    # session dict carries its own ``agent``, we route the mirror
+    # through the existing ``_mirror_slash_side_effects`` name, but
+    # capture per-session using a wrapping closure that filters on sid.
+    def route_mirror(sid_arg, sess_arg, cmd):
+        if sid_arg == sid_a:
+            return fake_mirror_a(sid_arg, sess_arg, cmd)
+        if sid_arg == sid_b:
+            return fake_mirror_b(sid_arg, sess_arg, cmd)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", route_mirror)
+
+    # Profile A: /foo
+    server._methods["slash.exec"](1, {"command": "/foo", "session_id": sid_a})
+    # Profile B: /foo (different profile's worker)
+    server._methods["slash.exec"](1, {"command": "/foo", "session_id": sid_b})
+
+    # Profile A: built-in, mirror sees /foo verbatim
+    assert len(captured_a) == 1
+    assert captured_a[0].lower() == "/foo"
+
+    # Profile B: model, mirror sees /model foo
+    assert len(captured_b) == 1
+    cmd_b = captured_b[0].lower()
+    assert cmd_b.startswith("/model")
+    assert "foo" in cmd_b
+
+
+# ── 8. Multi-profile with same alias name, different targets ──────────
+
+
+def test_multi_profile_same_alias_different_targets_isolated(
+    server, session, monkeypatch
+):
+    """Profile A maps ``/foo`` -> model X. Profile B maps ``/foo`` ->
+    model Y. The two live sessions must NOT contaminate each other.
+    The mirror decision is entirely derived from the worker's
+    profile-scoped metadata.
+    """
+    sid_a, _, sess_a = session
+
+    sid_b = "sid-different-models"
+    sess_b = {
+        "session_key": "tui-different-models",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+    }
+    server._sessions[sid_b] = sess_b
+
+    captured_a, captured_b = [], []
+
+    def route_mirror(sid_arg, sess_arg, cmd):
+        if sid_arg == sid_a:
+            captured_a.append(cmd)
+        else:
+            captured_b.append(cmd)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", route_mirror)
+
+    meta_a = {
+        "canonical": "model",
+        "raw_args": "foo",
+        "args": "foo",
+        "target": "model-x",
+        "side_effect": "model_switch",
+    }
+    meta_b = {
+        "canonical": "model",
+        "raw_args": "foo",
+        "args": "foo",
+        "target": "model-y",
+        "side_effect": "model_switch",
+    }
+    _install_worker(sess_a, _make_worker_double(slash_meta=meta_a))
+    _install_worker(sess_b, _make_worker_double(slash_meta=meta_b))
+
+    server._methods["slash.exec"](1, {"command": "/foo", "session_id": sid_a})
+    server._methods["slash.exec"](1, {"command": "/foo", "session_id": sid_b})
+
+    # Both sessions get model switches; the targets differ only in
+    # resolution, which is the worker's concern. The parent's mirror
+    # contract is: re-emit ``/model foo`` because the worker said so.
+    # No global cache leak must propagate one session's meta into the
+    # other — and indeed it cannot, because the dict lookup of
+    # ``slash_worker`` per session is local.
+    assert len(captured_a) == 1
+    assert captured_a[0].lower().startswith("/model")
+    assert len(captured_b) == 1
+    assert captured_b[0].lower().startswith("/model")
+
+
+# ── 9. Sequential calls do not leak state across sessions ─────────────
+
+
+def test_sequential_calls_do_not_leak_across_sessions(
+    server, session, monkeypatch
+):
+    """A second slash.exec on session B after session A's model switch
+    must not re-trigger A's switch. State is local to each session's
+    worker metadata snapshot.
+    """
+    sid_a, _, sess_a = session
+    sid_b = "sid-sequential"
+    sess_b = {
+        "session_key": "tui-sequential",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+    }
+    server._sessions[sid_b] = sess_b
+
+    captured_a, captured_b = [], []
+
+    def route_mirror(sid_arg, sess_arg, cmd):
+        if sid_arg == sid_a:
+            captured_a.append(cmd)
+        else:
+            captured_b.append(cmd)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", route_mirror)
+
+    # Profile A: first a model switch, then a non-model built-in.
+    meta_a_switch = {
+        "canonical": "model",
+        "raw_args": "sonnet",
+        "args": "sonnet",
+        "target": "sonnet",
+        "side_effect": "model_switch",
+    }
+    worker_a = _make_worker_double()
+    worker_a.run_with_meta = MagicMock(
+        side_effect=[("ok", meta_a_switch), ("ok", None)]
+    )
+    _install_worker(sess_a, worker_a)
+
+    # Profile B: only built-in.
+    worker_b = _make_worker_double(slash_meta=None)
+    _install_worker(sess_b, worker_b)
+
+    server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid_a})
+    server._methods["slash.exec"](1, {"command": "/version", "session_id": sid_a})
+    server._methods["slash.exec"](1, {"command": "/personality", "session_id": sid_b})
+
+    assert len(captured_a) == 2
+    # First call: model switch mirror
+    assert captured_a[0].lower().startswith("/model")
+    # Second call: built-in (worker said meta=None)
+    assert captured_a[1].lower() == "/version"
+
+    assert len(captured_b) == 1
+    assert captured_b[0].lower() == "/personality"
+
+
+# ── 10. Worker reports non-model canonical; parent does not switch ──
+
+
+def test_worker_reports_builtin_canonical_does_not_mirror_model(
+    server, session, monkeypatch
+):
+    """If the worker explicitly reports ``canonical="version"`` and
+    ``side_effect != "model_switch"``, the parent must not perform a
+    model switch even if the typed token happens to be a model alias.
+    """
+    sid, _, sess = session
+    fake_mirror, captured = _capturing_mirror()
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+
+    meta = {
+        "canonical": "version",
+        "raw_args": "",
+        "args": "",
+        "target": None,
+        "side_effect": None,
+    }
+    worker = _make_worker_double(slash_meta=meta)
+    _install_worker(sess, worker)
+
+    server._methods["slash.exec"](1, {"command": "/version", "session_id": sid})
+
+    assert len(captured) == 1
+    cmd = captured[0].lower()
+    assert cmd == "/version"
+    assert not cmd.startswith("/model")
+
+
+# ── Guarantee: parent never re-imports DIRECT_ALIASES / MODEL_ALIASES ─
+
+
+def test_parent_does_not_import_global_alias_cache(
+    server, session, monkeypatch
+):
+    """Hard guarantee that the TUI mirror call site is NOT consulting
+    the global alias registry. The contract is: trust the worker's
+    profile-scoped meta. We force the parent's attempted import to
+    blow up if it ever re-introduces a global alias cache lookup.
+    """
+    import builtins
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        # Allow the canonical helper under gateway/_model_alias_normalize
+        # to keep being importable (the helper is the only sanctioned
+        # resolver). The forbidden paths are direct reads of the live
+        # alias caches from the TUI mirror call site.
+        if name in {
+            "hermes_cli.model_switch",
+        } and any(
+            mod in (kwargs.get("globals", {}) or {}).get("__name__", "")
+            for mod in ["tui_gateway.methods_tools", "tui_gateway.server"]
+        ):
+            raise ImportError(
+                "TUI mirror is forbidden from importing the global alias cache"
+            )
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    sid, _, sess = session
+    fake_mirror, captured = _capturing_mirror()
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+
+    # Worker says built-in (meta=None): no switch.
+    worker = _make_worker_double(slash_meta=None)
+    _install_worker(sess, worker)
+
+    server._methods["slash.exec"](1, {"command": "/version", "session_id": sid})
+
+    assert len(captured) == 1
+    assert captured[0].lower() == "/version"
+
+
+# ── Direct protocol test: /<alias> from worker reports model_switch ──
+
+
+def test_alias_meta_says_model_switch_and_preserves_args(
+    server, session, monkeypatch
+):
+    """When the worker reports ``side_effect="model_switch"`` with
+    extra raw args (e.g. ``/sonnet --provider openrouter``), the
+    parent's mirror command must include those args verbatim.
+    """
+    sid, _, sess = session
+    fake_mirror, captured = _capturing_mirror()
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+
+    meta = {
+        "canonical": "model",
+        "raw_args": "sonnet --provider openrouter",
+        "args": "sonnet --provider openrouter",
+        "target": "anthropic/claude-sonnet",
+        "side_effect": "model_switch",
+    }
+    worker = _make_worker_double(slash_meta=meta)
+    _install_worker(sess, worker)
+
+    server._methods["slash.exec"](
+        1, {"command": "/sonnet --provider openrouter", "session_id": sid}
+    )
+
+    assert len(captured) == 1
+    cmd = captured[0].lower()
+    assert cmd.startswith("/model")
+    assert "sonnet" in cmd
+    assert "--provider openrouter" in cmd
+
+
+# ── SlashWorker.run_with_meta passes through meta unchanged ───────────
+
+
+def test_slash_worker_run_with_meta_returns_meta(server, monkeypatch):
+    """Contract on _SlashWorker.run_with_meta: must return the worker's
+    metadata dict verbatim, not a derived / re-derived one.
+    """
+    worker = server._SlashWorker.__new__(server._SlashWorker)
+    worker._lock = threading.Lock()
+    worker._seq = 0
+    import queue
+
+    captured_meta = {"canonical": "model", "side_effect": "model_switch"}
+
+    worker.proc = MagicMock()
+    worker.proc.poll = MagicMock(return_value=None)
+    worker._drain_stdout = lambda: None
+    worker._drain_stderr = lambda: None
+    worker.stdout_queue = queue.Queue()
+    worker.stdout_queue.put(
+        {"id": 1, "ok": True, "output": "ok", "meta": captured_meta}
+    )
+    worker.proc.stdin = MagicMock()
+    worker.stderr_tail = []
+
+    output, meta = worker.run_with_meta("/model sonnet")
+    assert output == "ok"
+    assert meta is captured_meta

--- a/tests/tui_gateway/test_model_alias_canonical_mirror.py
+++ b/tests/tui_gateway/test_model_alias_canonical_mirror.py
@@ -66,7 +66,7 @@ def session_with_agent(server):
     sid = "sid-resolved-mirror"
     session_key = "tui-resolved-mirror"
 
-    fake_agent = MagicMock(spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model"])
+    fake_agent = MagicMock(spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model", "run_conversation"])
     fake_agent.model = "initial-model"
     fake_agent.provider = "initial-provider"
     fake_agent.base_url = "https://initial.api"
@@ -313,20 +313,33 @@ def test_concurrent_profile_cross_talk_isolation(server, hermes_home, patched_ru
     assert os.environ.get("HERMES_HOME") == initial_env_home
 
 
-# ── Scenario 3: Closed --once 7-phase lifecycle and restore ───────────────
+# ── Scenario 3: Closed --once lifecycle (real production turn chain) ─────
 
 
-def test_once_full_lifecycle_restore(server, session_with_agent):
-    """Complete 7-phase validation for --once model switch:
-    Phase 1: Worker returns once metadata.
+def test_once_full_lifecycle_restore(server, session_with_agent, hermes_home, patched_runtime_provider):
+    """Complete 7-phase validation for --once model switch via the REAL
+    production turn chain (slash.exec -> prompt.submit -> _run_prompt_submit
+    finally).  No restore helper is called directly, no session state is
+    hand-popped, and the agent is never mutated by hand.
+
+    Phase 1: Worker returns once metadata (slash.exec applies it).
     Phase 2: Live agent switches to target model.
     Phase 3: Turn 1 executes using target model.
     Phase 4: Turn 1 completes and restores previous provider/model.
-    Phase 5: Session model_override once state and restore_snapshot cleared.
+    Phase 5: one_turn_model_restore consumed; NO model_override created.
     Phase 6: Turn 2 continues using original model.
-    Phase 7: Failure or cancellation paths leave no pending restore state.
+    Phase 7: Failure path leaves no pending restore state.
     """
     sid, _, sess, agent = session_with_agent
+    prof_dir = hermes_home / "prof_lifecycle_full"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sess["profile_home"] = str(prof_dir)
+    sess["agent_ready"] = threading.Event()
+    sess["agent_ready"].set()
+    # add run_conversation to the agent spec for the real turn chain
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
 
     orig_model = agent.model
     orig_provider = agent.provider
@@ -342,40 +355,39 @@ def test_once_full_lifecycle_restore(server, session_with_agent):
     }
     _install_worker(sess, _make_worker_double(slash_meta=meta_once))
 
-    # Phase 2: Parent mirrors slash exec
+    # Phase 1/2: Parent mirrors via real slash.exec; live agent switches
     res = server._methods["slash.exec"](1, {"command": "/temp-model --once", "session_id": sid})
     assert "result" in res
-
-    # Live agent switched to temp once model
     assert agent.model == "model-temp-once"
     assert agent.provider == "prov-once"
-    assert sess["model_override"]["scope"] == "once"
+    # once latches ONLY the restore snapshot, never a persistent override
+    assert "model_override" not in sess
     assert sess.get("one_turn_model_restore") is not None
 
-    # Phase 3: Assistant turn 1 executes with temp model
-    assert agent.model == "model-temp-once"
+    # Phase 3: Turn 1 executes with temp model (real prompt.submit chain)
+    res = server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    assert "result" in res
+    _wait_turn_threads(sess)
 
-    # Phase 4 & 5: Turn 1 finishes -> restore agent model runtime
-    restore_snap = sess.pop("one_turn_model_restore", None)
-    assert restore_snap is not None
-    server._restore_agent_model_runtime(agent, restore_snap)
-    sess["model_override"].pop("restore_snapshot", None)
-    sess.pop("model_override", None)
-
-    # Restored to original model and provider
+    # Phase 4 & 5: restored to original; snapshot consumed; no override left
     assert agent.model == orig_model
     assert agent.provider == orig_provider
-
-    # Phase 6: Turn 2 executes with original model
-    assert agent.model == orig_model
     assert "one_turn_model_restore" not in sess
     assert "model_override" not in sess
 
-    # Phase 7: Failure/cancellation leaves no pending restore state
+    # Phase 6: Turn 2 executes with original model
+    res = server._methods["prompt.submit"](3, {"session_id": sid, "text": "again"})
+    assert "result" in res
+    _wait_turn_threads(sess)
+    assert agent.model == orig_model
+    assert agent.provider == orig_provider
+
+    # Phase 7: Failure path (worker meta=None) leaves no pending state
     _install_worker(sess, _make_worker_double(slash_meta=None, output="Cancelled"))
-    server._methods["slash.exec"](2, {"command": "/bad-cmd", "session_id": sid})
+    server._methods["slash.exec"](4, {"command": "/bad-cmd", "session_id": sid})
     assert agent.model == orig_model
     assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
 
 
 # ── Scenario 4: Custom provider & No credentials in metadata ────────────
@@ -452,7 +464,11 @@ def test_scope_session_once_global_behavior(server, session_with_agent, hermes_h
     _install_worker(sess, _make_worker_double(slash_meta=meta_once))
     server._methods["slash.exec"](2, {"command": "/once-model --once", "session_id": sid})
     assert agent.model == "model-once"
-    assert sess["model_override"]["scope"] == "once"
+    # Upstream one-turn semantics: once never creates a persistent
+    # model_override — the previous session override stays untouched, and
+    # only the restore snapshot is latched.
+    assert sess["model_override"]["scope"] == "session"
+    assert sess.get("one_turn_model_restore") is not None
 
     # 3. Global scope
     meta_global = {
@@ -890,16 +906,38 @@ def _once_lifecycle_setup(server, hermes_home, patched_runtime_provider):
 
 
 def _wait_turn_threads(sess, timeout=120):
-    """Join both daemon turn threads: the ``prompt.submit``
-    ``run_after_agent_ready`` wrapper and the inner ``_run_prompt_submit``
-    ``run()`` thread that ``_run_prompt_submit`` stores back into
-    ``session["_run_thread"]`` when it starts the real turn body."""
-    first = sess.get("_run_thread")
-    if first is not None:
-        first.join(timeout=timeout)
-    inner = sess.get("_run_thread")
-    if inner is not None and inner is not first:
-        inner.join(timeout=timeout)
+    """Join the daemon turn threads spawned by prompt.submit.
+
+    prompt.submit stores ``session["_run_thread"]`` with the
+    ``run_after_agent_ready`` wrapper and starts it; that wrapper then
+    calls ``_run_prompt_submit``, which REPLACES the same key with the
+    inner ``run()`` thread (stored BEFORE .start()).  Both must finish
+    before we assert.  A handle may be observed in the not-yet-started
+    window, so wait for the thread to actually become alive before
+    joining, and never join a dead/already-consumed thread.
+    """
+    import time as _t
+
+    seen = set()
+    for _ in range(6):
+        t = sess.get("_run_thread")
+        if t is None:
+            return
+        if id(t) in seen:
+            return
+        # Wait for the not-yet-started window to pass.
+        for _ in range(20):
+            if t.is_alive():
+                break
+            _t.sleep(0.05)
+        if not t.is_alive():
+            # Thread finished before we could join (or was never going to
+            # start) — nothing more to wait for this handle.
+            return
+        seen.add(id(t))
+        t.join(timeout=timeout)
+        # _run_prompt_submit may have replaced the handle with the inner
+        # run() thread; loop again to pick it up.
 
 
 def test_once_real_turn_chain_success_restores(server, hermes_home, patched_runtime_provider):
@@ -928,10 +966,10 @@ def test_once_real_turn_chain_success_restores(server, hermes_home, patched_runt
     assert agent.provider == "orig-provider"
     # Phase 5: once snapshot consumed by the production turn finally
     assert "one_turn_model_restore" not in sess
-    # model_override scope remains "once" (production keeps it; the
-    # consumed snapshot is what drives the restore)
-    mo = sess.get("model_override", {})
-    assert mo.get("scope") == "once"
+    # Upstream one-turn semantics: NO persistent model_override is created
+    # (a leftover "once" override would skip config sync and re-apply the
+    # temp model on rebuild/resume//new).
+    assert "model_override" not in sess
 
 
 def test_once_real_turn_chain_error_restores(server, hermes_home, patched_runtime_provider):
@@ -953,8 +991,9 @@ def test_once_real_turn_chain_error_restores(server, hermes_home, patched_runtim
     # Agent restored despite turn error
     assert agent.model == "orig-model"
     assert agent.provider == "orig-provider"
-    # Once snapshot consumed
+    # Once snapshot consumed, no persistent override left behind
     assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
 
 
 def test_once_real_turn_chain_interrupt_restores(server, hermes_home, patched_runtime_provider):
@@ -995,3 +1034,220 @@ def test_once_real_turn_chain_interrupt_restores(server, hermes_home, patched_ru
     # Agent restored despite interrupt
     assert agent.model == "orig-model"
     assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
+
+
+# ── Scenario: --once with a pre-existing session override ─────────────────
+
+
+def test_once_with_existing_session_override_keeps_override(
+    server, hermes_home, patched_runtime_provider
+):
+    """A /model --once executed while the session already carries a
+    persistent override (prior /model A) must:
+      - temporarily switch the live agent to the once model,
+      - restore the agent to the pre-once runtime after the turn,
+      - KEEP the original override A (never delete the user's session model,
+        never create a stale once override).
+    """
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    # Plant a pre-existing session override A (as a prior /model A would)
+    sess["model_override"] = {
+        "model": "override-A",
+        "provider": "provider-A",
+        "base_url": "https://a.api",
+        "api_key": "a-key",
+        "api_mode": "chat_completions",
+    }
+    # Simulate the live agent already running override A
+    agent.model = "override-A"
+    agent.provider = "provider-A"
+    agent.base_url = "https://a.api"
+
+    # Mock turn body
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+    # Real slash.exec applies the once switch
+    res = server._methods["slash.exec"](1, {"command": "/temp-model --once", "session_id": sid})
+    assert "result" in res
+
+    # During the once window: live agent on temp model, restore latched,
+    # original override untouched
+    assert agent.model == "model-once-temp"
+    assert sess.get("one_turn_model_restore") is not None
+    assert sess["model_override"]["model"] == "override-A"
+
+    # Real prompt.submit turn; production finally restores
+    res = server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    assert "result" in res
+    _wait_turn_threads(sess)
+
+    # Agent back on the pre-once runtime (override A), override dict kept,
+    # no once residue
+    assert agent.model == "override-A"
+    assert agent.provider == "provider-A"
+    assert sess["model_override"]["model"] == "override-A"
+    assert "one_turn_model_restore" not in sess
+
+
+# ── Scenario: --once then real session rebuild (/_new / reset) ────────────
+
+
+def test_once_rebuild_does_not_reapply_temp_model(
+    server, hermes_home, patched_runtime_provider, monkeypatch
+):
+    """After a completed /model --once, a real session rebuild (the
+    production _reset_session_agent /new path) must build the new agent from
+    config / pre-once override — never from the once temp model.
+    """
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+    # Complete one real once turn (the once switch was already applied by
+    # _once_lifecycle_setup's slash.exec — do NOT re-apply it, that would
+    # snapshot the temp model instead of the original)
+    server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    _wait_turn_threads(sess)
+
+    # Once is fully consumed: agent restored, no override residue
+    assert agent.model == "orig-model"
+    assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
+
+    # The real rebuild path must not resurrect the once model. Stub only
+    # _make_agent (which would build a real AIAgent) — the rest of
+    # _reset_session_agent runs for real.
+    new_agent = MagicMock(
+        spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model"]
+    )
+    new_agent.model = "orig-model"  # config-derived model, not the once temp
+    new_agent.provider = "orig-provider"
+    monkeypatch.setattr(server, "_make_agent", lambda *a, **k: new_agent)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+
+    server._reset_session_agent(sid, sess)
+
+    # The rebuilt session must never carry the once temp model
+    assert sess["agent"].model == "orig-model"
+    assert sess["agent"].model != "model-once-temp"
+    assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
+
+
+def test_once_rebuild_keeps_pre_existing_override(
+    server, hermes_home, patched_runtime_provider, monkeypatch
+):
+    """Rebuild after /model --once when a session override A existed before:
+    the rebuild path clears session pins by design (/new semantics), so the
+    fresh agent must come from config — the once temp model must never
+    reappear.
+    """
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+    sess["model_override"] = {
+        "model": "override-A",
+        "provider": "provider-A",
+        "base_url": "https://a.api",
+        "api_key": "a-key",
+        "api_mode": "chat_completions",
+    }
+    agent.model = "override-A"
+    agent.provider = "provider-A"
+
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+    # Re-apply the once switch so the restore snapshot captures the
+    # PRE-ONCE override (override-A), not the setup's original model.
+    res = server._methods["slash.exec"](3, {"command": "/temp-model --once", "session_id": sid})
+    assert "result" in res
+    assert agent.model == "model-once-temp"
+    # The once switch must NOT clobber the pre-existing override A
+    assert sess["model_override"]["model"] == "override-A"
+
+    # Complete the real once turn
+    server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    _wait_turn_threads(sess)
+
+    assert agent.model == "override-A"
+    assert sess["model_override"]["model"] == "override-A"
+    assert "one_turn_model_restore" not in sess
+
+    new_agent = MagicMock(
+        spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model"]
+    )
+    new_agent.model = "orig-model"
+    new_agent.provider = "orig-provider"
+    monkeypatch.setattr(server, "_make_agent", lambda *a, **k: new_agent)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+
+    server._reset_session_agent(sid, sess)
+
+    assert sess["agent"].model == "orig-model"
+    assert sess["agent"].model != "model-once-temp"
+    assert "one_turn_model_restore" not in sess
+
+
+# ── Scenario: --once must not block global config sync afterwards ─────────
+
+
+def test_once_does_not_block_config_sync(server, hermes_home, patched_runtime_provider):
+    """After /model --once completes, no residual override may block
+    _sync_agent_model_with_config: a later config.yaml model change must be
+    adoptable on the next turn.
+    """
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+    # The once switch was already applied by _once_lifecycle_setup's
+    # slash.exec — complete the turn without re-applying.
+    server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    _wait_turn_threads(sess)
+
+    # Once fully consumed — the session must carry NO override so the sync
+    # is not short-circuited
+    assert agent.model == "orig-model"
+    assert "model_override" not in sess
+    assert "one_turn_model_restore" not in sess
+
+    # Simulate a global config.yaml model change
+    (Path(hermes_home) / "config.yaml").write_text(
+        "model:\n  default: new-global-model\n  provider: new-global-provider\n",
+        encoding="utf-8",
+    )
+    sess.pop("config_model_seen", None)
+    agent.model = "orig-model"
+    agent.provider = "orig-provider"
+
+    # Force the config cache to re-read the tmp config.yaml so the sync
+    # sees the change regardless of earlier tests' cache population.
+    server._cfg_cache = None
+    server._cfg_path = None
+    server._cfg_mtime = None
+
+    # The real production sync runs at turn start (no override blocks it).
+    # Patch only the switch helper it would call; assert it is invoked.
+    switch_calls = []
+
+    def spy_apply_model_switch(sid_, session_, raw, **kw):
+        switch_calls.append(raw)
+        return {"value": "new-global-model", "warning": "", "confirm_required": False}
+
+    import unittest.mock as um
+
+    with um.patch.object(server, "_apply_model_switch", spy_apply_model_switch):
+        server._sync_agent_model_with_config(sid, sess)
+
+    # The config change was adopted because nothing pinned the session
+    assert switch_calls, "config sync should have fired without an override"

--- a/tests/tui_gateway/test_model_alias_canonical_mirror.py
+++ b/tests/tui_gateway/test_model_alias_canonical_mirror.py
@@ -1,0 +1,1259 @@
+"""Tests for the TUI slash worker resolved-model mirror contract.
+
+The TUI slash worker (``tui_gateway.slash_worker``) runs inside the
+session's ``profile_home`` scope and resolves the typed command against
+its profile-scoped provider / model / alias registry. When a model
+switch succeeds, it emits structured metadata containing ONLY resolved,
+non-sensitive fields (``side_effect="model_switch"``, ``resolved_model``,
+``resolved_provider``, ``scope``, ``base_url``, ``api_mode``, ``raw_args``).
+
+The parent process (``tui_gateway.methods_tools`` / ``tui_gateway.server``)
+MUST consume this resolved metadata directly via
+``_mirror_resolved_model_switch``. It MUST NOT re-parse ``raw_args``,
+MUST NOT consult the parent process's alias cache, and MUST NOT transmit
+or receive credentials in metadata.
+
+These tests assert:
+  1. Multi-profile resolution isolation and agent state.
+  2. True concurrent interleaving execution without process-global environment tampering.
+  3. Closed 7-phase --once model switch lifecycle and restore.
+  4. Custom provider resolution without credential transmission.
+  5. Session, once, and global scope behavior (verifying config writes stay within profile home).
+  6. Worker failure / cancellation safety.
+  7. Parent apply failure rollback.
+  8. Consecutive command metadata resetting and collision immunity.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+@pytest.fixture()
+def session_with_agent(server):
+    sid = "sid-resolved-mirror"
+    session_key = "tui-resolved-mirror"
+
+    fake_agent = MagicMock(spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model", "run_conversation"])
+    fake_agent.model = "initial-model"
+    fake_agent.provider = "initial-provider"
+    fake_agent.base_url = "https://initial.api"
+    fake_agent.api_key = "secret-key"
+    fake_agent.api_mode = "chat_completions"
+
+    # ``**kwargs``: the production one-turn restore calls ``switch_model(...,
+    # capabilities=...)`` (upstream grew the kwarg), so the double must tolerate
+    # every keyword the real contract passes.
+    def fake_switch(new_model="", new_provider="", api_key="", base_url="", api_mode="", **_kwargs):
+        fake_agent.model = new_model
+        fake_agent.provider = new_provider
+        if base_url:
+            fake_agent.base_url = base_url
+
+    fake_agent.switch_model = MagicMock(side_effect=fake_switch)
+
+    s = {
+        "session_key": session_key,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+        "agent": fake_agent,
+    }
+    server._sessions[sid] = s
+    return sid, session_key, s, fake_agent
+
+
+def _make_worker_double(slash_meta=None, output=""):
+    w = MagicMock()
+    w.run = MagicMock(return_value=output)
+    w.run_with_meta = MagicMock(return_value=(output, slash_meta))
+    w.close = MagicMock()
+    return w
+
+
+def _install_worker(session_entry, worker):
+    session_entry["slash_worker"] = worker
+
+
+@pytest.fixture()
+def patched_runtime_provider(monkeypatch):
+    """Replace ``hermes_cli.runtime_provider.resolve_runtime_provider`` with a
+    stub that returns a deterministic runtime dict, so the mirror path can run
+    end-to-end against fake providers without trying to actually reach an LLM.
+    """
+    def fake_resolve(
+        requested=None,
+        target_model=None,
+        explicit_base_url=None,
+        **_kwargs,
+    ):
+        return {
+            "provider": requested or "",
+            "api_mode": "chat_completions",
+            "base_url": explicit_base_url or "",
+            "api_key": "fake-key",
+            "source": "test-stub",
+            "requested_provider": requested or "",
+        }
+
+    import hermes_cli.runtime_provider as _rp_module
+    _rp_module.resolve_runtime_provider = fake_resolve
+    monkeypatch.setattr(
+        _rp_module,
+        "resolve_runtime_provider",
+        fake_resolve,
+    )
+
+
+# ── Scenario 1: Multi-profile A vs B resolution & provider/model ─────
+
+
+def test_multi_profile_resolved_model_mirror(server, hermes_home, patched_runtime_provider):
+    """Profile A maps /foo -> provider-a/model-a.
+    Profile B maps /foo -> provider-b/model-b.
+    Executing /foo in B session mirrors provider-b/model-b on B's live agent.
+    """
+    sid_a = "sid-prof-a"
+    agent_a = MagicMock()
+    agent_a.model = "old-model"
+    agent_a.provider = "old-provider"
+    def switch_a(new_model="", new_provider="", **kw):
+        agent_a.model = new_model
+        agent_a.provider = new_provider
+    agent_a.switch_model = switch_a
+
+    sess_a = {
+        "session_key": "k-a",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "agent": agent_a,
+        "profile_home": str(hermes_home / "prof_a"),
+    }
+    server._sessions[sid_a] = sess_a
+
+    sid_b = "sid-prof-b"
+    agent_b = MagicMock()
+    agent_b.model = "old-model"
+    agent_b.provider = "old-provider"
+    def switch_b(new_model="", new_provider="", **kw):
+        agent_b.model = new_model
+        agent_b.provider = new_provider
+    agent_b.switch_model = switch_b
+
+    sess_b = {
+        "session_key": "k-b",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "agent": agent_b,
+        "profile_home": str(hermes_home / "prof_b"),
+    }
+    server._sessions[sid_b] = sess_b
+
+    meta_b = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-b",
+        "resolved_provider": "provider-b",
+        "base_url": "https://b.api",
+        "api_mode": "chat_completions",
+        "raw_args": "foo",
+    }
+    _install_worker(sess_b, _make_worker_double(slash_meta=meta_b))
+
+    res = server._methods["slash.exec"](1, {"command": "/foo", "session_id": sid_b})
+    assert "result" in res
+
+    # Assert live agent in session B is updated to provider-b / model-b
+    assert agent_b.model == "model-b"
+    assert agent_b.provider == "provider-b"
+    assert sess_b["model_override"]["model"] == "model-b"
+    assert sess_b["model_override"]["provider"] == "provider-b"
+
+    # Profile A must remain untouched
+    assert agent_a.model == "old-model"
+    assert agent_a.provider == "old-provider"
+
+
+# ── Scenario 2: Concurrent profile interleaving without env tampering ────
+
+
+def test_concurrent_profile_cross_talk_isolation(server, hermes_home, patched_runtime_provider):
+    """Execute Profile A and Profile B mirrors concurrently using a barrier
+    to force interleaving. Verify os.environ["HERMES_HOME"] is NEVER modified,
+    context overrides remain isolated, and both sessions end up in correct state.
+    """
+    initial_env_home = os.environ.get("HERMES_HOME")
+
+    prof_a_dir = hermes_home / "prof_conc_a"
+    prof_b_dir = hermes_home / "prof_conc_b"
+    prof_a_dir.mkdir(parents=True, exist_ok=True)
+    prof_b_dir.mkdir(parents=True, exist_ok=True)
+
+    sid_a = "sid-conc-a"
+    agent_a = MagicMock()
+    agent_a.model = "init"
+    agent_a.provider = "init"
+    def switch_a(new_model="", new_provider="", **kw):
+        agent_a.model = new_model
+        agent_a.provider = new_provider
+    agent_a.switch_model = switch_a
+
+    sess_a = {
+        "session_key": "k-conc-a",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "agent": agent_a,
+        "profile_home": str(prof_a_dir),
+    }
+
+    sid_b = "sid-conc-b"
+    agent_b = MagicMock()
+    agent_b.model = "init"
+    agent_b.provider = "init"
+    def switch_b(new_model="", new_provider="", **kw):
+        agent_b.model = new_model
+        agent_b.provider = new_provider
+    agent_b.switch_model = switch_b
+
+    sess_b = {
+        "session_key": "k-conc-b",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "agent": agent_b,
+        "profile_home": str(prof_b_dir),
+    }
+
+    meta_a = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "global",
+        "resolved_model": "model-a",
+        "resolved_provider": "provider-a",
+        "raw_args": "foo",
+    }
+    meta_b = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "global",
+        "resolved_model": "model-b",
+        "resolved_provider": "provider-b",
+        "raw_args": "foo",
+    }
+
+    barrier = threading.Barrier(2)
+
+    def run_mirror_a():
+        # Inject barrier inside resolution path
+        orig_res = server._mirror_resolved_model_switch
+        barrier.wait(timeout=5)
+        res = orig_res(sid_a, sess_a, meta_a)
+        # Assert process-global environment was NEVER mutated
+        assert os.environ.get("HERMES_HOME") == initial_env_home
+        return res
+
+    def run_mirror_b():
+        orig_res = server._mirror_resolved_model_switch
+        barrier.wait(timeout=5)
+        res = orig_res(sid_b, sess_b, meta_b)
+        assert os.environ.get("HERMES_HOME") == initial_env_home
+        return res
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        fut_a = executor.submit(run_mirror_a)
+        fut_b = executor.submit(run_mirror_b)
+        fut_a.result()
+        fut_b.result()
+
+    # Verify final agent models
+    assert agent_a.model == "model-a"
+    assert agent_a.provider == "provider-a"
+    assert agent_b.model == "model-b"
+    assert agent_b.provider == "provider-b"
+
+    # Verify configs persisted to respective profile homes without clobbering
+    cfg_a = (prof_a_dir / "config.yaml").read_text(encoding="utf-8")
+    cfg_b = (prof_b_dir / "config.yaml").read_text(encoding="utf-8")
+    assert "model-a" in cfg_a
+    assert "model-b" in cfg_b
+
+    # Final env assertion
+    assert os.environ.get("HERMES_HOME") == initial_env_home
+
+
+# ── Scenario 3: Closed --once lifecycle (real production turn chain) ─────
+
+
+def test_once_full_lifecycle_restore(server, session_with_agent, hermes_home, patched_runtime_provider):
+    """Complete 7-phase validation for --once model switch via the REAL
+    production turn chain (slash.exec -> prompt.submit -> _run_prompt_submit
+    finally).  No restore helper is called directly, no session state is
+    hand-popped, and the agent is never mutated by hand.
+
+    Phase 1: Worker returns once metadata (slash.exec applies it).
+    Phase 2: Live agent switches to target model.
+    Phase 3: Turn 1 executes using target model.
+    Phase 4: Turn 1 completes and restores previous provider/model.
+    Phase 5: one_turn_model_restore consumed; NO model_override created.
+    Phase 6: Turn 2 continues using original model.
+    Phase 7: Failure path leaves no pending restore state.
+    """
+    sid, _, sess, agent = session_with_agent
+    prof_dir = hermes_home / "prof_lifecycle_full"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sess["profile_home"] = str(prof_dir)
+    sess["agent_ready"] = threading.Event()
+    sess["agent_ready"].set()
+    # add run_conversation to the agent spec for the real turn chain
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+    orig_model = agent.model
+    orig_provider = agent.provider
+
+    # Phase 1: Worker returns once metadata
+    meta_once = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "once",
+        "resolved_model": "model-temp-once",
+        "resolved_provider": "prov-once",
+        "raw_args": "temp-model --once",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta_once))
+
+    # Phase 1/2: Parent mirrors via real slash.exec; live agent switches
+    res = server._methods["slash.exec"](1, {"command": "/temp-model --once", "session_id": sid})
+    assert "result" in res
+    assert agent.model == "model-temp-once"
+    assert agent.provider == "prov-once"
+    # once latches ONLY the restore snapshot, never a persistent override
+    assert "model_override" not in sess
+    assert sess.get("one_turn_model_restore") is not None
+
+    # Phase 3: Turn 1 executes with temp model (real prompt.submit chain)
+    res = server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    assert "result" in res
+    _wait_turn_threads(sess)
+
+    # Phase 4 & 5: restored to original; snapshot consumed; no override left
+    assert agent.model == orig_model
+    assert agent.provider == orig_provider
+    assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
+
+    # Phase 6: Turn 2 executes with original model
+    res = server._methods["prompt.submit"](3, {"session_id": sid, "text": "again"})
+    assert "result" in res
+    _wait_turn_threads(sess)
+    assert agent.model == orig_model
+    assert agent.provider == orig_provider
+
+    # Phase 7: Failure path (worker meta=None) leaves no pending state
+    _install_worker(sess, _make_worker_double(slash_meta=None, output="Cancelled"))
+    server._methods["slash.exec"](4, {"command": "/bad-cmd", "session_id": sid})
+    assert agent.model == orig_model
+    assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
+
+
+# ── Scenario 4: Custom provider & No credentials in metadata ────────────
+
+
+def test_custom_provider_metadata_has_no_secrets(server, session_with_agent, hermes_home, patched_runtime_provider):
+    """Ensure worker metadata contains no api_key/tokens, and custom provider resolves."""
+    sid, _, sess, agent = session_with_agent
+
+    prof_dir = hermes_home / "custom_prof"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sess["profile_home"] = str(prof_dir)
+
+    meta_custom = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "my-custom-model",
+        "resolved_provider": "my-custom-provider",
+        "base_url": "https://custom.endpoint/v1",
+        "api_mode": "chat_completions",
+        "raw_args": "custom-alias",
+    }
+
+    # Assert security constraint: metadata dict does not have api_key, token, or secret
+    assert "api_key" not in meta_custom
+    assert "token" not in meta_custom
+    assert "secret" not in meta_custom
+
+    _install_worker(sess, _make_worker_double(slash_meta=meta_custom))
+
+    res = server._methods["slash.exec"](1, {"command": "/custom-alias", "session_id": sid})
+    assert "result" in res
+
+    # Live agent updated
+    assert agent.model == "my-custom-model"
+    assert agent.provider == "my-custom-provider"
+    assert agent.base_url == "https://custom.endpoint/v1"
+
+
+# ── Scenario 5: --session, --once, --global scope behavior ───────────────
+
+
+def test_scope_session_once_global_behavior(server, session_with_agent, hermes_home, patched_runtime_provider):
+    """Test --session, --once, and --global metadata scope handling."""
+    sid, _, sess, agent = session_with_agent
+    prof_dir = hermes_home / "scope_prof"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sess["profile_home"] = str(prof_dir)
+
+    # 1. Session scope
+    meta_sess = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-sess",
+        "resolved_provider": "prov-sess",
+        "raw_args": "sess-model --session",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta_sess))
+    server._methods["slash.exec"](1, {"command": "/sess-model --session", "session_id": sid})
+    assert agent.model == "model-sess"
+    assert sess["model_override"]["scope"] == "session"
+
+    # 2. Once scope
+    meta_once = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "once",
+        "resolved_model": "model-once",
+        "resolved_provider": "prov-once",
+        "raw_args": "once-model --once",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta_once))
+    server._methods["slash.exec"](2, {"command": "/once-model --once", "session_id": sid})
+    assert agent.model == "model-once"
+    # Upstream one-turn semantics: once never creates a persistent
+    # model_override — the previous session override stays untouched, and
+    # only the restore snapshot is latched.
+    assert sess["model_override"]["scope"] == "session"
+    assert sess.get("one_turn_model_restore") is not None
+
+    # 3. Global scope
+    meta_global = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "global",
+        "resolved_model": "model-global",
+        "resolved_provider": "prov-global",
+        "raw_args": "global-model --global",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta_global))
+    server._methods["slash.exec"](3, {"command": "/global-model --global", "session_id": sid})
+    assert agent.model == "model-global"
+    assert sess["model_override"]["scope"] == "global"
+
+    # Check that global persisted ONLY to config.yaml under prof_dir
+    config_file = prof_dir / "config.yaml"
+    assert config_file.exists()
+    content = config_file.read_text(encoding="utf-8")
+    assert "model-global" in content
+
+
+# ── Scenario 6: Worker failure / rollback does NOT mirror ───────────────
+
+
+def test_worker_failure_does_not_mirror(server, session_with_agent):
+    """When the worker fails or returns meta=None, live agent is NOT modified."""
+    sid, _, sess, agent = session_with_agent
+
+    initial_model = agent.model
+    initial_provider = agent.provider
+
+    # Worker returns meta=None (failed execution or no model switch produced)
+    _install_worker(sess, _make_worker_double(slash_meta=None, output="Error: invalid model"))
+
+    server._methods["slash.exec"](1, {"command": "/invalid-model", "session_id": sid})
+
+    # Live agent must remain on initial state
+    assert agent.model == initial_model
+    assert agent.provider == initial_provider
+    assert "model_override" not in sess
+
+
+# ── Scenario 7: Parent apply failure rollback ────────────────────────────
+
+
+def test_parent_apply_failure_rollback(server, session_with_agent):
+    """If agent.switch_model fails on the parent, _mirror_resolved_model_switch
+    returns a warning message and does not corrupt session state.
+    """
+    sid, _, sess, agent = session_with_agent
+
+    agent.switch_model = MagicMock(side_effect=RuntimeError("connection refused"))
+
+    meta = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "broken-model",
+        "resolved_provider": "broken-prov",
+        "raw_args": "broken",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta))
+
+    res = server._methods["slash.exec"](1, {"command": "/broken", "session_id": sid})
+    assert "result" in res
+    assert "warning" in res["result"]
+    assert "model mirror failed" in res["result"]["warning"]
+
+
+# ── Scenario 8: Consecutive commands reset metadata & collision safety ───
+
+
+def test_consecutive_commands_metadata_reset(server, session_with_agent):
+    """First command switches model; second command (non-model) returns meta=None.
+    The second command must NOT re-apply the previous model switch metadata.
+    """
+    sid, _, sess, agent = session_with_agent
+
+    # Turn 1: model switch
+    meta_1 = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-turn-1",
+        "resolved_provider": "prov-1",
+        "raw_args": "turn-1",
+    }
+    worker = _make_worker_double()
+    worker.run_with_meta = MagicMock(side_effect=[
+        ("Switched", meta_1),
+        ("Help output", None),
+    ])
+    _install_worker(sess, worker)
+
+    server._methods["slash.exec"](1, {"command": "/turn-1", "session_id": sid})
+    assert agent.model == "model-turn-1"
+
+    # Turn 2: non-model command (meta=None)
+    fake_mirror = MagicMock(return_value="")
+    server._mirror_slash_side_effects = fake_mirror
+
+    server._methods["slash.exec"](2, {"command": "/help", "session_id": sid})
+    # Agent remains model-turn-1
+    assert agent.model == "model-turn-1"
+
+
+def test_builtin_plugin_skill_collision_no_model_mirror(server, session_with_agent):
+    """When token matches a built-in or plugin, worker resolves meta=None and no model switch happens."""
+    sid, _, sess, agent = session_with_agent
+
+    initial_model = agent.model
+
+    # Worker reports meta=None for built-in /version or plugin /foo
+    _install_worker(sess, _make_worker_double(slash_meta=None, output="Version 1.0"))
+
+    server._methods["slash.exec"](1, {"command": "/version", "session_id": sid})
+
+    # Live agent unchanged
+    assert agent.model == initial_model
+    assert "model_override" not in sess
+
+
+# ── Profile scope fail-closed tests ───────────────────────────────
+
+
+def _session_with_profile(server, profile_home: Path):
+    """Build a session dict wired with a real MagicMock agent."""
+    sid = f"sid-{profile_home.name}"
+    fake_agent = MagicMock(
+        spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model"]
+    )
+    fake_agent.model = "initial-model"
+    fake_agent.provider = "initial-provider"
+    fake_agent.base_url = "https://initial.api"
+    fake_agent.api_key = "secret-key"
+    fake_agent.api_mode = "chat_completions"
+
+    def fake_switch(new_model="", new_provider="", **kw):
+        fake_agent.model = new_model
+        fake_agent.provider = new_provider
+        if base_url:
+            fake_agent.base_url = base_url
+
+    fake_agent.switch_model = MagicMock(side_effect=fake_switch)
+
+    sess = {
+        "session_key": f"k-{profile_home.name}",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+        "agent": fake_agent,
+        "profile_home": str(profile_home),
+    }
+    server._sessions[sid] = sess
+    return sid, sess, fake_agent
+
+
+def test_fail_closed_home_scope_raises(server, hermes_home):
+    """``set_hermes_home_override`` raises -> mirror aborts BEFORE any
+    provider resolution, agent mutation, or model_override write."""
+    prof_dir = hermes_home / "prof_home_fail"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sid, sess, agent = _session_with_profile(server, prof_dir)
+
+    import hermes_constants
+    real_set = hermes_constants.set_hermes_home_override
+
+    def broken_set(path):
+        raise RuntimeError("scope setup failed")
+
+    hermes_constants.set_hermes_home_override = broken_set
+
+    meta = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-x",
+        "resolved_provider": "provider-x",
+        "raw_args": "x",
+    }
+
+    try:
+        warning = server._mirror_resolved_model_switch(sid, sess, meta)
+    finally:
+        hermes_constants.set_hermes_home_override = real_set
+
+    assert "mirror aborted" in warning
+    # Agent untouched
+    assert agent.model == "initial-model"
+    assert agent.provider == "initial-provider"
+    # No session mutation
+    assert "model_override" not in sess
+    # config.yaml not created on profile_home
+    assert not (prof_dir / "config.yaml").exists()
+
+
+def test_fail_closed_secret_scope_raises(server, hermes_home):
+    """``set_secret_scope`` raises AFTER home_token was established —
+    home_token must be reset (no ContextVar leak) and mirror aborts."""
+    prof_dir = hermes_home / "prof_secret_fail"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sid, sess, agent = _session_with_profile(server, prof_dir)
+
+    # Track that home override was set and reset
+    home_set_calls = []
+
+    real_set = None
+    real_reset = None
+    import hermes_constants
+
+    try:
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    except ImportError:
+        pytest.skip("hermes_constants unavailable")
+
+    real_set = set_hermes_home_override
+    real_reset = reset_hermes_home_override
+
+    def tracked_set(path):
+        tok = real_set(path)
+        home_set_calls.append(("set", tok))
+        return tok
+
+    def tracked_reset(tok):
+        home_set_calls.append(("reset", tok))
+        return real_reset(tok)
+
+    hermes_constants.set_hermes_home_override = tracked_set
+    hermes_constants.reset_hermes_home_override = tracked_reset
+
+    # Force set_secret_scope to raise
+    import agent.secret_scope as ss_module
+
+    def broken_set_scope(scope):
+        raise RuntimeError("secret scope setup failed")
+
+    original_set_secret_scope = ss_module.set_secret_scope
+    ss_module.set_secret_scope = broken_set_scope
+
+    try:
+        meta = {
+            "side_effect": "model_switch",
+            "canonical": "model",
+            "scope": "session",
+            "resolved_model": "model-x",
+            "resolved_provider": "provider-x",
+            "raw_args": "x",
+        }
+
+        warning = server._mirror_resolved_model_switch(sid, sess, meta)
+    finally:
+        ss_module.set_secret_scope = original_set_secret_scope
+        hermes_constants.set_hermes_home_override = real_set
+        hermes_constants.reset_hermes_home_override = real_reset
+
+    assert "mirror aborted" in warning
+    # home_token was set then reset by ExitStack
+    ops = [op for op, _ in home_set_calls]
+    assert ops.count("set") >= 1
+    assert ops.count("reset") >= 1
+    # Agent untouched, no session mutation
+    assert agent.model == "initial-model"
+    assert "model_override" not in sess
+
+
+def test_fail_closed_provider_resolution_raises(server, hermes_home, monkeypatch):
+    """``resolve_runtime_provider`` raises -> both scope tokens are reset."""
+    prof_dir = hermes_home / "prof_resolve_fail"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sid, sess, agent = _session_with_profile(server, prof_dir)
+
+    import hermes_cli.runtime_provider as rp
+    monkeypatch.setattr(rp, "resolve_runtime_provider",
+                       lambda *a, **k: (_ for _ in ()).throw(RuntimeError("resolve broken")))
+
+    meta = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-x",
+        "resolved_provider": "provider-x",
+        "raw_args": "x",
+    }
+
+    warning = server._mirror_resolved_model_switch(sid, sess, meta)
+
+    assert "provider resolution failed" in warning
+    assert agent.model == "initial-model"
+    assert "model_override" not in sess
+
+
+def test_fail_closed_agent_apply_raises(server, hermes_home, patched_runtime_provider):
+    """``agent.switch_model`` raises during apply -> scope tokens are reset."""
+    prof_dir = hermes_home / "prof_apply_fail"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sid, sess, agent = _session_with_profile(server, prof_dir)
+
+    # Force switch_model to raise on apply
+    def broken_switch(**kw):
+        raise RuntimeError("agent switch failed")
+    agent.switch_model = MagicMock(side_effect=broken_switch)
+
+    meta = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "session",
+        "resolved_model": "model-x",
+        "resolved_provider": "provider-x",
+        "raw_args": "x",
+    }
+
+    warning = server._mirror_resolved_model_switch(sid, sess, meta)
+
+    assert "model mirror failed" in warning
+    # Agent.switch_model did get called (and raised) but agent.model stays initial
+    assert agent.model == "initial-model"
+    # session was not mutated
+    assert "model_override" not in sess
+
+
+def test_fail_closed_secret_scope_init_raises(server, hermes_home):
+    """``build_profile_secret_scope`` raises (during init, before set_secret_scope)
+    — home_token already established; both attempts handled and tokens reset."""
+    prof_dir = hermes_home / "prof_build_secret_fail"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+    sid, sess, agent = _session_with_profile(server, prof_dir)
+
+    import hermes_constants
+    import agent.secret_scope as ss_module
+
+    home_resets = []
+
+    real_set = hermes_constants.set_hermes_home_override
+    real_reset = hermes_constants.reset_hermes_home_override
+
+    def tracked_reset(tok):
+        home_resets.append(tok)
+        return real_reset(tok)
+
+    hermes_constants.set_hermes_home_override = real_set
+    hermes_constants.reset_hermes_home_override = tracked_reset
+
+    def broken_build(path):
+        raise RuntimeError("build profile secret scope failed")
+
+    real_build = ss_module.build_profile_secret_scope
+    ss_module.build_profile_secret_scope = broken_build
+
+    try:
+        meta = {
+            "side_effect": "model_switch",
+            "canonical": "model",
+            "scope": "session",
+            "resolved_model": "model-x",
+            "resolved_provider": "provider-x",
+            "raw_args": "x",
+        }
+        warning = server._mirror_resolved_model_switch(sid, sess, meta)
+    finally:
+        ss_module.build_profile_secret_scope = real_build
+        hermes_constants.set_hermes_home_override = real_set
+        hermes_constants.reset_hermes_home_override = real_reset
+
+    assert "mirror aborted" in warning
+    # Agent untouched, no session mutation
+    assert agent.model == "initial-model"
+    assert "model_override" not in sess
+
+
+# ── Real production --once lifecycle integration ─────────────────────
+
+
+def _once_lifecycle_setup(server, hermes_home, patched_runtime_provider):
+    """Prepare a session with all prerequisites for prompt.submit production chain.
+
+    Returns: (sid, sess, agent)
+    """
+    prof_dir = hermes_home / "prof_lifecycle"
+    prof_dir.mkdir(parents=True, exist_ok=True)
+
+    sid = "sid-once-life"
+    agent = MagicMock(
+        spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model", "run_conversation"]
+    )
+    agent.model = "orig-model"
+    agent.provider = "orig-provider"
+    agent.base_url = "https://orig.api"
+    agent.api_key = "orig-key"
+    agent.api_mode = "chat_completions"
+
+    # ``**kwargs``: the production one-turn restore calls ``switch_model(...,
+    # capabilities=...)`` (upstream grew the kwarg), so the double must tolerate
+    # every keyword the real contract passes.
+    def fake_switch(new_model="", new_provider="", api_key="", base_url="", api_mode="", **_kwargs):
+        agent.model = new_model
+        agent.provider = new_provider
+        if base_url:
+            agent.base_url = base_url
+
+    agent.switch_model = MagicMock(side_effect=fake_switch)
+
+    sess = {
+        "session_key": "k-once-life",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+        "agent": agent,
+        "profile_home": str(prof_dir),
+        # Mark session as not running so prompt.submit runs _run_prompt_submit
+        "agent_ready": threading.Event(),
+    }
+    sess["agent_ready"].set()
+    server._sessions[sid] = sess
+
+    # Worker reports once metadata
+    meta_once = {
+        "side_effect": "model_switch",
+        "canonical": "model",
+        "scope": "once",
+        "resolved_model": "model-once-temp",
+        "resolved_provider": "prov-once-temp",
+        "raw_args": "temp-model --once",
+    }
+    _install_worker(sess, _make_worker_double(slash_meta=meta_once))
+
+    # Phase A: slash.exec applies once via production mirror path
+    res = server._methods["slash.exec"](1, {"command": "/temp-model --once", "session_id": sid})
+    assert "result" in res
+
+    return sid, sess, agent
+
+
+def _wait_turn_threads(sess, timeout=120):
+    """Join the daemon turn threads spawned by prompt.submit.
+
+    prompt.submit stores ``session["_run_thread"]`` with the
+    ``run_after_agent_ready`` wrapper and starts it; that wrapper then
+    calls ``_run_prompt_submit``, which REPLACES the same key with the
+    inner ``run()`` thread (stored BEFORE .start()).  Both must finish
+    before we assert.  A handle may be observed in the not-yet-started
+    window, so wait for the thread to actually become alive before
+    joining, and never join a dead/already-consumed thread.
+    """
+    import time as _t
+
+    seen = set()
+    for _ in range(6):
+        t = sess.get("_run_thread")
+        if t is None:
+            return
+        if id(t) in seen:
+            return
+        # Wait for the not-yet-started window to pass.
+        for _ in range(20):
+            if t.is_alive():
+                break
+            _t.sleep(0.05)
+        if not t.is_alive():
+            # Thread finished before we could join (or was never going to
+            # start) — nothing more to wait for this handle.
+            return
+        seen.add(id(t))
+        t.join(timeout=timeout)
+        # _run_prompt_submit may have replaced the handle with the inner
+        # run() thread; loop again to pick it up.
+
+
+def test_once_real_turn_chain_success_restores(server, hermes_home, patched_runtime_provider):
+    """Real production turn chain restores --once after successful turn."""
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    # Phase 2: live agent temp model after mirror
+    assert agent.model == "model-once-temp"
+    assert sess["one_turn_model_restore"] is not None
+
+    # Mock agent.run_conversation to return successfully without real LLM
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+    # Phase 3: real prompt.submit -> _run_prompt_submit -> turn-finally -> restore
+    res = server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    assert "result" in res
+
+    # Wait for daemon _run_thread to finish
+    _wait_turn_threads(sess)
+
+    # Phase 4: agent restored to original
+    assert agent.model == "orig-model"
+    assert agent.provider == "orig-provider"
+    # Phase 5: once snapshot consumed by the production turn finally
+    assert "one_turn_model_restore" not in sess
+    # Upstream one-turn semantics: NO persistent model_override is created
+    # (a leftover "once" override would skip config sync and re-apply the
+    # temp model on rebuild/resume//new).
+    assert "model_override" not in sess
+
+
+def test_once_real_turn_chain_error_restores(server, hermes_home, patched_runtime_provider):
+    """Real production turn chain restores --once even if turn raises."""
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    assert agent.model == "model-once-temp"
+
+    # Mock agent.run_conversation to raise an exception
+    def failing_run(*args, **kwargs):
+        raise RuntimeError("model provider rate-limit")
+    agent.run_conversation = MagicMock(side_effect=failing_run)
+
+    # Submit prompt through production chain
+    server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+
+    _wait_turn_threads(sess)
+
+    # Agent restored despite turn error
+    assert agent.model == "orig-model"
+    assert agent.provider == "orig-provider"
+    # Once snapshot consumed, no persistent override left behind
+    assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
+
+
+def test_once_real_turn_chain_interrupt_restores(server, hermes_home, patched_runtime_provider):
+    """Real production turn chain restores --once when session is interrupted."""
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    assert agent.model == "model-once-temp"
+
+    # Mock agent.run_conversation to honor interrupt flag and abort
+    def interruptible_run(*args, **kwargs):
+        # Read interrupt flag under lock to mimic real agent behavior
+        with sess["history_lock"]:
+            cancelled = bool(sess.get("_turn_cancel_requested"))
+        if cancelled:
+            raise RuntimeError("turn interrupted")
+        # Otherwise block; interrupt will set the flag
+        import time as _t
+        for _ in range(50):
+            with sess["history_lock"]:
+                if sess.get("_turn_cancel_requested"):
+                    raise RuntimeError("turn interrupted")
+            _t.sleep(0.1)
+        return {"messages": []}
+
+    agent.run_conversation = MagicMock(side_effect=interruptible_run)
+
+    # Submit prompt through production chain
+    server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+
+    # Set interrupt flag immediately
+    import time as _t
+    _t.sleep(0.2)
+    with sess["history_lock"]:
+        sess["_turn_cancel_requested"] = True
+
+    _wait_turn_threads(sess)
+
+    # Agent restored despite interrupt
+    assert agent.model == "orig-model"
+    assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
+
+
+# ── Scenario: --once with a pre-existing session override ─────────────────
+
+
+def test_once_with_existing_session_override_keeps_override(
+    server, hermes_home, patched_runtime_provider
+):
+    """A /model --once executed while the session already carries a
+    persistent override (prior /model A) must:
+      - temporarily switch the live agent to the once model,
+      - restore the agent to the pre-once runtime after the turn,
+      - KEEP the original override A (never delete the user's session model,
+        never create a stale once override).
+    """
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    # Plant a pre-existing session override A (as a prior /model A would)
+    sess["model_override"] = {
+        "model": "override-A",
+        "provider": "provider-A",
+        "base_url": "https://a.api",
+        "api_key": "a-key",
+        "api_mode": "chat_completions",
+    }
+    # Simulate the live agent already running override A
+    agent.model = "override-A"
+    agent.provider = "provider-A"
+    agent.base_url = "https://a.api"
+
+    # Mock turn body
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+    # Real slash.exec applies the once switch
+    res = server._methods["slash.exec"](1, {"command": "/temp-model --once", "session_id": sid})
+    assert "result" in res
+
+    # During the once window: live agent on temp model, restore latched,
+    # original override untouched
+    assert agent.model == "model-once-temp"
+    assert sess.get("one_turn_model_restore") is not None
+    assert sess["model_override"]["model"] == "override-A"
+
+    # Real prompt.submit turn; production finally restores
+    res = server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    assert "result" in res
+    _wait_turn_threads(sess)
+
+    # Agent back on the pre-once runtime (override A), override dict kept,
+    # no once residue
+    assert agent.model == "override-A"
+    assert agent.provider == "provider-A"
+    assert sess["model_override"]["model"] == "override-A"
+    assert "one_turn_model_restore" not in sess
+
+
+# ── Scenario: --once then real session rebuild (/_new / reset) ────────────
+
+
+def test_once_rebuild_does_not_reapply_temp_model(
+    server, hermes_home, patched_runtime_provider, monkeypatch
+):
+    """After a completed /model --once, a real session rebuild (the
+    production _reset_session_agent /new path) must build the new agent from
+    config / pre-once override — never from the once temp model.
+    """
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+    # Complete one real once turn (the once switch was already applied by
+    # _once_lifecycle_setup's slash.exec — do NOT re-apply it, that would
+    # snapshot the temp model instead of the original)
+    server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    _wait_turn_threads(sess)
+
+    # Once is fully consumed: agent restored, no override residue
+    assert agent.model == "orig-model"
+    assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
+
+    # The real rebuild path must not resurrect the once model. Stub only
+    # _make_agent (which would build a real AIAgent) — the rest of
+    # _reset_session_agent runs for real.
+    new_agent = MagicMock(
+        spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model"]
+    )
+    new_agent.model = "orig-model"  # config-derived model, not the once temp
+    new_agent.provider = "orig-provider"
+    monkeypatch.setattr(server, "_make_agent", lambda *a, **k: new_agent)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+
+    server._reset_session_agent(sid, sess)
+
+    # The rebuilt session must never carry the once temp model
+    assert sess["agent"].model == "orig-model"
+    assert sess["agent"].model != "model-once-temp"
+    assert "one_turn_model_restore" not in sess
+    assert "model_override" not in sess
+
+
+def test_once_rebuild_keeps_pre_existing_override(
+    server, hermes_home, patched_runtime_provider, monkeypatch
+):
+    """Rebuild after /model --once when a session override A existed before:
+    the rebuild path clears session pins by design (/new semantics), so the
+    fresh agent must come from config — the once temp model must never
+    reappear.
+    """
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+    sess["model_override"] = {
+        "model": "override-A",
+        "provider": "provider-A",
+        "base_url": "https://a.api",
+        "api_key": "a-key",
+        "api_mode": "chat_completions",
+    }
+    agent.model = "override-A"
+    agent.provider = "provider-A"
+
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+    # Re-apply the once switch so the restore snapshot captures the
+    # PRE-ONCE override (override-A), not the setup's original model.
+    res = server._methods["slash.exec"](3, {"command": "/temp-model --once", "session_id": sid})
+    assert "result" in res
+    assert agent.model == "model-once-temp"
+    # The once switch must NOT clobber the pre-existing override A
+    assert sess["model_override"]["model"] == "override-A"
+
+    # Complete the real once turn
+    server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    _wait_turn_threads(sess)
+
+    assert agent.model == "override-A"
+    assert sess["model_override"]["model"] == "override-A"
+    assert "one_turn_model_restore" not in sess
+
+    new_agent = MagicMock(
+        spec=["model", "provider", "base_url", "api_key", "api_mode", "switch_model"]
+    )
+    new_agent.model = "orig-model"
+    new_agent.provider = "orig-provider"
+    monkeypatch.setattr(server, "_make_agent", lambda *a, **k: new_agent)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
+
+    server._reset_session_agent(sid, sess)
+
+    assert sess["agent"].model == "orig-model"
+    assert sess["agent"].model != "model-once-temp"
+    assert "one_turn_model_restore" not in sess
+
+
+# ── Scenario: --once must not block global config sync afterwards ─────────
+
+
+def test_once_does_not_block_config_sync(server, hermes_home, patched_runtime_provider):
+    """After /model --once completes, no residual override may block
+    _sync_agent_model_with_config: a later config.yaml model change must be
+    adoptable on the next turn.
+    """
+    sid, sess, agent = _once_lifecycle_setup(server, hermes_home, patched_runtime_provider)
+
+    def fake_run_conversation(*args, **kwargs):
+        return {"messages": [{"role": "assistant", "content": "ok"}]}
+    agent.run_conversation = MagicMock(side_effect=fake_run_conversation)
+
+    # The once switch was already applied by _once_lifecycle_setup's
+    # slash.exec — complete the turn without re-applying.
+    server._methods["prompt.submit"](2, {"session_id": sid, "text": "hi"})
+    _wait_turn_threads(sess)
+
+    # Once fully consumed — the session must carry NO override so the sync
+    # is not short-circuited
+    assert agent.model == "orig-model"
+    assert "model_override" not in sess
+    assert "one_turn_model_restore" not in sess
+
+    # Simulate a global config.yaml model change
+    (Path(hermes_home) / "config.yaml").write_text(
+        "model:\n  default: new-global-model\n  provider: new-global-provider\n",
+        encoding="utf-8",
+    )
+    sess.pop("config_model_seen", None)
+    agent.model = "orig-model"
+    agent.provider = "orig-provider"
+
+    # Force the config cache to re-read the tmp config.yaml so the sync
+    # sees the change regardless of earlier tests' cache population.
+    server._cfg_cache = None
+    server._cfg_path = None
+    server._cfg_mtime = None
+
+    # The real production sync runs at turn start (no override blocks it).
+    # Patch only the switch helper it would call; assert it is invoked.
+    switch_calls = []
+
+    def spy_apply_model_switch(sid_, session_, raw, **kw):
+        switch_calls.append(raw)
+        return {"value": "new-global-model", "warning": "", "confirm_required": False}
+
+    import unittest.mock as um
+
+    with um.patch.object(server, "_apply_model_switch", spy_apply_model_switch):
+        server._sync_agent_model_with_config(sid, sess)
+
+    # The config change was adopted because nothing pinned the session
+    assert switch_calls, "config sync should have fired without an override"

--- a/tests/tui_gateway/test_model_alias_slash_dispatch.py
+++ b/tests/tui_gateway/test_model_alias_slash_dispatch.py
@@ -1,0 +1,230 @@
+"""Tests for /<alias> model switching via the TUI slash.exec path.
+
+Regression coverage for PR #59606 — a typed alias like /sonnet in the TUI
+must update the live session's model the same way /model sonnet does.
+Without the rewrite at the mirror call site, /sonnet would print
+"switched" in the worker thread but leave the live agent's model
+unchanged, because _mirror_slash_side_effects only recognises the
+literal command name "model".
+"""
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+@pytest.fixture()
+def session(server):
+    sid = "sid-alias-test"
+    session_key = "tui-alias-session"
+    s = {
+        "session_key": session_key,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+    }
+    server._sessions[sid] = s
+    return sid, session_key, s
+
+
+def _make_worker_double():
+    """Return a MagicMock that stands in for _SlashWorker.run() so we
+    can drive slash.exec without spawning the real worker subprocess.
+    """
+    w = MagicMock()
+    w.run = MagicMock(return_value="")
+    w.close = MagicMock()
+    return w
+
+
+def _install_worker(server, session_entry, worker):
+    """Attach the fake worker to a session dict."""
+    session_entry["slash_worker"] = worker
+
+
+def _apply_model_switch_double(server):
+    """Return an AsyncMock stand-in for _apply_model_switch."""
+    return MagicMock(return_value={"value": "sonnet-target", "warning": ""})
+
+
+# ── slash.exec /<alias> rewrites mirror command to /model ────────────
+
+
+def test_alias_mirror_command_is_canonical_model(server, session, monkeypatch):
+    """When slash.exec receives /sonnet, the command passed to
+    _mirror_slash_side_effects must be rewritten to /model sonnet so
+    the live agent actually switches."""
+    sid, _, sess = session
+
+    captured_mirror_cmd: list[str] = []
+
+    def fake_mirror(sid_arg, sess_arg, cmd):
+        captured_mirror_cmd.append(cmd)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+    # Stub the worker so we don't spawn a real subprocess.
+    fake_worker = _make_worker_double()
+    _install_worker(server, sess, fake_worker)
+
+    r = server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
+    assert "result" in r
+    assert len(captured_mirror_cmd) == 1, (
+        f"_mirror_slash_side_effects must be called exactly once, "
+        f"got calls: {captured_mirror_cmd}"
+    )
+    # The mirror must receive /model sonnet, NOT /sonnet.
+    cmd = captured_mirror_cmd[0].lower()
+    assert cmd.startswith("/model"), (
+        f"alias /sonnet must be rewritten to /model sonnet before "
+        f"reaching _mirror_slash_side_effects, got: {captured_mirror_cmd[0]!r}"
+    )
+    assert "sonnet" in cmd
+
+
+def test_alias_mirror_preserves_extra_args(server, session, monkeypatch):
+    """If the user types /sonnet --provider openrouter, the rewritten
+    mirror command must preserve the trailing flags so the model
+    switch respects them."""
+    sid, _, sess = session
+
+    captured: list[str] = []
+
+    def fake_mirror(sid_arg, sess_arg, cmd):
+        captured.append(cmd)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+    fake_worker = _make_worker_double()
+    _install_worker(server, sess, fake_worker)
+
+    r = server._methods["slash.exec"](
+        1, {"command": "/sonnet --provider openrouter", "session_id": sid}
+    )
+    assert "result" in r
+    assert len(captured) == 1
+    cmd = captured[0].lower()
+    assert cmd.startswith("/model")
+    assert "sonnet" in cmd
+    assert "--provider openrouter" in cmd
+
+
+def test_canonical_model_command_still_routes_to_model(
+    server, session, monkeypatch
+):
+    """Sanity: typing /model sonnet directly must still route to
+    /model sonnet in the mirror (the rewrite must not double-rewrite
+    or strip the canonical command name)."""
+    sid, _, sess = session
+
+    captured: list[str] = []
+
+    def fake_mirror(sid_arg, sess_arg, cmd):
+        captured.append(cmd)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+    fake_worker = _make_worker_double()
+    _install_worker(server, sess, fake_worker)
+
+    r = server._methods["slash.exec"](
+        1, {"command": "/model sonnet", "session_id": sid}
+    )
+    assert "result" in r
+    assert len(captured) == 1
+    # /model sonnet → /model sonnet (unchanged)
+    cmd = captured[0].lower()
+    assert cmd.startswith("/model")
+    assert "sonnet" in cmd
+
+
+def test_non_alias_command_is_passed_through_unchanged(
+    server, session, monkeypatch
+):
+    """Non-alias commands must be passed to the mirror unchanged so
+    the live-session sync continues to work for every other slash
+    command (personality, prompt, fast, etc.)."""
+    sid, _, sess = session
+
+    captured: list[str] = []
+
+    def fake_mirror(sid_arg, sess_arg, cmd):
+        captured.append(cmd)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+    fake_worker = _make_worker_double()
+    _install_worker(server, sess, fake_worker)
+
+    # /personality is a command that reaches the mirror verbatim.
+    r = server._methods["slash.exec"](
+        1, {"command": "/personality", "session_id": sid}
+    )
+    assert "result" in r
+    assert len(captured) == 1
+    assert captured[0].lower() == "/personality"
+
+
+def test_alias_unknown_command_does_not_rewrite_to_model(
+    server, session, monkeypatch
+):
+    """A non-alias unknown command must NOT be rewritten to /model —
+    the alias rewrite must not intercept arbitrary /<x> calls and
+    silently route them to a model switch."""
+    sid, _, sess = session
+
+    captured: list[str] = []
+
+    def fake_mirror(sid_arg, sess_arg, cmd):
+        captured.append(cmd)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+    fake_worker = _make_worker_double()
+    _install_worker(server, sess, fake_worker)
+
+    # /xyzzy-zzzz is not a model alias and not a recognized command.
+    # Whatever slash.exec returns, the rewrite at the mirror call site
+    # must NOT have promoted it to /model — that would silently route
+    # arbitrary text into a model switch and mask typos.
+    server._methods["slash.exec"](
+        1, {"command": "/xyzzy-zzzz", "session_id": sid}
+    )
+    if captured:
+        cmd = captured[0].lower()
+        assert not cmd.startswith("/model "), (
+            f"non-alias /xyzzy-zzzz must not be rewritten to /model "
+            f"xyzzy-zzzz (silent model switch), got: {captured[0]!r}"
+        )

--- a/tests/tui_gateway/test_model_alias_slash_dispatch.py
+++ b/tests/tui_gateway/test_model_alias_slash_dispatch.py
@@ -59,12 +59,17 @@ def session(server):
     return sid, session_key, s
 
 
-def _make_worker_double():
-    """Return a MagicMock that stands in for _SlashWorker.run() so we
+def _make_worker_double(slash_meta=None, output=""):
+    """Return a MagicMock that stands in for _SlashWorker so we
     can drive slash.exec without spawning the real worker subprocess.
+
+    ``run_with_meta`` is the canonical hook the parent uses to learn
+    the worker's structured side-effect metadata; ``run`` is kept for
+    backwards-compatible callers that only need the captured output.
     """
     w = MagicMock()
-    w.run = MagicMock(return_value="")
+    w.run = MagicMock(return_value=output)
+    w.run_with_meta = MagicMock(return_value=(output, slash_meta))
     w.close = MagicMock()
     return w
 
@@ -83,9 +88,12 @@ def _apply_model_switch_double(server):
 
 
 def test_alias_mirror_command_is_canonical_model(server, session, monkeypatch):
-    """When slash.exec receives /sonnet, the command passed to
+    """When slash.exec receives /sonnet and the worker reports the
+    canonical ``model`` side-effect, the command passed to
     _mirror_slash_side_effects must be rewritten to /model sonnet so
-    the live agent actually switches."""
+    the live agent actually switches. The parent's mirror decision is
+    driven by the worker's structured metadata — not by re-deriving
+    whether the typed token is in any global alias cache."""
     sid, _, sess = session
 
     captured_mirror_cmd: list[str] = []
@@ -95,8 +103,17 @@ def test_alias_mirror_command_is_canonical_model(server, session, monkeypatch):
         return ""
 
     monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-    # Stub the worker so we don't spawn a real subprocess.
-    fake_worker = _make_worker_double()
+    # The real worker reports model_switch because it routed /sonnet
+    # through the canonical /model path inside the session's profile.
+    fake_worker = _make_worker_double(
+        slash_meta={
+            "canonical": "model",
+            "raw_args": "sonnet",
+            "args": "sonnet",
+            "target": "anthropic/claude-sonnet",
+            "side_effect": "model_switch",
+        }
+    )
     _install_worker(server, sess, fake_worker)
 
     r = server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
@@ -105,7 +122,6 @@ def test_alias_mirror_command_is_canonical_model(server, session, monkeypatch):
         f"_mirror_slash_side_effects must be called exactly once, "
         f"got calls: {captured_mirror_cmd}"
     )
-    # The mirror must receive /model sonnet, NOT /sonnet.
     cmd = captured_mirror_cmd[0].lower()
     assert cmd.startswith("/model"), (
         f"alias /sonnet must be rewritten to /model sonnet before "
@@ -115,9 +131,10 @@ def test_alias_mirror_command_is_canonical_model(server, session, monkeypatch):
 
 
 def test_alias_mirror_preserves_extra_args(server, session, monkeypatch):
-    """If the user types /sonnet --provider openrouter, the rewritten
-    mirror command must preserve the trailing flags so the model
-    switch respects them."""
+    """If the user types /sonnet --provider openrouter, the worker's
+    metadata ``raw_args`` field carries those flags verbatim and the
+    mirror command must include them so the live-session model switch
+    respects them."""
     sid, _, sess = session
 
     captured: list[str] = []
@@ -127,7 +144,15 @@ def test_alias_mirror_preserves_extra_args(server, session, monkeypatch):
         return ""
 
     monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-    fake_worker = _make_worker_double()
+    fake_worker = _make_worker_double(
+        slash_meta={
+            "canonical": "model",
+            "raw_args": "sonnet --provider openrouter",
+            "args": "sonnet --provider openrouter",
+            "target": "anthropic/claude-sonnet",
+            "side_effect": "model_switch",
+        }
+    )
     _install_worker(server, sess, fake_worker)
 
     r = server._methods["slash.exec"](
@@ -145,8 +170,9 @@ def test_canonical_model_command_still_routes_to_model(
     server, session, monkeypatch
 ):
     """Sanity: typing /model sonnet directly must still route to
-    /model sonnet in the mirror (the rewrite must not double-rewrite
-    or strip the canonical command name)."""
+    /model sonnet in the mirror. The worker reports
+    ``side_effect == "model_switch"`` for canonical /model too, so the
+    parent re-emits ``/model sonnet`` unchanged."""
     sid, _, sess = session
 
     captured: list[str] = []
@@ -156,7 +182,15 @@ def test_canonical_model_command_still_routes_to_model(
         return ""
 
     monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-    fake_worker = _make_worker_double()
+    fake_worker = _make_worker_double(
+        slash_meta={
+            "canonical": "model",
+            "raw_args": "sonnet",
+            "args": "sonnet",
+            "target": "anthropic/claude-sonnet",
+            "side_effect": "model_switch",
+        }
+    )
     _install_worker(server, sess, fake_worker)
 
     r = server._methods["slash.exec"](
@@ -164,7 +198,6 @@ def test_canonical_model_command_still_routes_to_model(
     )
     assert "result" in r
     assert len(captured) == 1
-    # /model sonnet → /model sonnet (unchanged)
     cmd = captured[0].lower()
     assert cmd.startswith("/model")
     assert "sonnet" in cmd
@@ -173,9 +206,10 @@ def test_canonical_model_command_still_routes_to_model(
 def test_non_alias_command_is_passed_through_unchanged(
     server, session, monkeypatch
 ):
-    """Non-alias commands must be passed to the mirror unchanged so
+    """Non-model commands must be passed to the mirror unchanged so
     the live-session sync continues to work for every other slash
-    command (personality, prompt, fast, etc.)."""
+    command (personality, prompt, fast, etc.). Worker reports
+    ``meta=None`` for these, so the parent never rewrites."""
     sid, _, sess = session
 
     captured: list[str] = []
@@ -185,10 +219,9 @@ def test_non_alias_command_is_passed_through_unchanged(
         return ""
 
     monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-    fake_worker = _make_worker_double()
+    fake_worker = _make_worker_double()  # meta=None
     _install_worker(server, sess, fake_worker)
 
-    # /personality is a command that reaches the mirror verbatim.
     r = server._methods["slash.exec"](
         1, {"command": "/personality", "session_id": sid}
     )

--- a/tests/tui_gateway/test_model_alias_slash_dispatch.py
+++ b/tests/tui_gateway/test_model_alias_slash_dispatch.py
@@ -89,68 +89,64 @@ def _apply_model_switch_double(server):
 
 def test_alias_mirror_command_is_canonical_model(server, session, monkeypatch):
     """When slash.exec receives /sonnet and the worker reports the
-    canonical ``model`` side-effect, the command passed to
-    _mirror_slash_side_effects must be rewritten to /model sonnet so
-    the live agent actually switches. The parent's mirror decision is
-    driven by the worker's structured metadata — not by re-deriving
-    whether the typed token is in any global alias cache."""
+    canonical ``model`` side-effect, _mirror_resolved_model_switch
+    is called with the worker's resolved metadata."""
     sid, _, sess = session
 
-    captured_mirror_cmd: list[str] = []
+    captured_meta: list[dict] = []
 
-    def fake_mirror(sid_arg, sess_arg, cmd):
-        captured_mirror_cmd.append(cmd)
+    def fake_mirror(sid_arg, sess_arg, meta):
+        captured_meta.append(meta)
         return ""
 
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
-    # The real worker reports model_switch because it routed /sonnet
-    # through the canonical /model path inside the session's profile.
+    monkeypatch.setattr(server, "_mirror_resolved_model_switch", fake_mirror)
     fake_worker = _make_worker_double(
         slash_meta={
-            "canonical": "model",
-            "raw_args": "sonnet",
-            "args": "sonnet",
-            "target": "anthropic/claude-sonnet",
             "side_effect": "model_switch",
+            "canonical": "model",
+            "scope": "session",
+            "resolved_model": "anthropic/claude-sonnet",
+            "resolved_provider": "anthropic",
+            "base_url": None,
+            "api_mode": None,
+            "raw_args": "sonnet",
         }
     )
     _install_worker(server, sess, fake_worker)
 
     r = server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
     assert "result" in r
-    assert len(captured_mirror_cmd) == 1, (
-        f"_mirror_slash_side_effects must be called exactly once, "
-        f"got calls: {captured_mirror_cmd}"
+    assert len(captured_meta) == 1, (
+        f"_mirror_resolved_model_switch must be called exactly once, "
+        f"got calls: {captured_meta}"
     )
-    cmd = captured_mirror_cmd[0].lower()
-    assert cmd.startswith("/model"), (
-        f"alias /sonnet must be rewritten to /model sonnet before "
-        f"reaching _mirror_slash_side_effects, got: {captured_mirror_cmd[0]!r}"
-    )
-    assert "sonnet" in cmd
+    meta = captured_meta[0]
+    assert meta["resolved_model"] == "anthropic/claude-sonnet"
+    assert meta["resolved_provider"] == "anthropic"
 
 
 def test_alias_mirror_preserves_extra_args(server, session, monkeypatch):
     """If the user types /sonnet --provider openrouter, the worker's
-    metadata ``raw_args`` field carries those flags verbatim and the
-    mirror command must include them so the live-session model switch
-    respects them."""
+    metadata resolved fields carry those flags verbatim."""
     sid, _, sess = session
 
-    captured: list[str] = []
+    captured: list[dict] = []
 
-    def fake_mirror(sid_arg, sess_arg, cmd):
-        captured.append(cmd)
+    def fake_mirror(sid_arg, sess_arg, meta):
+        captured.append(meta)
         return ""
 
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+    monkeypatch.setattr(server, "_mirror_resolved_model_switch", fake_mirror)
     fake_worker = _make_worker_double(
         slash_meta={
-            "canonical": "model",
-            "raw_args": "sonnet --provider openrouter",
-            "args": "sonnet --provider openrouter",
-            "target": "anthropic/claude-sonnet",
             "side_effect": "model_switch",
+            "canonical": "model",
+            "scope": "session",
+            "resolved_model": "anthropic/claude-sonnet",
+            "resolved_provider": "openrouter",
+            "base_url": "https://openrouter.ai/api",
+            "api_mode": "chat_completions",
+            "raw_args": "sonnet --provider openrouter",
         }
     )
     _install_worker(server, sess, fake_worker)
@@ -160,35 +156,35 @@ def test_alias_mirror_preserves_extra_args(server, session, monkeypatch):
     )
     assert "result" in r
     assert len(captured) == 1
-    cmd = captured[0].lower()
-    assert cmd.startswith("/model")
-    assert "sonnet" in cmd
-    assert "--provider openrouter" in cmd
+    meta = captured[0]
+    assert meta["resolved_model"] == "anthropic/claude-sonnet"
+    assert meta["resolved_provider"] == "openrouter"
 
 
 def test_canonical_model_command_still_routes_to_model(
     server, session, monkeypatch
 ):
     """Sanity: typing /model sonnet directly must still route to
-    /model sonnet in the mirror. The worker reports
-    ``side_effect == "model_switch"`` for canonical /model too, so the
-    parent re-emits ``/model sonnet`` unchanged."""
+    _mirror_resolved_model_switch."""
     sid, _, sess = session
 
-    captured: list[str] = []
+    captured: list[dict] = []
 
-    def fake_mirror(sid_arg, sess_arg, cmd):
-        captured.append(cmd)
+    def fake_mirror(sid_arg, sess_arg, meta):
+        captured.append(meta)
         return ""
 
-    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+    monkeypatch.setattr(server, "_mirror_resolved_model_switch", fake_mirror)
     fake_worker = _make_worker_double(
         slash_meta={
-            "canonical": "model",
-            "raw_args": "sonnet",
-            "args": "sonnet",
-            "target": "anthropic/claude-sonnet",
             "side_effect": "model_switch",
+            "canonical": "model",
+            "scope": "session",
+            "resolved_model": "anthropic/claude-sonnet",
+            "resolved_provider": "anthropic",
+            "base_url": None,
+            "api_mode": None,
+            "raw_args": "sonnet",
         }
     )
     _install_worker(server, sess, fake_worker)
@@ -198,9 +194,8 @@ def test_canonical_model_command_still_routes_to_model(
     )
     assert "result" in r
     assert len(captured) == 1
-    cmd = captured[0].lower()
-    assert cmd.startswith("/model")
-    assert "sonnet" in cmd
+    meta = captured[0]
+    assert meta["resolved_model"] == "anthropic/claude-sonnet"
 
 
 def test_non_alias_command_is_passed_through_unchanged(

--- a/tests/tui_gateway/test_model_alias_slash_dispatch.py
+++ b/tests/tui_gateway/test_model_alias_slash_dispatch.py
@@ -1,0 +1,258 @@
+"""Tests for /<alias> model switching via the TUI slash.exec path.
+
+Regression coverage for PR #59606 — a typed alias like /sonnet in the TUI
+must update the live session's model the same way /model sonnet does.
+Without the rewrite at the mirror call site, /sonnet would print
+"switched" in the worker thread but leave the live agent's model
+unchanged, because _mirror_slash_side_effects only recognises the
+literal command name "model".
+"""
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+@pytest.fixture()
+def session(server):
+    sid = "sid-alias-test"
+    session_key = "tui-alias-session"
+    s = {
+        "session_key": session_key,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+    }
+    server._sessions[sid] = s
+    return sid, session_key, s
+
+
+def _make_worker_double(slash_meta=None, output=""):
+    """Return a MagicMock that stands in for _SlashWorker so we
+    can drive slash.exec without spawning the real worker subprocess.
+
+    ``run_with_meta`` is the canonical hook the parent uses to learn
+    the worker's structured side-effect metadata; ``run`` is kept for
+    backwards-compatible callers that only need the captured output.
+    """
+    w = MagicMock()
+    w.run = MagicMock(return_value=output)
+    w.run_with_meta = MagicMock(return_value=(output, slash_meta))
+    w.close = MagicMock()
+    return w
+
+
+def _install_worker(server, session_entry, worker):
+    """Attach the fake worker to a session dict."""
+    session_entry["slash_worker"] = worker
+
+
+def _apply_model_switch_double(server):
+    """Return an AsyncMock stand-in for _apply_model_switch."""
+    return MagicMock(return_value={"value": "sonnet-target", "warning": ""})
+
+
+# ── slash.exec /<alias> rewrites mirror command to /model ────────────
+
+
+def test_alias_mirror_command_is_canonical_model(server, session, monkeypatch):
+    """When slash.exec receives /sonnet and the worker reports the
+    canonical ``model`` side-effect, _mirror_resolved_model_switch
+    is called with the worker's resolved metadata."""
+    sid, _, sess = session
+
+    captured_meta: list[dict] = []
+
+    def fake_mirror(sid_arg, sess_arg, meta):
+        captured_meta.append(meta)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_resolved_model_switch", fake_mirror)
+    fake_worker = _make_worker_double(
+        slash_meta={
+            "side_effect": "model_switch",
+            "canonical": "model",
+            "scope": "session",
+            "resolved_model": "anthropic/claude-sonnet",
+            "resolved_provider": "anthropic",
+            "base_url": None,
+            "api_mode": None,
+            "raw_args": "sonnet",
+        }
+    )
+    _install_worker(server, sess, fake_worker)
+
+    r = server._methods["slash.exec"](1, {"command": "/sonnet", "session_id": sid})
+    assert "result" in r
+    assert len(captured_meta) == 1, (
+        f"_mirror_resolved_model_switch must be called exactly once, "
+        f"got calls: {captured_meta}"
+    )
+    meta = captured_meta[0]
+    assert meta["resolved_model"] == "anthropic/claude-sonnet"
+    assert meta["resolved_provider"] == "anthropic"
+
+
+def test_alias_mirror_preserves_extra_args(server, session, monkeypatch):
+    """If the user types /sonnet --provider openrouter, the worker's
+    metadata resolved fields carry those flags verbatim."""
+    sid, _, sess = session
+
+    captured: list[dict] = []
+
+    def fake_mirror(sid_arg, sess_arg, meta):
+        captured.append(meta)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_resolved_model_switch", fake_mirror)
+    fake_worker = _make_worker_double(
+        slash_meta={
+            "side_effect": "model_switch",
+            "canonical": "model",
+            "scope": "session",
+            "resolved_model": "anthropic/claude-sonnet",
+            "resolved_provider": "openrouter",
+            "base_url": "https://openrouter.ai/api",
+            "api_mode": "chat_completions",
+            "raw_args": "sonnet --provider openrouter",
+        }
+    )
+    _install_worker(server, sess, fake_worker)
+
+    r = server._methods["slash.exec"](
+        1, {"command": "/sonnet --provider openrouter", "session_id": sid}
+    )
+    assert "result" in r
+    assert len(captured) == 1
+    meta = captured[0]
+    assert meta["resolved_model"] == "anthropic/claude-sonnet"
+    assert meta["resolved_provider"] == "openrouter"
+
+
+def test_canonical_model_command_still_routes_to_model(
+    server, session, monkeypatch
+):
+    """Sanity: typing /model sonnet directly must still route to
+    _mirror_resolved_model_switch."""
+    sid, _, sess = session
+
+    captured: list[dict] = []
+
+    def fake_mirror(sid_arg, sess_arg, meta):
+        captured.append(meta)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_resolved_model_switch", fake_mirror)
+    fake_worker = _make_worker_double(
+        slash_meta={
+            "side_effect": "model_switch",
+            "canonical": "model",
+            "scope": "session",
+            "resolved_model": "anthropic/claude-sonnet",
+            "resolved_provider": "anthropic",
+            "base_url": None,
+            "api_mode": None,
+            "raw_args": "sonnet",
+        }
+    )
+    _install_worker(server, sess, fake_worker)
+
+    r = server._methods["slash.exec"](
+        1, {"command": "/model sonnet", "session_id": sid}
+    )
+    assert "result" in r
+    assert len(captured) == 1
+    meta = captured[0]
+    assert meta["resolved_model"] == "anthropic/claude-sonnet"
+
+
+def test_non_alias_command_is_passed_through_unchanged(
+    server, session, monkeypatch
+):
+    """Non-model commands must be passed to the mirror unchanged so
+    the live-session sync continues to work for every other slash
+    command (personality, prompt, fast, etc.). Worker reports
+    ``meta=None`` for these, so the parent never rewrites."""
+    sid, _, sess = session
+
+    captured: list[str] = []
+
+    def fake_mirror(sid_arg, sess_arg, cmd):
+        captured.append(cmd)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+    fake_worker = _make_worker_double()  # meta=None
+    _install_worker(server, sess, fake_worker)
+
+    r = server._methods["slash.exec"](
+        1, {"command": "/personality", "session_id": sid}
+    )
+    assert "result" in r
+    assert len(captured) == 1
+    assert captured[0].lower() == "/personality"
+
+
+def test_alias_unknown_command_does_not_rewrite_to_model(
+    server, session, monkeypatch
+):
+    """A non-alias unknown command must NOT be rewritten to /model —
+    the alias rewrite must not intercept arbitrary /<x> calls and
+    silently route them to a model switch."""
+    sid, _, sess = session
+
+    captured: list[str] = []
+
+    def fake_mirror(sid_arg, sess_arg, cmd):
+        captured.append(cmd)
+        return ""
+
+    monkeypatch.setattr(server, "_mirror_slash_side_effects", fake_mirror)
+    fake_worker = _make_worker_double()
+    _install_worker(server, sess, fake_worker)
+
+    # /xyzzy-zzzz is not a model alias and not a recognized command.
+    # Whatever slash.exec returns, the rewrite at the mirror call site
+    # must NOT have promoted it to /model — that would silently route
+    # arbitrary text into a model switch and mask typos.
+    server._methods["slash.exec"](
+        1, {"command": "/xyzzy-zzzz", "session_id": sid}
+    )
+    if captured:
+        cmd = captured[0].lower()
+        assert not cmd.startswith("/model "), (
+            f"non-alias /xyzzy-zzzz must not be rewritten to /model "
+            f"xyzzy-zzzz (silent model switch), got: {captured[0]!r}"
+        )

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1196,27 +1196,40 @@ def _(rid, params: dict) -> dict:
 
     try:
         output, slash_meta = worker.run_with_meta(cmd)
-        # Mirror decision MUST come from the worker-reported canonical
-        # metadata, not from re-deriving whether the typed token is in a
-        # global alias cache. The worker ran inside the session's
-        # ``profile_home`` scope, so ``slash_meta`` reflects that profile's
-        # resolution (built-in / quick / plugin / bundle / skill / model)
-        # — and never the parent process's global cache. This kills two
-        # cross-profile correctness bugs at once:
+        # Mirror decision MUST come from the worker-reported RESOLVED
+        # metadata (``resolved_model``, ``resolved_provider``,
+        # ``base_url``, ``api_mode``, ``scope``). The worker ran inside
+        # the session's ``profile_home`` scope, so its snapshot reflects
+        # THAT profile's provider / model resolution — never the parent
+        # process's global alias cache.
         #
-        #   1. ``/version`` when ``version`` is configured as a model alias:
-        #      worker resolves the built-in ``version`` command; the parent
-        #      would otherwise see ``version`` in ``MODEL_ALIASES`` and
-        #      falsely flip the live session to the alias target.
+        # The parent MUST NOT re-parse ``raw_args`` (which is
+        # deliberately absent from the mirror decision) and MUST NOT
+        # rebuild ``/model <alias>``. Re-parsing would force the parent
+        # to consult its own alias cache, pinning Profile B's session
+        # to Profile A's resolution when they disagree.
         #
-        #   2. Profile A and Profile B sharing a name mapped to different
-        #      models: the parent would otherwise read the global cache
-        #      and pin B's session to A's resolution.
-        mirror_cmd = cmd
+        # The handler runs with server.py's ``__globals__`` (see
+        # ``method_ctx.HandlerRegistry.install``), so unqualified
+        # ``_mirror_resolved_model_switch`` resolves to the server
+        # module's helper.
+        warning = ""
         if isinstance(slash_meta, dict) and slash_meta.get("side_effect") == "model_switch":
-            args = slash_meta.get("raw_args") or slash_meta.get("args") or ""
-            mirror_cmd = f"/model {args}".strip()
-        warning = _mirror_slash_side_effects(params.get("session_id", ""), session, mirror_cmd)
+            try:
+                warning = _mirror_resolved_model_switch(
+                    params.get("session_id", ""),
+                    session,
+                    slash_meta,
+                )
+            except Exception as exc:
+                warning = f"model mirror failed: {exc}"
+        else:
+            # Non-model or built-in/quick/plugin/bundle/skill command
+            # — pass through verbatim so other mirror side effects
+            # (compress, personality, prompt, …) still fire.
+            warning = _mirror_slash_side_effects(
+                params.get("session_id", ""), session, cmd
+            )
         payload = {"output": output or "(no output)"}
         if warning:
             payload["warning"] = warning

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1195,30 +1195,27 @@ def _(rid, params: dict) -> dict:
                     return _err(rid, 5030, f"slash worker start failed: {e}")
 
     try:
-        output = worker.run(cmd)
-        # Side-effect mirror only recognises canonical command names, so a
-        # typed alias like /sonnet must be rewritten to /model sonnet before
-        # it reaches _mirror_slash_side_effects — otherwise the live TUI
-        # session stays pinned to the old model while the worker thread
-        # (which already dispatches /<alias> through the canonical /model
-        # path) appears to switch it. The rewrite is lazy-imported because
-        # the slash worker already exercises the alias resolver; this site
-        # only needs to recognise the same set of keys.
+        output, slash_meta = worker.run_with_meta(cmd)
+        # Mirror decision MUST come from the worker-reported canonical
+        # metadata, not from re-deriving whether the typed token is in a
+        # global alias cache. The worker ran inside the session's
+        # ``profile_home`` scope, so ``slash_meta`` reflects that profile's
+        # resolution (built-in / quick / plugin / bundle / skill / model)
+        # — and never the parent process's global cache. This kills two
+        # cross-profile correctness bugs at once:
+        #
+        #   1. ``/version`` when ``version`` is configured as a model alias:
+        #      worker resolves the built-in ``version`` command; the parent
+        #      would otherwise see ``version`` in ``MODEL_ALIASES`` and
+        #      falsely flip the live session to the alias target.
+        #
+        #   2. Profile A and Profile B sharing a name mapped to different
+        #      models: the parent would otherwise read the global cache
+        #      and pin B's session to A's resolution.
         mirror_cmd = cmd
-        try:
-            from hermes_cli.model_switch import (
-                _ensure_direct_aliases,
-                DIRECT_ALIASES,
-                MODEL_ALIASES,
-            )
-            _ensure_direct_aliases()
-            _parts = cmd.lstrip("/").split(None, 1)
-            _head = _parts[0].lower() if _parts else ""
-            if _head in DIRECT_ALIASES or _head in MODEL_ALIASES:
-                _tail = (" " + _parts[1]) if len(_parts) > 1 else ""
-                mirror_cmd = f"/model {_parts[0]}{_tail}"
-        except ImportError:
-            pass
+        if isinstance(slash_meta, dict) and slash_meta.get("side_effect") == "model_switch":
+            args = slash_meta.get("raw_args") or slash_meta.get("args") or ""
+            mirror_cmd = f"/model {args}".strip()
         warning = _mirror_slash_side_effects(params.get("session_id", ""), session, mirror_cmd)
         payload = {"output": output or "(no output)"}
         if warning:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1196,7 +1196,30 @@ def _(rid, params: dict) -> dict:
 
     try:
         output = worker.run(cmd)
-        warning = _mirror_slash_side_effects(params.get("session_id", ""), session, cmd)
+        # Side-effect mirror only recognises canonical command names, so a
+        # typed alias like /sonnet must be rewritten to /model sonnet before
+        # it reaches _mirror_slash_side_effects — otherwise the live TUI
+        # session stays pinned to the old model while the worker thread
+        # (which already dispatches /<alias> through the canonical /model
+        # path) appears to switch it. The rewrite is lazy-imported because
+        # the slash worker already exercises the alias resolver; this site
+        # only needs to recognise the same set of keys.
+        mirror_cmd = cmd
+        try:
+            from hermes_cli.model_switch import (
+                _ensure_direct_aliases,
+                DIRECT_ALIASES,
+                MODEL_ALIASES,
+            )
+            _ensure_direct_aliases()
+            _parts = cmd.lstrip("/").split(None, 1)
+            _head = _parts[0].lower() if _parts else ""
+            if _head in DIRECT_ALIASES or _head in MODEL_ALIASES:
+                _tail = (" " + _parts[1]) if len(_parts) > 1 else ""
+                mirror_cmd = f"/model {_parts[0]}{_tail}"
+        except ImportError:
+            pass
+        warning = _mirror_slash_side_effects(params.get("session_id", ""), session, mirror_cmd)
         payload = {"output": output or "(no output)"}
         if warning:
             payload["warning"] = warning

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -856,8 +856,27 @@ def _(rid, params: dict) -> dict:
                 except Exception as e:
                     return _err(rid, 5030, f"slash worker start failed: {e}")
     try:
-        payload = {"output": worker.run(cmd) or "(no output)"}
-        if warning := _mirror_slash_side_effects(sid, session, cmd):
+        output, slash_meta = worker.run_with_meta(cmd)
+        # The mirror decision MUST come from the worker-reported RESOLVED metadata
+        # (``resolved_model`` / ``resolved_provider`` / ``base_url`` / ``api_mode`` /
+        # ``scope``). The worker ran inside the session's ``profile_home`` scope, so its
+        # snapshot reflects THAT profile's provider / model resolution — never the parent
+        # process's global alias cache. The parent MUST NOT re-parse ``raw_args`` and MUST
+        # NOT rebuild ``/model <alias>``: doing so would pin Profile B's session to
+        # Profile A's resolution when the two disagree.
+        warning = ""
+        if isinstance(slash_meta, dict) and slash_meta.get("side_effect") == "model_switch":
+            try:
+                warning = _mirror_resolved_model_switch(sid, session, slash_meta)
+            except Exception as exc:
+                warning = f"model mirror failed: {exc}"
+        else:
+            # Non-model command (or a built-in/quick/plugin/bundle/skill that reports no
+            # model side effect) — pass through verbatim so the other mirror side effects
+            # (compress, personality, prompt, …) still fire.
+            warning = _mirror_slash_side_effects(sid, session, cmd)
+        payload = {"output": output or "(no output)"}
+        if warning:
             payload["warning"] = warning
         if base in _SESSION_CONTROL_SLASHES:
             _publish_session_control_snapshot(sid, session)

--- a/tui_gateway/model_switch.py
+++ b/tui_gateway/model_switch.py
@@ -328,6 +328,149 @@ def _pending_switch_selection_warning(model: str, provider: str) -> str | None:
     return warning.message if warning is not None else None
 
 
+def _mirror_resolved_model_switch(sid: str, session: dict, slash_meta: dict) -> str:
+    """Mirror the worker-resolved model switch onto the live TUI session.
+
+    Consumes ONLY the structured snapshot the slash worker reported
+    (``resolved_model`` / ``resolved_provider`` / ``base_url`` / ``api_mode`` /
+    ``scope``). The worker ran inside the session's ``profile_home`` scope, so those
+    values are THAT profile's resolution: re-parsing ``raw_args`` (or consulting this
+    process's alias cache) would pin Profile B's session to Profile A's resolution
+    whenever the two disagree.
+
+    Fail-closed contract:
+      * The profile-home scope AND the secret scope must BOTH be established before any
+        provider resolution / config / agent mutation runs. Every token is registered
+        with an ``ExitStack``, so a failure that happens AFTER a token was installed —
+        including a failure to establish the NEXT scope — restores it in reverse order
+        and no ContextVar leaks.
+      * If either scope fails, provider resolution fails, the agent apply raises, or the
+        config write raises, the helper returns a warning and leaves the live agent,
+        session and config untouched.
+      * No global ``os.environ`` mutation is ever performed.
+
+    Returns a warning string (empty on success) for the ``slash.exec`` payload.
+    Raises ``ValueError`` when the metadata is malformed.
+    """
+    if not isinstance(slash_meta, dict) or slash_meta.get("side_effect") != "model_switch":
+        return ""
+    resolved_model = str(slash_meta.get("resolved_model") or "").strip()
+    resolved_provider = str(slash_meta.get("resolved_provider") or "").strip()
+    scope_value = str(slash_meta.get("scope") or "session").strip()
+    if not resolved_model or not resolved_provider:
+        # Worker reported the side effect but its resolved target is incomplete:
+        # refuse to mirror rather than silently drift onto the old model.
+        raise ValueError(
+            "slash worker reported model_switch without resolved_model/resolved_provider")
+
+    base_url = slash_meta.get("base_url") or ""
+    api_mode = slash_meta.get("api_mode") or ""
+    agent = session.get("agent")
+    profile_home = session.get("profile_home")
+
+    with contextlib.ExitStack() as stack:
+        if profile_home:
+            try:
+                from hermes_constants import set_hermes_home_override
+                home_token = set_hermes_home_override(Path(profile_home))
+                stack.callback(_safe_reset_home, home_token)
+            except Exception as exc:
+                return f"mirror aborted: profile home scope failed ({exc})"
+            try:
+                from agent.secret_scope import (
+                    build_profile_secret_scope,
+                    set_secret_scope,
+                )
+                secret_token = set_secret_scope(
+                    build_profile_secret_scope(Path(profile_home)))
+                stack.callback(_safe_reset_secret, secret_token)
+            except Exception as exc:
+                return f"mirror aborted: secret scope failed ({exc})"
+
+            try:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+                runtime = resolve_runtime_provider(
+                    requested=resolved_provider, target_model=resolved_model,
+                    explicit_base_url=str(base_url or "") or None) or {}
+            except Exception as exc:
+                # The scopes are live here; the stack unwinds them before returning.
+                return f"mirror aborted: provider resolution failed ({exc})"
+            api_key = str(runtime.get("api_key") or "")
+            base_url = str(runtime.get("base_url") or base_url or "")
+            api_mode = str(runtime.get("api_mode") or api_mode or "")
+        else:
+            # No profile home: the worker resolved against the launch profile's config and
+            # the live agent keeps the credentials it already holds (empty is the
+            # ``switch_model`` default — "no explicit key", not a cleared one).
+            api_key = ""
+
+        restore_snapshot = None
+        if agent is not None:
+            # Snapshot BEFORE the switch so a --once turn can restore the exact
+            # pre-switch runtime (upstream one-turn semantics).
+            if scope_value == "once":
+                restore_snapshot = _snapshot_agent_model_runtime(agent)
+            try:
+                agent.switch_model(
+                    new_model=resolved_model, new_provider=resolved_provider,
+                    api_key=api_key, base_url=base_url, api_mode=api_mode)
+            except Exception as exc:
+                # The agent helper rolls its own runtime back on failure; no session
+                # state has been written yet, so nothing else needs unwinding.
+                return f"model mirror failed: {exc}"
+
+        if scope_value == "global":
+            # Persist to THIS session profile's config.yaml; save_config_value reads the
+            # context-local home override installed above.
+            try:
+                from cli import save_config_value
+                save_config_value("model.default", resolved_model)
+                save_config_value("model.provider", resolved_provider)
+                save_config_value("model.base_url", base_url or None)
+                save_config_value("model.api_mode", api_mode or None)
+            except Exception as exc:
+                return f"model persistence failed: {exc}"
+
+        if scope_value == "once":
+            # A one-turn switch must NOT pin a persistent session override: a
+            # ``model_override`` entry would skip config sync (_sync_agent_model_with_config
+            # returns early) and re-apply the temporary model on rebuild/resume//new. Only
+            # the restore snapshot is latched; a pre-existing override is left untouched
+            # and the production turn finally restores the pre-switch runtime.
+            if restore_snapshot is not None:
+                session["one_turn_model_restore"] = restore_snapshot
+        else:
+            session["model_override"] = {
+                "provider": resolved_provider, "model": resolved_model,
+                "base_url": base_url, "api_key": api_key, "api_mode": api_mode,
+                "scope": scope_value}
+            session.pop("one_turn_model_restore", None)
+        # Success: the ExitStack restores both tokens in reverse order on exit.
+        return ""
+
+
+def _safe_reset_home(token) -> None:
+    """ExitStack callback: reset the home override token (never raises)."""
+    if token is None:
+        return
+    try:
+        from hermes_constants import reset_hermes_home_override
+        reset_hermes_home_override(token)
+    except Exception:
+        pass
+
+
+def _safe_reset_secret(token) -> None:
+    """ExitStack callback: reset the secret scope token (never raises)."""
+    if token is None:
+        return
+    try:
+        from agent.secret_scope import reset_secret_scope
+        reset_secret_scope(token)
+    except Exception:
+        pass
+
+
 def register(server) -> None:
     """Publish this module's helpers + handlers onto ``server``, rebound to its globals."""
     bind_module(globals(), server, skip=("_",))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4028,24 +4028,26 @@ def _mirror_resolved_model_switch(sid: str, session: dict, slash_meta: dict) -> 
     ``resolved_model`` / ``resolved_provider`` / ``base_url`` /
     ``api_mode`` / ``scope`` snapshot the worker reported.
 
-    Why this exists:
-      * The worker ran inside the session's ``profile_home`` scope.
-        Profile A and Profile B with the same alias name can map to
-        different providers / models.
-      * The parent process must NOT re-parse ``raw_args`` (which was
-        deliberately removed from the mirror decision); doing so would
-        read the parent's *own* alias cache and pin the session to a
-        provider/model from a different profile.
-      * The parent re-resolves credentials using context-local overrides
-        (``set_hermes_home_override`` / ``set_secret_scope``) for the
-        session's ``profile_home`` — ``resolve_runtime_provider`` picks
-        up the right custom providers from that profile's config.yaml
-        WITHOUT mutating global ``os.environ["HERMES_HOME"]``.
+    Fail-closed contract:
+      * Profile home scope AND secret scope MUST both be established
+        successfully before any provider / config / agent mutation runs.
+      * If either scope fails to establish, the helper returns a clear
+        warning string and leaves live agent / session / config
+        untouched. Tokens established earlier in the chain are reset
+        before return (reverse-order restoration via ``ExitStack``).
+      * Once any scope fails, we never reach provider resolution, agent
+        ``switch_model``, ``save_config_value``, or ``model_override``
+        mutation. No global ``os.environ`` mutation is ever performed.
+      * Agent ``switch_model`` failure during the apply step rolls the
+        helper back: scope tokens are reset and no session state is
+        mutated.
 
     Returns a warning string (or empty) for the ``slash.exec`` payload.
     Raises ``ValueError`` if the metadata is malformed or the worker's
     snapshot is missing the required fields.
     """
+    import contextlib
+
     if not isinstance(slash_meta, dict) or slash_meta.get("side_effect") != "model_switch":
         return ""
     resolved_model = str(slash_meta.get("resolved_model") or "").strip()
@@ -4062,26 +4064,40 @@ def _mirror_resolved_model_switch(sid: str, session: dict, slash_meta: dict) -> 
     base_url = slash_meta.get("base_url") or ""
     api_mode = slash_meta.get("api_mode") or ""
 
-    # Re-enter the session's profile_home scope via context-local overrides.
-    # The worker already chose the provider; the parent only needs to look
-    # up ``api_key`` / ``base_url`` against THIS profile's providers.
-    # NEVER mutate ``os.environ["HERMES_HOME"]`` which is process-global.
+    # Build profile home override and secret scope via context-local
+    # helpers. Both are required (in stack order) before any provider
+    # / config / agent mutation. Tokens are registered with an
+    # ExitStack so that any later failure (or our own return) restores
+    # them in reverse order, with no possibility of leak.
     profile_home = session.get("profile_home")
-    home_token = None
-    secret_token = None
-    if profile_home:
-        try:
-            from hermes_constants import set_hermes_home_override
-            home_token = set_hermes_home_override(Path(profile_home))
-        except Exception:
-            pass
-        try:
-            from agent.secret_scope import build_profile_secret_scope, set_secret_scope
-            secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
-        except Exception:
-            pass
-    try:
+    api_key = ""
+    runtime = None
+    scoped_resolved = False
+
+    with contextlib.ExitStack() as stack:
         if profile_home:
+            try:
+                from hermes_constants import set_hermes_home_override
+                home_token = set_hermes_home_override(Path(profile_home))
+                stack.callback(_safe_reset_home, home_token)
+            except Exception as exc:
+                return (
+                    f"mirror aborted: profile home scope failed ({exc})"
+                )
+            try:
+                from agent.secret_scope import (
+                    build_profile_secret_scope,
+                    set_secret_scope,
+                )
+                secret_token = set_secret_scope(
+                    build_profile_secret_scope(Path(profile_home))
+                )
+                stack.callback(_safe_reset_secret, secret_token)
+            except Exception as exc:
+                return (
+                    f"mirror aborted: secret scope failed ({exc})"
+                )
+
             try:
                 from hermes_cli.runtime_provider import resolve_runtime_provider
                 runtime = resolve_runtime_provider(
@@ -4089,86 +4105,96 @@ def _mirror_resolved_model_switch(sid: str, session: dict, slash_meta: dict) -> 
                     target_model=resolved_model,
                     explicit_base_url=str(base_url or "") or None,
                 )
+            except Exception as exc:
+                # Provider resolution failed even with scopes in place;
+                # the stack callback will reset tokens in reverse order
+                # before the function returns.
+                return f"mirror aborted: provider resolution failed ({exc})"
+
+            if runtime:
                 api_key = str(runtime.get("api_key") or "")
                 base_url = str(runtime.get("base_url") or base_url or "")
                 api_mode = str(runtime.get("api_mode") or api_mode or "")
-            except Exception:
-                # Profile-scoped resolve failed — fall back to the
-                # values the worker reported (no api_key, but base_url
-                # may still be usable for endpoint-only switches).
-                api_key = ""
+            scoped_resolved = True
         else:
             api_key = ""
-    finally:
-        if secret_token is not None:
-            try:
-                from agent.secret_scope import reset_secret_scope
-                reset_secret_scope(secret_token)
-            except Exception:
-                pass
-        if home_token is not None:
-            try:
-                from hermes_constants import reset_hermes_home_override
-                reset_hermes_home_override(home_token)
-            except Exception:
-                pass
 
-    restore_snapshot = None
-    agent = session.get("agent")
-    if agent is not None:
-        if scope_value == "once":
-            restore_snapshot = _snapshot_agent_model_runtime(agent)
-        try:
-            agent.switch_model(
-                new_model=resolved_model,
-                new_provider=resolved_provider,
-                api_key=api_key,
-                base_url=base_url,
-                api_mode=api_mode,
-            )
-        except Exception as exc:
-            # Mirror failed — propagate so the user sees the warning.
-            return f"model mirror failed: {exc}"
-
-    # Persist scope-aware state on the session dict so a /model restore,
-    # /status, and downstream turns pick up the resolved model.
-    if scope_value == "global":
-        # Persist to THIS profile's config.yaml using context-local override.
-        h_token = None
-        if profile_home:
+        # The two scopes are still live here only when scoped_resolved
+        # is True. We deliberately do not mutate agent / config / session
+        # until scopes have proven healthy.
+        restore_snapshot = None
+        agent = session.get("agent")
+        if agent is not None:
+            if scope_value == "once":
+                restore_snapshot = _snapshot_agent_model_runtime(agent)
             try:
-                from hermes_constants import set_hermes_home_override
-                h_token = set_hermes_home_override(Path(profile_home))
-            except Exception:
-                pass
-        try:
-            from cli import save_config_value as _tui_save
-            _tui_save("model.default", resolved_model)
-            _tui_save("model.provider", resolved_provider)
-            _tui_save("model.base_url", base_url or None)
-            _tui_save("model.api_mode", api_mode or None)
-        except Exception as exc:
-            return f"model persistence failed: {exc}"
-        finally:
-            if h_token is not None:
-                try:
-                    from hermes_constants import reset_hermes_home_override
-                    reset_hermes_home_override(h_token)
-                except Exception:
-                    pass
+                agent.switch_model(
+                    new_model=resolved_model,
+                    new_provider=resolved_provider,
+                    api_key=api_key,
+                    base_url=base_url,
+                    api_mode=api_mode,
+                )
+            except Exception as exc:
+                # Agent switch failed — restore_snapshot will not be
+                # installed on session (we raise before that step), so
+                # no rollback path needed beyond the live agent itself
+                # (the agent helper is responsible for its own rollback).
+                return f"model mirror failed: {exc}"
 
-    session["model_override"] = {
-        "provider": resolved_provider,
-        "model": resolved_model,
-        "base_url": base_url,
-        "api_key": api_key,
-        "api_mode": api_mode,
-        "scope": scope_value,
-        "restore_snapshot": restore_snapshot,
-    }
-    if scope_value == "once" and restore_snapshot is not None:
-        session["one_turn_model_restore"] = restore_snapshot
-    return ""
+        if scope_value == "global":
+            # Persist to THIS profile's config.yaml using the same
+            # scope established above. ``save_config_value`` reads the
+            # current context-local home override.
+            try:
+                from cli import save_config_value as _tui_save
+                _tui_save("model.default", resolved_model)
+                _tui_save("model.provider", resolved_provider)
+                _tui_save("model.base_url", base_url or None)
+                _tui_save("model.api_mode", api_mode or None)
+            except Exception as exc:
+                return f"model persistence failed: {exc}"
+
+        session["model_override"] = {
+            "provider": resolved_provider,
+            "model": resolved_model,
+            "base_url": base_url,
+            "api_key": api_key,
+            "api_mode": api_mode,
+            "scope": scope_value,
+            "restore_snapshot": restore_snapshot,
+        }
+        if scope_value == "once" and restore_snapshot is not None:
+            session["one_turn_model_restore"] = restore_snapshot
+        # Successful end: ExitStack __exit__ resets the tokens in
+        # reverse order (secret_token, home_token) before returning.
+        return ""
+
+
+def _safe_reset_home(token) -> None:
+    """ExitStack callback: reset the home override token (never raises)."""
+    if token is None:
+        return
+    try:
+        from hermes_constants import reset_hermes_home_override
+        reset_hermes_home_override(token)
+    except Exception:
+        # A truly final best-effort cleanup; the override token's
+        # resetter is allowed to silently no-op if hermes_constants is
+        # already gone. The helper is a guard against a teardown
+        # exception leaking past the stack callback boundary.
+        pass
+
+
+def _safe_reset_secret(token) -> None:
+    """ExitStack callback: reset the secret scope token (never raises)."""
+    if token is None:
+        return
+    try:
+        from agent.secret_scope import reset_secret_scope
+        reset_secret_scope(token)
+    except Exception:
+        pass
 
 
 def _snapshot_agent_model_runtime(agent) -> dict:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4155,17 +4155,30 @@ def _mirror_resolved_model_switch(sid: str, session: dict, slash_meta: dict) -> 
             except Exception as exc:
                 return f"model persistence failed: {exc}"
 
-        session["model_override"] = {
-            "provider": resolved_provider,
-            "model": resolved_model,
-            "base_url": base_url,
-            "api_key": api_key,
-            "api_mode": api_mode,
-            "scope": scope_value,
-            "restore_snapshot": restore_snapshot,
-        }
-        if scope_value == "once" and restore_snapshot is not None:
-            session["one_turn_model_restore"] = restore_snapshot
+        if scope_value == "once":
+            # Upstream native one-turn semantics (see _apply_model_switch):
+            # a /model --once must NOT pin a persistent session
+            # model_override — doing so would permanently skip config sync
+            # (_sync_agent_model_with_config returns early when
+            # session["model_override"] is set) and re-apply the temporary
+            # model on session rebuild/resume//new. Only the restore
+            # snapshot is latched; the turn finally consumes it and restores
+            # the agent runtime. A pre-existing session override (e.g. a
+            # prior /model A) is deliberately left untouched: the agent
+            # runtime snapshot restores the agent, and the original override
+            # dict still drives rebuilds exactly as before the once switch.
+            if restore_snapshot is not None:
+                session["one_turn_model_restore"] = restore_snapshot
+        else:
+            session["model_override"] = {
+                "provider": resolved_provider,
+                "model": resolved_model,
+                "base_url": base_url,
+                "api_key": api_key,
+                "api_mode": api_mode,
+                "scope": scope_value,
+            }
+            session.pop("one_turn_model_restore", None)
         # Successful end: ExitStack __exit__ resets the tokens in
         # reverse order (secret_token, home_token) before returning.
         return ""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -398,6 +398,24 @@ class _SlashWorker:
                 self.stderr_tail = (self.stderr_tail + [text])[-80:]
 
     def run(self, command: str) -> str:
+        """Run a slash command; return the captured Rich output string.
+
+        Kept for backwards compatibility with existing callers. New code
+        that needs the worker-reported canonical side-effect metadata
+        (e.g. ``model_switch``) should use ``run_with_meta()``.
+        """
+        return self.run_with_meta(command)[0]
+
+    def run_with_meta(self, command: str) -> tuple[str, dict | None]:
+        """Run a slash command and return ``(output, meta)``.
+
+        ``meta`` is the structured side-effect metadata the worker set on
+        its HermesCLI instance during command execution. ``None`` when the
+        command is non-model (built-in / quick / plugin / bundle / skill).
+        The metadata is read INSIDE the worker's session profile scope,
+        so Profile A and Profile B can each report different model
+        targets without cross-contamination.
+        """
         if self.proc.poll() is not None:
             raise RuntimeError("slash worker exited")
 
@@ -418,7 +436,10 @@ class _SlashWorker:
                     continue
                 if not msg.get("ok"):
                     raise RuntimeError(msg.get("error", "slash worker failed"))
-                return str(msg.get("output", "")).rstrip()
+                return (
+                    str(msg.get("output", "")).rstrip(),
+                    msg.get("meta"),
+                )
 
             raise RuntimeError(
                 f"slash worker closed pipe{': ' + chr(10).join(self.stderr_tail[-8:]) if self.stderr_tail else ''}"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4018,6 +4018,143 @@ def _persist_model_switch(result) -> None:
         save_config_value("model.base_url", None)
 
 
+def _mirror_resolved_model_switch(sid: str, session: dict, slash_meta: dict) -> str:
+    """Mirror the worker-resolved model switch onto the live TUI session.
+
+    This is the canonical TUI mirror path. Unlike the legacy
+    ``_apply_model_switch(raw_input=...)`` path — which calls
+    ``switch_model()`` and re-resolves the alias through the parent's
+    provider cache — this helper ONLY consumes the structured
+    ``resolved_model`` / ``resolved_provider`` / ``base_url`` /
+    ``api_mode`` / ``scope`` snapshot the worker reported.
+
+    Why this exists:
+      * The worker ran inside the session's ``profile_home`` scope.
+        Profile A and Profile B with the same alias name can map to
+        different providers / models.
+      * The parent process must NOT re-parse ``raw_args`` (which was
+        deliberately removed from the mirror decision); doing so would
+        read the parent's *own* alias cache and pin the session to a
+        provider/model from a different profile.
+      * The parent re-resolves credentials by re-entering the session's
+        ``profile_home`` scope via ``HERMES_HOME`` for the duration of
+        the mirror — ``resolve_runtime_provider`` picks up the right
+        custom providers from that profile's config.yaml.
+
+    Returns a warning string (or empty) for the ``slash.exec`` payload.
+    Raises ``ValueError`` if the metadata is malformed or the worker's
+    snapshot is missing the required fields.
+    """
+    if not isinstance(slash_meta, dict) or slash_meta.get("side_effect") != "model_switch":
+        return ""
+    resolved_model = str(slash_meta.get("resolved_model") or "").strip()
+    resolved_provider = str(slash_meta.get("resolved_provider") or "").strip()
+    scope_value = str(slash_meta.get("scope") or "session").strip()
+    if not resolved_model or not resolved_provider:
+        # Worker reported the side effect but the resolved result is
+        # incomplete — refuse to mirror and let the user see the worker's
+        # own error output instead of silently drifting.
+        raise ValueError(
+            "slash worker reported model_switch without resolved_model/resolved_provider"
+        )
+
+    base_url = slash_meta.get("base_url") or ""
+    api_mode = slash_meta.get("api_mode") or ""
+
+    # Re-enter the session's profile_home scope for credential resolution.
+    # The worker already chose the provider; the parent only needs to look
+    # up ``api_key`` / ``base_url`` against THIS profile's providers.
+    profile_home = session.get("profile_home")
+    prev_home = os.environ.get("HERMES_HOME")
+    try:
+        if profile_home:
+            os.environ["HERMES_HOME"] = str(profile_home)
+            try:
+                from hermes_cli.config import load_config as _tui_load_config
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+            except ImportError:
+                _tui_load_config = None
+                resolve_runtime_provider = None
+            if resolve_runtime_provider is not None:
+                try:
+                    runtime = resolve_runtime_provider(
+                        requested=resolved_provider,
+                        target_model=resolved_model,
+                        explicit_base_url=str(base_url or "") or None,
+                    )
+                    api_key = str(runtime.get("api_key") or "")
+                    base_url = str(runtime.get("base_url") or base_url or "")
+                    api_mode = str(runtime.get("api_mode") or api_mode or "")
+                except Exception:
+                    # Profile-scoped resolve failed — fall back to the
+                    # values the worker reported (no api_key, but base_url
+                    # may still be usable for endpoint-only switches).
+                    api_key = ""
+        else:
+            api_key = ""
+    finally:
+        # Restore the parent's HERMES_HOME so the rest of the gateway
+        # continues using the parent's profile, not the session's.
+        if prev_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = prev_home
+
+    agent = session.get("agent")
+    if agent is not None:
+        try:
+            agent.switch_model(
+                new_model=resolved_model,
+                new_provider=resolved_provider,
+                api_key=api_key,
+                base_url=base_url,
+                api_mode=api_mode,
+            )
+        except Exception as exc:
+            # Mirror failed — propagate so the user sees the warning.
+            return f"model mirror failed: {exc}"
+
+    # Persist scope-aware state on the session dict so a /model restore,
+    # /status, and downstream turns pick up the resolved model.
+    if scope_value == "global":
+        # Persist to THIS profile's config.yaml (worker wrote its own
+        # profile too, but the parent's mirror must converge the live
+        # TUI's persistence state — the worker is sandboxed).
+        try:
+            from cli import save_config_value as _tui_save
+
+            if profile_home:
+                prev_home = os.environ.get("HERMES_HOME")
+                os.environ["HERMES_HOME"] = str(profile_home)
+                try:
+                    _tui_save("model.default", resolved_model)
+                    _tui_save("model.provider", resolved_provider)
+                    _tui_save("model.base_url", base_url or None)
+                    _tui_save("model.api_mode", api_mode or None)
+                finally:
+                    if prev_home is None:
+                        os.environ.pop("HERMES_HOME", None)
+                    else:
+                        os.environ["HERMES_HOME"] = prev_home
+            else:
+                _tui_save("model.default", resolved_model)
+                _tui_save("model.provider", resolved_provider)
+                _tui_save("model.base_url", base_url or None)
+                _tui_save("model.api_mode", api_mode or None)
+        except Exception as exc:
+            return f"model persistence failed: {exc}"
+
+    session["model_override"] = {
+        "provider": resolved_provider,
+        "model": resolved_model,
+        "base_url": base_url,
+        "api_key": api_key,
+        "api_mode": api_mode,
+        "scope": scope_value,
+    }
+    return ""
+
+
 def _snapshot_agent_model_runtime(agent) -> dict:
     """Capture the current agent model runtime for a one-turn restore."""
     return {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4036,10 +4036,11 @@ def _mirror_resolved_model_switch(sid: str, session: dict, slash_meta: dict) -> 
         deliberately removed from the mirror decision); doing so would
         read the parent's *own* alias cache and pin the session to a
         provider/model from a different profile.
-      * The parent re-resolves credentials by re-entering the session's
-        ``profile_home`` scope via ``HERMES_HOME`` for the duration of
-        the mirror — ``resolve_runtime_provider`` picks up the right
-        custom providers from that profile's config.yaml.
+      * The parent re-resolves credentials using context-local overrides
+        (``set_hermes_home_override`` / ``set_secret_scope``) for the
+        session's ``profile_home`` — ``resolve_runtime_provider`` picks
+        up the right custom providers from that profile's config.yaml
+        WITHOUT mutating global ``os.environ["HERMES_HOME"]``.
 
     Returns a warning string (or empty) for the ``slash.exec`` payload.
     Raises ``ValueError`` if the metadata is malformed or the worker's
@@ -4061,47 +4062,62 @@ def _mirror_resolved_model_switch(sid: str, session: dict, slash_meta: dict) -> 
     base_url = slash_meta.get("base_url") or ""
     api_mode = slash_meta.get("api_mode") or ""
 
-    # Re-enter the session's profile_home scope for credential resolution.
+    # Re-enter the session's profile_home scope via context-local overrides.
     # The worker already chose the provider; the parent only needs to look
     # up ``api_key`` / ``base_url`` against THIS profile's providers.
+    # NEVER mutate ``os.environ["HERMES_HOME"]`` which is process-global.
     profile_home = session.get("profile_home")
-    prev_home = os.environ.get("HERMES_HOME")
+    home_token = None
+    secret_token = None
+    if profile_home:
+        try:
+            from hermes_constants import set_hermes_home_override
+            home_token = set_hermes_home_override(Path(profile_home))
+        except Exception:
+            pass
+        try:
+            from agent.secret_scope import build_profile_secret_scope, set_secret_scope
+            secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+        except Exception:
+            pass
     try:
         if profile_home:
-            os.environ["HERMES_HOME"] = str(profile_home)
             try:
-                from hermes_cli.config import load_config as _tui_load_config
                 from hermes_cli.runtime_provider import resolve_runtime_provider
-            except ImportError:
-                _tui_load_config = None
-                resolve_runtime_provider = None
-            if resolve_runtime_provider is not None:
-                try:
-                    runtime = resolve_runtime_provider(
-                        requested=resolved_provider,
-                        target_model=resolved_model,
-                        explicit_base_url=str(base_url or "") or None,
-                    )
-                    api_key = str(runtime.get("api_key") or "")
-                    base_url = str(runtime.get("base_url") or base_url or "")
-                    api_mode = str(runtime.get("api_mode") or api_mode or "")
-                except Exception:
-                    # Profile-scoped resolve failed — fall back to the
-                    # values the worker reported (no api_key, but base_url
-                    # may still be usable for endpoint-only switches).
-                    api_key = ""
+                runtime = resolve_runtime_provider(
+                    requested=resolved_provider,
+                    target_model=resolved_model,
+                    explicit_base_url=str(base_url or "") or None,
+                )
+                api_key = str(runtime.get("api_key") or "")
+                base_url = str(runtime.get("base_url") or base_url or "")
+                api_mode = str(runtime.get("api_mode") or api_mode or "")
+            except Exception:
+                # Profile-scoped resolve failed — fall back to the
+                # values the worker reported (no api_key, but base_url
+                # may still be usable for endpoint-only switches).
+                api_key = ""
         else:
             api_key = ""
     finally:
-        # Restore the parent's HERMES_HOME so the rest of the gateway
-        # continues using the parent's profile, not the session's.
-        if prev_home is None:
-            os.environ.pop("HERMES_HOME", None)
-        else:
-            os.environ["HERMES_HOME"] = prev_home
+        if secret_token is not None:
+            try:
+                from agent.secret_scope import reset_secret_scope
+                reset_secret_scope(secret_token)
+            except Exception:
+                pass
+        if home_token is not None:
+            try:
+                from hermes_constants import reset_hermes_home_override
+                reset_hermes_home_override(home_token)
+            except Exception:
+                pass
 
+    restore_snapshot = None
     agent = session.get("agent")
     if agent is not None:
+        if scope_value == "once":
+            restore_snapshot = _snapshot_agent_model_runtime(agent)
         try:
             agent.switch_model(
                 new_model=resolved_model,
@@ -4117,32 +4133,29 @@ def _mirror_resolved_model_switch(sid: str, session: dict, slash_meta: dict) -> 
     # Persist scope-aware state on the session dict so a /model restore,
     # /status, and downstream turns pick up the resolved model.
     if scope_value == "global":
-        # Persist to THIS profile's config.yaml (worker wrote its own
-        # profile too, but the parent's mirror must converge the live
-        # TUI's persistence state — the worker is sandboxed).
+        # Persist to THIS profile's config.yaml using context-local override.
+        h_token = None
+        if profile_home:
+            try:
+                from hermes_constants import set_hermes_home_override
+                h_token = set_hermes_home_override(Path(profile_home))
+            except Exception:
+                pass
         try:
             from cli import save_config_value as _tui_save
-
-            if profile_home:
-                prev_home = os.environ.get("HERMES_HOME")
-                os.environ["HERMES_HOME"] = str(profile_home)
-                try:
-                    _tui_save("model.default", resolved_model)
-                    _tui_save("model.provider", resolved_provider)
-                    _tui_save("model.base_url", base_url or None)
-                    _tui_save("model.api_mode", api_mode or None)
-                finally:
-                    if prev_home is None:
-                        os.environ.pop("HERMES_HOME", None)
-                    else:
-                        os.environ["HERMES_HOME"] = prev_home
-            else:
-                _tui_save("model.default", resolved_model)
-                _tui_save("model.provider", resolved_provider)
-                _tui_save("model.base_url", base_url or None)
-                _tui_save("model.api_mode", api_mode or None)
+            _tui_save("model.default", resolved_model)
+            _tui_save("model.provider", resolved_provider)
+            _tui_save("model.base_url", base_url or None)
+            _tui_save("model.api_mode", api_mode or None)
         except Exception as exc:
             return f"model persistence failed: {exc}"
+        finally:
+            if h_token is not None:
+                try:
+                    from hermes_constants import reset_hermes_home_override
+                    reset_hermes_home_override(h_token)
+                except Exception:
+                    pass
 
     session["model_override"] = {
         "provider": resolved_provider,
@@ -4151,7 +4164,10 @@ def _mirror_resolved_model_switch(sid: str, session: dict, slash_meta: dict) -> 
         "api_key": api_key,
         "api_mode": api_mode,
         "scope": scope_value,
+        "restore_snapshot": restore_snapshot,
     }
+    if scope_value == "once" and restore_snapshot is not None:
+        session["one_turn_model_restore"] = restore_snapshot
     return ""
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -274,6 +274,21 @@ class _SlashWorker:
                 self.stderr_tail = (self.stderr_tail + [text])[-80:]
 
     def run(self, command: str) -> str:
+        """Run a slash command; return the captured Rich output string.
+
+        Kept for callers that only need the text. Code that needs the worker-reported
+        canonical side-effect metadata (e.g. ``model_switch``) uses ``run_with_meta``.
+        """
+        return self.run_with_meta(command)[0]
+
+    def run_with_meta(self, command: str) -> tuple[str, dict | None]:
+        """Run a slash command and return ``(output, meta)``.
+
+        ``meta`` is the structured side-effect metadata the worker set on its HermesCLI
+        during command execution; ``None`` for commands with no such side effect. It is
+        read INSIDE the worker's session profile scope, so Profile A and Profile B each
+        report their own resolved model target without cross-contamination.
+        """
         if self.proc.poll() is not None:
             raise RuntimeError("slash worker exited")
         with self._lock:
@@ -292,7 +307,7 @@ class _SlashWorker:
                     continue
                 if not msg.get("ok"):
                     raise RuntimeError(msg.get("error", "slash worker failed"))
-                return str(msg.get("output", "")).rstrip()
+                return str(msg.get("output", "")).rstrip(), msg.get("meta")
             raise RuntimeError(
                 f"slash worker closed pipe{': ' + chr(10).join(self.stderr_tail[-8:]) if self.stderr_tail else ''}")
 

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -166,7 +166,10 @@ def main():
             req = json.loads(line)
             rid = req.get("id")
             out = _run(cli, req.get("command", ""))
-            sys.stdout.write(json.dumps({"id": rid, "ok": True, "output": out}) + "\n")
+            meta = getattr(cli, "_last_slash_metadata", None)
+            sys.stdout.write(
+                json.dumps({"id": rid, "ok": True, "output": out, "meta": meta}) + "\n"
+            )
             sys.stdout.flush()
         except Exception as e:
             sys.stdout.write(json.dumps({"id": rid, "ok": False, "error": str(e)}) + "\n")

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -126,7 +126,15 @@ def main():
         try:
             req = json.loads(line)
             rid = req.get("id")
-            _reply(id=rid, ok=True, output=_run(cli, req.get("command", "")))
+            out = _run(cli, req.get("command", ""))
+            # Structured, resolved side-effect metadata for the parent. The worker ran
+            # inside the session's profile scope, so the parent mirrors from THIS snapshot
+            # instead of re-resolving aliases against its own process state. Produced by
+            # the CLI's model-switch commit; never carries credentials.
+            _reply(
+                id=rid, ok=True, output=out,
+                meta=getattr(cli, "_last_slash_metadata", None),
+            )
         except Exception as e:
             _reply(id=rid, ok=False, error=str(e))
         finally:


### PR DESCRIPTION
## Summary

Model aliases can now be typed directly as slash commands: `/doubao`, `/ds4flash`, `/minimax`, `/sonnet`, `/gpt5`, etc. resolve exactly as `/model <alias>` in both the interactive CLI and the messaging Gateway.

Two alias sources are supported:
- **MODEL_ALIASES** — built-in catalog-backed aliases (sonnet, opus, gpt5, gemini, deepseek, and the rest)
- **DIRECT_ALIASES** — user-configured aliases from `config.yaml model_aliases:`

## CLI / Gateway behavior

- Typing `/<alias>` is equivalent to `/model <alias>`: the resolved model, provider, base URL and API mode are applied to the live session.
- Built-in commands, quick commands, plugins, skill bundles, skills, and unavailable-skill checks keep their existing priority — the alias check runs only when nothing else matches. If a built-in/plugin/skill shares a name with an alias, the built-in/plugin/skill wins (deterministic, tested).
- In the Gateway, alias-resolved commands enter the same unified access control, Hook, pending, and busy-path machinery as any other slash command — no bypass.
- Hooks that rewrite a command to an alias or to a non-model command are honored: the final canonical command is what executes, and the model side-effect mirror fires only when the worker actually resolves to a model switch.

## TUI resolved-model mirror (multi-profile safe)

- The TUI slash worker runs inside the session's `profile_home` scope and returns structured metadata with the **actual canonical command and resolved model/provider** it executed (`side_effect`, `resolved_model`, `resolved_provider`, `scope`, optional `base_url`/`api_mode`). No credentials ever appear in the metadata.
- The parent process never re-parses aliases: it mirrors the live session only from the worker's resolved result, so Profile A's alias mapping can never leak into Profile B's session.
- Profile scoped config reads, custom-provider resolution, and `--global` config writes run under context-local `set_hermes_home_override` / `set_secret_scope` with reverse-order token restoration — the process-global `HERMES_HOME` is never mutated, and concurrency tests prove interleaved Profile A/B mirrors stay isolated.
- Fail-closed: if the profile-home scope or secret scope cannot be established, provider resolution fails, or agent apply raises, the mirror aborts with a clear warning and leaves the live agent, session, and config untouched.

## Scope semantics

- `--session` — persistent session override (survives rebuild).
- `--once` — one-turn switch: the live agent is temporarily switched, the pre-switch runtime snapshot is latched, and after the turn (success, error, or interrupt) the agent is restored automatically by the production turn finally. `one_turn_model_restore` is consumed and **no persistent `model_override` is created**, so later config sync, session rebuild, resume, and `/new` never re-apply the once model. A pre-existing session override is left intact and restored.
- `--global` — persists to the session profile's `config.yaml` only.

## Tests

Coverage spans CLI, Gateway, and TUI layers: alias dispatch priority (built-in/quick/plugin/bundle/skill collisions), access/Hook/pending/busy-path integration, non-alias passthrough, custom providers, multi-profile ContextVar isolation with real concurrency, fail-closed scope failures, and real production turn lifecycle for `--once` across success/error/interrupt, session rebuild, and global config sync.

## Rebuilt on latest `main` (force-pushed, previous head `0578985ad1`)

Upstream split `cli.py`, `gateway/run.py` and `tui_gateway/server.py` into modules after this branch's base (`1c971769ec`), so the branch was rebuilt on `ee35a4624f` rather than replayed commit-by-commit: each semantic delta was re-applied at its new call site (`hermes_cli/cli_model_switch_mixin.py`, `hermes_cli/model_switch.py`, `gateway/run_inbound.py`, `tui_gateway/model_switch.py`, `tui_gateway/methods_tools.py`, `tui_gateway/server.py`, plus the unchanged `gateway/_model_alias_normalize.py`). Behaviour described above is unchanged, and `git merge-tree` against today's `main` is clean.

Two existing test doubles were widened to upstream's current production protocols, since the code under test now uses them:

- the `switch_model` double in `tests/tui_gateway/test_model_alias_canonical_mirror.py` accepts `capabilities=` (the one-turn restore passes it through),
- `_SlowWorker` in `tests/test_tui_gateway_server.py` implements `run_with_meta` (the `slash.exec` handler consumes `(output, meta)`).

Verification on this head: the five PR test files pass (76 tests), `ruff check` is clean, and the 22-file impact range produces a result set identical to a clean `upstream/main` checkout (the same 4 pre-existing Windows failures and 9 setup errors on both sides — no new failures).
