### PR TITLE
fix(desktop): mark Photon iMessage sessions in sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -10,7 +10,7 @@ import type { SessionInfo } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
-import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
+import { sessionOriginBadgeSource, sessionSourceLabel } from '@/lib/session-source'
 import { coarseElapsed } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { $attentionSessionIds } from '@/store/session'
@@ -69,11 +69,11 @@ export function SidebarSessionRow({
   const title = sessionTitle(session)
   const age = formatAge(session.last_active || session.started_at, r)
   const handleLabel = `Reorder ${title}`
-  // A handed-off session's live source is local, but it originated on a
-  // messaging platform — surface that origin as a small badge so e.g. a
-  // Telegram thread continued here still reads as Telegram.
-  const handoffSource = handoffOriginSource(session.handoff_state, session.handoff_platform)
-  const handoffLabel = handoffSource ? (sessionSourceLabel(handoffSource) ?? handoffSource) : null
+  // Surface the platform origin as a small badge. Handoffs keep their preserved
+  // origin; direct non-local sessions like Photon stay in Recents but still read
+  // as iMessage/Photon instead of anonymous local chats.
+  const originSource = sessionOriginBadgeSource(session.source, session.handoff_state, session.handoff_platform)
+  const originLabel = originSource ? (sessionSourceLabel(originSource) ?? originSource) : null
   // Subscribe per-row (the leaf) instead of drilling a set through the list —
   // the atom is tiny and rarely non-empty. True when a clarify prompt in this
   // session is waiting on the user.
@@ -198,12 +198,12 @@ export function SidebarSessionRow({
               <SessionRowLeadDot branchStem={branchStem} isWorking={isWorking} needsInput={needsInput} />
             </SidebarRowLead>
           )}
-          {handoffSource && handoffLabel ? (
-            <Tip label={r.handoffOrigin(handoffLabel)}>
+          {originSource && originLabel ? (
+            <Tip label={originLabel}>
               <PlatformAvatar
                 className="size-4 rounded-[4px] text-[0.5rem] [&_svg]:size-2.5"
-                platformId={handoffSource}
-                platformName={handoffLabel}
+                platformId={originSource}
+                platformName={originLabel}
               />
             </Tip>
           ) : null}

--- a/apps/desktop/src/app/messaging/platform-icon.tsx
+++ b/apps/desktop/src/app/messaging/platform-icon.tsx
@@ -44,6 +44,7 @@ const PLATFORM_ICONS: Record<string, PlatformIconSpec> = {
   signal: { Icon: SiSignal, color: '#3A76F0', kind: 'brand' },
   whatsapp: { Icon: SiWhatsapp, color: '#25D366', kind: 'brand' },
   bluebubbles: { Icon: SiApple, color: '#0BD318', kind: 'brand' },
+  photon: { Icon: SiApple, color: '#0BD318', kind: 'brand' },
   homeassistant: { Icon: SiHomeassistant, color: '#18BCF2', kind: 'brand' },
   email: { Icon: SiGmail, color: '#EA4335', kind: 'brand' },
   sms: { Icon: MessageSquareText, color: '#F43F5E', kind: 'generic' },

--- a/apps/desktop/src/lib/session-source.test.ts
+++ b/apps/desktop/src/lib/session-source.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isMessagingSource,
+  MESSAGING_SESSION_SOURCE_IDS,
+  sessionOriginBadgeSource,
+  sessionSourceLabel,
+  sessionSourceSearchTerms
+} from './session-source'
+
+describe('session-source', () => {
+  it('marks Photon iMessage sessions without moving them into a separate sidebar section', () => {
+    expect(MESSAGING_SESSION_SOURCE_IDS).not.toContain('photon')
+    expect(isMessagingSource('photon')).toBe(false)
+    expect(sessionOriginBadgeSource('photon', null, null)).toBe('photon')
+    expect(sessionSourceLabel('photon')).toBe('iMessage / Photon')
+    expect(sessionSourceSearchTerms('photon')).toEqual(expect.arrayContaining(['photon', 'iMessage / Photon', 'imessage']))
+  })
+})

--- a/apps/desktop/src/lib/session-source.ts
+++ b/apps/desktop/src/lib/session-source.ts
@@ -12,6 +12,7 @@ const SOURCE_LABELS: Record<string, string> = {
   local: 'Local',
   matrix: 'Matrix',
   mattermost: 'Mattermost',
+  photon: 'iMessage / Photon',
   qqbot: 'QQ',
   signal: 'Signal',
   slack: 'Slack',
@@ -29,6 +30,7 @@ const SOURCE_ALIASES: Record<string, string[]> = {
   cli: ['terminal'],
   desktop: ['app', 'gui'],
   local: ['machine'],
+  photon: ['apple messages', 'imessage', 'spectrum'],
   qqbot: ['qq'],
   telegram: ['tg'],
   tui: ['terminal'],
@@ -98,6 +100,31 @@ export function handoffOriginSource(
   const id = normalizeSessionSource(handoffPlatform)
 
   if (!id || LOCAL_SOURCE_IDS.has(id)) {
+    return null
+  }
+
+  return id
+}
+
+/**
+ * Platform badge shown on ordinary session rows. Completed handoffs keep using
+ * their preserved origin platform; direct non-local sources (Photon, etc.) get
+ * a lightweight row marker without being moved into their own sidebar section.
+ */
+export function sessionOriginBadgeSource(
+  source: null | string | undefined,
+  handoffState: null | string | undefined,
+  handoffPlatform: null | string | undefined
+): string | null {
+  const handoffSource = handoffOriginSource(handoffState, handoffPlatform)
+
+  if (handoffSource) {
+    return handoffSource
+  }
+
+  const id = normalizeSessionSource(source)
+
+  if (!id || LOCAL_SOURCE_IDS.has(id) || MESSAGING_SOURCE_IDS.has(id)) {
     return null
   }
 


### PR DESCRIPTION
## Summary
- label Photon sessions as `iMessage / Photon`
- show a lightweight platform badge on direct Photon sessions in the normal Sessions list
- keep Photon chats out of a separate messaging-platform sidebar section
- add Photon/iMessage search aliases and an Apple-style platform icon

<img width="1183" height="799" alt="image" src="https://github.com/user-attachments/assets/014632d1-2796-4ee2-b51a-af26173f7a8c" />

## Test Plan
- `npx vitest run apps/desktop/src/lib/session-source.test.ts --config apps/desktop/vite.config.ts`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop exec eslint -- src/lib/session-source.ts src/lib/session-source.test.ts src/app/chat/sidebar/session-row.tsx src/app/messaging/platform-icon.tsx`
- `git diff --check`

## Manual validation
Verified in the desktop dev app with real Photon sessions: the conversations stay under `Sessions` and show a small iMessage/Photon marker beside the chat title, rather than creating a separate `iMessage / Photon` sidebar section.

Screenshot available in the PR discussion.
