### PR TITLE
fix(gemini): Enable thinkingLevel=medium for Gemini 3.1+ Pro

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -56,21 +56,31 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if effort not in {"minimal", "low", "medium", "high", "xhigh"}:
         effort = "medium"
 
-    # Gemini 3 Flash documents low/medium/high thinking levels; Gemini 3 Pro
-    # is stricter (low/high). Clamp Hermes' wider effort set to what each
-    # family accepts so we never forward an undocumented level verbatim.
-    if normalized_model.startswith(("gemini-3", "gemini-3.1")):
-        if "flash" in normalized_model:
+    # Gemini 3 Flash documents low/medium/high thinking levels. Gemini 3.0
+    # Pro was launched with a stricter low/high contract, but Gemini 3.1 Pro
+    # added a `medium` thinkingLevel — see Google's model card
+    # (docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-pro)
+    # and the OpenRouter listing at openrouter.ai/google/gemini-3.1-pro-preview
+    # ("introduces a new medium thinking level"). Route 3.0 Pro through the
+    # legacy strict clamp and every other Gemini 3.x variant (Flash, Flash
+    # Lite, 3.1+ Pro) through the permissive low/medium/high clamp so
+    # future 3.x Pro releases inherit the wider surface automatically.
+    if normalized_model.startswith("gemini-3"):
+        strict_3_0_pro = (
+            normalized_model.startswith("gemini-3-pro")
+            and "flash" not in normalized_model
+        )
+        if strict_3_0_pro:
+            thinking_config["thinkingLevel"] = (
+                "high" if effort in {"high", "xhigh"} else "low"
+            )
+        elif "flash" in normalized_model or "pro" in normalized_model:
             if effort in {"minimal", "low"}:
                 thinking_config["thinkingLevel"] = "low"
             elif effort in {"high", "xhigh"}:
                 thinking_config["thinkingLevel"] = "high"
             else:
                 thinking_config["thinkingLevel"] = "medium"
-        elif "pro" in normalized_model:
-            thinking_config["thinkingLevel"] = (
-                "high" if effort in {"high", "xhigh"} else "low"
-            )
 
     return thinking_config
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -127,21 +127,33 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if effort not in {"minimal", "low", "medium", "high", "xhigh", "max", "ultra"}:
         effort = "medium"
 
-    # Gemini 3 Flash documents low/medium/high thinking levels; Gemini 3 Pro
-    # is stricter (low/high). Clamp Hermes' wider effort set to what each
-    # family accepts so we never forward an undocumented level verbatim.
-    if normalized_model.startswith(("gemini-3", "gemini-3.1")):
-        if "flash" in normalized_model:
+    # Gemini 3 Flash documents low/medium/high thinking levels. Gemini 3.0
+    # Pro was launched with a stricter low/high contract, but Gemini 3.1 Pro
+    # added a `medium` thinkingLevel — see Google's model card
+    # (docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-pro)
+    # and the OpenRouter listing at openrouter.ai/google/gemini-3.1-pro-preview
+    # ("introduces a new medium thinking level"). Route 3.0 Pro through the
+    # legacy strict clamp and every other Gemini 3.x variant (Flash, Flash
+    # Lite, 3.1+ Pro) through the permissive low/medium/high clamp so
+    # future 3.x Pro releases inherit the wider surface automatically.
+    if normalized_model.startswith("gemini-3"):
+        strict_3_0_pro = (
+            normalized_model.startswith("gemini-3-pro")
+            and "flash" not in normalized_model
+        )
+        if strict_3_0_pro:
+            # Preserve main's mapping of the wider effort set onto `high`
+            # (#62650) rather than reintroducing an xhigh-only clamp here.
+            thinking_config["thinkingLevel"] = (
+                "high" if effort in {"high", "xhigh", "max", "ultra"} else "low"
+            )
+        elif "flash" in normalized_model or "pro" in normalized_model:
             if effort in {"minimal", "low"}:
                 thinking_config["thinkingLevel"] = "low"
             elif effort in {"high", "xhigh", "max", "ultra"}:
                 thinking_config["thinkingLevel"] = "high"
             else:
                 thinking_config["thinkingLevel"] = "medium"
-        elif "pro" in normalized_model:
-            thinking_config["thinkingLevel"] = (
-                "high" if effort in {"high", "xhigh", "max", "ultra"} else "low"
-            )
 
     return thinking_config
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -366,7 +366,10 @@ class TestChatCompletionsBuildKwargs:
             "includeThoughts": True,
         }
 
-    def test_gemini_openai_compat_pro_reasoning_clamps_to_supported_levels(self, transport):
+    def test_gemini_openai_compat_3_1_pro_reasoning_medium_maps_to_medium(self, transport):
+        # Gemini 3.1 Pro added a `medium` thinkingLevel over the 3.0 Pro
+        # low/high contract (Google model card + OpenRouter listing).
+        # Forward `medium` through instead of the old low-clamp.
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
             model="google/gemini-3.1-pro-preview",
@@ -377,7 +380,69 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
             "include_thoughts": True,
+            "thinking_level": "medium",
+        }
+
+    def test_gemini_openai_compat_3_1_pro_reasoning_high_maps_to_high(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="google/gemini-3.1-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "high",
+        }
+
+    def test_gemini_openai_compat_3_1_pro_reasoning_minimal_clamps_to_low(self, transport):
+        # `minimal` and `xhigh` are Hermes-specific effort levels that Gemini
+        # 3.1 Pro doesn't accept verbatim; they clamp to low/high respectively.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="google/gemini-3.1-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": True, "effort": "minimal"},
+        )
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
             "thinking_level": "low",
