### PR TITLE
Add opt-in local SRL recall injection

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1234,6 +1234,8 @@ def init_agent(
     agent._memory_enabled = False
     agent._user_profile_enabled = False
     agent._memory_nudge_interval = 10
+    agent._srl_auto_inject_enabled = False
+    agent._srl_auto_inject_char_limit = 6000
     agent._turns_since_memory = 0
     agent._iters_since_skill = 0
     if not skip_memory:
@@ -1242,6 +1244,8 @@ def init_agent(
             agent._memory_enabled = mem_config.get("memory_enabled", False)
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
+            agent._srl_auto_inject_enabled = is_truthy_value(mem_config.get("srl_auto_inject", False))
+            agent._srl_auto_inject_char_limit = int(mem_config.get("srl_char_limit", 6000))
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
                 agent._memory_store = MemoryStore(

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -23,9 +23,11 @@ move-and-name refactor with no semantic change.
 from __future__ import annotations
 
 import logging
+import sys
 import threading
 import uuid
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.conversation_compression import conversation_history_after_compression
@@ -87,6 +89,63 @@ def _should_run_preflight_estimate(
     if len(messages) > protect_first_n + protect_last_n + 1:
         return True
     return estimate_messages_tokens_rough(messages) >= threshold_tokens
+
+
+def _load_local_srl_context(agent, query: str) -> str:
+    """Retrieve local SRL context for this turn when explicitly enabled."""
+    if not query or not getattr(agent, "_srl_auto_inject_enabled", False):
+        return ""
+    max_chars = int(getattr(agent, "_srl_auto_inject_char_limit", 6000) or 6000)
+    if max_chars <= 0:
+        return ""
+    try:
+        here = Path(__file__).resolve()
+        candidate_dirs = []
+        try:
+            from hermes_constants import get_hermes_home
+
+            candidate_dirs.append(get_hermes_home() / "skills" / "infinite-context")
+        except Exception:
+            pass
+        candidate_dirs.extend([
+            here.parents[1] / "skills" / "infinite-context",
+            here.parents[2] / "skills" / "infinite-context",
+        ])
+        seen = set()
+        srl_dir = None
+        for candidate in candidate_dirs:
+            key = str(candidate)
+            if key in seen:
+                continue
+            seen.add(key)
+            if (candidate / "srl_engine.py").exists():
+                srl_dir = candidate
+                break
+        if srl_dir is None:
+            return ""
+        if not (srl_dir / "srl_engine.py").exists():
+            return ""
+        srl_path = str(srl_dir)
+        if srl_path not in sys.path:
+            sys.path.insert(0, srl_path)
+        import srl_engine  # type: ignore
+
+        try:
+            from hermes_constants import get_hermes_home
+
+            state_db = get_hermes_home() / "state.db"
+            if state_db.exists():
+                srl_engine.STATE_DB = str(state_db)
+        except Exception:
+            pass
+
+        context = srl_engine.retrieve_context(query, max_chars=max_chars)
+        if not context or "Sources: 0 items" in context:
+            return ""
+        return context[:max_chars]
+    except Exception:
+        logger.debug("local SRL context injection skipped", exc_info=True)
+        return ""
 
 
 @dataclass
@@ -529,6 +588,20 @@ def build_turn_context(
             ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
         except Exception:
             pass
+
+    # Local SRL: retrieve from Hermes state.db without mutating the transcript or
+    # cached system prompt. Reuses the same fenced user-message injection path as
+    # external memory providers.
+    try:
+        _query = original_user_message if isinstance(original_user_message, str) else ""
+        _srl_context = _load_local_srl_context(agent, _query)
+        if _srl_context:
+            ext_prefetch_cache = (
+                f"{ext_prefetch_cache}\n\n{_srl_context}"
+                if ext_prefetch_cache else _srl_context
+            )
+    except Exception:
+        logger.debug("local SRL prefetch failed", exc_info=True)
 
     return TurnContext(
         user_message=user_message,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -539,6 +539,11 @@ memory:
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
 
+  # Optional local SRL recall: retrieve relevant state.db history before each
+  # LLM call and inject it into the current user message only.
+  srl_auto_inject: false
+  srl_char_limit: 6000
+
   # Periodic memory nudge: remind the agent to consider saving memories
   # every N user turns. Set to 0 to disable. Only active when memory is enabled.
   nudge_interval: 10        # Nudge every 10 user turns (0 = disabled)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2106,6 +2106,10 @@ DEFAULT_CONFIG = {
         "write_approval": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        # Optional local SRL recall: retrieve relevant state.db history before
+        # each LLM call and inject it into the current user message only.
+        "srl_auto_inject": False,
+        "srl_char_limit": 6000,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".


### PR DESCRIPTION
## Summary
- add opt-in `memory.srl_auto_inject` config for local Semantic Retrieval Layer recall
- inject recalled local SRL context into the current user message using the existing fenced memory-context path, preserving cached system prompt stability
- document `srl_auto_inject` and `srl_char_limit` in the example config

## Verification
- `python -m py_compile agent\turn_context.py agent\agent_init.py hermes_cli\config.py`
- local Hermes smoke test against existing `skills/infinite-context/srl_engine.py` returned bounded context from state.db