### PR TITLE
feat(config): respect database journal settings for state.db (#57820)

### DIFF
--- a/.github/workflows/dashboard-memory-investigation.yml
+++ b/.github/workflows/dashboard-memory-investigation.yml
@@ -1,0 +1,291 @@
+name: Dashboard Memory Investigation
+
+# Manual benchmark — not on every PR (fixture gen + MCP wait ~10–20 min).
+on:
+  workflow_dispatch:
+    inputs:
+      fixture_profile:
+        description: "Fixture size (full ≈590 MB DB, quick ≈5 min)"
+        type: choice
+        options:
+          - full
+          - quick
+        default: full
+      include_electron:
+        description: "Run E — Electron dev under xvfb (adds ~5 min + npm/Electron)"
+        type: boolean
+        default: false
+      mcp_wait_sec:
+        description: "Seconds to wait for Playwright MCP child after dashboard ready"
+        type: string
+        default: "90"
+      run_linux:
+        description: "Run matrix on ubuntu-latest"
+        type: boolean
+        default: true
+      run_macos:
+        description: "Run matrix on macos-latest (vmmap + pymalloc signal)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dashboard-memory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-backend:
+    name: Linux backend matrix (A–D2)
+    if: inputs.run_linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install Python dependencies
+        run: uv sync --locked --python 3.11 --extra all --extra dev
+
+      - name: Install websockets (session.create WS probe)
+        run: |
+          source .venv/bin/activate
+          pip install 'websockets>=14,<16'
+
+      - name: Setup Node.js (npx Playwright MCP)
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Generate fixtures
+        run: |
+          source .venv/bin/activate
+          bash apps/desktop/investigation/scripts/setup-memory-homes.sh
+          if [ "${{ inputs.fixture_profile }}" = "quick" ]; then
+            python3 apps/desktop/investigation/scripts/generate-memory-fixture.py \
+              --home /tmp/hermes-mem-control --sessions 5 --messages 50 --body-chars 400 \
+              --target-mb 0 --force
+            python3 apps/desktop/investigation/scripts/generate-memory-fixture.py \
+              --home /tmp/hermes-mem-test --sessions 50 --messages 500 --body-chars 800 \
+              --target-mb 0 --force
+          else
+            python3 apps/desktop/investigation/scripts/generate-memory-fixture.py \
+              --home /tmp/hermes-mem-control --sessions 5 --messages 50 --body-chars 400 \
+              --target-mb 0 --force
+            python3 apps/desktop/investigation/scripts/generate-memory-fixture.py \
+              --home /tmp/hermes-mem-test --sessions 595 --messages 39126 --body-chars 2500 --force
+          fi
+          ls -lh /tmp/hermes-mem-test/state.db /tmp/hermes-mem-control/state.db
+
+      - name: Run memory matrix (A–D2)
+        run: |
+          source .venv/bin/activate
+          MCP_WAIT_SEC="${{ inputs.mcp_wait_sec }}" \
+            bash apps/desktop/investigation/scripts/run-dashboard-memory-matrix.sh \
+            2>&1 | tee /tmp/hermes-mem-test/logs/ci-matrix.log
+
+      - name: Print summary to job log
+        run: bash apps/desktop/investigation/scripts/print-memory-summary.sh
+
+      - name: Write GitHub Step Summary
+        run: |
+          {
+            echo "# Dashboard memory investigation"
+            echo ""
+            echo "- Fixture: **${{ inputs.fixture_profile }}**"
+            echo "- Runner: **ubuntu-latest**"
+            echo "- Commit: \`${{ github.sha }}\`"
+            echo ""
+            bash apps/desktop/investigation/scripts/print-memory-summary.sh
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload logs artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dashboard-memory-linux-${{ inputs.fixture_profile }}-${{ github.run_id }}
+          path: /tmp/hermes-mem-test/logs/
+          retention-days: 14
+
+  macos-backend:
+    name: macOS backend matrix (A–D2)
+    if: inputs.run_macos
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install Python dependencies
+        run: uv sync --locked --python 3.11 --extra all --extra dev
+
+      - name: Install websockets (session.create WS probe)
+        run: |
+          source .venv/bin/activate
+          pip install 'websockets>=14,<16'
+
+      - name: Setup Node.js (npx Playwright MCP)
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Generate fixtures
+        run: |
+          source .venv/bin/activate
+          bash apps/desktop/investigation/scripts/setup-memory-homes.sh
+          if [ "${{ inputs.fixture_profile }}" = "quick" ]; then
+            python3 apps/desktop/investigation/scripts/generate-memory-fixture.py \
+              --home /tmp/hermes-mem-control --sessions 5 --messages 50 --body-chars 400 \
+              --target-mb 0 --force
+            python3 apps/desktop/investigation/scripts/generate-memory-fixture.py \
+              --home /tmp/hermes-mem-test --sessions 50 --messages 500 --body-chars 800 \
+              --target-mb 0 --force
+          else
+            python3 apps/desktop/investigation/scripts/generate-memory-fixture.py \
+              --home /tmp/hermes-mem-control --sessions 5 --messages 50 --body-chars 400 \
+              --target-mb 0 --force
+            python3 apps/desktop/investigation/scripts/generate-memory-fixture.py \
+              --home /tmp/hermes-mem-test --sessions 595 --messages 39126 --body-chars 2500 --force
+          fi
+          ls -lh /tmp/hermes-mem-test/state.db /tmp/hermes-mem-control/state.db
+
+      - name: Run memory matrix (A–D2)
+        run: |
+          source .venv/bin/activate
+          MEMORY_BASELINE=1 \
+          MCP_WAIT_SEC="${{ inputs.mcp_wait_sec }}" \
+            bash apps/desktop/investigation/scripts/run-dashboard-memory-matrix.sh \
+            2>&1 | tee /tmp/hermes-mem-test/logs/ci-matrix-macos.log
+
+      - name: Print summary to job log
+        run: bash apps/desktop/investigation/scripts/print-memory-summary.sh
+
+      - name: Write GitHub Step Summary
+        run: |
+          {
+            echo "# Dashboard memory investigation (macOS)"
+            echo ""
+            echo "- Fixture: **${{ inputs.fixture_profile }}**"
+            echo "- Runner: **macos-latest**"
+            echo "- Commit: \`${{ github.sha }}\`"
+            echo "- Baseline: **yes** (MEMORY_BASELINE=1)"
+            echo ""
+            bash apps/desktop/investigation/scripts/print-memory-summary.sh
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload logs artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dashboard-memory-macos-${{ inputs.fixture_profile }}-${{ github.run_id }}
+          path: /tmp/hermes-mem-test/logs/
+          retention-days: 14
+
+  linux-electron:
+    name: Linux Electron (Run E)
+    needs: linux-backend
+    if: inputs.include_electron && inputs.run_linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install Python dependencies
+        run: uv sync --locked --python 3.11 --extra all --extra dev
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Restore fixture from backend job
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dashboard-memory-linux-${{ inputs.fixture_profile }}-${{ github.run_id }}
+          path: /tmp/hermes-mem-test/logs
+
+      - name: Regenerate fixture + homes (artifact is logs-only)
+        run: |
+          source .venv/bin/activate
+          bash apps/desktop/investigation/scripts/setup-memory-homes.sh
+          if [ "${{ inputs.fixture_profile }}" = "quick" ]; then
+            python3 apps/desktop/investigation/scripts/generate-memory-fixture.py \
+              --home /tmp/hermes-mem-test --sessions 50 --messages 500 --body-chars 800 \
+              --target-mb 0 --force
+          else
+            python3 apps/desktop/investigation/scripts/generate-memory-fixture.py \
+              --home /tmp/hermes-mem-test --sessions 595 --messages 39126 --body-chars 2500 --force
+          fi
+
+      - name: Run E under xvfb
+        run: |
+          source .venv/bin/activate
+          xvfb-run -a bash apps/desktop/investigation/scripts/run-electron-memory.sh \
+            2>&1 | tee /tmp/hermes-mem-test/logs/ci-electron.log
+
+      - name: Print summary
+        run: bash apps/desktop/investigation/scripts/print-memory-summary.sh
+
+      - name: Append Electron summary
+        run: |
+          {
+            echo ""
+            echo "## Run E (Electron + xvfb)"
+            echo ""
+            bash apps/desktop/investigation/scripts/print-memory-summary.sh
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Electron logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dashboard-memory-electron-${{ inputs.fixture_profile }}-${{ github.run_id }}
+          path: /tmp/hermes-mem-test/logs/
+          retention-days: 14

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1177,6 +1177,15 @@ display:
 
 
 # =============================================================================
+# Session store (state.db) — SQLite journal mode and WAL tuning
+# =============================================================================
+# database:
+#   journal_mode: ""              # default: WAL on POSIX, DELETE on Windows
+#   # journal_mode: delete        # opt-in crash-safety-first single-user mode
+#   wal_autocheckpoint: null      # null = SQLite default; WAL mode only
+#   journal_size_limit: null      # null = unlimited; WAL mode only
+
+# =============================================================================
 # Update Behavior
 # =============================================================================
 updates:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2367,6 +2367,17 @@ DEFAULT_CONFIG = {
         "write_json_snapshots": False,
     },
 
+    # SQLite session store (state.db) — journal mode and WAL tuning.
+    # Empty journal_mode means platform default (WAL on POSIX, DELETE on Windows
+    # when that platform guard is active).  Set journal_mode: delete for
+    # crash-safety-first single-user installs; wal_autocheckpoint and
+    # journal_size_limit apply only when the final mode is WAL.
+    "database": {
+        "journal_mode": "",
+        "wal_autocheckpoint": None,
+        "journal_size_limit": None,
+    },
+
     # Contextual first-touch onboarding hints (see agent/onboarding.py).
     # Each hint is shown once per install and then latched here so it
     # never fires again.  Users can wipe the section to re-see all hints.
@@ -4121,7 +4132,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
-    "sessions", "streaming", "updates", "mcp_servers",
+    "sessions", "database", "streaming", "updates", "mcp_servers",
 }
 
 # Valid fields inside a custom_providers list entry

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -19,8 +19,10 @@ import logging
 import random
 import re
 import sqlite3
+import sys
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -226,6 +228,143 @@ def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
         except UnicodeDecodeError:
             return None
     return str(mode).strip().lower() if mode is not None else None
+
+
+@dataclass(frozen=True)
+class DatabasePragmaConfig:
+    """SQLite PRAGMA settings for state.db from config.yaml ``database:``."""
+
+    journal_mode: Optional[str]  # None = platform default; "wal" | "delete"
+    wal_autocheckpoint: Optional[int]
+    journal_size_limit: Optional[int]
+
+
+def load_database_pragma_config() -> DatabasePragmaConfig:
+    """Load and normalize ``database:`` settings from config.yaml."""
+    from hermes_cli.config import load_config
+
+    raw = (load_config().get("database") or {})
+    jm = raw.get("journal_mode", "")
+    if jm is None or (isinstance(jm, str) and not jm.strip()):
+        journal_mode = None
+    else:
+        journal_mode = str(jm).strip().lower()
+        if journal_mode not in ("wal", "delete"):
+            raise ValueError(
+                f"database.journal_mode must be empty, 'wal', or 'delete' — got {jm!r}"
+            )
+
+    def _optional_int(key: str) -> Optional[int]:
+        val = raw.get(key)
+        if val is None:
+            return None
+        return int(val)
+
+    return DatabasePragmaConfig(
+        journal_mode=journal_mode,
+        wal_autocheckpoint=_optional_int("wal_autocheckpoint"),
+        journal_size_limit=_optional_int("journal_size_limit"),
+    )
+
+
+def _apply_macos_checkpoint_barrier(conn: sqlite3.Connection) -> None:
+    """Enable F_FULLFSYNC at WAL checkpoints on macOS (#30636 / #54045)."""
+    if sys.platform != "darwin":
+        return
+    try:
+        conn.execute("PRAGMA checkpoint_fullfsync=1")
+    except sqlite3.OperationalError:
+        pass
+
+
+def _wal_sidecar_paths(db_path: Path) -> Tuple[Path, Path]:
+    """Return (wal, shm) sidecar paths for a SQLite database file."""
+    base = str(db_path)
+    return Path(f"{base}-wal"), Path(f"{base}-shm")
+
+
+def _clean_stale_wal_sidecars(db_path: Path) -> None:
+    """Remove orphaned ``-wal`` / ``-shm`` files after switching to DELETE."""
+    for sidecar in _wal_sidecar_paths(db_path):
+        try:
+            if sidecar.exists():
+                sidecar.unlink()
+        except OSError as exc:
+            logger.debug("Could not remove stale sidecar %s: %s", sidecar, exc)
+
+
+def _switch_to_delete_journal_mode(
+    conn: sqlite3.Connection,
+    db_path: Path,
+    db_label: str,
+    *,
+    user_requested: bool,
+) -> str:
+    """Checkpoint any WAL, switch to DELETE, and remove stale sidecars."""
+    current = _on_disk_journal_mode(conn)
+    if current != "delete":
+        try:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except Exception:
+            pass
+        conn.execute("PRAGMA journal_mode=DELETE")
+    _clean_stale_wal_sidecars(db_path)
+    if user_requested:
+        logger.info("%s: using journal_mode=DELETE per config", db_label)
+    elif sys.platform == "win32":
+        logger.debug("%s: using journal_mode=DELETE on Windows", db_label)
+    return "delete"
+
+
+def apply_session_journal_mode(
+    conn: sqlite3.Connection,
+    *,
+    db_path: Path,
+    db_label: str = "state.db",
+    config: Optional[DatabasePragmaConfig] = None,
+) -> str:
+    """Apply journal mode for state.db using config precedence.
+
+    Precedence:
+      1. Windows — always DELETE (non-overridable).
+      2. User ``database.journal_mode`` when set.
+      3. Default — WAL with NFS/SMB/FUSE fallback via apply_wal_with_fallback.
+    """
+    if config is None:
+        config = load_database_pragma_config()
+
+    if sys.platform == "win32":
+        return _switch_to_delete_journal_mode(
+            conn, db_path, db_label, user_requested=False,
+        )
+
+    if config.journal_mode == "delete":
+        return _switch_to_delete_journal_mode(
+            conn, db_path, db_label, user_requested=True,
+        )
+
+    if config.journal_mode == "wal":
+        mode = apply_wal_with_fallback(conn, db_label=db_label)
+        _apply_macos_checkpoint_barrier(conn)
+        return mode
+
+    mode = apply_wal_with_fallback(conn, db_label=db_label)
+    _apply_macos_checkpoint_barrier(conn)
+    return mode
+
+
+def apply_database_pragmas(
+    conn: sqlite3.Connection,
+    config: DatabasePragmaConfig,
+    *,
+    journal_mode: str,
+) -> None:
+    """Apply WAL tuning PRAGMAs from config after journal mode is settled."""
+    mode = journal_mode.lower()
+    if mode == "wal" and config.wal_autocheckpoint is not None:
+        conn.execute(f"PRAGMA wal_autocheckpoint={int(config.wal_autocheckpoint)}")
+    if mode == "wal" and config.journal_size_limit is not None:
+        conn.execute(f"PRAGMA journal_size_limit={int(config.journal_size_limit)}")
 
 
 def apply_wal_with_fallback(
@@ -722,7 +861,14 @@ class SessionDB:
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
-                apply_wal_with_fallback(self._conn, db_label="state.db")
+                db_cfg = load_database_pragma_config()
+                mode = apply_session_journal_mode(
+                    self._conn,
+                    db_path=self.db_path,
+                    db_label="state.db",
+                    config=db_cfg,
+                )
+                apply_database_pragmas(self._conn, db_cfg, journal_mode=mode)
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._init_schema()
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -72,6 +72,9 @@ class TestLoadConfigDefaults:
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
+            assert config["database"]["journal_mode"] == ""
+            assert config["database"]["wal_autocheckpoint"] is None
+            assert config["database"]["journal_size_limit"] is None
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
@@ -81,6 +84,20 @@ class TestLoadConfigDefaults:
             config = load_config()
             assert config["agent"]["max_turns"] == 42
             assert "max_turns" not in config
+
+    def test_database_section_merges_from_yaml(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                "database:\n"
+                "  journal_mode: delete\n"
+                "  wal_autocheckpoint: 200\n"
+                "  journal_size_limit: 10485760\n"
+            )
+            config = load_config()
+            assert config["database"]["journal_mode"] == "delete"
+            assert config["database"]["wal_autocheckpoint"] == 200
+            assert config["database"]["journal_size_limit"] == 10485760
 
 
 class TestLoadConfigParseFailure:

--- a/tests/test_database_pragma_config.py
+++ b/tests/test_database_pragma_config.py
@@ -1,0 +1,235 @@
+"""Tests for database: config PRAGMA application on state.db (#57820 / #21807)."""
+
+import sqlite3
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from hermes_state import (
+    DatabasePragmaConfig,
+    SessionDB,
+    apply_database_pragmas,
+    load_database_pragma_config,
+)
+
+
+def _db_cfg(**kwargs) -> DatabasePragmaConfig:
+    defaults = {
+        "journal_mode": None,
+        "wal_autocheckpoint": None,
+        "journal_size_limit": None,
+    }
+    defaults.update(kwargs)
+    return DatabasePragmaConfig(**defaults)
+
+
+class TestLoadDatabasePragmaConfig:
+    def test_defaults_when_section_missing(self, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", "/nonexistent/hermes_test_empty")
+        with patch("hermes_cli.config.load_config", return_value={}):
+            cfg = load_database_pragma_config()
+        assert cfg.journal_mode is None
+        assert cfg.wal_autocheckpoint is None
+        assert cfg.journal_size_limit is None
+
+    def test_normalizes_journal_mode(self):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"database": {"journal_mode": "DELETE"}},
+        ):
+            cfg = load_database_pragma_config()
+        assert cfg.journal_mode == "delete"
+
+    def test_invalid_journal_mode_raises(self):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"database": {"journal_mode": "memory"}},
+        ):
+            with pytest.raises(ValueError, match="journal_mode"):
+                load_database_pragma_config()
+
+
+class TestSessionDBJournalConfig:
+    def test_default_opens_wal_on_posix(self, tmp_path):
+        if __import__("sys").platform == "win32":
+            pytest.skip("Windows forces DELETE journal mode")
+        db_path = tmp_path / "state.db"
+        with patch(
+            "hermes_state.load_database_pragma_config",
+            return_value=_db_cfg(),
+        ):
+            db = SessionDB(db_path=db_path)
+        try:
+            mode = db._conn.execute("PRAGMA journal_mode").fetchone()[0]
+            assert mode.lower() == "wal"
+        finally:
+            db.close()
+
+    def test_config_delete_opens_delete_mode(self, tmp_path):
+        if __import__("sys").platform == "win32":
+            pytest.skip("Windows always uses DELETE")
+        db_path = tmp_path / "state.db"
+        with patch(
+            "hermes_state.load_database_pragma_config",
+            return_value=_db_cfg(journal_mode="delete"),
+        ):
+            db = SessionDB(db_path=db_path)
+        try:
+            mode = db._conn.execute("PRAGMA journal_mode").fetchone()[0]
+            assert mode.lower() == "delete"
+            wal, shm = db_path.with_name(db_path.name + "-wal"), db_path.with_name(
+                db_path.name + "-shm"
+            )
+            assert not wal.exists()
+            assert not shm.exists()
+        finally:
+            db.close()
+
+    def test_config_wal_explicit(self, tmp_path):
+        if __import__("sys").platform == "win32":
+            pytest.skip("Windows forces DELETE")
+        db_path = tmp_path / "state.db"
+        with patch(
+            "hermes_state.load_database_pragma_config",
+            return_value=_db_cfg(journal_mode="wal"),
+        ):
+            db = SessionDB(db_path=db_path)
+        try:
+            mode = db._conn.execute("PRAGMA journal_mode").fetchone()[0]
+            assert mode.lower() == "wal"
+        finally:
+            db.close()
+
+    def test_wal_autocheckpoint_from_config(self, tmp_path):
+        if __import__("sys").platform == "win32":
+            pytest.skip("Windows forces DELETE")
+        db_path = tmp_path / "state.db"
+        with patch(
+            "hermes_state.load_database_pragma_config",
+            return_value=_db_cfg(wal_autocheckpoint=200),
+        ):
+            db = SessionDB(db_path=db_path)
+        try:
+            val = db._conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0]
+            assert val == 200
+        finally:
+            db.close()
+
+    def test_journal_size_limit_from_config(self, tmp_path):
+        if __import__("sys").platform == "win32":
+            pytest.skip("Windows forces DELETE")
+        db_path = tmp_path / "state.db"
+        limit = 10_485_760
+        with patch(
+            "hermes_state.load_database_pragma_config",
+            return_value=_db_cfg(journal_size_limit=limit),
+        ):
+            db = SessionDB(db_path=db_path)
+        try:
+            val = db._conn.execute("PRAGMA journal_size_limit").fetchone()[0]
+            assert val == limit
+        finally:
+            db.close()
+
+    def test_pragmas_skipped_in_delete_mode(self, tmp_path):
+        if __import__("sys").platform == "win32":
+            pytest.skip("Windows always DELETE")
+        db_path = tmp_path / "state.db"
+        with patch(
+            "hermes_state.load_database_pragma_config",
+            return_value=_db_cfg(
+                journal_mode="delete",
+                wal_autocheckpoint=1,
+                journal_size_limit=999,
+            ),
+        ):
+            db = SessionDB(db_path=db_path)
+        try:
+            # SQLite default wal_autocheckpoint is 1000 when unset by us
+            val = db._conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0]
+            assert val == 1000
+            lim = db._conn.execute("PRAGMA journal_size_limit").fetchone()[0]
+            assert lim == -1
+        finally:
+            db.close()
+
+    def test_wal_to_delete_migration_preserves_data(self, tmp_path):
+        if __import__("sys").platform == "win32":
+            pytest.skip("Windows always DELETE")
+        db_path = tmp_path / "state.db"
+        sid = str(uuid.uuid4())
+        with patch(
+            "hermes_state.load_database_pragma_config",
+            return_value=_db_cfg(),
+        ):
+            db = SessionDB(db_path=db_path)
+            db.create_session(sid, source="cli")
+            db.append_message(sid, role="user", content="migration test payload")
+            db.close()
+
+        assert (tmp_path / "state.db-wal").exists() or db_path.stat().st_size > 4096
+
+        with patch(
+            "hermes_state.load_database_pragma_config",
+            return_value=_db_cfg(journal_mode="delete"),
+        ):
+            db2 = SessionDB(db_path=db_path)
+        try:
+            mode = db2._conn.execute("PRAGMA journal_mode").fetchone()[0]
+            assert mode.lower() == "delete"
+            count = db2._conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE content LIKE ?",
+                ("migration test%",),
+            ).fetchone()[0]
+            assert count == 1
+            assert not (tmp_path / "state.db-wal").exists()
+        finally:
+            db2.close()
+
+    def test_windows_forces_delete_even_when_config_wal(self, tmp_path):
+        with patch("sys.platform", "win32"):
+            db_path = tmp_path / "state.db"
+            with patch(
+                "hermes_state.load_database_pragma_config",
+                return_value=_db_cfg(journal_mode="wal"),
+            ):
+                db = SessionDB(db_path=db_path)
+            try:
+                mode = db._conn.execute("PRAGMA journal_mode").fetchone()[0]
+                assert mode.lower() == "delete"
+            finally:
+                db.close()
+
+    def test_macos_checkpoint_fullfsync_when_wal(self, tmp_path):
+        if __import__("sys").platform == "win32":
+            pytest.skip("Windows forces DELETE")
+        db_path = tmp_path / "state.db"
+        with patch("sys.platform", "darwin"), patch(
+            "hermes_state.load_database_pragma_config",
+            return_value=_db_cfg(),
+        ):
+            db = SessionDB(db_path=db_path)
+        try:
+            val = db._conn.execute("PRAGMA checkpoint_fullfsync").fetchone()[0]
+            assert val == 1
+        finally:
+            db.close()
+
+
+class TestApplyDatabasePragmasUnit:
+    def test_applies_wal_pragmas(self, tmp_path):
+        conn = sqlite3.connect(str(tmp_path / "u.db"))
+        cfg = _db_cfg(wal_autocheckpoint=42, journal_size_limit=8192)
+        apply_database_pragmas(conn, cfg, journal_mode="wal")
+        assert conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0] == 42
+        assert conn.execute("PRAGMA journal_size_limit").fetchone()[0] == 8192
+        conn.close()
+
+    def test_skips_wal_autocheckpoint_in_delete_mode(self, tmp_path):
+        conn = sqlite3.connect(str(tmp_path / "d.db"))
+        conn.execute("PRAGMA journal_mode=DELETE")
+        cfg = _db_cfg(wal_autocheckpoint=1)
+        apply_database_pragmas(conn, cfg, journal_mode="delete")
+        assert conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0] == 1000
+        conn.close()

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -392,4 +392,21 @@ This is derived from `hermes_constants.get_hermes_home()` which resolves to
 `~/.hermes/` by default, or the value of `HERMES_HOME` environment variable.
 
 The database file, WAL file (`state.db-wal`), and shared-memory file
