### PR TITLE
fix(doctor): recognize provider-profile-only providers like vertex

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -52,6 +52,10 @@ _PROVIDER_ENV_HINTS = (
     "OPENCODE_GO_API_KEY",
     "XIAOMI_API_KEY",
     "TOKENHUB_API_KEY",
+    # vertex has no API-key env var (OAuth2 via a service-account JSON / ADC
+    # path), so recognize its credentials-path vars as auth being configured.
+    "VERTEX_CREDENTIALS_PATH",
+    "GOOGLE_APPLICATION_CREDENTIALS",
 )
 
 
@@ -781,7 +785,35 @@ def run_doctor(args):
                 if name:
                     known_providers.add("custom:" + name.lower().replace(" ", "-"))
 
-            valid_provider_ids = set(known_providers)
+            # Vertex-style providers live in the provider-profile registry
+            # (plugins/model-providers/*), not the legacy auth PROVIDER_REGISTRY,
+            # so treat those as known too. Record canonical names in
+            # known_providers (shown to the user) and aliases separately (matched
+            # but kept out of the message). Profiles whose default_aux_model is
+            # publisher-prefixed (e.g. google/...) use vendor/model slugs
+            # legitimately, so exempt them from the prefix warning below.
+            _profile_aliases: set = set()
+            _profile_prefix_providers: set = set()
+            try:
+                from providers import list_providers as _list_provider_profiles
+
+                for _profile in _list_provider_profiles():
+                    _pname = str(getattr(_profile, "name", "") or "").strip().lower()
+                    if not _pname:
+                        continue
+                    known_providers.add(_pname)
+                    _profile_ids = {_pname}
+                    for _alias in (getattr(_profile, "aliases", None) or ()):
+                        _a = str(_alias or "").strip().lower()
+                        if _a:
+                            _profile_ids.add(_a)
+                            _profile_aliases.add(_a)
+                    if "/" in str(getattr(_profile, "default_aux_model", "") or ""):
+                        _profile_prefix_providers.update(_profile_ids)
+            except Exception:
+                pass
+
+            valid_provider_ids = set(known_providers) | _profile_aliases
             provider_ids_to_accept = {provider} if provider else set()
             if _normalize_catalog_provider is not None:
                 for known_provider in known_providers:
@@ -810,6 +842,20 @@ def run_doctor(args):
             ):
                 provider_def = _resolve_provider_full(provider, user_providers, custom_providers)
                 catalog_provider = provider_def.id if provider_def is not None else None
+                if catalog_provider is None:
+                    # Profile-only providers (vertex, vertex-ai, gcp-vertex) have
+                    # no legacy ProviderDef, so resolve_provider_full returns None;
+                    # fall back to the profile registry so they resolve instead of
+                    # failing as "unknown". (google-vertex resolves via the
+                    # models.dev catalog above, so that path stays.)
+                    try:
+                        from providers import get_provider_profile as _get_provider_profile
+
+                        _prof = _get_provider_profile(provider)
+                        if _prof is not None:
+                            catalog_provider = str(getattr(_prof, "name", "") or "").strip().lower() or provider
+                    except Exception:
+                        pass
                 if catalog_provider is not None:
                     provider_ids_to_accept.add(catalog_provider)
 
@@ -848,6 +894,7 @@ def run_doctor(args):
             }
             provider_accepts_vendor_slug = (
                 provider_policy_id in providers_accepting_vendor_slugs
+                or provider_policy_id in _profile_prefix_providers
                 or provider_policy_id == "custom"
                 or provider_policy_id.startswith("custom:")
             )

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -46,6 +46,15 @@ class TestProviderEnvDetection:
         content = "KIMI_CN_API_KEY=sk-test\n"
         assert _has_provider_env_config(content)
 
