### PR TITLE
fix(goal-mode): align kanban_block dispatch contract

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15646,7 +15646,7 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     def _block(reason: str) -> None:
         c = _kb.connect()
         try:
-            _kb.block_task(c, task_id, reason=reason)
+            _kb.block_task(c, task_id, reason=reason, kind="needs_input")
         finally:
             try:
                 c.close()

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -296,3 +297,64 @@ def test_loop_stops_if_task_reclaimed(monkeypatch):
         first_response="x",
     )
     assert res["outcome"] == "stopped"
+
+
+# ---------------------------------------------------------------------------
+# Goal loop / kanban_block dispatch contract
+# ---------------------------------------------------------------------------
+
+def test_quiet_goal_loop_auto_block_uses_goal_mode_allowed_kind(
+    kanban_home, monkeypatch
+):
+    """The internal goal-loop blocker must not generate a rejected kind."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="goal task",
+            assignee="worker",
+            goal_mode=True,
+            goal_max_turns=1,
+        )
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    _patch_judge(monkeypatch, ["continue"])
+
+    from cli import _run_kanban_goal_loop_q
+
+    fake_cli = SimpleNamespace(
+        agent=SimpleNamespace(
+            run_conversation=lambda **_: pytest.fail("budget should block first")
+        ),
+        conversation_history=[],
+        session_id="s1",
+    )
+
+    _run_kanban_goal_loop_q(fake_cli, "not done yet")
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "blocked"
+    assert task.block_kind == "needs_input"
+
+
+def test_goal_mode_kanban_block_rejects_invalid_kind(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="goal task",
+            assignee="worker",
+            goal_mode=True,
+        )
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+
+    from tools import kanban_tools
+
+    monkeypatch.setattr(kanban_tools, "_goal_judge_available", lambda: True)
+    result = kanban_tools._handle_block(
+        {"task_id": tid, "reason": "blocked", "kind": "kanban_block"}
+    )
+
+    assert "kind must be one of" in result

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -358,3 +358,34 @@ def test_goal_mode_kanban_block_rejects_invalid_kind(kanban_home, monkeypatch):
     )
 
     assert "kind must be one of" in result
+
+
+def test_goal_mode_kanban_block_omitted_kind_defaults_to_needs_input(
+    kanban_home, monkeypatch
+):
+    """Model-facing path: omit kind on a goal_mode task → needs_input (#59764)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="goal task",
+            assignee="worker",
+            goal_mode=True,
+        )
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+
+    from tools import kanban_tools
+    import json
+
+    result = kanban_tools._handle_block(
+        {"task_id": tid, "reason": "need repo credentials"}
+    )
+    payload = json.loads(result)
+    assert payload.get("ok") is True
+    assert payload.get("block_kind") == "needs_input"
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "blocked"
+    assert task.block_kind == "needs_input"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -741,24 +741,40 @@ def _make_goal_mode_worker_env(monkeypatch, tmp_path):
     return goal_task_id
 
 
-def test_block_goal_mode_rejects_missing_kind(monkeypatch, tmp_path):
-    """A goal_mode worker calling kanban_block with no kind must not be able
-    to use it as an unguarded escape from the goal loop (Issue #38696,
-    sibling of the kanban_complete judge gate / Issue #38367)."""
+def test_block_goal_mode_omitted_kind_defaults_to_needs_input(monkeypatch, tmp_path):
+    """Schema marks kind optional; goal_mode coerces omit → needs_input (#59764).
+
+    Still a classified exit (needs_input), not an untyped escape hatch — the
+    #38696 gate continues to reject capability/transient.
+    """
     from tools import kanban_tools as kt
     from hermes_cli import kanban_db as kb
 
     tid = _make_goal_mode_worker_env(monkeypatch, tmp_path)
-    out = kt._handle_block({"reason": "giving up"})
+    out = kt._handle_block({"reason": "need repo credentials"})
     d = json.loads(out)
-    assert "error" in d
-    assert "goal_mode" in d["error"]
+    assert d.get("ok") is True
+    assert d.get("block_kind") == "needs_input"
 
     conn = kb.connect()
     try:
-        assert kb.get_task(conn, tid).status == "running"
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_kind == "needs_input"
     finally:
         conn.close()
