### PR TITLE
fix(config): align model resolution across desktop and gateway

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4797,6 +4797,20 @@ def _format_config_get_value(value, *, as_json: bool) -> str:
     return str(value)
 
 
+def resolve_model_name_from_config(model_cfg: Any) -> str:
+    """Return the configured main model name across supported config shapes."""
+    if isinstance(model_cfg, str):
+        return model_cfg.strip()
+    if not isinstance(model_cfg, dict):
+        return ""
+    return str(
+        model_cfg.get("default")
+        or model_cfg.get("model")
+        or model_cfg.get("name")
+        or ""
+    ).strip()
+
+
 def get_missing_config_fields() -> List[Dict[str, Any]]:
     """
     Check which config fields are missing or outdated (recursive).

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1804,6 +1804,21 @@ def test_resolve_model_strips_config_model(monkeypatch):
     assert server._resolve_model() == "nous/hermes-test"
 
 
+def test_resolve_model_accepts_legacy_model_keys(monkeypatch):
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"model": {"model": " mimo-v2.5-pro "}}
+    )
+    assert server._resolve_model() == "mimo-v2.5-pro"
+
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"model": {"name": " xiaomi/mimo "}}
+    )
+    assert server._resolve_model() == "xiaomi/mimo"
+
+
 def _sync_test_session(**extra):
     session = {
         "agent": types.SimpleNamespace(model="old/model"),
@@ -1990,6 +2005,25 @@ def test_config_model_target_never_reads_env(monkeypatch):
     monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"provider": "nous"}})
 
     assert server._config_model_target() == ("", "nous")
+
+
+@pytest.mark.parametrize(
+    ("legacy_key", "legacy_model"),
+    [
+        ("model", " mimo-v2.5-pro "),
+        ("name", " xiaomi/mimo "),
+    ],
+)
+def test_config_model_target_accepts_legacy_model_keys(
+    monkeypatch, legacy_key, legacy_model
+):
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"model": {legacy_key: legacy_model, "provider": "nous"}},
+    )
+
+    assert server._config_model_target() == (legacy_model.strip(), "nous")
 
 
 def test_apply_model_switch_persist_override_false_never_persists(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2345,11 +2345,12 @@ def _resolve_model() -> str:
     ).strip()
     if env:
         return env
+    from hermes_cli.config import resolve_model_name_from_config
+
     m = _load_cfg().get("model", "")
-    if isinstance(m, dict):
-        return str(m.get("default", "") or "").strip()
-    if isinstance(m, str) and m:
-        return m.strip()
+    resolved = resolve_model_name_from_config(m)
+    if resolved:
+        return resolved
     # No env seed and no config preference: fall back to the cost-safe silent
     # default (catalog-labeled, cache-only read), never an expensive Anthropic
     # flagship the user didn't pick.
@@ -2418,12 +2419,16 @@ def _config_model_target() -> tuple[str, str]:
     model = ""
     provider = ""
     if isinstance(cfg_model, dict):
-        model = str(cfg_model.get("default", "") or "").strip()
+        from hermes_cli.config import resolve_model_name_from_config
+
+        model = resolve_model_name_from_config(cfg_model)
         provider = str(cfg_model.get("provider") or "").strip()
         if provider.lower() == "auto":
             provider = ""
     elif isinstance(cfg_model, str):
-        model = cfg_model.strip()
+        from hermes_cli.config import resolve_model_name_from_config
+
+        model = resolve_model_name_from_config(cfg_model)
     # No fallback to _resolve_model() here: that reads HERMES_MODEL /
     # HERMES_INFERENCE_MODEL, which `hermes --tui -m <model>` sets as a
     # session-scoped seed for THIS launch. When config.yaml has no


### PR DESCRIPTION
## What does this PR do?

Centralizes model-name resolution across the TUI/Desktop gateway and messaging gateway, and makes gateway `/model` persistence update only the selected model fields from the latest on-disk config instead of writing back a stale full config object.

## Related Issue

## Shared root cause

- Desktop/TUI and Gateway resolved the main model from different subsets of the `model:` config block. Gateway accepted `model.default` and `model.model`, while TUI/Desktop only accepted `model.default`, so legacy or mixed configs could report one model in session metadata but build agents with an empty/default model elsewhere.
- Gateway `/model` persistence had two duplicated full-config rewrite blocks. Those blocks reloaded and rewrote the whole config through a generic dict path, making it easy for stale endpoint fields or sibling model settings to survive or be clobbered when another surface had just changed the same `model:` block.

## How this fixes each issue

- #37239: `_resolve_model()` and gateway model resolution now share `resolve_model_name_from_config()`, which accepts `model.default`, `model.model`, `model.name`, and scalar `model:` forms. Desktop/TUI startup and session metadata no longer diverge on mixed model config shapes.
- #37751: Gateway global `/model` persistence now reads the current config from disk at write time and updates only `model.default`, `model.provider`, and `model.base_url`, while preserving unrelated sibling keys and clearing stale inline endpoint credentials when switching away from custom providers.

## Changes Made

- Added `hermes_cli.config.resolve_model_name_from_config()` for shared model-name fallback rules.
- Updated `tui_gateway.server._resolve_model()`, `_config_model_target()`, and `gateway.run._resolve_gateway_model()` to use the shared resolver.
- Replaced duplicated Gateway `/model` full-config persistence blocks with `_persist_global_model_switch()`.
- Added regression coverage for legacy `model.model`/`model.name` config shapes and for targeted Gateway model-switch writes preserving sibling keys while clearing stale endpoint config.

## How to Test

1. `pytest tests/test_tui_gateway_server.py::test_resolve_model_uses_inference_model_env tests/test_tui_gateway_server.py::test_resolve_model_strips_config_model tests/test_tui_gateway_server.py::test_resolve_model_accepts_legacy_model_keys tests/gateway/test_model_command_flat_string_config.py tests/gateway/test_model_picker_persist.py -q --timeout=60`
2. `ruff check` on changed Python files
3. `python scripts/check-windows-footguns.py gateway/run.py gateway/slash_commands.py hermes_cli/config.py tests/gateway/test_model_command_flat_string_config.py tests/gateway/test_model_picker_persist.py tests/test_tui_gateway_server.py tui_gateway/server.py`
4. Attempted full suite with `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`; collection aborted because this environment lacks `fastapi` and lazy dependency installation is blocked by Homebrew's externally managed Python policy.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass; attempted, but collection aborted on missing `fastapi` in the local environment
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] Documentation N/A
- [x] `cli-config.yaml.example` N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A
- [x] Cross-platform impact considered; Windows footgun scan passed on changed files
- [x] Tool descriptions/schemas N/A

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #37239
Refs #37751

<!-- autocontrib:worker-id=pr-spanning-a70a6758 kind=pr-open -->