### PR TITLE
fix(qqbot): add missing is_reconnect parameter to connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
`BasePlatformAdapter.connect()` declares `async def connect(self, *, is_reconnect: bool = False) -> bool` (base.py:2864), but `QQAdapter.connect()` only has `async def connect(self) -> bool`, missing the `is_reconnect` keyword.

When the gateway attempts to reconnect the QQ bot platform, it calls `adapter.connect(is_reconnect=True)`, causing a `TypeError` because QQAdapter doesn't accept the parameter. This makes reconnection impossible without a gateway restart.

Fix: add the `*, is_reconnect: bool = False` parameter to QQAdapter.connect(), matching the base class signature.