### PR TITLE
fix(kanban): emit blocked event from gave_up circuit breaker

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6657,6 +6657,18 @@ def _record_task_failure(
             _append_event(
                 conn, task_id, "gave_up", payload, run_id=run_id,
             )
+            _append_event(
+                conn, task_id, "blocked",
+                {
+                    "reason": (
+                        f"auto_blocked: gave_up after "
+                        f"{failures} consecutive failures"
+                    ),
+                    "kind": "capability",
+                    "auto": True,
+                },
+                run_id=run_id,
+            )
             blocked = True
         else:
             # Below threshold.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1246,6 +1246,48 @@ def test_recompute_ready_skips_tasks_at_failure_limit(kanban_home):
         assert task.consecutive_failures == 0
 
 
+def test_gave_up_emits_blocked_event(kanban_home):
+    """When the gave_up circuit breaker trips, a ``blocked`` event must be
+    emitted alongside the ``gave_up`` event so diagnostics can see it.
+
+    Without the ``blocked`` event, blocked-from-gave_up cards have no
+    ``blocked`` audit trail — invisible to diagnostics rules like
+    ``_rule_stuck_in_blocked``.
+    """
+    import json
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="breaker-test", assignee="a")
+        kb.claim_task(conn, t)
+        # Trip the breaker immediately (failure_limit=1).
+        kb._record_task_failure(
+            conn, t, error="crash bang",
+            outcome="crashed", release_claim=True, end_run=True,
+            failure_limit=1,
+        )
+        task = kb.get_task(conn, t)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 1
+
+        events = conn.execute(
+            "SELECT kind, payload FROM task_events "
+            "WHERE task_id = ? ORDER BY id",
+            (t,),
+        ).fetchall()
+        kinds = [e["kind"] for e in events]
+        # Both events must be present.
+        assert "gave_up" in kinds, f"expected gave_up event; got {kinds}"
+        assert "blocked" in kinds, f"expected blocked event; got {kinds}"
+
+        # Verify the blocked event payload.
+        blocked_events = [e for e in events if e["kind"] == "blocked"]
+        assert len(blocked_events) == 1
+        payload = json.loads(blocked_events[0]["payload"])
+        assert payload["kind"] == "capability"
+        assert payload["auto"] is True
+        assert "gave_up after 1 consecutive failure" in payload["reason"]
+
+
 def test_recompute_ready_recovers_below_limit(kanban_home):
     """recompute_ready auto-recovers blocked tasks that haven't hit the
     failure limit yet — the counter is preserved across recovery."""


### PR DESCRIPTION
## Bug

`_record_task_failure` emits a `gave_up` event and sets the task status to `blocked` via a direct UPDATE, but it does not emit a `blocked` event.

## Impact

Event-based diagnostics and watchers, including blocked-task diagnostics, get no normal blocked audit trail for gave_up-blocked cards. These cards are harder to explain because the event log records `gave_up`, but not the resulting blocked state as a blocked event.

## Fix

Append a synthetic `blocked` event with `kind="capability"` and `auto=true` immediately after the `gave_up` event in the circuit-breaker branch of `_record_task_failure`.

The event reason is:

```text
auto_blocked: gave_up after N consecutive failures
```

## Non-change

- Existing `gave_up` event is preserved unchanged.
- Existing blocked status transition is preserved unchanged.
- No change to stickiness, retry, `recompute_ready`, state gates, dispatcher, triage, recurrence limits, workflow docs, or dashboard code.

## Relation

This is complementary to existing gave_up stickiness/remediation work. It does not replace that work.

## Tests

```bash
./venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -k "gave_up_emits_blocked_event" -q
# 1 passed, 223 deselected in 2.72s

./venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -q
# 224 passed in 39.31s

./venv/bin/python -m pytest tests/hermes_cli/test_kanban_blocked_sticky.py -q
# 6 passed in 1.36s
```