### PR TITLE
fix(multiplex): skip port-binding platform on secondary profiles instead of crashing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8365,19 +8365,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
             # A secondary profile must NOT enable a port-binding platform: the
             # default profile's listener already serves every profile via the
-            # /p/<profile>/ prefix, so a second bind can only collide. This is a
-            # config error, not a transient failure — fail fast and loud.
+            # /p/<profile>/ prefix, so a second bind can only collide. Rather
+            # than crash the entire gateway (which takes down ALL profiles
+            # including the default one), skip the platform with a warning so
+            # the operator can fix config.yaml without a crash-restart loop.
             if platform.value in _PORT_BINDING_PLATFORM_VALUES:
-                raise MultiplexConfigError(
-                    f"Profile '{profile_name}' enables the port-binding platform "
-                    f"'{platform.value}', but gateway.multiplex_profiles is on. The "
-                    f"default profile owns the single shared HTTP listener and "
-                    f"serves every profile through the /p/{profile_name}/ URL "
-                    f"prefix — a secondary profile cannot bind its own port. "
-                    f"Remove platforms.{platform.value} from profile "
-                    f"'{profile_name}'s config.yaml (configure it only on the "
-                    f"default profile)."
+                logger.warning(
+                    "Profile '%s' enables the port-binding platform '%s', but "
+                    "gateway.multiplex_profiles is on. The default profile owns "
+                    "the single shared HTTP listener and serves every profile "
+                    "through the /p/%s/ URL prefix. Skipping this platform for "
+                    "this profile — remove platforms.%s from this profile's "
+                    "config.yaml (configure it only on the default profile).",
+                    profile_name,
+                    platform.value,
+                    profile_name,
+                    platform.value,
                 )
+                continue
             with _profile_runtime_scope(profile_home):
                 adapter = self._create_adapter(platform, platform_config)
             if not adapter:

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -78,12 +78,11 @@ class TestProfileMessageHandler:
         assert seen["profile"] == "writer"
 
 
-class TestPortBindingHardError:
-    """A secondary profile enabling a port-binding platform aborts startup."""
+class TestPortBindingSkip:
+    """A secondary profile enabling a port-binding platform is skipped, not fatal."""
 
     @pytest.mark.asyncio
-    async def test_secondary_webhook_raises(self, monkeypatch):
-        from gateway.run import MultiplexConfigError
+    async def test_secondary_webhook_skipped(self, monkeypatch):
         from gateway.config import GatewayConfig, Platform, PlatformConfig
 
         runner = GatewayRunner.__new__(GatewayRunner)
@@ -99,10 +98,9 @@ class TestPortBindingHardError:
             "gateway.config.load_gateway_config", lambda: reviewer_cfg
         )
 
-        with pytest.raises(MultiplexConfigError) as ei:
-            await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
-        assert "webhook" in str(ei.value)
-        assert "reviewer" in str(ei.value)
+        # Should NOT raise — the platform is skipped with a warning.
+        connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
+        assert connected == 0  # nothing connected, but no crash
 
     @pytest.mark.asyncio
     async def test_secondary_non_binding_platform_ok(self, monkeypatch):


### PR DESCRIPTION
## Problem

When `gateway.multiplex_profiles` is on and a secondary profile has a port-binding platform (e.g. `api_server`) in its `config.yaml`, the gateway raised a **fatal `MultiplexConfigError`** that took down **ALL profiles** — including the default one — causing a crash-restart loop.

## Root cause

The multiplex guard in `_start_one_profile_adapters` treated a port-binding platform on a secondary profile as a hard error:

```python
if platform.value in _PORT_BINDING_PLATFORM_VALUES:
    raise MultiplexConfigError(...)  # crashes the entire gateway
```

This commonly happens when a secondary profile is created via `hermes profile create --clone`: the source profile's `config.yaml` is copied verbatim, including `platforms.api_server`. The secondary profile operator is then penalized for a **redundant** (not dangerous) config entry.

The port-binding platform is simply redundant on a secondary profile — the default profile owns the single shared HTTP listener and already serves every profile via the `/p/<profile>/` URL prefix. It cannot collide because it is never started.

## Fix

Replace the fatal `raise MultiplexConfigError` with:
- A `WARNING` log with a clear, actionable message explaining what to remove
- A `continue` (skip) — the platform is ignored for that profile
- The gateway continues starting all other platforms normally

```python
if platform.value in _PORT_BINDING_PLATFORM_VALUES:
    logger.warning(
        "Profile '%s' enables the port-binding platform '%s', but "
        "gateway.multiplex_profiles is on. The default profile owns "
        "the single shared HTTP listener and serves every profile "
        "through the /p/%s/ URL prefix. Skipping this platform for "
        "this profile — remove platforms.%s from this profile's "
        "config.yaml (configure it only on the default profile).",
        ...
    )
    continue
```

## Why skip instead of crash

A misconfigured secondary profile should not prevent the default profile (or other secondary profiles) from starting. The crash-restart loop punishes all profiles for one redundant config entry that is not a security risk — it is simply ignored by the multiplexer.

## Test

`test_secondary_webhook_raises` → `test_secondary_webhook_skipped` — asserts the platform is skipped (not started) with a warning, instead of asserting a crash.

## Validation

- 9/9 tests pass
- Tested live: added `api_server` to a secondary profile config, restarted gateway — previously crashed, now starts normally with 3 platforms and both Telegram bots responding
- Rebased on current main (`7426c09be`), 0 conflicts