### PR TITLE
fix(fallback): honor explicit api_mode and delegate to determine_api_mode()

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1300,43 +1300,41 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        # Determine api_mode for the fallback target.
+        #
+        # 1) An explicit ``api_mode`` on the fallback config entry always
+        #    wins — it is the user's declaration of the endpoint's wire
+        #    protocol (e.g. kimi-coding's https://api.kimi.com/coding only
+        #    speaks anthropic_messages; chat_completions 404s there).
+        # 2) Otherwise resolve via determine_api_mode() — the same resolver
+        #    the primary path uses — instead of re-implementing its host
+        #    heuristics inline. Divergent inline copies are what caused the
+        #    fallback-only 404 regressions (#32243, #49247, kimi-coding).
+        # 3) Keep the fallback-specific refinements determine_api_mode()
+        #    doesn't cover: Azure stays on chat_completions (no Responses
+        #    API), direct-OpenAI URLs and GPT-5.x models need the Responses
+        #    API (with provider exceptions like Copilot gpt-5-mini handled
+        #    inside _provider_model_requires_responses_api).
+        from hermes_cli.providers import TRANSPORT_TO_API_MODE, determine_api_mode
+
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
-            fb_api_mode = "codex_responses"
-        elif (
-            fb_provider == "anthropic"
-            or fb_base_url.rstrip("/").lower().endswith("/anthropic")
-            or base_url_hostname(fb_base_url) == "api.anthropic.com"
-        ):
-            # Custom providers (e.g. cron-anthropic) point at the native
-            # api.anthropic.com host with no "/anthropic" path suffix, so the
-            # name/suffix checks above miss them and they default to
-            # chat_completions → POST /v1/chat/completions → 404. Match the
-            # host the same way determine_api_mode() and _detect_api_mode_for_url()
-            # do on the primary path. (#32243, #49247)
-            fb_api_mode = "anthropic_messages"
-        elif _fb_is_azure:
-            # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
-            # support the Responses API. Stay on chat_completions.
-            fb_api_mode = "chat_completions"
-        elif agent._is_direct_openai_url(fb_base_url):
-            fb_api_mode = "codex_responses"
-        elif agent._provider_model_requires_responses_api(
-            fb_model,
-            provider=fb_provider,
-        ):
-            # GPT-5.x models usually need Responses API, but keep
-            # provider-specific exceptions like Copilot gpt-5-mini on
-            # chat completions.
-            fb_api_mode = "codex_responses"
-        elif fb_provider == "bedrock" or (
-            base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
-            and base_url_host_matches(fb_base_url, "amazonaws.com")
-        ):
-            fb_api_mode = "bedrock_converse"
+        fb_api_mode = str(fb.get("api_mode") or "").strip().lower()
+        if fb_api_mode not in set(TRANSPORT_TO_API_MODE.values()):
+            if fb_api_mode:
+                logger.warning(
+                    "Fallback %s/%s: ignoring unknown api_mode %r from config",
+                    fb_provider, fb_model, fb.get("api_mode"),
+                )
+            fb_api_mode = determine_api_mode(fb_provider, fb_base_url)
+            if fb_api_mode == "chat_completions" and not _fb_is_azure:
+                if agent._is_direct_openai_url(fb_base_url):
+                    fb_api_mode = "codex_responses"
+                elif agent._provider_model_requires_responses_api(
+                    fb_model,
+                    provider=fb_provider,
+                ):
+                    fb_api_mode = "codex_responses"
 
         old_model = agent.model
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -211,6 +211,89 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert agent.api_mode == "anthropic_messages"
 
