### PR TITLE
fix(daytona): forward env_passthrough variables to sandbox process.exec() (#59286)

### DIFF
--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -23,6 +23,7 @@ from tools.environments.file_sync import (
     quoted_rm_command,
     unique_parent_dirs,
 )
+from tools.env_passthrough import is_env_passthrough
 
 logger = logging.getLogger(__name__)
 
@@ -236,7 +237,8 @@ class DaytonaEnvironment(BaseEnvironment):
             shell_cmd = f"bash -c {shlex.quote(cmd_string)}"
 
         def exec_fn() -> tuple[str, int]:
-            response = sandbox.process.exec(shell_cmd, timeout=timeout)
+            env = {k: v for k, v in os.environ.items() if is_env_passthrough(k)}
+            response = sandbox.process.exec(shell_cmd, timeout=timeout, env=env)
             return (response.result or "", response.exit_code)
 
         return _ThreadedProcessHandle(exec_fn, cancel_fn=cancel)


### PR DESCRIPTION
## Summary

The Daytona backend completely ignored `terminal.env_passthrough` and `required_environment_variables` from skills. Allowlisted env vars present in the Hermes process environment were never forwarded to the remote sandbox, so commands run there saw them as empty/unset — while the same allowlist worked correctly on the `local` and `execute_code` backends.

## Fix

Import `is_env_passthrough` from `tools.env_passthrough` and collect passthrough vars from `os.environ` before each `sandbox.process.exec()` call, passing them as the `env` dict.

## Changes

| File | Δ |
|------|---|
| `tools/environments/daytona.py` | +3/-1 lines (import + env passthrough in exec_fn) |

Closes #59286