### PR TITLE
fix(delegate_task): mark tasks parameter nullable for strict OpenAI-compatible backends

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3360,6 +3360,13 @@ DELEGATE_TASK_SCHEMA = {
                 # delegation.max_concurrent_children (default 3) and
                 # enforced with a clear error in delegate_task().
                 "description": "(rebuilt at get_definitions() time)",
+                # Strict OpenAI-compatible backends reject function call
+                # arguments where an array-typed parameter receives null.
+                # Models frequently emit tasks: null for single-task mode;
+                # mark nullable so the backend's JSON Schema validator passes
+                # it through.  Runtime code already treats None as "no
+                # tasks" via args.get("tasks") (#59386).
+                "nullable": True,
             },
             "role": {
                 "type": "string",


### PR DESCRIPTION
## Summary

Strict OpenAI-compatible API proxies validate function call arguments against the JSON Schema. When models emit `tasks: null` for single-task mode, backends reject with `null is not of type array` (HTTP 400, non-retryable), killing the session immediately.

## Fix

Add `nullable: true` to the tasks parameter schema so the backend's validator passes null through. The runtime handler already treats None as "no tasks" via `args.get("tasks")`, so no handler changes needed.

## Testing

All 151 delegate_task tests pass.

Fixes #59386