### PR TITLE
fix(memory): scale honcho_reasoning tier with prompt complexity (#59470)

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -963,6 +963,131 @@ class HonchoMemoryProvider(MemoryProvider):
         cap_idx = self._LEVEL_ORDER.index(self._reasoning_level_cap)
         return self._LEVEL_ORDER[min(base_idx + bump, cap_idx)]
 
+    # ----- Issue #59470: complexity-aware tier selection for honcho_reasoning tool -----
+
+    # Stopwords stripped before counting distinct noun-phrase tokens. Kept
+    # intentionally small so this stays a deterministic heuristic and never
+    # tries to parse linguistic structure.
+    _COMPLEXITY_STOPWORDS = frozenset({
+        "a", "an", "and", "are", "as", "at", "be", "but", "by", "do", "for",
+        "from", "has", "have", "he", "her", "his", "i", "if", "in", "is",
+        "it", "its", "me", "my", "no", "not", "of", "on", "or", "our", "she",
+        "so", "than", "that", "the", "their", "them", "they", "this", "to",
+        "us", "was", "we", "were", "what", "when", "where", "which", "who",
+        "why", "will", "with", "you", "your",
+    })
+
+    # Tier thresholds for complexity-driven selection.
+    # simple   -> minimal (single factual lookup)
+    # moderate -> medium (multi-aspect synthesis)
+    # complex  -> high (multi-topic, multi-faceted)
+    _TIER_SIMPLE = "minimal"
+    _TIER_MODERATE = "medium"
+    _TIER_COMPLEX = "high"
+
+    @classmethod
+    def _count_distinct_topics(cls, text: str) -> int:
+        """Count distinct content tokens (rough noun-phrase proxy).
+
+        Returns the number of unique non-stopword tokens of length >=4.
+        Used as a cheap stand-in for "distinct topics/entities" without
+        needing an NLP parser.
+        """
+        if not text:
+            return 0
+        seen: set[str] = set()
+        for tok in re.findall(r"[A-Za-z][A-Za-z0-9'-]{3,}", text.lower()):
+            if tok in cls._COMPLEXITY_STOPWORDS:
+                continue
+            seen.add(tok)
+        return len(seen)
+
+    @classmethod
+    def _classify_query_complexity(cls, query: str) -> str:
+        """Classify a query's complexity into one of: simple / moderate / complex.
+
+        Heuristic (deterministic, no LLM):
+          - simple:   single sentence AND <=5 distinct content tokens.
+          - complex:  >=4 sentences OR >=10 distinct tokens OR
+                      multi-clause AND >=7 distinct tokens.
+          - moderate: any other multi-sentence / multi-clause prompt that
+                      still falls below the complex bar.
+        """
+        if not query or not query.strip():
+            return "simple"
+
+        text = query.strip()
+
+        # Sentence count via terminal punctuation. Requires whitespace or end
+        # after the punctuation so "v2.5" doesn't get split as a sentence.
+        sentences = [s for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()]
+        sentence_count = len(sentences)
+
+        # Clause-ish separator count. Treats ; and , as soft clause markers
+        # inside a single sentence; stacked clauses aren't double counted
+        # because we only count the separator chars.
+        separator_count = text.count(";") + text.count(",")
+
+        # Numbered-list style multi-question prompts ("1.", "2)", "1)") etc.
+        numbered_list = len(re.findall(r"(?:^|\s)\d+[.)]\s", text))
+
+        distinct_topics = cls._count_distinct_topics(text)
+
+        multi_clause = sentence_count >= 2 or separator_count >= 2 or numbered_list >= 2
+
+        if distinct_topics >= 10 or sentence_count >= 4 or (multi_clause and distinct_topics >= 7):
+            return "complex"
+        if multi_clause or distinct_topics >= 6:
+            return "moderate"
+        return "simple"
+
+    @classmethod
+    def _select_reasoning_level(
+        cls,
+        query: str,
+        explicit: str | None,
+        *,
+        default: str = "low",
+        cap: str = "high",
+    ) -> str:
+        """Pick the reasoning tier to send to Honcho.
+
+        Honors an explicit user-provided tier when it's in ``_LEVEL_ORDER``,
+        but applies a complexity floor so a caller that picks ``minimal`` for
+        a multi-faceted prompt is nudged upward to ``medium`` or ``high``
+        (fixes #59470: a "minimal" pick on a multi-fact query used to be
+        forwarded unchanged and exhausted Honcho's 250-token budget mid
+        chain-of-thought). The bump respects ``cap`` (default ``high``).
+        """
+        if cap not in cls._LEVEL_ORDER:
+            cap = "high"
+        cap_idx = cls._LEVEL_ORDER.index(cap)
+        if default not in cls._LEVEL_ORDER:
+            default = "low"
+
+        complexity = cls._classify_query_complexity(query)
+        if complexity == "complex":
+            target = cls._TIER_COMPLEX
+        elif complexity == "moderate":
+            target = cls._TIER_MODERATE
+        else:
+            target = cls._TIER_SIMPLE
+
+        target_idx = cls._LEVEL_ORDER.index(target)
+        target_idx = min(target_idx, cap_idx)
+
+        # Explicit user override: honor unless it would fall below the
+        # complexity floor. Still clamped to the cap.
+        if explicit and explicit in cls._LEVEL_ORDER:
+            explicit_idx = cls._LEVEL_ORDER.index(explicit)
+            chosen_idx = max(explicit_idx, target_idx)
+            chosen_idx = min(chosen_idx, cap_idx)
+            return cls._LEVEL_ORDER[chosen_idx]
+
+        # No explicit override — complexity heuristic picks the floor.
+        chosen_idx = min(target_idx, cap_idx)
+        return cls._LEVEL_ORDER[chosen_idx]
+
     def _resolve_pass_level(self, pass_idx: int, query: str = "") -> str:
         """Resolve reasoning level for a given pass index.
 
@@ -1354,7 +1479,17 @@ class HonchoMemoryProvider(MemoryProvider):
                 if not query:
                     return tool_error("Missing required parameter: query")
                 peer = args.get("peer", "user")
-                reasoning_level = args.get("reasoning_level")
+                explicit_level = args.get("reasoning_level")
+                # Issue #59470: complexity-aware tier selection. A caller that
+                # passes "minimal" for a multi-faceted prompt gets nudged up
+                # to medium/high so Honcho's 250-token cap can't truncate the
+                # answer mid chain-of-thought.
+                reasoning_level = self._select_reasoning_level(
+                    query,
+                    explicit_level,
+                    default=(self._config.dialectic_reasoning_level if self._config else "low"),
+                    cap=(self._config.reasoning_level_cap if self._config else "high"),
+                )
                 result = self._manager.dialectic_query(
                     self._session_key, query,
                     reasoning_level=reasoning_level,

--- a/tests/plugins/test_honcho_tier_selection.py
+++ b/tests/plugins/test_honcho_tier_selection.py
@@ -1,0 +1,371 @@
+"""Tests for honcho_reasoning tier selection (issue #59470).
+
+The ``honcho_reasoning`` tool used to forward whatever ``reasoning_level``
+the calling model chose, including ``minimal`` — Honcho's hard-capped
+250-token tier that truncates answers mid chain-of-thought on multi-fact
+queries.  These tests pin the new complexity-aware selection heuristic
+that nudges the tier up for multi-faceted prompts and lets the caller
+override explicitly when they really mean it.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.memory.honcho import HonchoMemoryProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider() -> HonchoMemoryProvider:
+    """Build an uninitialized provider suitable for static-helper testing."""
+    provider = HonchoMemoryProvider.__new__(HonchoMemoryProvider)
+    provider._manager = MagicMock()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+    provider._turn_count = 1
+    provider._dialectic_cadence = 1
+    provider._last_dialectic_turn = -999
+    provider._cron_skipped = False
+    provider._recall_mode = "tools"
+    provider._config = MagicMock()
+    provider._config.dialectic_reasoning_level = "low"
+    provider._config.reasoning_level_cap = "high"
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Complexity classifier
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyQueryComplexity:
+    """Pin the deterministic complexity classifier behavior."""
+
+    def test_empty_query_is_simple(self):
+        assert HonchoMemoryProvider._classify_query_complexity("") == "simple"
+
+    def test_whitespace_only_is_simple(self):
+        assert HonchoMemoryProvider._classify_query_complexity("   \n\t  ") == "simple"
+
+    def test_single_short_fact_is_simple(self):
+        assert HonchoMemoryProvider._classify_query_complexity("What is their name?") == "simple"
+
+    def test_single_sentence_with_many_tokens_is_simple(self):
+        # One short factual question with a few content tokens stays simple
+        # even though it has a couple of content words.
+        assert HonchoMemoryProvider._classify_query_complexity(
+            "What's their favorite editor?"
+        ) == "simple"
+
+    def test_two_sentences_are_moderate(self):
+        result = HonchoMemoryProvider._classify_query_complexity(
+            "Who is this person? What are their working preferences?"
+        )
+        assert result == "moderate"
+
+    def test_comma_separated_clauses_are_moderate(self):
+        result = HonchoMemoryProvider._classify_query_complexity(
+            "Summarize their role, projects, communication style, and tooling preferences."
+        )
+        assert result in {"moderate", "complex"}
+
+    def test_numbered_list_is_moderate(self):
+        result = HonchoMemoryProvider._classify_query_complexity(
+            "Answer each:\n1. Role\n2. Goals\n3. Preferences"
+        )
+        assert result in {"moderate", "complex"}
+
+    def test_many_distinct_topics_is_complex(self):
+        # >=10 distinct content tokens across multiple clauses -> complex.
+        query = (
+            "Compare the user's Python, JavaScript, Rust, Go, TypeScript, "
+            "Kotlin, Swift, Ruby, Haskell, and C++ experience."
+        )
+        assert HonchoMemoryProvider._classify_query_complexity(query) == "complex"
+
+    def test_four_plus_sentences_is_complex(self):
+        query = (
+            "Who is this user. What projects do they lead. "
+            "Which teams have they worked with. How do they prefer to communicate."
+        )
+        assert HonchoMemoryProvider._classify_query_complexity(query) == "complex"
+
+    def test_semicolon_separated_is_complex(self):
+        query = (
+            "Summarize known facts about this peer and communication preferences; "
+            "also describe their tooling stack, current projects, and team relationships; "
+            "highlight any recent changes in working style; note open follow-ups."
+        )
+        assert HonchoMemoryProvider._classify_query_complexity(query) == "complex"
+
+    def test_stopwords_are_ignored_in_topic_count(self):
+        # "the", "and", "of", etc. should not inflate the distinct-topic count.
+        # Only "user" and "name" remain as content tokens -> simple.
+        result = HonchoMemoryProvider._classify_query_complexity(
+            "What is the name of the user and the team of the user"
+        )
+        assert result == "simple"
+
+
+# ---------------------------------------------------------------------------
+# Tier selector — no explicit override
+# ---------------------------------------------------------------------------
+
+
+class TestSelectReasoningLevelNoOverride:
+    """When the caller passes no explicit level, complexity drives the pick."""
+
+    def test_single_fact_defaults_to_minimal(self):
+        level = HonchoMemoryProvider._select_reasoning_level(
+            "What is their name?", explicit=None
+        )
+        assert level == "minimal"
+
+    def test_multi_sentence_bumps_to_medium(self):
+        level = HonchoMemoryProvider._select_reasoning_level(
+            "Who is this person? What are their working preferences?",
+            explicit=None,
+        )
+        assert level == "medium"
+
+    def test_multi_topic_bumps_to_high(self):
+        level = HonchoMemoryProvider._select_reasoning_level(
+            (
+                "Compare the user's Python, JavaScript, Rust, Go, TypeScript, "
+                "Kotlin, Swift, Ruby, Haskell, and C++ experience."
+            ),
+            explicit=None,
+        )
+        assert level == "high"
+
+    def test_cap_honored_when_lowering_target(self):
+        # If the cap is "medium", a complex query must not exceed "medium".
+        level = HonchoMemoryProvider._select_reasoning_level(
+            (
+                "Compare the user's Python, JavaScript, Rust, Go, TypeScript, "
+                "Kotlin, Swift, Ruby, Haskell, and C++ experience."
+            ),
+            explicit=None,
+            cap="medium",
+        )
+        assert level == "medium"
+
+    def test_invalid_cap_falls_back_to_high(self):
+        level = HonchoMemoryProvider._select_reasoning_level(
+            (
+                "Compare the user's Python, JavaScript, Rust, Go, TypeScript, "
+                "Kotlin, Swift, Ruby, Haskell, and C++ experience."
+            ),
+            explicit=None,
+            cap="not-a-tier",
+        )
+        # Invalid cap is coerced to "high" — complex still maps to "high".
+        assert level == "high"
+
+    def test_invalid_explicit_is_treated_as_no_override(self):
+        # Garbage strings like "auto" / "default" should not crash; the
+        # complexity heuristic still picks a sensible tier.
+        level = HonchoMemoryProvider._select_reasoning_level(
+            "Who is this person? What are their preferences?",
+            explicit="auto",
+        )
+        assert level == "medium"
+
+
+# ---------------------------------------------------------------------------
+# Tier selector — explicit caller override
+# ---------------------------------------------------------------------------
+
+
+class TestSelectReasoningLevelExplicitOverride:
+    """The caller can override, but a 'minimal' override on a complex query
+    is floored to the complexity-derived tier."""
+
+    def test_explicit_low_on_simple_query_is_honored(self):
+        level = HonchoMemoryProvider._select_reasoning_level(
+            "What is their name?", explicit="low"
+        )
+        assert level == "low"
+
+    def test_explicit_max_on_simple_query_is_honored_when_cap_is_max(self):
+        # Default cap is "high", so "max" must be clamped to "high" unless
+        # the caller raises the cap.
+        level = HonchoMemoryProvider._select_reasoning_level(
+            "What is their name?", explicit="max"
+        )
+        assert level == "high"
+        # With cap raised to "max", the explicit pick survives.
+        level = HonchoMemoryProvider._select_reasoning_level(
+            "What is their name?", explicit="max", cap="max"
+        )
+        assert level == "max"
+
+    def test_explicit_minimal_on_complex_query_becomes_high(self):
+        # The bug from #59470: caller picks minimal, answer truncates.
+        # Heuristic floors the explicit pick up to the complexity tier.
+        level = HonchoMemoryProvider._select_reasoning_level(
+            (
+                "Summarize known facts about this peer and communication "
+                "preferences; describe their tooling, projects, and team "
+                "relationships; highlight recent changes; note open follow-ups."
+            ),
+            explicit="minimal",
+        )
+        assert level == "high"
+
+    def test_explicit_medium_on_complex_query_is_honored(self):
+        # "medium" >= complexity floor for moderate but < complex floor;
+        # explicit picks win when they exceed the floor.
+        level = HonchoMemoryProvider._select_reasoning_level(
+            (
+                "Compare the user's Python, JavaScript, Rust, Go, TypeScript, "
+                "Kotlin, Swift, Ruby, Haskell, and C++ experience."
+            ),
+            explicit="medium",
+        )
+        # "medium" (idx 2) < complexity target "high" (idx 3) -> floor wins.
+        assert level == "high"
+
+    def test_explicit_high_on_complex_query_is_honored(self):
+        level = HonchoMemoryProvider._select_reasoning_level(
+            (
+                "Compare the user's Python, JavaScript, Rust, Go, TypeScript, "
+                "Kotlin, Swift, Ruby, Haskell, and C++ experience."
+            ),
+            explicit="high",
+        )
+        assert level == "high"
+
+    def test_explicit_above_cap_is_clamped_to_cap(self):
+        # Caller asks for max, cap is medium -> medium wins.
+        level = HonchoMemoryProvider._select_reasoning_level(
+            "What is their name?", explicit="max", cap="medium"
+        )
+        assert level == "medium"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through handle_tool_call (issue #59470 regression)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleToolCallHonchoReasoning:
+    """Wire the heuristic into the actual ``honcho_reasoning`` tool path."""
+
+    def test_single_fact_passes_minimal_through(self):
+        provider = _make_provider()
+        provider._manager.dialectic_query = MagicMock(return_value="Alice")
+
+        result = provider.handle_tool_call(
+            "honcho_reasoning",
+            {"query": "What is their name?"},
+        )
+
+        call_kwargs = provider._manager.dialectic_query.call_args.kwargs
+        assert call_kwargs["reasoning_level"] == "minimal"
+        payload = json.loads(result)
+        assert payload["result"] == "Alice"
+
+    def test_multi_sentence_promotes_to_medium(self):
+        provider = _make_provider()
+        provider._manager.dialectic_query = MagicMock(return_value="synthesized")
+
+        result = provider.handle_tool_call(
+            "honcho_reasoning",
+            {"query": "Who is this person? What are their working preferences?"},
+        )
+
+        call_kwargs = provider._manager.dialectic_query.call_args.kwargs
+        assert call_kwargs["reasoning_level"] == "medium"
+        assert json.loads(result)["result"] == "synthesized"
+
+    def test_multi_topic_promotes_to_high(self):
+        provider = _make_provider()
+        provider._manager.dialectic_query = MagicMock(return_value="synthesized")
+
+        query = (
+            "Compare the user's Python, JavaScript, Rust, Go, TypeScript, "
+            "Kotlin, Swift, Ruby, Haskell, and C++ experience."
+        )
+        provider.handle_tool_call("honcho_reasoning", {"query": query})
+
+        call_kwargs = provider._manager.dialectic_query.call_args.kwargs
+        assert call_kwargs["reasoning_level"] == "high"
+
+    def test_explicit_max_is_clamped_to_default_cap(self):
+        # The default ``reasoning_level_cap`` is "high", so a caller that asks
+        # for "max" must be clamped to "high" — that's the safe default.
+        provider = _make_provider()
+        provider._manager.dialectic_query = MagicMock(return_value="answer")
+
+        provider.handle_tool_call(
+            "honcho_reasoning",
+            {"query": "What is their name?", "reasoning_level": "max"},
+        )
+
+        call_kwargs = provider._manager.dialectic_query.call_args.kwargs
+        assert call_kwargs["reasoning_level"] == "high"
+
+    def test_explicit_high_survives_end_to_end(self):
+        provider = _make_provider()
+        provider._manager.dialectic_query = MagicMock(return_value="answer")
+
+        provider.handle_tool_call(
+            "honcho_reasoning",
+            {"query": "What is their name?", "reasoning_level": "high"},
+        )
+
+        call_kwargs = provider._manager.dialectic_query.call_args.kwargs
+        assert call_kwargs["reasoning_level"] == "high"
+
+    def test_explicit_minimal_on_complex_query_is_floored_to_high(self):
+        """Regression for issue #59470: the model picking 'minimal' for a
+        multi-fact query must not silently truncate at 250 tokens."""
+        provider = _make_provider()
+        provider._manager.dialectic_query = MagicMock(return_value="answer")
+
+        provider.handle_tool_call(
+            "honcho_reasoning",
+            {
+                "query": (
+                    "Summarize known facts about this peer and communication "
+                    "preferences; describe their tooling, projects, and team "
+                    "relationships; highlight recent changes; note open follow-ups."
+                ),
+                "reasoning_level": "minimal",
+            },
+        )
+
+        call_kwargs = provider._manager.dialectic_query.call_args.kwargs
+        # The heuristic bumps the explicit "minimal" pick up to "high" so
+        # Honcho's dialectic tier has enough output budget.
+        assert call_kwargs["reasoning_level"] == "high"
+
+    def test_explicit_low_on_moderate_query_is_promoted_to_medium(self):
+        provider = _make_provider()
+        provider._manager.dialectic_query = MagicMock(return_value="answer")
+
+        provider.handle_tool_call(
+            "honcho_reasoning",
+            {
+                "query": (
+                    "Who is this person? What are their working preferences? "
+                    "How do they like to be contacted?"
+                ),
+                "reasoning_level": "low",
+            },
+        )
+
+        call_kwargs = provider._manager.dialectic_query.call_args.kwargs
+        assert call_kwargs["reasoning_level"] == "medium"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Fixes #59470

## Problem

The `honcho_reasoning` tool used to forward whatever `reasoning_level`
the calling model chose, including `minimal`. Honcho's minimal dialectic
tier hard-caps output at **250 tokens** (`MAX_OUTPUT_TOKENS=250`,
`MAX_TOOL_ITERATIONS=1`). On reasoning-capable backend models (OpenAI
gpt-5.x / o-series and similar) that 250-token budget is shared between
hidden reasoning tokens and visible output — so a multi-fact prompt that
needed real synthesis would exhaust the budget mid chain-of-thought and
return no synthesized answer.

The `minimal` framing in the tool description read as "fast/cheap" —
a normal quality dial — rather than "hard output cap that can
truncate before answering". So the model reliably picked `minimal` for
queries that weren't suited to it.

## Fix

Add a deterministic complexity heuristic in
`plugins/memory/honcho/__init__.py` and route every `honcho_reasoning`
tool call through it:

- **Classifier** (`_classify_query_complexity`) — counts sentences,
  clause separators (`;`/commas), numbered-list markers, and distinct
  content tokens (after stopword removal) to bucket the prompt into
  `simple` / `moderate` / `complex`.
- **Selector** (`_select_reasoning_level`) — maps the bucket to a tier
  (`minimal` / `medium` / `high`), honors an explicit caller override
  *unless* it would fall below the complexity floor (so `minimal` on a
  complex query is bumped to `high`), and clamps everything to the
  configured `reasoningLevelCap`.
- Wired into `handle_tool_call("honcho_reasoning", ...)` so every
  explicit tool call now benefits. The existing
  `_apply_reasoning_heuristic` for the auto-injected dialectic is left
  untouched — it still scales by query length for the implicit cadence
  path.

This is a heuristic, not an LLM classifier, matching the issue's
expected behavior.

## Tests

`tests/plugins/test_honcho_tier_selection.py` — 30 tests covering:

- classifier behavior on empty / whitespace / single-sentence /
  multi-sentence / numbered-list / semicolon / comma-separated inputs,
  distinct-topic counting, and stopword handling,
- tier selection with and without explicit caller override,
- cap clamping and invalid-input handling,
- end-to-end through `handle_tool_call`, including a regression for
  #59470's "model picks `minimal` for a multi-fact query" scenario
  (asserts the call ends up at `high`, not `minimal`).

All 30 tests pass: `pytest tests/plugins/test_honcho_tier_selection.py`.

## Relationship to existing PR #52395

That PR rewrites the tool-level `description` of `honcho_reasoning`
and the other tools. It does **not** touch the `reasoning_level`
parameter description or add runtime tier selection, so it's orthogonal.
This fix is at the handler level — the model can still see whatever
description we give it, but even if it picks `minimal` for a complex
query, the runtime promotes the tier so Honcho's hard cap can't
silently truncate the answer.

## Environment

Verified locally on Windows / Python 3.11 against a self-hosted Honcho
backend (the same reproduction as #59470).

AI-assisted fix by https://github.com/SquabbyZ/peaks-loop