### PR TITLE
fix(provider): expose full model list from Tencent TokenHub API (#59694)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -368,6 +368,24 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "tencent-tokenhub": [
         "hy3-preview",
+        "hy3",
+        "deepseek-v4-flash",
+        "deepseek-v4-flash-202605",
+        "deepseek-v4-pro",
+        "deepseek-v4-pro-202606",
+        "deepseek-v3.2",
+        "glm-5.2",
+        "glm-5.1",
+        "glm-5",
+        "glm-5-turbo",
+        "glm-5v-turbo",
+        "kimi-k2.7-code-highspeed",
+        "kimi-k2.6",
+        "kimi-k2.5",
+        "minimax-m3",
+        "minimax-m2.7",
+        "minimax-m2.5",
+        "hy-mt2-plus",
     ],
     "arcee": [
         "trinity-large-thinking",
@@ -2403,6 +2421,19 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             from hermes_cli.auth import resolve_api_key_provider_credentials
 
             creds = resolve_api_key_provider_credentials("gmi")
+            api_key = str(creds.get("api_key") or "").strip()
+            base_url = str(creds.get("base_url") or "").strip()
+            if api_key and base_url:
+                live = fetch_api_models(api_key, base_url)
+                if live:
+                    return live
+        except Exception:
+            pass
+    if normalized == "tencent-tokenhub":
+        try:
+            from hermes_cli.auth import resolve_api_key_provider_credentials
+
+            creds = resolve_api_key_provider_credentials("tencent-tokenhub")
             api_key = str(creds.get("api_key") or "").strip()
             base_url = str(creds.get("base_url") or "").strip()
             if api_key and base_url:


### PR DESCRIPTION
## Summary

Fixes #59694 — Tencent TokenHub provider only showed 1 model (`hy3-preview`) despite the API returning ~58 models.

## Changes

1. **Live-fetch handler** in `provider_model_ids()` — follows the same pattern as `stepfun` and `gmi`: resolves credentials via `resolve_api_key_provider_credentials()`, calls `fetch_api_models()` to pull the live model catalog from the configured Tencent TokenHub endpoint.

2. **Expanded static fallback** — added 18 additional models from the Tencent TokenHub API to `_PROVIDER_MODELS["tencent-tokenhub"]` so users also see them when offline/fallback path kicks in.

## Root Cause

`provider_model_ids("tencent-tokenhub")` had no dedicated live-fetch handler, falling through to the static `_PROVIDER_MODELS["tencent-tokenhub"]` list which contained only `["hy3-preview"]`.

Closes #59694