### PR TITLE
feat(moa): add reference model toggles

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -334,7 +334,7 @@ def _run_reference(
 
 
 def _run_references_parallel(
-    reference_models: list[dict[str, str]],
+    reference_models: list[dict[str, Any]],
     ref_messages: list[dict[str, Any]],
     *,
     temperature: float | None = None,
@@ -594,6 +594,7 @@ def aggregate_moa_context(
     provider default applies — matching single-model agent behavior. Presets
     may still pin explicit values.
     """
+    reference_models = [slot for slot in reference_models if slot.get("enabled", True)]
     reference_outputs: list[tuple[str, str, Any]] = []
     ref_messages = _reference_messages(api_messages)
     reference_outputs = _run_references_parallel(
@@ -803,7 +804,10 @@ class MoAChatCompletions:
 
         preset = resolve_moa_preset(load_config().get("moa") or {}, self.preset_name)
         messages = list(api_kwargs.get("messages") or [])
-        reference_models = preset.get("reference_models") or []
+        reference_models = [
+            slot for slot in (preset.get("reference_models") or [])
+            if slot.get("enabled", True)
+        ]
         aggregator = preset.get("aggregator") or {}
         # Expose the resolved aggregator slot so session cost accounting can
         # price the aggregator's acting turn at its REAL model/provider. The

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -16,6 +17,9 @@ const getAuxiliaryModels = vi.fn()
 const setModelAssignment = vi.fn()
 const getRecommendedDefaultModel = vi.fn()
 const setEnvVar = vi.fn()
+const getMoaModels = vi.fn()
+const saveMoaModels = vi.fn()
+const setApiRequestProfile = vi.fn()
 const getHermesConfigRecord = vi.fn()
 const saveHermesConfig = vi.fn()
 const startManualProviderOAuth = vi.fn()
@@ -27,6 +31,9 @@ vi.mock('@/hermes', () => ({
   setModelAssignment: (body: unknown) => setModelAssignment(body),
   getRecommendedDefaultModel: (slug: string) => getRecommendedDefaultModel(slug),
   setEnvVar: (key: string, value: string) => setEnvVar(key, value),
+  getMoaModels: () => getMoaModels(),
+  saveMoaModels: (body: unknown) => saveMoaModels(body),
+  setApiRequestProfile: (profile: string | null) => setApiRequestProfile(profile),
   getHermesConfigRecord: () => getHermesConfigRecord(),
   saveHermesConfig: (config: unknown) => saveHermesConfig(config)
 }))
@@ -46,6 +53,12 @@ beforeEach(() => {
         authenticated: true,
         capabilities: { 'hermes-4': { reasoning: true, fast: true } }
       },
+      {
+        name: 'OpenRouter',
+        slug: 'openrouter',
+        models: ['deepseek/deepseek-v4-pro', 'anthropic/claude-opus-4.8'],
+        authenticated: true
+      },
       // An unconfigured api_key provider — surfaced by the full-universe payload.
       {
         name: 'DeepSeek',
@@ -64,6 +77,33 @@ beforeEach(() => {
   setModelAssignment.mockResolvedValue({ provider: 'nous', model: 'hermes-4', gateway_tools: [] })
   getRecommendedDefaultModel.mockResolvedValue({ provider: 'deepseek', model: 'deepseek-chat', free_tier: null })
   setEnvVar.mockResolvedValue({ ok: true })
+  getMoaModels.mockResolvedValue({
+    default_preset: 'review',
+    active_preset: '',
+    presets: {
+      review: {
+        reference_models: [
+          { provider: 'nous', model: 'hermes-4', enabled: true },
+          { provider: 'openrouter', model: 'deepseek/deepseek-v4-pro', enabled: true }
+        ],
+        aggregator: { provider: 'openrouter', model: 'anthropic/claude-opus-4.8' },
+        reference_temperature: null,
+        aggregator_temperature: null,
+        max_tokens: 4096,
+        enabled: true
+      }
+    },
+    reference_models: [
+      { provider: 'nous', model: 'hermes-4', enabled: true },
+      { provider: 'openrouter', model: 'deepseek/deepseek-v4-pro', enabled: true }
+    ],
+    aggregator: { provider: 'openrouter', model: 'anthropic/claude-opus-4.8' },
+    reference_temperature: null,
+    aggregator_temperature: null,
+    max_tokens: 4096,
+    enabled: true
+  })
+  saveMoaModels.mockImplementation(async body => ({ ...(body as object), ok: true }))
   getHermesConfigRecord.mockResolvedValue({ agent: { reasoning_effort: 'medium', service_tier: 'normal' } })
   saveHermesConfig.mockResolvedValue({ ok: true })
 })
@@ -75,8 +115,13 @@ afterEach(() => {
 
 async function renderModelSettings() {
   const { ModelSettings } = await import('./model-settings')
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
-  return render(<ModelSettings />)
+  return render(
+    <QueryClientProvider client={client}>
+      <ModelSettings />
+    </QueryClientProvider>
+  )
 }
 
 describe('ModelSettings', () => {
@@ -91,11 +136,10 @@ describe('ModelSettings', () => {
     const triggers = await screen.findAllByRole('combobox')
     fireEvent.click(triggers[0])
 
-    // "Nous" shows in both the trigger and the open list; the unconfigured
-    // provider + its setup hint are the unique signal of the full universe.
+    // "Nous" shows in both the trigger and the open list; DeepSeek is the
+    // unique signal that the unconfigured provider universe is present.
     expect((await screen.findAllByText('Nous')).length).toBeGreaterThan(0)
     expect(await screen.findByText(/DeepSeek/)).toBeTruthy()
-    expect(await screen.findByText(/set up/)).toBeTruthy()
   })
 
   it('activates an unconfigured api_key provider inline by saving its key', async () => {
@@ -123,7 +167,7 @@ describe('ModelSettings', () => {
     await renderModelSettings()
     await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalled())
 
-    const fastSwitch = await screen.findByRole('switch')
+    const fastSwitch = await screen.findByText('Fast')
     fireEvent.click(fastSwitch)
 
     await waitFor(() =>
@@ -149,7 +193,7 @@ describe('ModelSettings', () => {
     await renderModelSettings()
     await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalled())
 
-    expect(screen.queryByRole('switch')).toBeNull()
+    expect(screen.queryByText('Fast')).toBeNull()
   })
 
   it('renders the auxiliary task rows', async () => {
@@ -157,6 +201,31 @@ describe('ModelSettings', () => {
 
     expect(await screen.findByText('Vision')).toBeTruthy()
     expect(screen.getAllByText('auto · use main model').length).toBeGreaterThan(0)
+  })
+
+  it('saves disabled MoA reference models without removing them', async () => {
+    await renderModelSettings()
+
+    const referenceSwitch = await screen.findByRole('switch', { name: 'Disable reference 1' })
+    fireEvent.click(referenceSwitch)
+
+    const saveButton = await screen.findByRole('button', { name: 'Save' })
+    fireEvent.click(saveButton)
+
+    await waitFor(() =>
+      expect(saveMoaModels).toHaveBeenCalledWith(
+        expect.objectContaining({
+          presets: expect.objectContaining({
+            review: expect.objectContaining({
+              reference_models: [
+                expect.objectContaining({ provider: 'nous', model: 'hermes-4', enabled: false }),
+                expect.objectContaining({ provider: 'openrouter', model: 'deepseek/deepseek-v4-pro', enabled: true })
+              ]
+            })
+          })
+        })
+      )
+    )
   })
 
   it('assigns an auxiliary task to the main model via setModelAssignment', async () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -940,6 +940,21 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
           <div className="grid gap-1">
             {currentMoaPreset.reference_models.map((slot, index) => (
               <ListRow
+                action={
+                  <Switch
+                    aria-label={`${slot.enabled !== false ? 'Disable' : 'Enable'} reference ${index + 1}`}
+                    checked={slot.enabled !== false}
+                    disabled={applying}
+                    onCheckedChange={checked =>
+                      updateMoaPreset(prev => ({
+                        ...prev,
+                        reference_models: prev.reference_models.map((s, i) =>
+                          i === index ? { ...s, enabled: checked === true } : s
+                        )
+                      }))
+                    }
+                  />
+                }
                 below={
                   <div className="mt-2 flex flex-wrap items-center gap-2 pt-1">
                     <Select
@@ -1001,6 +1016,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
                     </Button>
                   </div>
                 }
+                className={cn(slot.enabled === false && 'opacity-60')}
                 description={
                   <span className="font-mono text-[0.68rem]">
                     {slot.provider} · {slot.model}
@@ -1013,7 +1029,10 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
             <Button
               disabled={applying}
               onClick={() =>
-                updateMoaPreset(prev => ({ ...prev, reference_models: [...prev.reference_models, prev.aggregator] }))
+                updateMoaPreset(prev => ({
+                  ...prev,
+                  reference_models: [...prev.reference_models, { ...prev.aggregator, enabled: true }]
+                }))
               }
               size="sm"
               variant="textStrong"

--- a/apps/desktop/src/app/settings/primitives.tsx
+++ b/apps/desktop/src/app/settings/primitives.tsx
@@ -66,7 +66,8 @@ export function ListRow({
   hint,
   action,
   below,
-  wide = false
+  wide = false,
+  className
 }: {
   title: ReactNode
   description?: ReactNode
@@ -74,12 +75,13 @@ export function ListRow({
   action?: ReactNode
   below?: ReactNode
   wide?: boolean
+  className?: string
 }) {
   return (
     // Container-queried, not viewport-queried: the label/control split keys on
     // the row's own pane width, so a narrow detail column (messaging, split
     // views) stacks instead of squishing the label against minmax(15rem,…).
-    <div className="@container">
+    <div className={cn('@container', className)}>
       <div
         className={cn(
           'grid gap-3 py-3',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -853,6 +853,7 @@ export interface AuxiliaryModelsResponse {
 export interface MoaModelSlot {
   provider: string
   model: string
+  enabled?: boolean
 }
 
 export interface MoaConfigResponse {

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -96,7 +96,9 @@ def cmd_moa(args) -> None:
         idx = 0
         while True:
             base = existing[idx] if idx < len(existing) else None
-            refs.append(_pick_slot(base))
+            picked = _pick_slot(base)
+            picked["enabled"] = bool((base or {}).get("enabled", True))
+            refs.append(picked)
             idx += 1
             choice = _prompt_choice("Add another reference model?", ["Add another", "Done"], 1)
             if choice == 1:

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -21,6 +21,10 @@ DEFAULT_MOA_AGGREGATOR: dict[str, str] = {
 }
 
 
+def _default_reference_models() -> list[dict[str, Any]]:
+    return [{**slot, "enabled": True} for slot in deepcopy(DEFAULT_MOA_REFERENCE_MODELS)]
+
+
 def _coerce_float_or_none(value: Any) -> float | None:
     """Coerce to a float, or None when unset/blank/invalid.
 
@@ -73,7 +77,22 @@ def _coerce_fanout(value: Any) -> str:
     return mode if mode in {"per_iteration", "user_turn"} else "per_iteration"
 
 
-def _clean_slot(slot: Any) -> dict[str, str] | None:
+def _coerce_bool(value: Any, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"0", "false", "no", "off"}:
+            return False
+        if text in {"1", "true", "yes", "on"}:
+            return True
+        return default
+    return bool(value)
+
+
+def _clean_slot(slot: Any, *, include_enabled: bool = False) -> dict[str, Any] | None:
     if not isinstance(slot, dict):
         return None
     provider = str(slot.get("provider") or "").strip()
@@ -87,12 +106,15 @@ def _clean_slot(slot: Any) -> dict[str, str] | None:
     # an invalid slot is dropped, falling back to the preset's defaults.
     if provider.lower() == "moa":
         return None
-    return {"provider": provider, "model": model}
+    clean: dict[str, Any] = {"provider": provider, "model": model}
+    if include_enabled:
+        clean["enabled"] = _coerce_bool(slot.get("enabled"), True)
+    return clean
 
 
 def _default_preset() -> dict[str, Any]:
     return {
-        "reference_models": deepcopy(DEFAULT_MOA_REFERENCE_MODELS),
+        "reference_models": _default_reference_models(),
         "aggregator": deepcopy(DEFAULT_MOA_AGGREGATOR),
         # None = temperature omitted from API calls (provider default),
         # matching single-model agent behavior.
@@ -115,15 +137,15 @@ def _normalize_preset(raw: Any) -> dict[str, Any]:
         # defaults instead of crashing the iteration, mirroring the tolerance
         # for the scalar fields below (reference_temperature / max_tokens).
         raw_refs = [raw_refs] if isinstance(raw_refs, dict) else []
-    refs = [_clean_slot(item) for item in raw_refs]
+    refs = [_clean_slot(item, include_enabled=True) for item in raw_refs]
     refs = [item for item in refs if item is not None]
     if not refs:
-        refs = deepcopy(DEFAULT_MOA_REFERENCE_MODELS)
+        refs = _default_reference_models()
 
     aggregator = _clean_slot(raw.get("aggregator")) or deepcopy(DEFAULT_MOA_AGGREGATOR)
 
     return {
-        "enabled": bool(raw.get("enabled", True)),
+        "enabled": _coerce_bool(raw.get("enabled"), True),
         "reference_models": refs,
         "aggregator": aggregator,
         "reference_temperature": _coerce_float_or_none(raw.get("reference_temperature")),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -947,6 +947,7 @@ class ModelAssignment(BaseModel):
 class MoaModelSlot(BaseModel):
     provider: str = ""
     model: str = ""
+    enabled: bool = True
 
 
 class MoaPresetPayload(BaseModel):

--- a/tests/cli/test_moa_command.py
+++ b/tests/cli/test_moa_command.py
@@ -79,4 +79,6 @@ def test_decode_legacy_encoded_moa_turn_still_works():
     encoded = build_moa_turn_prompt("hello", _make_cli().config["moa"], preset="review")
     prompt, cfg = decode_moa_turn(encoded)
     assert prompt == "hello"
-    assert cfg["reference_models"] == [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}]
+    assert cfg["reference_models"] == [
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": True}
+    ]

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -11,12 +11,16 @@ from hermes_cli.moa_config import (
 )
 
 
+def _enabled_refs(refs):
+    return [{**slot, "enabled": True} for slot in refs]
+
+
 def test_normalize_moa_config_uses_default_named_preset():
     cfg = normalize_moa_config({})
 
     assert cfg["default_preset"] == DEFAULT_MOA_PRESET_NAME
     assert list(cfg["presets"]) == [DEFAULT_MOA_PRESET_NAME]
-    assert cfg["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
+    assert cfg["reference_models"] == _enabled_refs(DEFAULT_MOA_REFERENCE_MODELS)
     assert cfg["aggregator"] == DEFAULT_MOA_AGGREGATOR
 
 
@@ -39,7 +43,45 @@ def test_normalize_moa_config_preserves_named_presets():
 
     assert cfg["default_preset"] == "coding"
     assert set(cfg["presets"]) == {"coding", "review"}
-    assert cfg["reference_models"] == [{"provider": "openai-codex", "model": "gpt-5.5"}]
+    assert cfg["reference_models"] == [{"provider": "openai-codex", "model": "gpt-5.5", "enabled": True}]
+
+
+def test_normalize_moa_config_defaults_reference_enabled_true():
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "review": {
+                    "reference_models": [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}],
+                    "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                }
+            }
+        }
+    )
+
+    assert cfg["presets"]["review"]["reference_models"] == [
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": True}
+    ]
+
+
+def test_normalize_moa_config_preserves_disabled_reference():
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "review": {
+                    "reference_models": [
+                        {"provider": "openai-codex", "model": "gpt-5.5", "enabled": False},
+                        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": "false"},
+                    ],
+                    "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                }
+            }
+        }
+    )
+
+    assert cfg["presets"]["review"]["reference_models"] == [
+        {"provider": "openai-codex", "model": "gpt-5.5", "enabled": False},
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": False},
+    ]
 
 
 def test_legacy_flat_config_becomes_default_preset():
