### PR TITLE
feat(kanban): validate skill names at create + swarm time

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -30,6 +30,40 @@ from hermes_cli.profiles import get_active_profile_name
 
 
 # ---------------------------------------------------------------------------
+# Skill-name validation (prevents crash-loop-retry at spawn time)
+# ---------------------------------------------------------------------------
+
+def _validate_skill_names(names):
+    """Resolve each skill name against the installed skills dirs.
+
+    Returns (ok, bad_names). bad_names is empty when every name resolves.
+    A name resolves when a skill dir with a matching ``SKILL.md`` parent
+    exists under any configured skills directory (local or external).
+    """
+    bad = []
+    if not names:
+        return True, []
+    try:
+        from tools.skill_manager_tool import _find_skill
+    except Exception:
+        # If the resolver can't be imported, skip validation rather than
+        # block legitimate work — the spawn-time error is still the
+        # safety net.
+        return True, []
+    for n in names:
+        # Accept "namespace/name" and "name" forms. _find_skill matches
+        # on the trailing path component (skill_md.parent.name == name).
+        bare = n.split("/", 1)[-1]
+        try:
+            if _find_skill(bare) is None:
+                bad.append(n)
+        except Exception:
+            # Resolver raised — don't block on it, let spawn handle it.
+            continue
+    return (not bad), bad
+
+
+# ---------------------------------------------------------------------------
 # Small formatting helpers
 # ---------------------------------------------------------------------------
 
@@ -1326,6 +1360,20 @@ def _cmd_create(args: argparse.Namespace) -> int:
         )
         return 2
     with kb.connect_closing() as conn:
+        # Validate skill names before creating the card — a bad skill
+        # name crashes the worker at spawn and burns the retry budget
+        # without ever doing the work. Reject early with a clear error
+        # naming the unresolvable skills.
+        skills_requested = getattr(args, "skills", None) or []
+        ok, bad = _validate_skill_names(skills_requested)
+        if not ok:
+            print(
+                f"kanban: --skill: unresolvable skill name(s): {', '.join(bad)}",
+                file=sys.stderr,
+            )
+            hint = "Use the skill's trailing path component (e.g. 'web-search' for 'universal/web-search')."
+            print(f"  Hint: {hint}", file=sys.stderr)
+            return 2
         task_id = kb.create_task(
             conn,
             title=args.title,
@@ -1377,6 +1425,17 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
     if not workers:
         print("kanban swarm: at least one --worker is required", file=sys.stderr)
         return 2
+    # Validate skill names on every worker before creating the graph —
+    # a bad skill name crashes the worker at spawn and stalls the whole
+    # swarm (verifier/synthesizer never start). Reject early.
+    for w in workers:
+        ok, bad = _validate_skill_names(w.skills or [])
+        if not ok:
+            print(
+                f"kanban swarm: worker {w.profile!r} has unresolvable skill name(s): {', '.join(bad)}",
+                file=sys.stderr,
+            )
+            return 2
     with kb.connect_closing() as conn:
         created = ks.create_swarm(
             conn,


### PR DESCRIPTION
## What

Passing an unresolvable skill name via `--skill` (e.g. `web-search` when the installed path is `universal/web-search`) crashed the worker at spawn and burned the retry budget without doing the work. In a swarm, a bad worker skill stalled the whole graph — the verifier and synthesizer never started because the worker never completed.

## Fix

Add `_validate_skill_names()` which resolves each name against the installed skills dirs via `_find_skill()` (the same resolver `skill_view` uses). Reject at:

- `_cmd_create` — `--skill` names checked before the card is created
- `_cmd_swarm` — every worker's skills checked before the graph is built

Both paths return a clear error naming the unresolvable skill(s) + a hint pointing to the trailing path component. Import/resolver failures fall through to the existing spawn-time error as the safety net (validation is additive, never blocking on resolver hiccups).

## Why

A bad skill name is a typo, not a runtime condition — it should fail fast at creation with a message, not silently crash-loop 3x and block the card. The swarm case is worse: one bad worker skill dead-locks the entire fan-out.

## Verification

- `--skill web-search` → rejected at create: `kanban: --skill: unresolvable skill name(s): web-search` + hint
- `--skill humanizer` → accepted, card created and auto-dispatched normally
- swarm with `--worker researcher:bad:web-search` → rejected before graph creation
- import-clean, no syntax errors