### PR TITLE
fix(tui_gateway): drop interrupt sentinel before websocket delivery

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -18045,3 +18045,67 @@ def test_prompt_submit_unconfirmed_truncation_refuses_before_target_resolution(
         assert len(sess["history"]) == 4
     finally:
         server._sessions.pop(sid, None)
+
+
+class TestStripInterruptSentinel:
+    """Regression tests: the dashboard/TUI websocket surface must not render
+    Hermes' local "waiting for model response" cancellation sentinel as if
+    it were assistant prose. ACP (#41720) and the gateway's chat platforms
+    (#7921) already suppress it before delivery; this surface never got the
+    same guard.
+    """
+
+    def test_strips_sentinel_prefixed_text(self):
+        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+
+        text = f"{INTERRUPT_WAITING_FOR_MODEL_PREFIX}12.3s elapsed)."
+        assert server._strip_interrupt_sentinel(text) == ""
+
+    def test_leaves_normal_text_untouched(self):
+        assert server._strip_interrupt_sentinel("The answer is 42.") == "The answer is 42."
+
+    def test_handles_none_and_empty(self):
+        assert server._strip_interrupt_sentinel("") == ""
+        assert server._strip_interrupt_sentinel(None) == ""
+
+    def test_chat_reply_site_strips_sentinel(self):
+        """message.complete (main chat reply) — result dicts come straight
+        from AIAgent.run_conversation()'s return value."""
+        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+
+        interrupted = {
+            "final_response": f"{INTERRUPT_WAITING_FOR_MODEL_PREFIX}4.1s elapsed).",
+            "interrupted": True,
+        }
+        assert server._extract_chat_reply_text(interrupted) == ""
+
+        normal = {"final_response": "The answer is 42.", "interrupted": False}
+        assert server._extract_chat_reply_text(normal) == "The answer is 42."
+
+    def test_background_complete_site_strips_sentinel(self):
+        """background.complete (hermes chat -q-style background task)."""
+        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+
+        interrupted = {
+            "final_response": f"{INTERRUPT_WAITING_FOR_MODEL_PREFIX}9s elapsed).",
+        }
+        assert server._extract_background_complete_text(interrupted) == ""
+
+        normal = {"final_response": "Done."}
+        assert server._extract_background_complete_text(normal) == "Done."
+
+        # run_conversation() can also return a bare string result.
+        assert server._extract_background_complete_text("Done.") == "Done."
+
+    def test_preview_restart_complete_site_strips_sentinel(self):
+        """preview.restart.complete (hidden restart-preview agent)."""
+        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+
+        interrupted = {
+            "final_response": f"{INTERRUPT_WAITING_FOR_MODEL_PREFIX}1.2s elapsed).",
+        }
+        assert server._extract_preview_restart_text(interrupted) == ""
+
+        normal = {"final_response": "Restarted."}
+        assert server._extract_preview_restart_text(normal) == "Restarted."
+        assert server._extract_preview_restart_text("Restarted.") == "Restarted."

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1125,11 +1125,7 @@ def _(rid, params: dict) -> dict:
                 parent,
                 {
                     "task_id": task_id,
-                    "text": (
-                        result.get("final_response", str(result))
-                        if isinstance(result, dict)
-                        else str(result)
-                    ),
+                    "text": _extract_background_complete_text(result),
                 },
             )
         except Exception as e:
@@ -1233,11 +1229,7 @@ def _(rid, params: dict) -> dict:
                 task_id=task_id,
                 conversation_history=parent_history or None,
             )
