### PR TITLE
feat(cli): add --session-only flag to /model slash command (#58290)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7917,12 +7917,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
           /model                              — show current model + usage hints
           /model <name>                       — switch model (persists by default)
           /model <name> --session             — switch for this session only
+          /model <name> --session-only        — alias of --session (issue #58290)
+          /model <name> --no-save             — alias of --session
           /model <name> --global              — switch and persist (explicit)
+          /model <name> --persist             — alias of --global
           /model <name> --provider <provider> — switch provider + model
           /model --provider <provider>        — switch to provider, auto-detect model
 
         Persistence defaults to on (``model.persist_switch_by_default`` in
-        config.yaml, default True). Use ``--session`` for a one-off switch.
+        config.yaml, default True). Use ``--session`` / ``--session-only``
+        for a one-off switch.
         """
         from hermes_cli.model_switch import (
             switch_model,

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -132,7 +132,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("config", "Show current configuration", "Configuration",
                cli_only=True),
     CommandDef("model", "Switch model (persists by default)", "Configuration",
-               args_hint="[model] [--provider name] [--global|--session] [--refresh]"),
+               args_hint="[model] [--provider name] [--global|--persist|--session|--session-only|--no-save] [--refresh]"),
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]"),

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -353,7 +353,7 @@ class ModelSwitchResult:
 # ---------------------------------------------------------------------------
 
 def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool, bool]:
-    """Parse --provider, --global, --session, and --refresh flags from /model command args.
+    """Parse --provider, --global/--persist, --session/--session-only, and --refresh flags.
 
     Returns ``(model_input, explicit_provider, is_global, force_refresh, is_session)``.
 
@@ -362,14 +362,22 @@ def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool, bool]:
     :func:`resolve_persist_behavior` so the config-gated default
     (``model.persist_switch_by_default``) is applied in one place.
 
+    Both naming conventions are accepted, so the issue #58290 reporter's
+    expected ``--session-only`` and the existing ``--session`` work
+    identically. ``--persist`` is an alias for ``--global`` and ``--no-save``
+    is an alias for ``--session`` / ``--session-only``.
+
     Examples::
 
-        "sonnet"                         -> ("sonnet", "", False, False, False)
-        "sonnet --global"                -> ("sonnet", "", True, False, False)
-        "sonnet --session"               -> ("sonnet", "", False, False, True)
-        "sonnet --provider anthropic"    -> ("sonnet", "anthropic", False, False, False)
-        "--provider my-ollama"           -> ("", "my-ollama", False, False, False)
-        "--refresh"                      -> ("", "", False, True, False)
+        "sonnet"                          -> ("sonnet", "", False, False, False)
+        "sonnet --global"                 -> ("sonnet", "", True, False, False)
+        "sonnet --persist"                -> ("sonnet", "", True, False, False)
+        "sonnet --session"                -> ("sonnet", "", False, False, True)
+        "sonnet --session-only"           -> ("sonnet", "", False, False, True)
+        "sonnet --no-save"                -> ("sonnet", "", False, False, True)
+        "sonnet --provider anthropic"     -> ("sonnet", "anthropic", False, False, False)
+        "--provider my-ollama"            -> ("", "my-ollama", False, False, False)
+        "--refresh"                       -> ("", "", False, True, False)
         "sonnet --provider anthropic --global" -> ("sonnet", "anthropic", True, False, False)
     """
     is_global = False
@@ -378,19 +386,37 @@ def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool, bool]:
     is_session = False
 
     # Normalize Unicode dashes (Telegram/iOS auto-converts -- to em/en dash)
-    # A single Unicode dash before a flag keyword becomes "--"
+    # A single Unicode dash before a flag keyword becomes "--".
+    # Match the canonical flag names plus their aliases (--persist, --session-only,
+    # --no-save) so the same auto-correction works for the alternate spellings.
     import re as _re
-    raw_args = _re.sub(r'[\u2012\u2013\u2014\u2015](provider|global|session|refresh)', r'--\1', raw_args)
+    raw_args = _re.sub(
+        r'[\u2012\u2013\u2014\u2015]'
+        r'(provider|global|persist|session|session-only|no-save|refresh)',
+        r'--\1',
+        raw_args,
+    )
 
-    # Extract --global
-    if "--global" in raw_args:
+    # Extract --global / --persist (explicit persist)
+    if "--global" in raw_args or "--persist" in raw_args:
         is_global = True
-        raw_args = raw_args.replace("--global", "").strip()
+        raw_args = raw_args.replace("--global", "").replace("--persist", "").strip()
 
-    # Extract --session (explicit session-only; overrides the persist default)
-    if "--session" in raw_args:
+    # Extract --session / --session-only / --no-save (explicit session-only;
+    # overrides the persist default)
+    if (
+        "--session-only" in raw_args
+        or "--session" in raw_args
+        or "--no-save" in raw_args
+    ):
         is_session = True
