### PR TITLE
security(utils): cap config.yaml mode to 0600 in atomic_yaml_write

### DIFF
--- a/tests/hermes_cli/test_atomic_yaml_write.py
+++ b/tests/hermes_cli/test_atomic_yaml_write.py
@@ -124,3 +124,31 @@ class TestConfigYamlModeCap:
         atomic_yaml_write(target, {"key": "new"})
 
         assert self._mode(target) == 0o666
+
+    def test_managed_mode_skips_cap(self, tmp_path):
+        """The NixOS module sets config.yaml to group-readable 0640 so
+        interactive users in the 'hermes' group can read it alongside the
+        gateway service (hermes_cli.config._secure_file's documented
+        behavior). Capping to 0600 would silently fight that sharing --
+        the cap must be a no-op in managed mode, same as _secure_file()."""
+        target = tmp_path / "config.yaml"
+        target.write_text("agent:\n  system_prompt: old\n", encoding="utf-8")
+        os.chmod(target, 0o666)
+
+        with patch("hermes_cli.config.is_managed", return_value=True):
+            atomic_yaml_write(target, {"agent": {"system_prompt": "new"}})
+
+        assert self._mode(target) == 0o666
+
+    def test_container_mode_skips_cap(self, tmp_path, monkeypatch):
+        """Same as managed mode: containers with volume-mounted config often
+        need the gateway/dashboard (different UIDs) to both reach it -- see
+        hermes_cli.config._is_container's docstring."""
+        monkeypatch.setenv("HERMES_CONTAINER", "1")
+        target = tmp_path / "config.yaml"
+        target.write_text("agent:\n  system_prompt: old\n", encoding="utf-8")
+        os.chmod(target, 0o666)
+
+        atomic_yaml_write(target, {"agent": {"system_prompt": "new"}})
+
+        assert self._mode(target) == 0o666

--- a/tests/hermes_cli/test_atomic_yaml_write.py
+++ b/tests/hermes_cli/test_atomic_yaml_write.py
@@ -98,7 +98,8 @@ class TestConfigYamlModeCap:
     def _mode(self, path) -> int:
         return stat.S_IMODE(os.stat(path).st_mode)
 
