### PR TITLE
security(config): warn when HERMES_HOME_MODE grants group/other access

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -745,6 +745,9 @@ def _chown_to_hermes_uid(path) -> None:
         pass
 
 
+_HERMES_HOME_MODE_WARNED = False
+
+
 def _secure_dir(path):
     """Set directory to owner-only access (0700 by default). No-op on Windows.
 
@@ -756,7 +759,10 @@ def _secure_dir(path):
     (e.g. HERMES_HOME_MODE=0701) for deployments where a web server (nginx,
     caddy, etc.) needs to traverse HERMES_HOME to reach a served subdirectory.
     The execute-only bit on a directory permits cd-through without exposing
-    directory listings.
+    directory listings. If the override grants read or write to group/other
+    (beyond that documented execute-only pattern), every file inside relies
+    on its own mode for protection instead of the directory — we warn once
+    so a copy-pasted ``0755``/``0777`` doesn't silently widen exposure.
 
     Also applies ``HERMES_UID``/``HERMES_GID``-based ownership when those env
     vars are set (#34107 — Docker deployments need this so profile subdirs
@@ -770,6 +776,17 @@ def _secure_dir(path):
         mode = int(mode_str, 8) if mode_str else 0o700
     except ValueError:
         mode = 0o700
+    global _HERMES_HOME_MODE_WARNED
+    if mode & 0o066 and not _HERMES_HOME_MODE_WARNED:
+        _HERMES_HOME_MODE_WARNED = True
+        logger.warning(
+            "HERMES_HOME_MODE=%s grants read or write to group/other. "
+            "Files inside HERMES_HOME (state.db, logs, sessions) are no "
+            "longer protected by directory traversal and depend on their "
+            "own permissions. The documented pattern for web-server "
+            "traversal is execute-only (e.g. 0701/0711).",
+            oct(mode),
+        )
     try:
         os.chmod(path, mode)
     except (OSError, NotImplementedError):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -107,6 +107,49 @@ class TestEnsureHermesHome:
         assert not profile_home.exists()
 
 
+class TestSecureDirHomeModeWarning:
+    """HERMES_HOME_MODE overrides that grant group/other read or write should
+    warn once, since every file inside HERMES_HOME then relies on its own
+    mode instead of directory traversal for protection."""
+
+    def _reset_warned_flag(self):
+        import hermes_cli.config as config_module
+        config_module._HERMES_HOME_MODE_WARNED = False
+
+    def test_warns_when_mode_grants_group_or_other_access(self, tmp_path, caplog):
+        self._reset_warned_flag()
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path), "HERMES_HOME_MODE": "0755"}):
+            with caplog.at_level("WARNING", logger="hermes_cli.config"):
+                ensure_hermes_home()
+        assert any("HERMES_HOME_MODE" in r.message for r in caplog.records)
+
+    def test_no_warning_for_documented_execute_only_override(self, tmp_path, caplog):
+        self._reset_warned_flag()
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path), "HERMES_HOME_MODE": "0701"}):
+            with caplog.at_level("WARNING", logger="hermes_cli.config"):
+                ensure_hermes_home()
+        assert not any("HERMES_HOME_MODE" in r.message for r in caplog.records)
+
+    def test_no_warning_without_override(self, tmp_path, caplog):
+        self._reset_warned_flag()
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            os.environ.pop("HERMES_HOME_MODE", None)
+            with caplog.at_level("WARNING", logger="hermes_cli.config"):
+                ensure_hermes_home()
+        assert not any("HERMES_HOME_MODE" in r.message for r in caplog.records)
+
+    def test_warns_only_once_per_process(self, tmp_path, caplog):
+        self._reset_warned_flag()
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path), "HERMES_HOME_MODE": "0755"}):
+            with caplog.at_level("WARNING", logger="hermes_cli.config"):
+                # ensure_hermes_home() alone calls _secure_dir ~10 times
+                # (home + subdirs) -- confirms the warn-once guard holds
+                # across a single call, not just across separate calls.
+                ensure_hermes_home()
+        warn_count = sum(1 for r in caplog.records if "HERMES_HOME_MODE" in r.message)
+        assert warn_count == 1
+
+
 class TestLoadConfigDefaults:
     def test_returns_defaults_when_no_file(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -116,9 +116,10 @@ class TestSecureDirHomeModeWarning:
         import hermes_cli.config as config_module
         config_module._HERMES_HOME_MODE_WARNED = False
 
-    def test_warns_when_mode_grants_group_or_other_access(self, tmp_path, caplog):
+    @pytest.mark.parametrize("mode", ["0755", "0720", "0702"])
+    def test_warns_when_mode_grants_group_or_other_access(self, tmp_path, caplog, mode):
         self._reset_warned_flag()
-        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path), "HERMES_HOME_MODE": "0755"}):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path), "HERMES_HOME_MODE": mode}):
             with caplog.at_level("WARNING", logger="hermes_cli.config"):
                 ensure_hermes_home()
         assert any("HERMES_HOME_MODE" in r.message for r in caplog.records)


### PR DESCRIPTION
Fixes #59695

## Problem

`_secure_dir()` (`hermes_cli/config.py`) applies `HERMES_HOME_MODE` to `~/.hermes` and to every subdirectory it creates, with no validation. The documented use case is an execute-only override (`0701`/`0711`) for a web server that needs to traverse into a served subdirectory without gaining read access. A wider value — `0755`, `0777`, anything with a group/other read or write bit — silently removes the directory-level protection that `state.db` and session logs otherwise depend on, with no warning anywhere.

## Fix

Warn once per process when the resolved mode grants group or other read/write (`mode & 0o066`), naming the documented execute-only pattern as the intended alternative. Nothing is blocked — `HERMES_HOME_MODE` is an explicit operator override and stays fully honored; this only adds a missing signal.

```python
global _HERMES_HOME_MODE_WARNED
if mode & 0o066 and not _HERMES_HOME_MODE_WARNED:
    _HERMES_HOME_MODE_WARNED = True
    logger.warning(
        "HERMES_HOME_MODE=%s grants read or write to group/other. "
        "Files inside HERMES_HOME (state.db, logs, sessions) are no "
        "longer protected by directory traversal and depend on their "
        "own permissions. The documented pattern for web-server "
        "traversal is execute-only (e.g. 0701/0711).",
        oct(mode),
    )
```

The warn-once guard matters in practice: a single `ensure_hermes_home()` call invokes `_secure_dir()` roughly ten times (home + `cron`, `sessions`, `logs`, `logs/curator`, `memories`, `pairing`, `hooks`, `image_cache`, `audio_cache`, `skills`), so without it a wide `HERMES_HOME_MODE` would log the same warning on every subdirectory.

## Testing

Added `TestSecureDirHomeModeWarning` to `tests/hermes_cli/test_config.py`:
- warns when the override grants group/other read or write (`0755`)
- stays silent for the documented execute-only pattern (`0701`)
- stays silent with no override set
- warns exactly once across a full `ensure_hermes_home()` call (~10 `_secure_dir()` invocations)

Full `tests/hermes_cli/test_config.py` suite run clean against this branch (one pre-existing, unrelated failure on Windows in `TestGetHermesHome.test_default_path` reproduces identically on unmodified `main` — a Windows path-default test issue, not touched by this change).

## Scope

Out of scope for this PR, tracked separately: `state.db` is created `0644` with no explicit `chmod` (the directory protection this warning is about is the only thing standing between it and other local accounts today), and a handful of `config.yaml` writers that bypass `save_config()`'s final permission enforcement. Both are real but independent fixes.