-            text = (
-                result.get("final_response", str(result))
-                if isinstance(result, dict)
-                else str(result)
-            )
+            text = _extract_preview_restart_text(result)
             _emit("preview.restart.complete", parent, {"task_id": task_id, "text": text})
         except Exception as e:
             _emit(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9758,6 +9758,51 @@ def _plan_goal_compression_recovery(
     )
 
 
+def _strip_interrupt_sentinel(text: str) -> str:
+    """Drop Hermes' local "waiting for model response" cancellation sentinel.
+
+    It's cancellation metadata, not assistant prose — ACP (#41720) and the
+    gateway's chat platforms (#7921) already suppress it before delivery;
+    the dashboard/TUI websocket surface never got the same guard, so it was
+    rendered verbatim as if the agent had actually said it.
+    """
+    from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+
+    if not text:
+        return ""
+    if str(text).strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX):
+        return ""
+    return text
+
+
+def _extract_chat_reply_text(result: dict) -> str:
+    """Sentinel-stripped ``final_response`` text for the main chat reply
+    (message.complete) delivery site."""
+    return _strip_interrupt_sentinel(result.get("final_response", ""))
+
+
+def _extract_background_complete_text(result: Any) -> str:
+    """Sentinel-stripped completion text for the background.complete
+    delivery site (a `hermes chat -q`-style background task)."""
+    raw = (
+        result.get("final_response", str(result))
+        if isinstance(result, dict)
+        else str(result)
+    )
+    return _strip_interrupt_sentinel(raw)
+
+
+def _extract_preview_restart_text(result: Any) -> str:
+    """Sentinel-stripped completion text for the preview.restart.complete
+    delivery site (the hidden restart-preview agent)."""
+    raw = (
+        result.get("final_response", str(result))
+        if isinstance(result, dict)
+        else str(result)
+    )
+    return _strip_interrupt_sentinel(raw)
+
+
 def _run_prompt_submit(
     rid,
     sid: str,
@@ -10213,7 +10258,7 @@ def _run_prompt_submit(
                     sid, session, clear_pending_title=False, restart_slash_worker=True,
                 )
 
-                raw = result.get("final_response", "")
+                raw = _extract_chat_reply_text(result)
                 status = (
                     "interrupted"
                     if result.get("interrupted")


### PR DESCRIPTION
## What does this PR do?
Hermes' local "waiting for model response" cancellation sentinel (`INTERRUPT_WAITING_FOR_MODEL_PREFIX`, e.g. `"Operation interrupted: waiting for model response (12.3s elapsed)."`) is cancellation metadata, not assistant prose. ACP already suppresses it (#41720) and the gateway's chat platforms just got the same guard today (#59559) — the dashboard/TUI websocket surface (`tui_gateway/server.py`) never did, at any of its three `final_response` delivery sites: the main chat reply, the `background.complete` event, and the `preview.restart.complete` event. Users would see the raw sentinel text rendered verbatim as if the agent had actually said it.

Fix: new `_strip_interrupt_sentinel()` helper (mirrors the existing `gateway/run.py` and `acp_adapter/server.py` checks against the same constant), wired into all three sites.

## Related Issue
No filed issue — found via sibling-gap review of #59559 (gateway chat platforms) and the pre-existing ACP guard (#41720), neither of which covered this third consumer.

## Type of Change
- [x] 🐛 Bug fix (UX/data leak — internal cancellation metadata rendered as assistant prose, same class as #7921/#41720)

## Changes Made
- `tui_gateway/server.py`: add `_strip_interrupt_sentinel()`, wire it into the 3 `final_response` delivery sites
- `tests/test_tui_gateway_server.py`: new `TestStripInterruptSentinel` class — unit tests for the helper plus an AST invariant pin asserting all 3 sites call it (verified: fails without the fix, passes with it)

## Note on a nearby open PR
No overlap with #54908 (open, unmerged), which touches the same function (`_run_prompt_submit`) but a different branch: it synthesizes a fallback ("The task completed." / turn-completion explainer) for `status == "complete"` turns with an empty/`"(empty)"` `final_response`. This fix only touches text carrying the interrupt sentinel prefix, which is produced specifically for interrupted turns — verified by reading its diff, the two changes touch nearby but disjoint branches.

## How to Test
```
python3.11 -m pytest tests/test_tui_gateway_server.py::TestStripInterruptSentinel -v --override-ini="addopts="
```
Also re-ran the full file to confirm no regressions: 309 passed, 1 pre-existing failure unrelated to this change (`test_browser_manage_connect_default_local_reports_launch_hint`, fails identically on main without this diff — local macOS test box has no Chromium binary).

## Checklist
- [x] Read the Contributing Guide | Conventional Commits | No duplicate PR
- [x] Single logical fix | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A