### PR TITLE
fix(approval): deny dangerous commands instantly in guest-mode chats

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -513,6 +513,21 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     return await adapter.send(chat_id, content, metadata=metadata)
 
 
+def _resolve_approval_session_is_guest(status_adapter: Any, status_chat_id: Any) -> bool:
+    """Return whether *status_chat_id* is currently a guest-mode (non-member)
+    chat, per *status_adapter*'s own ``_is_guest_chat`` predicate.
+
+    A no-op (always False) until an adapter defines ``_is_guest_chat`` --
+    today none does; the Telegram Bot API 10.0 guest-mode work (see
+    plugins/platforms/telegram/adapter.py's ``_pending_guest_queries`` /
+    ``_guest_only_chats``) supplies the real predicate. Extracted to its own
+    function so this wiring is testable against that concrete adapter
+    contract independent of driving a full gateway turn.
+    """
+    is_guest_chat_fn = getattr(status_adapter, "_is_guest_chat", None)
+    return bool(callable(is_guest_chat_fn) and is_guest_chat_fn(status_chat_id))
+
+
 def _resolve_progress_thread_id(platform: Any, source_thread_id: Any, event_message_id: Any) -> Optional[str]:
     """Return thread/root ID that progress/status bubbles should target."""
     platform_value = getattr(platform, "value", platform)
@@ -19388,9 +19403,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # _await_gateway_decision short-circuit) instead of blocking the
             # agent thread for the full gateway_timeout on an approval that
             # can structurally never arrive.