-        raw_args = raw_args.replace("--session", "").strip()
+        raw_args = (
+            raw_args
+            .replace("--session-only", "")
+            .replace("--session", "")
+            .replace("--no-save", "")
+            .strip()
+        )
 
     # Extract --refresh (bust the model picker disk cache before listing)
     if "--refresh" in raw_args:

--- a/tests/cli/test_model_session_only.py
+++ b/tests/cli/test_model_session_only.py
@@ -1,0 +1,223 @@
+"""Tests for /model slash command session-only persistence (issue #58290).
+
+The bug reporter typed ``/model <name> --provider <provider>`` in Feishu and
+the agent silently persisted the change to ``config.yaml`` even though they
+never typed ``--global``. The fix introduces clearer flag aliases:
+
+- ``--session-only`` (and ``--no-save``) — alias for the existing ``--session``,
+  opts out of persisting to ``config.yaml`` for this session.
+- ``--persist`` — alias for the existing ``--global``, opts in to persisting.
+
+The default (no flag) is still controlled by ``model.persist_switch_by_default``
+in config.yaml (defaults to True). This test file pins the new flag aliases and
+the behavior ``resolve_persist_behavior`` derives from them so a future
+refactor can't silently regress the issue's UX.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import parse_model_flags, resolve_persist_behavior
+
+
+# ---------------------------------------------------------------------------
+# parse_model_flags: new aliases
+# ---------------------------------------------------------------------------
+
+
+class TestParseModelFlagsAliases:
+    """The issue #58290 reporter asked for ``--session-only``; we keep the
+    existing ``--session`` working AND accept the new aliases."""
+
+    def test_no_flags(self):
+        assert parse_model_flags("sonnet") == ("sonnet", "", False, False, False)
+
+    def test_session_flag_still_works(self):
+        assert parse_model_flags("sonnet --session") == (
+            "sonnet",
+            "",
+            False,
+            False,
+            True,
+        )
+
+    def test_session_only_flag(self):
+        # New alias requested by issue #58290.
+        assert parse_model_flags("sonnet --session-only") == (
+            "sonnet",
+            "",
+            False,
+            False,
+            True,
+        )
+
+    def test_no_save_flag(self):
+        # Another intuitive alias for the session-only opt-out.
+        assert parse_model_flags("sonnet --no-save") == (
+            "sonnet",
+            "",
+            False,
+            False,
+            True,
+        )
+
+    def test_global_flag_still_works(self):
+        assert parse_model_flags("sonnet --global") == (
+            "sonnet",
+            "",
+            True,
+            False,
+            False,
+        )
+
+    def test_persist_flag(self):
+        # New alias for --global.
+        assert parse_model_flags("sonnet --persist") == (
+            "sonnet",
+            "",
+            True,
+            False,
+            False,
+        )
+
+    def test_session_only_with_provider(self):
+        # Reproduces the exact shape from the bug report.
+        assert parse_model_flags(
+            "gpt-4o-mini --provider openai --session-only"
+        ) == ("gpt-4o-mini", "openai", False, False, True)
+
+    def test_persist_with_provider(self):
+        assert parse_model_flags(
+            "claude-sonnet-4-6 --provider anthropic --persist"
+        ) == ("claude-sonnet-4-6", "anthropic", True, False, False)
+
+    def test_session_only_takes_precedence_over_global(self):
+        # Defensive: even if someone types both, --session wins (explicit
+        # opt-out beats explicit opt-in).
+        assert parse_model_flags("sonnet --global --session-only") == (
+            "sonnet",
+            "",
+            True,
+            False,
+            True,
+        )
+
+    def test_session_flag_model_only_stripped(self):
+        # After flag stripping, no leftover fragments.
+        model_input, _, _, _, _ = parse_model_flags("sonnet --session-only")
+        assert model_input == "sonnet"
+
+    def test_persist_flag_model_only_stripped(self):
+        model_input, _, _, _, _ = parse_model_flags("sonnet --persist")
+        assert model_input == "sonnet"
+
+    def test_no_save_flag_model_only_stripped(self):
+        model_input, _, _, _, _ = parse_model_flags("sonnet --no-save")
+        assert model_input == "sonnet"
+
+
+# ---------------------------------------------------------------------------
+# resolve_persist_behavior: stays correct with the new aliases
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePersistBehaviorAliases:
+    """``resolve_persist_behavior`` doesn't know flag spellings — it just
+    takes the parsed (is_global, is_session) pair. These tests confirm the
+    alias surface flows through to the same True/False decision as the
+    canonical flags."""
+
+    def test_session_only_resolves_to_session(self):
+        # Same input as ``--session``: is_global=False, is_session=True.
+        with _config({"model": {"persist_switch_by_default": True}}):
+            assert resolve_persist_behavior(False, True) is False
+
+    def test_persist_resolves_to_persist(self):
+        # Same input as ``--global``: is_global=True, is_session=False.
+        with _config({"model": {"persist_switch_by_default": False}}):
+            assert resolve_persist_behavior(True, False) is True
+
+    def test_default_still_persists_when_config_true(self):
+        # No flag at all → defer to config default.
+        with _config({"model": {"persist_switch_by_default": True}}):
+            assert resolve_persist_behavior(False, False) is True
+
+    def test_default_session_only_when_config_false(self):
+        # User explicitly turned off the persist-by-default config key.
+        with _config({"model": {"persist_switch_by_default": False}}):
+            assert resolve_persist_behavior(False, False) is False
+
+
+# ---------------------------------------------------------------------------
+# end-to-end: reproduce the bug report shape and confirm the new flag wins
+# ---------------------------------------------------------------------------
+
+
+class TestBugReportScenario:
+    """The bug reporter ran ``/model <name> --provider <provider>`` and got
+    an unwanted persistence. The new ``--session-only`` alias matches the
+    wording they asked for in the issue's "Expected Behavior" section."""
+
+    def test_plain_slash_model_with_provider_persists_by_default(self):
+        # Documented behavior: without --session-only, default still
+        # persists when config default is True (this matches the existing
+        # ``model.persist_switch_by_default: True`` shipped default).
+        model_input, explicit_provider, is_global, _, is_session = parse_model_flags(
+            "claude-sonnet-4-6 --provider anthropic"
+        )
+        assert model_input == "claude-sonnet-4-6"
+        assert explicit_provider == "anthropic"
+        assert is_global is False
+        assert is_session is False
+        with _config({}):
+            # Empty config → default True → switch persists.
+            assert resolve_persist_behavior(is_global, is_session) is True
+
+    def test_slash_model_with_provider_and_session_only_does_not_persist(self):
+        # The exact fix the issue asks for: --session-only opts out.
+        _, _, is_global, _, is_session = parse_model_flags(
+            "claude-sonnet-4-6 --provider anthropic --session-only"
+        )
+        with _config({}):
+            assert resolve_persist_behavior(is_global, is_session) is False
+
+    def test_slash_model_with_provider_and_no_save_does_not_persist(self):
+        # --no-save is an equally valid alias for the same opt-out.
+        _, _, is_global, _, is_session = parse_model_flags(
+            "claude-sonnet-4-6 --provider anthropic --no-save"
+        )
+        with _config({}):
+            assert resolve_persist_behavior(is_global, is_session) is False
+
+    def test_slash_model_with_provider_and_persist_writes_config(self):
+        # The explicit persist path. Users who DO want the old behavior
+        # (silently write config.yaml) can opt in with --persist.
+        _, _, is_global, _, is_session = parse_model_flags(
+            "claude-sonnet-4-6 --provider anthropic --persist"
+        )
+        with _config({}):
+            assert resolve_persist_behavior(is_global, is_session) is True
+
+
+# ---------------------------------------------------------------------------
+# helper
+# ---------------------------------------------------------------------------
+
+
+class _config:
+    """Context manager that patches ``load_config`` to return a fixed dict."""
+
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+
+    def __enter__(self):
+        self._patch = patch(
+            "hermes_cli.config.load_config",
+            return_value=self.cfg,
+        )
+        # resolve_persist_behavior imports load_config lazily inside the
+        # function, so patching the source module is sufficient.
+        self._patch.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._patch.stop()