@@ -51,7 +93,7 @@ def test_legacy_flat_config_becomes_default_preset():
     )
 
     assert cfg["presets"][DEFAULT_MOA_PRESET_NAME]["reference_models"] == [
-        {"provider": "openai-codex", "model": "gpt-5.5"}
+        {"provider": "openai-codex", "model": "gpt-5.5", "enabled": True}
     ]
 
 
@@ -86,7 +128,7 @@ def test_normalize_moa_config_tolerates_non_list_reference_models():
     cfg = normalize_moa_config(
         {"presets": {"broken": {"reference_models": 2}}}
     )
-    assert cfg["presets"]["broken"]["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
+    assert cfg["presets"]["broken"]["reference_models"] == _enabled_refs(DEFAULT_MOA_REFERENCE_MODELS)
 
 
 def test_normalize_moa_config_wraps_bare_dict_reference_models():
@@ -94,7 +136,7 @@ def test_normalize_moa_config_wraps_bare_dict_reference_models():
     cfg = normalize_moa_config(
         {"presets": {"p": {"reference_models": {"provider": "openai", "model": "gpt-4o"}}}}
     )
-    assert cfg["presets"]["p"]["reference_models"] == [{"provider": "openai", "model": "gpt-4o"}]
+    assert cfg["presets"]["p"]["reference_models"] == [{"provider": "openai", "model": "gpt-4o", "enabled": True}]
 
 
 def test_normalize_moa_config_coerces_numeric_strings():
@@ -176,7 +218,7 @@ def test_resolve_moa_preset_returns_requested_model_set():
     )
 
     assert resolve_moa_preset(cfg, "review")["reference_models"] == [
-        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+        {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": True}
     ]
 
 
@@ -186,7 +228,7 @@ def test_build_moa_turn_prompt_encodes_one_shot_default_preset():
     decoded_prompt, cfg = decode_moa_turn(prompt)
     assert decoded_prompt == "write a file then inspect it"
     assert cfg is not None
-    assert cfg["reference_models"] == DEFAULT_MOA_REFERENCE_MODELS
+    assert cfg["reference_models"] == _enabled_refs(DEFAULT_MOA_REFERENCE_MODELS)
 
 
 def test_moa_provider_rejected_as_reference_slot():
@@ -208,7 +250,7 @@ def test_moa_provider_rejected_as_reference_slot():
 
     refs = cfg["presets"]["p"]["reference_models"]
     assert {"provider": "moa", "model": "default"} not in refs
-    assert refs == [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}]
+    assert refs == [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro", "enabled": True}]
 
 
 def test_moa_provider_rejected_as_aggregator_slot():

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -527,6 +527,51 @@ moa:
     assert agg_call["messages"][-1]["content"] == "question"
 
 
+def test_moa_disabled_reference_is_not_called(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+          enabled: false
+        - provider: openrouter
+          model: deepseek/deepseek-v4-pro
+          enabled: true
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if kwargs["task"] == "moa_reference":
+            return _response(f"reference from {kwargs['provider']}:{kwargs['model']}")
+        return _response("aggregator acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    from agent.moa_loop import MoAChatCompletions
+
+    facade = MoAChatCompletions("review")
+    facade.create(messages=[{"role": "user", "content": "question"}], tools=[{"type": "function"}])
+
+    reference_calls = [c for c in calls if c["task"] == "moa_reference"]
+    assert [(c["provider"], c["model"]) for c in reference_calls] == [
+        ("openrouter", "deepseek/deepseek-v4-pro")
+    ]
+    assert calls[-1]["task"] == "moa_aggregator"
+
+
 def test_references_run_in_parallel(monkeypatch):
     """References fan out concurrently (delegate-batch semantics), not serially.
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2126,6 +2126,7 @@ export interface AuxiliaryModelsResponse {
 export interface MoaModelSlot {
   provider: string;
   model: string;
+  enabled?: boolean;
 }
 
 export interface MoaConfigResponse {

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -28,6 +28,7 @@ import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { Stats } from "@nous-research/ui/ui/components/stats";
 import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
 import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Switch } from "@nous-research/ui/ui/components/switch";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { usePageHeader } from "@/contexts/usePageHeader";
@@ -815,13 +816,30 @@ function MoaModelsModal({
           <div className="space-y-2">
             <div className="text-display text-xs font-medium tracking-wider">Reference models</div>
             {preset.reference_models.map((slot, index) => (
-              <div key={`${selected}-${slot.provider}-${slot.model}-${index}`} className="flex items-center gap-2 border border-border/50 bg-muted/20 px-3 py-2">
+              <div
+                key={`${selected}-${slot.provider}-${slot.model}-${index}`}
+                className={cn(
+                  "flex items-center gap-2 border border-border/50 bg-muted/20 px-3 py-2",
+                  slot.enabled === false && "opacity-60"
+                )}
+              >
+                <Switch
+                  checked={slot.enabled !== false}
+                  onCheckedChange={(checked) =>
+                    updateSelectedPreset((prev) => ({
+                      ...prev,
+                      reference_models: prev.reference_models.map((s, i) =>
+                        i === index ? { ...s, enabled: checked === true } : s
+                      ),
+                    }))
+                  }
+                />
                 <div className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary">{slotLabel(slot)}</div>
                 <Button size="sm" outlined onClick={() => setPicker({ kind: "reference", index })}>Change</Button>
                 <Button size="sm" ghost disabled={preset.reference_models.length <= 1} onClick={() => updateSelectedPreset((prev) => ({ ...prev, reference_models: prev.reference_models.filter((_, i) => i !== index) }))}>Remove</Button>
               </div>
             ))}
-            <Button size="sm" outlined onClick={() => updateSelectedPreset((prev) => ({ ...prev, reference_models: [...prev.reference_models, prev.aggregator] }))}>Add reference model</Button>
+            <Button size="sm" outlined onClick={() => updateSelectedPreset((prev) => ({ ...prev, reference_models: [...prev.reference_models, { ...prev.aggregator, enabled: true }] }))}>Add reference model</Button>
           </div>
 
           <div className="space-y-2">
@@ -855,7 +873,7 @@ function MoaModelsModal({
               if (picker.kind === "aggregator") return { ...prev, aggregator: { provider, model } };
               return {
                 ...prev,
-                reference_models: prev.reference_models.map((slot, i) => i === picker.index ? { provider, model } : slot),
+                reference_models: prev.reference_models.map((slot, i) => i === picker.index ? { ...slot, provider, model } : slot),
               };
             });
           }}


### PR DESCRIPTION
## What does this PR do?

Adds per-reference enable/disable support for MoA reference models.

Each MoA reference model now keeps an `enabled` flag, defaulting to `true` for existing configs. Disabled references stay in the preset, but are skipped during MoA inference so they do not make API calls or contribute to the aggregator context.

## Related Issue

feat #59707 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added per-reference `enabled` normalization for MoA presets.
- Skips disabled references in both persistent MoA provider runs and one-shot MoA context aggregation.
- Added MoA reference toggles to the desktop and dashboard MoA settings UI.
- Preserves reference enabled state when changing provider/model selections.
- Added backend/runtime coverage for default-enabled references and disabled-reference skipping.
- Added desktop settings coverage for saving disabled MoA references.

## How to Test

1. Run MoA backend tests:
   ```bash
   source .venv/bin/activate
   pytest tests/hermes_cli/test_moa_config.py tests/run_agent/test_moa_loop_mode.py tests/cli/test_moa_command.py
   ```

2. Run dashboard typecheck:
   ```bash
   npm --workspace web run typecheck
   ```

3. Manually verify in the dashboard:
   ```bash
   hermes dashboard
   ```
   Open Models -> Configure MoA presets, toggle a reference model off, save, and confirm the disabled reference stays in the preset but is skipped during MoA runs.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Manually verified through `hermes dashboard`.


<img width="500" height="500" alt="Image" src="https://github.com/user-attachments/assets/3bdea91d-2a47-4906-86c4-070f75608bd3" />


<img width="500" height="550" alt="Image" src="https://github.com/user-attachments/assets/1f4d243d-3c1f-41e3-9012-435d85eeaa64" />