### PR TITLE
fix(hermes_cli): chmod 0600 on hermes backup zip

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -427,6 +427,11 @@ def run_backup(args) -> None:
     elapsed = time.monotonic() - t0
     zip_size = out_path.stat().st_size
 
+    # The zip may contain auth.json, state.db, and config.yaml — ensure it
+    # is only readable by the owner, even when the umask is permissive or
+    # the file is copied outside $HOME.
+    os.chmod(out_path, 0o600)
+
     # Summary
     print()
     print(f"Backup complete: {out_path}")


### PR DESCRIPTION
Closes #59735

The backup zip defaults to $HOME and contains auth.json, state.db, and config.yaml. Without an explicit chmod it lands at 0644 (umask 022), making those secrets world-readable the moment the zip is copied outside $HOME.

This adds `os.chmod(out_path, 0o600)` unconditionally after the zipfile is closed, regardless of whether `--output` was used.