### PR TITLE
test(tools): add unit tests for sensitive_query_param_name

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -9,6 +9,7 @@ from tools.url_safety import (
     is_always_blocked_url,
     normalize_url_for_request,
     redirect_target_from_response,
+    sensitive_query_param_name,
     _is_blocked_ip,
     _global_allow_private_urls,
     _reset_allow_private_cache,
@@ -689,3 +690,31 @@ class TestRedirectTargetFromResponse:
     def test_no_location_no_next_request_returns_none(self):
         resp = _FakeResponse(is_redirect=True)
         assert redirect_target_from_response(resp) is None
+
+
+class TestSensitiveQueryParamName:
+    @pytest.mark.parametrize("url,expected", [
+        ("https://example.com/a?token=abc", "token"),
+        # ``code`` is not sensitive; ``access_token`` is the first match.
+        ("https://example.com/cb?code=1&access_token=xyz", "access_token"),
+        # First sensitive parameter in query order wins.
+        ("https://example.com/a?token=1&password=2", "token"),
+        # Matching is case-insensitive but the original key casing is returned.
+        ("https://example.com/a?API_KEY=xyz", "API_KEY"),
+    ])
+    def test_detects_sensitive_param(self, url, expected):
+        assert sensitive_query_param_name(url) == expected
+
+    @pytest.mark.parametrize("url", [
+        "https://example.com/path",           # no query string
+        "https://example.com/a?foo=1&bar=2",  # no sensitive params
+        "not a url",                          # no "?"
+        "ftp://example.com/a?token=abc",       # non-http(s) scheme
+        "https://example.com/a?token=",        # sensitive key but empty value
+    ])
+    def test_returns_none_when_no_sensitive_param(self, url):
+        assert sensitive_query_param_name(url) is None
+
+    def test_non_string_returns_none(self):
+        assert sensitive_query_param_name(None) is None
+        assert sensitive_query_param_name(12345) is None


### PR DESCRIPTION
﻿## What does this PR do?

Adds unit test coverage for `sensitive_query_param_name` in `tools/url_safety.py`. The module already has a `test_url_safety.py`, but it covers the SSRF/private-IP checks — this security helper had no direct tests.

`sensitive_query_param_name` scans a URL for the first query parameter whose name looks like a credential (`token`, `access_token`, `api_key`, `password`, `signature`, `x_amz_signature`, …). It runs before handing URLs to third-party fetch/browser backends (`web_tools.py`, `browser_tool.py`) so opaque magic-link / signed-URL secrets can be redacted.

The added tests pin its contract:
- Detects the first sensitive param and returns its **original-cased** key (matching is case-insensitive): `?token=abc` → `token`, `?API_KEY=xyz` → `API_KEY`
- Returns the first match in query order when several are present
- Returns `None` for: no query string, no sensitive params, non-`http(s)` scheme, a sensitive key with an **empty** value, and non-string input

## Type of Change

- [x] Test coverage (no production code changed)

## Why

This is a security redaction guard on the path to external network fetches. Without tests, a future edit to the sensitive-name set or the empty-value / scheme guards could silently regress and start leaking (or over-redacting) credentials in outbound URLs.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_url_safety.py::TestSensitiveQueryParamName -v
```

## Notes

- 1 existing test file changed (+1 import, +1 test class). No production code touched.
- Pure input→output assertions — no mocks, no network, no filesystem.
- Follows the existing class-grouped style of `test_url_safety.py`.
