### PR TITLE
feat: add jargon skill — domain-aware term detection with plainspeak registry

### DIFF
--- a/skills/research/jargon/SKILL.md
+++ b/skills/research/jargon/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: jargon
+description: "Detect, decode, and track domain-specific jargon (acronyms, technical terms) with a multi-level plainspeak registry."
+version: 1.0.0
+author: "Hermes Agent"
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Jargon, Registry, Acronyms, Terminology, Domain-Specific, Parsing, Content-Processing]
+    related_skills: [youtube-content, structured-digest, hn-brief-digest, blogwatcher]
+---
+
+# Jargon Detection & Plainspeak Registry
+
+A generic tool for detecting, decoding, and tracking domain-specific jargon
+across any content stream. Uses a JSON registry keyed by term with plainspeak
+translations at three sophistication levels, a **saturation filter** for
+baseline terms, and per-digest deduplication.
+
+## Concepts
+
+### Registry
+
+A JSON file structured as:
+
+```json
+{
+  "LLM": {
+    "term": "LLM",
+    "expanded": "Large Language Model",
+    "plainspeak": {
+      "doctor": "A neural network with billions of parameters trained on text to generate coherent language and perform reasoning tasks.",
+      "high-school": "A computer program that has read a huge amount of text and can write essays, answer questions, and have conversations.",
+      "kindergarten": "A super smart computer that can talk and write like a person."
+    },
+    "category": "ai",
+    "saturated": false,
+    "since": "2023-01-01"
+  }
+}
+```
+
+Each entry has:
+
+| Field | Description |
+|-------|-------------|
+| `term` | The acronym or jargon term (canonical casing) |
+| `expanded` | The expanded/acronym-free form |
+| `plainspeak` | Three translations at `doctor`, `high-school`, and `kindergarten` levels |
+| `category` | Domain category (ai, mlops, infra, devops, crypto, bio, etc.) |
+| `saturated` | Flag. When true, the term is considered common baseline knowledge and skipped during detection |
+| `since` | ISO date when the term was added to the registry |
+
+### Saturation
+
+Mark a term as `"saturated": true` when it has become common knowledge for your
+audience (e.g., "API" for a developer audience). Saturated terms are skipped
+during scan — they don't trigger explanations and don't clutter output.
+
+### Per-Digest Dedup
+
+During a single digest run, each term is explained at most once. A runtime
+set tracks which terms have already been expanded. This prevents the same
+acronym being re-explained in every section.
+
+## Workflow
+
+```
+load registry → scan content → detect unknown terms → explain + optionally update registry
+```
+
+### 1. Load the registry
+
+```bash
+# Load into a shell variable
+JARGON_REGISTRY=$(cat /path/to/jargon-registry.json)
+```
+
+### 2. Scan content for known and unknown terms
+
+Extract acronyms and jargon from text, then cross-reference against the
+registry.
+
+```bash
+# Extract all-uppercase acronyms (3+ chars) from content
+CONTENT="$1"
+UNKNOWN_TERMS=$(echo "$CONTENT" | grep -oP '\b[A-Z]{2,}\b' | sort -u)
+```
+
+### 3. Filter known (explainable) vs unknown
+
+```python3
+import json, sys
+
+with open("jargon-registry.json") as f:
+    registry = json.load(f)
+
+content = sys.stdin.read()
+words = set(w for w in content.split() if w.isupper() and len(w) >= 2)
+
+# Known = in registry AND not saturated
+known = {t for t in words if t in registry and not registry[t].get("saturated", False)}
+# Unknown = uppercase term NOT in registry
+unknown = {t for t in words if t not in registry}
+
+print("KNOWN:", json.dumps(sorted(known)))
+print("UNKNOWN:", json.dumps(sorted(unknown)))
+```
+
+### 4. Explain with plainspeak
+
+For each known term, get the proper plainspeak level and append to the output:
+
+```python3
+def plainspeak(term, registry, level="high-school"):
+    entry = registry.get(term)
+    if not entry or entry.get("saturated"):
+        return None
+    return entry["plainspeak"].get(level, entry["plainspeak"].get("high-school"))
+```
+
+### 5. Dedup per digest run
+
+```python3
+seen = set()
+
+def explain_once(term, registry, level="high-school", seen=seen):
+    if term in seen:
+        return None
+    seen.add(term)
+    return plainspeak(term, registry, level)
+```
+
+### 6. Update the registry with new terms
+
+When unknown jargon is detected, add it to the registry:
+
+```python3
+def add_term(registry, term, expanded, doctor="", high_school="", kindergarten="", category="general"):
+    registry[term] = {
+        "term": term,
+        "expanded": expanded,
+        "plainspeak": {
+            "doctor": doctor,
+            "high-school": high_school,
+            "kindergarten": kindergarten
+        },
+        "category": category,
+        "saturated": False,
+        "since": "2025-01-01"
+    }
+```
+
+Then write back:
+
+```bash
+python3 -c "
+import json
+with open('jargon-registry.json') as f:
+    reg = json.load(f)
+# ... modify ...
+with open('jargon-registry.json', 'w') as f:
+    json.dump(reg, f, indent=2)
+"
+```
+
+## Complete Pipeline Example
+
+This end-to-end pipeline scans a text file, detects known jargon, explains it,
+and reports unknown terms:
+
+```bash
+#!/usr/bin/env bash
+# jargon-pipeline.sh — scan content and explain jargon
+set -euo pipefail
+
+CONTENT_FILE="${1:?Usage: $0 <content-file>}"
+REGISTRY="${2:-jargon-registry.json}"
+LEVEL="${3:-high-school}"
+EXPLAINED=$(mktemp)
+trap 'rm -f "$EXPLAINED"' EXIT
+
+python3 - "$CONTENT_FILE" "$REGISTRY" "$LEVEL" "$EXPLAINED" << 'PYEOF'
+import json, sys, re
+
+content_file, reg_file, level, explained_file = sys.argv[1:]
+
+with open(reg_file) as f:
+    registry = json.load(f)
+
+with open(content_file) as f:
+    content = f.read()
+
+terms = set(re.findall(r'\b[A-Z]{2,}\b', content))
+known = {t for t in terms if t in registry and not registry[t].get("saturated", False)}
+unknown = {t for t in terms if t not in registry}
+
+seen = set()
+explanations = []
+
+for t in sorted(known):
+    if t not in seen:
+        seen.add(t)
+        ps = registry[t]["plainspeak"].get(level, registry[t]["plainspeak"].get("high-school"))
+        expanded = registry[t].get("expanded", t)
+        explanations.append(f"**{t}** ({expanded}): {ps}")
+
+print("=== KNOWN TERMS ===")
+for e in explanations:
+    print(e)
+    print()
+
+if unknown:
+    print("=== UNKNOWN TERMS (not in registry) ===")
+    for t in sorted(unknown):
+        print(f"- {t}")
+
+with open(explained_file, 'w') as ef:
+    ef.write("\n".join(explanations))
+PYEOF
+```
+
+## Integration with Digest Skills
+
+This skill pairs naturally with digest-producing skills such as
+`hn-brief-digest`, `blogwatcher`, `youtube-content`, and
+`structured-digest`. After generating a digest body, pipe it through
+the pipeline above to produce a "Jargon Buster" appendix:
+
+> **Jargon Buster**
+> - **LLM** (Large Language Model): A computer program that has read
+>   a huge amount of text and can write essays and answer questions.
+> - **RAG** (Retrieval-Augmented Generation): A technique where the
+>   AI looks up relevant documents before answering, like checking your
+>   notes before a test.
+> - **MCP** (Model Context Protocol): A standard way for AI models to
+>   connect to external tools and data sources.
+
+## Skills
+
+- **detect**: Scan text for all uppercase/domain acronyms, cross-reference registry
+- **explain**: Return plainspeak definition for a single term at a given level
+- **saturate**: Mark a term as saturated so it's no longer flagged
+- **unsaturate**: Unmark a term
+- **register**: Add a new term to the registry interactively
+- **sync**: Merge updates from a shared/multi-source registry

