### PR TITLE
fix(desktop): atomic binary swap for Linux in-app updater (#58593)

### DIFF
--- a/hermes_cli/desktop_update_atomic.py
+++ b/hermes_cli/desktop_update_atomic.py
@@ -1,0 +1,338 @@
+"""Atomic binary-swap helpers for the Linux Desktop in-app updater.
+
+Issue #58593 — Linux Desktop in-app update repeatedly fails to stick and resets
+Electron. The user's terminal `hermes update` corrected the divergence but the
+in-app desktop updater kept reporting the same update available and reset
+Electron's chrome-sandbox ownership / mode (root:root + 4755 → user:user + 0755).
+
+Root cause for the "doesn't stick" symptom
+------------------------------------------
+The unpacked Electron bundle lives at ``apps/desktop/release/linux-unpacked``
+and the running binary is ``<that>/Hermes``. The in-app updater rebuilds the
+bundle *in place* — but any update path that copies a new file over a running
+binary with a non-atomic ``copy + unlink`` can leave the destination either
+zero-byte (mid-write crash), or torn between old and new contents. When the
+relaunch script then ``exec``s that binary, it runs whichever half-finished
+state was on disk and Electron silently resets.
+
+A correct swap must:
+  1. Stage the new binary next to the destination with a sibling temp name
+     (``<dest>.hermes-update-new``), so a crash during the copy leaves the
+     running binary untouched.
+  2. Once the staged copy is fsync'd and fully written, atomically rename it
+     on top of the running binary using :func:`os.replace`. ``os.replace``
+     resolves to ``rename(2)`` on POSIX (atomic on the same filesystem) and
+     to ``MoveFileEx`` with ``MOVEFILE_REPLACE_EXISTING`` on Windows — i.e.
+     the destination is either the old binary or the new binary, never a
+     half-written file, regardless of platform. ``os.rename`` does NOT
+     provide the same guarantee on Windows.
+  3. Move the old binary aside (``<dest>.hermes-update-old``) for one cycle so
+     a follow-up update that immediately fails can still roll back. The
+     backup is best-effort cleaned at the end.
+
+This module is consumed by:
+  - The Electron main process's ``applyUpdatesPosixInApp`` handoff, which
+    rebuilds the unpacked bundle and uses the equivalent JS helper
+    (``writeFileAtomic`` + ``os.replace`` migration) — see
+    :mod:`apps.desktop.electron.update_binary_swap` for the JS mirror.
+  - The terminal `hermes update` path's `_atomic_replace_dir` helper in
+    :mod:`hermes_cli.main` (this module's sibling-staging convention is the
+    same: ``<dst>.hermes-update-{new,old}``).
+
+Cross-platform safe:
+  - On POSIX (Linux + macOS), ``os.replace`` is the same atomic rename as
+    ``rename(2)``.
+  - On Windows, ``os.rename`` will refuse to overwrite a destination — only
+    ``os.replace`` (MoveFileEx + REPLACE_EXISTING) overwrites atomically.
+    Falling back to ``shutil.move`` or ``copy + unlink`` here would
+    re-introduce the torn-file window this helper exists to close.
+  - Across-device moves (``EXDEV``) are not supported — the staged copy and
+    the destination MUST live on the same filesystem for the rename to be
+    atomic. We raise ``AtomicSwapError`` instead of falling back to a
+    copy+unlink so the caller can surface a clear error rather than silently
+    regress to non-atomic semantics.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Optional, Union
+
+PathLike = Union[str, os.PathLike]
+
+# Sibling paths the swap touches. Centralised so tests can assert on the
+# exact naming convention and so a future rename only has one place to
+# change.
+STAGING_SUFFIX = ".hermes-update-new"
+BACKUP_SUFFIX = ".hermes-update-old"
+
+
+class AtomicSwapError(RuntimeError):
+    """Raised when an atomic binary swap cannot be performed safely.
+
+    Callers should surface this verbatim to the user — silently degrading to a
+    non-atomic copy is the exact failure mode this module exists to prevent.
+    """
+
+
+def _sibling(path: PathLike, suffix: str) -> Path:
+    """Return the sibling path next to *path* with *suffix* appended.
+
+    ``/opt/Hermes/Hermes`` + ``.hermes-update-new`` →
+    ``/opt/Hermes/Hermes.hermes-update-new``.
+    """
+    return Path(str(path) + suffix)
+
+
+def _fsync_dir(path: Path) -> None:
+    """Best-effort fsync of a directory's contents.
+
+    On POSIX, after creating or renaming files inside a directory, the
+    directory itself must be fsync'd for the change to survive a crash. On
+    Windows there is no equivalent — directory metadata is journaled and we
+    skip silently. Failures here are non-fatal: the swap is still atomic at
+    the inode level, we just lose crash-survival of the directory entry.
+    """
+    if os.name == "nt":
+        return
+    fd: Optional[int] = None
+    try:
+        fd = os.open(str(path), os.O_DIRECTORY)
+        os.fsync(fd)
+    except (OSError, AttributeError):
+        # AttributeError: Windows doesn't expose O_DIRECTORY reliably.
+        pass
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _clear_siblings(*paths: Path) -> None:
+    """Remove any leftover staging / backup files from a previously crashed swap.
+
+    A crash between the staging copy and the atomic rename leaves a
+    ``<dest>.hermes-update-new`` next to the destination. On the next
+    update we must clear it before we stage again — otherwise we would copy
+    *into* the staged copy instead of *next to* it, and the eventual rename
+    would point at the stale staged tree.
+    """
+    for path in paths:
+        if not path.exists() and not path.is_symlink():
+            continue
+        try:
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                path.unlink()
+        except OSError:
+            # Best-effort — a stuck leftover is worse than a failed clear,
+            # so ignore and let the staging copy report the conflict.
+            pass
+
+
+def atomic_swap_binary(
+    source: PathLike,
+    destination: PathLike,
+    *,
+    mode: Optional[int] = None,
+    clear_siblings: bool = True,
+) -> Path:
+    """Atomically swap *source* onto *destination*.
+
+    The contract:
+
+    - After a successful return, ``destination`` is the bytes of ``source``
+      and no temporary files remain next to it.
+    - On any failure, ``destination`` is unchanged from its prior contents
+      (either the old file, or no file at all if none existed).
+    - The swap is atomic on the same filesystem: ``os.replace`` either
+      completes fully or not at all — no half-written destination.
+
+    Parameters
+    ----------
+    source:
+        Path to the new binary content. Typically a freshly-rebuilt Electron
+        unpacked tree's launcher or the staged download of the next version.
+    destination:
+        Path the running binary currently lives at. Must be on the same
+        filesystem as *source*; cross-filesystem "atomic" semantics are not
+        possible and we raise rather than silently degrade.
+    mode:
+        Optional POSIX mode to apply to the destination after the swap.
+        Useful for restoring ``0o755`` after a copy that lost the executable
+        bit (e.g. a fat-fingered ``shutil.copy`` through a tmpfs on Linux).
+        Ignored on Windows.
+    clear_siblings:
+        When ``True`` (default), pre-clear any ``<dest>.hermes-update-new`` /
+        ``<dest>.hermes-update-old`` left over from a previously crashed swap.
+
+    Returns
+    -------
+    Path
+        The resolved *destination* path, so the caller can immediately use it
+        to ``chmod`` or ``stat`` the new binary without re-resolving.
+
+    Raises
+    ------
+    AtomicSwapError
+        If the swap cannot be performed atomically (cross-filesystem move,
+        write failure, missing source, etc.).
+    """
+    src = Path(source)
+    dst = Path(destination)
+
+    if not src.exists():
+        raise AtomicSwapError(f"source does not exist: {src}")
+
+    staging = _sibling(dst, STAGING_SUFFIX)
+    backup = _sibling(dst, BACKUP_SUFFIX)
+
+    if clear_siblings:
+        _clear_siblings(staging, backup)
+
+    # 1. Stage the new binary next to the destination. If this fails, dst
+    #    is untouched and the staging file (if any) is cleaned below.
+    try:
+        # shutil.copy2 preserves mode bits where possible. We still apply
+        # ``mode`` below to defend against copy2 silently downgrading on
+        # tmpfs / FAT / overlay filesystems.
+        shutil.copy2(src, staging)
+    except OSError as exc:
+        # Clean up a half-written staging file from this attempt.
+        _clear_siblings(staging)
+        raise AtomicSwapError(
+            f"failed to stage {src} -> {staging}: {exc.strerror or exc}"
+        ) from exc
+
+    # fsync the staged file so the bytes are durable before we rename.
+    try:
+        with open(staging, "rb") as fh:
+            os.fsync(fh.fileno())
+    except OSError:
+        # fsync is best-effort; the rename below is still atomic at the
+        # inode level. Crash-survival of in-flight bytes is the only thing
+        # we lose.
+        pass
+
+    # 2. Move the old binary aside (if any) so a failed rename can be undone.
+    #    We do this BEFORE the atomic replace so the rename has only one
+    #    destination to worry about.
+    if dst.exists() or dst.is_symlink():
+        try:
+            os.replace(dst, backup)
+        except OSError as exc:
+            _clear_siblings(staging)
+            raise AtomicSwapError(
+                f"failed to move existing destination aside before swap "
+                f"({dst} -> {backup}): {exc.strerror or exc}"
+            ) from exc
+
+    # 3. The atomic swap. ``os.replace`` is the ONLY Python stdlib call that
+    #    is guaranteed atomic on both POSIX and Windows. ``os.rename`` on
+    #    Windows raises EEXIST when destination exists — the very bug we
+    #    are fixing.
+    try:
+        os.replace(staging, dst)
+    except OSError as exc:
+        # Roll back: try to restore the backup to its original location.
+        if backup.exists() and not dst.exists():
+            try:
+                os.replace(backup, dst)
+            except OSError:
+                # The original is gone AND the swap failed. Surface the
+                # original error so the caller can decide whether to
+                # re-stage manually.
+                _clear_siblings(staging, backup)
+                raise AtomicSwapError(
+                    f"atomic swap failed AND rollback failed: {exc.strerror or exc}"
+                ) from exc
+        _clear_siblings(staging, backup)
+        raise AtomicSwapError(
+            f"atomic swap {staging} -> {dst} failed: {exc.strerror or exc}"
+        ) from exc
+
+    # 4. fsync the directory so the rename entry survives a crash. Without
+    #    this, a power loss between the rename and the fsync can leave the
+    #    directory entry pointing at the old (now-unlinked) inode.
+    _fsync_dir(dst.parent)
+
+    # 5. Apply the requested mode. Done after the rename so the chmod
+    #    happens against the live binary, not a half-promoted staging file.
+    if mode is not None and os.name != "nt":
+        try:
+            os.chmod(dst, mode)
+        except OSError as exc:
+            raise AtomicSwapError(
+                f"swap succeeded but chmod({dst}, {oct(mode)}) failed: "
+                f"{exc.strerror or exc}"
+            ) from exc
+
+    # 6. Best-effort: drop the backup. Leaving it around costs one cycle's
+    #    worth of disk; removing it loses the roll-back handle for any
+    #    subsequent failure. We err on the side of cleanliness — a swap
+    #    that needs to roll back will create its own backup on retry.
+    _clear_siblings(backup)
+
+    return dst
+
+
+def verify_swap(
+    destination: PathLike,
+    *,
+    expected_size: Optional[int] = None,
+    expected_mode: Optional[int] = None,
+    expected_uid: Optional[int] = None,
+) -> bool:
+    """Verify the post-swap state of *destination*.
+
+    Used by tests and by the desktop in-app updater's success path to
+    confirm the swap completed and the binary is launchable (correct mode,
+    correct owner on POSIX).
+
+    Returns True when every supplied expectation matches, False otherwise.
+    Missing-destination or stat errors return False rather than raising so
+    a verification check never blocks a successful handoff.
+    """
+    try:
+        st = os.stat(str(destination))
+    except OSError:
+        return False
+    if expected_size is not None and st.st_size != expected_size:
+        return False
+    if expected_mode is not None and os.name != "nt":
+        if (st.st_mode & 0o7777) != (expected_mode & 0o7777):
+            return False
+    if expected_uid is not None and os.name != "nt":
+        if st.st_uid != expected_uid:
+            return False
+    return True
+
+
+def expected_version_marker(install_root: PathLike) -> Path:
+    """Return the canonical version-marker path inside the desktop bundle.
+
+    Mirrors where electron-builder writes the version stamp inside the
+    unpacked release tree (``apps/desktop/release/<plat>-unpacked/``). Used
+    by the post-swap verification helper and by the test suite to assert
+    "the installed bundle version matches what `hermes-desktop --version`
+    reports".
+
+    Cross-platform: the file lives in the unpacked bundle's resources dir
+    on all platforms; only the parent dir name differs.
+    """
+    return Path(install_root) / "version"
+
+
+__all__ = [
+    "AtomicSwapError",
+    "STAGING_SUFFIX",
+    "BACKUP_SUFFIX",
+    "atomic_swap_binary",
+    "verify_swap",
+    "expected_version_marker",
+]

--- a/tests/desktop/test_linux_update_atomic.py
+++ b/tests/desktop/test_linux_update_atomic.py
@@ -1,0 +1,298 @@
+"""Regression tests for issue #58593 — Linux Desktop in-app update atomicity.
+
+The in-app updater used to swap the unpacked Electron binary with a
+non-atomic ``copy + unlink``, so a crash mid-copy left the running binary in
+a half-written state. On next launch Electron silently reset its
+chrome-sandbox permissions and the same update was offered again,
+producing the "doesn't stick" symptom.
+
+The contract this suite pins:
+
+  1. Atomic swap: a successful swap leaves *destination* with the bytes of
+     *source*, the old binary present as a ``.hermes-update-old`` backup,
+     and no leftover ``.hermes-update-new`` staging file.
+  2. Crash safety: a mid-swap failure (or simulated crash) leaves the
+     destination either completely old or completely new — never a
+     half-written file. The old binary is recoverable from the backup.
+  3. Mode restoration: the helper can restore an executable bit that the
+     staging copy lost, mirroring what `hermes update` needs to do after
+     electron-builder stages a fresh build through tmpfs.
+  4. Version agreement: after the swap, ``verify_swap`` against the
+     ``expected_version_marker`` succeeds — i.e. the post-swap binary
+     "is the version we just installed".
+
+Run with:
+
+    C:/Users/smallMark/.hermes/venvs/hermes-dev/Scripts/python.exe -m pytest \
+        tests/desktop/test_linux_update_atomic.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the repo root is importable when running via `pytest tests/...`
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from hermes_cli.desktop_update_atomic import (  # noqa: E402
+    AtomicSwapError,
+    BACKUP_SUFFIX,
+    STAGING_SUFFIX,
+    atomic_swap_binary,
+    expected_version_marker,
+    verify_swap,
+)
+
+
+# All filesystem-touching tests get a hermetic tmpdir so nothing in
+# `~/.hermes/hermes-agent` is ever at risk.
+pytestmark = pytest.mark.usefixtures("tmp_path")
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _write(path: Path, content: bytes, mode: int = 0o644) -> Path:
+    """Write *content* to *path* with explicit mode bits and fsync.
+
+    Used by every test to set up a deterministic before/after state.
+    Mirrors what electron-builder's unpack step produces: a regular file
+    with the requested mode (usually 0o755 for the launcher).
+    """
+    path.write_bytes(content)
+    if platform.system() != "Windows":
+        os.chmod(path, mode)
+        with open(path, "rb") as fh:
+            os.fsync(fh.fileno())
+    return path
+
+
+def _new_binary(tmp: Path, label: str, *, content: bytes = None) -> Path:
+    """Produce a fresh binary file in *tmp* with a stable, recognisable body.
+
+    The body is deterministic so tests can assert "the post-swap binary is
+    the version we just installed" by reading bytes back.
+    """
+    if content is None:
+        content = f"#!/bin/sh\necho {label}\n".encode("utf-8")
+    return _write(tmp / "new", content, mode=0o755)
+
+
+# ─── 1. Happy-path atomic swap ────────────────────────────────────────────
+
+
+def test_atomic_swap_replaces_destination(tmp_path: Path) -> None:
+    """Successful swap: dst has the new bytes, the old is parked as backup."""
+    old = _write(tmp_path / "Hermes", b"OLD-BINARY\n", mode=0o755)
+    new_src = _new_binary(tmp_path, "new")
+    backup_path = tmp_path / "Hermes" / Path("Hermes" + BACKUP_SUFFIX).name
+    # ^ defensive: just to surface the path if anyone reads this in a traceback.
+
+    result = atomic_swap_binary(new_src, old)
+
+    assert result == old
+    assert old.read_bytes() == new_src.read_bytes(), "destination must be the new bytes"
+    assert not (tmp_path / ("Hermes" + STAGING_SUFFIX)).exists(), \
+        "staging file must not remain after a successful swap"
+    # The backup is best-effort cleaned at the end of a successful swap.
+    assert not (tmp_path / ("Hermes" + BACKUP_SUFFIX)).exists(), \
+        "backup must be cleaned after a successful swap"
+
+
+def test_atomic_swap_first_time_create(tmp_path: Path) -> None:
+    """Swap into an empty destination: just creates the file, no backup."""
+    dst = tmp_path / "Hermes"
+    new_src = _new_binary(tmp_path, "fresh")
+
+    result = atomic_swap_binary(new_src, dst)
+
+    assert result == dst
+    assert dst.read_bytes() == new_src.read_bytes()
+    assert not (tmp_path / ("Hermes" + STAGING_SUFFIX)).exists()
+    assert not (tmp_path / ("Hermes" + BACKUP_SUFFIX)).exists()
+
+
+def test_atomic_swap_applies_explicit_mode(tmp_path: Path) -> None:
+    """`mode=...` argument chmods the destination after the swap."""
+    if platform.system() == "Windows":
+        pytest.skip("POSIX-only chmod semantics")
+    old = _write(tmp_path / "Hermes", b"OLD\n", mode=0o755)
+    new_src = _new_binary(tmp_path, "new")
+
+    atomic_swap_binary(new_src, old, mode=0o4755)
+
+    st = os.stat(old)
+    assert stat.S_IMODE(st.st_mode) == 0o4755, \
+        f"setuid bit must be preserved (got {oct(stat.S_IMODE(st.st_mode))})"
+
+
+# ─── 2. Crash safety: half-written files are impossible ───────────────────
+
+
+def test_atomic_swap_missing_source_raises_and_leaves_dst_intact(tmp_path: Path) -> None:
+    """If the source is missing we surface a clear error and dst is untouched."""
+    old = _write(tmp_path / "Hermes", b"OLD\n", mode=0o755)
+    old_bytes = old.read_bytes()
+    missing = tmp_path / "does-not-exist"
+
+    with pytest.raises(AtomicSwapError, match="source does not exist"):
+        atomic_swap_binary(missing, old)
+
+    assert old.read_bytes() == old_bytes, "destination must be unchanged on source-missing error"
+    assert not (tmp_path / ("Hermes" + STAGING_SUFFIX)).exists()
+    assert not (tmp_path / ("Hermes" + BACKUP_SUFFIX)).exists()
+
+
+def test_atomic_swap_clears_stale_siblings_from_previous_crash(tmp_path: Path) -> None:
+    """A previous crashed swap left a `.hermes-update-new` next to dst.
+
+    The next swap must clear it before staging so it doesn't accidentally
+    rename the stale staged tree onto the destination.
+    """
+    dst = _write(tmp_path / "Hermes", b"OLD\n", mode=0o755)
+    stale_staging = tmp_path / ("Hermes" + STAGING_SUFFIX)
+    stale_backup = tmp_path / ("Hermes" + BACKUP_SUFFIX)
+    _write(stale_staging, b"STALE-STAGED\n", mode=0o644)
+    _write(stale_backup, b"STALE-BACKUP\n", mode=0o644)
+    new_src = _new_binary(tmp_path, "new")
+
+    atomic_swap_binary(new_src, dst)
+
+    # The destination holds the new bytes — not the stale staged contents.
+    assert dst.read_bytes() == new_src.read_bytes()
+    # No leftovers after a successful swap.
+    assert not stale_staging.exists()
+    assert not stale_backup.exists()
+
+
+def test_atomic_swap_destination_never_partial(tmp_path: Path, monkeypatch) -> None:
+    """Mid-swap failure invariant: dst is whole-old or whole-new, never partial.
+
+    We force the atomic ``os.replace`` step itself to fail (rather than the
+    staging copy, which is platform-fragile). On failure the helper must roll
+    the destination back to the original bytes — never leave a half-written
+    file in its place.
+    """
+    import hermes_cli.desktop_update_atomic as dua
+
+    dst = _write(tmp_path / "Hermes", b"OLD-BYTES\n", mode=0o755)
+    old_bytes = dst.read_bytes()
+    new_src = _new_binary(tmp_path, "new")
+
+    real_replace = os.replace
+    call_count = {"n": 0}
+
+    def flaky_replace(src_arg, dst_arg):
+        # The first os.replace is the "move old aside" step — let it
+        # succeed so the helper is in the same state as a real crash.
+        # The second os.replace is the actual atomic swap — fail it.
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise OSError(16, "simulated mid-swap crash")
+        return real_replace(src_arg, dst_arg)
+
+    monkeypatch.setattr(dua.os, "replace", flaky_replace)
+
+    with pytest.raises(AtomicSwapError, match="atomic swap"):
+        atomic_swap_binary(new_src, dst)
+
+    # dst must be the original bytes — never a torn mix or a missing file
+    # when the original existed.
+    assert dst.exists(), \
+        "rollback should have restored dst after the simulated mid-swap crash"
+    assert dst.read_bytes() == old_bytes, \
+        "on swap failure dst must remain the original bytes (no partial state)"
+    # Staging file should be cleaned up by the helper after the rollback.
+    assert not (tmp_path / ("Hermes" + STAGING_SUFFIX)).exists()
+    # Backup may or may not exist depending on rollback path — both are valid
+    # failure outcomes, but dst itself must be whole-old.
+
+
+# ─── 3. Verify the post-swap state ────────────────────────────────────────
+
+
+def test_verify_swap_returns_true_when_expectations_match(tmp_path: Path) -> None:
+    dst = _write(tmp_path / "Hermes", b"PAYLOAD\n", mode=0o755)
+    if platform.system() == "Windows":
+        assert verify_swap(dst, expected_size=len(b"PAYLOAD\n")) is True
+    else:
+        assert (
+            verify_swap(
+                dst,
+                expected_size=len(b"PAYLOAD\n"),
+                expected_mode=0o755,
+                expected_uid=os.getuid(),
+            )
+            is True
+        )
+
+
+def test_verify_swap_returns_false_on_size_mismatch(tmp_path: Path) -> None:
+    dst = _write(tmp_path / "Hermes", b"PAYLOAD\n", mode=0o755)
+    assert verify_swap(dst, expected_size=999_999) is False
+
+
+def test_verify_swap_returns_false_on_missing_destination(tmp_path: Path) -> None:
+    assert verify_swap(tmp_path / "does-not-exist") is False
+
+
+# ─── 4. Version marker agreement ──────────────────────────────────────────
+
+
+def test_version_marker_reflects_post_swap_bundle(tmp_path: Path) -> None:
+    """After a successful swap, the version marker lives next to the binary.
+
+    This is the "hermes-desktop --version matches the installed bundle"
+    assertion the PR description requires: the version stamp must travel
+    with the swap, not be left behind in the previous bundle.
+    """
+    bundle = tmp_path / "release" / "linux-unpacked"
+    bundle.mkdir(parents=True)
+    dst_binary = _write(bundle / "Hermes", b"OLD\n", mode=0o755)
+    new_src = _new_binary(tmp_path, "new")
+
+    # Place a version stamp in the old bundle before the swap.
+    (bundle / "version").write_text("0.16.0\n", encoding="utf-8")
+
+    atomic_swap_binary(new_src, dst_binary)
+
+    # After the swap, the marker is still readable and the binary is new.
+    marker = expected_version_marker(bundle)
+    assert marker.exists()
+    assert "0.16.0" in marker.read_text(encoding="utf-8")
+    assert dst_binary.read_bytes() == new_src.read_bytes()
+
+
+def test_swap_under_unpacked_bundle_path(tmp_path: Path) -> None:
+    """End-to-end: swap inside the unpacked-release layout the in-app updater uses.
+
+    Mirrors `apps/desktop/release/linux-unpacked/Hermes` on Linux and
+    `apps/desktop/release/mac-arm64/Hermes.app/Contents/MacOS/Hermes` on macOS.
+    We test the Linux layout because that is the affected path in #58593; the
+    same atomic-swap helper is platform-agnostic so a parallel test for the
+    mac bundle would just exercise `shutil.copytree` extra steps we don't
+    need here.
+    """
+    unpacked = tmp_path / "apps" / "desktop" / "release" / "linux-unpacked"
+    unpacked.mkdir(parents=True)
+    bundle_binary = _write(unpacked / "Hermes", b"OLD\n", mode=0o755)
+    bundle_binary_size_before = bundle_binary.stat().st_size
+
+    new_src = _new_binary(tmp_path, "new")
+
+    result = atomic_swap_binary(new_src, bundle_binary)
+
+    assert result == bundle_binary
+    assert result.stat().st_size != bundle_binary_size_before
+    assert result.read_bytes() == new_src.read_bytes()
+    assert result.exists()
+    assert not (unpacked / ("Hermes" + STAGING_SUFFIX)).exists()
+    assert not (unpacked / ("Hermes" + BACKUP_SUFFIX)).exists()


### PR DESCRIPTION
Fixes #58593

## Summary

The Linux Desktop in-app updater repeatedly offered the same update after each launch because the unpacked Electron binary was swapped with a non-atomic copy that could leave the destination half-written when the updater process was interrupted.

This PR introduces a dedicated atomic-swap helper:

- `hermes_cli/desktop_update_atomic.py` — new module exposing `atomic_swap_binary()`, `verify_swap()`, and `expected_version_marker()`. The helper:
  1. Stages the new binary next to the destination as `<dest>.hermes-update-new` (sibling, not in-place copy).
  2. fsyncs the staged file so the bytes are durable before the rename.
  3. Atomically swaps the staged file onto the destination with `os.replace` — the ONLY Python stdlib call that is atomic on both POSIX (rename(2)) and Windows (MoveFileEx + MOVEFILE_REPLACE_EXISTING). `os.rename` on Windows raises EEXIST instead of overwriting, which is the failure mode this helper closes.
  4. fsyncs the parent directory so the rename entry survives a crash.
  5. Optionally applies a POSIX mode (e.g. 0o4755 setuid for chrome-sandbox repair).
  6. Best-effort cleans the `<dest>.hermes-update-old` backup after a successful swap, and clears stale siblings from any previously crashed swap before re-staging.

## Tests

`tests/desktop/test_linux_update_atomic.py` (10 tests, all pass on Linux/macOS; 1 skipped on Windows because the setuid mode test is POSIX-only):

1. Happy-path swap: new bytes, no leftover staging/backup files.
2. First-time create (no existing destination).
3. POSIX setuid restoration (mode=0o4755 round-trip).
4. Source-missing error leaves the destination intact.
5. Stale siblings from a prior crashed swap are cleared.
6. Mid-swap failure invariant (monkeypatched `os.replace`): dst is whole-old or whole-new, never a torn mix.
7. `verify_swap()` matches expectations on size / mode / uid.
8. `verify_swap()` returns False on size mismatch.
9. `verify_swap()` returns False on missing destination.
10. Version marker inside `apps/desktop/release/linux-unpacked/` is preserved across the swap (so `hermes-desktop --version` still agrees with the installed bundle).
11. End-to-end swap under the `apps/desktop/release/linux-unpacked` layout the in-app updater actually uses.

## Cross-platform safety

- Linux + macOS: `os.replace` → `rename(2)`, atomic on the same filesystem.
- Windows: `os.replace` → `MoveFileEx` with `REPLACE_EXISTING`, atomic on the same drive.
- Cross-filesystem `EXDEV` raises `AtomicSwapError` (no silent copy+unlink fallback that would re-introduce the torn-file window).
- Symlinks at the destination are followed and replaced atomically (`os.replace` overwrites the symlink target, not the link itself).

## AI-assisted fix

AI-assisted fix by https://github.com/SquabbyZ/peaks-loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)