### PR TITLE
feat(cron): make BLOCK_RECURANCE_LIMIT configurable (#59333)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -366,6 +366,35 @@ browser:
   inactivity_timeout: 120
 
 # =============================================================================
+# Kanban Board (multi-agent coordination)
+# =============================================================================
+# The kanban dispatcher coordinates workers across profiles. Most options live
+# in the in-tree defaults; only the knobs users commonly need to tune are
+# surfaced here. See `hermes_cli/kanban_db.py` for the full schema.
+#
+kanban:
+  # Auto-block a task after this many consecutive non-success attempts
+  # (spawn_failed, timed_out, crashed). Reassignment to a new profile resets
+  # the streak. Default 2.
+  # failure_limit: 2
+
+  # Unblock-loop breaker: after a task has been blocked → unblocked →
+  # re-blocked this many times for the SAME kind, route it to ``triage``
+  # instead of ``blocked`` so a cron can't keep flipping it forever. Default
+  # 2. Raise this if your pipeline legitimately needs more than two passes
+  # through the unblock↔re-block cycle (issue #59333).
+  # block_recurrence_limit: 2
+
+  # Seconds between dispatcher ticks. Lower = snappier pickup; higher = less
+  # SQL pressure. Default 60.
+  # dispatch_interval_seconds: 60
+
+  # Stale detection: running tasks whose last heartbeat is older than this
+  # many seconds are auto-reclaimed to ``ready`` on the next tick (and the
+  # worker is terminated). 0 disables stale detection entirely.
+  # dispatch_stale_timeout_seconds: 14400
+
+# =============================================================================
 # Tool Loop Guardrails
 # =============================================================================
 # Soft warnings are enabled by default. They append guidance to repeated failed

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -131,10 +131,102 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # human-in-the-loop decision. Mirrors the dispatcher's ``DEFAULT_FAILURE_LIMIT``
 # spirit (default 2) but counts a different signal: manual unblock recurrences,
 # not dispatcher spawn/crash/timeout failures.
+#
+# Configurable at runtime via ``kanban.block_recurrence_limit`` in
+# ``~/.hermes/config.yaml`` (issue #59333). The hard-coded value below stays
+# as the fallback default so legacy installs and external code that imports
+# ``BLOCK_RECURRENCE_LIMIT`` keep working unchanged. See
+# :func:`get_block_recurrence_limit` for the resolved-at-call-site reader.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
+
+
+def get_block_recurrence_limit() -> int:
+    """Resolve the effective unblock-loop recurrence limit at call time.
+
+    Resolution order:
+
+      1. ``kanban.block_recurrence_limit`` from ``~/.hermes/config.yaml`` —
+         the user-configurable override added in #59333. A positive int wins;
+         any other value (None, missing key, non-int, string, list, <=0) is
+         ignored and falls through to the default.
+      2. :data:`BLOCK_RECURRENCE_LIMIT` — the hard-coded default (2). Keeps
+         legacy installs and external imports of the constant working
+         unchanged.
+
+    Reading the config fresh on each call (rather than caching at module
+    import) means runtime edits to ``config.yaml`` are picked up by the next
+    ``block_task`` invocation without restarting the dispatcher. The
+    underlying ``load_config()`` is itself mtime-cached, so the read cost
+    is negligible — sub-millisecond on a warm cache.
+
+    The function never raises: a broken or missing config falls back to
+    the default with a single ``_log.warning`` so a misconfigured user
+    doesn't break ``block_task``.
+    """
+    raw = None
+    try:
+        # Lazy import: ``hermes_cli.config`` pulls in YAML + a sizeable
+        # transitive set, and ``kanban_db`` is imported very early by
+        # dispatcher / gateway / dashboard / test paths. A function-level
+        # import keeps cold-start cost out of the common case where the
+        # override is absent.
+        from hermes_cli.config import load_config
+
+        kanban_cfg = (load_config().get("kanban") or {})
+        raw = kanban_cfg.get("block_recurrence_limit")
+    except Exception as exc:  # pragma: no cover - defensive
+        _log.warning(
+            "kanban.block_recurrence_limit: failed to read config (%s); "
+            "using default %d",
+            exc, BLOCK_RECURRENCE_LIMIT,
+        )
+        return BLOCK_RECURRENCE_LIMIT
+
+    if raw is None:
+        return BLOCK_RECURRENCE_LIMIT
+
+    # bool is a subclass of int in Python — reject it explicitly so
+    # ``True``/``False`` don't silently become 1/0.
+    if isinstance(raw, bool):
+        _log.warning(
+            "kanban.block_recurrence_limit=%r is a bool; using default %d",
+            raw, BLOCK_RECURRENCE_LIMIT,
+        )
+        return BLOCK_RECURRENCE_LIMIT
+
+    # Accept ints directly. Coerce numeric strings (e.g. "5" from a
+    # hand-edited YAML) but reject anything that doesn't parse cleanly.
+    if isinstance(raw, int):
+        value = raw
+    elif isinstance(raw, str):
+        try:
+            value = int(raw.strip())
+        except (TypeError, ValueError):
+            _log.warning(
+                "kanban.block_recurrence_limit=%r is not a positive int; "
+                "using default %d",
+                raw, BLOCK_RECURRENCE_LIMIT,
+            )
+            return BLOCK_RECURRENCE_LIMIT
+    else:
+        _log.warning(
+            "kanban.block_recurrence_limit=%r is not a positive int; "
+            "using default %d",
+            raw, BLOCK_RECURRENCE_LIMIT,
+        )
+        return BLOCK_RECURRENCE_LIMIT
+
+    if value < 1:
+        _log.warning(
+            "kanban.block_recurrence_limit=%d is below 1; using default %d",
+            value, BLOCK_RECURRENCE_LIMIT,
+        )
+        return BLOCK_RECURRENCE_LIMIT
+
+    return value
 
 
 def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None:
@@ -4649,7 +4741,11 @@ def block_task(
         same_cause = prev_kind == kind
         recurrences = prev_recurrences + 1 if same_cause else 1
 
-        if recurrences >= BLOCK_RECURRENCE_LIMIT:
+        # Resolve the loop-breaker threshold from config so users can raise it
+        # without editing code (#59333). Falls back to the module constant
+        # when the config key is missing / invalid.
+        recurrence_limit = get_block_recurrence_limit()
+        if recurrences >= recurrence_limit:
             # Loop detected — stop letting the unblocker spin this task. Route
             # to triage for a human-in-the-loop decision instead of blocked.
             cur = conn.execute(
@@ -4684,7 +4780,7 @@ def block_task(
                     "reason": reason,
                     "kind": kind,
                     "recurrences": recurrences,
-                    "limit": BLOCK_RECURRENCE_LIMIT,
+                    "limit": recurrence_limit,
                 },
                 run_id=run_id,
             )

--- a/tests/cron/test_block_recurrence_config.py
+++ b/tests/cron/test_block_recurrence_config.py
@@ -1,0 +1,288 @@
+"""Tests for the configurable ``kanban.block_recurrence_limit`` (issue #59333).
+
+Covers the user-facing knob that lets pipelines raise the unblock-loop
+breaker above the hard-coded default of 2 without editing ``kanban_db.py``.
+The constant ``BLOCK_RECURRENCE_LIMIT`` stays as the legacy fallback so
+existing imports keep working; the new resolver
+:func:`hermes_cli.kanban_db.get_block_recurrence_limit` is the call-site
+read path that ``block_task`` uses.
+
+Each test writes its own minimal ``~/.hermes/config.yaml`` under the
+hermetic ``HERMES_HOME`` provided by ``tests/conftest.py`` and asserts the
+resolver behaviour for one configuration shape. ``load_config`` is
+mtime-cached so a fresh write between tests is observed without any extra
+cache-busting.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_config(home: Path, body: str) -> Path:
+    """Write a raw YAML config under the test's HERMES_HOME.
+
+    We deliberately bypass ``save_config`` here: we want to test the
+    resolver's tolerance of hand-edited YAML, and ``save_config`` strips
+    keys whose values match ``DEFAULT_CONFIG`` (which would defeat the
+    whole point of these tests).
+    """
+    config_path = home / "config.yaml"
+    config_path.write_text(dedent(body).lstrip("\n"), encoding="utf-8")
+    return config_path
+
+
+def _running_task(conn):
+    """Create a task and drive it to ``running`` so block_task can act."""
+    tid = kb.create_task(conn, title="t", assignee="worker")
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    assert kb.claim_task(conn, tid, claimer="worker") is not None
+    return tid
+
+
+def _make_running_again(conn, tid):
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    assert kb.claim_task(conn, tid, claimer="worker") is not None
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Hermetic HERMES_HOME wired to ``init_db`` for end-to-end block_task tests."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Default behaviour — config key absent
+# ---------------------------------------------------------------------------
+
+
+def test_default_when_config_missing(kanban_home: Path) -> None:
+    """No config.yaml at all → resolver falls back to the module default (2)."""
+    assert not (kanban_home / "config.yaml").exists()
+    assert kb.get_block_recurrence_limit() == kb.BLOCK_RECURRENCE_LIMIT == 2
+
+
+def test_default_when_kanban_section_present_but_key_missing(
+    kanban_home: Path,
+) -> None:
+    """``kanban:`` exists but ``block_recurrence_limit`` is unset → default."""
+    _write_config(
+        kanban_home,
+        """
+        kanban:
+          failure_limit: 5
+          dispatch_interval_seconds: 30
+        """,
+    )
+    assert kb.get_block_recurrence_limit() == 2
+
+
+# ---------------------------------------------------------------------------
+# Custom value applied when config key present
+# ---------------------------------------------------------------------------
+
+
+def test_custom_int_value_applied(kanban_home: Path) -> None:
+    """A positive int override is honoured."""
+    _write_config(
+        kanban_home,
+        """
+        kanban:
+          block_recurrence_limit: 5
+        """,
+    )
+    assert kb.get_block_recurrence_limit() == 5
+
+
+def test_custom_numeric_string_coerced(kanban_home: Path) -> None:
+    """Hand-edited YAML often yields strings — coerce when possible."""
+    _write_config(
+        kanban_home,
+        """
+        kanban:
+          block_recurrence_limit: "7"
+        """,
+    )
+    assert kb.get_block_recurrence_limit() == 7
+
+
+def test_other_kanban_keys_ignored(kanban_home: Path) -> None:
+    """Unrelated kanban settings don't accidentally trip the override."""
+    _write_config(
+        kanban_home,
+        """
+        kanban:
+          failure_limit: 99
+          dispatch_interval_seconds: 1
+        """,
+    )
+    # Still 2 — the user did not set the recurrence knob.
+    assert kb.get_block_recurrence_limit() == 2
+
+
+# ---------------------------------------------------------------------------
+# Invalid values fall back to default (never raise)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_yaml, description",
+    [
+        (
+            "kanban:\n  block_recurrence_limit: 0\n",
+            "zero is not a valid recurrence count",
+        ),
+        (
+            "kanban:\n  block_recurrence_limit: -3\n",
+            "negative values are rejected",
+        ),
+        (
+            "kanban:\n  block_recurrence_limit: 'oops'\n",
+            "non-numeric strings fall through to the default",
+        ),
+        (
+            "kanban:\n  block_recurrence_limit: true\n",
+            "bools are rejected (not silently coerced to 1/0)",
+        ),
+        (
+            "kanban:\n  block_recurrence_limit: [1, 2]\n",
+            "lists are rejected",
+        ),
+        (
+            "kanban:\n  block_recurrence_limit: 1.5\n",
+            "floats are rejected (limit is a count, must be an int)",
+        ),
+    ],
+)
+def test_invalid_values_fall_back_to_default(
+    kanban_home: Path, bad_yaml: str, description: str
+) -> None:
+    """Any garbage value resolves to the default 2 — never raises."""
+    _write_config(kanban_home, bad_yaml)
+    assert kb.get_block_recurrence_limit() == 2, description
+
+
+# ---------------------------------------------------------------------------
+# Config reload picks up runtime changes
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_config_change_picked_up(kanban_home: Path) -> None:
+    """Edits to config.yaml between calls are honoured without a process restart.
+
+    ``load_config`` is mtime-cached, so writing the file with a new mtime is
+    sufficient to invalidate the cache on the next read. This is the
+    contract users will rely on when tweaking the value at runtime.
+    """
+    _write_config(
+        kanban_home,
+        """
+        kanban:
+          block_recurrence_limit: 3
+        """,
+    )
+    assert kb.get_block_recurrence_limit() == 3
+
+    # Rewrite with a different value. Use a fresh write (not append) so
+    # the mtime definitely advances even on coarse-grained filesystems.
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  block_recurrence_limit: 8\n", encoding="utf-8"
+    )
+    assert kb.get_block_recurrence_limit() == 8
+
+    # And removing the key drops back to the default.
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  failure_limit: 9\n", encoding="utf-8"
+    )
+    assert kb.get_block_recurrence_limit() == 2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the override actually changes block_task's routing behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_high_override_defers_triage_routing(kanban_home: Path) -> None:
+    """With ``block_recurrence_limit: 5``, a 2-cycle loop stays in ``blocked``.
+
+    Mirrors the original ``test_same_cause_reblock_routes_to_triage`` in
+    ``tests/hermes_cli/test_kanban_block_kinds.py`` but raises the limit so
+    the same two cycles do NOT trip the breaker. The task lands in
+    ``blocked`` (still inside the human bucket) until the user-configured
+    threshold is reached.
+    """
+    _write_config(
+        kanban_home,
+        """
+        kanban:
+          block_recurrence_limit: 5
+        """,
+    )
+
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        assert kb.block_task(conn, tid, reason="need creds", kind="needs_input")
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        assert kb.block_task(conn, tid, reason="still need creds", kind="needs_input")
+        t = kb.get_task(conn, tid)
+        # Default limit was 2 → would have routed to triage. With 5, still blocked.
+        assert t.status == "blocked"
+        assert t.block_recurrences == 2
+
+
+def test_override_at_threshold_routes_to_triage(kanban_home: Path) -> None:
+    """Hitting the configured limit still triggers the loop-breaker."""
+    _write_config(
+        kanban_home,
+        """
+        kanban:
+          block_recurrence_limit: 1
+        """,
+    )
+
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        # First block itself reaches the (lowered) limit → triage immediately.
+        assert kb.block_task(conn, tid, reason="x", kind="capability")
+        t = kb.get_task(conn, tid)
+        assert t.status == "triage"
+        # The block_loop_detected event records the effective limit, not
+        # the hard-coded constant.
+        events = [
+            e for e in kb.list_events(conn, tid)
+            if e.kind == "block_loop_detected"
+        ]
+        assert events, "expected a block_loop_detected event"
+        payload = events[-1].payload or {}
+        assert payload.get("limit") == 1
+
+
+# ---------------------------------------------------------------------------
+# Legacy constant still importable (back-compat)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_constant_still_exported() -> None:
+    """External callers that import ``BLOCK_RECURRENCE_LIMIT`` keep working."""
+    assert hasattr(kb, "BLOCK_RECURRENCE_LIMIT")
+    assert kb.BLOCK_RECURRENCE_LIMIT == 2


