### PR TITLE
fix(gemini): fix double-nested thinking_config in extra_body (#59283)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -433,11 +433,9 @@ class ChatCompletionsTransport(ProviderTransport):
             if _is_gemini_openai_compat_base_url(base_url):
                 thinking_config = _snake_case_gemini_thinking_config(raw_thinking_config)
                 if thinking_config:
-                    openai_compat_extra = extra_body.get("extra_body", {})
-                    google_extra = openai_compat_extra.get("google", {})
+                    google_extra = extra_body.get("google", {})
                     google_extra["thinking_config"] = thinking_config
-                    openai_compat_extra["google"] = google_extra
-                    extra_body["extra_body"] = openai_compat_extra
+                    extra_body["google"] = google_extra
             elif raw_thinking_config:
                 extra_body["thinking_config"] = raw_thinking_config
 


### PR DESCRIPTION
## Summary

Fix Gemini OpenAI-compat `thinking_config` double-nesting in `extra_body` that causes Google's API to reject requests with `400 Invalid JSON payload`.

## Root cause

In `agent/transports/chat_completions.py` (lines 436-440), the `thinking_config` builder wrapped the payload inside an extra `"extra_body"` key:

```python
openai_compat_extra = extra_body.get("extra_body", {})
google_extra = openai_compat_extra.get("google", {})
google_extra["thinking_config"] = thinking_config
openai_compat_extra["google"] = google_extra
extra_body["extra_body"] = openai_compat_extra
```

Since `extra_body` is passed directly as the OpenAI SDK's `extra_body` parameter (merged into the top-level JSON body), this produced:

```json
{"extra_body": {"extra_body": {"google": {"thinking_config": {...}}}}}
```

Instead of the correct:

```json
{"extra_body": {"google": {"thinking_config": {...}}}}
``"

## Fix

Set `google` directly on `extra_body` instead of wrapping it in another `"extra_body"` key:

```python
google_extra = extra_body.get("google", {})
google_extra["thinking_config"] = thinking_config
extra_body["google"] = google_extra
``"

## Changes

| File | Change |
|------|--------|
| `agent/transports/chat_completions.py` | Fix double-nested `thinking_config` by setting `google` directly on `extra_body` |

Closes #59283