+
+
+def test_block_schema_documents_goal_mode_kind_contract():
+    """Published tool schema must match the goal_mode handler contract (#59764)."""
+    from tools.kanban_tools import KANBAN_BLOCK_SCHEMA
+
+    desc = KANBAN_BLOCK_SCHEMA["description"]
+    kind_desc = KANBAN_BLOCK_SCHEMA["parameters"]["properties"]["kind"]["description"]
+    for text in (desc, kind_desc):
+        assert "goal_mode" in text
+        assert "needs_input" in text
+    assert "defaults to" in kind_desc or "default" in desc.lower()
 
 
 def test_block_goal_mode_rejects_disallowed_kind(monkeypatch, tmp_path):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -694,24 +694,27 @@ def _handle_block(args: dict, **kw) -> str:
         # as terminal, identically to `done`, regardless of kind. Without
         # this, a worker that learns kanban_complete is gated can just call
         # kanban_block(reason="anything") to escape the loop instead.
-        # Restrict goal_mode tasks to the kinds that represent a genuine
-        # external blocker the worker cannot resolve itself; `capability`
-        # and `transient` (or an unset kind) route back through
-        # kanban_complete, which the judge now gates.
+        # Restrict goal_mode tasks to kinds that represent a genuine external
+        # blocker the worker cannot resolve itself; `capability` and
+        # `transient` still route back through kanban_complete / the judge.
+        #
+        # Schema marks ``kind`` optional ("Omit only if none apply"). Meet
+        # that contract on goal_mode by coercing a missing kind to
+        # ``needs_input`` rather than rejecting the call (#59764 Part a).
         task = kb.get_task(conn, tid)
-        if (
-            task
-            and task.goal_mode
-            and kind not in _GOAL_MODE_BLOCK_ALLOWED_KINDS
-        ):
-            conn.close()
-            return tool_error(
-                f"goal_mode tasks can only block with kind in "
-                f"{sorted(_GOAL_MODE_BLOCK_ALLOWED_KINDS)} (got {kind!r}). "
-                f"If the task is actually finished or cannot proceed for "
-                f"another reason, call kanban_complete instead — the "
-                f"completion judge will evaluate it."
-            )
+        if task and task.goal_mode:
+            if kind is None:
+                kind = "needs_input"
+            elif kind not in _GOAL_MODE_BLOCK_ALLOWED_KINDS:
+                conn.close()
+                return tool_error(
+                    f"goal_mode tasks can only block with kind in "
+                    f"{sorted(_GOAL_MODE_BLOCK_ALLOWED_KINDS)} (got {kind!r}). "
+                    f"Omit kind to default to 'needs_input'. If the task is "
+                    f"actually finished or cannot proceed for another reason, "
+                    f"call kanban_complete instead — the completion judge will "
+                    f"evaluate it."
+                )
         try:
             ok = kb.block_task(
                 conn, tid,
@@ -1296,6 +1299,10 @@ KANBAN_BLOCK_SCHEMA = {
         "needed), 'needs_input' (you need a human decision/answer), "
         "'capability' (a hard wall: no access, missing credentials, an action "
         "no agent can do), or 'transient' (a flaky failure that may clear). "
+        "On goal_mode tasks only 'dependency' and 'needs_input' are accepted; "
+        "omitting ``kind`` defaults to 'needs_input'. 'capability' and "
+        "'transient' are not valid exits from goal_mode — use kanban_complete "
+        "and let the completion judge evaluate instead. "
         "``reason`` is shown to the human on the board. If a task keeps "
         "getting unblocked and re-blocked for the same reason, it is "
         "auto-escalated to triage. Use for genuine blockers only — don't "
@@ -1322,7 +1329,9 @@ KANBAN_BLOCK_SCHEMA = {
                 "description": (
                     "Why you're blocked. 'dependency' waits in todo and "
                     "resumes automatically; the others surface to a human. "
-                    "Omit only if none apply."
+                    "On goal_mode tasks only 'dependency' and 'needs_input' "
+                    "are allowed; if omitted, goal_mode defaults to "
+                    "'needs_input'. On non-goal tasks, omit only if none apply."
                 ),
             },
             "board": _board_schema_prop(),


### PR DESCRIPTION
Addresses Part (a) of #59764.

This PR fixes the goal-mode auto-block dispatch-contract mismatch by ensuring the quiet goal-loop auto-block path generates a block kind that is already accepted by the goal-mode contract.

Changes:
- Update goal-mode auto-block creation to call `block_task(..., kind="needs_input")`.
- Add regression coverage for the quiet goal-loop auto-block path.
- Add coverage that invalid `kanban_block` block kinds are still rejected.

This intentionally does not address the card skills / worker profile part of #59764.

Verification:
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_goal_mode.py`
- Result: 14 passed
