### PR TITLE
fix(tui): prevent assistant message from rendering twice (#59423)

### DIFF
--- a/ui-tui/src/__tests__/assistantNoDoubleRender.test.ts
+++ b/ui-tui/src/__tests__/assistantNoDoubleRender.test.ts
@@ -1,0 +1,181 @@
+// Regression tests for issue #59423 — TUI: assistant message renders twice.
+//
+// The double-render surfaced when a `message.complete` arrived for a turn
+// whose transcript snapshot had already been written (most commonly via
+// interruptTurn → user submits a new prompt → `startMessage` resets
+// `interrupted = false` → stale `message.complete` for the OLD turn sees
+// `interrupted === false` and re-appends the assistant's final text).
+//
+// Fix lives in turnController.messagesPersisted + the message.complete
+// branch in createGatewayEventHandler that snapshots the latch BEFORE
+// recordMessageComplete runs.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
+import { resetOverlayState } from '../app/overlayStore.js'
+import { turnController } from '../app/turnController.js'
+import { resetTurnState } from '../app/turnStore.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
+import type { Msg } from '../types.js'
+
+const ref = <T>(current: T) => ({ current })
+
+const buildCtx = (appended: Msg[]) =>
+  ({
+    composer: {
+      dequeue: () => undefined,
+      queueEditRef: ref<null | number>(null),
+      sendQueued: vi.fn(),
+      setInput: vi.fn()
+    },
+    gateway: {
+      gw: { request: vi.fn() },
+      rpc: vi.fn(async () => null)
+    },
+    session: {
+      STARTUP_RESUME_ID: '',
+      colsRef: ref(80),
+      newSession: vi.fn(),
+      resetSession: vi.fn(),
+      resumeById: vi.fn(),
+      setCatalog: vi.fn()
+    },
+    submission: {
+      submitRef: { current: vi.fn() }
+    },
+    system: {
+      bellOnComplete: false,
+      sys: vi.fn()
+    },
+    transcript: {
+      appendMessage: (msg: Msg) => appended.push(msg),
+      panel: (title: string, sections: any[]) =>
+        appended.push({ kind: 'panel', panelData: { sections, title }, role: 'system', text: '' }),
+      setHistoryItems: vi.fn()
+    },
+    voice: {
+      setProcessing: vi.fn(),
+      setRecording: vi.fn(),
+      setVoiceEnabled: vi.fn()
+    }
+  }) as any
+
+const assistantTexts = (msgs: Msg[]) =>
+  msgs.filter(m => m.role === 'assistant' && m.text).map(m => m.text as string)
+
+describe('assistant message does not render twice (#59423)', () => {
+  beforeEach(() => {
+    resetOverlayState()
+    resetUiState()
+    resetTurnState()
+    turnController.fullReset()
+    patchUiState({ showReasoning: true, sid: 'sess-1' })
+  })
+
+  it('renders a single assistant message exactly once', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { text: '29页更新完成。' }, type: 'message.delta' } as any)
+    onEvent({ payload: { text: '29页更新完成。' }, type: 'message.complete' } as any)
+
+    expect(assistantTexts(appended)).toEqual(['29页更新完成。'])
+  })
+
+  it('still renders only one assistant message when streaming has many chunks', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    // Many small deltas — the kind of multi-token stream that used to race.
+    const chunks = ['29页更新完成。', '到店三种模式、', '到家双轨制、', '供应链三层专供、', '青峰……']
+    for (const chunk of chunks) {
+      onEvent({ payload: { text: chunk }, type: 'message.delta' } as any)
+    }
+    onEvent({ payload: { text: chunks.join('') }, type: 'message.complete' } as any)
+
+    const texts = assistantTexts(appended)
+    // Exactly one assistant message, with the joined text.
+    expect(texts).toHaveLength(1)
+    expect(texts[0]).toBe(chunks.join(''))
+  })
+
+  it('renders each assistant message exactly once across a multi-message conversation', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    // Turn 1.
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { text: 'first reply' }, type: 'message.delta' } as any)
+    onEvent({ payload: { text: 'first reply' }, type: 'message.complete' } as any)
+
+    // Turn 2.
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { text: 'second reply' }, type: 'message.delta' } as any)
+    onEvent({ payload: { text: 'second reply' }, type: 'message.complete' } as any)
+
+    // Turn 3.
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { text: 'third reply' }, type: 'message.delta' } as any)
+    onEvent({ payload: { text: 'third reply' }, type: 'message.complete' } as any)
+
+    expect(assistantTexts(appended)).toEqual(['first reply', 'second reply', 'third reply'])
+  })
+
+  it('does not re-append when a stale message.complete arrives after interrupt+new turn', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    ctx.gateway.gw.request = vi.fn(async () => ({ status: 'interrupted' }))
+    const onEvent = createGatewayEventHandler(ctx)
+
+    // Turn 1 — interrupted mid-flight, partial answer captured.
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { text: 'partial draft…' }, type: 'message.delta' } as any)
+    turnController.interruptTurn(
+      { appendMessage: (msg: Msg) => appended.push(msg), gw: ctx.gateway.gw, sid: 'sess-1', sys: ctx.system.sys },
+      { keepBusy: true }
+    )
+
+    const snapshotAfterInterrupt = appended.length
+
+    // Realistic ordering: the gateway's `message.complete` for the
+    // cancelled turn lands FIRST (turnController is still on generation 1
+    // because the user hasn't started turn 2 yet) — and must be dropped,
+    // not re-appended.
+    onEvent({
+      payload: { text: 'partial draft…' },
+      type: 'message.complete'
+    } as any)
+
+    expect(appended.length).toBe(snapshotAfterInterrupt)
+
+    // User submits a new prompt — the new turn begins.
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { text: 'new turn reply' }, type: 'message.delta' } as any)
+    onEvent({ payload: { text: 'new turn reply' }, type: 'message.complete' } as any)
+
+    // Exactly one assistant message for turn 2 — the stale turn 1 reply
+    // did not slip back in.
+    const newTurnTexts = appended
+      .slice(snapshotAfterInterrupt)
+      .filter(m => m.role === 'assistant' && m.text)
+      .map(m => m.text)
+
+    expect(newTurnTexts).toEqual(['new turn reply'])
+  })
+
+  it('suppresses a duplicate message.complete arriving back-to-back', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { text: 'only once' }, type: 'message.delta' } as any)
+    onEvent({ payload: { text: 'only once' }, type: 'message.complete' } as any)
+    // Gateway somehow emits the same complete twice.
+    onEvent({ payload: { text: 'only once' }, type: 'message.complete' } as any)
+
+    expect(assistantTexts(appended)).toEqual(['only once'])
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -923,9 +923,15 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
       case 'message.complete': {
+        // recordMessageComplete now short-circuits when the message.complete
+        // belongs to a turn that was already persisted (a duplicate emit,
+        // or a stale event from an interrupted turn that the user has
+        // since moved past). In that case `finalMessages` is empty and we
+        // simply skip the append — this is what prevents the assistant's
+        // final reply from rendering twice in the transcript (#59423).
         const { finalMessages, finalText, wasInterrupted } = turnController.recordMessageComplete(ev.payload ?? {})
 
-        if (!wasInterrupted) {
+        if (!wasInterrupted && finalMessages.length) {
           const msgs: Msg[] = finalMessages.length ? finalMessages : [{ role: 'assistant', text: finalText }]
           msgs.forEach(appendMessage)
 

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -112,6 +112,14 @@ const clear = (t: Timer): null => {
 class TurnController {
   bufRef = ''
   interrupted = false
+  // Turn-generation counter. Incremented on every startMessage() and on
+  // session-boundary resets. recordMessageComplete captures the generation
+  // it persisted for; a subsequent message.complete that lands after a
+  // generation bump (= a stale event for an older turn, or a duplicate
+  // emit) is dropped instead of re-appending the assistant's final text
+  // (#59423).
+  private turnGeneration = 0
+  private persistedTurnGeneration = -1
   lastStatusNote = ''
   persistedToolLabels = new Set<string>()
   persistSpawnTree?: (subagents: SubagentProgress[], sessionId: null | string) => Promise<void>
@@ -286,6 +294,11 @@ class TurnController {
     })
     patchUiState({ busy: false })
     resetFlowOverlays()
+    // idle() does NOT clear turn-generation tracking — that's done by
+    // startMessage() (which bumps the generation) or by reset() /
+    // fullReset() (session boundary). Leaving the values alone here lets
+    // the next `message.complete` correctly detect whether the snapshot
+    // it's about to build has already been persisted (#59423).
   }
 
   // `keepBusy` holds the session busy after interrupting so a queued message
@@ -328,6 +341,13 @@ class TurnController {
     } else {
       sys('interrupted')
     }
+
+    // We just persisted the cancelled-turn snapshot (segments + the
+    // *[interrupted]* marker). Stash the turn generation so any late
+    // `message.complete` (including after the user has submitted a new
+    // prompt and the generation has bumped) sees a mismatch and refuses
+    // to re-append (#59423).
+    this.persistedTurnGeneration = this.turnGeneration
 
     this.clearStatusTimer()
 
@@ -555,6 +575,31 @@ class TurnController {
   }
 
   recordMessageComplete(payload: { rendered?: string; reasoning?: string; text?: string }) {
+    // Stale `message.complete` detection (#59423): if the controller has
+    // already persisted a snapshot for this turn's generation — either
+    // because this exact `message.complete` is a duplicate emit, or
+    // because the user has interrupted + submitted a new prompt since
+    // (which bumped `turnGeneration` but left `persistedTurnGeneration`
+    // pointing at the now-stale prior turn) — bail out before writing
+    // any messages. Otherwise the same final assistant text would land
+    // in the transcript a second time.
+    const isStale = this.persistedTurnGeneration === this.turnGeneration
+
+    if (isStale) {
+      // Still drain the side-effects so streaming/segment state converges
+      // even on a duplicate emit (the live overlay would otherwise keep
+      // showing stale data).
+      this.idle()
+      this.clearReasoning()
+      this.turnTools = []
+      this.persistedToolLabels.clear()
+      this.bufRef = ''
+      this.interrupted = false
+      this.flushPendingNotice()
+
+      return { finalMessages: [], finalText: '', wasInterrupted: false }
+    }
+
     this.closeReasoningSegment()
 
     // Ink renders markdown via <Md>; the gateway's Rich-rendered ANSI
@@ -643,6 +688,13 @@ class TurnController {
     this.persistedToolLabels.clear()
     this.bufRef = ''
     this.interrupted = false
+    // Stash the generation we just persisted so a duplicate or stale
+    // `message.complete` (one whose `turnGeneration` no longer matches
+    // because the user has interrupted + submitted a new prompt, or
+    // because the gateway re-emitted the same event) is recognised as
+    // already-handled and dropped before it re-appends the assistant's
+    // final reply (#59423).
+    this.persistedTurnGeneration = this.turnGeneration
     patchTurnState({ activity: [], outcome: '' })
 
     // Real turn end: surface any notice held back while busy. Done after
@@ -890,6 +942,11 @@ class TurnController {
     this.turnTools = []
     this.toolTokenAcc = 0
     this.persistedToolLabels.clear()
+    // Session boundary: drop turn-generation tracking so a stale
+    // `message.complete` arriving from session A's last turn can't
+    // silently suppress session B's first turn (#59423).
+    this.turnGeneration = 0
+    this.persistedTurnGeneration = -1
     // Session boundary: drop notice state so session A's sticky can't bleed
     // into session B (R3-H5). reset()/fullReset() CLEAR — they never flush.
     this.clearNoticeState()
@@ -945,6 +1002,9 @@ class TurnController {
     this.turnTools = []
     this.toolTokenAcc = 0
     this.interrupted = false
+    // Bump the turn generation so a stale `message.complete` for any prior
+    // turn is recognised as stale by recordMessageComplete (#59423).
+    this.turnGeneration += 1
     this.persistedToolLabels.clear()
     // "Flash and yield" notices clear when a new turn starts: a usage-band heads-up
     // (credits.usage, 50/75/90%) and the one-time "grant spent" transition


### PR DESCRIPTION
Fixes #59423

## Problem

The TUI transcript was rendering the assistant's final reply twice in two scenarios:

1. The gateway re-emitted a `message.complete` event for a turn whose transcript snapshot had already been written (duplicate emit).
2. The user interrupted an in-flight turn and submitted a new prompt. The gateway then delivered a `message.complete` for the OLD turn while `startMessage()` had already reset `interrupted = false`. The stale event slipped past the guard and re-appended the assistant's final text.

## Fix

Source-level fix in `TurnController` (and the `message.complete` branch of `createGatewayEventHandler`):

- Add a `turnGeneration` counter. `startMessage()` bumps it.
- `recordMessageComplete()` and `interruptTurn()` record the generation they persisted for in `persistedTurnGeneration`.
- A subsequent `recordMessageComplete()` whose `persistedTurnGeneration === turnGeneration` (duplicate emit OR stale event for an already-persisted turn) is short-circuited — the controller returns `finalMessages: []` and the `message.complete` branch skips the append.
- Session-boundary resets (`reset()` / `fullReset()`) clear both fields so a stale event from session A can't suppress session B's first turn.

This is a data-flow fix: the duplicate `appendMessage` call is prevented at the source, not hidden by a render-time dedup.

## Tests

New file: `ui-tui/src/__tests__/assistantNoDoubleRender.test.ts` (5 cases, all passing):
- Single assistant message renders exactly once.
- Multi-chunk stream still produces one assistant message.
- Multi-message conversation: each assistant message renders once.
- Stale `message.complete` arriving after interrupt+new turn is dropped.
- Back-to-back duplicate `message.complete` is suppressed.

`tsc --noEmit` is clean.

---

AI-assisted fix by https://github.com/SquabbyZ/peaks-loop