### PR TITLE
fix(model-switch): keep bare custom endpoint visible when not the active provider

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.custom-providers.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.custom-providers.test.tsx
@@ -1,0 +1,152 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, findByText, render } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
+import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
+
+import { ModelMenuPanel } from './model-menu-panel'
+
+// Radix calls these on open; jsdom doesn't implement them.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+const getGlobalModelOptions = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getGlobalModelOptions: (...args: unknown[]) => getGlobalModelOptions(...args)
+}))
+
+// The exact payload shape observed live from /api/model/options for a config
+// with one bare `model.provider: custom` main model plus two named
+// `custom_providers` entries. Reproduces issue #59702: the Desktop picker
+// shows only one of these three rows even though the backend/network payload
+// is always complete (verified independently 3 ways: REST with refresh, REST
+// without refresh, and the live gateway WebSocket JSON-RPC call).
+const MAIN_CUSTOM_PROVIDER = {
+  api_url: 'http://10.0.0.1:8090/v1',
+  is_current: true,
+  is_user_defined: true,
+  models: ['Qwen3.6-27B-NVFP4-MTP-GGUF.gguf'],
+  name: 'Custom endpoint',
+  slug: 'custom',
+  source: 'model-config',
+  total_models: 1
+}
+
+const NAMED_CUSTOM_PROVIDER_A = {
+  api_url: 'http://10.0.0.2:8080/v1',
+  is_current: false,
+  is_user_defined: true,
+  models: ['gemma-4-12b-omni'],
+  name: '3090-gemma4-12b',
+  slug: 'custom:3090-gemma4-12b',
+  source: 'user-config',
+  total_models: 1
+}
+
+const NAMED_CUSTOM_PROVIDER_B = {
+  api_url: 'http://10.0.0.3:8000/v1',
+  is_current: false,
+  is_user_defined: true,
+  models: ['gemma-4-26b-a4b-nvfp4'],
+  name: 'spark-gemma4-26b-a4b',
+  slug: 'custom:spark-gemma4-26b-a4b',
+  source: 'user-config',
+  total_models: 1
+}
+
+beforeEach(() => {
+  $activeSessionId.set('runtime-1')
+  $currentModel.set('Qwen3.6-27B-NVFP4-MTP-GGUF.gguf')
+  $currentProvider.set('custom')
+  getGlobalModelOptions.mockResolvedValue({
+    providers: [MAIN_CUSTOM_PROVIDER, NAMED_CUSTOM_PROVIDER_A, NAMED_CUSTOM_PROVIDER_B]
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function renderPanel(onSelectModel = vi.fn()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <DropdownMenu open>
+        <DropdownMenuContent>
+          <ModelMenuPanel onSelectModel={onSelectModel} requestGateway={vi.fn() as never} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </QueryClientProvider>
+  )
+
+  return onSelectModel
+}
+
+describe('ModelMenuPanel multiple custom_providers entries (#59702)', () => {
+  it('renders all three custom provider groups when three are configured', async () => {
+    renderPanel()
+
+    // Wait for the async useQuery to resolve and the panel to re-render.
+    await findByText(document.body, 'Custom endpoint')
+
+    expect(document.body.textContent).toContain('Custom endpoint')
+    expect(document.body.textContent).toContain('3090-gemma4-12b')
+    expect(document.body.textContent).toContain('spark-gemma4-26b-a4b')
+  })
+
+  it('renders each provider group model row, not just the first', async () => {
+    renderPanel()
+
+    await findByText(document.body, 'Custom endpoint')
+
+    expect(
+      document.body.textContent?.includes('Qwen3.6-27B-NVFP4-MTP-GGUF.gguf') ||
+        document.body.textContent?.includes('Qwen3.6 27B NVFP4 MTP GGUF.Gguf')
+    ).toBe(true)
+    expect(document.body.textContent).toContain('Gemma 4 12b Omni')
+    // spark's model id renders as its family display name, accept either the
+    // raw id or the humanized form. We only care whether the ROW exists at all.
+    expect(
+      document.body.textContent?.includes('gemma-4-26b-a4b-nvfp4') ||
+        document.body.textContent?.includes('Gemma 4 26b A4b Nvfp4')
+    ).toBe(true)
+  })
+
+  it('renders all three groups via the real gateway.request path (not the REST fallback)', async () => {
+    // Prod always goes through gateway.request once connected. model-options.ts
+    // only falls back to REST getGlobalModelOptions when `gateway` is undefined.
+    // Earlier tests only exercised the REST fallback and passed; this exercises
+    // the actual code path a connected Desktop app uses.
+    const gatewayRequest = vi.fn().mockResolvedValue({
+      providers: [MAIN_CUSTOM_PROVIDER, NAMED_CUSTOM_PROVIDER_A, NAMED_CUSTOM_PROVIDER_B]
+    })
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    render(
+      <QueryClientProvider client={client}>
+        <DropdownMenu open>
+          <DropdownMenuContent>
+            <ModelMenuPanel
+              gateway={{ request: gatewayRequest } as never}
+              onSelectModel={vi.fn()}
+              requestGateway={vi.fn() as never}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </QueryClientProvider>
+    )
+
+    await findByText(document.body, 'Custom endpoint')
+
+    expect(gatewayRequest).toHaveBeenCalledWith('model.options', expect.objectContaining({ session_id: 'runtime-1' }))
+    expect(document.body.textContent).toContain('Custom endpoint')
+    expect(document.body.textContent).toContain('3090-gemma4-12b')
+    expect(document.body.textContent).toContain('spark-gemma4-26b-a4b')
+  })
+})

--- a/apps/desktop/src/app/shell/model-menu-panel.custom-providers.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.custom-providers.test.tsx
@@ -22,10 +22,10 @@ vi.mock('@/hermes', () => ({
 
 // The exact payload shape observed live from /api/model/options for a config
 // with one bare `model.provider: custom` main model plus two named
-// `custom_providers` entries. Reproduces issue #59702: the Desktop picker
-// shows only one of these three rows even though the backend/network payload
-// is always complete (verified independently 3 ways: REST with refresh, REST
-// without refresh, and the live gateway WebSocket JSON-RPC call).
+// `custom_providers` entries (issue #59702). These tests pin down that when
+// the payload carries all three rows, the panel renders all three: the #59702
+// bug lives in the backend payload (the bare custom row arriving with an
+// empty model list), not in this component's grouping or render logic.
 const MAIN_CUSTOM_PROVIDER = {
   api_url: 'http://10.0.0.1:8090/v1',
   is_current: true,
@@ -105,17 +105,10 @@ describe('ModelMenuPanel multiple custom_providers entries (#59702)', () => {
 
     await findByText(document.body, 'Custom endpoint')
 
-    expect(
-      document.body.textContent?.includes('Qwen3.6-27B-NVFP4-MTP-GGUF.gguf') ||
-        document.body.textContent?.includes('Qwen3.6 27B NVFP4 MTP GGUF.Gguf')
-    ).toBe(true)
+    // Model ids render as their humanized family display names.
+    expect(document.body.textContent).toContain('Qwen3.6 27B NVFP4 MTP GGUF.Gguf')
     expect(document.body.textContent).toContain('Gemma 4 12b Omni')
-    // spark's model id renders as its family display name, accept either the
-    // raw id or the humanized form. We only care whether the ROW exists at all.
-    expect(
-      document.body.textContent?.includes('gemma-4-26b-a4b-nvfp4') ||
-        document.body.textContent?.includes('Gemma 4 26b A4b Nvfp4')
-    ).toBe(true)
+    expect(document.body.textContent).toContain('Gemma 4 26b A4b Nvfp4')
   })
 
   it('renders all three groups via the real gateway.request path (not the REST fallback)', async () => {
@@ -126,6 +119,7 @@ describe('ModelMenuPanel multiple custom_providers entries (#59702)', () => {
     const gatewayRequest = vi.fn().mockResolvedValue({
       providers: [MAIN_CUSTOM_PROVIDER, NAMED_CUSTOM_PROVIDER_A, NAMED_CUSTOM_PROVIDER_B]
     })
+
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
     render(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2080,17 +2080,55 @@ def list_authenticated_providers(
             if _pair[0] and _pair[1]:
                 _section3_emitted_pairs.add(_pair)
 
-    # --- 3b. Active bare custom endpoint from model config ---
+    # --- 3b. Bare custom endpoint declared in model config ---
     # A config can still use the direct one-off form:
     #   model.provider: custom
     #   model.base_url: https://some-openai-compatible/v1
     # In that shape there is no named providers:/custom_providers row for the
-    # picker to render, but the gateway only passes this current model slice to
-    # list_authenticated_providers(). Surface the active endpoint explicitly so
-    # /model does not look like it ignored config.yaml.
+    # picker to render.
+    #
+    # Two sources can identify this endpoint:
+    #   1. The caller-supplied current_provider/current_base_url/current_model
+    #      (what existing callers pass to describe "the active endpoint" for
+    #      the current request).
+    #   2. The static config.yaml `model:` block, read directly here, for when
+    #      the caller's current_provider reflects a *different*, currently
+    #      active provider (e.g. the live session switched to another model).
+    #      Without this fallback, the row only appeared while it happened to
+    #      be the session's active provider. Switching to any other model made
+    #      it vanish from the picker entirely, and since it never re-populated
+    #      `seen_slugs`, the unconfigured-canonical-provider fallback then
+    #      inserted a misleading 0-model "run `hermes model` to configure"
+    #      skeleton in its place (#59702).
+    _base_url = ""
+    _default_model = ""
+    _api_key = ""
+    _is_current = False
+
+    if _current_provider_norm == "custom" and current_base_url:
+        _base_url = str(current_base_url).strip()
+        _default_model = current_model or ""
+        _is_current = True
+    else:
+        try:
+            from hermes_cli.config import load_config as _load_config_3b
+            _model_cfg = _load_config_3b().get("model") or {}
+        except Exception:
+            _model_cfg = {}
+
+        _configured_provider = str(_model_cfg.get("provider", "") or "").strip().lower()
+        _configured_base_url = str(_model_cfg.get("base_url", "") or "").strip()
+
+        if _configured_provider == "custom" and _configured_base_url:
+            _base_url = _configured_base_url
+            _default_model = str(_model_cfg.get("default", "") or "").strip()
+            _api_key = str(_model_cfg.get("api_key", "") or "").strip()
+            _is_current = bool(current_base_url) and str(current_base_url).strip().rstrip("/").lower() == (
+                _base_url.rstrip("/").lower()
+            )
+
     if (
-        _current_provider_norm == "custom"
-        and current_base_url
+        _base_url
         and "custom" not in seen_slugs
         and not any(
             isinstance(_cp, dict)
@@ -2099,29 +2137,40 @@ def list_authenticated_providers(
                 or _cp.get("url", "")
                 or _cp.get("api", "")
             ).strip().rstrip("/").lower()
-            == str(current_base_url).strip().rstrip("/").lower()
+            == _base_url.strip().rstrip("/").lower()
             for _cp in (custom_providers or [])
         )
     ):
-        _models = [current_model] if current_model else []
-        if refresh or probe_current_custom_provider:
+        _models = [_default_model] if _default_model else []
+
+        # Caller-supplied branch keeps the existing refresh/probe-current
+        # timing (an explicit refresh, or probe_current_custom_provider's
+        # "probe only the active endpoint" middle ground). The config-sourced
+        # fallback branch has no caller-supplied current_model to fall back
+        # to, so it always defers to the shared probing policy instead.
+        _should_probe_3b = (
+            (refresh or probe_current_custom_provider)
+            if _is_current and _current_provider_norm == "custom"
+            else _can_probe_custom_provider(row_is_current=_is_current)
+        )
+        if _should_probe_3b:
             try:
                 from hermes_cli.models import fetch_api_models
-
-                _live_models = fetch_api_models("", str(current_base_url).strip().rstrip("/"))
-                if _live_models:
-                    _models = _live_models
+                live_models = fetch_api_models(_api_key, _base_url, headers=None)
+                if live_models:
+                    _models = live_models
             except Exception:
                 pass
+
         results.append({
             "slug": "custom",
             "name": "Custom endpoint",
-            "is_current": True,
+            "is_current": _is_current,
             "is_user_defined": True,
             "models": _models[:max_models] if max_models is not None else _models,
             "total_models": len(_models),
             "source": "model-config",
-            "api_url": str(current_base_url).strip().rstrip("/"),
+            "api_url": _base_url.strip().rstrip("/"),
         })
         seen_slugs.add("custom")
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2112,9 +2112,13 @@ def list_authenticated_providers(
     else:
         try:
             from hermes_cli.config import load_config as _load_config_3b
-            _model_cfg = _load_config_3b().get("model") or {}
+            _model_cfg_raw = _load_config_3b().get("model")
         except Exception:
-            _model_cfg = {}
+            _model_cfg_raw = None
+        # config.model can be a bare string in older configs (see
+        # hermes_cli/inventory.py's ConfigContext loader) — only a mapping
+        # carries a provider/base_url to recover here.
+        _model_cfg = _model_cfg_raw if isinstance(_model_cfg_raw, dict) else {}
 
         _configured_provider = str(_model_cfg.get("provider", "") or "").strip().lower()
         _configured_base_url = str(_model_cfg.get("base_url", "") or "").strip()

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2111,8 +2111,8 @@ def list_authenticated_providers(
         _is_current = True
     else:
         try:
-            from hermes_cli.config import load_config as _load_config_3b
-            _model_cfg_raw = _load_config_3b().get("model")
+            from hermes_cli.config import load_config
+            _model_cfg_raw = load_config().get("model")
         except Exception:
             _model_cfg_raw = None
         # config.model can be a bare string in older configs (see

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -265,6 +265,32 @@ def test_list_authenticated_providers_bare_custom_endpoint_defers_to_matching_na
     assert any(p["slug"] == "custom:my-endpoint" for p in providers)
 
 
+def test_list_authenticated_providers_tolerates_legacy_scalar_model_config(monkeypatch):
+    """A legacy bare-string `model:` config value must not crash the picker.
+
+    hermes_cli/inventory.py's ConfigContext loader already treats config.model
+    as a bare string in older configs. The config-sourced 3b fallback must
+    tolerate the same shape instead of calling ``.get()`` on a str.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": "gpt-4o"},
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="xai-oauth",
+        current_base_url="",
+        current_model="grok-4",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+    )
+
+    assert not any(p["slug"] == "custom" for p in providers)
+
+
 def test_switch_model_accepts_explicit_bare_custom_current_endpoint(monkeypatch):
     """Picker selections for bare custom endpoints should route to current base_url."""
     monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -185,6 +185,86 @@ def test_list_authenticated_providers_can_probe_active_bare_custom_endpoint(monk
     assert bare_custom["models"] == ["gpt-4o", "gpt-4o-mini"]
 
 
+def test_list_authenticated_providers_bare_custom_endpoint_survives_provider_switch(monkeypatch):
+    """Regression for #59702: the bare model.provider=custom row must not
+    vanish from the picker when the live session is on a different provider.
+
+    The caller only passes the session's current provider slice, so when the
+    session has switched away from the bare custom endpoint, the row has to be
+    recovered from the static config.yaml ``model:`` block instead. Before the
+    fix, the row silently disappeared and the unconfigured-canonical-provider
+    fallback replaced it with a misleading 0-model setup skeleton.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {
+                "default": "gpt-4o",
+                "provider": "custom",
+                "base_url": "https://www.ccsub.net/v1",
+            }
+        },
+    )
+    # The config-sourced fallback live-probes the endpoint; keep the test
+    # hermetic and prove the config default model is used when the probe
+    # returns nothing.
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: [])
+
+    providers = list_authenticated_providers(
+        current_provider="xai-oauth",
+        current_base_url="",
+        current_model="grok-4",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+    )
+
+    bare_custom = next((p for p in providers if p["slug"] == "custom"), None)
+    assert bare_custom is not None
+    assert bare_custom["name"] == "Custom endpoint"
+    assert bare_custom["is_current"] is False
+    assert bare_custom["is_user_defined"] is True
+    assert bare_custom["models"] == ["gpt-4o"]
+    assert bare_custom["api_url"] == "https://www.ccsub.net/v1"
+
+
+def test_list_authenticated_providers_bare_custom_endpoint_defers_to_matching_named_entry(monkeypatch):
+    """The config-sourced bare row must not duplicate a named custom_providers
+    entry that already covers the same base_url."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {
+                "default": "gpt-4o",
+                "provider": "custom",
+                "base_url": "https://www.ccsub.net/v1",
+            }
+        },
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="xai-oauth",
+        current_base_url="",
+        current_model="grok-4",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "my-endpoint",
+                "base_url": "https://www.ccsub.net/v1",
+                "model": "gpt-4o",
+            }
+        ],
+        max_models=50,
+    )
+
+    assert not any(p["slug"] == "custom" for p in providers)
+    assert any(p["slug"] == "custom:my-endpoint" for p in providers)
+
+
 def test_switch_model_accepts_explicit_bare_custom_current_endpoint(monkeypatch):
     """Picker selections for bare custom endpoints should route to current base_url."""
     monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)


### PR DESCRIPTION
## What does this PR do?

Fixes the bare `model.provider: custom` + `model.base_url` picker row (no named `custom_providers:`/`providers:` entry) so it stays visible in the model picker regardless of which provider the current session happens to be on.

Previously, section 3b of `list_authenticated_providers` only built this row when `current_provider == "custom"`, i.e. only while it was the session's active model. As soon as the session switched to any other provider, the row disappeared and never marked itself in `seen_slugs`, so the unconfigured-canonical-provider fallback in `inventory.py` silently inserted a misleading 0-model "run `hermes model` to configure" placeholder in its place, even though the endpoint was fully configured and reachable.

Named `custom_providers:` entries never had this problem, since section 4 surfaces them unconditionally.

I verified this against a live Desktop instance by capturing the raw `model.options` WebSocket frame (via CDP, Network domain) at the exact moment the picker showed the row missing, and confirmed the payload itself carried `models: []` for the `custom` slug. This rules out a rendering/clipping issue: the frontend was correctly reflecting empty data, not hiding present data.

## Related Issue

Fixes #59702

## Changes Made

- `hermes_cli/model_switch.py`: section 3b now falls back to reading the static `model:` config block directly when the caller-supplied `current_provider`/`current_base_url` do not identify a bare custom endpoint (i.e. the session is on a different provider). Also adds a live `/models` probe in that fallback path (mirroring section 4's policy) since there is no caller-supplied `current_model` to rely on there, and computes `is_current` by comparison instead of hardcoding it to `True`.
- `tests/hermes_cli/test_model_switch_custom_providers.py`: two backend regressions for the fix. `test_list_authenticated_providers_bare_custom_endpoint_survives_provider_switch` fails on current `main` and passes with this change (verified both ways); the second pins that the config-sourced fallback defers to a named `custom_providers` entry covering the same `base_url` instead of duplicating it.
- `apps/desktop/src/app/shell/model-menu-panel.custom-providers.test.tsx` (new): isolated `ModelMenuPanel` test using the exact live payload shape from #59702 (one bare custom endpoint plus two named `custom_providers` entries), exercised through both the REST fallback and the real `gateway.request` path. These pass against current `main` as well, pinning down that the panel renders a complete payload correctly and the bug was the payload itself.

## How to Test

1. Configure `model.provider: custom` + `model.base_url` in `config.yaml` without a matching `custom_providers:`/`providers:` entry, then switch the active session to a different provider (e.g. an OAuth provider).
2. Open the Desktop model picker and confirm the "Custom endpoint" row still appears with its configured model, instead of a 0-model "run `hermes model` to configure" placeholder.
3. `pytest tests/hermes_cli/test_model_switch_custom_providers.py -q` (35 passed; the new survives-provider-switch regression fails when run against `main`'s `model_switch.py`) and the broader `pytest tests/hermes_cli/ -q -k "model_switch or model_options or custom_provider"` (226 passed).
4. `npm run test:ui -- src/app/shell/model-menu-panel.custom-providers.test.tsx` (3 passed), plus eslint and prettier on the new test file.

## Checklist

- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (#59803 addresses a different, renderer-side theory for the same issue; this PR fixes the underlying data bug I confirmed via a live WebSocket frame capture)
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_model_switch_custom_providers.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] Tested on macOS