### PR TITLE
fix: auto-detect K8s pods for Chromium sandbox bypass

### DIFF
--- a/tests/tools/test_browser_open_timeout.py
+++ b/tests/tools/test_browser_open_timeout.py
@@ -33,6 +33,27 @@ class TestSandboxBypass:
         monkeypatch.setattr(bt, "_running_in_docker", lambda: True)
         assert bt._needs_chromium_sandbox_bypass() is True
 
+    def test_k8s_pod_triggers_bypass(self, monkeypatch):
+        monkeypatch.setattr(bt, "_running_in_docker", lambda: False)
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+        assert bt._needs_chromium_sandbox_bypass() is True
+
+    def test_k8s_absent_does_not_trigger(self, monkeypatch):
+        monkeypatch.setattr(bt, "_running_in_docker", lambda: False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        # Ensure AppArmor sysctl is absent so we don't get a false positive.
+        import builtins
+
+        real_open = builtins.open
+
+        def _open(path, *args, **kwargs):
+            if "apparmor_restrict_unprivileged_userns" in str(path):
+                raise FileNotFoundError(path)
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", _open)
+        assert bt._needs_chromium_sandbox_bypass() is False
+
     def test_apparmor_userns_triggers_bypass(self, monkeypatch, tmp_path):
         monkeypatch.setattr(bt, "_running_in_docker", lambda: False)
         sysctl = tmp_path / "apparmor_restrict_unprivileged_userns"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -304,6 +304,12 @@ def _needs_chromium_sandbox_bypass() -> bool:
         return True
     if _running_in_docker():
         return True
+    # Kubernetes pods: restricted security contexts (drop ALL capabilities,
+    # seccomp, read-only rootfs) prevent Chrome's sandbox from creating
+    # user namespaces. KUBERNETES_SERVICE_HOST is injected by the kubelet
+    # into every container.
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        return True
     userns_restrict = "/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
     try:
         with open(userns_restrict, encoding="utf-8") as f:


### PR DESCRIPTION
## Problem

When Hermes Agent runs inside a Kubernetes pod with a restricted security context (drop ALL capabilities, seccomp `RuntimeDefault`, read-only rootfs, non-root uid), Chrome's sandbox fails to start because it cannot create the user namespaces it requires. The browser hits a `No usable sandbox!` error on startup.

The existing `_needs_chromium_sandbox_bypass()` function in `tools/browser_tool.py` detects three cases:
1. running as root (`os.geteuid() == 0`)
2. running inside Docker (`_running_in_docker()`)
3. AppArmor unprivileged userns restriction (`/proc/sys/kernel/apparmor_restrict_unprivileged_userns == 1`)

It does **not** detect Kubernetes pods, so users running Hermes in K8s must manually set `AGENT_BROWSER_ARGS=--no-sandbox` to get a working browser.

## Fix

Add a K8s pod detection check between the Docker check and the AppArmor check. The kubelet injects `KUBERNETES_SERVICE_HOST` into every container in a pod, so its presence is a reliable signal that we're in K8s:

```python
# Kubernetes pods: restricted security contexts (drop ALL capabilities,
# seccomp, read-only rootfs) prevent Chrome's sandbox from creating
# user namespaces. KUBERNETES_SERVICE_HOST is injected by the kubelet
# into every container.
if os.environ.get("KUBERNETES_SERVICE_HOST"):
    return True
```

This makes `--no-sandbox` auto-inject in K8s environments, so the browser starts reliably without any user config.

## Tests

Added two cases to `tests/tools/test_browser_open_timeout.py`:
- `test_k8s_pod_triggers_bypass`: `KUBERNETES_SERVICE_HOST` set -> bypass returns True
- `test_k8s_absent_does_not_trigger`: env var unset, no other triggers -> bypass returns False

All 11 tests in the file pass.

## Verification

```
$ uv run --with pytest pytest tests/tools/test_browser_open_timeout.py -x -q
...........                                                              [100%]
11 passed in 1.36s
```