### PR TITLE
feat(desktop): add toggle to hide unconfigured providers in model picker

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -28,12 +28,15 @@ import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { $modelPresets, applyModelPreset, modelPresetKey } from '@/store/model-presets'
 import {
+  $hideUnconfiguredProviders,
   $visibleModels,
   collapseModelFamilies,
   DEFAULT_VISIBLE_PER_PROVIDER,
   effectiveVisibleKeys,
+  filterConfiguredProviders,
   type ModelFamily,
   modelVisibilityKey,
+  setHideUnconfiguredProviders,
   setModelVisibilityOpen
 } from '@/store/model-visibility'
 import {
@@ -80,6 +83,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
   const currentReasoningEffort = useStore($currentReasoningEffort)
   const modelPresets = useStore($modelPresets)
   const visibleModels = useStore($visibleModels)
+  const hideUnconfigured = useStore($hideUnconfiguredProviders)
 
   const modelOptions = useQuery({
     queryKey: ['model-options', activeSessionId || 'global'],
@@ -113,10 +117,13 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
     [providers]
   )
 
-  const pickerProviders = useMemo(
-    () => providers?.filter(provider => provider.slug.toLowerCase() !== 'moa') ?? [],
-    [providers]
-  )
+  const pickerProviders = useMemo(() => {
+    const base = providers?.filter(provider => provider.slug.toLowerCase() !== 'moa') ?? []
+
+    // Optionally hide providers the user hasn't set up (no usable credentials),
+    // always keeping the active provider so the current model can't vanish.
+    return filterConfiguredProviders(base, hideUnconfigured, optionsProvider)
+  }, [providers, hideUnconfigured, optionsProvider])
 
   const effectiveVisibleModels = useMemo(
     () => effectiveVisibleKeys(visibleModels, pickerProviders),
@@ -358,6 +365,18 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
       >
         <Codicon className={cn(refreshing && 'animate-spin')} name="sync" size="0.75rem" />
         {copy.refreshModels}
+      </DropdownMenuItem>
+
+      <DropdownMenuItem
+        className={cn(dropdownMenuRow, 'text-(--ui-text-tertiary)')}
+        onSelect={event => {
+          event.preventDefault()
+          setHideUnconfiguredProviders(!hideUnconfigured)
+        }}
+      >
+        <Codicon name="filter" size="0.75rem" />
+        <span className="min-w-0 flex-1 truncate">{copy.hideUnconfigured}</span>
+        {hideUnconfigured ? <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" /> : null}
       </DropdownMenuItem>
 
       <DropdownMenuItem

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1982,6 +1982,7 @@ export const en: Translations = {
       noModels: 'No models found',
       editModels: 'Edit Models…',
       refreshModels: 'Refresh Models',
+      hideUnconfigured: 'Hide Unconfigured Providers',
       fast: 'Fast',
       medium: 'Med'
     },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1623,6 +1623,7 @@ export interface Translations {
       noModels: string
       editModels: string
       refreshModels: string
+      hideUnconfigured: string
       fast: string
       medium: string
     }

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2150,6 +2150,7 @@ export const zh: Translations = {
       noModels: '未找到模型',
       editModels: '编辑模型…',
       refreshModels: '刷新模型',
+      hideUnconfigured: '隐藏未配置的提供商',
       fast: '快速',
       medium: '中'
     },

--- a/apps/desktop/src/store/model-visibility.test.ts
+++ b/apps/desktop/src/store/model-visibility.test.ts
@@ -7,6 +7,7 @@ import {
   defaultVisibleKeys,
   effectiveVisibleKeys,
   emptyProviderSentinelKey,
+  filterConfiguredProviders,
   isProviderSentinel,
   modelVisibilityKey,
   resolveVisibleKeys,
@@ -222,5 +223,44 @@ describe('resolveVisibleKeys', () => {
 
   it('returns an empty set for an empty (non-null) stored set', () => {
     expect([...resolveVisibleKeys(new Set(), providers)]).toEqual([])
+  })
+})
+
+describe('filterConfiguredProviders', () => {
+  const authed = (slug: string, authenticated?: boolean): ModelOptionProvider => ({
+    authenticated,
+    models: [`${slug}-model`],
+    name: slug,
+    slug
+  })
+
+  const providers = [authed('deepseek', true), authed('openai', false), authed('nous', false)]
+
+  it('returns every provider unchanged when the toggle is off', () => {
+    const result = filterConfiguredProviders(providers, false)
+
+    expect(result.map(p => p.slug)).toEqual(['deepseek', 'openai', 'nous'])
+    // A fresh array is returned, never the caller's reference.
+    expect(result).not.toBe(providers)
+  })
+
+  it('drops providers whose credentials are explicitly missing when the toggle is on', () => {
+    const result = filterConfiguredProviders(providers, true)
+
+    expect(result.map(p => p.slug)).toEqual(['deepseek'])
+  })
+
+  it('treats a missing authenticated flag as configured (only explicit false is filtered)', () => {
+    const result = filterConfiguredProviders([authed('deepseek', true), authed('custom', undefined)], true)
+
+    expect(result.map(p => p.slug)).toEqual(['deepseek', 'custom'])
+  })
+
+  it('always keeps the current provider even when it is unconfigured', () => {
+    const result = filterConfiguredProviders(providers, true, 'openai')
+
+    // deepseek stays (authenticated), openai stays (it is the active provider),
+    // nous is dropped (unconfigured and not active).
+    expect(result.map(p => p.slug)).toEqual(['deepseek', 'openai'])
   })
 })

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -1,9 +1,10 @@
 import { atom } from 'nanostores'
 
-import { persistString, storedString } from '@/lib/storage'
+import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
 import type { ModelOptionProvider } from '@/types/hermes'
 
 const STORAGE_KEY = 'hermes.desktop.visible-models'
+const HIDE_UNCONFIGURED_KEY = 'hermes.desktop.hide-unconfigured-providers'
 
 /** Models shown per provider in the status-bar dropdown before the user has
  *  customized the list. Backend `models` are already relevance-ordered. */
@@ -97,6 +98,35 @@ export function setVisibleModels(keys: Set<string>): void {
 
 export function setModelVisibilityOpen(open: boolean): void {
   $modelVisibilityOpen.set(open)
+}
+
+/** When true, the picker hides providers without usable credentials — the
+ *  canonical rows surfaced with a setup affordance that the user hasn't set up.
+ *  Opt-in (default false) so the "show everything, incl. setup rows" behavior is
+ *  unchanged for users who don't enable it. (#59483) */
+export const $hideUnconfiguredProviders = atom<boolean>(storedBoolean(HIDE_UNCONFIGURED_KEY, false))
+
+export function setHideUnconfiguredProviders(hide: boolean): void {
+  $hideUnconfiguredProviders.set(hide)
+  persistBoolean(HIDE_UNCONFIGURED_KEY, hide)
+}
+
+/** Drop providers with no usable credentials when `hide` is on. A missing
+ *  `authenticated` flag is treated as configured — only an explicit `false`
+ *  (unconfigured canonical rows) is filtered. The current provider is always
+ *  kept so the active model never disappears from the picker. */
+export function filterConfiguredProviders(
+  providers: readonly ModelOptionProvider[],
+  hide: boolean,
+  currentProviderSlug?: string
+): ModelOptionProvider[] {
+  if (!hide) {
+    return [...providers]
+  }
+
+  return providers.filter(
+    provider => provider.authenticated !== false || provider.slug === currentProviderSlug
+  )
 }
 
 /** The default-visible key set: the curated top-N per provider. Used both as


### PR DESCRIPTION
## What

Adds an opt-in **"Hide Unconfigured Providers"** toggle to the Desktop model-picker footer (next to *Edit Models*). When enabled, the picker hides providers the user has no usable credentials for, so someone who only configured a couple of providers isn't scrolling past the entire catalog.

Resolves NousResearch/hermes-agent#59483.

## Why

The picker lists every provider from the catalog, including canonical rows surfaced with a setup affordance that the user hasn't set up. The issue reporter (uses only DeepSeek) has to scroll past Anthropic, OpenAI, Google, OpenRouter, etc. every time.

The data needed already exists on the frontend; `ModelOptionProvider.authenticated` is *"True when the provider has usable credentials"*, so no backend change is required.

## Changes

- **`store/model-visibility.ts`**: new persisted `$hideUnconfiguredProviders` atom + setter (reuses the existing `storedBoolean`/`persistBoolean` storage pattern), and a pure `filterConfiguredProviders(providers, hide, currentProviderSlug)` helper.
- **`app/shell/model-menu-panel.tsx`**: reads the store, filters `pickerProviders`, and renders the toggle with a check mark when active.
- **i18n**: `hideUnconfigured` string added to `en.ts`, `zh.ts`, and `types.ts`.
- **`store/model-visibility.test.ts`**: 4 new unit tests for the filter helper.

## Design notes

- **Opt-in, default off** — chosen over the issue's alternative "make it the default", which would change behavior for all users.
- **Only an explicit `authenticated === false` is filtered**;  a missing flag is treated as configured (safe default for user/custom providers).
- **The active provider is always kept visible**, so the currently-selected model can never disappear from the picker.
- Setting persists across restarts via localStorage, matching the sibling model-visibility feature.

## Testing

- `vitest run` on the affected suites: **26 passed** (incl. 4 new).
- `tsc --noEmit`: clean.
- `eslint` on all changed files: clean.
- Manual: open the model picker → toggle *Hide Unconfigured Providers* → providers without credentials disappear (check appears); toggle again to restore; persists across restart.

Renderer typecheck/tests only; full desktop build (`tsc -b` + vite) not run.