### PR TITLE
feat: include quick_commands in SlashCommandCompleter autocomplete

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -2055,6 +2055,32 @@ class SlashCommandCompleter(Completer):
         except Exception:
             pass
 
+        # User-defined quick commands (type: exec / alias in config.yaml)
+        try:
+            from hermes_cli.config import load_config_readonly
+            qcmds = (load_config_readonly() or {}).get("quick_commands", {}) or {}
+            for qname, qc in sorted(qcmds.items()):
+                if not isinstance(qc, dict):
+                    continue
+                if qname.startswith(word):
+                    qtype = qc.get("type", "")
+                    if qtype == "exec":
+                        default_desc = f"exec: {qc.get('command', '')}"
+                    elif qtype == "alias":
+                        default_desc = f"alias → {qc.get('target', '')}"
+                    else:
+                        default_desc = qtype or "quick command"
+                    desc = str(qc.get("description") or default_desc)
+                    short_desc = desc[:50] + ("..." if len(desc) > 50 else "")
+                    yield Completion(
+                        self._completion_text(qname, word),
+                        start_position=-len(word),
+                        display=f"/{qname}",
+                        display_meta=f"⚡ {short_desc}",
+                    )
+        except Exception:
+            pass
+
 
 # ---------------------------------------------------------------------------
 # Inline auto-suggest (ghost text) for slash commands

--- a/hermes_cli/commands_completion.py
+++ b/hermes_cli/commands_completion.py
@@ -462,6 +462,26 @@ class SlashCommandCompleter(Completer):
         except Exception:
             pass
 
+        try:
+            from hermes_cli.config import load_config_readonly
+            qcmds = (load_config_readonly() or {}).get("quick_commands", {}) or {}
+            for qname, qc in sorted(qcmds.items()):
+                if not isinstance(qc, dict):
+                    continue
+                if qname.startswith(word):
+                    qtype = qc.get("type", "")
+                    if qtype == "exec":
+                        default_desc = f"exec: {qc.get('command', '')}"
+                    elif qtype == "alias":
+                        default_desc = f"alias → {qc.get('target', '')}"
+                    else:
+                        default_desc = qtype or "quick command"
+                    desc = str(qc.get("description") or default_desc)
+                    short_desc = desc[:50] + ("..." if len(desc) > 50 else "")
+                    yield _cmd_completion(qname, f"⚡ {short_desc}")
+        except Exception:
+            pass
+
 
 class SlashCommandAutoSuggest(AutoSuggest):
     """Inline ghost-text for slash commands and subcommands; history fallback for other input."""

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -616,6 +616,131 @@ class TestSlashCommandCompleter:
         assert "Skill command" in completions[0].display_meta_text
 
 
