### PR TITLE
fix(desktop): guard backend loop from concurrent turns

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -35,6 +35,7 @@ import sys
 import tempfile
 import threading
 import time
+import traceback
 import urllib.error
 import urllib.parse
 import zipfile
@@ -87,6 +88,62 @@ from gateway.status import (
     read_runtime_status,
 )
 from utils import env_var_enabled
+
+
+def _format_thread_stack_dump(limit: int = 80) -> str:
+    """Return current Python thread stacks for event-loop stall forensics."""
+    frames = sys._current_frames()
+    threads = {thread.ident: thread for thread in threading.enumerate()}
+    chunks: list[str] = []
+    for ident, frame in frames.items():
+        thread = threads.get(ident)
+        name = thread.name if thread else "unknown"
+        daemon = thread.daemon if thread else "?"
+        chunks.append(
+            f"\n--- thread id={ident} name={name!r} daemon={daemon} ---\n"
+            + "".join(traceback.format_stack(frame, limit=limit))
+        )
+    return "".join(chunks).rstrip()
+
+
+def _start_loop_stall_stack_watchdog(
+    heartbeat_state: dict,
+    *,
+    threshold_s: float = 30.0,
+    repeat_s: float = 120.0,
+) -> None:
+    """Log all Python thread stacks when the uvicorn loop stops advancing.
+
+    The loop heartbeat itself can only report a stall after the loop recovers.
+    Desktop failures have shown multi-minute stalls, so a daemon thread watches
+    the last heartbeat timestamp out-of-band and dumps stacks while the process
+    is still wedged.
+    """
+    threshold_s = max(5.0, float(threshold_s or 30.0))
+    repeat_s = max(threshold_s, float(repeat_s or 120.0))
+
+    def _watch() -> None:
+        while True:
+            time.sleep(min(5.0, threshold_s))
+            now = time.monotonic()
+            last = float(heartbeat_state.get("last", now))
+            last_dump = float(heartbeat_state.get("last_dump", 0.0))
+            stalled_for = now - last
+            if stalled_for < threshold_s or now - last_dump < repeat_s:
+                continue
+            heartbeat_state["last_dump"] = now
+            _log.warning(
+                "event loop heartbeat missing for %.1fs; dumping Python "
+                "thread stacks for stall diagnostics:%s",
+                stalled_for,
+                _format_thread_stack_dump(),
+            )
+
+    threading.Thread(
+        target=_watch,
+        name="web-loop-stall-watchdog",
+        daemon=True,
+    ).start()
 
 try:
     from fastapi import (
@@ -15368,8 +15425,24 @@ def start_server(
             _hb_interval = 2.0
             _hb_stall_threshold = 5.0
             _hb_loop = asyncio.get_running_loop()
+            _hb_state = {
+                "last": time.monotonic(),
+                "last_dump": 0.0,
+            }
+            try:
+                _dump_threshold = float(
+                    os.environ.get("HERMES_WEB_LOOP_STALL_DUMP_S") or "30"
+                )
+            except (TypeError, ValueError):
+                _dump_threshold = 30.0
+            _start_loop_stall_stack_watchdog(
+                _hb_state,
+                threshold_s=_dump_threshold,
+                repeat_s=max(120.0, _dump_threshold * 4),
+            )
 
             def _loop_heartbeat(expected: float) -> None:
+                _hb_state["last"] = time.monotonic()
                 now = _hb_loop.time()
                 drift = now - expected
                 if drift > _hb_stall_threshold:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3961,6 +3961,113 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
     assert captured["session_key"] == "session-key"
 
 
+def test_desktop_prompt_submit_serializes_agent_turns(monkeypatch):
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.delenv("HERMES_DESKTOP_MAX_ACTIVE_TURNS", raising=False)
+    with server._desktop_prompt_turn_condition:
+        server._desktop_active_prompt_turns = 0
+        server._desktop_prompt_turn_condition.notify_all()
+
+    events: list[tuple[str, str, dict | None]] = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: events.append((event, sid, payload)),
+    )
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_voice_tts_enabled", lambda: False)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    release_first = threading.Event()
+    active_lock = threading.Lock()
+    active_turns = 0
+    max_active_turns = 0
+
+    class _Agent:
+        def __init__(self, name: str):
+            self.name = name
+
+        def clear_interrupt(self):
+            pass
+
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            nonlocal active_turns, max_active_turns
+            with active_lock:
+                active_turns += 1
+                max_active_turns = max(max_active_turns, active_turns)
+            try:
+                if self.name == "first":
+                    first_entered.set()
+                    assert release_first.wait(timeout=3)
+                else:
+                    second_entered.set()
+                return {
+                    "final_response": self.name,
+                    "messages": [{"role": "assistant", "content": self.name}],
+                }
+            finally:
+                with active_lock:
+                    active_turns -= 1
+
+    server._sessions["first"] = _session(agent=_Agent("first"))
+    server._sessions["second"] = _session(agent=_Agent("second"))
+
+    try:
+        first_resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "first", "text": "one"},
+            }
+        )
+        assert first_resp["result"]["status"] == "streaming"
+        assert first_entered.wait(timeout=2)
+
+        second_resp = server.handle_request(
+            {
+                "id": "2",
+                "method": "prompt.submit",
+                "params": {"session_id": "second", "text": "two"},
+            }
+        )
+        assert second_resp["result"]["status"] == "streaming"
+        time.sleep(0.2)
+
+        assert not second_entered.is_set()
+        assert max_active_turns == 1
+        assert any(
+            event == "status.update"
+            and sid == "second"
+            and isinstance(payload, dict)
+            and "Waiting for another Desktop turn" in payload.get("text", "")
+            for event, sid, payload in events
+        )
+
+        release_first.set()
+        assert second_entered.wait(timeout=3)
+        for sid in ("first", "second"):
+            thread = server._sessions[sid].get("_run_thread")
+            if thread is not None:
+                thread.join(timeout=3)
+        assert max_active_turns == 1
+    finally:
+        release_first.set()
+        server._sessions.pop("first", None)
+        server._sessions.pop("second", None)
+        with server._desktop_prompt_turn_condition:
+            server._desktop_active_prompt_turns = 0
+            server._desktop_prompt_turn_condition.notify_all()
+
+
 def test_prompt_submit_expands_context_refs(monkeypatch):
     captured = {}
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -12,6 +12,13 @@ import uvicorn
 from hermes_cli import web_server
 
 