+    def test_detects_vertex_credentials_path(self):
+        # Credential-file provider (vertex): a configured SA path IS auth (#56906).
+        content = "VERTEX_CREDENTIALS_PATH=/home/u/.hermes/sa.json\n"
+        assert _has_provider_env_config(content)
+
+    def test_detects_google_application_credentials(self):
+        content = "GOOGLE_APPLICATION_CREDENTIALS=/home/u/.hermes/sa.json\n"
+        assert _has_provider_env_config(content)
+
     def test_returns_false_when_no_provider_settings(self):
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
@@ -612,6 +621,133 @@ def test_run_doctor_accepts_vendor_slugs_for_named_custom_provider(monkeypatch, 
     assert "Either set model.provider to 'openrouter', or drop the vendor prefix." not in out
 
 
+@pytest.mark.parametrize("provider", ["vertex", "google-vertex", "vertex-ai", "gcp-vertex"])
+def test_run_doctor_accepts_vertex_profile_registry_provider(monkeypatch, tmp_path, provider):
+    """Regression for #56906.
+
+    Vertex ships only in the provider-profile registry (plugins/model-providers/
+    vertex), not the legacy auth PROVIDER_REGISTRY, and its OpenAI-compat models
+    are publisher-prefixed (``google/gemini-...``). doctor must recognize it as a
+    known provider (by canonical name and by alias) and must NOT emit the
+    vendor/model-slug warning for its mandatory ``google/`` prefix.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        f"  provider: {provider}\n"
+        "  default: google/gemini-3-flash-preview\n",
+        encoding="utf-8",
+    )
+    (home / ".env").write_text("VERTEX_CREDENTIALS_PATH=/tmp/sa.json\n", encoding="utf-8")
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert f"model.provider '{provider}' is not a recognised provider" not in out
+    assert f"model.provider '{provider}' is unknown" not in out
+    assert (
+        f"model.default 'google/gemini-3-flash-preview' uses a vendor/model slug "
+        f"but provider is '{provider}'"
+        not in out
+    )
+    assert f"is vendor-prefixed but model.provider is '{provider}'" not in out
+    # A configured service-account credentials path IS auth for vertex, so the
+    # generic "no API key" nudge must not false-positive on a vertex-only .env.
+    assert "No API key found in" not in out
+    assert "Run 'hermes setup' to configure API keys" not in out
+    # The provider-validation block must have run to completion. If it raised, the
+    # outer "Could not validate…" guard would swallow it and every assertion above
+    # would pass vacuously, so assert both that the guard did NOT fire and that
+    # vertex is actively accepted (named in no reported issue).
+    assert "Could not validate model/provider config" not in out
+    issues_block = out.rsplit("issue(s) to address:", 1)[-1] if "issue(s) to address:" in out else out
+    assert f"'{provider}'" not in issues_block
+    # Positive signal: the config-file check (printed right before provider
+    # validation) fired, so the validation block was actually reached. Guards
+    # against a future early-return making the negatives above pass vacuously.
+    assert "config.yaml exists" in out
+
+
+def _run_doctor_for_provider(monkeypatch, tmp_path, provider, default_model):
+    """Drive run_doctor against an isolated home for (provider, default_model)."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n" f"  provider: {provider}\n" f"  default: {default_model}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+    monkeypatch.setitem(
+        sys.modules,
+        "model_tools",
+        types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        ),
+    )
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    return buf.getvalue()
+
+
+@pytest.mark.parametrize("provider", ["totally-bogus-xyz", "not-a-real-provider"])
+def test_run_doctor_still_rejects_unknown_provider(monkeypatch, tmp_path, provider):
+    """The provider-profile fallback (#56906) must not weaken rejection of a
+    genuinely unknown provider: both the unknown-provider failure and the
+    vendor/model-slug warning (for its ``/``-prefixed default) must still fire.
+    """
+    out = _run_doctor_for_provider(monkeypatch, tmp_path, provider, "vendor/some-model")
+    assert f"model.provider '{provider}' is unknown" in out
+    assert f"is vendor-prefixed but model.provider is '{provider}'" in out
+
+
+def test_run_doctor_exempts_publisher_prefixed_profile_from_vendor_slug_warning(
+    monkeypatch, tmp_path
+):
+    """Deriving the exemption from the profile's publisher-prefixed
+    default_aux_model (#56906) intentionally also covers the other
+    aggregator-style profiles, not just vertex. novita's catalog is
+    vendor-prefixed (default_aux_model ``deepseek/…``), so a vendor/model slug
+    on it is legitimate and must not warn.
+    """
+    out = _run_doctor_for_provider(
+        monkeypatch, tmp_path, "novita", "deepseek/deepseek-v3-0324"
+    )
+    assert "uses a vendor/model slug but provider is 'novita'" not in out
+    assert "is vendor-prefixed but model.provider is 'novita'" not in out
 
 
 def test_run_doctor_accepts_kimi_coding_cn_provider(monkeypatch, tmp_path):


### PR DESCRIPTION
Fixes #56906.

`hermes doctor` reports a working vertex config as broken: it says `model.provider 'vertex' is unknown` and warns that the mandatory `google/` prefix is a stray vendor slug. The provider itself chats fine, it's only doctor that's wrong.

The reason is that the salvage that landed vertex registered it only in the new provider-profile registry (`plugins/model-providers/vertex/`), but doctor still validates `model.provider` against the legacy `auth.PROVIDER_REGISTRY`. So `resolve_provider_full("vertex")` returns None and doctor treats it as unknown.

This teaches doctor's config validation to also consult the provider-profile registry:

- Profile providers (and their aliases) now count as known.
- `catalog_provider` falls back to the profile when the legacy lookup returns None.
- Providers whose profile ships publisher-prefixed models (like vertex's `google/...`) are exempt from the vendor-slug warning. This also covers gmi and novita, which had the same latent false positive.

Also added vertex's credential-path vars (`VERTEX_CREDENTIALS_PATH`, `GOOGLE_APPLICATION_CREDENTIALS`) to the `.env` hint list, so a vertex-only `.env` no longer trips the "No API key found" nudge.

Everything here is additive. Unknown providers still fail, and the exemptions can only suppress a false warning, never add one. Added regression tests for vertex and its aliases, unknown-provider rejection, the publisher-prefix exemption, and the new env hints (227 passing across the doctor and provider suites).
