### PR TITLE
fix(cli): strip credentials from origin URL before _is_fork() comparison (#59584)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6670,6 +6670,12 @@ def _is_fork(origin_url: Optional[str]) -> bool:
     normalized = origin_url.rstrip("/")
     if normalized.endswith(".git"):
         normalized = normalized[:-4]
+    # Strip embedded credentials (https://<token>@github.com/...) so the
+    # comparison works regardless of auth tokens in the remote URL (#59584)
+    import re as _re
+    _m = _re.match(r"https://[^@]+@", normalized)
+    if _m:
+        normalized = "https://" + normalized[_m.end():]
     for official in OFFICIAL_REPO_URLS:
         official_normalized = official.rstrip("/")
         if official_normalized.endswith(".git"):


### PR DESCRIPTION
## Summary

When the git origin remote URL contains an embedded authentication token (e.g. `https://<token>@github.com/NousResearch/hermes-agent.git`), `_is_fork()` does a naive string comparison against `OFFICIAL_REPO_URLS` that fails because none of the official URLs include a credentials prefix. This produces a false `⚠ Updating from fork:` warning during `hermes update`.

## Fix

Strip `https://<credentials>@` from the normalized URL before comparison using a regex match, so both `https://token@github.com/...` and `https://user:token@github.com/...` patterns are handled.

## Changes

| File | Δ |
|------|---|
| `hermes_cli/main.py` | +6 lines |

Closes #59584