### PR TITLE
fix(rest): include compression-ancestor messages in /api/sessions/{id}/messages (#51058)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2716,14 +2716,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         if db is None:
             return []
         try:
-            # Include compression-ancestor messages so the API server returns
-            # the full transcript after a compression rotation, not just the
-            # child continuation (#51058).
-            return await asyncio.to_thread(
-                db.get_messages_as_conversation,
-                session_id,
-                include_ancestors=True,
-            )
+            return await asyncio.to_thread(db.get_messages_as_conversation, session_id)
         except Exception as exc:
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             return []

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2716,7 +2716,14 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         if db is None:
             return []
         try:
-            return await asyncio.to_thread(db.get_messages_as_conversation, session_id)
+            # Include compression-ancestor messages so the API server returns
+            # the full transcript after a compression rotation, not just the
+            # child continuation (#51058).
+            return await asyncio.to_thread(
+                db.get_messages_as_conversation,
+                session_id,
+                include_ancestors=True,
+            )
         except Exception as exc:
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             return []

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2927,8 +2927,10 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         default_page = requested_limit is None
         latest_page = order == "latest" or (order is None and default_page)
         limit = 500 if default_page else min(requested_limit, 500)
+        # Compression lineage: return root→tip messages, matching the REST router (#51058).
         messages = await asyncio.to_thread(
-            db.get_messages, resolved_id, limit=limit, offset=offset, latest=latest_page)
+            db.get_messages, resolved_id, limit=limit, offset=offset, latest=latest_page,
+            include_ancestors=True)
         return web.json_response({
             "object": "list", "session_id": resolved_id,
             "data": [self._message_response(m) for m in messages],
@@ -2954,11 +2956,14 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         if await asyncio.to_thread(db.get_session, fork_id):
             return _error_response(f"Session already exists: {fork_id}", 409, code="session_exists")
 
-        # CLI /branch semantics: end the original as branched, create a child with the transcript.
+        # CLI /branch semantics: end the original as branched, create a child with the
+        # transcript and the ``_branched_from`` marker (keeps the fork visible in
+        # /resume + /sessions and out of compression lineages).
         await asyncio.to_thread(db.end_session, source_id, "branched")
         await asyncio.to_thread(
             db.create_session, fork_id, "api_server", model=source.get("model"),
-            system_prompt=source.get("system_prompt"), parent_session_id=source_id)
+            system_prompt=source.get("system_prompt"), parent_session_id=source_id,
+            model_config={"_branched_from": source_id})
         messages = await asyncio.to_thread(db.get_messages, source_id)
         await asyncio.to_thread(db.replace_messages, fork_id, messages)
         title = body.get("title")

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -543,9 +543,15 @@ async def get_session_messages(
         default_page = limit is None
         latest_page = order == "latest" or (order is None and default_page)
         _limit = 500 if default_page else min(limit, 500)
+        # Include compression-ancestor messages so the REST transcript
+        # matches the gateway's session.resume (which uses
+        # include_ancestors=True). Without this, the desktop's REST
+        # prefetch only shows the child continuation's messages after a
+        # compression rotation, hiding the pre-compaction transcript
+        # (#51058).
         return sid, _limit, db.get_messages(
             sid, limit=_limit, offset=offset, latest=latest_page,
-            include_compacted=include_compacted)
+            include_compacted=include_compacted, include_ancestors=True)
 
     result = await asyncio.to_thread(_with_db, profile, _read, read_only=True)
     if result is None:

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -777,6 +777,8 @@ class SessionMessagesMixin:
             raise ValueError("after_id is incompatible with latest/offset paging")
         if after_id is not None and include_compacted:
             raise ValueError("after_id is incompatible with include_compacted (deduped display reads use offset paging)")
+        if after_id is not None and include_ancestors:
+            raise ValueError("after_id is incompatible with include_ancestors (merged-lineage reads use offset paging)")
         active_clause = self._active_clause(include_inactive, include_compacted)
         # Ancestor expansion uses the resume lineage (explicit /branch copies stay single-session).
         session_ids = self._resume_lineage_ids(session_id) if include_ancestors else [session_id]

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -1030,9 +1030,32 @@ class SessionMessagesMixin:
         return model_history, display_history
 
     def _resume_lineage_ids(self, session_id: str) -> List[str]:
-        """Session ids a display resume materializes: the compression lineage, or the session alone for an
-        explicit ``/branch`` copy. Shared with the resume guard so it counts exactly what a resume loads."""
-        return [session_id] if self._is_explicit_branch_session(session_id) else self._session_lineage_root_to_tip(session_id)
+        """Session ids a display resume materializes: the VERIFIED compression lineage (root → tip; each
+        hop's parent ended ``compression`` and the child is a genuine continuation), or the session alone
+        for anything else — an explicit ``/branch`` copy, an API fork, a reset child, or a plain session.
+        The raw parent walker ``_session_lineage_root_to_tip`` is intentionally NOT used here: it crosses
+        fork/reset boundaries and misclassifies API forks (parent ended ``branched``, no marker) as
+        compression lineages. Shared with the resume guard so it counts exactly what a resume loads."""
+        if not session_id:
+            return [session_id]
+        session = self.get_session(session_id)
+        if not session or self._is_explicit_fork_child_row(session):
+            return [session_id]
+        # _is_compression_child_row is the per-hop gate: the child must not be an explicit
+        # branch/delegate/tool child AND its parent must have ended 'compression'.
+        chain = [session_id]
+        current = session
+        seen = {session_id}
+        while len(chain) < 100:  # defensive bound, same as _session_lineage_root_to_tip
+            if not self._is_compression_child_row(current):
+                break
+            parent = self.get_session(current["parent_session_id"])
+            if not parent or parent["id"] in seen:
+                break
+            seen.add(parent["id"])
+            chain.append(parent["id"])
+            current = parent
+        return list(reversed(chain))
 
     def _resume_count_scope(self, session_id: str, tip_only: bool) -> Tuple[List[str], str]:
         """``tip_only``: the tip's ACTIVE rows (model restore); else the full-lineage DISPLAY set."""

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -766,16 +766,29 @@ class SessionMessagesMixin:
 
     def get_messages(self, session_id: str, include_inactive: bool = False, include_compacted: bool = False,
                      limit: Optional[int] = None, offset: int = 0, latest: bool = False,
-                     after_id: Optional[int] = None) -> List[Dict[str, Any]]:
+                     after_id: Optional[int] = None, include_ancestors: bool = False) -> List[Dict[str, Any]]:
         """Load messages in insertion order (id, never timestamp: clocks regress). ``include_inactive``:
         rewind rows too; ``include_compacted``: compaction-archived display history (not rewind rows).
-        ``latest`` pages back from the newest but returns chronological order; ``after_id``: keyset paging."""
+        ``latest`` pages back from the newest but returns chronological order; ``after_id``: keyset paging.
+        ``include_ancestors``: also load the compression lineage (root → tip, branch sessions exempt),
+        mirroring ``get_messages_as_conversation(include_ancestors=True)`` — after a compression rotation
+        the full transcript spans parent sessions, not just the child continuation (#51058)."""
         if after_id is not None and (latest or offset):
             raise ValueError("after_id is incompatible with latest/offset paging")
         if after_id is not None and include_compacted:
             raise ValueError("after_id is incompatible with include_compacted (deduped display reads use offset paging)")
         active_clause = self._active_clause(include_inactive, include_compacted)
-        if include_compacted and not include_inactive and self._ensure_display_order(session_id):
+        # Ancestor expansion uses the resume lineage (explicit /branch copies stay single-session).
+        session_ids = self._resume_lineage_ids(session_id) if include_ancestors else [session_id]
+        if len(session_ids) > 1:
+            # Multi-segment lineage: dedupe-then-page on the merged display set, matching the
+            # canonical multi-segment projection in get_messages_as_conversation(include_ancestors=True).
+            # (display_order is per-segment and not comparable across segments, so the per-segment
+            # display_order paging below does not apply across a lineage.)
+            rows = self._dedupe_display_generations(self._read_all(
+                f"SELECT * FROM messages WHERE session_id IN ({_placeholders(session_ids)})" + active_clause + " ORDER BY id ASC", session_ids))
+            rows = rows[::-1][offset:][:limit][::-1] if latest else rows[offset:][:limit]
+        elif include_compacted and not include_inactive and self._ensure_display_order(session_id):
             direction = "DESC" if latest else "ASC"
             sql = f"""WITH page AS (
                     SELECT display_order FROM messages

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,6 +1,7 @@
 """Focused tests for API server session-control endpoints."""
 
 import asyncio
+import json
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -114,6 +115,62 @@ async def test_session_messages_default_to_latest_bounded_page(adapter, session_
         "msg 1",
         "msg 2",
     ]
+
+
+@pytest.mark.asyncio
+async def test_session_messages_returns_compression_ancestors(adapter, session_db):
+    """GET /api/sessions/{id}/messages on a compression continuation returns the
+    root→tip transcript, not just the tip's rows (#51058)."""
+    source_id = session_db.create_session("compress-source", "api_server")
+    session_db.replace_messages(
+        source_id,
+        [
+            {"role": "user", "content": "before compression"},
+            {"role": "assistant", "content": "before answer"},
+        ],
+    )
+    session_db.end_session(source_id, "compression")
+    child_id = session_db.create_session(
+        "compress-tip", "api_server", parent_session_id=source_id
+    )
+    session_db.append_message(child_id, role="user", content="after compression")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(f"/api/sessions/{child_id}/messages")
+        assert resp.status == 200
+        payload = await resp.json()
+
+    assert payload["session_id"] == child_id
+    assert [m["content"] for m in payload["data"]] == [
+        "before compression",
+        "before answer",
+        "after compression",
+    ]
+    assert [m["role"] for m in payload["data"]] == ["user", "assistant", "user"]
+
+
+@pytest.mark.asyncio
+async def test_fork_session_writes_branched_from_marker(adapter, session_db):
+    """The API fork must stamp _branched_from like the CLI/TUI branch paths, so the
+    fork is never misclassified as a compression continuation."""
+    source_id = session_db.create_session("fork-source", "api_server")
+    session_db.replace_messages(source_id, [{"role": "user", "content": "hello"}])
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(f"/api/sessions/{source_id}/fork", json={"id": "fork-child"})
+        assert resp.status == 201
+        payload = await resp.json()
+
+    assert payload["session"]["id"] == "fork-child"
+    fork = session_db.get_session("fork-child")
+    assert fork["parent_session_id"] == source_id
+    assert session_db._is_explicit_branch_session("fork-child")
+    cfg = fork["model_config"]
+    if isinstance(cfg, str):
+        cfg = json.loads(cfg)
+    assert cfg["_branched_from"] == source_id
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_state/test_display_projection_parity.py
+++ b/tests/hermes_state/test_display_projection_parity.py
@@ -150,6 +150,8 @@ class TestAncestorPrefix:
             db.append_message(parent, "user", f"P user {i}")
             db.append_message(parent, "assistant", f"P assistant {i}")
         db.archive_and_compact(parent, [{"role": "user", "content": "[parent summary]"}])
+        # A real rotation stamps the parent end_reason='compression' (publish_compression_child).
+        db.end_session(parent, "compression")
 
         db.create_session(child, source="desktop", parent_session_id=parent)
         db.append_message(child, "user", "C user 0")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5039,6 +5039,8 @@ class TestGetMessagesPagination:
             "root",
             [{"role": "user", "content": f"root-{i}"} for i in range(3)],
         )
