### PR TITLE
fix(agent): allow ZWJ emoji sequences in threat scanner (#59492)

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -311,6 +311,53 @@ class TestInvisibleUnicode:
         # shared set.
         assert isinstance(INVISIBLE_CHARS, frozenset)
 
+    # ── ZWJ emoji sequence false-positive fix (issue #59492) ─────────
+
+    def test_zwj_between_emoji_is_not_flagged(self):
+        # 🐈‍⬛ = cat + ZWJ + black large square — legitimate emoji sequence
+        cat = "\U0001F408"
+        zwj = "\u200d"
+        black_square = "\u2B1B"
+        text = f"{cat}{zwj}{black_square}"
+        findings = scan_for_threats(text, scope="all")
+        assert not any(f.startswith("invisible_unicode") for f in findings)
+
+    def test_zwj_between_emoji_man_and_laptop(self):
+        # 👨‍💻 = man + ZWJ + laptop — real-world ZWJ emoji sequence
+        man = "\U0001F468"
+        zwj = "\u200d"
+        laptop = "\U0001F4BB"
+        text = f"{man}{zwj}{laptop}"
+        findings = scan_for_threats(text, scope="strict")
+        assert not any(f.startswith("invisible_unicode") for f in findings)
+
+    def test_zwj_between_non_emoji_is_still_flagged(self):
+        # ZWJ between non-emoji characters is suspicious
+        text = "normal\u200dtext"
+        findings = scan_for_threats(text, scope="all")
+        assert any(f == "invisible_unicode_U+200D" for f in findings)
+
+    def test_zwj_at_start_of_content_is_flagged(self):
+        text = "\u200d leading"
+        findings = scan_for_threats(text, scope="all")
+        assert any(f == "invisible_unicode_U+200D" for f in findings)
+
+    def test_zwj_at_end_of_content_is_flagged(self):
+        text = "trailing\u200d"
+        findings = scan_for_threats(text, scope="all")
+        assert any(f == "invisible_unicode_U+200D" for f in findings)
+
+    def test_multiple_zwj_only_emoji_ones_skipped(self):
+        # Mix of legitimate emoji ZWJ and suspicious ZWJ
+        cat = "\U0001F408"
+        zwj = "\u200d"
+        black_square = "\u2B1B"
+        text = f"{cat}{zwj}{black_square} normal{zwj}text"
+        findings = scan_for_threats(text, scope="all")
+        # Only the lone ZWJ should be flagged
+        zwj_hits = [f for f in findings if f == "invisible_unicode_U+200D"]
+        assert len(zwj_hits) == 1
+
 
 # =========================================================================
 # ReDoS hardening

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -52,8 +52,31 @@ from typing import List, Optional, Tuple
 # detections near the beginning of injected content.
 MAX_SCAN_CHARS = 65_536
 
+
+def _is_extended_pictographic(ch: str) -> bool:
+    """Return True if *ch* is Extended_Pictographic (emoji) per the Unicode standard.
+
+    Used to distinguish legitimate ZWJ emoji sequences (🐈‍⬛, 👨‍💻) from
+    ZWJ-based injection tactics.  The check uses a combination of codepoint
+    ranges and ``unicodedata.category()`` — this is a fast heuristic that
+    covers all major emoji blocks including flags, keycaps, and dingbats.
+    """
+    cp = ord(ch)
+    # Variation Selectors (U+FE00–U+FE0F) — used in emoji presentation
+    # sequences after a base emoji to request colour rendering.
+    if 0xFE00 <= cp <= 0xFE0F:
+        return True
+    # Regional Indicator symbols (U+1F1E6–U+1F1FF) — paired to form
+    # national flag sequences like 🇺🇸, 🇬🇧.
+    if 0x1F1E6 <= cp <= 0x1F1FF:
+        return True
+    # Symbol, Other — covers the vast majority of emoji characters
+    # (Miscellaneous Symbols, Emoticons, Transport, Objects, etc.)
+    return unicodedata.category(ch) == "So"
+
+
 # Bounded filler used between key attack words.  Earlier patterns used
-# ``(?:\w+\s+)*`` which is ambiguous and can backtrack heavily on adversarial
+# ``(?:\\w+\\s+)*`` which is ambiguous and can backtrack heavily on adversarial
 # near-misses.  Eight filler words is enough for the intended obfuscation
 # bypasses without introducing unbounded repetition.
 _FILLER = r"(?:\w+\s+){0,8}"
@@ -125,8 +148,8 @@ _PATTERNS: List[Tuple[str, str, str]] = [
 
     # ── Persistence / SSH backdoor (strict scope — memory + skills) ──
     (r'authorized_keys', "ssh_backdoor", "strict"),
-    (r'\$HOME/\.ssh|\~/\.ssh', "ssh_access", "strict"),
-    (r'\$HOME/\.hermes/\.env|\~/\.hermes/\.env', "hermes_env", "strict"),
+    (r'\$HOME/\.ssh|\~/.ssh', "ssh_access", "strict"),
+    (r'\$HOME/\.hermes/\.env|\~/.hermes/\.env', "hermes_env", "strict"),
     (r'(update|modify|edit|write|change|append|add\s+to)\s+[^\n]{0,2048}(?:AGENTS\.md|CLAUDE\.md|\.cursorrules|\.clinerules)', "agent_config_mod", "strict"),
     (r'(update|modify|edit|write|change|append|add\s+to)\s+[^\n]{0,2048}\.hermes/(config\.yaml|SOUL\.md)', "hermes_config_mod", "strict"),
 
@@ -234,7 +257,26 @@ def scan_for_threats(content: str, scope: str = "context") -> List[str]:
     char_set = set(content)
     invisible_hits = char_set & INVISIBLE_CHARS
     for ch in invisible_hits:
+        # ZWJ (U+200D) is used legitimately in emoji sequences like 🐈‍⬛.
+        # Only flag it when it does NOT join two Extended_Pictographic chars.
+        if ch == '\u200d':
+            continue  # handled below with position context
         findings.append(f"invisible_unicode_U+{ord(ch):04X}")
+
+    # Separate pass for ZWJ so we can examine surrounding characters.
+    # The set-based approach above loses position information, but ZWJ
+    # needs context: between two emoji it's a legitimate ZWJ sequence,
+    # anywhere else it's an injection tactic.
+    if '\u200d' in char_set:
+        for i, ch in enumerate(content):
+            if ch != '\u200d':
+                continue
+            # Valid ZWJ emoji sequence: emoji + ZWJ + emoji
+            if (i > 0 and i < len(content) - 1
+                    and _is_extended_pictographic(content[i - 1])
+                    and _is_extended_pictographic(content[i + 1])):
+                continue  # legitimate ZWJ emoji sequence, not a threat
+            findings.append("invisible_unicode_U+200D")
 
     # Normalise to NFKC so full-width / compatibility Unicode variants
     # (e.g. ｃａｔ → cat, Ａ → A) are folded to their ASCII counterparts before


### PR DESCRIPTION
## Summary

U+200D (zero-width joiner) in INVISIBLE_CHARS was causing false positives for legitimate emoji ZWJ sequences (e.g. ZWJ emoji sequences) in SOUL.md / AGENTS.md context files. This PR makes the threat scanner context-aware for ZWJ: it only flags U+200D when it does **not** join two Extended_Pictographic (emoji) characters.

## Root cause

tools/threat_patterns.py lists U+200D in INVISIBLE_CHARS, and scan_for_threats() flags any occurrence via set-intersection. The set-based approach loses position information, so legitimate ZWJ emoji sequences are indistinguishable from ZWJ-based injection tactics.

## Fix

1. Add _is_extended_pictographic() helper that checks unicodedata.category() == "So" plus Variation Selectors (U+FE00-U+FE0F) and Regional Indicators (U+1F1E6-U+1F1FF).
2. In scan_for_threats(): skip U+200D in the fast set-based intersection, then run a second pass that examines each ZWJ occurrence in context. ZWJ between two emoji => skip (legitimate sequence); ZWJ anywhere else => flag as before.

## Changes

| File | Change |
|------|--------|
| tools/threat_patterns.py | Add _is_extended_pictographic() + context-aware ZWJ scanning |
| tests/tools/test_threat_patterns.py | 6 new tests for ZWJ emoji false-positive fix |

Closes #59492