+# ── Quick-command completion (config-backed exec / alias) ───────────────
+
+
+def _quick_cmd_config(tmp_path, commands: dict):
+    """Write a config.yaml with the given quick_commands and point HERMES_HOME at it."""
+    import yaml
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({"quick_commands": commands}))
+    return str(tmp_path)
+
+
+class TestQuickCommandCompletion:
+    """Quick commands from config.yaml appear in SlashCommandCompleter output."""
+
+    def test_exec_command_completed_with_description(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "backup": {
+                    "type": "exec",
+                    "command": "tar czf /tmp/backup.tar.gz ~/.hermes",
+                    "description": "Backup Hermes data",
+                },
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/backup")
+        assert len(completions) == 1
+        assert completions[0].text == "backup "  # trailing space on exact match (same as builtins)
+        assert completions[0].display_text == "/backup"
+        assert "Backup Hermes data" in completions[0].display_meta_text
+
+    def test_exec_fallback_when_no_description(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "disk": {
+                    "type": "exec",
+                    "command": "df -h /",
+                },
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/disk")
+        assert len(completions) == 1
+        meta = completions[0].display_meta_text
+        assert "df -h /" in meta
+
+    def test_alias_command_completed_with_target(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "restart": {
+                    "type": "alias",
+                    "target": "/gateway restart",
+                },
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/restart")
+        assert len(completions) == 1
+        assert completions[0].text == "restart "  # trailing space on exact match
+        meta = completions[0].display_meta_text
+        assert "alias" in meta
+        assert "/gateway restart" in meta
+
+    def test_prefix_match_filters_other_commands(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "status": {"type": "exec", "command": "systemctl status hermes"},
+                "stats": {"type": "exec", "command": "echo stats"},
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/sta")
+        texts = {c.text for c in completions}
+        assert "status" in texts
+        assert "stats" in texts
+
+    def test_no_quick_commands_section_yields_nothing(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("display:\n  tool_progress_command: true\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        completions = _completions(SlashCommandCompleter(), "/zzz")
+        assert completions == []
+
+    def test_malformed_entries_are_ignored(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "good": {"type": "exec", "command": "echo hi"},
+                "bad-string": "not a dict",
+                "bad-null": None,
+                "bad-list": [1, 2, 3],
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/good")
+        assert len(completions) == 1
+        assert completions[0].text == "good "  # trailing space on exact match
+
+    def test_unknown_type_uses_type_as_fallback(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "weird": {"type": "custom-type", "description": "Custom thing"},
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/weird")
+        assert len(completions) == 1
+        assert "Custom thing" in completions[0].display_meta_text
+
+    def test_long_description_truncated(self, tmp_path, monkeypatch):
+        long_desc = "X" * 80
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "long": {"type": "exec", "command": "true", "description": long_desc},
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/long")
+        assert len(completions) == 1
+        meta = completions[0].display_meta_text
+        assert "..." in meta
+        assert len(meta) < len(long_desc) + 10  # ⚡ prefix + truncation
+
+
 # ── Stacked slash-skill completion ──────────────────────────────────────
 
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -345,6 +345,133 @@ class TestSlashCommandCompleter:
         assert "help" in texts
 
 
+# ── Quick-command completion (config-backed exec / alias) ───────────────
+
+
+def _quick_cmd_config(tmp_path, commands: dict):
+    """Write a config.yaml with the given quick_commands and point HERMES_HOME at it."""
+    import yaml
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({"quick_commands": commands}))
+    return str(tmp_path)
+
+
+class TestQuickCommandCompletion:
+    """Quick commands from config.yaml appear in SlashCommandCompleter output."""
+
+    def test_exec_command_completed_with_description(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "backup": {
+                    "type": "exec",
+                    "command": "tar czf /tmp/backup.tar.gz ~/.hermes",
+                    "description": "Backup Hermes data",
+                },
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/backup")
+        assert len(completions) == 1
+        assert completions[0].text == "backup "  # trailing space on exact match (same as builtins)
+        assert completions[0].display_text == "/backup"
+        assert "Backup Hermes data" in completions[0].display_meta_text
+
+    def test_exec_fallback_when_no_description(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "disk": {
+                    "type": "exec",
+                    "command": "df -h /",
+                },
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/disk")
+        assert len(completions) == 1
+        meta = completions[0].display_meta_text
+        assert "df -h /" in meta
+
+    def test_alias_command_completed_with_target(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "restart": {
+                    "type": "alias",
+                    "target": "/gateway restart",
+                },
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/restart")
+        assert len(completions) == 1
+        assert completions[0].text == "restart "  # trailing space on exact match
+        meta = completions[0].display_meta_text
+        assert "alias" in meta
+        assert "/gateway restart" in meta
+
+    def test_prefix_match_filters_other_commands(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "status": {"type": "exec", "command": "systemctl status hermes"},
+                "stats": {"type": "exec", "command": "echo stats"},
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/sta")
+        texts = {c.text for c in completions}
+        assert "status" in texts
+        assert "stats" in texts
+
+    def test_no_quick_commands_section_yields_nothing(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("display:\n  tool_progress_command: true\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        completions = _completions(SlashCommandCompleter(), "/zzz")
+        assert completions == []
+
+    def test_malformed_entries_are_ignored(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "good": {"type": "exec", "command": "echo hi"},
+                "bad-string": "not a dict",
+                "bad-null": None,
+                "bad-list": [1, 2, 3],
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/good")
+        assert len(completions) == 1
+        assert completions[0].text == "good "  # trailing space on exact match
+
+    def test_unknown_type_uses_type_as_fallback(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "weird": {"type": "custom-type", "description": "Custom thing"},
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/weird")
+        assert len(completions) == 1
+        assert "Custom thing" in completions[0].display_meta_text
+
+    def test_long_description_truncated(self, tmp_path, monkeypatch):
+        long_desc = "X" * 80
+        monkeypatch.setenv(
+            "HERMES_HOME",
+            _quick_cmd_config(tmp_path, {
+                "long": {"type": "exec", "command": "true", "description": long_desc},
+            }),
+        )
+        completions = _completions(SlashCommandCompleter(), "/long")
+        assert len(completions) == 1
+        meta = completions[0].display_meta_text
+        assert "..." in meta
+        assert len(meta) < len(long_desc) + 10  # ⚡ prefix + truncation
+
+
+
+
 # ── Stacked slash-skill completion ──────────────────────────────────────
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1698,7 +1698,7 @@ Usage: type `/status`, `/disk`, `/update`, `/gpu`, or `/restart` in the CLI or a
 
 - **30-second timeout** — long-running commands are killed with an error message
 - **Priority** — quick commands are checked before skill commands, so you can override skill names
-- **Autocomplete** — quick commands are resolved at dispatch time and are not shown in the built-in slash-command autocomplete tables
+- **Autocomplete** — quick commands appear in the built-in slash-command autocomplete with a ⚡ prefix and their description (or the underlying command/target as a fallback)
 - **Type** — supported types are `exec` and `alias`; other types show an error
 - **Works everywhere** — CLI, Telegram, Discord, Slack, WhatsApp, Signal, Email, Home Assistant
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2425,7 +2425,7 @@ Usage: type `/status`, `/disk`, `/update`, `/gpu`, or `/restart` in the CLI or a
 
 - **30-second timeout** — long-running commands are killed with an error message
 - **Priority** — quick commands are checked before skill commands, so you can override skill names
-- **Autocomplete** — quick commands are resolved at dispatch time and are not shown in the built-in slash-command autocomplete tables
+- **Autocomplete** — quick commands appear in the built-in slash-command autocomplete with a ⚡ prefix and their description (or the underlying command/target as a fallback)
 - **Type** — supported types are `exec` and `alias`; other types show an error
 - **Works everywhere** — CLI, Telegram, Discord, Slack, WhatsApp, Signal, Email, Home Assistant
 


### PR DESCRIPTION
## Problem

User-defined quick commands ("quick_commands" in config.yaml, type: exec or alias) are invisible in TUI autocomplete suggestions. They only appear in /help and work when typed in full.

## Root Cause

The TUI input-box autocomplete path is:

`complete.slash` RPC → `SlashCommandCompleter.get_completions()`

This completer checked four sources:
1. COMMAND_REGISTRY (built-in slash commands)
2. skill_bundles
3. skill_commands
4. plugin_commands

But it did **not** traverse the `quick_commands` config section.

Meanwhile, the `commands.catalog` RPC (used by the /help panel) **already** includes quick_commands under the "User commands" category (`tui_gateway/server.py:11296-11317`). So /help shows them, but the autocomplete suggestions do not — an inconsistency.

## Fix

Add a quick_commands traversal block to `SlashCommandCompleter.get_completions()` that mirrors the catalog RPC's logic:

- Read config via `load_config_readonly()` (read-only hot path, no deepcopy)
- Filter by prefix match (same as all other command sources)
- Yield `Completion` with `⚡` prefix and description fallback (raw command string for exec, `alias → target` for alias)

## Verification

```python
from hermes_cli.commands import SlashCommandCompleter
from prompt_toolkit.document import Document

completer = SlashCommandCompleter()
doc = Document('/backup', len('/backup'))
completions = list(completer.get_completions(doc, None))
# Found 1 completion(s):
#   text='backup-profiles'  display='/backup-profiles'  meta='⚡ Backup all Hermes profiles to Google Drive + prune...'
```

All existing tests pass:
- `tests/cli/test_quick_commands.py` — 18/18 passed
- `tests/cli/` (complet+slash+quick filter) — 90/90 passed