### PR TITLE
fix(dashboard-auth): skip auto-SSO redirect for password-only providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,16 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+
+    # Auto-SSO is only meaningful for OAuth/redirect providers.  A
+    # pure-password provider (supports_password=True, e.g. basic) has no
+    # IDP to silently bounce to — its start_login() raises
+    # NotImplementedError.  Return None so the caller falls through to
+    # _unauth_response, which renders the /login interstitial with the
+    # password form.
+    if getattr(provider, "supports_password", False):
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -593,3 +593,50 @@ def test_unverifiable_token_with_reachable_providers_redirects(_gated_state):
     r = client.get("/api/auth/me")
     assert r.status_code == 401
     assert "unreachable" not in r.text.lower()
+
+
+def test_auto_sso_skips_password_only_provider():
+    """When the sole provider is password-only (e.g. basic), auto-SSO must NOT
+    redirect to /auth/login (which would hit start_login() and crash with
+    NotImplementedError).  Instead the middleware should fall through to
+    _unauth_response → /login, where the password form renders.
+
+    Regression guard for #56067 / #57211 / #58166.
+    """
+    from plugins.dashboard_auth.basic import BasicAuthProvider, hash_password
+
+    clear_providers()
+    register_provider(
+        BasicAuthProvider(
+            username="admin",
+            password_hash=hash_password("test-password"),
+            secret=b"test-secret-at-least-16-bytes!!",
+        )
+    )
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    try:
+        client = TestClient(
+            web_server.app, base_url="https://fly-app.fly.dev"
+        )
+        r = client.get("/", follow_redirects=False)
+        assert r.status_code == 302, (
+            f"Expected 302, got {r.status_code}: {r.text}"
+        )
+        # Must redirect to /login (password form), NOT /auth/login (OAuth).
+        location = r.headers["location"]
+        assert "/login" in location, f"Expected redirect to /login, got {location}"
+        assert "/auth/login" not in location, (
+            f"auto-SSO must NOT redirect to /auth/login for a password-only "
+            f"provider — that would crash with NotImplementedError. "
+            f"Got: {location}"
+        )
+    finally:
+        clear_providers()
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port
+        web_server.app.state.auth_required = prev_required


### PR DESCRIPTION
When the sole registered auth provider is password-only (supports_password=True, e.g. BasicAuthProvider), _auto_sso_response redirected to /auth/login which calls start_login() — a method that pure-password providers implement as a NotImplementedError stub. This crashed the dashboard with HTTP 500 on first load.

Now _auto_sso_response returns None for password-only providers, falling through to _unauth_response which correctly renders the /login page with the password form.

Fixes #56067, #57211, #58166

## What does this PR do?

Hermes dashboard auto-SSO silently redirects to `/auth/login` when exactly one auth provider is registered, skipping the login chooser. However, `BasicAuthProvider` is password-only — its `start_login()` method raises `NotImplementedError` (by design). 

When basic auth is the only provider, the redirect hits `start_login()` and crashes the dashboard with an HTTP 500.

This PR adds a `supports_password` guard in `_auto_sso_response` so password-only providers fall through to `_unauth_response` → `/login`. Users now see the password login form instead of a server crash.

## Related Issue

Fixes #56067
Fixes #57211
Fixes #58166

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/dashboard_auth/middleware.py`**: Added an early return in `_auto_sso_response()` when `provider.supports_password is True`.
- **`tests/hermes_cli/test_dashboard_auth_middleware.py`**: Added the regression test `test_auto_sso_skips_password_only_provider` to ensure `BasicAuthProvider` correctly routes to `/login` without crashing.

## How to Test

1. Configure `hermes-agent` with exactly one auth provider: `basic`.
2. Visit the dashboard root URL (`/`) without an active session cookie.
3. Observe that you are safely redirected to the `/login` page containing the basic auth form, rather than encountering an HTTP 500 crash.
4. Run `pytest tests/hermes_cli/test_dashboard_auth_middleware.py -v` and observe that the new test `test_auto_sso_skips_password_only_provider` passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## AI Usage Disclosure
- IDE: Antigravity IDE
- Model: Gemini 3.1 Pro
- Used for: Writing tests