### PR TITLE
feat(cli): add `hermes config remove <key>` subcommand (#59598)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4373,6 +4373,53 @@ def _set_nested(config, dotted_key: str, value):
         current[last] = value
 
 
+def _delete_nested(config, dotted_key: str) -> bool:
+    """Delete a value at an arbitrarily nested dotted key path.
+
+    Mirrors the navigation semantics of ``_set_nested`` (dict and list
+    traversal, numeric indices for lists) but performs a delete instead
+    of an assign. Returns ``True`` when a key was actually removed,
+    ``False`` when the key was absent or the path could not be navigated.
+
+    Empty parents are NOT pruned — a delete of ``a.b.c`` leaves ``a`` and
+    ``a.b`` as empty dicts. The user's existing config style is preserved
+    (no surprise cascade-rewrites).
+    """
+    parts = dotted_key.split(".")
+    current = config
+    for part in parts[:-1]:
+        if isinstance(current, list):
+            try:
+                idx = int(part)
+            except (TypeError, ValueError):
+                return False
+            if not (0 <= idx < len(current)):
+                return False
+            current = current[idx]
+        elif isinstance(current, dict):
+            if part not in current:
+                return False
+            current = current[part]
+        else:
+            return False
+    last = parts[-1]
+    if isinstance(current, list):
+        try:
+            idx = int(last)
+        except (TypeError, ValueError):
+            return False
+        if not (0 <= idx < len(current)):
+            return False
+        del current[idx]
+        return True
+    if isinstance(current, dict):
+        if last not in current:
+            return False
+        del current[last]
+        return True
+    return False
+
+
 def clear_model_endpoint_credentials(
     model_cfg: Dict[str, Any],
     *,
@@ -7883,6 +7930,85 @@ def set_config_value(key: str, value: str):
     print(f"✓ Set {key} = {_display_value} in {config_path}")
 
 
+def remove_config_value(key: str) -> None:
+    """Remove a configuration key from config.yaml.
+
+    Companion to :func:`set_config_value`. Where ``set`` writes a value
+    (creating intermediates), ``remove`` deletes a leaf key without
+    rewriting the rest of the file. Mirrors ``hermes config set``'s path
+    semantics — supports dotted keys and numeric list indices, refuses
+    managed-scope keys, and exits non-zero when the key is absent.
+
+    For env-shaped keys (API keys / tokens) the value is removed from
+    ``.env``; config.yaml is left untouched.
+    """
+    if is_managed():
+        managed_error("remove configuration values")
+        return
+
+    from hermes_cli import managed_scope
+
+    if managed_scope.is_key_managed(key):
+        managed_dir = managed_scope.get_managed_dir()
+        src = (managed_dir / "config.yaml") if managed_dir else "the managed scope"
+        print(
+            f"Cannot remove '{key}': it is managed by your administrator ({src}) "
+            f"and cannot be changed. Contact your administrator to modify it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    api_keys = {
+        'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY',
+        'VOICE_TOOLS_OPENAI_KEY', 'EXA_API_KEY', 'PARALLEL_API_KEY',
+        'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL', 'FIRECRAWL_GATEWAY_URL',
+        'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
+        'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
+        'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
+        'GITHUB_TOKEN', 'HONCHO_API_KEY',
+    }
+
+    upper_key = key.upper()
+    is_env_key = (
+        upper_key in api_keys
+        or upper_key.endswith(('_API_KEY', '_TOKEN'))
+        or upper_key.startswith('TERMINAL_SSH')
+    )
+    if is_env_key:
+        env_path = get_env_path()
+        if not env_path.exists():
+            print(f"✗ {key} not present in {env_path}", file=sys.stderr)
+            sys.exit(1)
+        removed = remove_env_value(upper_key)
+        if not removed:
+            print(f"✗ {key} not present in {env_path}", file=sys.stderr)
+            sys.exit(1)
+        print(f"✓ Removed {key} from {env_path}")
+        return
+
+    config_path = get_config_path()
+    if not config_path.exists():
+        print(f"✗ {key} not present in {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    user_config = {}
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            user_config = fast_safe_load(f) or {}
+    except Exception:
+        user_config = {}
+
+    if not _delete_nested(user_config, key):
+        print(f"✗ {key} not present in {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    ensure_hermes_home()
+    from utils import atomic_yaml_write
+    atomic_yaml_write(config_path, user_config, sort_keys=False)
+
+    print(f"✓ Removed {key} from {config_path}")
+
+
 # =============================================================================
 # Command handler
 # =============================================================================
@@ -7909,6 +8035,18 @@ def config_command(args):
             print("  hermes config set OPENROUTER_API_KEY sk-or-...")
             sys.exit(1)
         set_config_value(key, value)
+
+    elif subcmd in ("remove", "delete"):
+        key = getattr(args, 'key', None)
+        if not key:
+            print("Usage: hermes config remove <key>")
+            print()
+            print("Examples:")
+            print("  hermes config remove model.api_key")
+            print("  hermes config remove providers.hp-old-name")
+            print("  hermes config remove OPENROUTER_API_KEY")
+            sys.exit(1)
+        remove_config_value(key)
     
     elif subcmd == "path":
         print(get_config_path())
@@ -8017,6 +8155,7 @@ def config_command(args):
         print("  hermes config           Show current configuration")
         print("  hermes config edit      Open config in editor")
         print("  hermes config set <key> <value>   Set a config value")
+        print("  hermes config remove <key>         Remove a config key (alias: delete)")
         print("  hermes config check     Check for missing/outdated config")
         print("  hermes config migrate   Update config with new options")
         print("  hermes config path      Show config file path")

--- a/hermes_cli/subcommands/config.py
+++ b/hermes_cli/subcommands/config.py
@@ -34,6 +34,16 @@ def build_config_parser(subparsers, *, cmd_config: Callable) -> None:
     )
     config_set.add_argument("value", nargs="?", help="Value to set")
 
+    # config remove / config delete
+    config_remove = config_subparsers.add_parser(
+        "remove",
+        aliases=["delete"],
+        help="Remove a configuration key from config.yaml (or .env for API keys/tokens)",
+    )
+    config_remove.add_argument(
+        "key", help="Configuration key (e.g., model, terminal.backend, OPENROUTER_API_KEY)"
+    )
+
     # config path
     config_subparsers.add_parser("path", help="Print config file path")
 

--- a/tests/hermes_cli/test_remove_config_value.py
+++ b/tests/hermes_cli/test_remove_config_value.py
@@ -1,0 +1,182 @@
+"""Tests for remove_config_value + _delete_nested — companion to set_config_value.
+
+Covers issue #59598: ``hermes config remove <key>`` was missing — users had to
+fake it by setting the value to the empty string, which left a stale YAML key.
+
+These tests verify the four behaviours the issue calls out:
+
+1. Existing top-level keys are deleted cleanly (no empty-string residue).
+2. Nested dotted keys delete without touching siblings.
+3. Numeric list indices splice the element out.
+4. Missing keys exit non-zero with a clear message.
+
+Plus parity with :func:`set_config_value`:
+- Env-shaped keys (API keys / tokens) go to .env, not config.yaml.
+- Managed-scope keys refuse with a clear error.
+"""
+
+import argparse
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import (
+    _delete_nested,
+    config_command,
+    remove_config_value,
+    set_config_value,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(tmp_path):
+    """Point HERMES_HOME at a temp dir so tests never touch real config."""
+    env_file = tmp_path / ".env"
+    env_file.touch()
+    config_file = tmp_path / "config.yaml"
+    config_file.touch()
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        yield tmp_path
+
+
+def _read_env(tmp_path):
+    return (tmp_path / ".env").read_text()
+
+
+def _read_config(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    return config_path.read_text() if config_path.exists() else ""
+
+
+# ---------------------------------------------------------------------------
+# _delete_nested — pure unit tests
+# ---------------------------------------------------------------------------
+
+class TestDeleteNestedUnit:
+    def test_dict_top_level(self):
+        cfg = {"a": 1, "b": 2}
+        assert _delete_nested(cfg, "a") is True
+        assert cfg == {"b": 2}
+
+    def test_dict_nested(self):
+        cfg = {"a": {"b": {"c": 1, "d": 2}}}
+        assert _delete_nested(cfg, "a.b.c") is True
+        assert cfg == {"a": {"b": {"d": 2}}}
+
+    def test_missing_returns_false(self):
+        cfg = {"a": {"b": 1}}
+        assert _delete_nested(cfg, "a.c") is False
+        assert _delete_nested(cfg, "x.y.z") is False
+        # Tree untouched
+        assert cfg == {"a": {"b": 1}}
+
+    def test_list_index(self):
+        cfg = {"providers": ["alpha", "bravo", "charlie"]}
+        assert _delete_nested(cfg, "providers.1") is True
+        assert cfg == {"providers": ["alpha", "charlie"]}
+
+    def test_list_index_out_of_range(self):
+        cfg = {"providers": ["alpha"]}
+        assert _delete_nested(cfg, "providers.5") is False
+        assert cfg == {"providers": ["alpha"]}
+
+    def test_list_non_numeric_segment_returns_false(self):
+        cfg = {"providers": ["alpha"]}
+        assert _delete_nested(cfg, "providers.alpha") is False
+        assert cfg == {"providers": ["alpha"]}
+
+    def test_navigate_into_scalar_returns_false(self):
+        cfg = {"a": "scalar"}
+        assert _delete_nested(cfg, "a.b") is False
+
+    def test_empty_parents_not_pruned(self):
+        """Delete of a.b.c leaves a.b as an empty dict — by design."""
+        cfg = {"a": {"b": {"c": 1}}}
+        _delete_nested(cfg, "a.b.c")
+        assert cfg == {"a": {"b": {}}}
+
+
+# ---------------------------------------------------------------------------
+# remove_config_value — config.yaml paths
+# ---------------------------------------------------------------------------
+
+class TestRemoveFromConfigYaml:
+    def test_top_level_key(self, tmp_path):
+        set_config_value("model", "gpt-4o")
+        assert "model: gpt-4o" in _read_config(tmp_path)
+        remove_config_value("model")
+        assert "model" not in _read_config(tmp_path)
+
+    def test_nested_key(self, tmp_path):
+        set_config_value("terminal.backend", "docker")
+        set_config_value("terminal.cwd", "/tmp")
+        remove_config_value("terminal.backend")
+        cfg = _read_config(tmp_path)
+        assert "backend" not in cfg
+        # sibling preserved
+        assert "cwd" in cfg
+
+    def test_missing_key_exits_nonzero(self, tmp_path, capsys):
+        with pytest.raises(SystemExit) as exc:
+            remove_config_value("does.not.exist")
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "not present" in err
+
+    def test_remove_cleans_empty_string_residue(self, tmp_path):
+        """Issue #59598: ``set ... ''`` leaves a stale empty key — remove cleans it."""
+        set_config_value("providers.hp-old-name", "")
+        cfg_before = _read_config(tmp_path)
+        assert "hp-old-name" in cfg_before
+        remove_config_value("providers.hp-old-name")
+        assert "hp-old-name" not in _read_config(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# remove_config_value — .env paths (env-shaped keys)
+# ---------------------------------------------------------------------------
+
+class TestRemoveFromEnv:
+    def test_explicit_api_key(self, tmp_path):
+        set_config_value("OPENROUTER_API_KEY", "sk-test")
+        assert "OPENROUTER_API_KEY=sk-test" in _read_env(tmp_path)
+        remove_config_value("OPENROUTER_API_KEY")
+        assert "OPENROUTER_API_KEY" not in _read_env(tmp_path)
+
+    def test_suffix_match_api_key(self, tmp_path):
+        set_config_value("CUSTOM_API_KEY", "secret")
+        remove_config_value("CUSTOM_API_KEY")
+        assert "CUSTOM_API_KEY" not in _read_env(tmp_path)
+
+    def test_missing_env_key_exits_nonzero(self, tmp_path, capsys):
+        with pytest.raises(SystemExit) as exc:
+            remove_config_value("OPENAI_API_KEY")
+        assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# config_command dispatch (handler-level integration)
+# ---------------------------------------------------------------------------
+
+class TestConfigCommandDispatch:
+    def test_remove_subcommand(self, tmp_path, capsys):
+        set_config_value("model", "gpt-4o")
+        args = argparse.Namespace(key="model", config_command="remove")
+        config_command(args)
+        out = capsys.readouterr().out
+        assert "Removed" in out
+        assert "model" not in _read_config(tmp_path)
+
+    def test_delete_alias(self, tmp_path, capsys):
+        set_config_value("model", "gpt-4o")
+        # argparse normalises aliases to the canonical choice
+        args = argparse.Namespace(key="model", config_command="delete")
+        config_command(args)
+        assert "model" not in _read_config(tmp_path)
+
+    def test_missing_key_arg(self, tmp_path, capsys):
+        args = argparse.Namespace(key=None, config_command="remove")
+        with pytest.raises(SystemExit):
+            config_command(args)


### PR DESCRIPTION
Fixes #59598

## Summary

Adds a real `hermes config remove <key>` subcommand so users no longer have to fake key removal by setting the value to an empty string (which leaves stale YAML like `providers.hp-old-name: ''`).

## What changed

* `hermes config remove <key>` (and `delete` alias) deletes the key from `config.yaml`.
* Env-shaped keys (`*_API_KEY`, `*_TOKEN`, `TERMINAL_SSH_*`, explicit allowlist) delete from `~/.hermes/.env` instead — mirrors `set_config_value`'s routing.
* Numeric list indices splice the element out (`providers.2`), matching `_set_nested`'s navigation semantics.
* Managed-scope keys refuse with the same hard-reject message as `set`, preserving admin overrides.
* Missing keys exit non-zero with a clear "not present" message.
* New helper `_delete_nested` mirrors `_set_nested`'s dict/list traversal without creating intermediate containers or pruning empty parents.

## How to test

```bash
# 1. Add a value, then remove it cleanly
hermes config set providers.hp-old-name ""
hermes config remove providers.hp-old-name
hermes config show | grep hp-old-name          # → no output (clean)

# 2. Numeric list index
hermes config set custom_providers.0.api_key sk-x
hermes config remove custom_providers.0        # removes the whole entry

# 3. Env-shaped key routing
hermes config set OPENROUTER_API_KEY sk-test
hermes config remove OPENROUTER_API_KEY        # removes from .env, not config.yaml

# 4. Missing key exits non-zero
hermes config remove does.not.exist; echo $?    # → 1
```

## Test plan

* 18 new tests in `tests/hermes_cli/test_remove_config_value.py` (pure `_delete_nested` unit + `remove_config_value` integration + `config_command` dispatch for both `remove` and `delete`).
* All 37 existing `set_config_value` tests still pass.
* Local run: `bash scripts/run_tests.sh tests/hermes_cli/test_remove_config_value.py -q` → **18 passed in 1.02s**.

## Platforms tested

* Linux (CI-equivalent, `TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0 python -m pytest`)

## AI-assisted contribution

This PR was drafted as part of an automated contribution sweep driven by [peaks-loop](https://github.com/SquabbyZ/peaks-loop). All changes were generated by an AI coding assistant working from the issue body. The commit body and PR description are written for human reviewers — please flag anything that looks off.