### PR DESCRIPTION
Fixes #59333

AI-assisted fix by https://github.com/SquabbyZ/peaks-loop

## Problem
The unblock-loop breaker's threshold (`BLOCK_RECURRENCE_LIMIT`) was hard-coded to 2 in `hermes_cli/kanban_db.py`. Pipelines that legitimately need more than two passes through the blocked → unblocked → re-blocked cycle got broken on every Hermes update, because the hard-coded value overwrote any local edit.

## Solution
Add a runtime config knob `kanban.block_recurrence_limit` in `~/.hermes/config.yaml`, resolved by a new `get_block_recurrence_limit()` reader. The hard-coded `BLOCK_RECURRENCE_LIMIT = 2` constant is preserved as the fallback default so existing installs and any external imports keep working unchanged.

* Reads `kanban.block_recurrence_limit` fresh on each call — picks up runtime edits to `config.yaml` without restarting the dispatcher.
* Falls back to the default on missing key, invalid value (None, zero, negative, non-numeric string, bool, list, float), or config parse error. Never raises; logs a single warning.
* Surfaces the new knob (alongside the existing kanban settings) in a new `# Kanban Board (multi-agent coordination)` section of `cli-config.yaml.example` so users can discover it.

## Files
- `hermes_cli/kanban_db.py`: Add `get_block_recurrence_limit()`; route the two runtime uses through it.
- `cli-config.yaml.example`: Document the new knob and the most common kanban settings.
- `tests/cron/test_block_recurrence_config.py`: 15 tests covering default fallback, custom values, string coercion, six invalid-input cases, runtime config reload, end-to-end `block_task` routing under both raised and lowered thresholds, and the legacy constant export.

## Tests
`C:/Users/smallMark/.hermes/venvs/hermes-dev/Scripts/python.exe -m pytest tests/cron/test_block_recurrence_config.py tests/hermes_cli/test_kanban_block_kinds.py -v` → 26/26 passing. No regressions in the existing block_kinds suite.

AI-assisted fix by https://github.com/SquabbyZ/peaks-loop