### PR TITLE
fix(agent): skip compression when latest summary leaves no messages to summarize

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2777,6 +2777,15 @@ This compaction should PRIORITISE preserving all information related to the focu
             if summary_body and not self._previous_summary:
                 self._previous_summary = summary_body
             turns_to_summarize = messages[max(compress_start, summary_idx + 1):compress_end]
+            if not turns_to_summarize:
+                self._ineffective_compression_count += 1
+                self._last_compression_savings_pct = 0.0
+                if not self.quiet_mode:
+                    logger.warning(
+                        "Compression skipped: latest context summary leaves no messages "
+                        "between protected head and tail"
+                    )
+                return messages
         elif self._previous_summary:
             # No handoff summary found in the current messages, but
             # _previous_summary is non-empty — it was set by a different


### PR DESCRIPTION
Closes #59496

When a persisted handoff summary sits in the protected head after resume, the compression window recomputes `turns_to_summarize` as an empty slice. Previously Hermes would call `_generate_summary([])`, which triggers a noisy 'Context compression aborted' warning with no actual data loss.

This adds an early-return guard immediately after the slice is recomputed, mirroring the earlier `compress_start >= compress_end` no-op path and avoiding an unnecessary context engine request.