### PR TITLE
fix(gateway): render execute_code progress as code block

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16674,10 +16674,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
-        # True when the previously enqueued progress line was a terminal
-        # fenced code block — consecutive terminal calls then drop the
-        # repeated "💻 terminal" header and render back-to-back blocks.
-        last_was_terminal_block = [False]
+        # Name of the previous fenced progress block's tool. Consecutive
+        # same-tool blocks drop the repeated header and render back-to-back.
+        last_code_block_tool = [None]
 
         # ── Discord voice "verbal ack before tool calls" ────────────────
         # When the bot is in a voice channel with the continuous mixer
@@ -16853,20 +16852,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _progress_adapter = self._adapter_for_source(source)
             except Exception:
                 _progress_adapter = None
+            _tool_code_arg = (
+                args.get("command" if tool_name == "terminal" else "code")
+                if isinstance(args, dict) and tool_name in ("terminal", "execute_code")
+                else None
+            )
             if (
                 getattr(_progress_adapter, "supports_code_blocks", False)
-                and tool_name == "terminal"
-                and isinstance(args, dict)
-                and isinstance(args.get("command"), str)
-                and args["command"].strip()
+                and tool_name in ("terminal", "execute_code")
+                and isinstance(_tool_code_arg, str)
+                and _tool_code_arg.strip()
             ):
                 from agent.display import get_tool_preview_max_len
-                _cmd_full = args["command"].rstrip()
-                # Consecutive terminal calls: drop the repeated
-                # "💻 terminal" header so back-to-back commands render as
-                # adjacent code blocks under a single header.
+                _cmd_full = _tool_code_arg.rstrip()
                 _block_header = (
-                    "" if last_was_terminal_block[0] else f"{emoji} {tool_name}\n"
+                    "" if last_code_block_tool[0] == tool_name else f"{emoji} {tool_name}\n"
                 )
                 _code_block_full = f"{_block_header}```\n{_cmd_full}\n```"
                 # Single-line, capped preview for non-verbose modes.
@@ -16884,10 +16884,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Verbose mode: show detailed arguments, respects tool_preview_length
             if progress_mode == "verbose":
                 if _code_block_full is not None:
-                    last_was_terminal_block[0] = True
+                    last_code_block_tool[0] = tool_name
                     progress_queue.put(_code_block_full)
                     return
-                last_was_terminal_block[0] = False
+                last_code_block_tool[0] = None
                 if args:
                     from agent.display import get_tool_preview_max_len
                     _pl = get_tool_preview_max_len()
@@ -16912,7 +16912,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # fenced block (built above) instead of the truncated preview.
             if _code_block_short is not None:
                 msg = _code_block_short
-                last_was_terminal_block[0] = True
+                last_code_block_tool[0] = tool_name
             elif preview:
                 from agent.display import (
                     get_tool_preview_max_len,
@@ -16937,10 +16937,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         msg = f"{emoji} {_verb}{tool_verb_connector(tool_name)}{preview}"
                 else:
                     msg = f"{emoji} {tool_name}: \"{preview}\""
-                last_was_terminal_block[0] = False
+                last_code_block_tool[0] = None
             else:
                 msg = f"{emoji} {tool_name}..."
-                last_was_terminal_block[0] = False
+                last_code_block_tool[0] = None
             
             # Dedup: collapse consecutive identical progress messages.
             # Common with execute_code where models iterate with the same

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1424,6 +1424,28 @@ class TerminalCommandAgent:
         return {"final_response": "done", "messages": [], "api_calls": 1}
 
 
+class ExecuteCodeAgent:
+    """Emits an execute_code tool.started with real, multi-line code."""
+
+    CODE = (
+        "import sys, os\n"
+        "sys.path.insert(0, '/opt/data/skills/advisors/scripts')\n"
+        "print('ready')"
+    )
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback(
+            "tool.started", "execute_code", self.CODE, {"code": self.CODE}
+        )
+        # Let the async progress task drain the queue and send before returning.
+        time.sleep(0.35)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
 @pytest.mark.asyncio
 async def test_terminal_progress_renders_fenced_code_block(monkeypatch, tmp_path):
     """Terminal progress on a markdown-capable (supports_code_blocks) gateway
@@ -1477,6 +1499,53 @@ async def test_terminal_progress_renders_fenced_code_block(monkeypatch, tmp_path
     assert "node --version" not in all_content
     # No truncated quoted preview for the terminal command.
     assert 'terminal: "' not in all_content
+
+
+@pytest.mark.asyncio
+async def test_execute_code_progress_renders_fenced_code_block(monkeypatch, tmp_path):
+    """execute_code progress on markdown-capable gateways uses the same fenced
+    code-block path as terminal, reading the script from args["code"]."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ExecuteCodeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = CodeBlockProgressAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-execute-code-code-block",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    all_content = " ".join(call["content"] for call in adapter.sent)
+    all_content += " ".join(call["content"] for call in adapter.edits)
+    assert "```" in all_content
+    assert "```python" not in all_content
+    assert "import sys, os" in all_content
+    assert "sys.path.insert" not in all_content
+    assert "print('ready')" not in all_content
+    assert 'execute_code: "' not in all_content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes #59273.

`execute_code` progress on Markdown-capable gateway platforms now renders as a fenced code block, like `terminal` already does. This keeps multi-line Python snippets readable instead of collapsing them into one long inline line.

The change reuses the existing code-block path. `terminal` still reads `args["command"]`; `execute_code` reads `args["code"]`.

## Related Issue

Fixes #59273

## Changes Made

- Allow `execute_code` to use the existing fenced progress block path on adapters with `supports_code_blocks`.
- Keep non-verbose progress compact by showing only the first code line with the existing length cap.
- Track repeated code-block headers by tool name, so different tools still show their own header.
- Add a focused gateway progress regression test for `execute_code`.

## Verification

- `/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/gateway/test_run_progress_topics.py -q`
- `git diff --check`

## Checklist

- [x] Linked the source issue.
- [x] Added focused test coverage.
- [x] Kept the change limited to gateway progress rendering.
