### PR TITLE
fix(agent): handle unread streaming response in _summarize_api_error (#59769)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2143,7 +2143,10 @@ class AIAgent:
         # widens exposure vs the old empty-body "HTTP 400" string).
         response = getattr(error, "response", None)
         if response is not None:
-            snippet = (getattr(response, "text", None) or "").strip()
+            try:
+                snippet = (response.text or "").strip()
+            except Exception:
+                snippet = ""
             if snippet:
                 status_code = getattr(error, "status_code", None)
                 prefix = f"HTTP {status_code}: " if status_code else ""


### PR DESCRIPTION
## Summary

Fix #59769 — `_summarize_api_error` crasha com `httpx.ResponseNotRead` quando encontra erros de streaming Gemini.

## Root Cause

Em `run_agent.py`, `_summarize_api_error()` tenta acessar `response.text` em um `httpx.Response` de streaming que foi consumido via `iter_bytes()` e nunca passou por `.read()`. Isso levanta `httpx.ResponseNotRead`, substituindo o erro original (ex: 429 quota) por um crash secundário.

## Fix

Wrap o acesso a `response.text` em `try/except Exception` — se o response não foi lido (streaming), o fallback silencioso retorna `snippet = ""` e o método cai no fallback geral `str(error)[:500]`.

**Arquivo:** `run_agent.py`, função `_summarize_api_error`, linha 2146

**Diff:**
```diff
-            snippet = (getattr(response, "text", None) or "").strip()
+            try:
+                snippet = (response.text or "").strip()
+            except Exception:
+                snippet = ""
```

## Testes

- [x] `httpx.ResponseNotRead` em response de streaming → `snippet = ""` → fallback para `str(error)[:500]`
- [x] Response normal (lido) → comportamento inalterado
- [x] Sem atributo `.body` no erro → comportamento inalterado

Closes #59769