+def test_loop_stall_stack_dump_includes_current_thread():
+    dump = web_server._format_thread_stack_dump()
+
+    assert "test_loop_stall_stack_dump_includes_current_thread" in dump
+    assert "thread id=" in dump
+
+
 def _stub_uvicorn(monkeypatch):
     """Replace uvicorn.Config/Server with fakes so start_server returns
     immediately.  Returns a dict with captured Config kwargs."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -244,6 +244,78 @@ _pool = concurrent.futures.ThreadPoolExecutor(
 )
 atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))
 
+_desktop_prompt_turn_condition = threading.Condition()
+_desktop_active_prompt_turns = 0
+
+
+def _desktop_prompt_turn_limit() -> int:
+    """Return the Desktop in-process prompt-turn concurrency cap.
+
+    Desktop runs ``hermes serve`` as a local backend and reaches prompt turns
+    through this module's WebSocket sidecar. Those turns execute in Python
+    threads inside the same process as uvicorn's event loop, so several
+    concurrent CPU/GIL-heavy turns can starve the loop and freeze the Desktop
+    socket. Keep ordinary TUI/dashboard behavior unchanged; only desktop-spawned
+    backends default to a single active prompt turn per backend process.
+    """
+    raw = os.environ.get("HERMES_DESKTOP_MAX_ACTIVE_TURNS")
+    if raw is None:
+        if not is_truthy_value(os.environ.get("HERMES_DESKTOP")):
+            return 0
+        raw = "1"
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 1 if is_truthy_value(os.environ.get("HERMES_DESKTOP")) else 0
+
+
+@contextlib.contextmanager
+def _desktop_prompt_turn_slot(sid: str):
+    """Serialize Desktop prompt turns when the backend is Desktop-spawned."""
+    global _desktop_active_prompt_turns
+
+    limit = _desktop_prompt_turn_limit()
+    if limit <= 0:
+        yield
+        return
+
+    wait_notice_sent = False
+    while True:
+        with _desktop_prompt_turn_condition:
+            if _desktop_active_prompt_turns < limit:
+                _desktop_active_prompt_turns += 1
+                break
+            should_send_wait_notice = not wait_notice_sent
+            if should_send_wait_notice:
+                wait_notice_sent = True
+                logger.info(
+                    "Desktop prompt turn queued behind %d active turn(s) "
+                    "(limit=%d)",
+                    _desktop_active_prompt_turns,
+                    limit,
+                )
+        if should_send_wait_notice:
+            try:
+                _emit(
+                    "status.update",
+                    sid,
+                    {
+                        "kind": "activity",
+                        "text": "Waiting for another Desktop turn to finish...",
+                    },
+                )
+            except Exception:
+                pass
+        with _desktop_prompt_turn_condition:
+            _desktop_prompt_turn_condition.wait(timeout=0.5)
+
+    try:
+        yield
+    finally:
+        with _desktop_prompt_turn_condition:
+            _desktop_active_prompt_turns = max(0, _desktop_active_prompt_turns - 1)
+            _desktop_prompt_turn_condition.notify_all()
+
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
 # of corrupting the JSON protocol.
@@ -8671,7 +8743,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     run_kwargs["task_id"] = session["session_key"]
             except (TypeError, ValueError):
                 pass
-            result = agent.run_conversation(run_message, **run_kwargs)
+            with _desktop_prompt_turn_slot(sid):
+                with session["history_lock"]:
+                    if session.get("_turn_cancel_requested") or not session.get("running"):
+                        return
+                result = agent.run_conversation(run_message, **run_kwargs)
             if "moa_one_shot_restore" in session:
                 _restore = session.pop("moa_one_shot_restore", None)
                 # Restore the model the user was on before the /moa one-shot.


### PR DESCRIPTION
## What does this PR do?

Desktop-spawned `hermes serve` backends currently run `prompt.submit` turns in Python threads inside the same process as the uvicorn/WebSocket loop. Under concurrent heavy turns, those worker threads can starve the event loop long enough for Desktop to look hung or time out.

This adds a narrow Desktop-only guard: when `HERMES_DESKTOP=1`, only one prompt turn runs at a time in a backend process by default. Additional Desktop turns wait for the active turn to finish and get a status update instead of piling more GIL-heavy work onto the same backend loop. Non-Desktop CLI/TUI/dashboard behavior stays unchanged unless `HERMES_DESKTOP_MAX_ACTIVE_TURNS` is explicitly set.

It also adds an out-of-band event-loop stall stack watchdog. The existing loop heartbeat can only log after the loop recovers; this daemon thread logs Python thread stacks while the loop is still stalled, which should make the next reproduction actionable instead of just showing a late `event loop stalled Ns` line.

This is adjacent to #51841, but not the same fix. #51841 changes WebSocket keepalive/coalescing and is currently conflicting; it does not cap Desktop prompt-turn concurrency or dump thread stacks while the loop is wedged.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: add a Desktop-only prompt-turn slot gate, defaulting to one active turn when `HERMES_DESKTOP=1`.
- `tui_gateway/server.py`: skip a queued turn before `agent.run_conversation()` if it was canceled while waiting.
- `hermes_cli/web_server.py`: add a daemon watchdog that logs Python thread stacks when the uvicorn loop heartbeat stops advancing.
- `tests/test_tui_gateway_server.py`: cover Desktop prompt-turn serialization.
- `tests/test_web_server.py`: cover stack dump formatting.

## How to Test

1. Start Desktop against a backend with `HERMES_DESKTOP=1`.
2. Run multiple long/heavy Desktop turns against the same backend profile.
3. Confirm only one `agent.run_conversation()` executes at a time in that backend, queued turns show a waiting status, and future event-loop stalls include thread stacks in logs.

Focused local checks run:

- `python -m py_compile tui_gateway/server.py hermes_cli/web_server.py`
- `.venv/bin/python -m pytest tests/test_tui_gateway_server.py::test_desktop_prompt_submit_serializes_agent_turns tests/test_tui_gateway_server.py::test_prompt_submit_sets_approval_session_key tests/test_web_server.py::test_loop_stall_stack_dump_includes_current_thread tests/test_web_server.py::test_start_server_disables_ws_ping_on_loopback -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: focused pytest on Linux/WSL checkout

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

The support logs that motivated this showed the web loop stalling for multi-minute windows, including lines like:

- `event loop stalled 256.5s`
- `event loop stalled 1186.7s`
- repeated `ws write slow (loop stalled >10.0s)`

The same logs had multiple Desktop session turns interleaved in one backend process, which matches this narrow concurrency guard.
