### PR TITLE
fix(cli): exclude lifecycle flags from stale-dashboard match (#59626)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6610,6 +6610,12 @@ def _find_stale_dashboard_pids(
         "hermes_cli.main serve",
         "hermes_cli/main.py serve",
     ]
+    # Lifecycle flags that are short-lived CLI commands, not long-lived servers.
+    # A wrapper/sandbox shell whose cmdline merely contains e.g.
+    # `hermes dashboard --status` or `hermes_cli.main dashboard --stop` should
+    # not be reaped as a stale dashboard process — only true servers (no
+    # lifecycle flag) are candidates. (#59626)
+    lifecycle_flags = ("--status", "--stop")
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -6647,6 +6653,7 @@ def _find_stale_dashboard_pids(
                     pid_str = line[len("ProcessId=") :]
                     if (
                         any(p in current_cmd for p in patterns)
+                        and not any(f in current_cmd for f in lifecycle_flags)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -6679,7 +6686,11 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if (
+                        any(p in command for p in patterns)
+                        and not any(f in command for f in lifecycle_flags)
+                        and pid != self_pid
+                    ):
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -230,6 +230,59 @@ class TestFindStaleDashboardPids:
             pids = _find_stale_dashboard_pids(exclude_pids={12345})
         assert pids == []
 
+    def test_lifecycle_flags_excluded_from_match(self):
+        """A wrapper shell whose cmdline contains `hermes dashboard --status`
+        or `hermes dashboard --stop` (or the equivalent `hermes_cli.main
+        dashboard ...` form) is a short-lived lifecycle command, not a
+        long-lived server. It must NOT be reaped as a stale dashboard.
+        (#59626)
+        """
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(12345, "python3 -m hermes_cli.main dashboard --port 9119"),
+                    _ps_line(12346, "python3 -m hermes_cli.main dashboard --status"),
+                    _ps_line(12347, "bash -c 'hermes dashboard --status'"),
+                    _ps_line(12348, "bash -c 'hermes dashboard --stop'"),
+                    _ps_line(12349, "python -m hermes_cli.main serve --status"),
+                    _ps_line(12350, "grep hermes dashboard"),
+                ]) + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        # Only the real server (no lifecycle flag) is matched.
+        assert pids == [12345]
+
+    def test_lifecycle_flags_excluded_windows_wmic(self):
+        """Same exclusion applies to the Windows wmic path — a wrapper
+        spawning `hermes_cli.main dashboard --status` must not match.
+        (#59626)
+        """
+        wmic_output = "\n".join([
+            "CommandLine=python -m hermes_cli.main dashboard --port 9119",
+            "ProcessId=12345",
+            "",
+            "CommandLine=python -m hermes_cli.main dashboard --status",
+            "ProcessId=12346",
+            "",
+            "CommandLine=bash -c hermes dashboard --stop",
+            "ProcessId=12347",
+            "",
+            "CommandLine=hermes dashboard",
+            "ProcessId=12348",
+            "",
+        ])
+        with patch("hermes_cli.main.sys.platform", "win32"), \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=wmic_output, stderr=""
+            )
+            pids = _find_stale_dashboard_pids()
+        # 12345 (real server) and 12348 (bare `hermes dashboard`) match;
+        # 12346 / 12347 carry lifecycle flags and are excluded.
+        assert sorted(pids) == [12345, 12348]
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX kill semantics")
 class TestKillStaleDashboardPosix:


### PR DESCRIPTION
## Summary

`hermes_cli.main._find_stale_dashboard_pids` matched any cmdline containing
`hermes dashboard` or `hermes_cli.main dashboard`, so a wrapper or sandbox
shell whose command line merely included a lifecycle flag
(`--status`, `--stop`) was reported as a running dashboard process even
though no server was actually listening.

This caused false-positive output from `hermes dashboard --status`:

```
$ python -m hermes_cli.main dashboard --status
1 hermes dashboard process(es) running:
    PID 12346: python -m hermes_cli.main dashboard --status
```

while a direct TCP probe of `127.0.0.1:9119` failed, leaving users to
chase SSH tunnel or Tailscale issues that don't exist.

## Fix

Add a `lifecycle_flags = ("--status", "--stop")` exclusion to the match
predicate on both the POSIX (`ps -A`) and Windows (`wmic`) paths, so
short-lived CLI invocations are not reaped as stale dashboards. A real
server (no lifecycle flag in its cmdline) is still matched exactly as
before.

## Diff

- `hermes_cli/main.py`: 7 lines added (1 predicate line on each of the
  two platforms + a 4-line comment block).
- `tests/hermes_cli/test_update_stale_dashboard.py`: 2 new tests
  (POSIX and Windows paths).

## Verification

- `python3 -m py_compile hermes_cli/main.py` — passes
- `python3 -m pytest tests/hermes_cli/test_update_stale_dashboard.py`
  tests/hermes_cli/test_dashboard_lifecycle_flags.py` — 34/34 pass
- `git stash` round-trip on the new tests: the 2 new tests fail without
  the source fix and pass with it.

Closes #59626