### PR TITLE
fix(network): support CIDR notation in no_proxy (#59465)

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -23,12 +23,93 @@ unchanged.
 
 from __future__ import annotations
 
+import ipaddress
 import os
 import sys
 import urllib.request
 from typing import Any, Optional
 
 from utils import base_url_hostname, normalize_proxy_url
+
+
+def _no_proxy_matches_no_proxy_env(host: str) -> bool:
+    """Check ``NO_PROXY`` for a host, including CIDR entries the stdlib ignores.
+
+    Wraps ``urllib.request.proxy_bypass_environment(host)`` (which only honors
+    exact / suffix hostnames like ``localhost`` or ``.example.com``) and adds
+    support for:
+
+    * CIDR ranges — e.g. ``10.0.0.0/24``, ``2001:db8::/32``.
+    * Bare single-IP entries — e.g. ``192.168.1.5`` (matched exactly when the
+      resolved target host is an IP).
+
+    Many other tools (curl, browsers, ``requests-toolbelt``-style stacks,
+    Node's ``http-proxy-agent``) have honored CIDR in ``NO_PROXY`` for years;
+    Python's stdlib still does not, which makes
+    ``urllib.request.proxy_bypass_environment()`` silently route traffic
+    around an operator's expected bypass. See #59465.
+    """
+    try:
+        if urllib.request.proxy_bypass_environment(host):
+            return True
+    except Exception:
+        # Fall through to manual CIDR / exact-IP matching.
+        pass
+
+    no_proxy_value = os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or ""
+    if not no_proxy_value or not host:
+        return False
+
+    def _strip_brackets(token: str) -> str:
+        if token.startswith("[") and token.endswith("]"):
+            return token[1:-1]
+        return token
+
+    def _ip_version(token: str) -> int:
+        """Return the ipaddress version (4 or 6) of a bare IP literal; default 4."""
+        try:
+            return ipaddress.ip_address(token).version
+        except ValueError:
+            return 4
+
+    for raw_entry in no_proxy_value.split(","):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+        # Hostname entries (e.g. ``.internal``, ``example.com``) and bare names
+        # (``localhost``) are already covered by ``proxy_bypass_environment``
+        # above; only the IP-flavored entries need additional parsing.
+        if "/" in entry:
+            # CIDR — e.g. ``10.0.0.0/24`` or ``2001:db8::/32``.
+            try:
+                network = ipaddress.ip_network(entry, strict=False)
+            except ValueError:
+                continue
+            try:
+                addr = ipaddress.ip_address(host)
+            except ValueError:
+                return False
+            if addr.version != network.version:
+                continue
+            if addr in network:
+                return True
+        else:
+            token = _strip_brackets(entry)
+            try:
+                ipaddress.ip_address(token)
+            except ValueError:
+                # Bare hostname like ``localhost`` already handled by stdlib
+                # branch above.
+                continue
+            try:
+                addr = ipaddress.ip_address(host)
+            except ValueError:
+                return False
+            if addr.version != _ip_version(token):
+                continue
+            if str(addr) == token:
+                return True
+    return False
 
 
 # Cached at module level so we only pay the OpenAI SDK import cost once
@@ -124,7 +205,12 @@ def _get_proxy_from_env() -> Optional[str]:
 
 
 def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
-    """Return an env-configured proxy unless NO_PROXY excludes this base URL."""
+    """Return an env-configured proxy unless NO_PROXY excludes this base URL.
+
+    Honors both stdlib ``no_proxy`` semantics (exact / suffix hostnames) and
+    CIDR / single-IP entries via :func:`_no_proxy_matches_no_proxy_env`. See
+    #59465 for why the CIDR support matters.
+    """
     proxy = _get_proxy_from_env()
     if not proxy or not base_url:
         return proxy
@@ -134,9 +220,11 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
         return proxy
 
     try:
-        if urllib.request.proxy_bypass_environment(host):
+        if _no_proxy_matches_no_proxy_env(host):
             return None
     except Exception:
+        # Match the previous fault-tolerance — a bad ``no_proxy`` entry must
+        # never break connectivity.
         pass
 
     return proxy

--- a/tests/test_no_proxy_cidr.py
+++ b/tests/test_no_proxy_cidr.py
@@ -1,0 +1,148 @@
+"""Regression tests for #59465 — ``no_proxy`` must honor CIDR / single-IP entries.
+
+``urllib.request.proxy_bypass_environment()`` (which underlies
+``_get_proxy_for_base_url``) only matches exact hostnames / domain suffixes.
+CIDR ranges such as ``10.0.0.0/24`` and bare single-IP entries like
+``192.168.1.5`` are silently ignored, so a custom provider whose
+``base_url`` lives inside the operator's intended exclusion subnet gets
+routed through the unrelated HTTP proxy and fails with an empty 503.
+
+These tests pin the extended behavior added by
+:func:`agent.process_bootstrap._no_proxy_matches_no_proxy_env`:
+
+* CIDR subnet — host inside the subnet bypasses the proxy.
+* CIDR subnet — host outside the subnet still uses the proxy.
+* Single-IP ``no_proxy`` entry — bypass only for that exact IP.
+* Plain hostname entry — continues to match (no regression on #14966).
+* Mixed entries — both hostnames and CIDR apply.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agent.process_bootstrap import (
+    _get_proxy_for_base_url,
+    _no_proxy_matches_no_proxy_env,
+)
+
+
+PROXY_ENV_KEYS = (
+    "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+    "https_proxy", "http_proxy", "all_proxy",
+    "NO_PROXY", "no_proxy",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_proxy_env(monkeypatch):
+    """Wipe every proxy-related env var before each test."""
+    for key in PROXY_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    yield
+
+
+def test_cidr_subnet_bypasses_proxy_for_inside_target():
+    """``no_proxy=10.0.0.0/24`` excludes ``10.0.0.5`` (inside the subnet)."""
+    import os
+    os.environ["HTTPS_PROXY"] = "http://corp:8080"
+    os.environ["NO_PROXY"] = "10.0.0.0/24"
+
+    assert _get_proxy_for_base_url("http://10.0.0.5:4001/v1") is None
+
+
+def test_cidr_subnet_does_not_bypass_outside_target():
+    """``no_proxy=10.0.0.0/24`` does NOT exclude ``10.0.1.5`` (outside)."""
+    import os
+    os.environ["HTTPS_PROXY"] = "http://corp:8080"
+    os.environ["NO_PROXY"] = "10.0.0.0/24"
+
+    assert _get_proxy_for_base_url("http://10.0.1.5:4001/v1") == "http://corp:8080"
+
+
+def test_single_ip_bypasses_exact_match():
+    """``no_proxy=192.168.1.5`` excludes only ``192.168.1.5``."""
+    import os
+    os.environ["HTTPS_PROXY"] = "http://corp:8080"
+    os.environ["NO_PROXY"] = "192.168.1.5"
+
+    assert _get_proxy_for_base_url("http://192.168.1.5:4001/v1") is None
+    # An adjacent IP on the same /24 is NOT covered by a single-IP entry.
+    assert _get_proxy_for_base_url("http://192.168.1.6:4001/v1") == "http://corp:8080"
+
+
+def test_plain_hostname_bypasses_no_regression():
+    """Plain hostname ``no_proxy=example.com`` still bypasses (no regression)."""
+    import os
+    os.environ["HTTPS_PROXY"] = "http://corp:8080"
+    os.environ["NO_PROXY"] = "example.com"
+
+    assert _get_proxy_for_base_url("https://api.example.com/v1") is None
+
+
+def test_mixed_hostname_and_cidr_entries_both_apply():
+    """Mixed ``no_proxy`` entries — hostnames via stdlib, CIDR via this fix."""
+    import os
+    os.environ["HTTPS_PROXY"] = "http://corp:8080"
+    os.environ["NO_PROXY"] = "localhost,127.0.0.1,10.10.10.0/24"
+
+    # Hostname matches
+    assert _get_proxy_for_base_url("http://localhost:11434/v1") is None
+    assert _get_proxy_for_base_url("http://127.0.0.1:11434/v1") is None
+    # CIDR match
+    assert _get_proxy_for_base_url("http://10.10.10.101:4001/v1") is None
+    # Outside the CIDR — proxy still applies.
+    assert _get_proxy_for_base_url("http://10.10.11.5:4001/v1") == "http://corp:8080"
+    # Public host — proxy still applies.
+    assert _get_proxy_for_base_url("https://api.openai.com/v1") == "http://corp:8080"
+
+
+def test_lowercase_no_proxy_also_recognized():
+    """``no_proxy`` (lowercase) must be honored just like ``NO_PROXY``."""
+    import os
+    os.environ["HTTPS_PROXY"] = "http://corp:8080"
+    os.environ["no_proxy"] = "10.0.0.0/24"
+
+    assert _get_proxy_for_base_url("http://10.0.0.5:4001/v1") is None
+    assert _get_proxy_for_base_url("http://10.0.1.5:4001/v1") == "http://corp:8080"
+
+
+def test_ipv6_cidr_bypasses_ipv6_target():
+    """IPv6 CIDR ranges also work — e.g. ``2001:db8::/32``."""
+    import os
+    os.environ["HTTPS_PROXY"] = "http://corp:8080"
+    os.environ["NO_PROXY"] = "2001:db8::/32"
+
+    assert _get_proxy_for_base_url("http://[2001:db8::5]:4001/v1") is None
+    # IPv4 target against an IPv6 CIDR — mismatch, proxy applies.
+    assert _get_proxy_for_base_url("http://10.0.0.5:4001/v1") == "http://corp:8080"
+
+
+def test_malformed_cidr_entry_does_not_break_other_entries():
+    """A bad CIDR entry must not torpedo the rest of the ``no_proxy`` list."""
+    import os
+    os.environ["HTTPS_PROXY"] = "http://corp:8080"
+    os.environ["NO_PROXY"] = "not-an-ip/99,10.0.0.0/24"
+
+    # Valid CIDR still wins after the malformed entry.
+    assert _get_proxy_for_base_url("http://10.0.0.5:4001/v1") is None
+    # Unrelated target — proxy still applies.
+    assert _get_proxy_for_base_url("https://api.openai.com/v1") == "http://corp:8080"
+
+
+def test_helper_direct_no_proxy_returns_true_for_cidr_match():
+    """Direct unit-test of the helper for the inside-CIDR case."""
+    import os
+    os.environ["NO_PROXY"] = "10.0.0.0/24"
+
+    assert _no_proxy_matches_no_proxy_env("10.0.0.5") is True
+    assert _no_proxy_matches_no_proxy_env("10.0.1.5") is False
+
+
+def test_helper_preserves_localhost_match():
+    """Direct unit-test — helper still honors localhost/stdlib semantics."""
+    import os
+    os.environ["NO_PROXY"] = "localhost,127.0.0.1"
+
+    assert _no_proxy_matches_no_proxy_env("localhost") is True
+    assert _no_proxy_matches_no_proxy_env("127.0.0.1") is True
+    assert _no_proxy_matches_no_proxy_env("10.0.0.5") is False


### PR DESCRIPTION
Fixes #59465

## Summary

`urllib.request.proxy_bypass_environment()` — the stdlib primitive we delegate to inside `_get_proxy_for_base_url` (used by every custom OpenAI-compatible client's keepalive HTTP client) — only matches exact / suffix hostnames (e.g. `localhost`, `.example.com`). CIDR ranges like `10.0.0.0/24` or bare single-IP entries like `192.168.1.5` are silently ignored.

In practice that means: when an operator has a global `HTTPS_PROXY` (e.g. for Telegram from restricted regions) AND `NO_PROXY=localhost,127.0.0.1,10.10.10.0/24`, calls to a custom provider whose `base_url` is inside `10.10.10.0/24` (but not literally the same string) get routed through the unrelated proxy. The OpenAI SDK surfaces that as `InternalServerError: Error code: 503` with an empty body — looking exactly like a provider outage, with zero traffic actually arriving at the provider host.

This PR adds CIDR / single-IP awareness to `NO_PROXY` parsing while preserving every existing stdlib behavior for hostname/suffix matches (no #14966 regression).

## Changes

- **`agent/process_bootstrap.py`** — new `_no_proxy_matches_no_proxy_env(host)` helper that wraps `urllib.request.proxy_bypass_environment()` for hostname/suffix entries and additionally parses:
  - `a.b.c.d/n` / `2001:db8::/32` — via `ipaddress.ip_network()` + `addr in network`
  - bare `a.b.c.d` / `[::1]` — exact single-IP match via `ipaddress.ip_address()`

  `_get_proxy_for_base_url` now delegates to this helper. Fault-tolerance against malformed `NO_PROXY` entries is preserved (bad entries are skipped, not raised).

- **`tests/test_no_proxy_cidr.py`** — 10 tests covering the spec from the issue plus adjacent edge cases: lowercase `no_proxy`, IPv6 CIDR, mixed hostname+CIDR lists, malformed entries, direct helper unit tests, and the explicit "no regression on hostname match" case.

## Test run

```
$ pytest tests/test_no_proxy_cidr.py -v
tests/test_no_proxy_cidr.py::test_cidr_subnet_bypasses_proxy_for_inside_target PASSED
tests/test_no_proxy_cidr.py::test_cidr_subnet_does_not_bypass_outside_target PASSED
tests/test_no_proxy_cidr.py::test_single_ip_bypasses_exact_match PASSED
tests/test_no_proxy_cidr.py::test_plain_hostname_bypasses_no_regression PASSED
tests/test_no_proxy_cidr.py::test_mixed_hostname_and_cidr_entries_both_apply PASSED
tests/test_no_proxy_cidr.py::test_lowercase_no_proxy_also_recognized PASSED
tests/test_no_proxy_cidr.py::test_ipv6_cidr_bypasses_ipv6_target PASSED
tests/test_no_proxy_cidr.py::test_malformed_cidr_entry_does_not_break_other_entries PASSED
tests/test_no_proxy_cidr.py::test_helper_direct_no_proxy_returns_true_for_cidr_match PASSED
tests/test_no_proxy_cidr.py::test_helper_preserves_localhost_match PASSED
===================== 10 passed in 0.54s =====================
```

The previously-existing `test_get_proxy_for_base_url_*` tests in `tests/run_agent/test_create_openai_client_proxy_env.py` and `tests/agent/test_auxiliary_client_proxy_env.py` continue to pass (no regression on the hostname/suffix path).

## Cross-platform

Uses only the `ipaddress` stdlib module. No new dependencies. Pure-Python, no platform-specific code.

---

AI-assisted fix by https://github.com/SquabbyZ/peaks-loop
