### PR TITLE
fix(agent): notify user when AGENTS.md/context files are blocked by threat scanner (#59612)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -53,10 +53,21 @@ def _scan_context_content(content: str, filename: str) -> str:
     cloned repo (security research, infra docs).  Content matching is
     BLOCKED at this layer because the file would otherwise enter the
     system prompt verbatim and the user has no chance to intervene.
+
+    When content is blocked, a user-facing warning is also recorded via
+    ``_record_truncation_warning`` so the caller (system_prompt.py) can
+    surface it through ``agent._emit_status()`` — the user sees the
+    notification in chat instead of only in the log file (#59612).
     """
     findings = _scan_for_threats(content, scope="context")
     if findings:
+        msg = (
+            f"\u26a0\ufe0f  Context file {filename} BLOCKED: "
+            f"{', '.join(findings)} \u2014 "
+            f"file content removed from the system prompt!"
+        )
         logger.warning("Context file %s blocked: %s", filename, ", ".join(findings))
+        _record_truncation_warning(msg)
         return f"[BLOCKED: {filename} contained potential prompt injection ({', '.join(findings)}). Content not loaded.]"
 
     return content


### PR DESCRIPTION
## Description

Fixes #59612 — AGENTS.md Silent Threat-Scanner Block — No User Notification

When the threat-pattern scanner blocks a context file (AGENTS.md, CLAUDE.md, .cursorrules, SOUL.md), the content was silently replaced with a `[BLOCKED: ...]` placeholder. The only indication was a `logger.warning` call that went to the log file — the user never saw it.

## What changed

In `agent/prompt_builder.py`, the `_scan_context_content` function now also calls `_record_truncation_warning()` when content is blocked. This uses the same `contextvars`-based warning mechanism already used by `_truncate_content` for file-size truncation warnings, which surfaces through `agent._emit_status()` in `agent/system_prompt.py`.

This means:
- **CLI users** see a warning banner in their terminal
- **Gateway/Dashboard users** see the notification via the agent status channel
- **Logs** continue to record the event as before

The warning message format is: `⚠️  Context file <filename> BLOCKED: <pattern_ids> — file content removed from the system prompt!`

## Files modified
- `agent/prompt_builder.py` — added `_record_truncation_warning()` call in `_scan_context_content()` when content is blocked

## Testing
All 161 existing tests in `tests/agent/test_prompt_builder.py` continue to pass.

Closes #59612