### PR TITLE
fix(gateway): strip tool-call-shaped JSON envelope from Telegram output (#59291)

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -461,6 +461,254 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
     return found
 
 
+# ---------------------------------------------------------------------------
+# Tool-call-shaped envelope suppression (#59291)
+# ---------------------------------------------------------------------------
+#
+# Local / weak models (Ollama, vLLM, llama.cpp backends — e.g. gpt-oss:120b)
+# occasionally emit a JSON object that *looks* like a tool invocation
+# directly into plain assistant ``content`` instead of routing it through
+# the structured ``tool_calls`` channel.  Two shapes are observed:
+#
+#   * OpenAI-style:    {"name": "clarify", "arguments": {...}}
+#                      {"function": {"name": "...", "arguments": "..."}}
+#   * Pseudo-style:    {"action": "clarify", "question": "...",
+#                       "choices": [...]}
+#                      — the invented ``action`` key is the giveaway;
+#                      no real Hermes schema defines it.
+#
+# The other sanitizers in this module only repair JSON *inside* an
+# already-recognised ``tool_calls`` array, so a shape-alike envelope
+# sitting in plain content passes through untouched and reaches end
+# users verbatim — most visibly on the Telegram gateway, where the raw
+# JSON replaces the intended inline-keyboard / numbered-list render of
+# a ``clarify`` prompt.
+#
+# ``_strip_tool_call_envelope`` is the structural guard for that case.
+# It scans assistant content (not ``tool_calls``) for a JSON object
+# whose shape matches a tool invocation and removes it, protecting any
+# fenced or inline code regions so user-intended JSON samples survive.
+
+# Fenced code block: ```lang\n ... \n```  (non-greedy, multiline)
+_FENCED_CODE_RE = re.compile(
+    r'(```[^\n]*\n[\s\S]*?```|```[\s\S]*?```)',
+)
+# Inline code: ` ... `
+_INLINE_CODE_RE = re.compile(r'(`[^`\n]+`)')
+
+
+def _protect_code_regions(text: str) -> tuple:
+    """Replace fenced + inline code regions with NUL-byte placeholders.
+
+    Returns ``(protected_text, placeholders)`` so the caller can
+    re-hydrate the originals after editing non-code regions.
+    """
+    placeholders: dict = {}
+    counter = [0]
+
+    def _stash(match: "re.Match[str]") -> str:
+        token = f"\x00CODE{counter[0]}\x00"
+        counter[0] += 1
+        placeholders[token] = match.group(0)
+        return token
+
+    protected = _FENCED_CODE_RE.sub(_stash, text)
+    protected = _INLINE_CODE_RE.sub(_stash, protected)
+    return protected, placeholders
+
+
+def _restore_code_regions(text: str, placeholders: dict) -> str:
+    """Inverse of :func:`_protect_code_regions`."""
+    if not placeholders:
+        return text
+    out = text
+    for token, original in placeholders.items():
+        out = out.replace(token, original)
+    return out
+
+
+def _try_extract_json_object(text: str, start: int) -> tuple | None:
+    """Try to extract a balanced JSON object starting at ``text[start]``.
+
+    Walks the string tracking nesting depth while ignoring braces
+    inside string literals.  Returns ``(start, end, parsed)`` where
+    ``end`` is the index just past the closing ``}``, or ``None`` if no
+    balanced object can be located / parsed.
+    """
+    if start >= len(text) or text[start] != "{":
+        return None
+    depth = 0
+    in_string = False
+    escape = False
+    i = start
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            i += 1
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                candidate = text[start:i + 1]
+                try:
+                    parsed = json.loads(candidate, strict=False)
+                except (json.JSONDecodeError, ValueError):
+                    return None
+                if isinstance(parsed, dict):
+                    return (start, i + 1, parsed)
+                return None
+        i += 1
+    return None
+
+
+def _is_tool_call_envelope(obj: dict) -> bool:
+    """Heuristic: does this dict *look* like a tool-call invocation?
+
+    Returns True for either of the canonical shapes observed from
+    local-model emissions:
+
+      * OpenAI-style:   ``name`` + ``arguments`` (or ``args`` /
+        ``parameters``); or a ``function`` wrapper; or a top-level
+        ``tool`` / ``tool_name`` / ``tool_call`` / ``tool_calls`` key.
+      * Pseudo-style:   an invented ``action`` key — no real Hermes
+        schema defines ``action``, so its presence is a strong signal
+        of a hallucinated pseudo-call (#59291).
+    """
+    if not isinstance(obj, dict) or not obj:
+        return False
+    keys = set(obj.keys())
+    if "name" in keys and ("arguments" in keys or "args" in keys or "parameters" in keys or "params" in keys):
+        return True
+    if "function" in keys and isinstance(obj.get("function"), dict):
+        return True
+    if "tool" in keys or "tool_name" in keys or "tool_call" in keys or "tool_calls" in keys:
+        return True
+    # The invented ``action`` pseudo-key is the strongest single
+    # signal — it's not part of any registered tool schema.
+    if "action" in keys:
+        return True
+    return False
+
+
+def _strip_tool_call_envelope(
+    text: str,
+    *,
+    replacement: str = "",
+    logger_: "logging.Logger | None" = None,
+) -> str:
+    """Strip tool-call-shaped JSON envelopes from a plain-text assistant message.
+
+    Local/weak models occasionally emit a JSON object that *looks* like
+    a tool invocation directly into assistant ``content`` instead of
+    routing it through ``tool_calls``.  The literal JSON then reaches
+    end users (most visibly on the Telegram gateway, where it replaces
+    the intended inline-keyboard / numbered-list render of a
+    ``clarify`` prompt).  This helper detects and removes those
+    envelopes while preserving any fenced or inline code the user may
+    have intended to display (#59291).
+
+    Parameters
+    ----------
+    text:
+        Raw assistant content string.  ``None`` and empty strings are
+        returned unchanged.  Non-string inputs are coerced to ``""``
+        so callers can pass ``response.choices[0].message.content``
+        directly without isinstance checks.
+    replacement:
+        String used to replace each stripped envelope.  Defaults to
+        empty string (silently dropped).  Callers can pass a friendly
+        placeholder such as ``"(handled)"`` if they prefer an explicit
+        note in the rendered output.
+    logger_:
+        Optional logger override — defaults to this module's logger.
+        Each suppression logs one DEBUG line summarising how many
+        envelopes were removed and the total byte count, so operators
+        can audit which models / sessions trip the guard without
+        spamming normal output.
+
+    Notes
+    -----
+    * Code blocks (```` ``` ... ``` ````) and inline code (``...``)
+      are protected so user-intended JSON samples survive untouched.
+    * The detector is structural (matches ``name`` + ``arguments``
+      keys and the ``action``-invention pseudo-shape) rather than a
+      string heuristic — consistent with the other deterministic
+      guards in this module.
+    * Multiple envelopes in one message are all stripped in a single
+      pass.
+    """
+    if text is None or not isinstance(text, str) or not text:
+        return text if text is not None else ""
+
+    log = logger_ or logger
+    protected, placeholders = _protect_code_regions(text)
+
+    out_parts: list = []
+    cursor = 0
+    suppressed_count = 0
+    suppressed_bytes = 0
+    n = len(protected)
+
+    while cursor < n:
+        # Pass through placeholder tokens verbatim.
+        if protected[cursor] == "\x00":
+            end_tok = protected.index("\x00", cursor + 1)
+            out_parts.append(protected[cursor:end_tok + 1])
+            cursor = end_tok + 1
+            continue
+
+        if protected[cursor] != "{":
+            out_parts.append(protected[cursor])
+            cursor += 1
+            continue
+
+        extracted = _try_extract_json_object(protected, cursor)
+        if extracted is None:
+            out_parts.append(protected[cursor])
+            cursor += 1
+            continue
+
+        start, end, parsed = extracted
+        if not _is_tool_call_envelope(parsed):
+            # Not a tool-call envelope — keep the leading ``{`` and
+            # advance one character so we don't loop on the same byte.
+            out_parts.append(protected[cursor])
+            cursor += 1
+            continue
+
+        suppressed_count += 1
+        suppressed_bytes += end - start
+        if replacement:
+            out_parts.append(replacement)
+        # Skip past the entire envelope.
+        cursor = end
+
+    result = _restore_code_regions("".join(out_parts), placeholders)
+
+    if suppressed_count:
+        log.debug(
+            "Stripped %d tool-call-shaped JSON envelope(s) from assistant "
+            "content (%d bytes total)",
+            suppressed_count,
+            suppressed_bytes,
+        )
+
+    return result
+
+
 __all__ = [
     "_SURROGATE_RE",
     "close_interrupted_tool_sequence",
@@ -474,4 +722,9 @@ __all__ = [
     "_sanitize_tools_non_ascii",
     "_strip_images_from_messages",
     "_sanitize_structure_non_ascii",
+    "_strip_tool_call_envelope",
+    "_is_tool_call_envelope",
+    "_protect_code_regions",
+    "_restore_code_regions",
+    "_try_extract_json_object",
 ]

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -19,6 +19,8 @@ import threading
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
+from agent.message_sanitization import _strip_tool_call_envelope
+
 logger = logging.getLogger(__name__)
 
 
@@ -6351,6 +6353,20 @@ class TelegramAdapter(BasePlatformAdapter):
         (headers, bold, italic, links) are translated to MarkdownV2 syntax,
         and all remaining special characters are escaped.
         """
+        if not content:
+            return content
+
+        # 0) Suppress tool-call-shaped JSON envelopes (#59291).  Local /
+        #    weak models (Ollama, vLLM — e.g. gpt-oss:120b) sometimes
+        #    emit a JSON object that *looks* like a tool invocation
+        #    directly into assistant ``content`` instead of routing it
+        #    through ``tool_calls``.  Without this guard the raw JSON
+        #    reaches the user verbatim, replacing the intended UI
+        #    affordance (inline keyboard for ``clarify``, etc.).
+        #    The sanitizer protects fenced + inline code regions so
+        #    user-intended JSON samples survive untouched.
+        content = _strip_tool_call_envelope(content)
+
         if not content:
             return content
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -177,6 +177,7 @@ from agent.message_sanitization import (  # noqa: F401
     _sanitize_tools_non_ascii,
     _strip_images_from_messages,
     _sanitize_structure_non_ascii,
+    _strip_tool_call_envelope,
 )
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,

--- a/tests/gateway/test_telegram_output_sanitization.py
+++ b/tests/gateway/test_telegram_output_sanitization.py
@@ -1,0 +1,379 @@
+"""Tests for the Telegram output-sanitization guard (#59291).
+
+When a local model (Ollama, vLLM — e.g. gpt-oss:120b) emits a
+tool-call-shaped JSON envelope directly in plain assistant ``content``
+instead of routing it through ``tool_calls``, the literal JSON would
+otherwise reach end users verbatim.  The fix is a deterministic
+structural guard in :mod:`agent.message_sanitization` that:
+
+  * Strips tool-call-shaped envelopes from plain assistant text.
+  * Preserves any JSON the user *intentionally* placed in fenced or
+    inline code regions.
+  * Logs each suppression at DEBUG level.
+
+These tests cover the four required cases for the Telegram adapter
+pipeline:
+
+  1. Plain text -> forwarded as-is.
+  2. Tool-call-shaped JSON envelope -> stripped (default; replaced
+     with a friendly placeholder when one is supplied).
+  3. JSON inside a fenced code block -> preserved (user-intended).
+  4. Empty / None input -> handled gracefully (no exception).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.message_sanitization import (
+    _is_tool_call_envelope,
+    _protect_code_regions,
+    _restore_code_regions,
+    _strip_tool_call_envelope,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock the telegram package so the adapter can be imported.
+# ---------------------------------------------------------------------------
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def adapter():
+    config = PlatformConfig(enabled=True, token="fake-token")
+    return TelegramAdapter(config)
+
+
+# =========================================================================
+# 1) Plain text -> forwarded as-is
+# =========================================================================
+
+
+class TestPlainTextForwarded:
+    """Plain assistant content must NOT be mutated by the sanitizer."""
+
+    def test_plain_prose_passes_through_unchanged(self):
+        text = "Hello, world! Here is a normal sentence."
+        assert _strip_tool_call_envelope(text) == text
+
+    def test_multiline_prose_passes_through_unchanged(self):
+        text = "Line one.\nLine two.\nLine three with **bold** and `code`."
+        assert _strip_tool_call_envelope(text) == text
+
+    def test_empty_string_returned_unchanged(self):
+        assert _strip_tool_call_envelope("") == ""
+
+    def test_none_returned_as_empty_string(self):
+        # ``None`` is coerced to ``""`` so callers can pass
+        # ``response.choices[0].message.content`` directly without
+        # isinstance checks.
+        assert _strip_tool_call_envelope(None) == ""
+
+    def test_non_string_input_does_not_raise(self):
+        # Non-string inputs are returned unchanged rather than crashing
+        # — callers should always pass strings, but a stray ``int`` or
+        # ``list`` must not blow up the conversation loop.
+        assert _strip_tool_call_envelope(0) == 0  # type: ignore[arg-type]
+        assert _strip_tool_call_envelope([]) == []  # type: ignore[arg-type]
+        # The string-only fast-path still applies for str inputs.
+        assert _strip_tool_call_envelope("") == ""
+
+
+# =========================================================================
+# 2) Tool-call-shaped JSON envelope -> stripped / replaced
+# =========================================================================
+
+
+class TestEnvelopeSuppression:
+    """Tool-call-shaped JSON must be removed from the visible output."""
+
+    def test_pseudo_style_action_envelope_stripped(self):
+        # The exact shape from the bug report — invented ``action`` key.
+        raw = '{"action":"clarify","question":"Which color?","choices":["red","blue"]}'
+        result = _strip_tool_call_envelope(raw)
+        assert result == ""
+        assert "action" not in result
+        assert "clarify" not in result
+
+    def test_openai_style_name_arguments_stripped(self):
+        raw = '{"name":"clarify","arguments":{"question":"q","choices":["a","b"]}}'
+        result = _strip_tool_call_envelope(raw)
+        assert result == ""
+
+    def test_function_wrapper_stripped(self):
+        raw = '{"function":{"name":"foo","arguments":"{}"}}'
+        result = _strip_tool_call_envelope(raw)
+        assert result == ""
+
+    def test_envelope_embedded_in_prose_is_stripped(self):
+        text = (
+            "Sure, let me ask you:\n"
+            '{"action":"clarify","question":"Which color?","choices":["red","blue"]}\n'
+            "Hope that helps!"
+        )
+        result = _strip_tool_call_envelope(text)
+        assert "action" not in result
+        assert "clarify" not in result
+        assert "Which color?" not in result
+        assert "Sure, let me ask you:" in result
+        assert "Hope that helps!" in result
+
+    def test_multiple_envelopes_all_stripped(self):
+        text = (
+            '{"action":"clarify","question":"q1"}\n'
+            "Some prose.\n"
+            '{"name":"foo","arguments":{"x":1}}\n'
+        )
+        result = _strip_tool_call_envelope(text)
+        assert "action" not in result
+        assert "clarify" not in result
+        assert '"name"' not in result
+        assert "Some prose." in result
+
+    def test_replacement_parameter_is_used(self):
+        raw = '{"action":"clarify","question":"q"}'
+        result = _strip_tool_call_envelope(raw, replacement="(handled)")
+        assert result == "(handled)"
+
+    def test_envelope_strip_logs_at_debug_level(self, caplog):
+        raw = '{"action":"clarify","question":"q","choices":["a"]}'
+        with caplog.at_level(logging.DEBUG, logger="agent.message_sanitization"):
+            _strip_tool_call_envelope(raw)
+        assert any(
+            "tool-call-shaped JSON envelope" in rec.message
+            for rec in caplog.records
+        ), f"expected DEBUG suppression log; got: {[r.message for r in caplog.records]}"
+
+    def test_no_log_when_nothing_stripped(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="agent.message_sanitization"):
+            _strip_tool_call_envelope("Plain text, no envelopes here.")
+        assert not any(
+            "tool-call-shaped JSON envelope" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_non_envelope_json_object_left_alone(self):
+        # A plain JSON object without any tool-call-shaped keys should
+        # not be stripped — it may be a deliberate user message
+        # (e.g. ``{"hello": "world"}``).
+        text = 'Here is data: {"hello": "world", "n": 42}'
+        result = _strip_tool_call_envelope(text)
+        assert result == text
+
+
+# =========================================================================
+# 3) JSON inside code blocks -> preserved (user-intended)
+# =========================================================================
+
+
+class TestCodeBlockPreservation:
+    """User-intended JSON samples inside code regions must survive."""
+
+    def test_json_in_fenced_code_block_preserved(self):
+        text = (
+            "Here is an example:\n"
+            "```json\n"
+            '{"name":"foo","arguments":{"q":"x"}}\n'
+            "```\n"
+        )
+        result = _strip_tool_call_envelope(text)
+        assert result == text
+        assert '{"name":"foo","arguments":{"q":"x"}}' in result
+
+    def test_json_in_inline_code_preserved(self):
+        text = 'Use the `{"action":"x","y":1}` pattern for that.'
+        result = _strip_tool_call_envelope(text)
+        assert result == text
+
+    def test_plain_envelope_stripped_but_code_block_preserved(self):
+        text = (
+            "Intro text.\n"
+            '{"action":"clarify","question":"q"}\n'
+            "Then a code block:\n"
+            "```json\n"
+            '{"action":"also_clarify","question":"q2"}\n'
+            "```\n"
+            "End text."
+        )
+        result = _strip_tool_call_envelope(text)
+        # Outside-code envelope gone.
+        assert '{"action":"clarify","question":"q"}' not in result
+        # Inside-code envelope preserved.
+        assert '{"action":"also_clarify","question":"q2"}' in result
+        assert "End text." in result
+        assert "Then a code block:" in result
+
+    def test_multiple_fenced_blocks_all_preserved(self):
+        text = (
+            "```json\n"
+            '{"name":"a","arguments":{}}\n'
+            "```\n"
+            "between\n"
+            "```\n"
+            '{"function":{"name":"b","arguments":"{}"}}\n'
+            "```\n"
+        )
+        result = _strip_tool_call_envelope(text)
+        assert result == text
+
+
+# =========================================================================
+# 4) Edge cases: empty / None / non-dict JSON
+# =========================================================================
+
+
+class TestEmptyAndEdgeCases:
+    """Empty / None / non-object JSON must not crash or misbehave."""
+
+    def test_whitespace_only_returns_unchanged(self):
+        # Whitespace-only input passes through — the function never
+        # mutates content that has no JSON object to suppress.
+        text = "   \n\t  "
+        assert _strip_tool_call_envelope(text) == text
+
+    def test_unbalanced_braces_do_not_crash(self):
+        text = 'Some text with a stray { but no closing brace'
+        assert _strip_tool_call_envelope(text) == text
+
+    def test_json_array_not_treated_as_envelope(self):
+        # Arrays are tool-call-shaped only when wrapped in a dict; a
+        # bare array must not trigger the suppressor.
+        text = 'Here is a list: ["a", "b", {"name": "x", "arguments": {}}]'
+        result = _strip_tool_call_envelope(text)
+        # The dict *inside* the array will be stripped (it's still a
+        # tool-call envelope when extracted as a balanced object).
+        # The bare list shape itself isn't mistaken for an envelope.
+        assert "[\"a\"" in result or "['a'" in result or result.startswith("Here is a list")
+
+    def test_partial_json_object_is_not_misidentified(self):
+        # Truncated JSON that doesn't parse should pass through.
+        text = 'Incomplete: {"name":"foo","argum'
+        assert _strip_tool_call_envelope(text) == text
+
+
+# =========================================================================
+# Telegram adapter integration
+# =========================================================================
+
+
+class TestTelegramAdapterFormatMessage:
+    """The Telegram adapter's ``format_message`` must apply the guard."""
+
+    def test_adapter_strips_envelope(self, adapter):
+        raw = '{"action":"clarify","question":"Which color?","choices":["red","blue"]}'
+        result = adapter.format_message(raw)
+        # Default replacement is empty string — output is blank.
+        assert result == ""
+
+    def test_adapter_preserves_plain_prose(self, adapter):
+        # Avoid MarkdownV2 special characters in the test string — the
+        # adapter is expected to escape ``!``, ``.``, etc. for
+        # MarkdownV2.  We just want to confirm the sanitizer itself
+        # does not mutate the underlying content.
+        text = "Hello world"
+        result = adapter.format_message(text)
+        # Strip the MarkdownV2 escapes that ``format_message`` adds —
+        # ``!``, ``.``, ``(``, etc. — by replacing ``\!`` / ``\.`` etc.
+        # back to their unescaped form.  Easier: just check the
+        # substantive characters survive unchanged.
+        assert "Hello world" in result
+
+    def test_adapter_preserves_json_in_code_block(self, adapter):
+        text = (
+            "Example:\n"
+            "```json\n"
+            '{"name":"foo","arguments":{"q":"x"}}\n'
+            "```\n"
+        )
+        result = adapter.format_message(text)
+        # The fenced code block survives intact (with MarkdownV2
+        # escaping applied inside the body).
+        assert "```" in result
+        assert "name" in result
+        assert "foo" in result
+
+
+# =========================================================================
+# Internal helpers (defensive coverage)
+# =========================================================================
+
+
+class TestEnvelopeDetection:
+    """Direct unit coverage of :func:`_is_tool_call_envelope`."""
+
+    def test_empty_dict_is_not_envelope(self):
+        assert _is_tool_call_envelope({}) is False
+
+    def test_non_dict_is_not_envelope(self):
+        assert _is_tool_call_envelope("string") is False  # type: ignore[arg-type]
+        assert _is_tool_call_envelope(None) is False  # type: ignore[arg-type]
+        assert _is_tool_call_envelope([1, 2]) is False  # type: ignore[arg-type]
+
+    def test_openai_style_name_with_arguments(self):
+        assert _is_tool_call_envelope({"name": "foo", "arguments": {}}) is True
+
+    def test_openai_style_name_with_args(self):
+        assert _is_tool_call_envelope({"name": "foo", "args": {}}) is True
+
+    def test_function_wrapper(self):
+        assert _is_tool_call_envelope({"function": {"name": "foo"}}) is True
+
+    def test_invented_action_key(self):
+        assert _is_tool_call_envelope({"action": "clarify", "question": "q"}) is True
+
+    def test_tool_key(self):
+        assert _is_tool_call_envelope({"tool": "foo"}) is True
+
+    def test_unrelated_dict_is_not_envelope(self):
+        assert _is_tool_call_envelope({"hello": "world", "n": 42}) is False
+
+
+class TestProtectRestoreCodeRegions:
+    """Round-trip the protect / restore helpers."""
+
+    def test_fenced_code_is_stashed_and_restored(self):
+        text = 'pre\n```json\n{"a": 1}\n```\npost'
+        protected, phs = _protect_code_regions(text)
+        assert "```" not in protected
+        assert '{"a": 1}' not in protected
+        assert phs, "expected at least one placeholder"
+        restored = _restore_code_regions(protected, phs)
+        assert restored == text
+
+    def test_inline_code_is_stashed_and_restored(self):
+        text = "Use `foo` here."
+        protected, phs = _protect_code_regions(text)
+        assert "foo" not in protected or "`foo`" not in protected
+        restored = _restore_code_regions(protected, phs)
+        assert restored == text
+
+    def test_restore_with_empty_placeholders_is_noop(self):
+        assert _restore_code_regions("hello", {}) == "hello"


### PR DESCRIPTION
## Summary

Fixes #59291

Local / weak models (Ollama, vLLM — e.g. `gpt-oss:120b`) sometimes emit a JSON object that *looks* like a tool invocation directly into plain assistant content instead of routing it through the structured `tool_calls` channel. Two shapes are observed:

- **OpenAI-style**: `{name: ..., arguments: {...}}`
- **Pseudo-style**: `{action: clarify, question: ..., choices: [...]}` — invented `action` key, not part of any real Hermes schema

Hermes's existing message sanitizers only repair JSON *inside* an already-recognised `tool_calls` array (`_repair_tool_call_arguments`), so a shape-alike envelope sitting in plain content passed through untouched and reached end users verbatim. On the Telegram gateway this manifests as a raw JSON blob replacing the intended inline-keyboard / numbered-list render of a `clarify` prompt.

## Fix

Add a deterministic structural guard complementary to `_repair_tool_call_arguments`:

- New `_strip_tool_call_envelope` in `agent/message_sanitization.py` scans assistant content (not `tool_calls`) for a JSON object whose shape matches a tool invocation and removes it. Detects both the OpenAI `name` + `arguments` shape and the invented-`action` pseudo-shape.
- Fenced (```...```) and inline (`...` code regions are protected so user-intended JSON samples survive untouched.
- Each suppression is logged at DEBUG level (envelope count + bytes suppressed) so operators can audit which models / sessions trip the guard.
- Wired into the Telegram adapter's `format_message` pipeline so every outgoing message is screened.
- New function is also re-exported from `run_agent.py` for backward-compatible downstream imports.

## Tests

`tests/gateway/test_telegram_output_sanitization.py` — 36 tests, all passing:

- Plain text → forwarded as-is (5 tests)
- Tool-call-shaped JSON envelope → stripped / replaced, multi-envelope, embedded-in-prose, replacement override, DEBUG log assertion, non-envelope JSON left alone (9 tests)
- JSON inside code blocks → preserved (fenced + inline + mixed envelope-stripped-but-code-preserved scenarios) (4 tests)
- Empty / None / unbalanced braces / array JSON / partial JSON → handled gracefully (5 tests)
- Telegram adapter integration via `format_message` (3 tests)
- Internal helpers: `_is_tool_call_envelope`, `_protect_code_regions`, `_restore_code_regions` (10 tests)

## Why prompt-level mitigation is insufficient

Per the original report: `agent.tool_use_enforcement: auto` and a targeted `agent.environment_hint` reduce the leak frequency but do not eliminate it — this is a weak-local-model structured-output-fidelity issue, not a missing-instruction issue. This is a deterministic output-side guard, consistent with the design intent of the existing sanitizers in `agent/message_sanitization.py`.

## AI-assisted fix

AI-assisted fix by https://github.com/SquabbyZ/peaks-loop