### PR TITLE
fix(computer-use): fail unverified CUA actions closed

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1987,6 +1987,103 @@ class TestClickButtonPassthrough:
         assert args["x"] == 10 and args["y"] == 20
 
 
+class TestCuaActionVerificationAndWindowTargeting:
+    def _backend_with_active_target(self, *, data: Any = "ok",
+                                    structured: Dict[str, Any] | None = None):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session.call_tool.return_value = {
+            "data": data,
+            "images": [],
+            "image_mime_types": [],
+            "structuredContent": structured,
+            "isError": False,
+        }
+        backend._session.supports_capability = lambda cap, tool=None: False
+        backend._active_pid = 123
+        backend._active_window_id = 456
+        backend._session_id = "hermes-test-session"
+        return backend
+
+    def test_action_fails_closed_when_driver_reports_unverified(self):
+        backend = self._backend_with_active_target(
+            data="Sent (unverified) 5 char(s).",
+            structured={
+                "verified": False,
+                "effect": "unverifiable",
+                "path": "key_events",
+            },
+        )
+
+        result = backend._action("type_text", {"pid": 123, "text": "hello"})
+
+        assert result.ok is False
+        assert result.message == "Sent (unverified) 5 char(s)."
+        assert result.meta["verified"] is False
+        assert result.meta["effect"] == "unverifiable"
+        assert result.meta["path"] == "key_events"
+
+    def test_type_text_carries_window_id_and_fails_closed(self):
+        backend = self._backend_with_active_target(
+            data="Sent (unverified) 5 char(s).",
+            structured={
+                "verified": False,
+                "effect": "unverifiable",
+                "path": "key_events",
+            },
+        )
+
+        result = backend.type_text("hello")
+
+        assert result.ok is False
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "type_text"
+        assert args["pid"] == 123
+        assert args["window_id"] == 456
+        assert args["text"] == "hello"
+
+    def test_key_actions_carry_window_id(self):
+        backend = self._backend_with_active_target(
+            data={"message": "ok"},
+            structured={"verified": True},
+        )
+
+        result = backend.key("a")
+        assert result.ok is True
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "press_key"
+        assert args["pid"] == 123
+        assert args["window_id"] == 456
+        assert args["key"] == "a"
+
+        backend.key("cmd+a")
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "hotkey"
+        assert args["pid"] == 123
+        assert args["window_id"] == 456
+        assert args["keys"] == ["cmd", "a"]
+
+    def test_key_actions_fail_closed_when_driver_reports_unverified(self):
+        backend = self._backend_with_active_target(
+            data={"message": "sent but unverified"},
+            structured={
+                "verified": False,
+                "effect": "unverifiable",
+                "path": "key_events",
+            },
+        )
+
+        result = backend.key("cmd+a")
+
+        assert result.ok is False
+        assert result.message == "sent but unverified"
+        assert result.meta["verified"] is False
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "hotkey"
+        assert args["window_id"] == 456
+
+
 class TestImageMimeTypePropagation:
     """Surface 7 (NousResearch/hermes-agent#47072): trycua/cua#1961 made
     `mimeType` part of every MCP image-part response, so the wrapper no

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1679,7 +1679,10 @@ class CuaDriverBackend(ComputerUseBackend):
         if pid is None:
             return ActionResult(ok=False, action="type_text",
                                 message="No active window — call capture() first.")
-        return self._action("type_text", {"pid": pid, "text": text})
+        args: Dict[str, Any] = {"pid": pid, "text": text}
+        if self._active_window_id is not None:
+            args["window_id"] = self._active_window_id
+        return self._action("type_text", args)
 
     def key(self, keys: str) -> ActionResult:
         pid = self._active_pid
@@ -1692,11 +1695,17 @@ class CuaDriverBackend(ComputerUseBackend):
             return ActionResult(ok=False, action="key",
                                 message=f"Could not parse key from '{keys}'.")
 
+        args: Dict[str, Any] = {"pid": pid}
+        if self._active_window_id is not None:
+            args["window_id"] = self._active_window_id
+
         if modifiers:
             # hotkey requires at least one modifier + one key.
-            return self._action("hotkey", {"pid": pid, "keys": modifiers + [key_name]})
+            args["keys"] = modifiers + [key_name]
+            return self._action("hotkey", args)
         else:
-            return self._action("press_key", {"pid": pid, "key": key_name})
+            args["key"] = key_name
+            return self._action("press_key", args)
 
     # ── Value setter ────────────────────────────────────────────────
     def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
@@ -2094,9 +2103,15 @@ class CuaDriverBackend(ComputerUseBackend):
         ok = not out["isError"]
         message = ""
         data = out["data"]
+        meta: Dict[str, Any] = {}
         if isinstance(data, dict):
             message = str(data.get("message", ""))
+            meta.update(data)
         elif isinstance(data, str):
             message = data
-        return ActionResult(ok=ok, action=name, message=message,
-                            meta=data if isinstance(data, dict) else {})
+        structured = out.get("structuredContent")
+        if isinstance(structured, dict):
+            meta.update(structured)
+            if structured.get("verified") is False:
+                ok = False
+        return ActionResult(ok=ok, action=name, message=message, meta=meta)


### PR DESCRIPTION
## What does this PR do?

Fail CUA-backed `computer_use` actions closed when `cua-driver` reports `structuredContent.verified: false`, and preserve the structured action metadata in `ActionResult.meta` even when the human-readable `data` field is a string.

The same change also sends the active `window_id` on keyboard actions (`type_text`, `press_key`, `hotkey`) when `capture()` has already resolved a target window. That keeps keyboard input aligned with the same window-local targeting contract already used by capture, `set_value`, and element actions.

This is related to #59387, which preserves structured action metadata and adds `window_id` for coordinate pointer actions. It does not duplicate that PR completely: #59387 still returns `ok=True` for `verified:false` and does not pass `window_id` for bare active-window `type_text`/key actions.

## Related Issue

Fixes #59731

Related: #59387

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/computer_use/cua_backend.py`
  - merge `structuredContent` into action metadata for all CUA actions
  - set `ActionResult.ok=False` when `structuredContent.verified is False`
  - include active `window_id` on `type_text`, `press_key`, and `hotkey` calls when available
- `tests/tools/test_computer_use.py`
  - add regression coverage for `verified:false` fail-closed behavior
  - add coverage that `type_text`, `press_key`, and `hotkey` carry `window_id`
  - add coverage that unverified key actions fail closed

## How to Test

Reproduced on latest `origin/main` at `7426c09bee` with an isolated fake CUA session: `type_text` and `hotkey` returned `result_ok: true`, empty metadata, and no `window_id`, even though the simulated driver payload contained `structuredContent.verified: false`.

Patched commit `cdd9b29eaf` returns `result_ok: false`, preserves `verified:false`/`effect`/`path` in `meta`, and sends `window_id: 456` for the same active-window keyboard calls.

Validation run locally:

```bash
scripts/run_tests.sh tests/tools/test_computer_use.py tests/tools/test_computer_use_null_pid_windows.py tests/computer_use/test_doctor.py tests/computer_use/test_cua_spawn_env_sanitization.py -q
# 202 tests passed, 0 failed

python -m ruff check tools/computer_use/cua_backend.py tests/tools/test_computer_use.py tests/tools/test_computer_use_null_pid_windows.py tests/computer_use/test_doctor.py tests/computer_use/test_cua_spawn_env_sanitization.py
# All checks passed!

git diff --check
# passed

python -m py_compile tools/computer_use/cua_backend.py tests/tools/test_computer_use.py
# passed
```

Non-destructive live smoke on macOS with `cua-driver 0.7.0` also passed: backend start, `list_apps`, and `capture(mode="som")` completed successfully.

Real action smoke on macOS with a disposable Tk text window:

- Hermes resolved the probe window via real `cua-driver` `list_windows` (`app_name: "python"`, concrete `pid` and `window_id`).
- `backend.type_text(...)` sent the active `window_id` and the Tk process observed the typed text land in the widget.
- The real driver still returned `structuredContent.verified: false` (`path: "key_events"`, `effect: "unverifiable"`), so the patched branch returned `ActionResult.ok == False` while preserving that metadata.
- A direct foreground delivery probe also landed text, but `cua-driver` still returned `verified:false` (`path: "key_events_fg"`). This is a driver verification limitation; the wrapper should not report it as confirmed success.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched existing issues and PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, with isolated synthetic CUA repro and non-destructive live CUA smoke

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Baseline `origin/main` synthetic repro:

```json
{
  "type_text": {"result_ok": true, "result_meta": {}, "call_args": {"pid": 123, "session": "hermes-repro-fake", "text": "hello"}},
  "hotkey": {"result_ok": true, "result_meta": {}, "call_args": {"pid": 123, "session": "hermes-repro-fake", "keys": ["cmd", "a"]}}
}
```

Patched synthetic repro:

```json
{
  "type_text": {"result_ok": false, "result_meta": {"verified": false, "effect": "unverifiable", "path": "key_events"}, "call_args": {"pid": 123, "session": "hermes-repro-fake", "text": "hello", "window_id": 456}},
  "hotkey": {"result_ok": false, "result_meta": {"verified": false, "effect": "unverifiable", "path": "key_events"}, "call_args": {"pid": 123, "session": "hermes-repro-fake", "keys": ["cmd", "a"], "window_id": 456}}
}
```