### PR DESCRIPTION
Fixes #58290

## Summary

Issue #58290: a Feishu user reported that `/model <name> --provider <provider>` silently wrote the new model+provider to `config.yaml` as the default, even though they never typed `--global`. The existing `--session` flag already opts out of persistence, but the wording did not match the user's expectation.

This PR adds three flag aliases on top of the existing `--session` / `--global` behavior so users can spell the intent the way they think of it:

- `--session-only`  (alias of `--session`; opt out of persisting)
- `--no-save`       (alias of `--session`; opt out of persisting)
- `--persist`       (alias of `--global`; opt in to persisting)

`parse_model_flags()` strips any of those flags and translates to the same `(is_global, is_session)` tuple that `resolve_persist_behavior()` already understands, so no downstream call site changes are needed.

Defaults remain unchanged: a plain `/model <name>` still defers to `model.persist_switch_by_default` in `config.yaml` (True by default), so existing user workflows are preserved.

## Test plan

- [x] `tests/cli/test_model_session_only.py` — 20 new tests covering all three new aliases (`--session-only`, `--no-save`, `--persist`) plus the bug-report scenario (`/model <name> --provider <provider>` with and without the new opt-out flags)
- [x] `tests/hermes_cli/test_model_switch_persist_default.py` — all 13 existing tests still pass (no regressions)

`pytest tests/cli/test_model_session_only.py tests/hermes_cli/test_model_switch_persist_default.py -v` → 33 passed.

## Files changed

- `hermes_cli/model_switch.py` — `parse_model_flags` accepts the new flag aliases and the Unicode-dash auto-correction list now includes them
- `hermes_cli/commands.py` — `/model` `args_hint` reflects the new flags
- `cli.py` — `_handle_model_switch` docstring lists the new flags
- `tests/cli/test_model_session_only.py` — new test file

---

AI-assisted fix by https://github.com/SquabbyZ/peaks-loop