--- a/skills/research/jargon/references/jargon-registry.json
+++ b/skills/research/jargon/references/jargon-registry.json
@@ -1,0 +1,338 @@
+{
+  "API": {
+    "term": "API",
+    "expanded": "Application Programming Interface",
+    "plainspeak": {
+      "doctor": "A defined contract enabling software components to communicate via structured requests and responses over a network or within a process boundary.",
+      "high-school": "A set of rules that lets one program talk to another program, like a waiter taking your order to the kitchen.",
+      "kindergarten": "A way for computer programs to ask each other for things."
+    },
+    "category": "infra",
+    "saturated": true,
+    "since": "2023-01-01"
+  },
+  "CLI": {
+    "term": "CLI",
+    "expanded": "Command-Line Interface",
+    "plainspeak": {
+      "doctor": "A text-based interface for interacting with a computer system by issuing commands as lines of text, typically through a shell or terminal emulator.",
+      "high-school": "A way to control a computer by typing commands instead of clicking buttons.",
+      "kindergarten": "Talking to a computer by typing words."
+    },
+    "category": "infra",
+    "saturated": true,
+    "since": "2023-01-01"
+  },
+  "CPU": {
+    "term": "CPU",
+    "expanded": "Central Processing Unit",
+    "plainspeak": {
+      "doctor": "The primary processor in a computer that executes instructions from programs through fetch-decode-execute cycles, containing arithmetic-logic and control units.",
+      "high-school": "The brain of a computer that does all the calculations and runs your programs.",
+      "kindergarten": "The part of a computer that does the thinking."
+    },
+    "category": "hardware",
+    "saturated": true,
+    "since": "2023-01-01"
+  },
+  "CRDT": {
+    "term": "CRDT",
+    "expanded": "Conflict-Free Replicated Data Type",
+    "plainspeak": {
+      "doctor": "A data structure that allows multiple users to edit concurrently without coordination, automatically resolving conflicts through mathematically guaranteed merge semantics.",
+      "high-school": "A way for multiple people to edit the same document at the same time without getting conflicts, even if they're offline.",
+      "kindergarten": "A trick that lets two people write on the same page at the same time without messing it up."
+    },
+    "category": "distributed-systems",
+    "saturated": false,
+    "since": "2024-06-01"
+  },
+  "CUDA": {
+    "term": "CUDA",
+    "expanded": "Compute Unified Device Architecture",
+    "plainspeak": {
+      "doctor": "NVIDIA's parallel computing platform that enables general-purpose computation on GPUs, allowing thousands of threads to execute concurrently.",
+      "high-school": "A technology that lets programmers use graphics cards to do math really fast, which is great for AI training.",
+      "kindergarten": "A special way to make the powerful part of a graphics card do super-fast calculations."
+    },
+    "category": "hardware",
+    "saturated": false,
+    "since": "2023-01-01"
+  },
+  "DAG": {
+    "term": "DAG",
+    "expanded": "Directed Acyclic Graph",
+    "plainspeak": {
+      "doctor": "A finite directed graph with no directed cycles, representing a partially ordered set of nodes where edges define dependencies and topological ordering is always possible.",
+      "high-school": "A flowchart where arrows go one way and you can never loop back to where you started. Used to manage task dependencies.",
+      "kindergarten": "A drawing of connected boxes where the arrows never come back to the start."
+    },
+    "category": "cs",
+    "saturated": false,
+    "since": "2023-06-01"
+  },
+  "GPU": {
+    "term": "GPU",
+    "expanded": "Graphics Processing Unit",
+    "plainspeak": {
+      "doctor": "A specialized processor with thousands of cores designed for parallel computation, originally for rendering graphics but now essential for AI workloads.",
+      "high-school": "A powerful chip originally made for games that turned out to be amazing for AI because it can do many calculations at once.",
+      "kindergarten": "A super-fast calculator chip that helps AI learn."
+    },
+    "category": "hardware",
+    "saturated": true,
+    "since": "2023-01-01"
+  },
+  "IDE": {
+    "term": "IDE",
+    "expanded": "Integrated Development Environment",
+    "plainspeak": {
+      "doctor": "A comprehensive software application combining a source code editor, build automation tools, debugger, and often language server support into a single interface.",
+      "high-school": "An all-in-one app for writing code that includes a text editor, tools to run your code, and ways to find bugs.",
+      "kindergarten": "A special program for writing computer programs."
+    },
+    "category": "devtools",
+    "saturated": false,
+    "since": "2023-01-01"
+  },
+  "JSON": {
+    "term": "JSON",
+    "expanded": "JavaScript Object Notation",
+    "plainspeak": {
+      "doctor": "A lightweight, language-independent data interchange format using human-readable key-value pairs and arrays, defined by ECMA-404 and RFC 8259.",
+      "high-school": "A way to write data using curly braces and colons that's easy for both humans and computers to read.",
+      "kindergarten": "A way to write down information that computers can understand."
+    },
+    "category": "infra",
+    "saturated": true,
+    "since": "2023-01-01"
+  },
+  "LLM": {
+    "term": "LLM",
+    "expanded": "Large Language Model",
+    "plainspeak": {
+      "doctor": "A neural network with billions to trillions of parameters trained auto-regressively on massive text corpora, capable of generating coherent text and performing in-context learning.",
+      "high-school": "A computer program that has read billions of pages of text and can write essays, answer questions, and have conversations.",
+      "kindergarten": "A super smart computer that can talk and write like a person."
+    },
+    "category": "ai",
+    "saturated": false,
+    "since": "2023-01-01"
+  },
+  "LSP": {
+    "term": "LSP",
+    "expanded": "Language Server Protocol",
+    "plainspeak": {
+      "doctor": "A protocol (JSON-RPC based) that standardizes communication between a code editor and a language server, providing features like autocomplete, go-to-definition, and diagnostics.",
+      "high-school": "A standard way for code editors to get smart features like auto-complete and error checking by talking to a background program.",
+      "kindergarten": "A helper that makes coding programs better at guessing what you are trying to type."
+    },
+    "category": "devtools",
+    "saturated": false,
+    "since": "2023-01-01"
+  },
+  "MCP": {
+    "term": "MCP",
+    "expanded": "Model Context Protocol",
+    "plainspeak": {
+      "doctor": "An open protocol standardized by Anthropic that defines how LLMs connect to external tools, data sources, and services through a unified server-client architecture.",
+      "high-school": "A standard way for AI models to plug into tools and databases, like a USB port for AI capabilities.",
+      "kindergarten": "A way to plug AI into other computer programs so it can do more things."
+    },
+    "category": "ai",
+    "saturated": false,
+    "since": "2024-11-01"
+  },
+  "ML": {
+    "term": "ML",
+    "expanded": "Machine Learning",
+    "plainspeak": {
+      "doctor": "A subset of AI where algorithms improve through experience by identifying patterns in data, typically via statistical models trained on labeled or unlabeled datasets.",
+      "high-school": "Teaching a computer to learn from examples instead of giving it step-by-step instructions.",
+      "kindergarten": "Showing a computer lots of examples so it can learn to do things on its own."
+    },
+    "category": "ai",
+    "saturated": true,
+    "since": "2023-01-01"
+  },
+  "NER": {
+    "term": "NER",
+    "expanded": "Named Entity Recognition",
+    "plainspeak": {
+      "doctor": "An NLP task that identifies and classifies named entities (persons, organizations, locations, dates, etc.) in unstructured text into predefined categories.",
+      "high-school": "A computer skill that picks out names, places, and dates from text and labels what they are.",
+      "kindergarten": "Teaching a computer to find people's names and place names in stories."
+    },
+    "category": "ai",
+    "saturated": false,
+    "since": "2023-06-01"
+  },
+  "NLP": {
+    "term": "NLP",
+    "expanded": "Natural Language Processing",
+    "plainspeak": {
+      "doctor": "A subfield of AI focused on the interaction between computers and human language, encompassing tasks like parsing, generation, translation, and sentiment analysis.",
+      "high-school": "Technology that helps computers understand, process, and generate human language like English.",
+      "kindergarten": "Teaching computers to understand what people say and write."
+    },
+    "category": "ai",
+    "saturated": false,
+    "since": "2023-01-01"
+  },
+  "RAG": {
+    "term": "RAG",
+    "expanded": "Retrieval-Augmented Generation",
+    "plainspeak": {
+      "doctor": "A technique that enhances LLM outputs by first retrieving relevant documents from a knowledge base and conditioning the model's generation on that retrieved context.",
+      "high-school": "A method where an AI looks up facts in a database before answering, like checking your notes before a test.",
+      "kindergarten": "Letting the AI peek at a book for the right answer before it speaks."
+    },
+    "category": "ai",
+    "saturated": false,
+    "since": "2023-10-01"
+  },
+  "RLHF": {
+    "term": "RLHF",
+    "expanded": "Reinforcement Learning from Human Feedback",
+    "plainspeak": {
+      "doctor": "A fine-tuning paradigm where a reward model trained on human preference data guides policy optimization of an LLM using reinforcement learning.",
+      "high-school": "A training method where humans rate AI outputs, and the AI learns to produce better answers based on those ratings.",
+      "kindergarten": "Teaching an AI by telling it which answers are good and which are bad, like giving a gold star or a frown."
+    },
+    "category": "ai",
+    "saturated": false,
+    "since": "2023-06-01"
+  },
+  "SDK": {
+    "term": "SDK",
+    "expanded": "Software Development Kit",
+    "plainspeak": {
+      "doctor": "A collection of libraries, tools, documentation, and sample code that enables developers to build applications for a specific platform or service.",
+      "high-school": "A toolkit with code libraries and instructions that helps programmers build apps for a specific platform.",
+      "kindergarten": "A box of tools for building programs that work with a particular service."
+    },
+    "category": "devtools",
+    "saturated": false,
+    "since": "2023-01-01"
+  },
+  "SLO": {
+    "term": "SLO",
+    "expanded": "Service Level Objective",
+    "plainspeak": {
+      "doctor": "A target metric (e.g., 99.9% uptime) defining the desired reliability level for a service, used with SLIs and SLAs to manage operational risk.",
+      "high-school": "A promise about how reliable a service will be, like 'this website will work 99.9% of the time.'",
+      "kindergarten": "A goal for how often a service should work without breaking."
+    },
+    "category": "devops",
+    "saturated": false,
+    "since": "2023-01-01"
+  },
+  "SSH": {
+    "term": "SSH",
+    "expanded": "Secure Shell",
+    "plainspeak": {
+      "doctor": "A cryptographic network protocol for operating services securely over an unsecured network, providing encrypted remote login and command execution.",
+      "high-school": "A secure way to log into another computer over the internet and run commands on it.",
+      "kindergarten": "A secret tunnel to another computer so you can use it from far away."
+    },
+    "category": "infra",
+    "saturated": true,
+    "since": "2023-01-01"
+  },
+  "TLS": {
+    "term": "TLS",
+    "expanded": "Transport Layer Security",
+    "plainspeak": {
+      "doctor": "A cryptographic protocol providing end-to-end encryption, authentication, and integrity for communications over a computer network, the successor to SSL.",
+      "high-school": "The technology that keeps your internet traffic private by encrypting it so nobody can spy on it.",
+      "kindergarten": "A secret code that keeps what you see on the internet safe from snoops."
+    },
+    "category": "infra",
+    "saturated": false,
+    "since": "2023-01-01"
+  },
+  "TPU": {
+    "term": "TPU",
+    "expanded": "Tensor Processing Unit",
+    "plainspeak": {
+      "doctor": "Google's custom ASIC designed specifically for accelerating machine learning workloads, optimized for TensorFlow operations with matrix arithmetic.",
+      "high-school": "A special chip Google made just for AI calculations, even faster than a GPU for certain tasks.",
+      "kindergarten": "A super-fast computer chip made just for AI."
+    },
+    "category": "hardware",
+    "saturated": false,
+    "since": "2023-01-01"
+  },
+  "UI": {
+    "term": "UI",
+    "expanded": "User Interface",
+    "plainspeak": {
+      "doctor": "The point of human-computer interaction comprising visual elements, controls, and feedback mechanisms that enable a user to operate a software application.",
+      "high-school": "The screens, buttons, and menus you see and click on when using an app or website.",
+      "kindergarten": "The pictures and buttons you see on a screen that you can tap or click."
+    },
+    "category": "devtools",
+    "saturated": true,
+    "since": "2023-01-01"
+  },
+  "UX": {
+    "term": "UX",
+    "expanded": "User Experience",
+    "plainspeak": {
+      "doctor": "The overall quality of interaction a person has with a system, encompassing usability, accessibility, aesthetics, and emotional response throughout the user journey.",
+      "high-school": "How easy and pleasant it feels to use a website or app.",
+      "kindergarten": "How much fun and easy it is to use something."
+    },
+    "category": "devtools",
+    "saturated": false,
+    "since": "2023-01-01"
+  },
+  "VLLM": {
+    "term": "VLLM",
+    "expanded": "Virtual Large Language Model / vLLM Engine",
+    "plainspeak": {
+      "doctor": "A high-throughput, memory-efficient serving engine for LLMs featuring PagedAttention, continuous batching, and tensor parallelism for production inference.",
+      "high-school": "A system that runs AI models efficiently and handles lots of users at the same time without running out of memory.",
+      "kindergarten": "A smart program that lets lots of people use a big AI at the same time."
+    },
+    "category": "mlops",
+    "saturated": false,
+    "since": "2024-01-01"
+  },
+  "WSL": {
+    "term": "WSL",
+    "expanded": "Windows Subsystem for Linux",
+    "plainspeak": {
+      "doctor": "A compatibility layer in Windows that enables running Linux binary executables natively through a Linux kernel interface provided by Microsoft.",
+      "high-school": "A way to run Linux programs directly on Windows without needing a separate computer or virtual machine.",
+      "kindergarten": "Lets you use Linux programs on a Windows computer."
+    },
+    "category": "infra",
+    "saturated": false,
+    "since": "2023-01-01"
+  },
+  "YAML": {
+    "term": "YAML",
+    "expanded": "YAML Ain't Markup Language",
+    "plainspeak": {
+      "doctor": "A human-readable data serialization language using indentation-based structure, commonly used for configuration files in CI/CD and application deployments.",
+      "high-school": "A way to write configuration files using indentation (spaces) that's easy for humans to read and edit.",
+      "kindergarten": "A way to write settings for programs using spaces and dashes."
+    },
+    "category": "infra",
+    "saturated": true,
+    "since": "2023-01-01"
+  },
+  "YOLO": {
+    "term": "YOLO",
+    "expanded": "You Only Look Once",
+    "plainspeak": {
+      "doctor": "A real-time object detection system that frames detection as a single regression problem, directly predicting bounding boxes and class probabilities from full images in one pass.",
+      "high-school": "An AI system that can spot objects in images or video in real time by looking at the whole picture at once.",
+      "kindergarten": "A clever computer program that can find things in pictures really fast."
+    },
+    "category": "ai",
+    "saturated": false,
+    "since": "2023-01-01"
+  }
+}


### PR DESCRIPTION
Adds a new skill for detecting, decoding, and tracking domain-specific jargon across any content pipeline.

**What this adds:**
- `skills/research/jargon/SKILL.md` — full workflow: load registry → scan content → detect known/unknown terms → explain → update registry
- `skills/research/jargon/references/jargon-registry.json` — initial registry with 27 common AI/tech terms, each with three-level plainspeak (doctor, high-school, kindergarten)

**Key features:**
- **Saturation filter**: common baseline terms (API, CLI, CPU, GPU, LLM, etc.) are pre-marked as saturated — they're tracked internally but suppressed from digest output
- **Per-digest dedup**: each term is explained at most once per run
- **Unknown-term detection**: unfamiliar capitalized acronyms are flagged for registry addition
- **Plainspeak at three levels**: doctor (domain expert), high-school (tech-literate generalist), kindergarten (general audience)

Part of a batch (see also: `feat/unified-digest-themes-skill`, `feat/arxiv-adhoc-list-workflow`).