-    def test_wide_preexisting_config_yaml_is_capped_to_0600(self, tmp_path):
+    def test_wide_preexisting_config_yaml_is_capped_to_0600(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         target = tmp_path / "config.yaml"
         target.write_text("agent:\n  system_prompt: old\n", encoding="utf-8")
         os.chmod(target, 0o666)
@@ -107,16 +108,18 @@ class TestConfigYamlModeCap:
 
         assert self._mode(target) == 0o600
 
-    def test_new_config_yaml_is_0600(self, tmp_path):
+    def test_new_config_yaml_is_0600(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         target = tmp_path / "config.yaml"
 
         atomic_yaml_write(target, {"agent": {"system_prompt": "hello"}})
 
         assert self._mode(target) == 0o600
 
-    def test_non_config_yaml_file_mode_still_preserved(self, tmp_path):
+    def test_non_config_yaml_file_mode_still_preserved(self, tmp_path, monkeypatch):
         """Sanity check: the cap is name-scoped to config.yaml -- it must not
         regress the Docker/NAS mode-preservation behavior for other files."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         target = tmp_path / "other.yaml"
         target.write_text("key: old\n", encoding="utf-8")
         os.chmod(target, 0o666)
@@ -125,12 +128,32 @@ class TestConfigYamlModeCap:
 
         assert self._mode(target) == 0o666
 
-    def test_managed_mode_skips_cap(self, tmp_path):
+    def test_unrelated_config_yaml_outside_hermes_home_still_preserved(self, tmp_path, monkeypatch):
+        """The cap is scoped to Hermes's own config.yaml (get_config_path()),
+        not any file that happens to share the basename. A Docker/NAS install
+        writing an unrelated config.yaml through this generic YAML writer
+        must keep its existing mode-preservation behavior unchanged."""
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        unrelated_dir = tmp_path / "unrelated_app"
+        unrelated_dir.mkdir()
+        target = unrelated_dir / "config.yaml"
+        target.write_text("key: old\n", encoding="utf-8")
+        os.chmod(target, 0o666)
+
+        atomic_yaml_write(target, {"key": "new"})
+
+        assert self._mode(target) == 0o666
+
+    def test_managed_mode_skips_cap(self, tmp_path, monkeypatch):
         """The NixOS module sets config.yaml to group-readable 0640 so
         interactive users in the 'hermes' group can read it alongside the
         gateway service (hermes_cli.config._secure_file's documented
         behavior). Capping to 0600 would silently fight that sharing --
         the cap must be a no-op in managed mode, same as _secure_file()."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         target = tmp_path / "config.yaml"
         target.write_text("agent:\n  system_prompt: old\n", encoding="utf-8")
         os.chmod(target, 0o666)
@@ -144,6 +167,7 @@ class TestConfigYamlModeCap:
         """Same as managed mode: containers with volume-mounted config often
         need the gateway/dashboard (different UIDs) to both reach it -- see
         hermes_cli.config._is_container's docstring."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.setenv("HERMES_CONTAINER", "1")
         target = tmp_path / "config.yaml"
         target.write_text("agent:\n  system_prompt: old\n", encoding="utf-8")

--- a/tests/hermes_cli/test_atomic_yaml_write.py
+++ b/tests/hermes_cli/test_atomic_yaml_write.py
@@ -1,5 +1,8 @@
 """Tests for utils.atomic_yaml_write — crash-safe YAML file writes."""
 
+import os
+import stat
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -74,3 +77,50 @@ class TestAtomicYamlWrite:
         assert "(=^･ω･^=)" in text
         # And it reloads to exactly what was written.
         assert yaml.safe_load(text) == data
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX mode bits not enforced on Windows",
+)
+class TestConfigYamlModeCap:
+    """config.yaml must never round-trip wider than 0600 through this
+    function, even for call sites that write it directly without following
+    up with hermes_cli.config._secure_file() (slash commands, auth, doctor
+    migrations, onboarding all do this today).
+
+    Without the cap, a config.yaml that was ever wide (pre-hardening
+    install, a HERMES_HOME_MODE window, a manual chmod) stays wide forever
+    through those call sites, because _restore_file_mode() otherwise
+    round-trips whatever mode the file had before the write.
+    """
+
+    def _mode(self, path) -> int:
+        return stat.S_IMODE(os.stat(path).st_mode)
+
+    def test_wide_preexisting_config_yaml_is_capped_to_0600(self, tmp_path):
+        target = tmp_path / "config.yaml"
+        target.write_text("agent:\n  system_prompt: old\n", encoding="utf-8")
+        os.chmod(target, 0o666)
+
+        atomic_yaml_write(target, {"agent": {"system_prompt": "new"}})
+
+        assert self._mode(target) == 0o600
+
+    def test_new_config_yaml_is_0600(self, tmp_path):
+        target = tmp_path / "config.yaml"
+
+        atomic_yaml_write(target, {"agent": {"system_prompt": "hello"}})
+
+        assert self._mode(target) == 0o600
+
+    def test_non_config_yaml_file_mode_still_preserved(self, tmp_path):
+        """Sanity check: the cap is name-scoped to config.yaml -- it must not
+        regress the Docker/NAS mode-preservation behavior for other files."""
+        target = tmp_path / "other.yaml"
+        target.write_text("key: old\n", encoding="utf-8")
+        os.chmod(target, 0o666)
+
+        atomic_yaml_write(target, {"key": "new"})
+
+        assert self._mode(target) == 0o666

--- a/utils.py
+++ b/utils.py
@@ -35,6 +35,25 @@ def env_var_enabled(name: str, default: str = "") -> bool:
     return is_truthy_value(os.getenv(name, default), default=False)
 
 
+def _skip_config_yaml_mode_cap() -> bool:
+    """True when the config.yaml 0600 cap in atomic_yaml_write should be skipped.
+
+    Mirrors hermes_cli.config._secure_file's own managed/container checks: the
+    NixOS module deliberately sets config.yaml to group-readable 0640 so
+    interactive users in the ``hermes`` group can read it alongside the
+    gateway service, and containers with volume-mounted config often need the
+    gateway/dashboard -- running as different UIDs -- to both reach it.
+    Capping to 0600 would silently fight both of those documented sharing
+    setups. Lazy import avoids a hard dependency from this lower-level module
+    on hermes_cli.config.
+    """
+    try:
+        from hermes_cli.config import is_managed, _is_container
+    except ImportError:
+        return False
+    return is_managed() or _is_container()
+
+
 def _preserve_file_mode(path: Path) -> "int | None":
     """Capture the permission bits of *path* if it exists, else ``None``."""
     try:
@@ -250,7 +269,11 @@ def atomic_yaml_write(
     path.parent.mkdir(parents=True, exist_ok=True)
 
     original_mode = _preserve_file_mode(path)
-    if original_mode is not None and path.name == "config.yaml":
+    if (
+        original_mode is not None
+        and path.name == "config.yaml"
+        and not _skip_config_yaml_mode_cap()
+    ):
         # config.yaml must never round-trip wider than 0600, even if it was
         # ever created wider (pre-hardening install, a HERMES_HOME_MODE
         # window, a manual chmod). save_config() enforces 0600 with a final
@@ -258,7 +281,8 @@ def atomic_yaml_write(
         # config.yaml through this function directly (slash commands, auth,
         # doctor migrations, onboarding) without that follow-up -- capping
         # here closes the gap for all of them at the source instead of
-        # relying on every call site to remember it.
+        # relying on every call site to remember it. Skipped in
+        # managed/container mode (see _skip_config_yaml_mode_cap).
         original_mode &= 0o600
     original_owner = _preserve_file_owner(path)
 

--- a/utils.py
+++ b/utils.py
@@ -250,6 +250,16 @@ def atomic_yaml_write(
     path.parent.mkdir(parents=True, exist_ok=True)
 
     original_mode = _preserve_file_mode(path)
+    if original_mode is not None and path.name == "config.yaml":
+        # config.yaml must never round-trip wider than 0600, even if it was
+        # ever created wider (pre-hardening install, a HERMES_HOME_MODE
+        # window, a manual chmod). save_config() enforces 0600 with a final
+        # _secure_file() chmod, but several other call sites write
+        # config.yaml through this function directly (slash commands, auth,
+        # doctor migrations, onboarding) without that follow-up -- capping
+        # here closes the gap for all of them at the source instead of
+        # relying on every call site to remember it.
+        original_mode &= 0o600
     original_owner = _preserve_file_owner(path)
 
     fd, tmp_path = tempfile.mkstemp(

--- a/utils.py
+++ b/utils.py
@@ -54,6 +54,30 @@ def _skip_config_yaml_mode_cap() -> bool:
     return is_managed() or _is_container()
 
 
+def _is_canonical_hermes_config_yaml(path: Path) -> bool:
+    """True when *path* is Hermes's own config.yaml, not just same-named.
+
+    ``atomic_yaml_write()`` is a generic arbitrary-path YAML writer (Docker/NAS
+    installs route other YAML files through it too), so matching on basename
+    alone would also cap the mode of unrelated files that happen to be named
+    ``config.yaml`` elsewhere. Comparing against the profile-aware canonical
+    path (``hermes_cli.config.get_config_path()``, which honors ``HERMES_HOME``
+    and active-profile resolution) scopes the 0600 cap to Hermes's own config.
+    Lazy import avoids a hard dependency from this lower-level module on
+    hermes_cli.config.
+    """
+    if path.name != "config.yaml":
+        return False
+    try:
+        from hermes_cli.config import get_config_path
+    except ImportError:
+        return False
+    try:
+        return path.resolve() == get_config_path().resolve()
+    except OSError:
+        return False
+
+
 def _preserve_file_mode(path: Path) -> "int | None":
     """Capture the permission bits of *path* if it exists, else ``None``."""
     try:
@@ -271,7 +295,7 @@ def atomic_yaml_write(
     original_mode = _preserve_file_mode(path)
     if (
         original_mode is not None
-        and path.name == "config.yaml"
+        and _is_canonical_hermes_config_yaml(path)
         and not _skip_config_yaml_mode_cap()
     ):
         # config.yaml must never round-trip wider than 0600, even if it was


### PR DESCRIPTION
Fixes #59726

## Problem

`atomic_yaml_write()` (`utils.py`) preserves a file's pre-existing mode across the atomic replace by design, so Docker/NAS-backed installs that rely on broader permissions aren't silently narrowed. `save_config()` enforces `0600` on `config.yaml` on top of that with an explicit `_secure_file()` chmod after the write -- but ~10 other call sites (`gateway/slash_commands.py` x8, `hermes_cli/auth.py` x2, `hermes_cli/doctor.py`, `agent/onboarding.py`, `gateway/platforms/yuanbao.py`, `tui_gateway/server.py`) write `config.yaml` directly through `atomic_yaml_write()` without that follow-up. If `config.yaml` was ever wider than `0600`, any of those call sites re-applies that wide mode forever, since only `save_config()` actually narrows it.

## Fix

```python
original_mode = _preserve_file_mode(path)
if (
    original_mode is not None
    and path.name == "config.yaml"
    and not _skip_config_yaml_mode_cap()
):
    # config.yaml must never round-trip wider than 0600, even if it was
    # ever created wider (pre-hardening install, a HERMES_HOME_MODE
    # window, a manual chmod). save_config() enforces 0600 with a final
    # _secure_file() chmod, but several other call sites write
    # config.yaml through this function directly (slash commands, auth,
    # doctor migrations, onboarding) without that follow-up -- capping
    # here closes the gap for all of them at the source instead of
    # relying on every call site to remember it. Skipped in
    # managed/container mode (see _skip_config_yaml_mode_cap).
    original_mode &= 0o600
```

Name-scoped to `config.yaml` specifically -- every other file `atomic_yaml_write()` touches (there are other YAML configs in the codebase) keeps the existing preserve-on-replace behavior unchanged, so the Docker/NAS use case this function was built for isn't affected.

Considered the alternative of adding `_secure_file()` calls to all ~10 bypass sites instead -- rejected because it's more diff, and any future call site would need to remember to do the same thing. Capping at the one shared function closes it for all current and future writers at once.

**Update:** the cap now also no-ops in managed (NixOS) or container mode, mirroring `hermes_cli.config._secure_file`'s own checks (`is_managed()` / `_is_container()`). The NixOS module deliberately sets `config.yaml` to group-readable `0640` so interactive users in the `hermes` group can read it alongside the gateway service, and containers with volume-mounted config often need the gateway/dashboard -- running as different UIDs -- to both reach it. Forcing `0600` would silently fight both documented sharing setups, so a new `_skip_config_yaml_mode_cap()` gate (lazy-imports `hermes_cli.config`, same pattern as the companion `state.db` fix) short-circuits the cap when either check is true.

## Testing

New `TestConfigYamlModeCap` in `tests/hermes_cli/test_atomic_yaml_write.py` (POSIX-only, skipped on Windows like the repo's other mode-bit tests):

- a pre-existing `0666` `config.yaml` is capped to `0600` after a direct `atomic_yaml_write()` call (the exact bypass scenario above)
- a brand-new `config.yaml` lands at `0600`
- a non-`config.yaml` file (`other.yaml`) keeps the existing preserve-on-replace behavior at `0666` -- confirms the cap is scoped correctly and doesn't regress the Docker/NAS case
- managed mode (`is_managed() == True`) and container mode (`HERMES_CONTAINER=1`) both skip the cap, leaving a wide pre-existing `config.yaml` untouched

`tests/hermes_cli/test_atomic_yaml_write.py` runs clean (4 passed, 5 POSIX-only skipped on this Windows dev box); logic double-checked with a direct manual repro of the managed-mode skip path.

## Scope

Out of scope for this PR, tracked separately: the `HERMES_HOME_MODE` warning and `state.db` creation mode (companion issues/PRs, already merged-pending). Both are real but independent fixes.
