### PR TITLE
fix(utils): cap config.yaml mode at 0600 in atomic_yaml_write

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -282,6 +282,12 @@ def atomic_yaml_write(
         real_path = atomic_replace(tmp_path, path)
         real_path_obj = Path(real_path)
         _restore_file_owner(real_path_obj, original_owner)
+        # config.yaml may carry quick_commands executed with shell=True —
+        # cap the restored mode to 0600 so any write path that bypasses
+        # save_config()'s explicit _secure_file() call cannot leave it
+        # world-readable.
+        if path.name == "config.yaml" and original_mode is not None:
+            original_mode = min(original_mode, 0o600)
         _restore_file_mode(real_path_obj, original_mode)
     except BaseException:
         # Match atomic_json_write: cleanup must also happen for process-level


### PR DESCRIPTION
Closes #59726

atomic_yaml_write() preserves the original file mode before writing, then restores it afterward. If config.yaml was ever wider than 0600, every one of the ~10 call sites that bypass save_config()'s explicit _secure_file() call re-applies that wide mode.

This adds a mode cap (min(original_mode, 0o600)) when the target is config.yaml, so all call paths — /personality, /memory approval, /skills approval, OAuth login flow, Yuanbao channel-bind, TUI config save, etc. — all produce a safe 0600 file. A world-writable config.yaml is a local privilege-escalation primitive via quick_commands executed with shell=True.