### PR TITLE
fix(desktop): show session title actions in pop-out windows

### DIFF
--- a/apps/desktop/src/app/chat/header-state.test.ts
+++ b/apps/desktop/src/app/chat/header-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { HERMES_WINDOW_TITLE, shouldShowChatHeader, windowTitleForChat } from './header-state'
+
+describe('shouldShowChatHeader', () => {
+  it('keeps the clickable title header for loaded session pop-out windows', () => {
+    expect(
+      shouldShowChatHeader({
+        activeSessionId: 'runtime-1',
+        isRoutedSessionView: false,
+        selectedSessionId: 'stored-1'
+      })
+    ).toBe(true)
+  })
+
+  it('keeps the header while a routed secondary session is still resolving', () => {
+    expect(
+      shouldShowChatHeader({
+        activeSessionId: null,
+        isRoutedSessionView: true,
+        selectedSessionId: null
+      })
+    ).toBe(true)
+  })
+
+  it('hides the header only for a truly empty draft', () => {
+    expect(
+      shouldShowChatHeader({
+        activeSessionId: null,
+        isRoutedSessionView: false,
+        selectedSessionId: null
+      })
+    ).toBe(false)
+  })
+})
+
+describe('windowTitleForChat', () => {
+  it('uses the session title in the native window title', () => {
+    expect(windowTitleForChat('Mission Control')).toBe('Mission Control — Hermes')
+  })
+
+  it('falls back to Hermes for empty titles', () => {
+    expect(windowTitleForChat('   ')).toBe(HERMES_WINDOW_TITLE)
+  })
+})

--- a/apps/desktop/src/app/chat/header-state.ts
+++ b/apps/desktop/src/app/chat/header-state.ts
@@ -1,0 +1,23 @@
+export interface ChatHeaderVisibilityInput {
+  activeSessionId: null | string
+  isRoutedSessionView: boolean
+  selectedSessionId: null | string
+}
+
+export const HERMES_WINDOW_TITLE = 'Hermes'
+
+export function shouldShowChatHeader({
+  activeSessionId,
+  isRoutedSessionView,
+  selectedSessionId
+}: ChatHeaderVisibilityInput): boolean {
+  // Session pop-out windows still need the same clickable title/actions header
+  // as the primary chat. Only a true empty draft has nothing meaningful to show.
+  return Boolean(selectedSessionId || activeSessionId || isRoutedSessionView)
+}
+
+export function windowTitleForChat(title: string): string {
+  const trimmed = title.trim()
+
+  return trimmed && trimmed !== HERMES_WINDOW_TITLE ? `${trimmed} — ${HERMES_WINDOW_TITLE}` : HERMES_WINDOW_TITLE
+}

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -7,7 +7,7 @@ import {
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
-import { Suspense, useCallback, useMemo, useRef } from 'react'
+import { Suspense, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { Thread } from '@/components/assistant-ui/thread'
@@ -57,6 +57,7 @@ import { ChatBar, ChatBarFallback } from './composer'
 import { requestComposerInsert, requestComposerInsertRefs } from './composer/focus'
 import { droppedFileInlineRefs, type SessionDragPayload, sessionInlineRef } from './composer/inline-refs'
 import type { ChatBarState } from './composer/types'
+import { shouldShowChatHeader, windowTitleForChat } from './header-state'
 import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-actions'
 import { useFileDropZone } from './hooks/use-file-drop-zone'
 import { ScrollToBottomButton } from './scroll-to-bottom-button'
@@ -117,6 +118,10 @@ function ChatHeader({
 
   const title = activeStoredSession ? sessionTitle(activeStoredSession) : 'New session'
 
+  useEffect(() => {
+    document.title = windowTitleForChat(title)
+  }, [title])
+
   // Pins live on the durable lineage-root id, but selectedSessionId is the live
   // (tip) id — resolve through the loaded row so the menu reflects the pin
   // state after auto-compression rotates the id.
@@ -126,10 +131,10 @@ function ChatHeader({
       ? pinnedSessionIds.includes(selectedSessionId)
       : false
 
-  // Secondary windows (new-session scratch, subagent watch, cmd-click pop-out)
-  // are compact side panels — they drop the session-actions header + border
-  // entirely. A brand-new draft has nothing to pin/delete/rename either.
-  if (isSecondaryWindow() || (!selectedSessionId && !activeSessionId && !isRoutedSessionView)) {
+  // Session pop-outs should mirror the primary window title/action affordance so
+  // users can identify and rename each OS window. Only a brand-new draft has
+  // nothing to pin/delete/rename.
+  if (!shouldShowChatHeader({ activeSessionId, isRoutedSessionView, selectedSessionId })) {
     return null
   }
 
@@ -147,6 +152,7 @@ function ChatHeader({
           onDelete={selectedSessionId ? onDeleteSelectedSession : undefined}
           onPin={selectedSessionId ? onToggleSelectedPin : undefined}
           pinned={selectedIsPinned}
+          profile={activeStoredSession?.profile}
           sessionId={selectedSessionId || activeSessionId || ''}
           sideOffset={8}
           title={title}


### PR DESCRIPTION
## Summary
- keep the chat title/action header visible for routed session pop-out windows instead of suppressing it for every secondary window
- update the native Electron/browser document title from the active chat title so each pop-out is identifiable in OS window surfaces
- pass the resolved session profile into the header actions menu so rename/export keep the same profile context as sidebar actions

## Tests
- `npm run test:ui -- src/app/chat/header-state.test.ts`
- `npm run test:ui -- src/app/chat/sidebar/session-actions-menu.test.ts src/app/chat/header-state.test.ts`
- `npm run typecheck`
- `../../node_modules/.bin/eslint src/app/chat/index.tsx src/app/chat/header-state.ts src/app/chat/header-state.test.ts`
- `../../node_modules/.bin/prettier --check src/app/chat/index.tsx src/app/chat/header-state.ts src/app/chat/header-state.test.ts`
