### PR TITLE
fix(agent): include max_tokens in _resolve_runtime_agent_kwargs_for_provider return dict (#59763)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1872,11 +1872,32 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
+        _get_model_config,
     )
     try:
         runtime = resolve_runtime_provider(requested=provider)
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
+
+    max_tokens = None
+    _env_mt = os.environ.get("HERMES_MAX_TOKENS")
+    if _env_mt:
+        try:
+            max_tokens = int(_env_mt)
+        except (ValueError, TypeError):
+            max_tokens = None
+    elif isinstance(_get_model_config(), dict):
+        mt = _get_model_config().get("max_tokens")
+        if isinstance(mt, int):
+            max_tokens = mt
+    # Fall back to a per-provider output cap (custom_providers max_output_tokens)
+    # only when the documented global model.max_tokens isn't set, so the global
+    # key always wins.
+    if max_tokens is None:
+        _runtime_mot = runtime.get("max_output_tokens")
+        if isinstance(_runtime_mot, int) and _runtime_mot > 0:
+            max_tokens = _runtime_mot
+
     return {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
@@ -1885,6 +1906,7 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "max_tokens": max_tokens,
     }
 
 


### PR DESCRIPTION
## Descrição

`_resolve_runtime_agent_kwargs_for_provider()` não incluía `max_tokens` em seu dict de retorno, fazendo com que `model.max_tokens` do `config.yaml`, `HERMES_MAX_TOKENS` env var, e per-provider `max_output_tokens` fossem ignorados em qualquer rota com provider fixo (channel overrides, etc.).

A função irmã `_resolve_runtime_agent_kwargs()` já implementava essa resolução corretamente — `_resolve_runtime_agent_kwargs_for_provider()` simplesmente não tinha o bloco equivalente.

## O que foi feito

Adicionada a mesma lógica de resolução de `max_tokens` que existe em `_resolve_runtime_agent_kwargs()` para `_resolve_runtime_agent_kwargs_for_provider()`:

1. **`HERMES_MAX_TOKENS` env var** — lida primeiro (priority mais alta)
2. **`model.max_tokens` do `config.yaml`** — via `_get_model_config()`
3. **Per-provider `max_output_tokens`** — fallback de `custom_providers` no runtime, apenas quando os anteriores não estão definidos
4. **Retorno** — `max_tokens` incluído no dict retornado

## Arquivos alterados

- `gateway/run.py` — +22 linhas em `_resolve_runtime_agent_kwargs_for_provider()`

## Contexto adicional

O issue também mencionava `_build_call_kwargs()` em `agent/auxiliary_client.py` dropando `max_tokens` para OpenRouter no caminho auxiliar. Analisando o código, a omissão de `max_tokens` em `_build_call_kwargs` para providers não-Anthropic/NVIDIA é **intencional** (documentado no comentário das linhas 5870-5902) — omitir o parâmetro permite que a maioria dos providers use o limite máximo do modelo, que é o desejado para calls auxiliares (sumarização, títulos, etc.). Portanto o fix se concentra exclusivamente em `_resolve_runtime_agent_kwargs_for_provider`.

Closes #59763