### PR TITLE
fix(agent): drop empty text content on assistant tool-call turns in pre-API sanitizer

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2423,6 +2423,43 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             dropped_empty_tool_calls,
         )
 
+    # --- Drop empty/whitespace-only text content on assistant tool-call turns ---
+    # An assistant turn that emitted only ``tool_calls`` carries ``content=""``
+    # (empty string) in Hermes' stored history. Most providers accept that, but
+    # strict validators reject it: AWS Bedrock's Converse API returns a
+    # ``ValidationException`` — "messages: text content blocks must contain
+    # non-whitespace text" — and fails the entire request. This is deterministic
+    # on a model fallback (e.g. Opus 4.6 -> Sonnet 4.6 on Bedrock), where the
+    # history built by the lenient primary is replayed verbatim to the stricter
+    # fallback and the user is left with a silent zero-response (#59593). A
+    # tool-calls-only assistant turn does not need a text block, so drop the
+    # empty ``content`` key on a per-call shallow copy (keeping stored history
+    # and prompt caching byte-stable, per the #56980 review). Only touch turns
+    # that still carry tool_calls — a content-less, tool-call-less assistant
+    # turn is handled by the thinking-only drop downstream.
+    stripped_empty_content = 0
+    rebuilt: List[Dict[str, Any]] = []
+    for msg in messages:
+        if (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and isinstance(msg.get("tool_calls"), list)
+            and msg["tool_calls"]
+            and "content" in msg
+            and isinstance(msg.get("content"), str)
+            and not msg["content"].strip()
+        ):
+            msg = {k: v for k, v in msg.items() if k != "content"}
+            stripped_empty_content += 1
+        rebuilt.append(msg)
+    if stripped_empty_content:
+        messages = rebuilt
+        _ra().logger.debug(
+            "Pre-call sanitizer: dropped empty text content on %d assistant "
+            "tool-call turn(s)",
+            stripped_empty_content,
+        )
+
     # --- Repair tool_calls whose function.name is empty/missing ---
     # Some providers (and partially-streamed responses) emit a tool_call with
     # id="call_xxx" but function.name="". Downstream Responses-API adapters

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2437,9 +2437,13 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # and prompt caching byte-stable, per the #56980 review). Only touch turns
     # that still carry tool_calls — a content-less, tool-call-less assistant
     # turn is handled by the thinking-only drop downstream.
+    # Lazy copy: the common case strips nothing, so avoid rebuilding the whole
+    # list on every pre-API call. Only allocate ``rebuilt`` once we actually
+    # hit a turn that needs its empty ``content`` stripped; until then keep
+    # iterating the original ``messages`` untouched.
     stripped_empty_content = 0
-    rebuilt: List[Dict[str, Any]] = []
-    for msg in messages:
+    rebuilt: Optional[List[Dict[str, Any]]] = None
+    for idx, msg in enumerate(messages):
         if (
             isinstance(msg, dict)
             and msg.get("role") == "assistant"
@@ -2449,11 +2453,15 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             and isinstance(msg.get("content"), str)
             and not msg["content"].strip()
         ):
+            if rebuilt is None:
+                rebuilt = list(messages[:idx])
             msg = {k: v for k, v in msg.items() if k != "content"}
             stripped_empty_content += 1
-        rebuilt.append(msg)
+            rebuilt.append(msg)
+        elif rebuilt is not None:
+            rebuilt.append(msg)
     if stripped_empty_content:
