### PR TITLE
fix(plugins): support legacy terminal output hooks

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1167,8 +1167,58 @@ class PluginContext:
                 hook_name,
                 ", ".join(sorted(VALID_HOOKS)),
             )
+        if hook_name == "transform_terminal_output":
+            callback = self._wrap_legacy_transform_terminal_output_hook(callback)
         self._manager._hooks.setdefault(hook_name, []).append(callback)
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
+
+    def _wrap_legacy_transform_terminal_output_hook(
+        self,
+        callback: Callable,
+    ) -> Callable:
+        """Adapt the legacy ``(output, context)`` terminal-output hook shape."""
+        try:
+            sig = inspect.signature(callback)
+        except (TypeError, ValueError):
+            return callback
+
+        params = list(sig.parameters.values())
+        has_var_keyword = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in params
+        )
+        if has_var_keyword:
+            return callback
+
+        positional = [
+            p
+            for p in params
+            if p.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        ]
+        if [p.name for p in positional] != ["output", "context"]:
+            return callback
+
+        logger.warning(
+            "Plugin '%s' registered transform_terminal_output using the legacy "
+            "(output, context) signature. Wrapping it for compatibility; update "
+            "the plugin to accept keyword arguments.",
+            self.manifest.name,
+        )
+
+        def _compat_transform_terminal_output(**kwargs: Any) -> Any:
+            output = kwargs.get("output", "")
+            context = {k: v for k, v in kwargs.items() if k != "output"}
+            return callback(output, context)
+
+        _compat_transform_terminal_output.__name__ = getattr(
+            callback,
+            "__name__",
+            "legacy_transform_terminal_output",
+        )
+        return _compat_transform_terminal_output
 
     # -- middleware registration -------------------------------------------
 

--- a/tests/hermes_cli/test_plugin_hook_compat.py
+++ b/tests/hermes_cli/test_plugin_hook_compat.py
@@ -1,0 +1,47 @@
+"""Compatibility tests for legacy plugin hook signatures."""
+
+import logging
+
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+
+def test_legacy_transform_terminal_output_hook_warns_once_and_runs(caplog):
+    calls = []
+
+    def legacy_transform(output, context):
+        calls.append((output, dict(context)))
+        return f"{context['command']}|{context['returncode']}|{output}"
+
+    manager = PluginManager()
+    ctx = PluginContext(PluginManifest(name="legacy-plugin", source="user"), manager)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+        ctx.register_hook("transform_terminal_output", legacy_transform)
+        first = manager.invoke_hook(
+            "transform_terminal_output",
+            command="echo hello",
+            output="abcdef",
+            returncode=7,
+            task_id="task-1",
+            env_type="local",
+        )
+        second = manager.invoke_hook(
+            "transform_terminal_output",
+            command="printf ok",
+            output="xyz",
+            returncode=0,
+            task_id="task-2",
+            env_type="local",
+        )
+
+    assert first == ["echo hello|7|abcdef"]
+    assert second == ["printf ok|0|xyz"]
+    assert calls[0][1]["task_id"] == "task-1"
+    assert calls[1][1]["env_type"] == "local"
+
+    warnings = [
+        record.message
+        for record in caplog.records
+        if "legacy (output, context) signature" in record.message
+    ]
+    assert len(warnings) == 1


### PR DESCRIPTION
## What does this PR do?

Adds a compatibility wrapper for plugins that still register `transform_terminal_output` with the legacy `(output, context)` callback signature.

The wrapper is installed at hook registration time, so old plugins keep working and the migration warning is emitted once when the hook is registered rather than on every terminal-output hook invocation. Existing keyword-argument style hooks continue to run unchanged.

## Related Issue

Fixes #59262

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/plugins.py`
  - Detects legacy `transform_terminal_output(output, context)` callbacks when hooks are registered.
  - Wraps legacy callbacks so they receive the current hook payload as `context` without raising per invocation.
  - Logs a single registration-time migration warning.
- `tests/hermes_cli/test_plugin_hook_compat.py`
  - Adds regression coverage that the legacy hook runs on repeated invocations and warns only once.

## How to Test

1. `uv run --extra dev pytest tests/hermes_cli/test_plugin_hook_compat.py tests/tools/test_terminal_output_transform_hook.py -q`
2. `uv run --extra dev pytest tests/hermes_cli/test_plugins.py::TestPluginHooks -q`
3. `python -m py_compile hermes_cli/plugins.py tests/hermes_cli/test_plugin_hook_compat.py tests/hermes_cli/test_plugins.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 / Python 3.11.9

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

N/A