### PR TITLE
feat: support MiniMax China (CN) endpoint for TTS

### DIFF
--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -238,3 +238,41 @@ class TestMinimaxTtsLegacyTextToSpeech:
         _, output = self._run({}, tmp_path, monkeypatch)
         with open(output, "rb") as f:
             assert f.read() == b"\x00\x01\x02\x03"
+
+
+class TestMinimaxTtsCnEndpoint:
+    """CN endpoint auto-detection when MINIMAX_CN_API_KEY is set."""
+
+    CN_BASE_URL = "https://api.minimaxi.com/v1/t2a_v2"
+
+    def _run(self, tts_config, tmp_path, monkeypatch, response=None):
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "test-cn-key")
+        resp = response if response is not None else _hex_response()
+        with patch("requests.post", return_value=resp) as mock_post:
+            from tools.tts_tool import _generate_minimax_tts
+            output = _generate_minimax_tts("Hello", str(tmp_path / "out.mp3"), tts_config)
+        return mock_post, output
+
+    def test_cn_key_uses_cn_url(self, tmp_path, monkeypatch):
+        """MINIMAX_CN_API_KEY auto-selects api.minimaxi.com."""
+        mock_post, _ = self._run({}, tmp_path, monkeypatch)
+        url = mock_post.call_args[0][0]
+        assert url == self.CN_BASE_URL
+
+    def test_explicit_url_overrides_cn_auto(self, tmp_path, monkeypatch):
+        """Explicit base_url in config overrides CN auto-detect."""
+        cfg = {"minimax": {"base_url": "https://api.minimax.io/v1/t2a_v2"}}
+        mock_post, _ = self._run(cfg, tmp_path, monkeypatch)
+        url = mock_post.call_args[0][0]
+        assert url == "https://api.minimax.io/v1/t2a_v2"
+
+    def test_global_key_uses_global_url(self, tmp_path, monkeypatch):
+        """Only MINIMAX_API_KEY set uses the global endpoint."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-global-key")
+        monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
+        resp = _hex_response()
+        with patch("requests.post", return_value=resp) as mock_post:
+            from tools.tts_tool import _generate_minimax_tts
+            _generate_minimax_tts("Hello", str(tmp_path / "out.mp3"), {})
+        url = mock_post.call_args[0][0]
+        assert "api.minimax.io" in url

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -185,6 +185,7 @@ DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-02-hd"
 DEFAULT_MINIMAX_VOICE_ID = "English_expressive_narrator"
 DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1/t2a_v2"
+DEFAULT_MINIMAX_CN_BASE_URL = "https://api.minimaxi.com/v1/t2a_v2"
 DEFAULT_MISTRAL_TTS_MODEL = "voxtral-mini-tts-2603"
 DEFAULT_MISTRAL_TTS_VOICE_ID = "c69964a6-ab8b-4f8a-9465-ec0925096ec8"  # Paul - Neutral
 DEFAULT_XAI_VOICE_ID = "eve"
@@ -1318,14 +1319,20 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     """
     import requests
 
-    api_key = (get_env_value("MINIMAX_API_KEY") or "")
+    api_key = (get_env_value("MINIMAX_API_KEY") or get_env_value("MINIMAX_CN_API_KEY") or "")
     if not api_key:
-        raise ValueError("MINIMAX_API_KEY not set. Get one at https://platform.minimax.io/")
+        raise ValueError(
+            "MINIMAX_API_KEY or MINIMAX_CN_API_KEY not set. "
+            "Get one at https://platform.minimax.io (global) or https://platform.minimaxi.com (China)."
+        )
 
     mm_config = tts_config.get("minimax", {})
     model = mm_config.get("model", DEFAULT_MINIMAX_MODEL)
     voice_id = mm_config.get("voice_id", DEFAULT_MINIMAX_VOICE_ID)
-    base_url = mm_config.get("base_url", DEFAULT_MINIMAX_BASE_URL)
+    # Auto-detect China endpoint when CN key is used and no explicit base_url.
+    has_explicit_url = "base_url" in mm_config
+    use_cn = get_env_value("MINIMAX_CN_API_KEY") and not has_explicit_url
+    base_url = mm_config.get("base_url", DEFAULT_MINIMAX_CN_BASE_URL if use_cn else DEFAULT_MINIMAX_BASE_URL)
     speed = mm_config.get("speed", 1.0)
     vol = mm_config.get("vol", 1.0)
     pitch = mm_config.get("pitch", 0)


### PR DESCRIPTION
## Summary

MiniMax TTS previously required `MINIMAX_API_KEY` (global endpoint). China-based users with `MINIMAX_CN_API_KEY` had no way to use MiniMax TTS without manually setting `base_url` in config.

## Changes

- **`tools/tts_tool.py`**: Check both `MINIMAX_API_KEY` and `MINIMAX_CN_API_KEY` env vars. Auto-detect China endpoint (`api.minimaxi.com`) when `MINIMAX_CN_API_KEY` is set and no explicit `base_url` in config. Explicit `base_url` config still takes precedence. Added `DEFAULT_MINIMAX_CN_BASE_URL` constant.
- **`tests/tools/test_tts_speed.py`**: Added `TestMinimaxTtsCnEndpoint` class with 3 tests:
  - CN key auto-selects `api.minimaxi.com`
  - Explicit `base_url` overrides CN auto-detect
  - Global key alone still uses global endpoint

## Testing

All 22 TTS tests pass (19 existing + 3 new).