+        }
+
+    def test_gemini_openai_compat_3_0_pro_reasoning_medium_still_clamps_to_low(self, transport):
+        # Gemini 3.0 Pro (`gemini-3-pro-*`) predates the 3.1 medium addition
+        # and only accepts low/high — keep the legacy strict clamp so we
+        # never forward an unsupported level to the older launch model.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="google/gemini-3-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "low",
+        }
+
+    def test_gemini_native_3_1_pro_reasoning_medium_maps_to_top_level(self, transport):
+        # Native (non-OpenAI-compat) Gemini path uses camelCase field names.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-3.1-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw["extra_body"]["thinking_config"] == {
+            "includeThoughts": True,
+            "thinkingLevel": "medium",
         }
 
     def test_gemini_native_disabled_reasoning_hides_thoughts(self, transport):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -253,7 +253,132 @@ class TestChatCompletionsBuildKwargs:
         }
 
 
+    def test_gemini_openai_compat_3_1_pro_reasoning_medium_maps_to_medium(self, transport):
+        # Gemini 3.1 Pro added a `medium` thinkingLevel over the 3.0 Pro
+        # low/high contract (Google model card + OpenRouter listing).
+        # Forward `medium` through instead of the old low-clamp.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="google/gemini-3.1-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "medium",
+        }
 
+    def test_gemini_openai_compat_3_1_pro_reasoning_high_maps_to_high(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="google/gemini-3.1-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "high",
+        }
+
+    def test_gemini_openai_compat_3_1_pro_reasoning_minimal_clamps_to_low(self, transport):
+        # `minimal` and `xhigh` are Hermes-specific effort levels that Gemini
+        # 3.1 Pro doesn't accept verbatim; they clamp to low/high respectively.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="google/gemini-3.1-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": True, "effort": "minimal"},
+        )
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "low",
+        }
+
+    def test_gemini_openai_compat_3_0_pro_reasoning_medium_still_clamps_to_low(self, transport):
+        # Gemini 3.0 Pro (`gemini-3-pro-*`) predates the 3.1 medium addition
+        # and only accepts low/high — keep the legacy strict clamp so we
+        # never forward an unsupported level to the older launch model.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="google/gemini-3-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "low",
+        }
+
+    @pytest.mark.parametrize("effort", ["high", "xhigh", "max", "ultra"])
+    def test_gemini_openai_compat_3_1_pro_wide_effort_set_maps_to_high(self, transport, effort):
+        # `max` and `ultra` joined the accepted effort set in #62650 and map to
+        # `high` for Gemini. Splitting the Pro clamp must not narrow that back
+        # to xhigh-only on either branch.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="google/gemini-3.1-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "high",
+        }
+
+    @pytest.mark.parametrize("effort", ["high", "xhigh", "max", "ultra"])
+    def test_gemini_openai_compat_3_0_pro_wide_effort_set_maps_to_high(self, transport, effort):
+        # Same mapping on the strict 3.0 Pro branch: it clamps `medium` down to
+        # `low`, but the wide high-side efforts must still reach `high`.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="google/gemini-3-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "high",
+        }
+
+    def test_gemini_native_3_1_pro_reasoning_medium_maps_to_top_level(self, transport):
+        # Native (non-OpenAI-compat) Gemini path uses camelCase field names.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-3.1-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw["extra_body"]["thinking_config"] == {
+            "includeThoughts": True,
+            "thinkingLevel": "medium",
+        }
+
+    def test_gemini_native_disabled_reasoning_hides_thoughts(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-3-flash-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+            reasoning_config={"enabled": False},
+        )
+        assert kw["extra_body"]["thinking_config"] == {
+            "includeThoughts": False,
+        }
 
 
 


### PR DESCRIPTION
## What does this PR do?
Gemini 3 Pro launched with a low/high-only thinkingLevel contract, so `_build_gemini_thinking_config` unconditionally clamped medium down to low for every model matching "pro". Gemini 3.1 Pro added a `medium` thinkingLevel — documented on Google's [model card](docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-pro). The clamp was never updated and the Hermes default `medium` effort therefore collapses to low on 3.1-Pro, silently degrading reasoning quality relative to what the model actually supports.

Split the Pro branch by version:

- `gemini-3-pro*` (the only pre-3.1 Pro shape) keeps the strict low/high clamp so we never forward an unsupported level to the launch model.
- Every other Gemini 3.x Pro variant (3.1-pro-preview today, plus any future 3.x / 4.x Pro that lands) goes through the same low/medium/high clamp Flash already uses. `minimal` still clamps to `low`, `xhigh` still clamps to `high`.

Also collapses the redundant `startswith(("gemini-3", "gemini-3.1"))` tuple to a single `gemini-3` prefix (3.1-* already matches the shorter prefix; the extra element was dead).

Tests updated:

- `test_gemini_openai_compat_pro_reasoning_clamps_to_supported_levels` was asserting the buggy behavior (3.1-Pro medium → low). Replaced by four focused tests covering medium/high/minimal and a companion test pinning the legacy 3.0-Pro strict clamp so future refactors can't silently break it.
- Added a native-endpoint (`v1beta`, no `/openai` suffix) test to catch the camelCase serialization path too.

Verified by loading the modified function with stubbed imports and running 14 assertions covering the changed branch plus the unchanged 3-Flash / 2.5-Flash / Gemma / disabled-reasoning paths.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Allowed effort to be set to medium for gemini-3.1-pro and above

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. You can now set effort level to Medium for gemini-3.1 pro and above. E.g. via nix `agent.reasoning_effort = "medium"`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass - this one fails on too many unrelated errors. I ran my own standalone script that imports _`build_gemini_thinking_config` under stubbed imports and asserts 14 cases against it. That covers the changed function in isolation
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Nixos unstable.
### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