+    def test_explicit_api_mode_from_config_wins(self):
+        """An explicit ``api_mode`` on the fallback config entry must be
+        honored even when no URL/provider heuristic would detect it. The
+        config is the user's declaration of the endpoint's wire protocol."""
+        fbs = [
+            {
+                "provider": "my-proxy",
+                "model": "some-model",
+                "base_url": "https://proxy.example.com/v1",
+                "api_mode": "anthropic_messages",
+                "key_env": "MY_FALLBACK_KEY",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch.dict("os.environ", {"MY_FALLBACK_KEY": "env-secret"}, clear=False),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url="https://proxy.example.com/v1"),
+                    "some-model",
+                ),
+            ),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_mode == "anthropic_messages"
+
+    def test_kimi_coding_endpoint_uses_anthropic_messages(self):
+        """The Kimi /coding endpoint only speaks anthropic_messages —
+        chat_completions POSTs /chat/completions and 404s. Even without an
+        explicit ``api_mode`` in the entry, the fallback path must resolve
+        it via determine_api_mode() like the primary path does."""
+        fbs = [
+            {
+                "provider": "kimi-coding",
+                "model": "kimi-k2.7-code",
+                "base_url": "https://api.kimi.com/coding",
+                "key_env": "MY_FALLBACK_KEY",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch.dict("os.environ", {"MY_FALLBACK_KEY": "env-secret"}, clear=False),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url="https://api.kimi.com/coding"),
+                    "kimi-k2.7-code",
+                ),
+            ),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_mode == "anthropic_messages"
+
+    def test_invalid_api_mode_falls_back_to_heuristics(self):
+        """An unknown ``api_mode`` string in config is ignored (with a
+        warning) and heuristic resolution still applies."""
+        fbs = [
+            {
+                "provider": "kimi-coding",
+                "model": "kimi-k2.7-code",
+                "base_url": "https://api.kimi.com/coding",
+                "api_mode": "not-a-real-mode",
+                "key_env": "MY_FALLBACK_KEY",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch.dict("os.environ", {"MY_FALLBACK_KEY": "env-secret"}, clear=False),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url="https://api.kimi.com/coding"),
+                    "kimi-k2.7-code",
+                ),
+            ),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_mode == "anthropic_messages"
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 


### PR DESCRIPTION
## Symptom

When the primary model fails over (e.g. HTTP 429 usage cap on openai-codex, HTTP 529 overload on z.ai), a fallback entry pointing at an Anthropic-Messages-only endpoint fails every attempt with:

```
API call failed: NotFoundError [HTTP 404]
Provider: kimi-coding  Model: kimi-k2.7-code
Endpoint: https://api.kimi.com/coding
{'message': 'The requested resource was not found', 'type': 'resource_not_found_error'}
```

The request dump shows the fallback POSTed `https://api.kimi.com/coding/chat/completions` — but that endpoint only speaks Anthropic Messages (`/v1/messages`). This happens even when the config entry explicitly declares the protocol:

```yaml
fallback_providers:
  - provider: kimi-coding
    model: kimi-k2.7-code
    base_url: https://api.kimi.com/coding
    api_mode: anthropic_messages   # ignored by the fallback path
```

## Root cause

`try_activate_fallback` (agent/chat_completion_helpers.py) re-implemented wire-protocol detection as an inline copy of heuristics and never read the entry's explicit `api_mode`. The inline copy was missing the `api.kimi.com/coding` rule that the primary path's shared resolver, `determine_api_mode()` (hermes_cli/providers.py), already has — so the primary works but every failover to the same provider 404s. This is the same divergence that previously caused the fallback-only Anthropic-host 404s fixed in #32243 / #49247; the inline copy drifted again.

## Fix

1. An explicit `api_mode` on the fallback config entry always wins (validated against `TRANSPORT_TO_API_MODE`; unknown values log a warning and fall through).
2. Otherwise resolve via `determine_api_mode()` — the same resolver the primary path uses — instead of maintaining a divergent inline copy.
3. Keep the fallback-specific refinements `determine_api_mode()` doesn't cover: Azure stays on chat_completions; direct-OpenAI URLs and GPT-5.x models use the Responses API (provider exceptions like Copilot gpt-5-mini still handled by `_provider_model_requires_responses_api`).

Behavior parity for every branch of the old inline chain was verified against `determine_api_mode()` (openai-codex, anthropic host/suffix, Azure, direct OpenAI, Responses-API models, bedrock).

## Tests

Four regression tests added in `tests/run_agent/test_provider_fallback.py`:
- explicit `api_mode` from config is honored even when no heuristic would detect it
- `kimi-coding` / `api.kimi.com/coding` resolves to `anthropic_messages` even without an explicit `api_mode`
- unknown `api_mode` strings are ignored safely and heuristics still apply
- existing anthropic-host custom-provider test still passes

Also verified live against the real endpoint: `POST /coding/v1/messages` → 200, `POST /coding/chat/completions` → 404.