### PR TITLE
fix(desktop): dismiss stale prompt overlays

### DIFF
--- a/apps/desktop/src/components/prompt-overlays.test.tsx
+++ b/apps/desktop/src/components/prompt-overlays.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $gateway } from '@/store/gateway'
+import { notifyError } from '@/store/notifications'
+import { $secretRequest, $sudoRequest, clearAllPrompts, setSecretRequest, setSudoRequest } from '@/store/prompts'
+import { $activeSessionId } from '@/store/session'
+
+import { PromptOverlays } from './prompt-overlays'
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+
+function renderPrompts() {
+  render(
+    <I18nProvider configClient={null}>
+      <PromptOverlays />
+    </I18nProvider>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  clearAllPrompts()
+  $activeSessionId.set(null)
+  $gateway.set(null)
+  vi.clearAllMocks()
+})
+
+describe('PromptOverlays', () => {
+  it('dismisses a stale sudo dialog when the gateway no longer has the password request', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('no pending password request'))
+
+    $activeSessionId.set('s1')
+    $gateway.set({ request } as never)
+    setSudoRequest({ requestId: 'sudo-1', sessionId: 's1' })
+
+    renderPrompts()
+
+    expect(screen.getByText('Administrator password')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect($sudoRequest.get()).toBeNull())
+    expect(request).toHaveBeenCalledWith('sudo.respond', { password: '', request_id: 'sudo-1' })
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('dismisses a stale secret dialog when the gateway no longer has the value request', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('no pending value request'))
+
+    $activeSessionId.set('s1')
+    $gateway.set({ request } as never)
+    setSecretRequest({ envVar: 'TEST_SECRET', prompt: 'Paste a secret', requestId: 'secret-1', sessionId: 's1' })
+
+    renderPrompts()
+
+    expect(screen.getByText('TEST_SECRET')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => expect($secretRequest.get()).toBeNull())
+    expect(request).toHaveBeenCalledWith('secret.respond', { request_id: 'secret-1', value: '' })
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { useI18n } from '@/i18n'
+import { isMissingPendingPromptRequest } from '@/lib/gateway-rpc'
 import { triggerHaptic } from '@/lib/haptics'
 import { KeyRound, Loader2, Lock } from '@/lib/icons'
 import { $gateway } from '@/store/gateway'
@@ -69,6 +70,12 @@ function SudoDialog() {
         triggerHaptic('submit')
         clearSudoRequest(request.sessionId, request.requestId)
       } catch (error) {
+        if (isMissingPendingPromptRequest(error, 'password')) {
+          clearSudoRequest(request.sessionId, request.requestId)
+
+          return
+        }
+
         notifyError(error, copy.sudoSendFailed)
         setSubmitting(false)
       }
@@ -165,6 +172,12 @@ function SecretDialog() {
         triggerHaptic('submit')
         clearSecretRequest(request.sessionId, request.requestId)
       } catch (error) {
+        if (isMissingPendingPromptRequest(error, 'value')) {
+          clearSecretRequest(request.sessionId, request.requestId)
+
+          return
+        }
+
         notifyError(error, copy.secretSendFailed)
         setSubmitting(false)
       }

--- a/apps/desktop/src/lib/gateway-rpc.test.ts
+++ b/apps/desktop/src/lib/gateway-rpc.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isMissingRpcMethod } from './gateway-rpc'
+import { isMissingPendingPromptRequest, isMissingRpcMethod } from './gateway-rpc'
 
 describe('isMissingRpcMethod', () => {
   it('detects JSON-RPC method-not-found errors', () => {
@@ -12,5 +12,17 @@ describe('isMissingRpcMethod', () => {
   it('ignores unrelated failures', () => {
     expect(isMissingRpcMethod(new Error('Hermes gateway is not connected'))).toBe(false)
     expect(isMissingRpcMethod(new Error('no such project'))).toBe(false)
+  })
+})
+
+describe('isMissingPendingPromptRequest', () => {
+  it('detects stale prompt response errors from the gateway', () => {
+    expect(isMissingPendingPromptRequest(new Error('no pending password request'), 'password')).toBe(true)
+    expect(isMissingPendingPromptRequest(new Error('RPC failed: no pending value request'), 'value')).toBe(true)
+  })
+
+  it('ignores unrelated gateway failures', () => {
+    expect(isMissingPendingPromptRequest(new Error('gateway not connected'), 'password')).toBe(false)
+    expect(isMissingPendingPromptRequest(new Error('no pending value request'), 'password')).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/gateway-rpc.ts
+++ b/apps/desktop/src/lib/gateway-rpc.ts
@@ -4,3 +4,10 @@ export function isMissingRpcMethod(error: unknown): boolean {
 
   return /method not found|-32601|unknown method|no such method/i.test(message)
 }
+
+/** True when a prompt response raced a backend-side timeout / completion. */
+export function isMissingPendingPromptRequest(error: unknown, key: string): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return message.toLowerCase().includes(`no pending ${key.toLowerCase()} request`)
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #59765.

Hermes Desktop can show sudo/admin or secret prompt overlays whose backend-side pending request has already timed out or completed. Before this change, responding/cancelling after that race produced a `no pending ... request` gateway error, showed an error toast, and left the local overlay store populated, so the dialog stayed stuck on screen.

This PR treats that specific stale-prompt gateway response as an already-resolved prompt: clear the local overlay state and do not show a failure toast for the stale response. Other gateway failures still keep the dialog open and surface the existing error notification.

## Related Issue

Fixes #59765

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/prompt-overlays.tsx`
  - Clears stale sudo prompt overlays when `sudo.respond` returns `no pending password request`.
  - Clears stale secret prompt overlays when `secret.respond` returns `no pending value request`.
  - Avoids showing an error toast for those stale-prompt races, while preserving the existing error path for unrelated failures.
- `apps/desktop/src/lib/gateway-rpc.ts`
  - Adds `isMissingPendingPromptRequest(...)` for detecting stale prompt-response errors from the JSON-RPC gateway.
- `apps/desktop/src/components/prompt-overlays.test.tsx`
  - Adds renderer coverage for stale sudo and secret prompt dismissal.
  - Verifies stale prompt dismissal does not show a failure toast.
- `apps/desktop/src/lib/gateway-rpc.test.ts`
  - Covers stale prompt-response error detection and unrelated error rejection.

## How to Test

1. Manual repro path:
   - Trigger a Desktop sudo/admin password prompt.
   - Let the backend-side pending password request disappear first, e.g. by timeout/completion/race.
   - Click `Cancel`/close on the Desktop dialog.
   - Expected: the dialog disappears and no stale `no pending password request` failure toast is shown.
2. Automated checks run locally after rebasing onto latest `origin/main`:

```bash
NODE_ENV=test NODE_OPTIONS='--max-old-space-size=8192 --localstorage-file=/tmp/hermes-vitest-pr59778-final-localstorage.json' \
  npm --workspace apps/desktop exec -- vitest run --environment jsdom \
  src/components/prompt-overlays.test.tsx \
  src/lib/gateway-rpc.test.ts

NODE_ENV=test npm --workspace apps/desktop run typecheck

NODE_ENV=test npm --workspace apps/desktop exec -- eslint \
  src/components/prompt-overlays.tsx \
  src/components/prompt-overlays.test.tsx \
  src/lib/gateway-rpc.ts \
  src/lib/gateway-rpc.test.ts

NODE_ENV=production npm --workspace apps/desktop run build

git diff --check HEAD
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant automated checks for this desktop-only TypeScript/React change (see How to Test; no Python files touched, so `pytest tests/ -q` is N/A here)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (CachyOS), Node.js v25.4.0 / npm 11.7.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, behavior is covered by tests and inline helper comment
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — browser/React-only overlay logic, no platform-specific APIs added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Local verification results after rebasing onto latest `origin/main`:

- Targeted Vitest: `2 passed`, `6 tests passed`.
- TypeScript: `tsc -p . --noEmit` passed.
- Changed-file ESLint: passed.
- Desktop production build: passed; `assert-dist-built` confirmed `dist/index.html + assets present`.
- `git diff --check HEAD`: passed.
