### PR TITLE
feat(moa): support one-shot preset selection

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -162,7 +162,12 @@ class ResponsesApiTransport(ProviderTransport):
             elif reasoning_config.get("effort"):
                 reasoning_effort = reasoning_config["effort"]
 
-        _effort_clamp = {"minimal": "low"}
+        # OpenAI/Codex Responses accepts Hermes's xhigh fast path but rejects
+        # the global Anthropic-style "max" effort with HTTP 400. Clamp here at
+        # the Responses transport boundary so a user/global config typo cannot
+        # brick Codex turns; Anthropic/DeepSeek-specific "max" handling lives on
+        # their own adapters.
+        _effort_clamp = {"minimal": "low", "max": "xhigh"}
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
         response_tools = _responses_tools(tools)

--- a/cli.py
+++ b/cli.py
@@ -7452,10 +7452,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if not choices:
             return None
 
+        choice_numbers = "1/2/3" if len(choices) == 3 else f"1-{len(choices)}"
+
         # If prompt_toolkit is not running (unit tests / non-interactive calls),
         # keep the simple stdin fallback.
         if not getattr(self, "_app", None):
-            return self._prompt_text_input("Choice [1/2/3]: ")
+            return self._prompt_text_input(f"Choice [{choice_numbers}]: ")
 
         try:
             app_loop = self._app.loop
@@ -7472,7 +7474,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if sys.platform == "win32" and not in_main_thread:
                 self._invalidate()
                 return None
-            return self._prompt_text_input("Choice [1/2/3]: ")
+            return self._prompt_text_input(f"Choice [{choice_numbers}]: ")
 
         if not in_main_thread and app_loop is None:
             return _stdin_fallback()
@@ -7554,9 +7556,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
     ) -> str | None:
         if raw is None:
             return None
-        choice_raw = raw.strip().lower()
-        if not choice_raw:
+        choice_text = raw.strip()
+        if not choice_text:
             return None
+        allowed = {choice[0] for choice in choices}
+        if choice_text in allowed:
+            return choice_text
+        choice_raw = choice_text.lower()
+        if choice_raw.isdigit():
+            idx = int(choice_raw) - 1
+            if 0 <= idx < len(choices):
+                return choices[idx][0]
         aliases = {
             "1": "once",
             "once": "once",
@@ -7573,12 +7583,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "no": "cancel",
             "n": "cancel",
         }
-        allowed = {choice[0] for choice in choices}
         normalized = aliases.get(choice_raw)
         if normalized in allowed:
             return normalized
-        if choice_raw in allowed:
-            return choice_raw
+        lowered_allowed = {choice.lower(): choice for choice in allowed}
+        if choice_raw in lowered_allowed:
+            return lowered_allowed[choice_raw]
         return None
 
     def _get_slash_confirm_display_fragments(self):
@@ -7591,6 +7601,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         detail = state.get("detail") or ""
         choices = state.get("choices") or []
         selected = state.get("selected", 0)
+        choice_numbers = "1/2/3" if len(choices) == 3 else f"1-{len(choices)}"
+        choice_hint = f"Type {choice_numbers} or use ↑/↓ then Enter. ESC/Ctrl+C cancels."
 
         def _panel_box_width(title_text: str, content_lines: list[str], min_width: int = 56, max_width: int = 86) -> int:
             term_cols = shutil.get_terminal_size((100, 20)).columns
@@ -7623,7 +7635,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         for idx, (_value, label, desc) in enumerate(choices):
             marker = "❯" if idx == selected else " "
             preview_lines.extend(_wrap_panel_text(f"{marker} [{idx + 1}] {label} — {desc}", 72, subsequent_indent="    "))
-        preview_lines.append("Type 1/2/3 or use ↑/↓ then Enter. ESC/Ctrl+C cancels.")
+        preview_lines.append(choice_hint)
 
         box_width = _panel_box_width(title, preview_lines)
         inner_text_width = max(8, box_width - 2)
@@ -7657,7 +7669,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             style = 'class:approval-selected' if idx == selected else 'class:approval-choice'
             _append_panel_line(lines, 'class:approval-border', style, wrapped, box_width)
         _append_blank_panel_line(lines, 'class:approval-border', box_width)
