### PR TITLE
fix(tui): support model picker refresh

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -119,6 +119,7 @@ def build_models_payload(
     force_fresh_nous_tier: bool = False,
     refresh: bool = False,
     probe_custom_providers: bool = True,
+    probe_current_custom_provider: bool = False,
     max_models: int | None = None,
 ) -> dict:
     """Build the ``{providers, model, provider}`` shape every consumer
@@ -155,6 +156,10 @@ def build_models_payload(
       opens should leave this false unless the user explicitly refreshes; the
       row can still render its configured model immediately, and slow/offline
       local endpoints no longer block the dialog.
+    - ``probe_current_custom_provider``: when ``probe_custom_providers`` is
+      false, still live-probe the current custom endpoint. This keeps normal
+      GUI/TUI picker opens fast while making the active custom provider's model
+      list match the classic CLI picker.
     """
     from hermes_cli.model_switch import list_authenticated_providers
 
@@ -168,6 +173,7 @@ def build_models_payload(
         max_models=max_models,
         refresh=refresh,
         probe_custom_providers=probe_custom_providers,
+        probe_current_custom_provider=probe_current_custom_provider,
     )
 
     moa_row = _moa_provider_row(ctx.current_provider)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1455,6 +1455,7 @@ def list_authenticated_providers(
     current_model: str = "",
     refresh: bool = False,
     probe_custom_providers: bool = True,
+    probe_current_custom_provider: bool = False,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -1486,6 +1487,11 @@ def list_authenticated_providers(
     custom OpenAI-compatible endpoints. Keep the default true for CLI parity;
     GUI picker opens can pass false to show configured models immediately
     without waiting on offline local endpoints.
+
+    ``probe_current_custom_provider`` is the middle ground for GUI picker
+    opens: probe only the currently-selected custom endpoint so its model list
+    matches the active provider without blocking on every saved/offline custom
+    endpoint.
     """
     import os
     from agent.models_dev import (
@@ -1515,6 +1521,12 @@ def list_authenticated_providers(
     results: List[dict] = []
     seen_slugs: set = set()  # lowercase-normalized to catch case variants (#9545)
     seen_mdev_ids: set = set()  # prevent duplicate entries for aliases (e.g. kimi-coding + kimi-coding-cn)
+    _current_provider_norm = str(current_provider or "").strip().lower()
+    _current_base_url_norm = str(current_base_url or "").strip().rstrip("/").lower()
+
+    def _can_probe_custom_provider(*, row_is_current: bool) -> bool:
+        return bool(probe_custom_providers or (probe_current_custom_provider and row_is_current))
+
     # Effective base URLs of every built-in row we emit (normalized lower+rstrip).
     # Section 4 uses this to hide ``custom_providers`` entries that point at the
     # same endpoint as a built-in (e.g. a user-defined "my-dashscope" on
@@ -2021,7 +2033,19 @@ def list_authenticated_providers(
             if isinstance(discover, str):
                 discover = discover.lower() not in {"false", "no", "0"}
             has_explicit_models = bool(models_list)
-            should_probe = probe_custom_providers and bool(api_url) and discover and (
+            _ep_url_norm = str(api_url).strip().rstrip("/").lower()
+            _ep_slug_norm = str(ep_name).strip().lower()
+            _ep_custom_slug_norm = custom_provider_slug(display_name).lower()
+            _ep_is_current = (
+                _ep_slug_norm == _current_provider_norm
+                or _ep_custom_slug_norm == _current_provider_norm
+                or (
+                    _current_provider_norm == "custom"
+                    and bool(_current_base_url_norm)
+                    and _ep_url_norm == _current_base_url_norm
+                )
+            )
+            should_probe = _can_probe_custom_provider(row_is_current=_ep_is_current) and bool(api_url) and discover and (
                 bool(api_key) or not has_explicit_models
             )
             if should_probe:
@@ -2040,7 +2064,7 @@ def list_authenticated_providers(
             results.append({
                 "slug": ep_name,
                 "name": display_name,
-                "is_current": ep_name == current_provider,
+                "is_current": _ep_is_current,
                 "is_user_defined": True,
                 "models": models_list,
                 "total_models": len(models_list) if models_list else 0,
@@ -2064,7 +2088,6 @@ def list_authenticated_providers(
     # picker to render, but the gateway only passes this current model slice to
     # list_authenticated_providers(). Surface the active endpoint explicitly so
     # /model does not look like it ignored config.yaml.
-    _current_provider_norm = str(current_provider or "").strip().lower()
     if (
         _current_provider_norm == "custom"
         and current_base_url
@@ -2081,6 +2104,15 @@ def list_authenticated_providers(
         )
     ):
         _models = [current_model] if current_model else []
+        if _can_probe_custom_provider(row_is_current=True):
+            try:
+                from hermes_cli.models import fetch_api_models
+
+                _live_models = fetch_api_models("", str(current_base_url).strip().rstrip("/"))
+                if _live_models:
+                    _models = _live_models
+            except Exception:
+                pass
         results.append({
             "slug": "custom",
             "name": "Custom endpoint",
@@ -2203,7 +2235,6 @@ def list_authenticated_providers(
                     groups[group_key]["models"].append(model_id)
 
         _section4_emitted_slugs: set = set()
-        _current_base_url_norm = str(current_base_url or "").strip().rstrip("/").lower()
         _current_base_url_group_count = sum(
             1
             for _grp in groups.values()
@@ -2275,8 +2306,14 @@ def list_authenticated_providers(
             #   api_key is present. This supports endpoints that expose a
             #   full aggregator catalog via /models but only serve a subset
             #   (parity with section 3's user ``providers:`` behaviour).
+            _grp_is_current = slug.lower() == _current_provider_norm or (
+                _current_provider_norm == "custom"
+                and bool(_current_base_url_norm)
+                and _grp_url_norm == _current_base_url_norm
+                and _current_base_url_group_count == 1
+            )
             should_probe = (
-                probe_custom_providers
+                _can_probe_custom_provider(row_is_current=_grp_is_current)
                 and bool(api_url)
                 and (bool(api_key) or not grp["models"])
                 and grp.get("discover_models", True)
@@ -2298,12 +2335,7 @@ def list_authenticated_providers(
             results.append({
                 "slug": slug,
                 "name": grp["name"],
-                "is_current": slug == current_provider or (
-                    current_provider == "custom"
-                    and bool(_current_base_url_norm)
-                    and _grp_url_norm == _current_base_url_norm
-                    and _current_base_url_group_count == 1
-                ),
+                "is_current": _grp_is_current,
                 "is_user_defined": True,
                 "models": grp["models"],
                 "total_models": len(grp["models"]),

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2104,7 +2104,7 @@ def list_authenticated_providers(
         )
     ):
         _models = [current_model] if current_model else []
-        if _can_probe_custom_provider(row_is_current=True):
+        if refresh or probe_current_custom_provider:
             try:
                 from hermes_cli.models import fetch_api_models
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4305,6 +4305,7 @@ def get_model_options(profile: Optional[str] = None, refresh: bool = False):
                 capabilities=True,
                 refresh=bool(refresh),
                 probe_custom_providers=bool(refresh),
+                probe_current_custom_provider=not bool(refresh),
             )
     except HTTPException:
         raise

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -258,6 +258,24 @@ def test_build_models_payload_can_skip_custom_provider_probes():
     assert mock_list.call_args.kwargs["probe_custom_providers"] is False
 
 
+def test_build_models_payload_can_probe_only_current_custom_provider():
+    ctx = _empty_ctx()
+    rows = []
+    with patch(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        return_value=rows,
+    ) as mock_list:
+        build_models_payload(
+            ctx,
+            probe_custom_providers=False,
+            probe_current_custom_provider=True,
+        )
+
+    mock_list.assert_called_once()
+    assert mock_list.call_args.kwargs["probe_custom_providers"] is False
+    assert mock_list.call_args.kwargs["probe_current_custom_provider"] is True
+
+
 def test_list_authenticated_providers_force_fresh_is_keyword_only():
     """``force_fresh_nous_tier`` must be keyword-only on the public listing API.
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -69,6 +69,49 @@ def test_list_authenticated_providers_can_skip_custom_provider_live_probe(monkey
     assert row["total_models"] == 1
 
 
+def test_list_authenticated_providers_can_probe_only_current_custom_provider(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fetch(api_key, api_url, **kwargs):
+        calls.append(api_url)
+        if api_url == "http://active.local/v1":
+            return ["active-a", "active-b"]
+        raise AssertionError(f"unexpected probe for {api_url}")
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="custom:active-proxy",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Active Proxy",
+                "base_url": "http://active.local/v1",
+                "api_key": "sk-active",
+                "model": "configured-active",
+            },
+            {
+                "name": "Offline Proxy",
+                "base_url": "http://offline.local/v1",
+                "api_key": "sk-offline",
+                "model": "configured-offline",
+            },
+        ],
+        probe_custom_providers=False,
+        probe_current_custom_provider=True,
+    )
+
+    active = next(p for p in providers if p["slug"] == "custom:active-proxy")
+    offline = next(p for p in providers if p["slug"] == "custom:offline-proxy")
+    assert calls == ["http://active.local/v1"]
+    assert active["is_current"] is True
+    assert active["models"] == ["active-a", "active-b"]
+    assert offline["models"] == ["configured-offline"]
+
+
 def test_resolve_provider_full_finds_named_custom_provider():
     """Explicit /model --provider should resolve saved custom_providers entries."""
     resolved = resolve_provider_full(
@@ -117,6 +160,29 @@ def test_list_authenticated_providers_includes_active_bare_custom_endpoint(monke
     assert bare_custom["is_user_defined"] is True
     assert bare_custom["models"] == ["gpt-4o"]
     assert bare_custom["api_url"] == "https://www.ccsub.net/v1"
+
+
+def test_list_authenticated_providers_can_probe_active_bare_custom_endpoint(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, api_url, **kwargs: ["gpt-4o", "gpt-4o-mini"],
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="https://www.ccsub.net/v1",
+        current_model="gpt-4o",
+        user_providers={},
+        custom_providers=[],
+        probe_custom_providers=False,
+        probe_current_custom_provider=True,
+    )
+
+    bare_custom = next(p for p in providers if p["slug"] == "custom")
+    assert bare_custom["is_current"] is True
+    assert bare_custom["models"] == ["gpt-4o", "gpt-4o-mini"]
 
 
 def test_switch_model_accepts_explicit_bare_custom_current_endpoint(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5887,6 +5887,7 @@ def test_model_options_does_not_overwrite_curated_models(monkeypatch):
     # list_authenticated_providers is the single source.
     assert listing.call_count == 1
     assert listing.call_args.kwargs["probe_custom_providers"] is False
+    assert listing.call_args.kwargs["probe_current_custom_provider"] is True
 
 
 def test_model_options_propagates_list_exception(monkeypatch):
@@ -5926,6 +5927,7 @@ def test_model_options_refresh_allows_custom_provider_probes(monkeypatch):
 
     assert "result" in resp, resp
     assert listing.call_args.kwargs["probe_custom_providers"] is True
+    assert listing.call_args.kwargs["probe_current_custom_provider"] is False
 
 
 class _ImmediateThread:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12375,6 +12375,7 @@ def _(rid, params: dict) -> dict:
             capabilities=True,
             refresh=bool(params.get("refresh")),
             probe_custom_providers=bool(params.get("refresh")),
+            probe_current_custom_provider=not bool(params.get("refresh")),
         )
         return _ok(rid, payload)
     except Exception as e:

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -183,6 +183,15 @@ describe('createSlashHandler', () => {
     })
   })
 
+  it('opens the model picker with refresh for /model --refresh', () => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/model --refresh')).toBe(true)
+    expect(getOverlayState().modelPicker).toEqual({ refresh: true })
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+  })
+
   it('honors TUI picker session scope without adding --global', async () => {
     patchUiState({ sid: 'sid-abc' })
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -135,7 +135,7 @@ export interface OverlayState {
   clarify: ClarifyReq | null
   confirm: ConfirmReq | null
   journey: boolean
-  modelPicker: boolean
+  modelPicker: boolean | { refresh?: boolean }
   pager: null | PagerState
   petPicker: boolean
   pluginsHub: boolean

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -73,6 +73,10 @@ export const sessionCommands: SlashCommand[] = [
         return patchOverlayState({ modelPicker: true })
       }
 
+      if (arg.trim() === '--refresh') {
+        return patchOverlayState({ modelPicker: { refresh: true } })
+      }
+
       const switchModel = (confirmExpensiveModel = false) =>
         ctx.gateway
           .rpc<ConfigSetResponse>('config.set', {

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -180,6 +180,7 @@ export function FloatingOverlays({
         <FloatBox color={theme.color.border}>
           <ModelPicker
             gw={gw}
+            initialRefresh={typeof overlay.modelPicker === 'object' && overlay.modelPicker.refresh === true}
             onCancel={() => patchOverlayState({ modelPicker: false })}
             onSelect={onModelSelect}
             sessionId={sid}

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -27,7 +27,15 @@ export function providerIndexAfterClearingFilter(providerRows: ProviderRow[], pr
   return providerRows.findIndex(row => row.provider.slug === provider.slug)
 }
 
-export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect, sessionId, t }: ModelPickerProps) {
+export function ModelPicker({
+  allowPersistGlobal = true,
+  gw,
+  initialRefresh = false,
+  onCancel,
+  onSelect,
+  sessionId,
+  t
+}: ModelPickerProps) {
   const [providers, setProviders] = useState<ModelOptionProvider[]>([])
   const [currentModel, setCurrentModel] = useState('')
   const [err, setErr] = useState('')
@@ -50,7 +58,10 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
   const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
 
   useEffect(() => {
-    gw.request<ModelOptionsResponse>('model.options', sessionId ? { session_id: sessionId } : {})
+    gw.request<ModelOptionsResponse>('model.options', {
+      ...(sessionId ? { session_id: sessionId } : {}),
+      ...(initialRefresh ? { refresh: true } : {})
+    })
       .then(raw => {
         const r = asRpcResult<ModelOptionsResponse>(raw)
 
@@ -79,7 +90,7 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
         setErr(rpcErrorMessage(e))
         setLoading(false)
       })
-  }, [gw, sessionId])
+  }, [gw, initialRefresh, sessionId])
 
   const names = useMemo(() => providerDisplayNames(providers), [providers])
 
@@ -677,6 +688,7 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
 interface ModelPickerProps {
   allowPersistGlobal?: boolean
   gw: GatewayClient
+  initialRefresh?: boolean
   onCancel: () => void
   onSelect: (value: string) => void
   sessionId: string | null


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI model picker path for saved/custom providers.

After #58183, normal TUI `model.options` calls intentionally stopped live-probing custom providers so offline local/custom endpoints would not block the picker. That kept the picker fast, but it also meant plain TUI `/model` could show only configured/cached models for the currently selected custom provider, while classic CLI `/model` still called `build_models_payload(ctx)` with the default live probe path.

This PR keeps the #58183 performance behavior for saved/offline providers, but makes normal TUI picker opens live-probe only the currently selected custom provider. Explicit refresh still probes every custom provider.

## Related Issue

Discord support thread: https://discord.com/channels/1053877538025386074/1523726255479066836

Related merged behavior change: https://github.com/NousResearch/hermes-agent/pull/58183

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_switch.py`: adds `probe_current_custom_provider` so GUI/TUI callers can probe only the active custom endpoint without probing every saved custom provider.
- `hermes_cli/inventory.py`: forwards the new selective-probe option through the shared model inventory payload builder.
- `tui_gateway/server.py`: normal `model.options` calls now probe only the active custom provider; `refresh: true` still probes all custom providers.
- `hermes_cli/web_server.py`: dashboard model options use the same active-provider-only normal open behavior and all-provider refresh behavior.
- `ui-tui/src/...`: `/model --refresh` opens the model picker with `refresh: true` instead of treating `--refresh` as a model switch target.
- Tests cover selective active-provider probing, bare custom endpoints, inventory forwarding, TUI `model.options` flags, and the `/model --refresh` slash-command route.

## How to Test

1. Configure a custom provider with more live `/models` entries than the static configured model list.
2. Start TUI with that provider selected.
3. Run `/model` and confirm the selected custom provider row shows the live model list.
4. Run `/model --refresh` and confirm it still opens the picker while requesting a full custom-provider refresh.
5. Confirm saved/offline custom providers do not block normal picker opens unless refresh is requested.

Local checks run:

- `npm run typecheck` from `ui-tui`
- `npx eslint src/components/modelPicker.tsx src/components/appOverlays.tsx src/app/slash/commands/session.ts src/__tests__/createSlashHandler.test.ts` from `ui-tui`
- `npx vitest run src/__tests__/createSlashHandler.test.ts` from `ui-tui`
- `venv/bin/python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py::test_list_authenticated_providers_can_probe_only_current_custom_provider tests/hermes_cli/test_model_switch_custom_providers.py::test_list_authenticated_providers_can_probe_active_bare_custom_endpoint tests/hermes_cli/test_inventory.py::test_build_models_payload_can_probe_only_current_custom_provider tests/test_tui_gateway_server.py::test_model_options_does_not_overwrite_curated_models tests/test_tui_gateway_server.py::test_model_options_refresh_allows_custom_provider_probes -q`

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I have tested on my platform: TUI TypeScript checks, focused unit tests, and focused Python tests only

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is broadly useful to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that are not already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I have tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

N/A. This is a TUI/model-options routing fix with focused unit coverage.

## Infographic

![model-picker-cluster](https://v3b.fal.media/files/b/0aa1345a/JpBOXiKjVlluIx315bUHl_lQcaPYUw.png)