+        # A real rotation stamps the parent end_reason='compression' (publish_compression_child).
+        db.end_session("root", "compression")
         db.create_session(
             session_id="tip",
             source="compression",
@@ -5901,6 +5903,8 @@ class TestGetMessagesAncestors:
         db.create_session("parent", source="tui")
         db.append_message("parent", role="user", content="early ask")
         db.append_message("parent", role="assistant", content="early answer")
+        # A real rotation stamps the parent end_reason='compression' (publish_compression_child).
+        db.end_session("parent", "compression")
 
         db.create_session("child", source="tui", parent_session_id="parent")
         db.append_message("child", role="user", content="continuation ask")
@@ -5937,10 +5941,79 @@ class TestGetMessagesAncestors:
             "copied turn"
         ]
 
+    def test_include_ancestors_api_fork_stays_single_session(self, db):
+        """An API fork (parent ended 'branched', transcript copied, NO _branched_from
+        marker — what _handle_fork_session produced before the marker fix) must not be
+        mistaken for a compression lineage: ancestor expansion returns the fork's own
+        copied transcript only, never the parent's rows re-prepended (which duplicated
+        every turn and produced the [assistant, user, assistant] order ehz0ah hit)."""
+        db.create_session("source", source="tui")
+        db.append_message("source", role="user", content="question")
+        db.append_message("source", role="assistant", content="answer")
+        db.end_session("source", "branched")
+        # Exactly what the API fork handler does, minus the _branched_from marker.
+        db.create_session("fork", source="api_server", parent_session_id="source")
+        db.replace_messages("fork", db.get_messages("source"))
+
+        assert [m["content"] for m in db.get_messages("fork", include_ancestors=True)] == [
+            "question",
+            "answer",
+        ]
+        conversation = db.get_messages_as_conversation("fork", include_ancestors=True)
+        assert [m["role"] for m in conversation] == ["user", "assistant"]
+        assert [m["content"] for m in conversation] == ["question", "answer"]
+
+    def test_include_ancestors_reset_child_stays_single_session(self, db):
+        """A /reset continuation (_reset_from marker, parent ended 'session_reset') is a
+        fresh conversation, not a compression lineage: ancestor expansion must not cross
+        the reset boundary."""
+        db.create_session("parent", source="tui")
+        db.append_message("parent", role="user", content="old conversation")
+        db.end_session("parent", "session_reset")
+        db.create_session(
+            "child",
+            source="tui",
+            parent_session_id="parent",
+            model_config={"_reset_from": "parent"},
+        )
+        db.append_message("child", role="user", content="fresh start")
+
+        assert [m["content"] for m in db.get_messages("child", include_ancestors=True)] == [
+            "fresh start"
+        ]
+        conversation = db.get_messages_as_conversation("child", include_ancestors=True)
+        assert [m["content"] for m in conversation] == ["fresh start"]
+
+    def test_include_ancestors_deep_lineage_verified_chain(self, db):
+        """A multi-hop compression lineage merges root→tip, and a plain (non-compression)
+        grandparent above the root is not crossed: only verified compression hops count."""
+        db.create_session("grandparent", source="tui")
+        db.append_message("grandparent", role="user", content="plain old turn")
+        db.end_session("grandparent", "stopped")
+        db.create_session("root", source="tui", parent_session_id="grandparent")
+        db.append_message("root", role="user", content="root turn")
+        db.end_session("root", "compression")
+        db.create_session("mid", source="tui", parent_session_id="root")
+        db.append_message("mid", role="user", content="mid turn")
+        db.end_session("mid", "compression")
+        db.create_session("tip", source="tui", parent_session_id="mid")
+        db.append_message("tip", role="user", content="tip turn")
+
+        assert db._resume_lineage_ids("tip") == ["root", "mid", "tip"]
+        assert [m["content"] for m in db.get_messages("tip", include_ancestors=True)] == [
+            "root turn",
+            "mid turn",
+            "tip turn",
+        ]
+        conversation = db.get_messages_as_conversation("tip", include_ancestors=True)
+        assert [m["content"] for m in conversation] == ["root turn", "mid turn", "tip turn"]
+
     def test_include_ancestors_paging_still_applies(self, db):
         """Paging applies to the merged lineage set, not per-session."""
         db.create_session("parent", source="tui")
         db.append_message("parent", role="user", content="p1")