-        messages = rebuilt
+        messages = rebuilt  # type: ignore[assignment]
         _ra().logger.debug(
             "Pre-call sanitizer: dropped empty text content on %d assistant "
             "tool-call turn(s)",

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -132,6 +132,53 @@ class TestSanitizeApiMessages:
         assert len(tool_msgs) == 1
         assert tool_msgs[0]["tool_call_id"] == "c_valid"
 
+    def test_empty_content_dropped_on_tool_call_turn(self):
+        """Assistant tool-call turns with empty text content lose the content
+        key so strict validators (Bedrock Sonnet) don't 400 (#59593)."""
+        msgs = [
+            {"role": "user", "content": "run it"},
+            {"role": "assistant", "content": "",
+             "tool_calls": [assistant_dict_call("c1")]},
+            tool_result("c1"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        asst = [m for m in out if m.get("role") == "assistant"][0]
+        assert "content" not in asst
+        assert asst["tool_calls"]  # tool_calls preserved
+
+    def test_whitespace_only_content_dropped_on_tool_call_turn(self):
+        msgs = [
+            {"role": "assistant", "content": "   \n",
+             "tool_calls": [assistant_dict_call("c2")]},
+            tool_result("c2"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        asst = [m for m in out if m.get("role") == "assistant"][0]
+        assert "content" not in asst
+
+    def test_nonempty_content_on_tool_call_turn_preserved(self):
+        """A tool-call turn WITH real text keeps its content."""
+        msgs = [
+            {"role": "assistant", "content": "Let me check.",
+             "tool_calls": [assistant_dict_call("c3")]},
+            tool_result("c3"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        asst = [m for m in out if m.get("role") == "assistant"][0]
+        assert asst["content"] == "Let me check."
+
+    def test_empty_content_without_tool_calls_untouched(self):
+        """Empty content on a plain assistant turn (no tool_calls) is left as-is
+        for the downstream thinking-only drop — this sanitizer only touches
+        tool-call turns."""
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": ""},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        asst = [m for m in out if m.get("role") == "assistant"][0]
+        assert "content" in asst  # not this sanitizer's job
+
 
 # ---------------------------------------------------------------------------
 # Phase 2a — _cap_delegate_task_calls


### PR DESCRIPTION
## What does this PR do?

Teaches the pre-API message sanitizer (`sanitize_api_messages`) to drop empty/whitespace-only text `content` on assistant tool-call turns, so a stricter fallback provider doesn't reject the replayed history.

When an assistant turn emits **only** `tool_calls`, Hermes stores it with `content=""` (empty string). Lenient providers accept that, but strict validators reject it. AWS Bedrock's Converse API returns a `ValidationException` — *"messages: text content blocks must contain non-whitespace text"* — and fails the entire request. This is **deterministic on a model fallback** (e.g. Opus 4.6 → Sonnet 4.6 on Bedrock, #59593): the primary hits a 429 quota limit, the fallback activates, the lenient-primary history is replayed verbatim to the stricter fallback, and the fallback 400s on every retry — leaving the user with a **silent zero-response** (primary down on quota, fallback down on bad history).

`sanitize_api_messages` is the final pre-API chokepoint (invoked on every call, including after a fallback model swap) and already normalizes analogous strict-provider hazards — empty `tool_calls` arrays (#58755), duplicate `tool_call_id` (#58327), `call_id||id` matching (#58168). It had no handling for empty/whitespace-only assistant `content`: a textbook sibling-site miss in the same normalization section.

The new block mirrors the #58755 empty-`tool_calls` block directly above it: it drops the empty `content` key on a **per-call shallow copy**, so stored history and prompt caching stay byte-stable (per the #56980 review). It only touches turns that still carry a **non-empty `tool_calls` list** — a content-less, tool-call-less assistant turn is left for the downstream thinking-only drop. List-shaped multimodal content is untouched (`isinstance(..., str)` guard); only the empty-string case is the Bedrock hazard.

## Related Issue

Fixes #59593

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py` — in `sanitize_api_messages`, add a normalization block (immediately after the empty-`tool_calls` drop, before the empty-`function.name` repair) that strips empty/whitespace-only string `content` from assistant turns that still carry a truthy `tool_calls` list, on a per-call shallow copy, with a logged counter.
- `tests/run_agent/test_agent_guardrails.py` — add 4 tests to `TestSanitizeApiMessages`: empty content dropped, whitespace-only content dropped, non-empty content preserved, and empty content on a tool-call-less turn left untouched.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/run_agent/test_agent_guardrails.py -v` → 41 passed (37 existing + 4 new).
2. **Fail-before / pass-after:** revert only the production hunk in `agent/agent_runtime_helpers.py`; the two "dropped" assertions fail (empty/whitespace `content` survives as `""`), while the control tests (non-empty preserved, no-tool_calls untouched) still pass. Restore the hunk → all green.
3. Repro shape: an assistant turn `{"role": "assistant", "content": "", "tool_calls": [...]}` followed by its `tool` result now leaves the API copy without the `content` key, which the Bedrock Converse validator accepts.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Sequoia)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure message-shape normalization, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A