### PR TITLE
fix(moa): handle None _ref_usage for CanonicalUsage (#59541)

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -918,7 +918,7 @@ class MoAChatCompletions:
             for _lbl, _txt, _acct in reference_outputs:
                 if isinstance(_acct, _RefAccounting):
                     if isinstance(_acct.usage, CanonicalUsage):
-                        _ref_usage = _ref_usage + _acct.usage
+                        _ref_usage = (_ref_usage or CanonicalUsage()) + _acct.usage
                     if _acct.cost_usd is not None:
                         _ref_cost = (_ref_cost or 0) + _acct.cost_usd
             self._pending_reference_usage = _ref_usage

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3340,6 +3340,7 @@ DELEGATE_TASK_SCHEMA = {
             },
             "tasks": {
                 "type": "array",
+                "default": [],
                 "items": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
## Summary

Fixes #59541 — MOA mode fails with TypeError when _ref_usage is None and an addition with CanonicalUsage is attempted.

## Changes

- **agent/moa_loop.py**: Add defensive fallback `(_ref_usage or CanonicalUsage())` so that even if _ref_usage is None (e.g. from a code path that bypasses initialization), the addition with CanonicalUsage works correctly instead of raising TypeError: unsupported operand type(s) for +: NoneType and CanonicalUsage.
- **tools/delegate_tool.py**: Add `"default": []` to the tasks field in DELEGATE_TASK_SCHEMA so that omitting the tasks parameter does not cause schema validation errors.