### PR TITLE
fix(desktop): add MoA preset enabled toggle

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -321,4 +321,25 @@ describe('ModelSettings MoA preset editor', () => {
       vi.useRealTimers()
     }
   })
+
+  it('autosaves the selected preset when its enabled switch is toggled', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    try {
+      await openReferenceEditor()
+
+      fireEvent.click(screen.getByRole('switch', { name: 'Enabled' }))
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(saveMoaModels).toHaveBeenCalledWith(
+        expect.objectContaining({
+          presets: expect.objectContaining({
+            default: expect.objectContaining({ enabled: false })
+          })
+        })
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -954,6 +954,15 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                 ))}
               </SelectContent>
             </Select>
+            <label className="flex items-center gap-2 rounded-sm border border-border px-2 py-1 text-xs">
+              Enabled
+              <Switch
+                checked={currentMoaPreset.enabled !== false}
+                disabled={applying}
+                onCheckedChange={checked => updateMoaPreset(prev => ({ ...prev, enabled: checked }))}
+                size="xs"
+              />
+            </label>
             <Button
               disabled={applying}
               onClick={() => {


### PR DESCRIPTION
## Summary
- add an Enabled switch for the selected Desktop MoA preset
- persist the selected preset enabled flag through the existing MoA settings save path
- cover toggling the flag in the model settings test harness

Closes #59723

## Tests
- npm run test:ui -- src/app/settings/model-settings.test.tsx
- ../../node_modules/.bin/eslint src/app/settings/model-settings.tsx src/app/settings/model-settings.test.tsx
- ./node_modules/.bin/prettier --check apps/desktop/src/app/settings/model-settings.tsx apps/desktop/src/app/settings/model-settings.test.tsx
- git diff --check

Note: eslint passed with the existing react-hooks/exhaustive-deps warning in model-settings.tsx.