### PR TITLE
feat(webhook): detect event type from payload.action field

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -557,6 +557,7 @@ class WebhookAdapter(BasePlatformAdapter):
             or request.headers.get("X-GitLab-Event", "")
             or payload.get("event_type", "")
             or payload.get("type", "")
+            or payload.get("action", "")
             or "unknown"
         )
         allowed_events = route_config.get("events", [])


### PR DESCRIPTION
## Summary

The webhook event type detection chain currently checks `X-GitHub-Event`, `X-GitLab-Event`, `payload.event_type`, and `payload.type` — but does not check `payload.action`, the field used by **Sentry**, **PagerDuty**, and many other services to discriminate events.

## Change

Adds `payload.get("action", "")` to the fallback chain so services that use `action` as the event discriminator are correctly routed.

## Testing

Tested with live Sentry webhook events through a Hermes gateway instance. Before this change, Sentry `error.created` events were classified as `unknown` and ignored by event-type filters. After this change, they are correctly identified as `error.created` and routed to the appropriate agent run.

## Compatibility

- Backward compatible: the `action` field is checked **after** all existing fields, so GitHub (`X-GitHub-Event`), GitLab (`X-GitLab-Event`), and services using `event_type`/`type` are unaffected.
- No schema changes, no new dependencies.