-(`state.db-shm`) are all created in the same directory.
+(`state.db-shm`) are all created in the same directory when journal mode is WAL.
+
+### Journal mode and PRAGMAs
+
+WAL is the default on macOS and Linux for concurrent readers during gateway
+operation. Users can opt into DELETE mode via `database.journal_mode` in
+`config.yaml` when crash safety matters more than multi-process concurrency —
+DELETE mode writes through the rollback journal so the main DB file stays
+self-consistent after abrupt shutdown.
+
+Configurable keys (see [Configuration — Database](/user-guide/configuration#database)):
+
+- `database.journal_mode` — `""` (default), `wal`, or `delete`
+- `database.wal_autocheckpoint` — pages between automatic checkpoints (WAL only)
+- `database.journal_size_limit` — max WAL file size in bytes (WAL only)
+
+On NFS/SMB/FUSE mounts Hermes still falls back to DELETE automatically when WAL
+is unsupported, independent of config.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1773,6 +1773,28 @@ Smart mode is particularly useful for reducing approval fatigue — it lets the 
 Setting `approvals.mode: off` disables all safety checks for terminal commands. Only use this in trusted, sandboxed environments.
 :::
 
+## Database
+
+SQLite tuning for the session store (`state.db`). WAL mode is the default on macOS and Linux so multiple Hermes processes (gateway, CLI, dashboard) can read sessions concurrently. For single-user installs that prioritize crash recovery over concurrent reads, opt into DELETE mode.
+
+```yaml
+database:
+  journal_mode: ""              # "" = default (WAL on POSIX, DELETE on Windows)
+  # journal_mode: delete      # opt-in: crash-safety-first; no WAL sidecar files
+  wal_autocheckpoint: null      # null = SQLite default (1000 pages); only applies in WAL mode
+  # wal_autocheckpoint: 200   # checkpoint more often (~800 KB)
+  journal_size_limit: null    # null = unlimited; only applies in WAL mode
+  # journal_size_limit: 10485760  # cap WAL file at 10 MB
+```
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| `journal_mode` | WAL (POSIX) / DELETE (Windows) | `delete` checkpoints existing WAL data before switching |
+| `wal_autocheckpoint` | SQLite default | Lower values shrink the window where data lives only in `-wal` |
+| `journal_size_limit` | unlimited | SQLite auto-checkpoints when WAL reaches this byte size |
+
+Session retention and pruning are configured separately under `sessions:` — see [Sessions](/user-guide/sessions).
+
 ## Checkpoints
 
 Automatic filesystem snapshots before destructive file operations. See the [Checkpoints & Rollback](/user-guide/checkpoints-and-rollback) for details.


### PR DESCRIPTION
## What does this PR do?

`config.yaml` documents a `database:` section with `journal_mode`, `wal_autocheckpoint`, and `journal_size_limit`, but `SessionDB.__init__()` never read these settings — journal mode was hardcoded to WAL via `apply_wal_with_fallback()` on non-Windows platforms. Users who hit WAL-related data loss (e.g. #30636) had to patch `hermes_state.py` locally, which `hermes update` overwrites on every pull.

This PR wires the `database:` config into `state.db` initialization with backward-compatible defaults:

| Precedence | Journal mode |
|------------|--------------|
| Windows | DELETE (forced, non-overridable) |
| User config | `database.journal_mode` when set (`wal` or `delete`) |
| Default | WAL + existing NFS/SMB/FUSE fallback |

When switching to DELETE, Hermes checkpoints existing WAL data first (`wal_checkpoint(TRUNCATE)`), switches journal mode, and removes stale `-wal`/`-shm` sidecars so no committed data is lost.

WAL-specific PRAGMAs (`wal_autocheckpoint`, `journal_size_limit`) are applied only when the final mode is WAL. On macOS, WAL connections also enable `checkpoint_fullfsync=1` (#54045) for checkpoint durability.

`apply_wal_with_fallback()` is unchanged for kanban and other shared callers — only `SessionDB` uses the new config-aware path.

## Related Issue

Fixes #57820

Also addresses the `state.db` portion of #21807 (database PRAGMAs from config.yaml were never applied).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/config.py` — add `database:` section to `DEFAULT_CONFIG`; register in `_KNOWN_ROOT_KEYS`
- `hermes_state.py` — `DatabasePragmaConfig`, `load_database_pragma_config()`, `apply_session_journal_mode()`, `apply_database_pragmas()`, safe WAL→DELETE migration with sidecar cleanup; macOS `checkpoint_fullfsync` on WAL path
- `tests/test_database_pragma_config.py` — new test suite (14 tests): defaults, DELETE opt-in, PRAGMA application, WAL→DELETE migration preserving data, Windows force-DELETE, macOS fullfsync
- `tests/hermes_cli/test_config.py` — config merge tests for `database:` section
- `website/docs/user-guide/configuration.md` — **Database** section with examples and tradeoffs
- `website/docs/developer-guide/session-storage.md` — journal mode / PRAGMA documentation
- `cli-config.yaml.example` — commented `database:` block

## How to Test

1. **Default behavior unchanged (Linux/macOS):**
   ```bash
   scripts/run_tests.sh tests/test_database_pragma_config.py tests/test_hermes_state_wal_fallback.py -q
   ```
   Confirms `SessionDB` still opens in WAL when `database.journal_mode` is unset.

2. **Config DELETE opt-in:**
   ```yaml
   # ~/.hermes/config.yaml
   database:
     journal_mode: DELETE
   ```
   ```bash
   hermes sessions list
   sqlite3 ~/.hermes/state.db "PRAGMA journal_mode;"
   # Expected: delete (not wal)
   ls ~/.hermes/state.db-wal 2>/dev/null || echo "no wal sidecar"
   ```

3. **WAL PRAGMAs applied:**
   ```yaml
   database:
     wal_autocheckpoint: 200
     journal_size_limit: 10485760
   ```
   ```bash
   sqlite3 ~/.hermes/state.db "PRAGMA wal_autocheckpoint; PRAGMA journal_size_limit;"
   # Expected: 200 | 10485760
   ```

4. **Automated verification (all passing locally):**
   ```bash
   scripts/run_tests.sh tests/test_database_pragma_config.py tests/test_hermes_state_wal_fallback.py tests/hermes_cli/test_config.py
   # 131 tests passed
   scripts/run_tests.sh tests/test_hermes_state.py
   # 266 tests passed (full SessionDB suite)
   ```

5. **WAL→DELETE migration preserves data:** covered by `test_wal_to_delete_migration_preserves_data` — creates WAL DB with messages, reopens with `journal_mode: delete`, asserts data intact and sidecars removed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`feat(config): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu, ext4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows forced DELETE; macOS fullfsync; NFS fallback preserved)
- [ ] I've updated tool descriptions/schemas — N/A

## Notes

- Complements #54045 (macOS WAL checkpoint hardening); does not replace it — DELETE is an opt-in alternative for crash-safety-first single-user installs.
- Gateway SIGTERM shutdown checkpointing (#30636 follow-up) is intentionally out of scope for this PR.
- Kanban DB (`kanban_db.py`) is unchanged; it keeps its own WAL tuning.