### PR TITLE
fix(display): omit URL userinfo from tool progress

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from difflib import unified_diff
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from utils import safe_json_loads
 from agent.redact import redact_sensitive_text
@@ -1278,6 +1279,22 @@ def get_cute_tool_message(
         limit = _tool_preview_max_len
         return ("..." + p[-(limit-3):]) if len(p) > limit else p
 
+    def _display_url_host(url) -> str:
+        raw = str(url or "").strip()
+        if not raw:
+            return ""
+        parsed = urlparse(raw if "://" in raw else f"//{raw}")
+        host = parsed.hostname
+        if not host:
+            return raw.replace("https://", "").replace("http://", "").split("/")[0]
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        return f"{host}:{port}" if port is not None else host
+
     def _wrap(line: str) -> str:
         """Apply skin tool prefix and failure suffix."""
         if skin_prefix != "┊":
@@ -1292,7 +1309,7 @@ def get_cute_tool_message(
         urls = args.get("urls", [])
         if urls:
             url = urls[0] if isinstance(urls, list) else str(urls)
-            domain = url.replace("https://", "").replace("http://", "").split("/")[0]
+            domain = _display_url_host(url)
             extra = f" +{len(urls)-1}" if len(urls) > 1 else ""
             return _wrap(f"┊ 📄 fetch     {_trunc(domain, 35)}{extra}  {dur}")
         return _wrap(f"┊ 📄 fetch     pages  {dur}")
@@ -1317,7 +1334,7 @@ def get_cute_tool_message(
         return _wrap(f"┊ 🔎 {verb:9} {pattern}  {dur}")
     if tool_name == "browser_navigate":
         url = args.get("url", "")
-        domain = url.replace("https://", "").replace("http://", "").split("/")[0]
+        domain = _display_url_host(url)
         return _wrap(f"┊ 🌐 navigate  {_trunc(domain, 35)}  {dur}")
     if tool_name == "browser_snapshot":
         mode = "full" if args.get("full") else "compact"
@@ -1422,5 +1439,4 @@ def get_cute_tool_message(
 # =========================================================================
 # Honcho session line (one-liner with clickable OSC 8 hyperlink)
 # =========================================================================
-
 

--- a/agent/display.py
+++ b/agent/display.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from difflib import unified_diff
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 from utils import safe_json_loads
 from agent.redact import redact_sensitive_text
@@ -178,6 +178,84 @@ def _truncate_preview(text: str, max_len: int | None) -> str:
             return "." * max_len
         return text[:max_len - 3] + "..."
     return text
+
+
+def sanitize_url_for_display(url: Any) -> str:
+    """Return *url* with userinfo credentials stripped for progress labels.
+
+    Tool-progress surfaces (CLI spinner, TUI, API progress stream, completion
+    lines) must never echo ``user:secret@`` from browser/web tool args.
+
+    ``https://user:secret@example.com/path`` → ``https://example.com/path``
+    Non-URL strings and unparseable input are returned as stripped text.
+    """
+    raw = str(url or "").strip()
+    if not raw:
+        return ""
+    # Fast path: no credential marker in the authority section.
+    if "@" not in raw:
+        return raw
+
+    has_scheme = "://" in raw
+    to_parse = raw if has_scheme else f"//{raw}"
+    try:
+        parsed = urlparse(to_parse)
+    except Exception:
+        return raw
+
+    host = parsed.hostname
+    if not host:
+        return raw
+
+    # Bracket IPv6 literals when rebuilding netloc.
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    netloc = f"{host}:{port}" if port is not None else host
+
+    rebuilt = urlunparse(
+        (
+            parsed.scheme if has_scheme else "",
+            netloc,
+            parsed.path,
+            parsed.params,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+    if not has_scheme and rebuilt.startswith("//"):
+        rebuilt = rebuilt[2:]
+    return rebuilt
+
+
+def display_url_host(url: Any) -> str:
+    """Host[:port] for compact completion lines; never includes userinfo."""
+    raw = str(url or "").strip()
+    if not raw:
+        return ""
+    try:
+        parsed = urlparse(raw if "://" in raw else f"//{raw}")
+    except Exception:
+        parsed = None
+
+    host = parsed.hostname if parsed is not None else None
+    if not host:
+        cleaned = sanitize_url_for_display(raw)
+        return cleaned.replace("https://", "").replace("http://", "").split("/")[0]
+
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    return f"{host}:{port}" if port is not None else host
+
+
+_URL_PREVIEW_TOOLS = frozenset({"browser_navigate", "web_extract"})
 
 
 _SHELL_SILENT_HEADS = {"cd", "pushd", "popd", "export", "set", "unset", "source", ".", "true", "false", ":"}
@@ -529,6 +607,11 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
     value = args[key]
     if isinstance(value, list):
         value = value[0] if value else ""
+
+    # Browser/web tools surface URLs in spinner/TUI/API progress via this
+    # shared path — strip credentials before any truncation or join.
+    if tool_name in _URL_PREVIEW_TOOLS or key in ("url", "urls"):
+        value = sanitize_url_for_display(value)
 
     preview = _oneline(str(value))
     if not preview:
@@ -1279,22 +1362,6 @@ def get_cute_tool_message(
         limit = _tool_preview_max_len
         return ("..." + p[-(limit-3):]) if len(p) > limit else p
 
-    def _display_url_host(url) -> str:
-        raw = str(url or "").strip()
-        if not raw:
-            return ""
-        parsed = urlparse(raw if "://" in raw else f"//{raw}")
-        host = parsed.hostname
-        if not host:
-            return raw.replace("https://", "").replace("http://", "").split("/")[0]
-        if ":" in host and not host.startswith("["):
-            host = f"[{host}]"
-        try:
-            port = parsed.port
-        except ValueError:
-            port = None
-        return f"{host}:{port}" if port is not None else host
-
     def _wrap(line: str) -> str:
         """Apply skin tool prefix and failure suffix."""
         if skin_prefix != "┊":
@@ -1309,7 +1376,7 @@ def get_cute_tool_message(
         urls = args.get("urls", [])
         if urls:
             url = urls[0] if isinstance(urls, list) else str(urls)
-            domain = _display_url_host(url)
+            domain = display_url_host(url)
             extra = f" +{len(urls)-1}" if len(urls) > 1 else ""
             return _wrap(f"┊ 📄 fetch     {_trunc(domain, 35)}{extra}  {dur}")
         return _wrap(f"┊ 📄 fetch     pages  {dur}")
@@ -1324,7 +1391,7 @@ def get_cute_tool_message(
     if tool_name == "read_file":
         return _wrap(f"┊ 📖 read      {_trunc(build_tool_preview(tool_name, args) or args.get('path', ''), 42)}  {dur}")
     if tool_name == "write_file":
-        return _wrap(f"┊ ✍️  write     {_path(args.get('path', ''))}  {dur}")
+        return _wrap(f"┊ ✏️  write     {_path(args.get('path', ''))}  {dur}")
     if tool_name == "patch":
         return _wrap(f"┊ 🔧 patch     {_path(args.get('path', ''))}  {dur}")
     if tool_name == "search_files":
@@ -1334,7 +1401,7 @@ def get_cute_tool_message(
         return _wrap(f"┊ 🔎 {verb:9} {pattern}  {dur}")
     if tool_name == "browser_navigate":
         url = args.get("url", "")
-        domain = _display_url_host(url)
+        domain = display_url_host(url)
         return _wrap(f"┊ 🌐 navigate  {_trunc(domain, 35)}  {dur}")
     if tool_name == "browser_snapshot":
         mode = "full" if args.get("full") else "compact"

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -295,6 +295,26 @@ class TestCuteToolMessagePreviewLength:
 
         assert text in line
 
+    def test_browser_navigate_cute_message_omits_url_userinfo(self):
+        line = get_cute_tool_message(
+            "browser_navigate",
+            {"url": "https://user:secret@example.com/path"},
+            0.1,
+        )
+
+        assert "user:secret" not in line
+        assert "example.com" in line
+
+    def test_web_extract_cute_message_omits_url_userinfo(self):
+        line = get_cute_tool_message(
+            "web_extract",
+            {"urls": ["https://user:secret@example.com/path"]},
+            0.1,
+        )
+
+        assert "user:secret" not in line
+        assert "example.com" in line
+
 
 class TestEditDiffPreview:
     def test_extract_edit_diff_for_patch(self):

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -315,6 +315,50 @@ class TestCuteToolMessagePreviewLength:
         assert "user:secret" not in line
         assert "example.com" in line
 
+    def test_browser_navigate_preview_and_label_omit_url_userinfo(self):
+        from agent.display import build_tool_label, build_tool_preview
+
+        args = {"url": "https://user:secret@example.com/path"}
+        preview = build_tool_preview("browser_navigate", args)
+        label = build_tool_label("browser_navigate", args)
+
+        assert preview is not None
+        assert "user:secret" not in preview
+        assert "example.com" in preview
+        assert "https://example.com/path" in preview
+
+        assert label is not None
+        assert "user:secret" not in label
+        assert "example.com" in label
+        assert label.startswith("Browsing ")
+
+    def test_web_extract_preview_and_label_omit_url_userinfo(self):
+        from agent.display import build_tool_label, build_tool_preview
+
+        args = {"urls": ["https://user:secret@example.com/docs"]}
+        preview = build_tool_preview("web_extract", args)
+        label = build_tool_label("web_extract", args)
+
+        assert preview is not None
+        assert "user:secret" not in preview
+        assert "example.com" in preview
+        assert "https://example.com/docs" in preview
+
+        assert label is not None
+        assert "user:secret" not in label
+        assert "example.com" in label
+        assert label.startswith("Reading ")
+
+    def test_sanitize_url_for_display_strips_userinfo_only(self):
+        from agent.display import sanitize_url_for_display
+
+        assert (
+            sanitize_url_for_display("https://user:secret@example.com:8443/a?b=1")
+            == "https://example.com:8443/a?b=1"
+        )
+        assert sanitize_url_for_display("https://example.com/ok") == "https://example.com/ok"
+        assert sanitize_url_for_display("") == ""
+
 
 class TestEditDiffPreview:
     def test_extract_edit_diff_for_patch(self):


### PR DESCRIPTION
Summary
- parse browser/web tool URLs before rendering progress labels
- avoid showing URL userinfo such as user:secret in CLI progress lines
- add regression tests for browser_navigate and web_extract

Tests
- .venv/bin/python -m pytest tests/agent/test_display.py -q
- scripts/run_tests.sh tests/agent/test_display.py -q
- git diff --check

Supersedes #59641 with a clean branch containing only the display URL userinfo fix and tests.