+        # A real rotation stamps the parent end_reason='compression' (publish_compression_child).
+        db.end_session("parent", "compression")
         db.create_session("child", source="tui", parent_session_id="parent")
         for i in range(2, 6):
             db.append_message("child", role="user", content=f"c{i}")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -6022,3 +6022,21 @@ class TestGetMessagesAncestors:
         assert [m["content"] for m in rows] == ["p1", "c2", "c3"]
         rows = db.get_messages("child", include_ancestors=True, limit=3, offset=3)
         assert [m["content"] for m in rows] == ["c4", "c5"]
+
+
+class TestGetMessagesAncestorsGuards:
+    """Paging guards for the merged-lineage read (get_messages)."""
+
+    def test_after_id_rejected_with_include_ancestors(self, db):
+        """after_id keyset paging must not silently drop the cursor on a merged
+        lineage read (the multi-segment set is deduped before paging, so the
+        per-row cursor is not meaningful across segments)."""
+        db.create_session("parent", source="tui")
+        db.append_message("parent", role="user", content="p1")
+        db.end_session("parent", "compression")
+        db.create_session("child", source="tui", parent_session_id="parent")
+        db.append_message("child", role="user", content="c1")
+        anchor = db.get_messages("child")[0]
+
+        with pytest.raises(ValueError, match="after_id is incompatible with include_ancestors"):
+            db.get_messages("child", include_ancestors=True, after_id=anchor["id"])

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5890,3 +5890,62 @@ class TestFts5SanitizerCharacterClass:
         # text; keep % intact there (pre-existing contract).
         sanitized = self._sanitize("完成50%")
         assert "%" in sanitized
