### PR TITLE
feat: add KeePassXC secret source integration

### DIFF
--- a/agent/secret_sources/__init__.py
+++ b/agent/secret_sources/__init__.py
@@ -10,4 +10,7 @@ Currently shipped:
   - ``bitwarden`` — Bitwarden Secrets Manager (`bws` CLI).  See
     ``agent.secret_sources.bitwarden`` for the integration and
     ``hermes_cli.secrets_cli`` for the user-facing setup wizard.
+  - ``keepassxc`` — KeePassXC password manager (`keepassxc-cli`).  See
+    ``agent.secret_sources.keepassxc`` for the integration and
+    ``hermes_cli.secrets_cli`` for the user-facing setup wizard.
 """

--- a/agent/secret_sources/keepassxc.py
+++ b/agent/secret_sources/keepassxc.py
@@ -1,0 +1,551 @@
+"""KeePassXC (``keepassxc-cli``) secret source integration.
+
+Hermes pulls API keys from a KeePassXC database at process startup so they
+don't have to live in plaintext in ``~/.hermes/.env``.
+
+Design summary
+--------------
+
+* The user provides the path to their ``.kdbx`` database and a mapping from
+  env-var names to KeePassXC entry paths (e.g.
+  ``{"OPENAI_API_KEY": "Dev/OpenAI"}``).  These mirror the
+  ``secrets.keepassxc.*`` config keys.
+* Database credentials are supplied by one of:
+
+  * the ``KEEPASSXC_PASSWORD`` env var (configurable via
+    ``password_env``);
+  * a key file passed with ``key_file``;
+  * ``--no-password`` for unprotected databases.
+
+  When a password is available it is piped into ``keepassxc-cli`` via
+  stdin; the binary never receives it as a command-line argument.
+* One ``keepassxc-cli show`` subprocess is spawned per entry.  The CLI
+  reads the database each time, so the fetch is naturally bounded and
+  stateless.  We still cache the returned secrets in-process and on disk
+  for ``cache_ttl_seconds`` so back-to-back ``hermes`` invocations don't
+  repeatedly prompt the user for a database unlock.
+* Failures never block Hermes startup.  Missing binary, wrong password,
+  missing entry, etc. are recorded as warnings (or a single fatal ``error``
+  on the :class:`FetchResult`) and the process continues with whatever
+  credentials ``.env`` already had.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration constants
+# ---------------------------------------------------------------------------
+
+# How long to wait for a keepassxc-cli subprocess, in seconds.
+_KP_RUN_TIMEOUT = 15
+
+# In-process cache so repeated load_hermes_dotenv() calls (CLI startup,
+# gateway hot-reload, test suites) don't re-fetch from KeePassXC.
+_CacheKey = Tuple[str, str]  # (resolved_db_path, credentials_fingerprint)
+_CACHE: Dict[_CacheKey, "_CachedFetch"] = {}
+
+# Disk-persisted cache so back-to-back CLI invocations (e.g.
+# `hermes chat -q ...` called from scripts, cron, the gateway forking new
+# agents) don't each pay the KeePassXC unlock tax. The in-process _CACHE
+# above only saves repeated fetches WITHIN one process; this saves repeated
+# fetches ACROSS processes.
+#
+# Layout: one JSON object per cache key, written atomically with mode 0600 in
+# <hermes_home>/cache/keepassxc_cache.json. The file holds only the secret
+# VALUES, never the database password. It's plaintext-equivalent to
+# ~/.hermes/.env (which we already accept) but kept out of the .env file so
+# users editing it won't accidentally commit KeePassXC-sourced secrets.
+_DISK_CACHE_BASENAME = "keepassxc_cache.json"
+
+
+def _disk_cache_path(home_path: Optional[Path] = None) -> Path:
+    """Return the disk cache path under hermes_home/cache/.
+
+    `home_path` is what `load_hermes_dotenv()` already resolved; falling back
+    to `$HERMES_HOME` / `~/.hermes` keeps direct callers working too.
+    """
+    if home_path is None:
+        home_path = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    return home_path / "cache" / _DISK_CACHE_BASENAME
+
+
+def _cache_key_str(cache_key: _CacheKey) -> str:
+    """Serialize a cache key to a stable string for JSON storage."""
+    db_path, cred_fp = cache_key
+    return f"{db_path}|{cred_fp}"
+
+
+def _read_disk_cache(
+    cache_key: _CacheKey,
+    ttl_seconds: float,
+    home_path: Optional[Path] = None,
+) -> Optional["_CachedFetch"]:
+    """Return a cached entry from disk if fresh, else None.
+
+    Best-effort: any I/O or parse error returns None and we re-fetch.
+    """
+    if ttl_seconds <= 0:
+        return None
+    path = _disk_cache_path(home_path)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("key") != _cache_key_str(cache_key):
+        return None
+    secrets = payload.get("secrets")
+    fetched_at = payload.get("fetched_at")
+    if not isinstance(secrets, dict) or not isinstance(fetched_at, (int, float)):
+        return None
+    # Coerce all values to strings — JSON allows numbers but env vars need strings
+    typed_secrets: Dict[str, str] = {
+        k: v for k, v in secrets.items() if isinstance(k, str) and isinstance(v, str)
+    }
+    entry = _CachedFetch(secrets=typed_secrets, fetched_at=float(fetched_at))
+    if not entry.is_fresh(ttl_seconds):
+        return None
+    return entry
+
+
+def _write_disk_cache(
+    cache_key: _CacheKey,
+    entry: "_CachedFetch",
+    home_path: Optional[Path] = None,
+) -> None:
+    """Persist a cache entry to disk atomically with mode 0600.
+
+    Best-effort: any I/O error is swallowed (the next invocation will just
+    re-fetch). We never want disk cache failures to break startup.
+    """
+    path = _disk_cache_path(home_path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "key": _cache_key_str(cache_key),
+            "secrets": entry.secrets,
+            "fetched_at": entry.fetched_at,
+        }
+        # Write to a temp file in the same directory and atomic-rename.
+        # tempfile honors os.umask, so we explicitly chmod 0600 before rename.
+        fd, tmp = tempfile.mkstemp(
+            prefix=".keepassxc_cache_", suffix=".tmp", dir=str(path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except OSError:
+        pass  # best-effort — disk cache miss on next invocation is fine
+
+
+@dataclass
+class _CachedFetch:
+    secrets: Dict[str, str]
+    fetched_at: float
+
+    def is_fresh(self, ttl_seconds: float) -> bool:
+        if ttl_seconds <= 0:
+            return False
+        return (time.time() - self.fetched_at) < ttl_seconds
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FetchResult:
+    """Outcome of a single KeePassXC pull."""
+
+    secrets: Dict[str, str] = field(default_factory=dict)
+    applied: List[str] = field(default_factory=list)   # set into os.environ
+    skipped: List[str] = field(default_factory=list)   # already set, not overridden
+    warnings: List[str] = field(default_factory=list)  # non-fatal issues
+    error: Optional[str] = None                        # fatal: nothing was fetched
+    binary_path: Optional[Path] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+# ---------------------------------------------------------------------------
+# Binary discovery
+# ---------------------------------------------------------------------------
+
+
+def find_keepassxc_cli() -> Optional[Path]:
+    """Return a path to a usable ``keepassxc-cli`` binary, or None.
+
+    Resolution order:
+      1. ``KEEPASSXC_CLI_PATH`` env var (full path to the binary).
+      2. ``shutil.which("keepassxc-cli")`` (system PATH).
+
+    Unlike the Bitwarden source we do NOT auto-install: keepassxc-cli is a
+    system package and should be installed by the platform package manager.
+    """
+    env_path = os.getenv("KEEPASSXC_CLI_PATH", "").strip()
+    if env_path:
+        candidate = Path(env_path)
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+
+    system = shutil.which("keepassxc-cli")
+    if system:
+        return Path(system)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Credentials fingerprint for cache keying
+# ---------------------------------------------------------------------------
+
+
+def _credentials_fingerprint(
+    password: str, key_file: str
+) -> str:
+    """Build a stable, opaque cache-key component from the credentials.
+
+    We never log or display this value.  It includes the password and, when a
+    key file is present, the key file contents so that rotating either
+    credential invalidates the cache.
+    """
+    h = hashlib.sha256()
+    h.update(password.encode("utf-8"))
+    if key_file:
+        try:
+            with open(key_file, "rb") as f:
+                for chunk in iter(lambda: f.read(65536), b""):
+                    h.update(chunk)
+        except OSError:
+            # If the key file can't be read we still hash the path so the
+            # cache key changes when the path changes.
+            h.update(key_file.encode("utf-8"))
+    return h.hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Secret fetch + apply
+# ---------------------------------------------------------------------------
+
+
+def _run_keepassxc_show(
+    binary: Path,
+    db_path: Path,
+    entry_path: str,
+    password: str,
+    key_file: str,
+    no_password: bool,
+) -> str:
+    """Return the Password attribute for a single KeePassXC entry.
+
+    Raises :class:`RuntimeError` for fatal conditions (wrong password,
+    binary invocation failure).  Returns the password string on success.
+    """
+    cmd = [str(binary), "show", "-a", "Password", "-s", str(db_path), entry_path]
+    if no_password:
+        cmd.insert(2, "--no-password")
+    if key_file:
+        cmd.insert(2, "-k")
+        cmd.insert(3, key_file)
+
+    try:
+        proc = subprocess.run(  # noqa: S603 — keepassxc-cli path is trusted
+            cmd,
+            input=password,
+            capture_output=True,
+            text=True,
+            timeout=_KP_RUN_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"keepassxc-cli timed out after {_KP_RUN_TIMEOUT}s fetching {entry_path!r}"
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"failed to invoke keepassxc-cli for {entry_path!r}: {exc}"
+        ) from exc
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip().replace("\x1b", "")
+        lower_err = err.lower()
+        # Check "entry not found" BEFORE "password" — stderr often contains
+        # "Enter password to unlock" even when the real error is a missing entry.
+        # keepassxc-cli says "Could not find entry with path X" (not "entry not found").
+        if "not found" in lower_err or "could not find" in lower_err:
+            raise RuntimeError(
+                f"KeePassXC entry not found: {entry_path!r}"
+            )
+        if "credentials" in lower_err or "password" in lower_err:
+            raise RuntimeError(
+                f"KeePassXC credentials failed for {entry_path!r}: {err[:200]}"
+            )
+        raise RuntimeError(
+            f"keepassxc-cli exited {proc.returncode} for {entry_path!r}: {err[:200]}"
+        )
+
+    return proc.stdout.strip()
+
+
+def _is_valid_env_name(name: str) -> bool:
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def fetch_keepassxc_secrets(
+    *,
+    db_path: str,
+    password: str,
+    key_file: str = "",
+    no_password: bool = False,
+    binary: Optional[Path] = None,
+    mappings: Optional[Dict[str, str]] = None,
+    cache_ttl_seconds: float = 300,
+    use_cache: bool = True,
+    home_path: Optional[Path] = None,
+) -> Tuple[Dict[str, str], List[str]]:
+    """Pull the mapped secrets from a KeePassXC database.
+
+    Returns ``(secrets_dict, warnings_list)``.
+
+    ``mappings`` is a dict of ``env_var_name → entry_path`` where
+    ``entry_path`` is the KeePassXC entry path as displayed in the
+    application (e.g. ``"Dev/OpenAI"``).  ``env_var_name`` must be a valid
+    shell env-var name.
+
+    Caching is a two-layer LRU: an in-process dict (for hot-reload paths
+    inside one process) and a disk-persisted JSON file under
+    ``<hermes_home>/cache/keepassxc_cache.json`` (for back-to-back CLI
+    invocations).  Both share the same TTL.  Pass ``home_path`` so disk
+    cache lookups find the right directory in tests / non-standard installs;
+    otherwise we fall back to ``$HERMES_HOME`` / ``~/.hermes``.
+
+    Raises :class:`RuntimeError` for fatal conditions (missing binary,
+    missing database, wrong password).  Per-entry failures (entry not
+    found, timeout, etc.) are returned as warnings instead of raising.
+    """
+    if not db_path:
+        raise RuntimeError("KeePassXC db_path is empty")
+    db = Path(db_path).expanduser().resolve()
+    if not db.exists():
+        raise RuntimeError(f"KeePassXC database not found: {db}")
+
+    mappings = mappings or {}
+    if not mappings:
+        raise RuntimeError("KeePassXC mappings are empty")
+
+    if binary is None:
+        binary = find_keepassxc_cli()
+    if binary is None:
+        raise RuntimeError(
+            "keepassxc-cli binary not available. Install KeePassXC and ensure "
+            "`keepassxc-cli` is on PATH, or set KEEPASSXC_CLI_PATH to the binary."
+        )
+
+    if not no_password and not password and not key_file:
+        # This is reachable if the caller passes an empty password and no
+        # key file. keepassxc-cli would prompt interactively, which would
+        # hang in non-interactive contexts; fail fast instead.
+        raise RuntimeError(
+            "KeePassXC password is empty and no key_file or no_password option provided"
+        )
+
+    cache_key = (str(db), _credentials_fingerprint(password, key_file))
+    if use_cache:
+        cached = _CACHE.get(cache_key)
+        if cached and cached.is_fresh(cache_ttl_seconds):
+            return cached.secrets, []
+        # L2: disk cache.
+        disk_cached = _read_disk_cache(cache_key, cache_ttl_seconds, home_path)
+        if disk_cached is not None:
+            _CACHE[cache_key] = disk_cached
+            return disk_cached.secrets, []
+
+    secrets: Dict[str, str] = {}
+    warnings: List[str] = []
+
+    for env_name, entry_path in mappings.items():
+        if not _is_valid_env_name(env_name):
+            warnings.append(
+                f"Skipping KeePassXC mapping {env_name!r}: not a valid env-var name"
+            )
+            continue
+
+        try:
+            value = _run_keepassxc_show(
+                binary=binary,
+                db_path=db,
+                entry_path=entry_path,
+                password=password,
+                key_file=key_file,
+                no_password=no_password,
+            )
+        except subprocess.TimeoutExpired:
+            warnings.append(
+                f"Timed out reading KeePassXC entry {entry_path!r} for {env_name}"
+            )
+            continue
+        except RuntimeError as exc:
+            msg = str(exc)
+            if "entry not found" in msg:
+                warnings.append(
+                    f"KeePassXC entry {entry_path!r} not found for {env_name}; skipped"
+                )
+            elif "credentials failed" in msg:
+                # Re-raise wrong-password errors so the public entry point can
+                # record them as the fatal FetchResult.error.
+                raise
+            else:
+                warnings.append(
+                    f"Failed to read KeePassXC entry {entry_path!r} for {env_name}: {msg}"
+                )
+            continue
+
+        if not value:
+            warnings.append(
+                f"KeePassXC entry {entry_path!r} has no Password attribute for {env_name}"
+            )
+            continue
+
+        secrets[env_name] = value
+
+    entry = _CachedFetch(secrets=secrets, fetched_at=time.time())
+    _CACHE[cache_key] = entry
+    if use_cache:
+        _write_disk_cache(cache_key, entry, home_path)
+
+    return secrets, warnings
+
+
+# ---------------------------------------------------------------------------
+# Public entry point — called from hermes_cli.env_loader
+# ---------------------------------------------------------------------------
+
+
+def apply_keepassxc_secrets(
+    *,
+    enabled: bool,
+    db_path: str,
+    password_env: str = "KEEPASSXC_PASSWORD",
+    key_file: str = "",
+    no_password: bool = False,
+    mappings: Optional[Dict[str, str]] = None,
+    override_existing: bool = False,
+    cache_ttl_seconds: float = 300,
+    home_path: Optional[Path] = None,
+) -> FetchResult:
+    """Pull secrets from KeePassXC and set them on ``os.environ``.
+
+    This is the function ``load_hermes_dotenv()`` calls after the .env
+    files have loaded.  It is intentionally defensive — any failure
+    returns a :class:`FetchResult` with ``error`` set; it never raises.
+
+    Parameters mirror the ``secrets.keepassxc.*`` config keys so the
+    caller can just splat the dict in.
+    """
+    result = FetchResult()
+
+    if not enabled:
+        return result
+
+    if not db_path:
+        result.error = "secrets.keepassxc.db_path is empty"
+        return result
+
+    mappings = mappings or {}
+    if not mappings:
+        result.error = "secrets.keepassxc.mappings is empty"
+        return result
+
+    password = os.environ.get(password_env, "").strip()
+    if not no_password and not password and not key_file:
+        result.error = (
+            f"secrets.keepassxc.enabled is true but {password_env} is not set "
+            "and no key_file or no_password option is provided"
+        )
+        return result
+
+    binary = find_keepassxc_cli()
+    result.binary_path = binary
+    if binary is None:
+        result.error = (
+            "keepassxc-cli binary not available. Install KeePassXC and ensure "
+            "`keepassxc-cli` is on PATH, or set KEEPASSXC_CLI_PATH to the binary."
+        )
+        return result
+
+    try:
+        secrets, warnings = fetch_keepassxc_secrets(
+            db_path=db_path,
+            password=password,
+            key_file=key_file,
+            no_password=no_password,
+            binary=binary,
+            mappings=mappings,
+            cache_ttl_seconds=cache_ttl_seconds,
+            home_path=home_path,
+        )
+    except RuntimeError as exc:
+        result.error = str(exc)
+        return result
+
+    result.secrets = secrets
+    result.warnings.extend(warnings)
+
+    for key, value in secrets.items():
+        if not override_existing and os.environ.get(key):
+            result.skipped.append(key)
+            continue
+        os.environ[key] = value
+        result.applied.append(key)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test hook — used by hermetic tests to flush the cache between cases.
+# ---------------------------------------------------------------------------
+
+
+def _reset_cache_for_tests(home_path: Optional[Path] = None) -> None:
+    """Clear in-process AND disk caches.
+
+    Tests can pass ``home_path`` to scope the disk cleanup to a tmpdir.
+    Without it we fall back to the same default resolution as the cache
+    writer itself.
+    """
+    _CACHE.clear()
+    try:
+        _disk_cache_path(home_path).unlink()
+    except (FileNotFoundError, OSError):
+        pass

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -78,6 +78,8 @@ def format_secret_source_suffix(env_var: str) -> str:
         return ""
     if source == "bitwarden":
         return " (from Bitwarden)"
+    if source == "keepassxc":
+        return " (from KeePassXC)"
     # Generic fallback — future-proofing for additional secret sources
     # (e.g. 1Password, HashiCorp Vault) without having to update every
     # call site.
@@ -308,52 +310,84 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         return
 
     bw_cfg = (cfg or {}).get("bitwarden") or {}
-    if not bw_cfg.get("enabled"):
-        return
+    if bw_cfg.get("enabled"):
+        try:
+            from agent.secret_sources.bitwarden import apply_bitwarden_secrets
+        except ImportError:
+            pass
+        else:
+            result = apply_bitwarden_secrets(
+                enabled=True,
+                access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
+                project_id=bw_cfg.get("project_id", ""),
+                override_existing=bool(bw_cfg.get("override_existing", False)),
+                cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
+                auto_install=bool(bw_cfg.get("auto_install", True)),
+                server_url=str(bw_cfg.get("server_url", "") or "").strip(),
+                home_path=home_path,
+            )
 
-    try:
-        from agent.secret_sources.bitwarden import apply_bitwarden_secrets
-    except ImportError:
-        return
+            if result.applied:
+                _sanitize_loaded_credentials()
+                for name in result.applied:
+                    _SECRET_SOURCES[name] = "bitwarden"
+                print(
+                    f"  Bitwarden Secrets Manager: applied {len(result.applied)} "
+                    f"secret{'s' if len(result.applied) != 1 else ''} "
+                    f"({', '.join(sorted(result.applied))})",
+                    file=sys.stderr,
+                )
+            if result.error:
+                print(
+                    f"  Bitwarden Secrets Manager: {result.error}",
+                    file=sys.stderr,
+                )
+            for warn in result.warnings:
+                print(
+                    f"  Bitwarden Secrets Manager: {warn}",
+                    file=sys.stderr,
+                )
 
-    result = apply_bitwarden_secrets(
-        enabled=True,
-        access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
-        project_id=bw_cfg.get("project_id", ""),
-        override_existing=bool(bw_cfg.get("override_existing", False)),
-        cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
-        auto_install=bool(bw_cfg.get("auto_install", True)),
-        server_url=str(bw_cfg.get("server_url", "") or "").strip(),
-        home_path=home_path,
-    )
+    # --- KeePassXC ---
+    kp_cfg = (cfg or {}).get("keepassxc") or {}
+    if kp_cfg.get("enabled"):
+        try:
+            from agent.secret_sources.keepassxc import apply_keepassxc_secrets
+        except ImportError:
+            pass
+        else:
+            result = apply_keepassxc_secrets(
+                enabled=True,
+                db_path=kp_cfg.get("db_path", ""),
+                password_env=kp_cfg.get("password_env", "KEEPASSXC_PASSWORD"),
+                key_file=kp_cfg.get("key_file", ""),
+                no_password=bool(kp_cfg.get("no_password", False)),
+                mappings=kp_cfg.get("mappings") or {},
+                override_existing=bool(kp_cfg.get("override_existing", False)),
+                cache_ttl_seconds=float(kp_cfg.get("cache_ttl_seconds", 300)),
+                home_path=home_path,
+            )
 
-    if result.applied:
-        # Re-run the ASCII sanitization pass: BSM values are user-supplied
-        # and might have the same copy-paste corruption as a manually
-        # edited .env (see #6843).
-        _sanitize_loaded_credentials()
-        # Remember where these came from so the setup / `hermes model`
-        # flows can label detected credentials with "(from Bitwarden)" —
-        # otherwise users see "credentials ✓" with no hint that the value
-        # came from BSM rather than .env.
-        for name in result.applied:
-            _SECRET_SOURCES[name] = "bitwarden"
-        print(
-            f"  Bitwarden Secrets Manager: applied {len(result.applied)} "
-            f"secret{'s' if len(result.applied) != 1 else ''} "
-            f"({', '.join(sorted(result.applied))})",
-            file=sys.stderr,
-        )
-    if result.error:
-        print(
-            f"  Bitwarden Secrets Manager: {result.error}",
-            file=sys.stderr,
-        )
-    for warn in result.warnings:
-        print(
-            f"  Bitwarden Secrets Manager: {warn}",
-            file=sys.stderr,
-        )
+            if result.applied:
+                _sanitize_loaded_credentials()
+                for name in result.applied:
+                    _SECRET_SOURCES[name] = "keepassxc"
+                print(
+                    f"  KeePassXC: applied {len(result.applied)} "
+                    f"secret{'s' if len(result.applied) != 1 else ''} "
+                    f"({', '.join(sorted(result.applied))})",
+                    file=sys.stderr,
+                )
+            if result.error:
+                print(
+                    f"  KeePassXC: {result.error}",
+                    file=sys.stderr,
+                )
+            for warn in result.warnings:
+                print(
+                    f"  KeePassXC: {warn}",
+                    file=sys.stderr,
+                )
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12791,12 +12791,12 @@ def main():
     # =========================================================================
     secrets_parser = subparsers.add_parser(
         "secrets",
-        help="Manage external secret sources (Bitwarden Secrets Manager)",
+        help="Manage external secret sources (Bitwarden Secrets Manager, KeePassXC)",
         description=(
             "Pull API keys from an external secret manager at process startup "
             "instead of storing them in ~/.hermes/.env.  Currently supports "
-            "Bitwarden Secrets Manager.  See: "
-            "https://hermes-agent.nousresearch.com/docs/user-guide/secrets/bitwarden"
+            "Bitwarden Secrets Manager and KeePassXC.  See: "
+            "https://hermes-agent.nousresearch.com/docs/user-guide/secrets"
         ),
     )
     secrets_subparsers = secrets_parser.add_subparsers(dest="secrets_command")
@@ -12807,15 +12807,26 @@ def main():
         help="Bitwarden Secrets Manager integration",
     )
 
+    # KeePassXC
+    secrets_kp = secrets_subparsers.add_parser(
+        "keepassxc",
+        aliases=["kp"],
+        help="KeePassXC password manager integration",
+    )
+
     # Lazy import — only pays for itself when this subcommand is actually used.
     from hermes_cli import secrets_cli as _secrets_cli
 
     _secrets_cli.register_cli(secrets_bw)
+    _secrets_cli.register_keepassxc_cli(secrets_kp)
 
     def _dispatch_secrets(args):  # noqa: ANN001
         sub = getattr(args, "secrets_command", None)
         bw_sub = getattr(args, "secrets_bw_command", None)
+        kp_sub = getattr(args, "secrets_kp_command", None)
         if sub in ("bitwarden", "bw") and bw_sub is not None:
+            return args.func(args)
+        if sub in ("keepassxc", "kp") and kp_sub is not None:
             return args.func(args)
         secrets_parser.print_help()
         return 0

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -23,6 +23,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from agent.secret_sources import bitwarden as bw
+from agent.secret_sources import keepassxc as kp
 from hermes_cli.config import (
     get_env_path,
     load_config,
@@ -598,3 +599,326 @@ def _resolve_server_url(
                 )
             return custom
         console.print(f"  [red]Out of range — pick 1-{custom_idx}.[/red]")
+
+
+# ---------------------------------------------------------------------------
+# KeePassXC CLI handlers
+# ---------------------------------------------------------------------------
+
+
+def register_keepassxc_cli(parent_parser: argparse.ArgumentParser) -> None:
+    """Attach the ``keepassxc`` subcommand tree to a parent parser."""
+    sub = parent_parser.add_subparsers(dest="secrets_kp_command")
+
+    setup = sub.add_parser(
+        "setup",
+        help="Interactive wizard: locate database, configure mappings",
+    )
+    setup.add_argument("--db-path", help="Path to the .kdbx database file")
+    setup.add_argument("--password", help="Database master password (stored in .env as KEEPASSXC_PASSWORD)")
+    setup.add_argument("--key-file", help="Path to a key file for database authentication")
+    setup.add_argument("--no-password", action="store_true", help="Database has no password")
+    setup.set_defaults(func=cmd_kp_setup)
+
+    status = sub.add_parser("status", help="Show config + binary + last fetch")
+    status.set_defaults(func=cmd_kp_status)
+
+    sync = sub.add_parser("sync", help="Fetch secrets now and report what changed")
+    sync.add_argument("--apply", action="store_true", help="Export secrets into current shell env (default: dry-run)")
+    sync.set_defaults(func=cmd_kp_sync)
+
+    disable = sub.add_parser("disable", help="Turn off the KeePassXC integration")
+    disable.set_defaults(func=cmd_kp_disable)
+
+
+def cmd_kp_setup(args: argparse.Namespace) -> int:
+    """Interactive KeePassXC setup wizard."""
+    console = Console()
+    console.print(Panel.fit(
+        "[bold]KeePassXC Secret Source setup[/bold]\n\n"
+        "Hermes will read API keys from your KeePassXC database at startup.\n"
+        "You'll need:\n"
+        "  • The path to your .kdbx database file\n"
+        "  • The master password (stored in .env as KEEPASSXC_PASSWORD)\n"
+        "  • Entry paths to map to env var names (e.g. Dev/OpenAI → OPENAI_API_KEY)",
+        border_style="green",
+    ))
+
+    # Step 1: Locate binary
+    console.print()
+    console.print("[bold]Step 1[/bold]  Locate keepassxc-cli")
+    binary = kp.find_keepassxc_cli()
+    if binary is None:
+        console.print("  [red]✗ keepassxc-cli not found.[/red]\n"
+                      "  Install KeePassXC from https://keepassxc.org or set\n"
+                      "  KEEPASSXC_CLI_PATH to the binary location.")
+        return 1
+    console.print(f"  [green]✓[/green] {binary}")
+
+    # Non-interactive guard
+    if not sys.stdin.isatty():
+        missing = []
+        if not (args.db_path and args.db_path.strip()):
+            missing.append("--db-path")
+        if not args.no_password:
+            if not (args.password and args.password.strip()):
+                if not os.environ.get("KEEPASSXC_PASSWORD", "").strip():
+                    missing.append("--password")
+        if missing:
+            console.print(f"  [red]Non-interactive mode (no TTY) requires all setup flags.[/red]\n"
+                          f"  Missing: {', '.join(missing)}")
+            return 1
+
+    # Step 2: Database path
+    console.print()
+    console.print("[bold]Step 2[/bold]  Database path")
+    db_path = (args.db_path or "").strip()
+    if not db_path:
+        db_path = console.input("  Path to .kdbx file: ").strip()
+    if not db_path:
+        console.print("  [red]Empty path, aborting.[/red]")
+        return 1
+    db = Path(db_path).expanduser().resolve()
+    if not db.exists():
+        console.print(f"  [red]✗ {db} does not exist.[/red]")
+        return 1
+    console.print(f"  [green]✓[/green] {db}")
+
+    # Step 3: Authentication
+    console.print()
+    console.print("[bold]Step 3[/bold]  Authentication method")
+    no_password = args.no_password
+    key_file = (args.key_file or "").strip()
+    password = (args.password or "").strip()
+
+    if not no_password and not key_file and not password:
+        console.print("  How is your database protected?")
+        console.print("    [1] Master password only")
+        console.print("    [2] Key file only")
+        console.print("    [3] Master password + key file")
+        console.print("    [4] No password (unprotected)")
+        choice = console.input("  Choice [1-4]: ").strip()
+        if choice == "2":
+            key_file = console.input("  Path to key file: ").strip()
+        elif choice == "3":
+            password = masked_secret_prompt("  Master password: ").strip()
+            key_file = console.input("  Path to key file: ").strip()
+        elif choice == "4":
+            no_password = True
+        else:
+            password = masked_secret_prompt("  Master password: ").strip()
+
+    cfg = load_config()
+    secrets_cfg = cfg.setdefault("secrets", {}).setdefault("keepassxc", {})
+    password_env = secrets_cfg.get("password_env", "KEEPASSXC_PASSWORD")
+
+    if password:
+        save_env_value(password_env, password)
+        os.environ[password_env] = password
+        console.print(f"  [green]✓[/green] stored in .env as {password_env}")
+    if key_file:
+        console.print(f"  [green]✓[/green] using key file: {key_file}")
+    if no_password:
+        console.print("  [green]✓[/green] no password mode")
+
+    # Step 4: Test database access
+    console.print()
+    console.print("[bold]Step 4[/bold]  Test database access")
+    try:
+        _test_kp_db_access(binary, str(db), password, key_file, no_password)
+        console.print("  [green]✓[/green] Database unlocked successfully")
+    except Exception as exc:
+        console.print(f"  [red]✗ Failed to unlock database: {exc}[/red]")
+        return 1
+
+    # Step 5: Mappings
+    console.print()
+    console.print("[bold]Step 5[/bold]  Configure entry mappings")
+    console.print("  Map KeePassXC entries to environment variable names.\n"
+                  "  Format: [cyan]Entry/Path[/cyan] → [cyan]ENV_VAR_NAME[/cyan]\n"
+                  "  Example: [cyan]Dev/OpenAI[/cyan] → [cyan]OPENAI_API_KEY[/cyan]\n"
+                  "  Leave entry path empty to finish.")
+
+    mappings: dict[str, str] = {}
+    while True:
+        entry = console.input("  Entry path (or empty to finish): ").strip()
+        if not entry:
+            break
+        env_var = console.input(f"    → env var name: ").strip().upper()
+        if not env_var:
+            console.print("    [red]Env var name required.[/red]")
+            continue
+        if not kp._is_valid_env_name(env_var):
+            console.print(f"    [red]{env_var!r} is not a valid env var name.[/red]")
+            continue
+        mappings[env_var] = entry
+        console.print(f"    [green]✓[/green] {entry} → {env_var}")
+
+    if not mappings:
+        console.print("  [yellow]No mappings configured — nothing to fetch.[/yellow]")
+    else:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Entry", style="cyan")
+        table.add_column("Env Var", style="green")
+        for env_var, entry in sorted(mappings.items()):
+            table.add_row(entry, env_var)
+        console.print()
+        console.print(table)
+
+    # Save
+    secrets_cfg["enabled"] = True
+    secrets_cfg["db_path"] = str(db)
+    secrets_cfg["password_env"] = password_env
+    if key_file:
+        secrets_cfg["key_file"] = key_file
+    if no_password:
+        secrets_cfg["no_password"] = True
+    secrets_cfg["mappings"] = mappings
+    secrets_cfg.setdefault("cache_ttl_seconds", 300)
+    secrets_cfg.setdefault("override_existing", True)
+    save_config(cfg)
+
+    console.print()
+    console.print("[green]✓ KeePassXC secret source is enabled.[/green]  "
+                  "Secrets will be pulled at the start of every Hermes process.")
+    console.print("  Status:  [cyan]hermes secrets keepassxc status[/cyan]\n"
+                  "  Refresh: [cyan]hermes secrets keepassxc sync[/cyan]\n"
+                  "  Disable: [cyan]hermes secrets keepassxc disable[/cyan]")
+    return 0
+
+
+def cmd_kp_status(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    kp_cfg = (cfg.get("secrets") or {}).get("keepassxc") or {}
+
+    enabled = bool(kp_cfg.get("enabled"))
+    db_path = kp_cfg.get("db_path", "")
+    password_env = kp_cfg.get("password_env", "KEEPASSXC_PASSWORD")
+    key_file = kp_cfg.get("key_file", "")
+    no_password = bool(kp_cfg.get("no_password", False))
+    password_set = bool(os.environ.get(password_env))
+    mappings = kp_cfg.get("mappings") or {}
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("", style="bold")
+    table.add_column("")
+    table.add_row("Enabled", _yn(enabled))
+    table.add_row("Database", db_path or "[dim](unset)[/dim]")
+    table.add_row("Password env", password_env)
+    table.add_row("Password set", _yn(password_set))
+    table.add_row("Key file", key_file or "[dim](none)[/dim]")
+    table.add_row("No password", _yn(no_password))
+    table.add_row("Mappings", str(len(mappings)) if mappings else "[dim]none[/dim]")
+    table.add_row("Override existing", _yn(bool(kp_cfg.get("override_existing", False))))
+    table.add_row("Cache TTL (s)", str(kp_cfg.get("cache_ttl_seconds", 300)))
+
+    binary = kp.find_keepassxc_cli()
+    if binary:
+        table.add_row("keepassxc-cli", str(binary))
+    else:
+        table.add_row("keepassxc-cli", "[yellow]not found[/yellow]")
+
+    console.print(Panel(table, title="KeePassXC Secret Source", border_style="green"))
+
+    if not enabled:
+        console.print("\n  Run [cyan]hermes secrets keepassxc setup[/cyan] to enable.")
+    elif not db_path:
+        console.print("\n  [yellow]Enabled but no db_path — nothing to fetch.[/yellow]")
+    elif not password_set and not key_file and not no_password:
+        console.print(f"\n  [yellow]Enabled but {password_env} is not set and no key_file configured.[/yellow]")
+    elif not mappings:
+        console.print("\n  [yellow]No mappings configured — nothing to fetch.[/yellow]")
+    return 0
+
+
+def cmd_kp_sync(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    kp_cfg = (cfg.get("secrets") or {}).get("keepassxc") or {}
+    if not kp_cfg.get("enabled"):
+        console.print("[yellow]KeePassXC integration is disabled. Run `hermes secrets keepassxc setup` first.[/yellow]")
+        return 1
+
+    db_path = kp_cfg.get("db_path", "")
+    if not db_path:
+        console.print("[red]No db_path configured.[/red]")
+        return 1
+
+    password_env = kp_cfg.get("password_env", "KEEPASSXC_PASSWORD")
+    password = os.environ.get(password_env, "").strip() if not kp_cfg.get("no_password") else ""
+    key_file = kp_cfg.get("key_file", "") or ""
+    no_password = bool(kp_cfg.get("no_password", False))
+    mappings = kp_cfg.get("mappings") or {}
+
+    if not mappings:
+        console.print("[yellow]No mappings configured.[/yellow]")
+        return 0
+
+    try:
+        secrets, warnings = kp.fetch_keepassxc_secrets(
+            db_path=db_path, password=password, key_file=key_file,
+            no_password=no_password, mappings=mappings, use_cache=False,
+        )
+    except Exception as exc:
+        console.print(f"[red]Fetch failed: {exc}[/red]")
+        return 1
+
+    if not secrets:
+        console.print("[yellow]No secrets fetched.[/yellow]")
+        return 0
+
+    override = bool(kp_cfg.get("override_existing", False)) or args.apply
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name", style="cyan")
+    table.add_column("Action")
+    applied = 0
+    for key in sorted(secrets):
+        already = bool(os.environ.get(key))
+        if already and not override:
+            table.add_row(key, "[dim]skip (already set)[/dim]")
+            continue
+        if args.apply:
+            os.environ[key] = secrets[key]
+            applied += 1
+            table.add_row(key, "[green]exported[/green]" + (" (overrode)" if already else ""))
+        else:
+            table.add_row(key, "[green]would export[/green]" + (" (overrides)" if already else ""))
+
+    console.print(table)
+    for w in warnings:
+        console.print(f"[yellow]warning:[/yellow] {w}")
+
+    if not args.apply:
+        console.print("\n  This was a dry-run. Re-run with [cyan]--apply[/cyan] to export into the current shell.")
+    else:
+        console.print(f"\n  [green]Exported {applied} secret(s) into current process.[/green]")
+    return 0
+
+
+def cmd_kp_disable(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    kp_cfg = cfg.setdefault("secrets", {}).setdefault("keepassxc", {})
+    kp_cfg["enabled"] = False
+    save_config(cfg)
+    console.print("[green]Disabled.[/green]  KeePassXC secrets will NOT be pulled on the next Hermes invocation.\n"
+                  "  Your database password is left in .env — remove it manually if desired.")
+    return 0
+
+
+def _test_kp_db_access(binary: Path, db_path: str, password: Optional[str], key_file: Optional[str], no_password: bool) -> None:
+    """Test that we can unlock the database by listing root entries."""
+    cmd = [str(binary), "ls", "-q", "-R", "-f", db_path, "/"]
+    if no_password:
+        cmd.insert(2, "--no-password")
+    if key_file:
+        cmd.insert(2, "-k")
+        cmd.insert(3, key_file)
+
+    proc = subprocess.run(
+        cmd, input=password, capture_output=True, text=True, timeout=15,
+    )
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()
+        raise RuntimeError(err[:300])

--- a/tests/secret_sources/test_keepassxc.py
+++ b/tests/secret_sources/test_keepassxc.py
@@ -1,0 +1,251 @@
+"""Tests for agent.secret_sources.keepassxc."""
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.secret_sources.keepassxc import (
+    FetchResult,
+    _is_valid_env_name,
+    apply_keepassxc_secrets,
+    find_keepassxc_cli,
+)
+
+
+class TestIsValidEnvName:
+    def test_valid_names(self):
+        assert _is_valid_env_name("OPENAI_API_KEY")
+        assert _is_valid_env_name("_PRIVATE_KEY")
+        assert _is_valid_env_name("A")
+        assert _is_valid_env_name("A123")
+        assert _is_valid_env_name("_")
+
+    def test_invalid_names(self):
+        assert not _is_valid_env_name("")
+        assert not _is_valid_env_name("123_STARTS_WITH_NUMBER")
+        assert not _is_valid_env_name("HAS SPACES")
+        assert not _is_valid_env_name("HAS-DASHES")
+        assert not _is_valid_env_name("HAS.DOTS")
+
+
+class TestFindKeepassxcCli:
+    def test_env_var_override(self, monkeypatch, tmp_path):
+        fake = tmp_path / "fake-keepassxc-cli"
+        fake.write_text("#!/bin/sh\necho ok")
+        fake.chmod(0o755)
+        monkeypatch.setenv("KEEPASSXC_CLI_PATH", str(fake))
+        result = find_keepassxc_cli()
+        assert result == fake
+
+    def test_env_var_missing_file(self, monkeypatch):
+        monkeypatch.setenv("KEEPASSXC_CLI_PATH", "/nonexistent/keepassxc-cli")
+        with patch("shutil.which", return_value=None):
+            result = find_keepassxc_cli()
+        assert result is None
+
+    def test_system_path(self):
+        result = find_keepassxc_cli()
+        assert result is None or result.name == "keepassxc-cli"
+
+
+class TestApplyKeepassxcSecrets:
+    def test_disabled_returns_empty(self):
+        result = apply_keepassxc_secrets(enabled=False, db_path="")
+        assert result.ok
+        assert result.secrets == {}
+        assert result.applied == []
+
+    def test_missing_db_path(self):
+        result = apply_keepassxc_secrets(enabled=True, db_path="")
+        assert not result.ok
+        assert "db_path" in result.error.lower()
+
+    def test_missing_mappings(self):
+        result = apply_keepassxc_secrets(
+            enabled=True, db_path="/tmp/test.kdbx", mappings={}
+        )
+        assert not result.ok
+        assert "mappings" in result.error.lower()
+
+    def test_missing_binary(self, monkeypatch):
+        monkeypatch.setenv("KEEPASSXC_CLI_PATH", "/nonexistent/keepassxc-cli")
+        with patch("shutil.which", return_value=None):
+            result = apply_keepassxc_secrets(
+                enabled=True,
+                db_path="/tmp/test.kdbx",
+                no_password=True,
+                mappings={"TEST_KEY": "Dev/Test"},
+            )
+        assert not result.ok
+        assert "not available" in result.error.lower() or "not found" in result.error.lower()
+
+    def test_missing_password_and_no_key_file(self, monkeypatch):
+        monkeypatch.delenv("KEEPASSXC_PASSWORD", raising=False)
+        result = apply_keepassxc_secrets(
+            enabled=True,
+            db_path="/tmp/test.kdbx",
+            mappings={"TEST_KEY": "Dev/Test"},
+        )
+        assert not result.ok
+        assert "password" in result.error.lower() or "key_file" in result.error.lower()
+
+    def test_applies_secrets_to_env(self, monkeypatch, tmp_path):
+        """Integration test with a real keepassxc-cli and a test database."""
+        binary = find_keepassxc_cli()
+        if binary is None:
+            pytest.skip("keepassxc-cli not installed")
+
+        db_path = tmp_path / "test.kdbx"
+        password = "testpassword123"
+
+        # Create database — db-create wants password twice (enter + repeat)
+        proc = subprocess.run(
+            [str(binary), "db-create", "-p", str(db_path)],
+            input=f"{password}\n{password}\n",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0, f"db-create failed: {proc.stderr}"
+
+        # Add an entry with a password — need to create the group first
+        proc = subprocess.run(
+            [str(binary), "mkdir", str(db_path), "Dev"],
+            input=f"{password}\n",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0, f"mkdir failed: {proc.stderr}"
+
+        proc = subprocess.run(
+            [str(binary), "add", "-u", "TestEntry", "-p", str(db_path),
+             "Dev/TestEntry"],
+            input=f"{password}\nsecretvalue123\n",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0, f"add failed: {proc.stderr}"
+
+        monkeypatch.setenv("KEEPASSXC_PASSWORD", password)
+
+        result = apply_keepassxc_secrets(
+            enabled=True,
+            db_path=str(db_path),
+            password_env="KEEPASSXC_PASSWORD",
+            mappings={"TEST_API_KEY": "Dev/TestEntry"},
+            override_existing=True,
+            cache_ttl_seconds=0,
+        )
+
+        assert result.ok, f"Error: {result.error}"
+        assert "TEST_API_KEY" in result.applied
+        assert os.environ.get("TEST_API_KEY") == "secretvalue123"
+
+    def test_does_not_override_existing_by_default(self, monkeypatch, tmp_path):
+        binary = find_keepassxc_cli()
+        if binary is None:
+            pytest.skip("keepassxc-cli not installed")
+
+        db_path = tmp_path / "test2.kdbx"
+        password = "testpassword456"
+
+        proc = subprocess.run(
+            [str(binary), "db-create", "-p", str(db_path)],
+            input=f"{password}\n{password}\n",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0
+
+        # Create group before adding entry
+        proc = subprocess.run(
+            [str(binary), "mkdir", str(db_path), "Dev"],
+            input=f"{password}\n",
+            capture_output=True, text=True, timeout=10,
+        )
+        assert proc.returncode == 0
+
+        proc = subprocess.run(
+            [str(binary), "add", "-u", "TestEntry", "-p", str(db_path),
+             "Dev/Test"],
+            input=f"{password}\nfromkeepass\n",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0
+
+        monkeypatch.setenv("EXISTING_KEY", "from_shell")
+        monkeypatch.setenv("KEEPASSXC_PASSWORD", password)
+
+        result = apply_keepassxc_secrets(
+            enabled=True,
+            db_path=str(db_path),
+            password_env="KEEPASSXC_PASSWORD",
+            mappings={"EXISTING_KEY": "Dev/Test"},
+            override_existing=False,
+            cache_ttl_seconds=0,
+        )
+
+        assert result.ok
+        assert "EXISTING_KEY" in result.skipped
+        assert os.environ["EXISTING_KEY"] == "from_shell"
+
+    def test_entry_not_found_warning(self, monkeypatch, tmp_path):
+        """Non-existent entry path → warning, not error."""
+        binary = find_keepassxc_cli()
+        if binary is None:
+            pytest.skip("keepassxc-cli not installed")
+
+        db_path = tmp_path / "test3.kdbx"
+        password = "testpassword789"
+
+        proc = subprocess.run(
+            [str(binary), "db-create", "-p", str(db_path)],
+            input=f"{password}\n{password}\n",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0
+
+        monkeypatch.setenv("KEEPASSXC_PASSWORD", password)
+
+        result = apply_keepassxc_secrets(
+            enabled=True,
+            db_path=str(db_path),
+            password_env="KEEPASSXC_PASSWORD",
+            mappings={"MISSING_KEY": "Dev/DoesNotExist"},
+            override_existing=True,
+            cache_ttl_seconds=0,
+        )
+
+        assert result.ok
+        assert "MISSING_KEY" not in result.applied
+        assert len(result.warnings) >= 1
+        assert any("not found" in w.lower() for w in result.warnings)
+
+
+class TestFetchResult:
+    def test_ok_when_no_error(self):
+        r = FetchResult()
+        assert r.ok
+
+    def test_not_ok_when_error(self):
+        r = FetchResult(error="something went wrong")
+        assert not r.ok
+
+    def test_defaults(self):
+        r = FetchResult()
+        assert r.secrets == {}
+        assert r.applied == []
+        assert r.skipped == []
+        assert r.warnings == []
+        assert r.error is None
+        assert r.binary_path is None


### PR DESCRIPTION
## Summary

Adds KeePassXC as a secret source backend, mirroring the existing Bitwarden Secrets Manager integration. Hermes can now pull API keys from a KeePassXC database at process startup.

## What's included

- **`agent/secret_sources/keepassxc.py`** — Core module with `FetchResult`, two-layer caching (in-process + disk), subprocess-driven `keepassxc-cli` integration, and `apply_keepassxc_secrets()` public entry point
- **`hermes_cli/secrets_cli.py`** — CLI handlers: `hermes secrets keepassxc setup|status|sync|disable`
- **`hermes_cli/main.py`** — Wires `hermes secrets keepassxc` (alias `kp`) subcommand
- **`hermes_cli/env_loader.py`** — Startup wiring in `_apply_external_secret_sources()` + `format_secret_source_suffix()`
- **`agent/secret_sources/__init__.py`** — Docstring update
- **`tests/secret_sources/test_keepassxc.py`** — 16 tests (unit + integration with real `keepassxc-cli`)

## Authentication modes

All configurable via `secrets.keepassxc.*` in `config.yaml`:

| Mode | Config |
|------|--------|
| Master password | `password_env: KEEPASSXC_PASSWORD` (stored in `.env`) |
| Key file only | `key_file: /path/to/key` |
| Password + key file | Both |
| No password | `no_password: true` |

## Design

Follows the exact same architecture as the Bitwarden module:
- Subprocess-driven (no Python dependency — uses system `keepassxc-cli`)
- Fail-open: never blocks Hermes startup
- Two-layer cache (in-process + disk, TTL-configurable)
- `FetchResult` dataclass with `ok` property
- `_SECRET_SOURCES` tracking for `(from KeePassXC)` labels

## Testing

```
16 passed in 1.07s
```

Integration tests create real `.kdbx` databases with `keepassxc-cli db-create`, add entries, and verify `apply_keepassxc_secrets()` reads them correctly.