### PR TITLE
feat(gitnexus-explorer): add optional HTTP Basic Auth to proxy

### DIFF
--- a/optional-skills/research/gitnexus-explorer/SKILL.md
+++ b/optional-skills/research/gitnexus-explorer/SKILL.md
@@ -150,10 +150,18 @@ http.createServer((req, res) => {
 npx gitnexus serve &
 
 # Terminal 2: Proxy (web UI + API on one port)
+# With Basic Auth (recommended for tunneling):
+GITNEXUS_USER=admin GITNEXUS_PASS=your-secret-password \
+  node "$GITNEXUS_DIR/proxy.mjs" "$GITNEXUS_DIR/gitnexus-web/dist" 8888 &
+
+# Without auth (localhost-only, skip tunnel):
 node "$GITNEXUS_DIR/proxy.mjs" "$GITNEXUS_DIR/gitnexus-web/dist" 8888 &
 ```
 
 Verify: `curl -s http://localhost:8888/api/repos` should return the indexed repo(s).
+
+When Basic Auth is enabled, the browser will prompt for credentials on first visit.
+Set `GITNEXUS_USER` and `GITNEXUS_PASS` to enable; omit both to skip auth entirely.
 
 ### 6. Tunnel with Cloudflare (optional — for remote access)
 

--- a/optional-skills/research/gitnexus-explorer/scripts/proxy.mjs
+++ b/optional-skills/research/gitnexus-explorer/scripts/proxy.mjs
@@ -7,15 +7,45 @@
  *   port: listen port (default: 8888)
  *
  * Environment:
- *   API_PORT: GitNexus serve backend port (default: 4747)
+ *   API_PORT:       GitNexus serve backend port (default: 4747)
+ *   GITNEXUS_USER:  Enable Basic Auth (required if GITNEXUS_PASS is set)
+ *   GITNEXUS_PASS:  Enable Basic Auth (required if GITNEXUS_USER is set)
  */
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
+import crypto from 'node:crypto';
 
 const API_PORT = parseInt(process.env.API_PORT || '4747');
 const DIST_DIR = process.argv[2] || './dist';
 const PORT = parseInt(process.argv[3] || '8888');
+const AUTH_USER = process.env.GITNEXUS_USER || '';
+const AUTH_PASS = process.env.GITNEXUS_PASS || '';
+const AUTH_ENABLED = !!(AUTH_USER && AUTH_PASS);
+
+function checkAuth(req, res) {
+  const header = req.headers.authorization || '';
+  const [scheme, encoded] = header.split(' ');
+  if (scheme !== 'Basic') return false;
+
+  const [user, pass] = Buffer.from(encoded, 'base64').toString().split(':');
+  // Constant-time comparison to prevent timing attacks
+  const userOk = crypto.timingSafeEqual
+    ? crypto.timingSafeEqual(Buffer.from(user), Buffer.from(AUTH_USER))
+    : user === AUTH_USER;
+  const passOk = crypto.timingSafeEqual
+    ? crypto.timingSafeEqual(Buffer.from(pass), Buffer.from(AUTH_PASS))
+    : pass === AUTH_PASS;
+  return userOk && passOk;
+}
+
+function sendAuthRequired(res) {
+  res.writeHead(401, {
+    'WWW-Authenticate': 'Basic realm="GitNexus Explorer", charset="UTF-8"',
+    'Content-Type': 'text/plain',
+  });
+  res.end('Authentication required');
+}
 
 const MIME = {
   '.html': 'text/html',
@@ -77,6 +107,10 @@ function serveStatic(req, res) {
 }
 
 const server = http.createServer((req, res) => {
+  if (AUTH_ENABLED && !checkAuth(req, res)) {
+    sendAuthRequired(res);
+    return;
+  }
   if (req.url.startsWith('/api')) {
     proxyToApi(req, res);
   } else {
@@ -89,4 +123,6 @@ server.listen(PORT, () => {
   console.log(`  Web UI: http://localhost:${PORT}/`);
   console.log(`  API:    http://localhost:${PORT}/api/repos`);
   console.log(`  Backend: http://127.0.0.1:${API_PORT}`);
+  if (AUTH_ENABLED) console.log(`  Auth:   Basic (user=${AUTH_USER})`);
+  else console.log('  Auth:   none (set GITNEXUS_USER + GITNEXUS_PASS to enable)');
 });


### PR DESCRIPTION
## Summary

Adds optional HTTP Basic Authentication support to the GitNexus Explorer proxy via `GITNEXUS_USER` / `GITNEXUS_PASS` environment variables. This addresses the security risk of exposing the knowledge graph publicly via Cloudflare tunnel with no authentication.

## What Changed

- **`scripts/proxy.mjs`** — Added `checkAuth()` and `sendAuthRequired()` functions using Node.js built-in `crypto` module. When both env vars are set, all requests (web UI + `/api/*`) require HTTP Basic Auth. Constant-time comparison via `crypto.timingSafeEqual` prevents timing attacks.
- **`SKILL.md`** — Updated step 5 with examples for both auth-enabled and auth-disabled usage.

## Behavior

| `GITNEXUS_USER` | `GITNEXUS_PASS` | Result |
|---|---|---|
| (not set) | (not set) | No auth — **fully backward-compatible** |
| set | set | Browser prompts for credentials, 401 otherwise |
| set | (not set) | No auth (both required) |
| (not set) | set | No auth (both required) |

## Test Plan

- [ ] Run with no env vars → proxy starts normally, no auth required
- [ ] Run with both env vars → browser prompts for login, correct credentials grant access
- [ ] Run with both env vars → wrong credentials return 401
- [ ] Run with both env vars → no Authorization header returns 401 with WWW-Authenticate
- [ ] Verify Cloudflare tunnel still works end-to-end with auth enabled