### PR TITLE
fix(tui): avoid duplicate assistant reply on session resume

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6638,6 +6638,8 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     """
     started = threading.Event()
     release = threading.Event()
+    history_committed = threading.Event()
+    finish_completion = threading.Event()
     done = threading.Event()
 
     class _Agent:
@@ -6660,7 +6662,14 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
 
     server._sessions["sid-live"] = _session(agent=_Agent())
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
-    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+
+    def _render_message(raw, cols):
+        # render_message runs after history commit but before message.complete.
+        history_committed.set()
+        assert finish_completion.wait(2), "test timed out waiting to finish completion"
+        return None
+
+    monkeypatch.setattr(server, "render_message", _render_message)
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "_session_info", lambda agent: {"model": agent.model})
 
@@ -6698,6 +6707,22 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
         assert resp["result"]["messages"] == []
 
         release.set()
+        assert history_committed.wait(2), "completed history was not committed"
+
+        at_commit_boundary = server.handle_request(
+            {
+                "id": "activate-committing",
+                "method": "session.activate",
+                "params": {"session_id": "sid-live"},
+            }
+        )
+        assert at_commit_boundary["result"].get("inflight") is None
+        assert at_commit_boundary["result"]["messages"] == [
+            {"role": "user", "text": "write a long answer"},
+            {"role": "assistant", "text": "partial answer complete"},
+        ]
+
+        finish_completion.set()
         assert done.wait(2), "fake model turn did not complete"
         completed = server.handle_request(
             {
@@ -6713,6 +6738,7 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
         ]
     finally:
         release.set()
+        finish_completion.set()
         done.wait(2)
         server._sessions.pop("sid-live", None)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9149,6 +9149,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
 
             last_reasoning = None
             status_note = None
+            inflight_cleared_with_history = False
             if isinstance(result, dict):
                 if isinstance(result.get("messages"), list):
                     with session["history_lock"]:
@@ -9156,6 +9157,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         if current_version == history_version:
                             session["history"] = result["messages"]
                             session["history_version"] = history_version + 1
+                            _clear_inflight_turn(session)
+                            inflight_cleared_with_history = True
                         else:
                             # History mutated externally during the turn
                             # (undo/compress/retry/rollback now guard on
@@ -9219,8 +9222,9 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             rendered = render_message(raw, cols)
             if rendered:
                 payload["rendered"] = rendered
-            with session["history_lock"]:
-                _clear_inflight_turn(session)
+            if not inflight_cleared_with_history:
+                with session["history_lock"]:
+                    _clear_inflight_turn(session)
             _emit("message.complete", sid, payload)
 
             # ── /goal continuation (Ralph-style loop) ─────────────────


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate assistant replies when the TUI activates or resumes a live session at the turn-completion boundary.

The gateway previously wrote the completed assistant reply to `session["history"]` and only cleared `inflight_turn` later, after rendering the completion payload. `session.activate` snapshots both values under `history_lock`, so it could briefly return the same reply in the transcript and as a `streaming: true` live tail.

This change commits completed history and clears its corresponding inflight turn in one atomic session-state transition. The existing live-stream behavior remains unchanged before history is committed, and history-version mismatch handling retains its previous cleanup timing and warning behavior.

## Related Issue

Fixes #59423

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tui_gateway/server.py`: clear the inflight turn under the same `history_lock` used to commit version-matched completed history.
- `tests/test_tui_gateway_server.py`: pause after history commit but before `message.complete`, activate the session at that boundary, and assert the payload contains the transcript without a duplicate inflight tail.

## How to Test

1. Start a live TUI turn and activate the session while output is still streaming; the partial inflight assistant text is returned.
2. Complete the model turn and activate again after history commit but before `message.complete`; the completed transcript is returned without `inflight`.
3. Verify the normal completed activation still returns the transcript without `inflight`.

Checks run locally:

- [x] `python -m pytest tests/test_tui_gateway_server.py -q -k "session_activate or prompt_submit_history_version"` (4 passed)
- [x] `python -m ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- [x] `python -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 / PowerShell

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered: session-state locking only
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

N/A - backend session-state race covered by a deterministic activation regression test.