-        _append_panel_line(lines, 'class:approval-border', 'class:approval-cmd', 'Type 1/2/3 or use ↑/↓ then Enter. ESC/Ctrl+C cancels.', box_width)
+        _append_panel_line(lines, 'class:approval-border', 'class:approval-cmd', choice_hint, box_width)
         lines.append(('class:approval-border', '╰' + ('─' * box_width) + '╯\n'))
         return lines
 
@@ -8795,6 +8807,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             from hermes_cli.moa_config import (
                 moa_usage,
                 normalize_moa_config,
+                parse_moa_slash_args,
+                summarize_moa_preset,
             )
 
             parts = cmd_original.split(None, 1)
@@ -8804,7 +8818,51 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 return True
             moa_cfg = self.config.get("moa") if isinstance(self.config, dict) else {}
             normalized = normalize_moa_config(moa_cfg)
-            preset = normalized["default_preset"]
+            try:
+                preset, prompt = parse_moa_slash_args(moa_cfg, payload)
+            except KeyError as exc:
+                _cprint(f"  Unknown MoA preset: {exc.args[0] or '(empty)'}")
+                _cprint(f"  {moa_usage()}")
+                return True
+
+            if preset is None and normalized.get("prompt_preset"):
+                presets = normalized.get("presets") or {}
+                preferred = str(normalized.get("active_preset") or normalized.get("default_preset") or "")
+                default_name = str(normalized.get("default_preset") or "")
+                active_name = str(normalized.get("active_preset") or "")
+                names = [str(name) for name in presets.keys()]
+                if preferred in presets:
+                    names = [preferred] + [name for name in names if name != preferred]
+                choices: list[tuple[str, str, str]] = [
+                    (
+                        name,
+                        name,
+                        summarize_moa_preset(
+                            name,
+                            presets[name],
+                            default_name=default_name,
+                            active_name=active_name,
+                        ),
+                    )
+                    for name in names
+                ]
+                choices.append(("__cancel__", "Cancel", "Do not run the MoA one-shot."))
+                raw_choice = self._prompt_text_input_modal(
+                    title="Select MoA preset",
+                    detail="Choose the preset for this one /moa turn. Explicit `/moa <preset> <prompt>` skips this picker.",
+                    choices=choices,
+                    timeout=120,
+                )
+                choice = self._normalize_slash_confirm_choice(raw_choice, choices)
+                if not choice or choice == "__cancel__":
+                    _cprint("  MoA one-shot cancelled.")
+                    return True
+                preset = choice
+
+            preset = preset or normalized["default_preset"]
+            if not prompt:
+                _cprint(f"  {moa_usage()}")
+                return True
             self._pending_moa_restore_model = {
                 "requested_provider": getattr(self, "requested_provider", None),
                 "provider": getattr(self, "provider", None),
@@ -8821,7 +8879,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self.api_mode = "chat_completions"
             self.agent = None
             self._pending_moa_disable_after_turn = True
-            self._pending_agent_seed = payload
+            self._pending_agent_seed = prompt
             _cprint(f"  MoA one-shot queued with preset {preset}; previous model will be restored after this turn.")
         elif canonical == "subgoal":
             self._handle_subgoal_command(cmd_original)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9735,18 +9735,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from hermes_cli.moa_config import (
                 moa_usage,
                 normalize_moa_config,
+                parse_moa_slash_args,
             )
             from hermes_cli.config import load_config
 
-            moa_payload = event.get_command_args().strip()
-            if not moa_payload:
+            raw_moa_payload = event.get_command_args().strip()
+            if not raw_moa_payload:
                 return moa_usage()
             try:
                 cfg = load_config()
                 moa_cfg = normalize_moa_config(cfg.get("moa") if isinstance(cfg, dict) else {})
             except Exception:
                 moa_cfg = normalize_moa_config({})
-            preset = moa_cfg["default_preset"]
+            try:
+                preset, moa_payload = parse_moa_slash_args(moa_cfg, raw_moa_payload)
+            except KeyError as exc:
+                return f"Unknown MoA preset: {exc.args[0] or '(empty)'}\n{moa_usage()}"
+            if not moa_payload:
+                return moa_usage()
+            preset = preset or moa_cfg["default_preset"]
             try:
                 event.text = moa_payload
                 event._moa_restore_override = self._session_model_overrides.get(_quick_key)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2205,6 +2205,9 @@ DEFAULT_CONFIG = {
     "moa": {
         "default_preset": "default",
         "active_preset": "",
+        # When true, bare `/moa <prompt>` in the TUI opens a per-turn preset
+        # picker; explicit `/moa <preset> <prompt>` / `--preset` bypasses it.
+        "prompt_preset": False,
         # When true, every MoA turn that runs the reference fan-out writes the
         # FULL turn (each reference's exact input messages + output + usage/cost,
         # and the aggregator's exact input + output) to a JSONL file at

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -183,6 +183,7 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
     return {
         "default_preset": default_name,
         "active_preset": active_name,
+        "prompt_preset": bool(raw.get("prompt_preset", False)),
         "presets": presets,
         # Compatibility/flattened view for existing dashboard/desktop callers.
         "reference_models": deepcopy(active["reference_models"]),
@@ -199,6 +200,78 @@ def normalize_moa_config(raw: Any) -> dict[str, Any]:
 def list_moa_presets(config: Any) -> list[str]:
     cfg = normalize_moa_config(config)
     return list(cfg["presets"].keys())
+
+
+def summarize_moa_preset(
+    name: str,
+    preset: dict[str, Any],
+    *,
+    default_name: str = "",
+    active_name: str = "",
+) -> str:
+    """Return a compact human label for a MoA preset picker row."""
+    refs = preset.get("reference_models") or []
+    aggregator = preset.get("aggregator") or {}
+    agg_provider = str(aggregator.get("provider") or "").strip()
+    agg_model = str(aggregator.get("model") or "").strip()
+    agg_label = f"{agg_provider}:{agg_model}" if agg_provider and agg_model else "unset"
+    flags: list[str] = []
+    if name == default_name:
+        flags.append("default")
+    if active_name and name == active_name:
+        flags.append("active")
+    if not preset.get("enabled", True):
+        flags.append("disabled")
+    flag_text = f" [{', '.join(flags)}]" if flags else ""
+    return f"agg {agg_label}, {len(refs)} refs{flag_text}"
+
+
+def _split_first(text: str) -> tuple[str, str]:
+    clean = str(text or "").strip()
+    if not clean:
+        return "", ""
+    parts = clean.split(None, 1)
+    return parts[0], parts[1].strip() if len(parts) > 1 else ""
+
+
+def parse_moa_slash_args(config: Any, payload: str) -> tuple[str | None, str]:
+    """Parse ``/moa`` arguments into ``(explicit_preset, prompt)``.
+
+    Supported explicit preset forms:
+      - ``/moa council compare these options``
+      - ``/moa --preset council compare these options``
+      - ``/moa -p council compare these options``
+      - ``/moa --preset=council compare these options``
+
+    If the first word is not a configured preset, it remains part of the natural
+    prompt. This is the important safety property for prompts like
+    ``/moa compare these options``: ``compare`` must not be consumed as a
+    would-be preset unless such a preset actually exists.
+    """
+    cfg = normalize_moa_config(config)
+    presets = cfg.get("presets") or {}
+    text = str(payload or "").strip()
+    if not text:
+        return None, ""
+
+    first, rest = _split_first(text)
+    preset_name: str | None = None
+    prompt = text
+
+    if first in {"--preset", "-p"}:
+        preset_name, prompt = _split_first(rest)
+    elif first.startswith("--preset="):
+        preset_name = first.split("=", 1)[1].strip()
+        prompt = rest
+    elif first in presets:
+        preset_name = first
+        prompt = rest
+
+    if preset_name is not None:
+        if not preset_name or preset_name not in presets:
+            raise KeyError(preset_name)
+        return preset_name, prompt.strip()
+    return None, text
 
 
 def resolve_moa_preset(config: Any, name: str | None = None) -> dict[str, Any]:
@@ -273,4 +346,4 @@ def build_moa_turn_prompt(user_prompt: str, config: Any = None, preset: str | No
 
 
 def moa_usage() -> str:
-    return "Usage: /moa <prompt>  (runs one prompt through the default MoA preset, then restores your model; pick a preset from the model picker to switch for the session)"
+    return "Usage: /moa [--preset <name>|<preset>] <prompt>  (runs one prompt through MoA, then restores your model; set moa.prompt_preset: true to pick a preset per /moa turn)"

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -272,6 +272,16 @@ class TestCodexBuildKwargs:
         # "minimal" should be clamped to "low"
         assert kw.get("reasoning", {}).get("effort") == "low"
 
+    def test_max_effort_clamped_to_xhigh_for_codex_responses(self, transport):
+        """OpenAI/Codex Responses rejects global ``max``; xhigh is the safe top tier."""
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.5", messages=messages, tools=[],
+            reasoning_config={"effort": "max"},
+            is_codex_backend=True,
+        )
+        assert kw.get("reasoning", {}).get("effort") == "xhigh"
+
     def test_xai_reasoning_effort_passed(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/cli/test_destructive_slash_confirm.py
+++ b/tests/cli/test_destructive_slash_confirm.py
@@ -211,6 +211,25 @@ def test_slash_confirm_display_fragments_include_choice_mapping():
     assert "Type 1/2/3" in rendered
 
 
+def test_slash_confirm_numeric_choice_uses_actual_choice_order():
+    """Numeric input maps to the displayed row, even for non-3-choice menus."""
+    from cli import HermesCLI
+
+    self_ = SimpleNamespace()
+    normalize = _bound(HermesCLI._normalize_slash_confirm_choice, self_)
+
+    two_choices = [
+        ("once", "Switch anyway", "proceed once"),
+        ("cancel", "Cancel", "abort"),
+    ]
+    assert normalize("2", two_choices) == "cancel"
+
+    many_choices = [(f"preset-{idx}", f"Preset {idx}", "") for idx in range(1, 12)]
+    assert normalize("11", many_choices) == "preset-11"
+
+    assert normalize("reviewpreset", [("ReviewPreset", "Review", "")]) == "ReviewPreset"
+
+
 # ---------------------------------------------------------------------------
 # Inline-skip escape hatch (issue #30768)
 #

--- a/tests/cli/test_moa_command.py
+++ b/tests/cli/test_moa_command.py
@@ -38,6 +38,10 @@ def _make_cli():
     return cli
 
 
+def _fail_modal(**_kwargs):
+    raise AssertionError("MoA preset picker should not open")
+
+
 def test_moa_bare_shows_usage_no_switch():
     # /moa with no prompt is usage-only now; switching to a preset for the
     # session is done via the model picker, not /moa.
@@ -50,16 +54,26 @@ def test_moa_bare_shows_usage_no_switch():
     assert cli._pending_moa_disable_after_turn is False
 
 
-def test_moa_arg_is_always_one_shot_prompt():
-    # Any argument (even a string that matches a preset name) is treated as a
-    # one-shot prompt through the DEFAULT preset, then the model is restored.
+def test_moa_explicit_preset_name_selects_preset_and_prompt():
     cli = _make_cli()
+    cli._prompt_text_input_modal = _fail_modal
     with patch("cli._cprint"):
-        cli.process_command("/moa review")
-    assert cli._pending_agent_seed == "review"
+        cli.process_command("/moa review inspect this project")
+    assert cli._pending_agent_seed == "inspect this project"
     assert cli._pending_moa_disable_after_turn is True
     assert cli.provider == "moa"
-    assert cli.model == "default"
+    assert cli.model == "review"
+
+
+def test_moa_explicit_preset_flag_bypasses_picker():
+    cli = _make_cli()
+    cli.config["moa"]["prompt_preset"] = True
+    cli._prompt_text_input_modal = _fail_modal
+    with patch("cli._cprint"):
+        cli.process_command("/moa --preset review inspect this project")
+    assert cli._pending_agent_seed == "inspect this project"
+    assert cli.provider == "moa"
+    assert cli.model == "review"
 
 
 def test_moa_non_preset_is_one_shot_prompt():
@@ -71,6 +85,26 @@ def test_moa_non_preset_is_one_shot_prompt():
     assert cli.provider == "moa"
     assert cli.model == "default"
     assert cli._pending_moa_restore_model["provider"] != "moa"
+
+
+def test_moa_prompt_preset_picker_preserves_natural_first_word():
+    cli = _make_cli()
+    cli.config["moa"]["prompt_preset"] = True
+    captured = {}
+
+    def _pick_review(**kwargs):
+        captured.update(kwargs)
+        return "review"
+
+    cli._prompt_text_input_modal = _pick_review
+    with patch("cli._cprint"):
+        cli.process_command("/moa inspect the flaky test")
+
+    assert cli._pending_agent_seed == "inspect the flaky test"
+    assert cli.provider == "moa"
+    assert cli.model == "review"
+    assert captured["title"] == "Select MoA preset"
+    assert any(choice[0] == "review" for choice in captured["choices"])
 
 
 def test_decode_legacy_encoded_moa_turn_still_works():

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -6,8 +6,10 @@ from hermes_cli.moa_config import (
     decode_moa_turn,
     exact_moa_preset_name,
     normalize_moa_config,
+    parse_moa_slash_args,
     resolve_moa_preset,
     set_active_moa_preset,
+    summarize_moa_preset,
 )
 
 
@@ -281,3 +283,52 @@ def test_reference_max_tokens_in_flattened_view():
     active preset's reference_max_tokens."""
     cfg = normalize_moa_config(_preset(reference_max_tokens=750))
     assert cfg["reference_max_tokens"] == 750
+
+
+def test_normalize_moa_config_exposes_prompt_preset_flag():
+    cfg = normalize_moa_config({"prompt_preset": True, "presets": {"p": {}}})
+
+    assert cfg["prompt_preset"] is True
+
+
+def test_parse_moa_slash_args_explicit_preset_forms():
+    config = {"default_preset": "default", "presets": {"default": {}, "review": {}}}
+
+    assert parse_moa_slash_args(config, "review inspect this") == ("review", "inspect this")
+    assert parse_moa_slash_args(config, "--preset review inspect this") == ("review", "inspect this")
+    assert parse_moa_slash_args(config, "-p review inspect this") == ("review", "inspect this")
+    assert parse_moa_slash_args(config, "--preset=review inspect this") == ("review", "inspect this")
+
+
+def test_parse_moa_slash_args_preserves_natural_first_word():
+    config = {"default_preset": "default", "presets": {"default": {}, "review": {}}}
+
+    assert parse_moa_slash_args(config, "compare these options") == (None, "compare these options")
+
+
+def test_parse_moa_slash_args_unknown_explicit_preset_raises():
+    config = {"default_preset": "default", "presets": {"default": {}}}
+
+    try:
+        parse_moa_slash_args(config, "--preset missing inspect")
+    except KeyError as exc:
+        assert exc.args[0] == "missing"
+    else:  # pragma: no cover - defensive assertion style for old pytest support
+        raise AssertionError("unknown explicit preset must raise KeyError")
+
+
+def test_summarize_moa_preset_marks_default_active_and_disabled():
+    summary = summarize_moa_preset(
+        "review",
+        {
+            "enabled": False,
+            "reference_models": [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}],
+            "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+        },
+        default_name="review",
+        active_name="review",
+    )
+
+    assert "agg openrouter:anthropic/claude-opus-4.8" in summary
+    assert "1 refs" in summary
+    assert "default" in summary and "active" in summary and "disabled" in summary

--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -231,9 +231,7 @@ moa:
     assert "model_override" not in s
 
 
-def test_moa_arg_is_always_one_shot(server, session, hermes_home):
-    # Any arg (even a preset name) is a one-shot prompt through the DEFAULT
-    # preset; /moa never does a sticky switch anymore.
+def test_moa_explicit_preset_name_selects_one_shot_preset(server, session, hermes_home):
     _write_moa_config(hermes_home, """
 moa:
   default_preset: default
@@ -248,15 +246,15 @@ moa:
         model: anthropic/claude-opus-4.8
 """)
     sid, _, s = session
-    r = _call(server, "command.dispatch", name="moa", arg="review", session_id=sid)
+    r = _call(server, "command.dispatch", name="moa", arg="review inspect this", session_id=sid)
     result = r["result"]
     assert result["type"] == "send"
-    assert result["message"] == "review"
+    assert result["message"] == "inspect this"
     assert "one-shot" in result["notice"]
     # Lazy session (no live agent) → MoA preset pinned via model_override for
-    # the build, and it is the DEFAULT preset, not the "review" arg.
+    # the build, and the explicit preset name is consumed from the prompt.
     assert s["model_override"]["provider"] == "moa"
-    assert s["model_override"]["model"] == "default"
+    assert s["model_override"]["model"] == "review"
 
 
 def test_moa_non_preset_returns_one_shot_send(server, session, hermes_home):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11531,7 +11531,7 @@ def _(rid, params: dict) -> dict:
         # for the rest of the session, pick it from the model picker (MoA
         # presets surface as a virtual "Mixture of Agents" provider).
         try:
-            from hermes_cli.moa_config import moa_usage, normalize_moa_config
+            from hermes_cli.moa_config import moa_usage, normalize_moa_config, parse_moa_slash_args
 
             if not arg:
                 return _err(rid, 4004, moa_usage())
@@ -11539,7 +11539,13 @@ def _(rid, params: dict) -> dict:
                 return _err(rid, 4001, "no active session")
             sid = params.get("session_id", "")
             moa_cfg = normalize_moa_config(_load_cfg().get("moa") or {})
-            preset = moa_cfg["default_preset"]
+            try:
+                preset, prompt = parse_moa_slash_args(moa_cfg, arg)
+            except KeyError as exc:
+                return _err(rid, 4004, f"Unknown MoA preset: {exc.args[0] or '(empty)'}\n{moa_usage()}")
+            if not prompt:
+                return _err(rid, 4004, moa_usage())
+            preset = preset or moa_cfg["default_preset"]
             # Record the live model identity so it can be restored after the
             # one-shot turn, then swap the agent's client in place (#53444:
             # setting session["model_override"] alone never switched the
@@ -11579,7 +11585,7 @@ def _(rid, params: dict) -> dict:
                 {
                     "type": "send",
                     "notice": f"MoA one-shot queued with preset {preset}; previous model will be restored after this turn.",
-                    "message": arg,
+                    "message": prompt,
                 },
             )
         except Exception as exc:


### PR DESCRIPTION
## Summary
- Add shared `/moa` argument parsing for one-shot explicit preset selection (`/moa <preset> <prompt>`, `--preset`, `-p`, `--preset=<name>`) while preserving natural prompts when the first word is not a preset.
- Add `moa.prompt_preset` and a TUI per-turn preset picker for bare `/moa <prompt>`; wire the same explicit-preset one-shot behavior through CLI, gateway, and TUI gateway paths.
- Keep Hermes as the gated acting tool loop by leaving MoA as the deliberation/recommendation model lane, and clamp OpenAI/Codex Responses `reasoning_effort: max` to `xhigh` so GPT-5.5 xhigh/fast remains safe.

## Test Plan
- `uv run --extra dev pytest tests/hermes_cli/test_moa_config.py tests/cli/test_moa_command.py tests/cli/test_destructive_slash_confirm.py tests/tui_gateway/test_goal_command.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_moa_loop_mode.py tests/gateway/test_moa_one_shot_restore.py -q` → `157 passed`
- `uv run --extra dev ruff check hermes_cli/moa_config.py cli.py gateway/run.py tui_gateway/server.py agent/transports/codex.py tests/hermes_cli/test_moa_config.py tests/cli/test_moa_command.py tests/cli/test_destructive_slash_confirm.py tests/tui_gateway/test_goal_command.py tests/agent/transports/test_codex_transport.py` → `All checks passed!`
- `uv run hermes config check` → `Config version: 33 ✓`
- `git diff --check` → clean
