### PR TITLE
fix(desktop): keep model menu rows visible

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -99,7 +99,13 @@ export function ModelPill({
           </Button>
         </DropdownMenuTrigger>
       </Tip>
-      <DropdownMenuContent align="end" className="w-64 p-0" side="top" sideOffset={8}>
+      <DropdownMenuContent
+        align="end"
+        className="w-64 p-0"
+        side="top"
+        sideOffset={8}
+        style={{ maxHeight: 'min(26rem, calc(100dvh - 1rem))', overflow: 'hidden' }}
+      >
         <ModelMenuCloseContext.Provider value={() => setOpen(false)}>
           {model.modelMenuContent}
         </ModelMenuCloseContext.Provider>

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -100,3 +100,48 @@ describe('ModelMenuPanel MoA presets', () => {
     expect(onSelectModel).toHaveBeenCalledWith({ model: 'BeastMode', provider: 'moa' })
   })
 })
+
+describe('ModelMenuPanel custom providers', () => {
+  it('renders the active bare custom endpoint and each named custom provider', async () => {
+    getGlobalModelOptions.mockResolvedValueOnce({
+      model: 'Qwen3.6-27B-NVFP4-MTP-GGUF.gguf',
+      provider: 'custom',
+      providers: [
+        {
+          api_url: 'http://192.168.50.124:8090/v1',
+          is_current: true,
+          is_user_defined: true,
+          models: ['Qwen3.6-27B-NVFP4-MTP-GGUF.gguf'],
+          name: 'Custom endpoint',
+          slug: 'custom',
+          source: 'model-config'
+        },
+        {
+          api_url: 'http://192.168.50.130:8080/v1',
+          is_user_defined: true,
+          models: ['gemma-4-12b-omni'],
+          name: '3090-gemma4-12b',
+          slug: 'custom:3090-gemma4-12b',
+          source: 'user-config'
+        },
+        {
+          api_url: 'http://192.168.50.125:8000/v1',
+          is_user_defined: true,
+          models: ['gemma-4-26b-a4b-nvfp4'],
+          name: 'spark-gemma4-26b-a4b',
+          slug: 'custom:spark-gemma4-26b-a4b',
+          source: 'user-config'
+        }
+      ]
+    })
+
+    renderPanel()
+
+    await findByText(document.body, 'Custom endpoint')
+    await findByText(document.body, '3090-gemma4-12b')
+    await findByText(document.body, 'spark-gemma4-26b-a4b')
+    expect(document.body.textContent).toContain('Qwen3.6 27B NVFP4 MTP GGUF.Gguf')
+    expect(document.body.textContent).toContain('Gemma 4 12b Omni')
+    expect(document.body.textContent).toContain('Gemma 4 26b A4b Nvfp4')
+  })
+})

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -229,7 +229,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
           {copy.noModels}
         </DropdownMenuItem>
       ) : (
-        <div className="max-h-[max(150px,30dvh)] overflow-y-auto py-0.5">
+        <div className="max-h-[min(18rem,50dvh)] overflow-y-auto py-0.5">
           {groups.map(group => (
             <DropdownMenuGroup className="py-0.5" key={group.provider.slug}>
               <DropdownMenuLabel className={dropdownMenuSectionLabel}>{group.provider.name}</DropdownMenuLabel>


### PR DESCRIPTION
## Summary
- keep the composer model dropdown shell from using the outer Radix scroll clipping path
- give the model-list section its own stable scroll budget so mounted provider groups stay visible
- add a regression covering the live #59702 payload shape: active bare custom endpoint plus two named custom providers

Closes #59702

## Tests
- npm run test:ui -- src/app/shell/model-menu-panel.test.tsx
- ../../node_modules/.bin/eslint src/app/chat/composer/model-pill.tsx src/app/shell/model-menu-panel.tsx src/app/shell/model-menu-panel.test.tsx
- ./node_modules/.bin/prettier --check apps/desktop/src/app/chat/composer/model-pill.tsx apps/desktop/src/app/shell/model-menu-panel.tsx apps/desktop/src/app/shell/model-menu-panel.test.tsx
- git diff --check