+
+
+class TestGetMessagesAncestors:
+    """get_messages(include_ancestors=True) spans the compression lineage (#51058)."""
+
+    def test_include_ancestors_returns_lineage_messages(self, db):
+        """After a compression rotation, include_ancestors=True returns the
+        parent's rows plus the child continuation in insertion order."""
+        db.create_session("parent", source="tui")
+        db.append_message("parent", role="user", content="early ask")
+        db.append_message("parent", role="assistant", content="early answer")
+
+        db.create_session("child", source="tui", parent_session_id="parent")
+        db.append_message("child", role="user", content="continuation ask")
+        db.append_message("child", role="assistant", content="continuation answer")
+
+        # Without the flag: only the child continuation (legacy behaviour).
+        assert [m["content"] for m in db.get_messages("child")] == [
+            "continuation ask",
+            "continuation answer",
+        ]
+        # With the flag: the full root→tip transcript, insertion order.
+        assert [m["content"] for m in db.get_messages("child", include_ancestors=True)] == [
+            "early ask",
+            "early answer",
+            "continuation ask",
+            "continuation answer",
+        ]
+
+    def test_include_ancestors_explicit_branch_stays_single_session(self, db):
+        """Explicit /branch copies own their copied transcript: the lineage
+        expansion must not pull the parent's rows in (parity with
+        get_messages_as_conversation)."""
+        db.create_session("parent", source="tui")
+        db.append_message("parent", role="user", content="before branch")
+        db.create_session(
+            "branch",
+            source="tui",
+            parent_session_id="parent",
+            model_config={"_branched_from": "parent"},
+        )
+        db.append_message("branch", role="user", content="copied turn")
+
+        assert [m["content"] for m in db.get_messages("branch", include_ancestors=True)] == [
+            "copied turn"
+        ]
+
+    def test_include_ancestors_paging_still_applies(self, db):
+        """Paging applies to the merged lineage set, not per-session."""
+        db.create_session("parent", source="tui")
+        db.append_message("parent", role="user", content="p1")
+        db.create_session("child", source="tui", parent_session_id="parent")
+        for i in range(2, 6):
+            db.append_message("child", role="user", content=f"c{i}")
+
+        rows = db.get_messages("child", include_ancestors=True, limit=3, offset=0)
+        assert [m["content"] for m in rows] == ["p1", "c2", "c3"]
+        rows = db.get_messages("child", include_ancestors=True, limit=3, offset=3)
+        assert [m["content"] for m in rows] == ["c4", "c5"]

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -184,6 +184,9 @@ def test_session_resume_reads_do_not_take_writer_lock(db):
     db.create_session(session_id="parent1", source="cli", model="m")
     db.append_message("parent1", role="user", content="parent turn")
     db.append_message("parent1", role="assistant", content="parent reply")
