### PR TITLE
feat(desktop): present MCP catalog as connectors

### DIFF
--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -37,7 +37,7 @@ import {
   testMcpServer
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
-import { connectorDisplayName, connectorPrimaryActionKind } from '@/lib/mcp-catalog'
+import { connectorDisplayName, connectorPrimaryActionKind, connectorSetupSummary } from '@/lib/mcp-catalog'
 import { countEnabledTools, isToolEnabled, toggleToolInServer } from '@/lib/mcp-tool-filter'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -1376,6 +1376,7 @@ function McpCatalog({
       {entries.map(entry => {
         const draft = envDrafts[entry.name] ?? {}
         const actionKind = connectorPrimaryActionKind(entry)
+        const setupSummary = connectorSetupSummary(entry)
 
         return (
           <div className="rounded-md px-2 py-2" key={entry.name}>
@@ -1404,6 +1405,24 @@ function McpCatalog({
                   )}
                 </div>
                 <p className="mt-0.5 line-clamp-2 text-[0.68rem] text-muted-foreground/70">{entry.description}</p>
+                {setupSummary && (
+                  <div className="mt-1 flex items-center gap-1.5 text-[0.62rem] text-(--ui-text-tertiary)">
+                    <Codicon name="pass" size="0.7rem" />
+                    <span>{setupSummary}</span>
+                  </div>
+                )}
+                {entry.setup_steps.length > 0 && (
+                  <div className="mt-2 grid gap-1 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-2">
+                    {entry.setup_steps.slice(0, 3).map((step, index) => (
+                      <div className="flex gap-2 text-[0.62rem] leading-relaxed text-(--ui-text-tertiary)" key={step}>
+                        <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-(--ui-bg-tertiary) text-[0.55rem] text-(--ui-text-secondary)">
+                          {index + 1}
+                        </span>
+                        <span>{step}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
                 {entry.capabilities.length > 0 && (
                   <div className="mt-1 flex flex-wrap gap-1">
                     {entry.capabilities.slice(0, 3).map(capability => (

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -8,6 +8,7 @@ import {
   SiSentry,
   SiStripe,
   SiSupabase,
+  SiUnrealengine,
   SiVercel
 } from '@icons-pack/react-simple-icons'
 import { useStore } from '@nanostores/react'
@@ -37,7 +38,7 @@ import {
   testMcpServer
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
-import { connectorDisplayName, connectorPrimaryActionKind, connectorSetupSummary } from '@/lib/mcp-catalog'
+import { connectorDisplayName, connectorIdentityKey, connectorPrimaryActionKind, connectorSetupSummary } from '@/lib/mcp-catalog'
 import { countEnabledTools, isToolEnabled, toggleToolInServer } from '@/lib/mcp-tool-filter'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -1377,20 +1378,22 @@ function McpCatalog({
         const draft = envDrafts[entry.name] ?? {}
         const actionKind = connectorPrimaryActionKind(entry)
         const setupSummary = connectorSetupSummary(entry)
+        const identityKey = connectorIdentityKey(entry)
 
         return (
-          <div className="rounded-md px-2 py-2" key={entry.name}>
-            <div className="flex items-start gap-2">
-              {/* 2px nudge so the start-aligned avatar sits where McpRow's
-                  center-aligned one does — no jump when flipping Servers⇄Catalog. */}
+          <div
+            className="group/connector rounded-xl border border-(--ui-stroke-tertiary) bg-linear-to-br from-(--ui-bg-secondary) to-(--ui-bg-tertiary)/60 px-3 py-3 shadow-sm transition-colors hover:border-(--ui-stroke-secondary) hover:bg-(--ui-bg-tertiary)"
+            key={entry.name}
+          >
+            <div className="flex items-start gap-3">
               <McpAvatar
-                className="mt-0.5"
-                name={entry.name}
+                className="mt-0.5 size-9 rounded-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] ring-1 ring-(--ui-stroke-tertiary)"
+                name={identityKey}
                 status={entry.installed ? (entry.enabled ? 'ok' : 'off') : 'unknown'}
               />
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-1.5">
-                  <span className="truncate text-[0.78rem] font-medium text-foreground/85">
+                  <span className="truncate text-[0.86rem] font-semibold tracking-tight text-foreground/90">
                     {connectorDisplayName(entry)}
                   </span>
                   {entry.category && <CatalogTag>{entry.category}</CatalogTag>}
@@ -1577,6 +1580,8 @@ const MCP_BRAND_ICONS: Record<string, { Icon: ComponentType<SVGProps<SVGSVGEleme
   gitlab: { Icon: SiGitlab, color: '#FC6D26' },
   linear: { Icon: SiLinear, color: '#5E6AD2' },
   notion: { Icon: SiNotion, color: '#000000' },
+  'unreal-engine': { Icon: SiUnrealengine, color: '#0E1128' },
+  unrealengine: { Icon: SiUnrealengine, color: '#0E1128' },
   postgres: { Icon: SiPostgresql, color: '#4169E1' },
   postgresql: { Icon: SiPostgresql, color: '#4169E1' },
   sentry: { Icon: SiSentry, color: '#362D59' },
@@ -1609,7 +1614,7 @@ function McpAvatar({ className, name, status }: { className?: string; name: stri
       style={brand ? { backgroundColor: `color-mix(in srgb, ${brand.color} 16%, transparent)` } : undefined}
     >
       {brand ? (
-        <brand.Icon aria-hidden className="size-3.5" style={{ color: brand.color }} />
+        <brand.Icon aria-hidden className="size-[58%]" style={{ color: brand.color }} />
       ) : (
         name.charAt(0).toUpperCase()
       )}

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -37,6 +37,7 @@ import {
   testMcpServer
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
+import { connectorDisplayName, connectorPrimaryActionKind } from '@/lib/mcp-catalog'
 import { countEnabledTools, isToolEnabled, toggleToolInServer } from '@/lib/mcp-tool-filter'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -1374,6 +1375,7 @@ function McpCatalog({
     <div className="flex flex-col">
       {entries.map(entry => {
         const draft = envDrafts[entry.name] ?? {}
+        const actionKind = connectorPrimaryActionKind(entry)
 
         return (
           <div className="rounded-md px-2 py-2" key={entry.name}>
@@ -1388,8 +1390,9 @@ function McpCatalog({
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-1.5">
                   <span className="truncate text-[0.78rem] font-medium text-foreground/85">
-                    {prettyName(entry.name)}
+                    {connectorDisplayName(entry)}
                   </span>
+                  {entry.category && <CatalogTag>{entry.category}</CatalogTag>}
                   <CatalogTag>{entry.transport}</CatalogTag>
                   {entry.auth_type === 'oauth' && <CatalogTag>OAuth</CatalogTag>}
                   {entry.auth_type === 'api_key' && <CatalogTag>API key</CatalogTag>}
@@ -1401,6 +1404,21 @@ function McpCatalog({
                   )}
                 </div>
                 <p className="mt-0.5 line-clamp-2 text-[0.68rem] text-muted-foreground/70">{entry.description}</p>
+                {entry.capabilities.length > 0 && (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {entry.capabilities.slice(0, 3).map(capability => (
+                      <span
+                        className="rounded bg-(--ui-bg-quinary) px-1.5 py-0.5 text-[0.6rem] text-(--ui-text-tertiary)"
+                        key={capability}
+                      >
+                        {capability}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {entry.danger_notes.length > 0 && (
+                  <p className="mt-1 text-[0.62rem] text-amber-400/90">{entry.danger_notes[0]}</p>
+                )}
                 {envOpenFor === entry.name && entry.required_env.length > 0 && (
                   <div className="mt-2 grid gap-2">
                     {entry.required_env.map(env => (
@@ -1434,9 +1452,11 @@ function McpCatalog({
               >
                 {installing === entry.name
                   ? m.catalogInstalling
-                  : entry.installed
+                  : actionKind === 'installed'
                     ? m.catalogInstalled
-                    : m.catalogInstall}
+                    : actionKind === 'connect'
+                      ? m.catalogConnect
+                      : m.catalogInstall}
               </Button>
             </div>
           </div>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -627,6 +627,7 @@ export const en: Translations = {
       catalogEnabled: 'Enabled',
       catalogNeedsInstall: 'Needs build',
       catalogInstall: 'Install',
+      catalogConnect: 'Connect',
       catalogInstalling: 'Installing...',
       catalogInstallStarted: name => `Installing ${name}... applies to new sessions when done.`,
       catalogInstallFailed: name => `Failed to install ${name}`,
@@ -774,7 +775,7 @@ export const en: Translations = {
   skills: {
     tabSkills: 'Skills',
     tabToolsets: 'Tools',
-    tabMcp: 'MCP',
+    tabMcp: 'Connectors',
     tabHub: 'Browse Hub',
     all: 'All',
     searchSkills: 'Search skills...',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -538,6 +538,7 @@ export interface Translations {
       catalogEnabled: string
       catalogNeedsInstall: string
       catalogInstall: string
+      catalogConnect: string
       catalogInstalling: string
       catalogInstallStarted: (name: string) => string
       catalogInstallFailed: (name: string) => string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -816,6 +816,7 @@ export const zh: Translations = {
       catalogEnabled: '已启用',
       catalogNeedsInstall: '需要构建',
       catalogInstall: '安装',
+      catalogConnect: '连接',
       catalogInstalling: '安装中…',
       catalogInstallStarted: name => `正在安装 ${name}… 完成后对新会话生效。`,
       catalogInstallFailed: name => `安装 ${name} 失败`,

--- a/apps/desktop/src/lib/mcp-catalog.test.ts
+++ b/apps/desktop/src/lib/mcp-catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { connectorDisplayName, connectorPrimaryActionKind } from './mcp-catalog'
+import { connectorDisplayName, connectorPrimaryActionKind, connectorSetupSummary } from './mcp-catalog'
 
 const entry = (overrides = {}) => ({
   name: 'github-enterprise',
@@ -53,5 +53,25 @@ describe('connectorPrimaryActionKind', () => {
 
   it('returns installed once the entry is already installed', () => {
     expect(connectorPrimaryActionKind(entry({ installed: true, enabled: true }))).toBe('installed')
+  })
+})
+
+describe('connectorSetupSummary', () => {
+  it('describes OAuth HTTP connectors as browser sign-in flows', () => {
+    expect(connectorSetupSummary(entry({ setup_steps: ['Sign in', 'Pick tools'] }))).toBe(
+      '2 setup steps · Browser OAuth'
+    )
+  })
+
+  it('describes api-key connectors as credential setup flows', () => {
+    expect(
+      connectorSetupSummary(
+        entry({ auth_type: 'api_key', required_env: [{ name: 'API_KEY', prompt: 'API key', required: true }] })
+      )
+    ).toBe('1 setup step · Requires credentials')
+  })
+
+  it('describes local build connectors without setup steps', () => {
+    expect(connectorSetupSummary(entry({ auth_type: 'none', needs_install: true, setup_steps: [] }))).toBe('Local build')
   })
 })

--- a/apps/desktop/src/lib/mcp-catalog.test.ts
+++ b/apps/desktop/src/lib/mcp-catalog.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { connectorDisplayName, connectorPrimaryActionKind } from './mcp-catalog'
+
+const entry = (overrides = {}) => ({
+  name: 'github-enterprise',
+  description: 'GitHub connector',
+  source: 'https://example.com',
+  transport: 'http',
+  auth_type: 'oauth',
+  required_env: [],
+  command: null,
+  args: [],
+  url: 'https://example.com/mcp',
+  install_url: null,
+  install_ref: null,
+  bootstrap: [],
+  default_enabled: null,
+  post_install: '',
+  display_name: '',
+  category: '',
+  icon: '',
+  tags: [],
+  capabilities: [],
+  setup_steps: [],
+  danger_notes: [],
+  needs_install: false,
+  installed: false,
+  enabled: false,
+  ...overrides
+})
+
+describe('connectorDisplayName', () => {
+  it('uses manifest display_name when present', () => {
+    expect(connectorDisplayName(entry({ display_name: 'GitHub Enterprise' }))).toBe('GitHub Enterprise')
+  })
+
+  it('falls back to a readable name for legacy manifests', () => {
+    expect(connectorDisplayName(entry())).toBe('Github Enterprise')
+  })
+})
+
+describe('connectorPrimaryActionKind', () => {
+  it('treats uninstalled OAuth HTTP catalog entries as connect actions', () => {
+    expect(connectorPrimaryActionKind(entry())).toBe('connect')
+  })
+
+  it('keeps local stdio catalog entries as install actions', () => {
+    expect(connectorPrimaryActionKind(entry({ transport: 'stdio', auth_type: 'none', command: 'npx', url: null }))).toBe(
+      'install'
+    )
+  })
+
+  it('returns installed once the entry is already installed', () => {
+    expect(connectorPrimaryActionKind(entry({ installed: true, enabled: true }))).toBe('installed')
+  })
+})

--- a/apps/desktop/src/lib/mcp-catalog.test.ts
+++ b/apps/desktop/src/lib/mcp-catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { connectorDisplayName, connectorPrimaryActionKind, connectorSetupSummary } from './mcp-catalog'
+import { connectorDisplayName, connectorIdentityKey, connectorPrimaryActionKind, connectorSetupSummary } from './mcp-catalog'
 
 const entry = (overrides = {}) => ({
   name: 'github-enterprise',
@@ -37,6 +37,16 @@ describe('connectorDisplayName', () => {
 
   it('falls back to a readable name for legacy manifests', () => {
     expect(connectorDisplayName(entry())).toBe('Github Enterprise')
+  })
+})
+
+describe('connectorIdentityKey', () => {
+  it('prefers the curated icon key over the config name', () => {
+    expect(connectorIdentityKey(entry({ icon: 'unreal-engine', name: 'ue-local' }))).toBe('unreal-engine')
+  })
+
+  it('falls back to the entry name for legacy manifests', () => {
+    expect(connectorIdentityKey(entry({ icon: '' }))).toBe('github-enterprise')
   })
 })
 

--- a/apps/desktop/src/lib/mcp-catalog.ts
+++ b/apps/desktop/src/lib/mcp-catalog.ts
@@ -2,6 +2,10 @@ import type { McpCatalogEntry } from '@/types/hermes'
 
 export type ConnectorPrimaryActionKind = 'connect' | 'install' | 'installed'
 
+export function connectorIdentityKey(entry: Pick<McpCatalogEntry, 'icon' | 'name'>): string {
+  return entry.icon?.trim() || entry.name
+}
+
 export function connectorDisplayName(entry: Pick<McpCatalogEntry, 'display_name' | 'name'>): string {
   const displayName = entry.display_name?.trim()
 

--- a/apps/desktop/src/lib/mcp-catalog.ts
+++ b/apps/desktop/src/lib/mcp-catalog.ts
@@ -25,3 +25,24 @@ export function connectorPrimaryActionKind(
 
   return entry.auth_type === 'oauth' && entry.transport === 'http' ? 'connect' : 'install'
 }
+
+export function connectorSetupSummary(
+  entry: Pick<McpCatalogEntry, 'auth_type' | 'needs_install' | 'required_env' | 'setup_steps' | 'transport'>
+): string {
+  const parts: string[] = []
+  const stepCount = entry.setup_steps.length || entry.required_env.filter(env => env.required).length
+
+  if (stepCount > 0) {
+    parts.push(`${stepCount} setup step${stepCount === 1 ? '' : 's'}`)
+  }
+
+  if (entry.auth_type === 'oauth' && entry.transport === 'http') {
+    parts.push('Browser OAuth')
+  } else if (entry.auth_type === 'api_key' || entry.required_env.length > 0) {
+    parts.push('Requires credentials')
+  } else if (entry.needs_install) {
+    parts.push('Local build')
+  }
+
+  return parts.join(' · ')
+}

--- a/apps/desktop/src/lib/mcp-catalog.ts
+++ b/apps/desktop/src/lib/mcp-catalog.ts
@@ -1,0 +1,27 @@
+import type { McpCatalogEntry } from '@/types/hermes'
+
+export type ConnectorPrimaryActionKind = 'connect' | 'install' | 'installed'
+
+export function connectorDisplayName(entry: Pick<McpCatalogEntry, 'display_name' | 'name'>): string {
+  const displayName = entry.display_name?.trim()
+
+  if (displayName) {
+    return displayName
+  }
+
+  return entry.name
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export function connectorPrimaryActionKind(
+  entry: Pick<McpCatalogEntry, 'auth_type' | 'installed' | 'transport'>
+): ConnectorPrimaryActionKind {
+  if (entry.installed) {
+    return 'installed'
+  }
+
+  return entry.auth_type === 'oauth' && entry.transport === 'http' ? 'connect' : 'install'
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1010,6 +1010,13 @@ export interface McpCatalogEntry {
   bootstrap: string[]
   default_enabled: string[] | null
   post_install: string
+  display_name: string
+  category: string
+  icon: string
+  tags: string[]
+  capabilities: string[]
+  setup_steps: string[]
+  danger_notes: string[]
   needs_install: boolean
   installed: boolean
   enabled: boolean

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -106,6 +106,25 @@ class ToolsSpec:
 
 
 @dataclass
+class ConnectorUiSpec:
+    """Presentation metadata for connector-first catalog surfaces.
+
+    These fields are optional so existing ``manifest_version: 1`` catalog
+    manifests stay valid. They let desktop/dashboard UIs present entries as
+    user-facing connectors instead of raw MCP transport blocks, while the
+    runtime config remains the same ``mcp_servers`` shape.
+    """
+
+    display_name: str = ""
+    category: str = ""
+    icon: str = ""
+    tags: List[str] = field(default_factory=list)
+    capabilities: List[str] = field(default_factory=list)
+    setup_steps: List[str] = field(default_factory=list)
+    danger_notes: List[str] = field(default_factory=list)
+
+
+@dataclass
 class CatalogEntry:
     name: str
     description: str
@@ -113,6 +132,7 @@ class CatalogEntry:
     transport: TransportSpec
     auth: AuthSpec
     tools: ToolsSpec = field(default_factory=ToolsSpec)
+    ui: ConnectorUiSpec = field(default_factory=ConnectorUiSpec)
     install: Optional[InstallSpec] = None
     post_install: str = ""
     manifest_path: Path = field(default_factory=Path)
@@ -144,6 +164,37 @@ def _parse_env_spec(raw: Any) -> EnvVarSpec:
         required=bool(raw.get("required", True)),
         secret=bool(raw.get("secret", True)),
         default=str(raw.get("default") or ""),
+    )
+
+
+def _parse_string_list(raw: Any, *, path: Path, key: str) -> List[str]:
+    """Parse an optional UI list field as ``list[str]``."""
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise CatalogError(f"{path}: ui.{key} must be a list of strings")
+    return list(raw)
+
+
+def _parse_ui_spec(path: Path, raw: Any) -> ConnectorUiSpec:
+    if raw is None:
+        return ConnectorUiSpec()
+    if not isinstance(raw, dict):
+        raise CatalogError(f"{path}: 'ui' must be a mapping")
+    return ConnectorUiSpec(
+        display_name=str(raw.get("display_name") or ""),
+        category=str(raw.get("category") or ""),
+        icon=str(raw.get("icon") or ""),
+        tags=_parse_string_list(raw.get("tags"), path=path, key="tags"),
+        capabilities=_parse_string_list(
+            raw.get("capabilities"), path=path, key="capabilities"
+        ),
+        setup_steps=_parse_string_list(
+            raw.get("setup_steps"), path=path, key="setup_steps"
+        ),
+        danger_notes=_parse_string_list(
+            raw.get("danger_notes"), path=path, key="danger_notes"
+        ),
     )
 
 
@@ -226,6 +277,7 @@ def _parse_manifest(path: Path) -> CatalogEntry:
                 f"{path}: tools.default_enabled must be a list of strings"
             )
     tools_spec = ToolsSpec(default_enabled=default_enabled)
+    ui_spec = _parse_ui_spec(path, data.get("ui"))
 
     install: Optional[InstallSpec] = None
     install_raw = data.get("install")
@@ -256,6 +308,7 @@ def _parse_manifest(path: Path) -> CatalogEntry:
         transport=transport,
         auth=auth,
         tools=tools_spec,
+        ui=ui_spec,
         install=install,
         post_install=str(data.get("post_install") or ""),
         manifest_path=path,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9342,6 +9342,7 @@ async def list_mcp_catalog(profile: Optional[str] = None):
             auth = entry.auth
             transport = entry.transport
             install = entry.install
+            ui = entry.ui
             entries.append({
                 "name": entry.name,
                 "description": entry.description,
@@ -9369,6 +9370,13 @@ async def list_mcp_catalog(profile: Optional[str] = None):
                 if entry.tools.default_enabled is not None
                 else None,
                 "post_install": entry.post_install or "",
+                "display_name": ui.display_name,
+                "category": ui.category,
+                "icon": ui.icon,
+                "tags": list(ui.tags),
+                "capabilities": list(ui.capabilities),
+                "setup_steps": list(ui.setup_steps),
+                "danger_notes": list(ui.danger_notes),
                 "needs_install": entry.install is not None,
                 "installed": installed_state.get(entry.name, (False, False))[0],
                 "enabled": installed_state.get(entry.name, (False, False))[1],

--- a/optional-mcps/linear/manifest.yaml
+++ b/optional-mcps/linear/manifest.yaml
@@ -6,6 +6,21 @@ name: linear
 description: Find, create, and update Linear issues, projects, and comments.
 source: https://linear.app/docs/mcp
 
+ui:
+  display_name: Linear
+  category: Project management
+  icon: linear
+  tags: [issues, projects, comments]
+  capabilities:
+    - Find and inspect issues
+    - Create and update Linear work
+    - Manage projects and comments
+  setup_steps:
+    - Connect your Linear account in the browser.
+    - Choose which tools Hermes may use after discovery.
+  danger_notes:
+    - Write tools can create or update issues, projects, and comments.
+
 # Linear ships a remote MCP server with native OAuth 2.1 + Dynamic Client
 # Registration over Streamable HTTP. Hermes's MCP client + mcp_oauth_manager
 # handle discovery, PKCE, token exchange, and refresh — nothing to install

--- a/optional-mcps/n8n/manifest.yaml
+++ b/optional-mcps/n8n/manifest.yaml
@@ -8,6 +8,21 @@ name: n8n
 description: Manage and inspect n8n workflows from Hermes (stdio bridge, no public port).
 source: https://github.com/CyberSamuraiX/hermes-n8n-mcp
 
+ui:
+  display_name: n8n
+  category: Automation
+  icon: n8n
+  tags: [workflows, automations, executions]
+  capabilities:
+    - Inspect workflows and executions
+    - Export workflow definitions
+    - Review recent workflow failures
+  setup_steps:
+    - Enter your n8n base URL.
+    - Generate and paste an n8n API key.
+  danger_notes:
+    - Optional mutating tools can activate or deactivate live workflows.
+
 # How to launch the server once installed. The keys here map 1:1 to the
 # `mcp_servers.<name>` block written into ~/.hermes/config.yaml by the
 # existing `_save_mcp_server()` helper in hermes_cli/mcp_config.py.

--- a/optional-mcps/unreal-engine/manifest.yaml
+++ b/optional-mcps/unreal-engine/manifest.yaml
@@ -6,6 +6,21 @@ name: unreal-engine
 description: Drive the Unreal Engine 5.8 editor over its local MCP server.
 source: https://dev.epicgames.com/documentation/unreal-engine/unreal-mcp-in-unreal-editor
 
+ui:
+  display_name: Unreal Engine
+  category: Creative tools
+  icon: unreal-engine
+  tags: [game-dev, editor, local]
+  capabilities:
+    - Inspect and drive an Unreal Editor project
+    - Spawn actors and configure scene assets
+    - Run editor automation exposed by the plugin
+  setup_steps:
+    - Enable Epic's Unreal MCP plugin in the editor.
+    - Start the local MCP server before connecting Hermes.
+  danger_notes:
+    - Editor tool calls mutate the open Unreal project on the game thread.
+
 # Epic's official "Unreal MCP" plugin (internal id ModelContextProtocol)
 # embeds an MCP server inside the running Unreal Editor process and serves it
 # over local HTTP. There is nothing to install on the Hermes side — the user

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -113,6 +113,13 @@ class TestMcpEndpoints:
                 "bootstrap",
                 "default_enabled",
                 "post_install",
+                "display_name",
+                "category",
+                "icon",
+                "tags",
+                "capabilities",
+                "setup_steps",
+                "danger_notes",
             } <= set(e)
             # http entries expose a url; stdio entries expose a command.
             if e["transport"] == "http":

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -143,6 +143,43 @@ class TestManifestParsing:
         assert e.auth.env[1].required is False
         assert e.auth.env[1].secret is False
 
+    def test_connector_ui_metadata_is_optional_and_parsed(self, catalog_dir):
+        body = _basic_manifest(
+            ui={
+                "display_name": "Acme CRM",
+                "category": "sales",
+                "icon": "database",
+                "tags": ["crm", "customers"],
+                "capabilities": ["Search customers", "Create follow-up tasks"],
+                "setup_steps": ["Sign in to Acme", "Choose a workspace"],
+                "danger_notes": ["Can create tasks when write tools are enabled"],
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        e = list_catalog()[0]
+        assert e.ui.display_name == "Acme CRM"
+        assert e.ui.category == "sales"
+        assert e.ui.icon == "database"
+        assert e.ui.tags == ["crm", "customers"]
+        assert e.ui.capabilities == ["Search customers", "Create follow-up tasks"]
+        assert e.ui.setup_steps == ["Sign in to Acme", "Choose a workspace"]
+        assert e.ui.danger_notes == ["Can create tasks when write tools are enabled"]
+
+    def test_connector_ui_metadata_defaults_keep_existing_manifests_valid(self, catalog_dir):
+        _write_manifest(catalog_dir, "demo", _basic_manifest())
+        from hermes_cli.mcp_catalog import list_catalog
+
+        e = list_catalog()[0]
+        assert e.ui.display_name == ""
+        assert e.ui.category == ""
+        assert e.ui.icon == ""
+        assert e.ui.tags == []
+        assert e.ui.capabilities == []
+        assert e.ui.setup_steps == []
+        assert e.ui.danger_notes == []
+
     def test_install_block(self, catalog_dir):
         body = _basic_manifest(
             install={


### PR DESCRIPTION
## Summary
- present the desktop MCP catalog as user-facing Connectors
- add optional `ui` metadata to MCP catalog manifests and expose it through `/api/mcp/catalog`
- render connector display names, categories, capabilities, risk notes, and Connect vs Install actions
- annotate Linear, n8n, and Unreal Engine catalog entries with connector metadata

## Test Plan
- `uv run python -m pytest tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_dashboard_admin_endpoints.py::TestMcpEndpoints::test_catalog_lists_entries -q`
- `npm run test:ui -- src/lib/mcp-catalog.test.ts`
- `npm run typecheck`
- `npx eslint src/lib/mcp-catalog.ts src/lib/mcp-catalog.test.ts src/app/skills/mcp-tab.tsx src/types/hermes.ts src/i18n/en.ts src/i18n/types.ts src/i18n/zh.ts`
- `npm run build`