### PR TITLE
fix(moa): preserve save_traces and trace_dir when saving from Desktop UI (#58819)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4486,6 +4486,13 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                     "enabled": body.enabled,
                 }
             normalized = normalize_moa_config(raw)
+            # Preserve fields that the Desktop/Dashboard MOA panel does not
+            # expose (save_traces, trace_dir) so hand-edited values survive
+            # saves.  See #58819.
+            _existing = cfg.get("moa", {})
+            for _key in ("save_traces", "trace_dir"):
+                if _key in _existing and _key not in normalized:
+                    normalized[_key] = _existing[_key]
             cfg["moa"] = normalized
             save_config(cfg)
             return {"ok": True, **normalized}


### PR DESCRIPTION
## Summary

Fixes #58819 — Desktop MOA settings panel silently drops `save_traces` and `trace_dir` from config.yaml on every save.

## Problem

The Desktop/Dashboard MOA settings panel calls `PUT /api/model/moa` to save preset changes. The endpoint's `MoaConfigPayload` model does not declare `save_traces` or `trace_dir` fields, and `set_moa_models` does a wholesale overwrite of `cfg["moa"]` with the normalized payload.

Any `save_traces: true` or `trace_dir` values set by hand-editing `~/.hermes/config.yaml` are silently dropped on every save through the Desktop UI — with no warning or log entry.

## Fix

After normalizing the payload, carry forward `save_traces` and `trace_dir` from the existing config if they were not included in the new payload:

```python
_existing = cfg.get("moa", {})
for _key in ("save_traces", "trace_dir"):
    if _key in _existing and _key not in normalized:
        normalized[_key] = _existing[_key]
```

This preserves hand-edited trace configuration across Desktop saves while still allowing the panel to set these fields if the payload includes them (for future Desktop UI enhancements).