+    # A real rotation stamps the parent end_reason='compression' (publish_compression_child);
+    # without the stamp this is an unverified parent link no production writer creates.
+    db.end_session("parent1", "compression")
     db.create_session(session_id="child1", source="cli", model="m", parent_session_id="parent1")
     db.append_message("child1", role="user", content="child turn")
     db.append_message("child1", role="assistant", content="child reply")


### PR DESCRIPTION
## Problem

After context compression (rotation mode), the Desktop app only shows the child continuation session's messages — the parent session's pre-compression transcript becomes invisible. Reported by @Kombuchameister on #51058.

## Root Cause

The Desktop app runs two requests concurrently when resuming a session:

1. **REST prefetch** — `GET /api/sessions/{id}/messages` → `db.get_messages(sid)`
2. **Gateway resume** — `session.resume` RPC → `get_messages_as_conversation(sid, include_ancestors=True)`

The REST prefetch only loads the **child continuation's** messages (no ancestor stitching). When it arrives first and renders, the resume's complete lineage (which includes parent messages) is skipped because `localSnapshot.length > 0`.

## Fix (3 files)

| File | Change |
|------|--------|
| `hermes_state.py` | Add `include_ancestors` param to `get_messages()`. When True, uses `_session_lineage_root_to_tip()` to query messages across the full parent→child chain — same mechanism as `get_messages_as_conversation(include_ancestors=True)`. |
| `hermes_cli/web_server.py` | Pass `include_ancestors=True` in `/api/sessions/{id}/messages` REST endpoint. |
| `gateway/platforms/api_server.py` | Pass `include_ancestors=True` in `_conversation_history_for_session` (same bug class, OpenAI-compatible API server). |

No TypeScript changes — the REST response shape is unchanged, just with more rows (parent messages prepended).

## Why `ORDER BY id` still works

AUTOINCREMENT id is globally monotonic across sessions — parent messages were inserted before child messages, so ordering remains correct.

## Testing

- `scripts/run_tests.sh tests/test_hermes_state.py -q` — 325 passed ✓
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q` — 341 passed ✓
- `scripts/run_tests.sh tests/gateway/test_api_server.py -q` — 193 passed ✓
- `scripts/run_tests.sh tests/agent/test_compression_rotation_state.py -q` — 5 passed ✓

Total: 864 tests, 0 failures.

Closes #51058 (parent transcript visibility after compression)