### PR TITLE
fix: use bearer auth for qweapi anthropic endpoints

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -482,6 +482,7 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     normalized = normalized.rstrip("/").lower()
     return (
         normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
+        or base_url_host_matches(normalized, "qweapi.com")
         or "azure.com" in normalized
     )
 


### PR DESCRIPTION
## Summary
- Use Bearer auth for qweapi Anthropic-compatible endpoints

## Test Plan
- Activated local `.venv`
- Verified `_requires_bearer_auth()` returns true for qweapi and MiniMax endpoints, false for official Anthropic endpoint

## Notes
- Only `agent/anthropic_adapter.py` was staged/committed
- Local large untracked work directories were left untouched
