### PR TITLE
chore(security-guidance): sync forked patterns

### DIFF
--- a/plugins/security-guidance/NOTICE
+++ b/plugins/security-guidance/NOTICE
@@ -7,15 +7,15 @@ licensed under the Apache License, Version 2.0.
 
     Source:    https://github.com/anthropics/claude-plugins-official
     Subpath:   plugins/security-guidance/hooks/patterns.py
-    Commit:    0bde168 (2026-05-26)
+    Commit:    12a5376 (2026-05-29)
     License:   Apache License 2.0 (see LICENSE in this directory)
 
 Forked content
 --------------
 
-The file patterns.py in this directory is a verbatim copy of the upstream
-patterns.py at the commit above, with a modified module docstring noting
-this attribution. The pattern data — 25 regex/substring rules covering
+The file patterns.py in this directory mirrors the upstream patterns.py at
+the commit above, with only the module docstring adjusted for Hermes-side
+attribution. The pattern data — 25 regex/substring rules covering
 unsafe deserialization, command injection, XSS sinks, crypto footguns,
 XXE, GitHub Actions injection, and TLS-verification disablement — is
 unmodified.

--- a/plugins/security-guidance/README.md
+++ b/plugins/security-guidance/README.md
@@ -79,9 +79,9 @@ not a substitute for code review, SAST, dependency scanning, or pen testing.
 
 ## Attribution and licensing
 
-* `patterns.py` is a verbatim fork from
+* `patterns.py` mirrors
   [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/security-guidance/hooks)
-  (commit `0bde168`, 2026-05-26), licensed under the
+  (commit `12a5376`, 2026-05-29; Hermes keeps only the attribution docstring), licensed under the
   [Apache License 2.0](./LICENSE). See [NOTICE](./NOTICE) for the full
   attribution.
 * `__init__.py`, `plugin.yaml`, `README.md`, and tests are original work by

--- a/plugins/security-guidance/patterns.py
+++ b/plugins/security-guidance/patterns.py
@@ -23,9 +23,9 @@ Forked verbatim from Anthropic's claude-plugins-official repository
   limitations under the License.
 
 Modifications by NousResearch for the Hermes Agent plugin port:
-  - none to the pattern data itself; this file is byte-for-byte the upstream
-    patterns.py at commit 0bde168 (2026-05-26). Hermes-side wiring lives in
-    __init__.py.
+  - none to the pattern data itself; this file mirrors the upstream
+    patterns.py at commit 12a5376 (2026-05-29), except for this attribution
+    docstring. Hermes-side wiring lives in __init__.py.
 """
 from enum import IntEnum
 
@@ -117,6 +117,9 @@ Only use exec() if you absolutely need shell features and the input is guarantee
     },
     {
         "ruleName": "new_function_injection",
+        # JS-only construct: gate to JS/TS files so docs/.md and other prose
+        # mentioning "new Function" don't trip the warning.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": ["new Function"],
         "reminder": "\u26a0\ufe0f Security Warning: Using new Function() with string interpolation is a CODE INJECTION vulnerability. If any variable is concatenated or interpolated into the function body string, an attacker controlling that variable can execute arbitrary code. Use safe alternatives: for property access use obj[key] or array.reduce((o, k) => o[k], root); for computation use a safe expression parser. NEVER interpolate untrusted strings into new Function() bodies.",
     },
@@ -130,16 +133,24 @@ Only use exec() if you absolutely need shell features and the input is guarantee
     },
     {
         "ruleName": "react_dangerously_set_html",
+        # JS/TS-only (React); gate so .md docs / .py / .go files don't trip.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": ["dangerouslySetInnerHTML"],
         "reminder": "⚠️ Security Warning: dangerouslySetInnerHTML can lead to XSS vulnerabilities if used with untrusted content. Ensure all content is properly sanitized using an HTML sanitizer library like DOMPurify, or use safe alternatives.",
     },
     {
         "ruleName": "document_write_xss",
+        # Browser DOM API: only meaningful in JS/TS source.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": ["document.write"],
         "reminder": "⚠️ Security Warning: document.write() can be exploited for XSS attacks and has performance issues. Use DOM manipulation methods like createElement() and appendChild() instead.",
     },
     {
         "ruleName": "innerHTML_xss",
+        # Browser DOM API: only meaningful in JS/TS source. Closes FPs like
+        # docs/example HTML, playground/self-contained skills that hardcode
+        # innerHTML strings with zero user input (#410).
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": [".innerHTML =", ".innerHTML="],
         "reminder": "⚠️ Security Warning: Setting innerHTML with untrusted content can lead to XSS vulnerabilities. Use textContent for plain text or safe DOM methods for HTML content. If you need HTML support, consider using an HTML sanitizer library such as DOMPurify.",
     },
@@ -240,11 +251,15 @@ Additionally, validate user inputs:
     },
     {
         "ruleName": "outerHTML_xss",
+        # Browser DOM API: only meaningful in JS/TS source.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": [".outerHTML =", ".outerHTML="],
         "reminder": "⚠️ Security Warning: Use textContent or sanitize with DOMPurify. outerHTML assignment is an XSS sink equivalent to innerHTML.",
     },
     {
         "ruleName": "insertAdjacentHTML_xss",
+        # Browser DOM API: only meaningful in JS/TS source.
+        "path_filter": lambda p: p.endswith(_JS_EXTS),
         "substrings": [".insertAdjacentHTML("],
         "reminder": "⚠️ Security Warning: Use insertAdjacentText() or sanitize with DOMPurify. insertAdjacentHTML is an XSS sink.",
     },

--- a/tests/plugins/test_security_guidance_plugin.py
+++ b/tests/plugins/test_security_guidance_plugin.py
@@ -157,6 +157,24 @@ class TestScanContent:
         )
         assert "react_dangerously_set_html" in [n for n, _ in findings]
 
+    def test_dangerously_set_inner_html_in_md_skipped_by_path_filter(self):
+        mod = _load_plugin_init()
+        findings = mod._scan_content(
+            "/tmp/foo.md", "<div dangerouslySetInnerHTML={{__html: x}} />"
+        )
+        assert "react_dangerously_set_html" not in [n for n, _ in findings]
+
+    def test_new_function_warns_in_ts_but_not_md(self):
+        mod = _load_plugin_init()
+        ts_findings = mod._scan_content(
+            "/tmp/foo.ts", "const f = new Function('user', body)"
+        )
+        md_findings = mod._scan_content(
+            "/tmp/foo.md", "Avoid using new Function in examples."
+        )
+        assert "new_function_injection" in [n for n, _ in ts_findings]
+        assert "new_function_injection" not in [n for n, _ in md_findings]
+
     def test_github_workflow_path_check_fires_on_path_alone(self):
         """github_actions_workflow has no regex/substring — fires on path."""
         mod = _load_plugin_init()


### PR DESCRIPTION
## Summary
- sync `plugins/security-guidance/patterns.py` to Anthropic upstream commit `12a5376` (from `0bde168`)
- gate six JS/browser-only XSS substring rules to JS-family paths to avoid false positives in docs and non-JS files
- add regression coverage for `.md` false positives while keeping `.ts`/`.tsx` detections intact
- update README/NOTICE provenance refs to the new upstream commit

## Upstream sources checked
- `anthropics/claude-plugins-official` → `plugins/security-guidance/hooks/patterns.py`
- `PCinkusz/hermes-achievements` → latest `plugin.yaml` addition at `9ad096f` (not included here; Hermes carries local bundled-plugin changes, so that needs a separate focused sync)
- `trycua/cua` / `cua-driver` releases (installer-managed binary; no vendored repo copy to bump here)

## Before / after refs
- Hermes before: `0bde168` (2026-05-26)
- Hermes after: `12a5376` (2026-05-29)
- Upstream change: `security-guidance: gate XSS pattern rules to JS-family files`

## Validation
- `scripts/run_tests.sh tests/plugins/test_security_guidance_plugin.py` → `29 tests passed`
- `python -m pytest tests/plugins/test_security_guidance_plugin.py -q -o addopts=''` → `29 passed in 0.95s`
- compared the executable body of `patterns.py` against upstream `12a5376` after stripping the Hermes attribution docstring → no diff

## Risks / follow-ups
- `plugins/hermes-achievements/` has newer upstream commits, but Hermes' bundled copy has substantial local backend/frontend changes. I left that for a separate focused PR instead of mixing it into this exact-source sync.
- `cua-driver` has newer upstream releases, but Hermes installs/refeshes the binary from upstream at runtime rather than vendoring the driver in-repo, so no code change was needed here.