-            _is_guest_chat_fn = getattr(_status_adapter, "_is_guest_chat", None)
-            _approval_session_is_guest = bool(
-                callable(_is_guest_chat_fn) and _is_guest_chat_fn(_status_chat_id)
+            _approval_session_is_guest = _resolve_approval_session_is_guest(
+                _status_adapter, _status_chat_id
             )
             if _approval_session_is_guest:
                 mark_session_guest(_approval_session_key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19114,9 +19114,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # The callback bridges sync→async to send the approval request
             # to the user immediately.
             from tools.approval import (
+                mark_session_guest,
                 register_gateway_notify,
                 reset_current_session_key,
                 set_current_session_key,
+                unmark_session_guest,
                 unregister_gateway_notify,
             )
 
@@ -19379,6 +19381,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
+            # Guest-mode Telegram chats (Bot API 10.0 @mention from a chat the
+            # bot isn't a member of) can never present or resolve an
+            # interactive approval prompt -- mark the session so a dangerous
+            # command denies immediately (tools/approval.py's
+            # _await_gateway_decision short-circuit) instead of blocking the
+            # agent thread for the full gateway_timeout on an approval that
+            # can structurally never arrive.
+            _is_guest_chat_fn = getattr(_status_adapter, "_is_guest_chat", None)
+            _approval_session_is_guest = bool(
+                callable(_is_guest_chat_fn) and _is_guest_chat_fn(_status_chat_id)
+            )
+            if _approval_session_is_guest:
+                mark_session_guest(_approval_session_key)
             try:
                 # If _prepare_inbound_message_text buffered image paths for native
                 # attachment, wrap the user turn as an OpenAI-style multimodal
@@ -19430,6 +19445,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
             finally:
                 unregister_gateway_notify(_approval_session_key)
+                if _approval_session_is_guest:
+                    unmark_session_guest(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent
                 # threads don't hang past the end of the run (interrupt,
                 # completion, gateway shutdown).  Idempotent.

--- a/tests/gateway/test_resolve_approval_session_is_guest.py
+++ b/tests/gateway/test_resolve_approval_session_is_guest.py
@@ -1,0 +1,202 @@
+"""gateway.run._resolve_approval_session_is_guest against the concrete Bot
+API 10.0 guest-mode adapter contract (plugins/platforms/telegram/adapter.py's
+``_is_guest_chat``, ``_pending_guest_queries``, ``_guest_only_chats`` — see
+the linked #56476 guest-mode PR), plus a regression test for the smart-
+approval bypass sweeper flagged: a guest session must deny BEFORE smart
+approval or cached per-session grants get a chance to auto-approve.
+
+Not theorized: no adapter on current main defines ``_is_guest_chat`` yet, so
+tests/tools/test_approval.py's own guest-mode tests exercise the approval
+short-circuit by calling ``mark_session_guest``/``unmark_session_guest``
+directly. The tests below instead build a stub adapter with the REAL shape
+#56476 ships (same attribute names, same ``str(chat_id)`` key normalization)
+and drive it through the actual ``getattr``-based wiring extracted from
+``gateway/run.py``, so the integration between that wiring and a real guest
+predicate is exercised — not just the approval module's internal state.
+"""
+from __future__ import annotations
+
+import os
+
+from unittest.mock import MagicMock
+
+from gateway.run import _resolve_approval_session_is_guest
+
+
+class _StubGuestAwareAdapter:
+    """Mirrors #56476's TelegramAdapter._is_guest_chat exactly:
+    True while a guest turn is in flight (_pending_guest_queries) or for
+    the remainder of processing after the query was consumed
+    (_guest_only_chats). Keys are normalized via str(chat_id).
+    """
+
+    def __init__(self):
+        self._pending_guest_queries: dict[str, object] = {}
+        self._guest_only_chats: set[str] = set()
+
+    def _is_guest_chat(self, chat_id) -> bool:
+        cid_str = str(chat_id)
+        return self._pending_guest_queries.get(cid_str) is not None or cid_str in self._guest_only_chats
+
+
+def test_false_when_neither_pending_nor_guest_only():
+    adapter = _StubGuestAwareAdapter()
+    assert _resolve_approval_session_is_guest(adapter, "12345") is False
+
+
+def test_true_when_chat_is_pending_guest_query():
+    adapter = _StubGuestAwareAdapter()
+    adapter._pending_guest_queries["12345"] = object()
+    assert _resolve_approval_session_is_guest(adapter, "12345") is True
+
+
+def test_true_when_chat_is_guest_only():
+    adapter = _StubGuestAwareAdapter()
+    adapter._guest_only_chats.add("12345")
+    assert _resolve_approval_session_is_guest(adapter, "12345") is True
+
+
+def test_normalizes_non_string_chat_id_like_the_real_predicate_does():
+    """gateway/run.py passes chat_id through as-is (may be int); the real
+    predicate's own str() conversion must still match a string-keyed entry."""
+    adapter = _StubGuestAwareAdapter()
+    adapter._guest_only_chats.add("12345")
+    assert _resolve_approval_session_is_guest(adapter, 12345) is True
+
+
+def test_false_for_adapter_without_is_guest_chat():
+    """Today's reality on main: no adapter defines _is_guest_chat at all --
+    must be a safe no-op, not an AttributeError."""
+    adapter = MagicMock(spec=[])  # no attributes at all
+    assert _resolve_approval_session_is_guest(adapter, "12345") is False
+
+
+def test_false_when_is_guest_chat_is_not_callable():
+    """Defensive: a plain attribute (not a method) must not be invoked."""
+    adapter = MagicMock()
+    adapter._is_guest_chat = "not callable"
+    assert _resolve_approval_session_is_guest(adapter, "12345") is False
+
+
+class TestGuestPredicateDrivesRealApprovalDenial:
+    """End-to-end: a real-shaped guest adapter resolving True, marked via
+    mark_session_guest (exactly as gateway/run.py's turn-dispatch wiring
+    does), must cause check_all_command_guards to deny a dangerous command
+    instantly and WITHOUT ever attempting to send an approval prompt -- both
+    in the default manual-approval flow AND when approvals.mode=smart would
+    otherwise auto-approve. The smart case is the regression this test suite
+    exists for: the guest check used to run only inside
+    _await_gateway_decision, which a smart-approve "approve" verdict never
+    reaches.
+    """
+
+    SESSION_KEY = "test-guest-predicate-session"
+
+    def setup_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._gateway_guest_sessions.clear()
+        mod._session_approved.clear()
+        mod._permanent_approved.clear()
+
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("HERMES_GATEWAY_SESSION", "HERMES_CRON_SESSION",
+                      "HERMES_YOLO_MODE", "HERMES_SESSION_KEY", "HERMES_INTERACTIVE")
+        }
+        os.environ.pop("HERMES_YOLO_MODE", None)
+        os.environ.pop("HERMES_INTERACTIVE", None)
+        os.environ.pop("HERMES_CRON_SESSION", None)
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY
+
+    def teardown_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._gateway_guest_sessions.clear()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _mark_guest_via_real_predicate(self) -> None:
+        from tools.approval import mark_session_guest
+
+        adapter = _StubGuestAwareAdapter()
+        adapter._guest_only_chats.add("999")
+        assert _resolve_approval_session_is_guest(adapter, "999") is True
+        mark_session_guest(self.SESSION_KEY)
+
+    def test_manual_mode_denies_without_notify(self):
+        from tools import approval as mod
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        self._mark_guest_via_real_predicate()
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == []
+
+    def test_smart_mode_approve_verdict_still_denies_guest(self, monkeypatch):
+        """The bug: smart approval's 'approve' verdict used to return
+        approved=True directly, before the guest check (which only lived in
+        _await_gateway_decision) ever ran. A guest session must deny even
+        when the aux LLM would have auto-approved."""
+        from tools import approval as mod
+
+        monkeypatch.setattr(mod, "_get_approval_mode", lambda: "smart")
+        monkeypatch.setattr(mod, "_smart_approve", lambda command, description: "approve")
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        self._mark_guest_via_real_predicate()
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == [], "smart-approve must not reach notify_cb for a guest session"
+
+    def test_cached_session_grant_still_denies_guest(self, monkeypatch):
+        """The other half of the bug: a pattern already approved earlier in
+        the session (is_approved) used to skip straight to approved=True,
+        never reaching the guest check either."""
+        from tools import approval as mod
+
+        monkeypatch.setattr(mod, "_get_approval_mode", lambda: "manual")
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        # Pre-approve the pattern this command will match, as if the user
+        # had approved it earlier in a non-guest turn on the same session.
+        _, pattern_key, _ = mod.detect_dangerous_command("rm -rf .git")
+        mod.approve_session(self.SESSION_KEY, pattern_key)
+        self._mark_guest_via_real_predicate()
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == []
+
+    def test_execute_code_smart_mode_approve_verdict_still_denies_guest(self, monkeypatch):
+        from tools import approval as mod
+
+        monkeypatch.setattr(mod, "_get_approval_mode", lambda: "smart")
+        monkeypatch.setattr(mod, "_smart_approve", lambda command, description: "approve")
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        self._mark_guest_via_real_predicate()
+
+        result = mod.check_execute_code_guard("import os; os.system('rm -rf /')", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == []

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2324,7 +2324,7 @@ class TestApprovalTimeoutIsNotConsent:
         assert "NOT consented" in msg
         assert "Silence is not consent" in msg
         # Both forms of evasion must be named:
-        assert "do NOT retry" in msg.lower() or "Do NOT retry" in msg
+        assert "do not retry" in msg.lower() or "Do NOT retry" in msg
         assert "rephrase" in msg.lower()
         assert "different command" in msg.lower()
 
@@ -2390,6 +2390,134 @@ class TestApprovalTimeoutIsNotConsent:
         assert last_post.get("choice") == "timeout", (
             f"hook choice should be 'timeout' on no-response, got {last_post.get('choice')!r}"
         )
+
+
+class TestGuestModeApprovalShortCircuit:
+    """Guest-mode chats (Telegram Bot API 10.0 @mention, bot not a member)
+    can never present or resolve an interactive approval prompt -- mirrors
+    the existing slash-command carve-out (declines at the front door with a
+    canned message) instead of depending on approval-routing/delivery being
+    fixed first. Session marked guest -> immediate BLOCKED, no queue entry,
+    no notify_cb call, no wait.
+    """
+
+    SESSION_KEY = "test-guest-session"
+
+    def setup_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._gateway_guest_sessions.clear()
+        mod._session_approved.clear()
+        mod._permanent_approved.clear()
+        mod._pending.clear()
+
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("HERMES_GATEWAY_SESSION", "HERMES_CRON_SESSION",
+                      "HERMES_YOLO_MODE",
+                      "HERMES_SESSION_KEY", "HERMES_INTERACTIVE")
+        }
+        os.environ.pop("HERMES_YOLO_MODE", None)
+        os.environ.pop("HERMES_INTERACTIVE", None)
+        os.environ.pop("HERMES_CRON_SESSION", None)
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY
+
+    def teardown_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._gateway_guest_sessions.clear()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_mark_unmark_is_session_guest_roundtrip(self):
+        from tools import approval as mod
+        assert mod.is_session_guest(self.SESSION_KEY) is False
+        mod.mark_session_guest(self.SESSION_KEY)
+        assert mod.is_session_guest(self.SESSION_KEY) is True
+        mod.unmark_session_guest(self.SESSION_KEY)
+        assert mod.is_session_guest(self.SESSION_KEY) is False
+
+    def test_terminal_guard_denies_immediately_without_notify(self):
+        """Guest session: BLOCKED without ever calling notify_cb."""
+        from tools import approval as mod
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        mod.mark_session_guest(self.SESSION_KEY)
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == [], "notify_cb must never be called for a guest session"
+        assert mod._gateway_queues.get(self.SESSION_KEY) in (None, []), (
+            "no queue entry should be created for a guest session"
+        )
+
+    def test_terminal_guard_denial_message_tells_agent_context_not_supported(self):
+        from tools import approval as mod
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: None)
+        mod.mark_session_guest(self.SESSION_KEY)
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        msg = result["message"]
+        assert "BLOCKED" in msg
+        assert "isn't supported in this context" in msg
+        assert "do not retry" in msg.lower()
+
+    def test_terminal_guard_denial_is_fast_even_with_long_timeout(self, monkeypatch):
+        """Must not pay the gateway_timeout wait -- denies before ever queuing."""
+        from tools import approval as mod
+        monkeypatch.setattr(
+            mod, "_get_approval_config",
+            lambda: {"mode": "manual", "gateway_timeout": 300, "timeout": 300},
+        )
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: None)
+        mod.mark_session_guest(self.SESSION_KEY)
+
+        start = time.monotonic()
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+        elapsed = time.monotonic() - start
+
+        assert result["approved"] is False
+        assert elapsed < 2.0, f"guest denial took {elapsed:.2f}s -- should be near-instant"
+
+    def test_execute_code_guard_denies_immediately_without_notify(self):
+        from tools import approval as mod
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        mod.mark_session_guest(self.SESSION_KEY)
+
+        result = mod.check_execute_code_guard("import os; os.system('rm -rf /')", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == []
+
+    def test_non_guest_session_unaffected(self, monkeypatch):
+        """Sanity check: without the guest marker, existing timeout behavior is unchanged."""
+        from tools import approval as mod
+        monkeypatch.setattr(
+            mod, "_get_approval_config",
+            lambda: {"mode": "manual", "gateway_timeout": 1, "timeout": 1},
+        )
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        # Deliberately NOT marking the session as guest.
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "timeout"
+        assert len(notified) == 1, "notify_cb should fire normally for a non-guest session"
 
 
 class TestTirithImportErrorFailOpenPolicy:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1505,6 +1505,18 @@ class _ApprovalEntry:
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+# session_key → guest-mode marker (Telegram Bot API 10.0 @mention from a chat
+# the bot isn't a member of). Guest chats can never present or resolve an
+# interactive approval prompt -- send_exec_approval's sendMessage is rejected
+# ("Forbidden: bot is not a member"), and there is no /approve path reachable
+# from a guest chat (slash commands are hard-blocked there for the same
+# reason). Marking the session lets _await_gateway_decision deny immediately,
+# the same way the adapter already declines slash commands at the front door,
+# instead of registering a queue entry and blocking the agent thread for the
+# full gateway_timeout waiting on an approval that can structurally never
+# arrive. This is independent of send_exec_approval / approval-routing
+# destination (home channel, etc.) -- the notify callback is never invoked.
+_gateway_guest_sessions: set[str] = set()
 
 
 def register_gateway_notify(session_key: str, cb) -> None:
@@ -1530,6 +1542,30 @@ def unregister_gateway_notify(session_key: str) -> None:
         entries = _gateway_queues.pop(session_key, [])
     for entry in entries:
         entry.event.set()
+
+
+def mark_session_guest(session_key: str) -> None:
+    """Mark *session_key* as a guest-mode chat for the duration of this turn.
+
+    Call once per turn dispatch, alongside :func:`register_gateway_notify`.
+    """
+    with _lock:
+        _gateway_guest_sessions.add(session_key)
+
+
+def unmark_session_guest(session_key: str) -> None:
+    """Clear the guest-mode marker for *session_key*.
+
+    Call once per turn teardown, alongside :func:`unregister_gateway_notify`.
+    """
+    with _lock:
+        _gateway_guest_sessions.discard(session_key)
+
+
+def is_session_guest(session_key: str) -> bool:
+    """Return whether *session_key* is currently marked as a guest-mode chat."""
+    with _lock:
+        return session_key in _gateway_guest_sessions
 
 
 def resolve_gateway_approval(session_key: str, choice: str,
@@ -2529,13 +2565,28 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     Returns ``{"resolved": bool, "choice": str|None}`` on completion, or
     ``{"resolved": False, "choice": None, "notify_failed": True}`` if the
-    notify callback raised.  Persistence of an approved choice and building
-    the final tool-facing result dict remain the caller's responsibility.
+    notify callback raised, or ``{"resolved": True, "choice": None,
+    "guest_unsupported": True}`` immediately if the session is marked guest
+    (see :func:`mark_session_guest`) -- no queue entry, no notify_cb call, no
+    wait, and no approval hooks fire for that case.  Persistence of an
+    approved choice and building the final tool-facing result dict remain the
+    caller's responsibility.
     """
     command = approval_data.get("command", "")
     description = approval_data.get("description", "")
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
+
+    # Guest-mode chats can never present or resolve an interactive approval
+    # (see _gateway_guest_sessions docstring above) -- deny immediately, the
+    # same way the adapter already declines slash commands at the front door,
+    # instead of registering a queue entry and blocking the agent thread for
+    # the full gateway_timeout on an approval that can structurally never
+    # arrive. Deliberately skips notify_cb and the pre/post approval hooks:
+    # this never becomes a real approval attempt, so nothing should observe
+    # it as one.
+    if is_session_guest(session_key):
+        return {"resolved": True, "choice": None, "guest_unsupported": True}
 
     entry = _ApprovalEntry(approval_data)
     with _lock:
@@ -2916,6 +2967,15 @@ def check_all_command_guards(command: str, env_type: str,
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
             )
+            if decision.get("guest_unsupported"):
+                return {
+                    "approved": False,
+                    "message": "BLOCKED: this action requires running a command that isn't supported in this context (a guest chat the bot isn't a member of has no way to grant approval). Do NOT retry this command, do NOT rephrase it, and do NOT attempt the same outcome via a different command -- there is no approval path available here. Tell the user you can't do that in this context.",
+                    "pattern_key": primary_key,
+                    "description": combined_desc,
+                    "outcome": "guest_unsupported",
+                    "user_consent": False,
+                }
             if decision.get("notify_failed"):
                 return {
                     "approved": False,
@@ -3247,6 +3307,15 @@ def check_execute_code_guard(code: str, env_type: str,
     decision = _await_gateway_decision(
         session_key, notify_cb, approval_data, surface="gateway"
     )
+    if decision.get("guest_unsupported"):
+        return {
+            "approved": False,
+            "message": "BLOCKED: this action requires running a command that isn't supported in this context (a guest chat the bot isn't a member of has no way to grant approval). Do NOT retry this command, do NOT rephrase it, and do NOT attempt the same outcome via a different command -- there is no approval path available here. Tell the user you can't do that in this context.",
+            "pattern_key": pattern_key,
+            "description": description,
+            "outcome": "guest_unsupported",
+            "user_consent": False,
+        }
     if decision.get("notify_failed"):
         return {
             "approved": False,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1568,6 +1568,33 @@ def is_session_guest(session_key: str) -> bool:
         return session_key in _gateway_guest_sessions
 
 
+def _guest_unsupported_block_result(pattern_key: str, description: str) -> dict:
+    """The fixed BLOCKED result for a guest-mode chat that structurally
+    cannot present or resolve an interactive approval prompt.
+
+    Shared by every guest-denial site in both command-guard entry points:
+    the early check (before cached grants/smart approval get a chance to
+    run) and _await_gateway_decision's own ``guest_unsupported`` result
+    (reached for a command that wasn't already caught early, e.g. a fresh
+    pattern with no prior findings gate).
+    """
+    return {
+        "approved": False,
+        "message": (
+            "BLOCKED: this action requires running a command that isn't "
+            "supported in this context (a guest chat the bot isn't a "
+            "member of has no way to grant approval). Do NOT retry this "
+            "command, do NOT rephrase it, and do NOT attempt the same "
+            "outcome via a different command -- there is no approval path "
+            "available here. Tell the user you can't do that in this context."
+        ),
+        "pattern_key": pattern_key,
+        "description": description,
+        "outcome": "guest_unsupported",
+        "user_consent": False,
+    }
+
+
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
                              reason: Optional[str] = None) -> int:
@@ -2866,6 +2893,27 @@ def check_all_command_guards(command: str, env_type: str,
 
     session_key = get_current_session_key()
 
+    # Guest-mode Telegram chats can never present or resolve an interactive
+    # approval prompt (see mark_session_guest's docstring). Fail closed for
+    # ANY warning-worthy command HERE — before cached per-session grants
+    # (is_approved, below) or smart approval get a chance to run. Both would
+    # otherwise short-circuit straight to "approved": True without ever
+    # reaching _await_gateway_decision's own guest check further down in
+    # Phase 3, silently defeating the guest denial for the two paths that
+    # matter most: a pattern already approved earlier in the session, or an
+    # aux-LLM "approve" verdict.
+    if is_session_guest(session_key) and (
+        tirith_result["action"] in {"block", "warn"} or is_dangerous
+    ):
+        if tirith_result["action"] in {"block", "warn"}:
+            guest_desc = _format_tirith_description(tirith_result)
+            findings = tirith_result.get("findings") or []
+            guest_key = f"tirith:{findings[0].get('rule_id', 'unknown')}" if findings else "tirith:unknown"
+        else:
+            guest_desc = description
+            guest_key = pattern_key
+        return _guest_unsupported_block_result(guest_key, guest_desc)
+
     # Tirith block/warn → approvable warning with rich findings.
     # Previously, tirith "block" was a hard block with no approval prompt.
     # Now both block and warn go through the approval flow so users can
@@ -2968,14 +3016,7 @@ def check_all_command_guards(command: str, env_type: str,
                 session_key, notify_cb, approval_data, surface="gateway"
             )
             if decision.get("guest_unsupported"):
-                return {
-                    "approved": False,
-                    "message": "BLOCKED: this action requires running a command that isn't supported in this context (a guest chat the bot isn't a member of has no way to grant approval). Do NOT retry this command, do NOT rephrase it, and do NOT attempt the same outcome via a different command -- there is no approval path available here. Tell the user you can't do that in this context.",
-                    "pattern_key": primary_key,
-                    "description": combined_desc,
-                    "outcome": "guest_unsupported",
-                    "user_consent": False,
-                }
+                return _guest_unsupported_block_result(primary_key, combined_desc)
             if decision.get("notify_failed"):
                 return {
                     "approved": False,
@@ -3206,6 +3247,14 @@ def check_execute_code_guard(code: str, env_type: str,
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
+
+    # Guest-mode Telegram chats can never present or resolve an interactive
+    # approval prompt (see mark_session_guest's docstring). Fail closed here,
+    # before cached per-session grants (is_approved, below) or smart approval
+    # get a chance to auto-approve — same reasoning as check_all_command_guards.
+    if is_session_guest(session_key):
+        return _guest_unsupported_block_result(pattern_key, description)
+
     # Built only now (past the early-return gates) so the common non-approval
     # paths don't pay to copy a potentially-large script into this string.
     command = f"execute_code <<'PY'\n{code}\nPY"
@@ -3308,14 +3357,7 @@ def check_execute_code_guard(code: str, env_type: str,
         session_key, notify_cb, approval_data, surface="gateway"
     )
     if decision.get("guest_unsupported"):
-        return {
-            "approved": False,
-            "message": "BLOCKED: this action requires running a command that isn't supported in this context (a guest chat the bot isn't a member of has no way to grant approval). Do NOT retry this command, do NOT rephrase it, and do NOT attempt the same outcome via a different command -- there is no approval path available here. Tell the user you can't do that in this context.",
-            "pattern_key": pattern_key,
-            "description": description,
-            "outcome": "guest_unsupported",
-            "user_consent": False,
-        }
+        return _guest_unsupported_block_result(pattern_key, description)
     if decision.get("notify_failed"):
         return {
             "approved": False,


### PR DESCRIPTION
## Summary

Guest-mode Telegram chats (Bot API 10.0 `@mention` from a chat the bot isn't a member of, see the `feat/guest-two-phase-reply-clean` / `feat/guest-media-delivery-clean` PR stack) can never present or resolve an interactive dangerous-command approval prompt:

- `send_exec_approval`'s `sendMessage` is rejected ("Forbidden: bot is not a member").
- There is no `/approve` path reachable from a guest chat — slash commands are hard-blocked there for the same reason (the adapter already declines them at the front door: "Slash commands aren't supported in this context — just ask me a question!").

Before this fix, a dangerous command attempted in a guest chat would silently fall through to a plain-text fallback (itself swallowed by the guest adapter's reply buffering once the guest-mode PRs land) and block the agent thread for the full `gateway_timeout` (default 300s) waiting on an approval that could structurally never arrive — with nothing visible to the guest in the meantime.

## Fix

Mirrors the existing slash-command carve-out instead of trying to make the approval *delivery* work in a context that fundamentally can't support it:

- `tools/approval.py`: new `mark_session_guest` / `unmark_session_guest` / `is_session_guest`, and `_await_gateway_decision` denies immediately when the session is marked guest — no queue entry, no `notify_cb` call, no wait, no approval hooks fire. `check_all_command_guards` and `check_execute_code_guard` return a clean `BLOCKED` result with a message telling the model this class of action isn't supported in this context (mirroring the slash-command tone), instead of the generic "denied by user"/"timed out" phrasing.
- `gateway/run.py`: marks the session at turn dispatch (alongside `register_gateway_notify`) by checking `_status_adapter._is_guest_chat(_status_chat_id)` via `getattr` — a no-op today since no adapter defines `_is_guest_chat` yet, becomes live once the guest-mode PR stack lands.

Independent of the guest-mode PR stack and of any approval-routing/delivery-destination work (home channel pinning, etc.) — the notify callback is never invoked for a guest session, so this doesn't depend on that landing first. The LLM's own follow-up reply after seeing the `BLOCKED` tool result flows through the normal reply path; no adapter-side bypass needed.

## Test plan

- [x] New `TestGuestModeApprovalShortCircuit` in `tests/tools/test_approval.py` (6 tests): mark/unmark roundtrip, terminal guard denies without calling `notify_cb`, denial message content, denial is near-instant even with a long `gateway_timeout`, `execute_code` guard denies the same way, and a sanity check that a non-guest session's existing timeout behavior is unchanged.
- [x] Full `tests/tools/test_approval.py` + `tests/gateway/test_approve_deny_commands.py` + `tests/tools/test_command_guards.py` suite green (two unrelated pre-existing test-pollution failures reproduced identically on a clean `main` checkout, confirmed not caused by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)