### PR TITLE
security(backup): default hermes backup under HERMES_HOME, chmod 0600

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -8,20 +8,24 @@ Backup and import commands for hermes CLI.
 HERMES_HOME root.
 """
 
+import contextlib
 import json
 import logging
 import os
 import shutil
 import sqlite3
+import stat
 import sys
 import tempfile
 import time
+import uuid
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
+from utils import atomic_replace
 
 logger = logging.getLogger(__name__)
 
@@ -289,6 +293,41 @@ def _format_size(nbytes: int) -> str:
     return f"{nbytes:.1f} TB"
 
 
+@contextlib.contextmanager
+def _atomic_owner_only_zip(out_path: Path) -> Iterator[zipfile.ZipFile]:
+    """Yield a ``ZipFile`` that lands at *out_path* as an owner-only 0o600 file.
+
+    ``zipfile.ZipFile(out_path, "w")`` would create the archive under the
+    process umask (often 0o644), leaving a TOCTOU window where a
+    secret-bearing backup (auth.json/state.db/config.yaml) is world- or
+    group-readable until a later chmod runs. Instead this stages the zip in
+    a sibling temp file created 0o600 from the first byte via O_EXCL, then
+    atomically replaces *out_path* on success -- mirroring the auth.json
+    write path (hermes_cli/auth.py:1125-1138, PR #59736 review).
+
+    On any exception the temp file is discarded and *out_path* is left
+    untouched.
+    """
+    tmp_path = out_path.parent / f".{out_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+    fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, stat.S_IRUSR | stat.S_IWUSR)
+    handle = os.fdopen(fd, "wb")
+    try:
+        with zipfile.ZipFile(handle, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+            yield zf
+        handle.flush()
+        os.fsync(handle.fileno())
+    except BaseException:
+        handle.close()
+        tmp_path.unlink(missing_ok=True)
+        raise
+    handle.close()
+    real_path = atomic_replace(tmp_path, out_path)
+    try:
+        os.chmod(real_path, stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+
+
 def run_backup(args) -> None:
     """Create a zip backup of the Hermes home directory."""
     hermes_root = get_default_hermes_root()
@@ -386,7 +425,7 @@ def run_backup(args) -> None:
     errors = []
     t0 = time.monotonic()
 
-    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+    with _atomic_owner_only_zip(out_path) as zf:
         for i, (abs_path, rel_path) in enumerate(files_to_add, 1):
             try:
                 # Safe copy for SQLite databases (handles WAL mode)
@@ -428,15 +467,6 @@ def run_backup(args) -> None:
             except (PermissionError, OSError, ValueError) as exc:
                 errors.append(f"  {arcname}: {exc}")
                 continue
-
-    # The zip carries auth.json/state.db/config.yaml verbatim -- lock it down
-    # regardless of where it landed (default backups/ dir or an explicit
-    # --output elsewhere), since it's an artifact meant to be moved/copied
-    # and can't rely on inheriting protection from its parent directory.
-    try:
-        os.chmod(out_path, 0o600)
-    except OSError:
-        pass
 
     elapsed = time.monotonic() - t0
     zip_size = out_path.stat().st_size
@@ -1192,7 +1222,7 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
         return None
 
     try:
-        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        with _atomic_owner_only_zip(out_path) as zf:
             for abs_path, rel_path in files_to_add:
                 try:
                     if abs_path.suffix == ".db":
@@ -1216,11 +1246,6 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                     continue
     except OSError as exc:
         logger.warning("Full-zip backup: zip write failed: %s", exc)
-        # Best-effort cleanup of partial file
-        try:
-            out_path.unlink(missing_ok=True)
-        except OSError:
-            pass
         return None
 
     return out_path

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -305,8 +305,13 @@ def run_backup(args) -> None:
             stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
             out_path = out_path / f"hermes-backup-{stamp}.zip"
     else:
+        # Default lands under HERMES_HOME/backups/ (the same directory the
+        # pre-update/pre-migration auto-backups use, already excluded from
+        # the file walk below) rather than $HOME directly -- the backup
+        # contains auth.json/state.db/config.yaml, and $HOME isn't
+        # protected by HERMES_HOME's 0700 mode the way ~/.hermes is.
         stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
-        out_path = Path.home() / f"hermes-backup-{stamp}.zip"
+        out_path = hermes_root / "backups" / f"hermes-backup-{stamp}.zip"
 
     # Ensure the suffix is .zip
     if out_path.suffix.lower() != ".zip":
@@ -423,6 +428,15 @@ def run_backup(args) -> None:
             except (PermissionError, OSError, ValueError) as exc:
                 errors.append(f"  {arcname}: {exc}")
                 continue
+
+    # The zip carries auth.json/state.db/config.yaml verbatim -- lock it down
+    # regardless of where it landed (default backups/ dir or an explicit
+    # --output elsewhere), since it's an artifact meant to be moved/copied
+    # and can't rely on inheriting protection from its parent directory.
+    try:
+        os.chmod(out_path, 0o600)
+    except OSError:
+        pass
 
     elapsed = time.monotonic() - t0
     zip_size = out_path.stat().st_size

--- a/hermes_cli/subcommands/backup.py
+++ b/hermes_cli/subcommands/backup.py
@@ -24,7 +24,7 @@ def build_backup_parser(subparsers, *, cmd_backup: Callable) -> None:
     backup_parser.add_argument(
         "-o",
         "--output",
-        help="Output path for the zip file (default: ~/hermes-backup-<timestamp>.zip)",
+        help="Output path for the zip file (default: <HERMES_HOME>/backups/hermes-backup-<timestamp>.zip)",
     )
     backup_parser.add_argument(
         "-q",

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -408,7 +408,11 @@ class TestBackup:
             assert pid_files == []
 
     def test_default_output_path(self, tmp_path, monkeypatch):
-        """When no output path given, zip goes to ~/hermes-backup-*.zip."""
+        """When no output path given, zip goes under HERMES_HOME/backups/,
+        not $HOME -- the backup carries auth.json/state.db/config.yaml, and
+        $HOME isn't protected by HERMES_HOME's 0700 mode the way ~/.hermes
+        is (see security hardening: the zip must not rely on inheriting
+        protection from a directory Hermes doesn't control)."""
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         (hermes_home / "config.yaml").write_text("model: test\n")
@@ -421,9 +425,40 @@ class TestBackup:
         from hermes_cli.backup import run_backup
         run_backup(args)
 
-        # Should exist in home dir
-        zips = list(tmp_path.glob("hermes-backup-*.zip"))
+        # Should NOT leak into $HOME.
+        assert list(tmp_path.glob("hermes-backup-*.zip")) == []
+
+        # Should exist under HERMES_HOME/backups/ instead.
+        zips = list((hermes_home / "backups").glob("hermes-backup-*.zip"))
         assert len(zips) == 1
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
+    def test_zip_is_owner_only_regardless_of_destination(self, tmp_path, monkeypatch):
+        """The zip must land at 0600 whether it's the default backups/
+        location or an explicit --output elsewhere -- it carries
+        auth.json/state.db/config.yaml and is meant to be moved/copied, so
+        it can't rely on its parent directory for protection."""
+        import stat
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("model: test\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        old_umask = os.umask(0o022)
+        try:
+            from hermes_cli.backup import run_backup
+
+            run_backup(Namespace(output=None))
+            default_zip = next((hermes_home / "backups").glob("hermes-backup-*.zip"))
+            assert stat.S_IMODE(default_zip.stat().st_mode) == 0o600
+
+            explicit_zip = tmp_path / "explicit-backup.zip"
+            run_backup(Namespace(output=str(explicit_zip)))
+            assert stat.S_IMODE(explicit_zip.stat().st_mode) == 0o600
+        finally:
+            os.umask(old_umask)
 
     def test_skips_symlinked_files(self, tmp_path, monkeypatch):
         """Backup must not dereference symlinks and leak files outside HERMES_HOME."""

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -460,6 +460,46 @@ class TestBackup:
         finally:
             os.umask(old_umask)
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
+    def test_atomic_owner_only_zip_stages_0600_before_write(self, tmp_path):
+        """The staging temp file must be created 0600 (via O_EXCL) before any
+        bytes are written -- ``zipfile.ZipFile(path, "w")`` alone creates the
+        archive under the process umask, leaving a window where a
+        secret-bearing backup is world/group-readable until a later chmod
+        (the TOCTOU teknium1 flagged on PR #59736)."""
+        import stat
+
+        from hermes_cli.backup import _atomic_owner_only_zip
+
+        out_path = tmp_path / "out.zip"
+        old_umask = os.umask(0o022)
+        try:
+            with _atomic_owner_only_zip(out_path) as zf:
+                tmp_files = [
+                    p for p in tmp_path.iterdir() if p.name.startswith(".out.zip.tmp.")
+                ]
+                assert len(tmp_files) == 1
+                assert stat.S_IMODE(tmp_files[0].stat().st_mode) == 0o600
+                zf.writestr("hello.txt", "world")
+            assert stat.S_IMODE(out_path.stat().st_mode) == 0o600
+            assert [p for p in tmp_path.iterdir() if p.name.startswith(".out.zip.tmp.")] == []
+        finally:
+            os.umask(old_umask)
+
+    def test_atomic_owner_only_zip_discards_tmp_on_error(self, tmp_path):
+        """A failure mid-write must leave neither a partial *out_path* nor a
+        leftover temp file behind."""
+        from hermes_cli.backup import _atomic_owner_only_zip
+
+        out_path = tmp_path / "out.zip"
+        with pytest.raises(RuntimeError):
+            with _atomic_owner_only_zip(out_path) as zf:
+                zf.writestr("hello.txt", "world")
+                raise RuntimeError("boom")
+
+        assert not out_path.exists()
+        assert [p for p in tmp_path.iterdir() if p.name.startswith(".out.zip.tmp.")] == []
+
     def test_skips_symlinked_files(self, tmp_path, monkeypatch):
         """Backup must not dereference symlinks and leak files outside HERMES_HOME."""
         hermes_home = tmp_path / ".hermes"
@@ -1918,6 +1958,24 @@ class TestPreUpdateBackup:
         assert out.parent == hermes_home / "backups"
         assert out.name.startswith("pre-update-")
         assert out.suffix == ".zip"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
+    def test_zip_is_owner_only(self, hermes_home):
+        """Pre-update backups carry the same secrets as ``hermes backup``
+        (auth.json/state.db/config.yaml) and share its zip writer, so they
+        must land 0600 regardless of process umask -- not just the
+        interactive ``hermes backup`` path."""
+        import stat
+
+        from hermes_cli.backup import create_pre_update_backup
+
+        old_umask = os.umask(0o022)
+        try:
+            out = create_pre_update_backup(hermes_home=hermes_home)
+        finally:
+            os.umask(old_umask)
+        assert out is not None
+        assert stat.S_IMODE(out.stat().st_mode) == 0o600
 
     def test_backup_contents_match_full_backup(self, hermes_home):
         """Pre-update backup should include the same user data that

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -800,7 +800,7 @@ Create a zip archive of your Hermes configuration, skills, sessions, and data. T
 
 | Option | Description |
 |--------|-------------|
-| `-o`, `--output <path>` | Output path for the zip file (default: `~/hermes-backup-<timestamp>.zip`). |
+| `-o`, `--output <path>` | Output path for the zip file (default: `~/.hermes/backups/hermes-backup-<timestamp>.zip`). |
 | `-q`, `--quick` | Quick snapshot: only critical state files (config.yaml, state.db, .env, auth, cron jobs). Much faster than a full backup. |
 | `-l`, `--label <name>` | Label for the snapshot (only used with `--quick`). |
 
@@ -815,7 +815,7 @@ The backup uses SQLite's `backup()` API for safe copying, so it works correctly 
 ### Examples
 
 ```bash
-hermes backup                           # Full backup to ~/hermes-backup-*.zip
+hermes backup                           # Full backup to ~/.hermes/backups/hermes-backup-*.zip
 hermes backup -o /tmp/hermes.zip        # Full backup to specific path
 hermes backup --quick                   # Quick state-only snapshot
 hermes backup --quick --label "pre-upgrade"  # Quick snapshot with label
@@ -877,8 +877,8 @@ Stop the gateway before importing to avoid conflicts with running processes.
 
 ### Examples
 ```bash
-hermes import ~/hermes-backup-20260423.zip           # Prompts before overwriting existing config
-hermes import ~/hermes-backup-20260423.zip --force   # Overwrite without prompting
+hermes import ~/.hermes/backups/hermes-backup-20260423.zip           # Prompts before overwriting existing config
+hermes import ~/.hermes/backups/hermes-backup-20260423.zip --force   # Overwrite without prompting
 ```
 
 ## `hermes logs`

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -743,12 +743,12 @@ Skills with very long descriptions are truncated to 40 characters in the Telegra
    ```bash
    hermes backup
    ```
-   This creates a zip of your entire `~/.hermes/` directory — config, API keys, memories, skills, sessions, and profiles — saved to your home directory as `~/hermes-backup-<timestamp>.zip`.
+   This creates a zip of your entire `~/.hermes/` directory — config, API keys, memories, skills, sessions, and profiles — saved as `~/.hermes/backups/hermes-backup-<timestamp>.zip` (owner-only, mode `0600`, since it carries those secrets verbatim).
 
 3. Copy the zip to the new machine and import it:
    ```bash
    # On the source machine
-   scp ~/hermes-backup-<timestamp>.zip newmachine:~/
+   scp ~/.hermes/backups/hermes-backup-<timestamp>.zip newmachine:~/
 
    # On the new machine
    hermes import ~/hermes-backup-<timestamp>.zip

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/cli-commands.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/cli-commands.md
@@ -603,7 +603,7 @@ hermes backup [options]
 
 | 选项 | 说明 |
 |--------|-------------|
-| `-o`, `--output <path>` | zip 文件的输出路径（默认：`~/hermes-backup-<timestamp>.zip`）。 |
+| `-o`, `--output <path>` | zip 文件的输出路径（默认：`~/.hermes/backups/hermes-backup-<timestamp>.zip`）。 |
 | `-q`, `--quick` | 快速快照：仅包含关键状态文件（config.yaml、state.db、.env、auth、cron 任务）。比完整备份快得多。 |
 | `-l`, `--label <name>` | 快照标签（仅与 `--quick` 配合使用）。 |
 
@@ -618,7 +618,7 @@ hermes backup [options]
 ### 示例
 
 ```bash
-hermes backup                           # 完整备份到 ~/hermes-backup-*.zip
+hermes backup                           # 完整备份到 ~/.hermes/backups/hermes-backup-*.zip
 hermes backup -o /tmp/hermes.zip        # 完整备份到指定路径
 hermes backup --quick                   # 仅状态快速快照
 hermes backup --quick --label "pre-upgrade"  # 带标签的快速快照
@@ -680,8 +680,8 @@ hermes import <zipfile> [options]
 
 ### 示例
 ```bash
-hermes import ~/hermes-backup-20260423.zip           # 覆盖现有配置前提示确认
-hermes import ~/hermes-backup-20260423.zip --force   # 不提示直接覆盖
+hermes import ~/.hermes/backups/hermes-backup-20260423.zip           # 覆盖现有配置前提示确认
+hermes import ~/.hermes/backups/hermes-backup-20260423.zip --force   # 不提示直接覆盖
 ```
 
 ## `hermes logs`


### PR DESCRIPTION
Fixes #59735

## Problem

`run_backup()` (`hermes_cli/backup.py`) defaulted to `Path.home() / f"hermes-backup-{stamp}.zip"` when `--output` wasn't given, and never chmod'd the resulting zip -- it landed at the process umask (`0644` under the common `022` default). The zip carries `auth.json`, `state.db`, and `config.yaml` verbatim.

`~/.hermes`'s `0700` mode is Hermes's actual protection for those files; `$HOME` isn't created or secured by Hermes, and its default mode is inconsistent across environments (`0700` on Debian/RHEL-family/Amazon Linux, `0750` group-readable on Ubuntu, `02755` world-readable under Alpine's busybox `adduser` -- tested directly, not assumed). A backup is also, by nature, meant to be copied elsewhere (upload, scp, cloud sync) -- at that point the zip's own mode is the only protection left regardless of where it started.

## Fix

```python
else:
    # Default lands under HERMES_HOME/backups/ (the same directory the
    # pre-update/pre-migration auto-backups use, already excluded from
    # the file walk below) rather than $HOME directly -- the backup
    # contains auth.json/state.db/config.yaml, and $HOME isn't
    # protected by HERMES_HOME's 0700 mode the way ~/.hermes is.
    stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
    out_path = hermes_root / "backups" / f"hermes-backup-{stamp}.zip"
```

and, after the zip is fully written:

```python
# The zip carries auth.json/state.db/config.yaml verbatim -- lock it down
# regardless of where it landed (default backups/ dir or an explicit
# --output elsewhere), since it's an artifact meant to be moved/copied
# and can't rely on inheriting protection from its parent directory.
try:
    os.chmod(out_path, 0o600)
except OSError:
    pass
```

`backups/` was already in `_EXCLUDED_DIRS` (used by the pre-update/pre-migration auto-backup paths), so the new default doesn't self-include or nest with prior backups.

## Testing

Updated `TestBackup::test_default_output_path` to assert the zip lands under `HERMES_HOME/backups/` and does *not* leak into `$HOME`. Added `test_zip_is_owner_only_regardless_of_destination` (POSIX-only): confirms `0600` both for the new default location and for an explicit `--output` elsewhere, under `umask 0022`.

Full `tests/hermes_cli/test_backup.py` (146 tests) run clean in a Linux sandbox. Windows run: 3 pre-existing failures confirmed unrelated (Windows path-separator string matching in profile-restoration and kanban-snapshot tests, reproduced identically on unmodified `main`) -- none touch the code this PR changes.

## Scope

Out of scope for this PR, tracked separately: `HERMES_HOME_MODE` validation warning, `state.db` creation mode, and `config.yaml` mode round-tripping (companion issues/PRs, already open). All are real but independent fixes.