### PR TITLE
fix(workers): align card skills profile contract

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -86,7 +86,7 @@ import logging
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Iterable, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
@@ -7220,6 +7220,21 @@ def _dispatch_once_locked(
                     (row["id"], row_assignee, current)
                 )
                 continue
+        task_for_skills = get_task(conn, row["id"])
+        if task_for_skills and task_for_skills.skills and not dry_run:
+            missing_skills = _worker_missing_card_skills(
+                row_assignee, task_for_skills.skills
+            )
+            if missing_skills:
+                reason = (
+                    "Card requested skill(s) unavailable to worker profile "
+                    f"{row_assignee!r}: {', '.join(missing_skills)}. "
+                    "Install the missing skill(s) for that profile or edit the "
+                    "card skills before dispatching."
+                )
+                block_task(conn, row["id"], reason=reason, kind="capability")
+                result.auto_blocked.append(row["id"])
+                continue
         # Respawn guard: refuse to re-spawn when useful work is already
         # in-flight/recent, or when the last failure is a deterministic
         # blocker (quota / auth). The guard defers the spawn this tick so
@@ -7657,6 +7672,147 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
             exc,
         )
         return None
+
+
+def _worker_missing_card_skills(
+    assignee: str,
+    skills: Optional[Iterable[str]],
+) -> list[str]:
+    """Return card skills unavailable to the assignee's worker profile.
+
+    Worker subprocesses resolve ``--skills`` after switching into the
+    assignee profile's HERMES_HOME. Validate against that same profile before
+    spawning so a card cannot silently run without its authored skill context
+    or crash-loop on a deterministic ``Unknown skill(s)`` startup error.
+    """
+    requested = [str(s).strip() for s in (skills or []) if str(s or "").strip()]
+    if not requested:
+        return []
+    try:
+        from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+
+        profile_home = resolve_profile_env(normalize_profile_name(assignee))
+    except Exception:
+        # Profile existence is checked separately in dispatch. If resolution is
+        # unavailable in a degraded/test environment, don't introduce a new
+        # spawn blocker here.
+        return []
+
+    try:
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from agent.skill_utils import (
+            get_all_skills_dirs,
+            get_disabled_skill_names,
+            is_skill_support_path,
+            iter_skill_index_files,
+            parse_frontmatter,
+            skill_matches_platform,
+        )
+    except Exception:
+        # Conservative guard: if the lightweight skill helpers are unavailable,
+        # avoid a false-positive block and let worker startup report the error.
+        return []
+
+    token = set_hermes_home_override(profile_home)
+    try:
+        search_dirs = [p for p in get_all_skills_dirs() if p.is_dir()]
+        disabled = get_disabled_skill_names()
+    finally:
+        reset_hermes_home_override(token)
+
+    def _frontmatter(path: Path) -> dict:
+        try:
+            raw = path.read_text(encoding="utf-8")
+            fm, _ = parse_frontmatter(raw)
+            return fm if isinstance(fm, dict) else {}
+        except Exception:
+            return {}
+
+    def _candidate_ok(identifier: str, skill_md: Path) -> bool:
+        fm = _frontmatter(skill_md)
+        if not skill_matches_platform(fm):
+            return False
+        resolved_name = str(fm.get("name") or skill_md.parent.name)
+        return resolved_name not in disabled and identifier not in disabled
+
+    def _exists(identifier: str) -> bool:
+        raw_identifier = identifier
+        identifier_path = Path(identifier).expanduser()
+        if identifier_path.is_absolute():
+            normalized = None
+            for search_dir in search_dirs:
+                try:
+                    normalized = str(identifier_path.relative_to(search_dir))
+                    break
+                except ValueError:
+                    continue
+            if normalized is None:
+                return False
+            identifier = normalized
+        elif (
+            PurePosixPath(identifier).is_absolute()
+            or PureWindowsPath(identifier).is_absolute()
+            or PureWindowsPath(identifier).drive
+            or ".." in PurePosixPath(identifier).parts
+            or ".." in PureWindowsPath(identifier).parts
+        ):
+            return False
+
+        # Plugin-qualified skills are resolved by the worker's plugin registry.
+        # Avoid blocking them here unless they also resolve as categorized
+        # profile skills via the normal category/name fallback.
+        category_fallback = None
+        if ":" in identifier:
+            namespace, _, bare = identifier.partition(":")
+            if namespace and bare:
+                category_fallback = f"{namespace}/{bare}"
+
+        matches: list[Path] = []
+        seen: set[str] = set()
+
+        def _record(skill_md: Path) -> None:
+            try:
+                key = str(skill_md.resolve())
+            except Exception:
+                key = str(skill_md)
+            if key not in seen and _candidate_ok(identifier, skill_md):
+                seen.add(key)
+                matches.append(skill_md)
+
+        names = [identifier]
+        if category_fallback:
+            names.append(category_fallback)
+
+        for search_dir in search_dirs:
+            for name in names:
+                direct = search_dir / name
+                if (
+                    not is_skill_support_path(direct)
+                    and direct.is_dir()
+                    and (direct / "SKILL.md").exists()
+                ):
+                    _record(direct / "SKILL.md")
+                md = direct.with_suffix(".md")
+                if md.exists() and not is_skill_support_path(md):
+                    _record(md)
+
+            for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+                if found_skill_md.parent.name == identifier:
+                    _record(found_skill_md)
+                    continue
+                fm = _frontmatter(found_skill_md)
+                if fm.get("name") == identifier:
+                    _record(found_skill_md)
+
+            for found_md in search_dir.rglob(f"{identifier}.md"):
+                if found_md.name != "SKILL.md" and not is_skill_support_path(found_md):
+                    _record(found_md)
+
+        if matches:
+            return len(matches) == 1
+        return ":" in raw_identifier
+
+    return [identifier for identifier in requested if not _exists(identifier)]
 
 
 def _default_spawn(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7221,7 +7221,7 @@ def _dispatch_once_locked(
                 )
                 continue
         task_for_skills = get_task(conn, row["id"])
-        if task_for_skills and task_for_skills.skills and not dry_run:
+        if task_for_skills and task_for_skills.skills:
             missing_skills = _worker_missing_card_skills(
                 row_assignee, task_for_skills.skills
             )
@@ -7232,7 +7232,11 @@ def _dispatch_once_locked(
                     "Install the missing skill(s) for that profile or edit the "
                     "card skills before dispatching."
                 )
-                block_task(conn, row["id"], reason=reason, kind="capability")
+                # Dry-run still resolves skills and reports a proposed block
+                # so operators see the same outcome as a real dispatch, but
+                # must not mutate the card (dispatch dry-run contract).
+                if not dry_run:
+                    block_task(conn, row["id"], reason=reason, kind="capability")
                 result.auto_blocked.append(row["id"])
                 continue
         # Respawn guard: refuse to re-spawn when useful work is already

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -198,3 +198,46 @@ def test_dispatch_allows_card_skill_present_in_worker_profile(
     assert spawned == [(tid, ["card-skill"])]
     assert result.spawned and result.spawned[0][0] == tid
     assert task.status == "running"
+
+
+def test_dispatch_dry_run_missing_card_skill_reports_block_without_mutating(
+    monkeypatch, tmp_path
+):
+    """Dry-run must surface the capability block, not a false spawn.
+
+    Real dispatch blocks cards whose requested skills are unavailable on the
+    assignee profile. Dry-run is documented to show that outcome without
+    mutating the DB — so missing skills belong in ``auto_blocked``, not
+    ``spawned``, and the card stays ``ready``.
+    """
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("", encoding="utf-8")
+    profile.joinpath("config.yaml").write_text("", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    kb.init_db()
+    spawned = []
+
+    def fake_spawn(task, workspace):
+        spawned.append(task.id)
+        return 789
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(
+            conn,
+            title="dry-run missing skill",
+            assignee="elias",
+            skills=["missing-card-skill"],
+        )
+        result = kb.dispatch_once(conn, spawn_fn=fake_spawn, dry_run=True)
+        task = kb.get_task(conn, tid)
+
+    assert spawned == []
+    assert tid in result.auto_blocked
+    assert result.spawned == []
+    assert task.status == "ready"
+    assert task.block_kind is None

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -3,6 +3,15 @@ from __future__ import annotations
 import subprocess
 
 
+def _write_skill(root, name: str) -> None:
+    skill_dir = root / "skills" / name
+    skill_dir.mkdir(parents=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Test skill\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
 def _make_task(kb, *, assignee: str):
     return kb.Task(
         id="t_spawn_tools",
@@ -116,3 +125,76 @@ toolsets:
     assert "web" in resolved
     assert "kanban" in resolved  # recovered worker lifecycle surface
     assert resolved != ["kanban"]
+
+
+def test_dispatch_blocks_card_with_skill_missing_from_worker_profile(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("", encoding="utf-8")
+    profile.joinpath("config.yaml").write_text("", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    kb.init_db()
+    spawned = []
+
+    def fake_spawn(task, workspace):
+        spawned.append(task.id)
+        return 123
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(
+            conn,
+            title="needs unavailable skill",
+            assignee="elias",
+            skills=["missing-card-skill"],
+        )
+        result = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        task = kb.get_task(conn, tid)
+        runs = kb.list_runs(conn, tid)
+
+    assert spawned == []
+    assert tid in result.auto_blocked
+    assert task.status == "blocked"
+    assert task.block_kind == "capability"
+    assert "missing-card-skill" in (runs[-1].summary or "")
+    assert "elias" in (runs[-1].summary or "")
+
+
+def test_dispatch_allows_card_skill_present_in_worker_profile(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("", encoding="utf-8")
+    profile.joinpath("config.yaml").write_text("", encoding="utf-8")
+    _write_skill(profile, "card-skill")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    kb.init_db()
+    spawned = []
+
+    def fake_spawn(task, workspace):
+        spawned.append((task.id, task.skills))
+        return 456
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(
+            conn,
+            title="has profile skill",
+            assignee="elias",
+            skills=["card-skill"],
+        )
+        result = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        task = kb.get_task(conn, tid)
+
+    assert spawned == [(tid, ["card-skill"])]
+    assert result.spawned and result.spawned[0][0] == tid
+    assert task.status == "running"


### PR DESCRIPTION
Addresses Part (b) of #59764.

This PR adds a conservative pre-spawn guard for card-level skills assigned to profile-scoped workers.

Before spawning a worker, dispatch now checks whether the card's requested skills are available to the assignee's worker profile. If any required card skill is unavailable, the task is blocked with `kind="capability"` and a board-visible reason naming the missing skill(s) and profile, instead of launching a worker that would crash-loop or silently lose part of the authored skill context.

Changes:
- Add dispatch-time validation for card skills against the assignee worker profile.
- Block tasks with a visible capability reason when required card skills are unavailable.
- Add regression coverage for:
  - missing card skill blocks before spawn;
  - profile-installed card skill still allows dispatch.

Risk notes:
- The guard is intentionally conservative. If lightweight profile/skill resolution is unavailable, it avoids false-positive blocking and lets worker startup remain authoritative.
- Plugin-qualified skill names are not aggressively blocked. If no local categorized fallback resolves, `namespace:skill` is allowed through so plugin registries remain authoritative.
- This does not change Part (a), goal-mode auto-block behavior, scheduler architecture, worker runtime architecture, or skill registration behavior.

Verification:
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_worker_spawn_toolsets.py`
- Result: 4 passed
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py`
- Result: 4 passed
