### PR TITLE
fix(moa): keep MoA manual, session-scoped, and non-persistent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7981,7 +7981,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # model.persist_switch_by_default (defaults to True so /model survives
         # across sessions).
         persist_global = resolve_persist_behavior(is_global_flag, is_session)
-        if explicit_provider.strip().lower() == "moa" and not is_global_flag:
+        if (explicit_provider or "").strip().lower() == "moa" and not is_global_flag:
             # MoA is allowed only as a manual interactive mode, not as the
             # unattended/default route. Plain `/model ... --provider moa`
             # therefore becomes session-only by default; `--global` is rejected

--- a/cli.py
+++ b/cli.py
@@ -7925,20 +7925,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     current_model=self.model or "",
                     current_base_url=self.base_url or "",
                     current_api_key=self.api_key or "",
-                    is_global=persist_global,
+                    is_global=(False if provider_data.get("slug") == "moa" else persist_global),
                     explicit_provider=provider_data.get("slug"),
                     user_providers=state.get("user_provs"),
                     custom_providers=state.get("custom_provs"),
                 )
+                picker_persist_global = False if provider_data.get("slug") == "moa" else persist_global
                 self._close_model_picker()
                 if getattr(self, "_app", None):
                     threading.Thread(
                         target=self._confirm_and_apply_model_switch_result,
-                        args=(result, persist_global),
+                        args=(result, picker_persist_global),
                         daemon=True,
                     ).start()
                 else:
-                    self._confirm_and_apply_model_switch_result(result, persist_global)
+                    self._confirm_and_apply_model_switch_result(result, picker_persist_global)
                 return
             self._close_model_picker()
 
@@ -7980,6 +7981,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # model.persist_switch_by_default (defaults to True so /model survives
         # across sessions).
         persist_global = resolve_persist_behavior(is_global_flag, is_session)
+        if explicit_provider.strip().lower() == "moa" and not is_global_flag:
+            # MoA is allowed only as a manual interactive mode, not as the
+            # unattended/default route. Plain `/model ... --provider moa`
+            # therefore becomes session-only by default; `--global` is rejected
+            # later in switch_model() with a targeted message.
+            persist_global = False
 
         # --refresh: wipe the on-disk picker cache before building the
         # provider list. Forces a live re-fetch of every authed provider's

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -847,7 +847,6 @@ def switch_model(
     resolved_alias = ""
     new_model = raw_input.strip()
     target_provider = current_provider
-    resolved_moa_preset = False
 
     # =================================================================
     # PATH A: Explicit --provider given
@@ -974,28 +973,11 @@ def switch_model(
     # PATH B: No explicit provider — resolve from model input
     # =================================================================
     else:
-        try:
-            from hermes_cli.config import load_config
-            from hermes_cli.moa_config import exact_moa_preset_name, normalize_moa_config
-
-            _moa_cfg = normalize_moa_config(load_config().get("moa") or {})
-            _moa_match = exact_moa_preset_name(_moa_cfg, raw_input)
-            if _moa_match:
-                target_provider = "moa"
-                new_model = _moa_match
-                resolved_alias = ""
-                resolved_moa_preset = True
-                alias_result = None
-            else:
-                alias_result = resolve_alias(raw_input, current_provider)
-        except Exception:
-            alias_result = resolve_alias(raw_input, current_provider)
+        alias_result = resolve_alias(raw_input, current_provider)
 
         # --- Step a: Try alias resolution on current provider ---
 
-        if resolved_moa_preset:
-            pass
-        elif alias_result is not None:
+        if alias_result is not None:
             target_provider, new_model, resolved_alias = alias_result
             logger.debug(
                 "Alias '%s' resolved to %s on %s",
@@ -1028,7 +1010,7 @@ def switch_model(
                             f"Try specifying the full model name."
                         ),
                     )
-            elif not resolved_moa_preset:
+            else:
                 # --- Step c: On aggregator, convert vendor:model to vendor/model ---
                 # Only convert when there's no slash — a slash means the name
                 # is already in vendor/model format and the colon is a variant
@@ -1147,6 +1129,18 @@ def switch_model(
 
     provider_changed = target_provider != current_provider
     provider_label = get_label(target_provider)
+    if target_provider == "moa" and is_global:
+        return ModelSwitchResult(
+            success=False,
+            target_provider=target_provider,
+            provider_label=provider_label,
+            is_global=is_global,
+            error_message=(
+                "MoA cannot be persisted as the default model/provider. "
+                "Use `/moa <prompt>` for a one-shot, or `/model <preset> --provider moa --session` "
+                "for a manual interactive session-only switch."
+            ),
+        )
     if target_provider == "custom" and current_base_url:
         provider_label = "Custom endpoint"
     if target_provider.startswith("custom:"):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4699,6 +4699,14 @@ def _apply_model_assignment_sync(
 
     if not provider:
         raise HTTPException(status_code=400, detail="provider required for auxiliary")
+    if provider.strip().lower() == "moa":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "MoA cannot be saved as an auxiliary/default model route. "
+                "Use `/moa <prompt>` for one-shot runs, or an interactive session-only `/model ... --provider moa --session` switch."
+            ),
+        )
 
     targets = [task] if task else list(_AUX_TASK_SLOTS)
     for slot in targets:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4572,6 +4572,14 @@ def _apply_model_assignment_sync(
     if scope == "main":
         if not provider or not model:
             raise HTTPException(status_code=400, detail="provider and model required for main")
+        if provider.strip().lower() == "moa":
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "MoA cannot be saved as the default model/provider. "
+                    "Use `/moa <prompt>` for one-shot runs, or an interactive session-only `/model ... --provider moa --session` switch."
+                ),
+            )
         provider, model = _normalize_main_model_assignment(provider, model)
         model_cfg = _apply_main_model_assignment(
             cfg.get("model", {}), provider, model, base_url, api_key

--- a/tests/hermes_cli/test_model_switch_moa_policy.py
+++ b/tests/hermes_cli/test_model_switch_moa_policy.py
@@ -1,0 +1,91 @@
+"""Policy tests for restricting MoA to manual interactive use.
+
+Covers:
+- MoA cannot be persisted as the default provider/model.
+- Explicit session-only MoA switches still work.
+- Bare preset names no longer implicitly switch onto the MoA provider.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOA_CFG = {
+    "moa": {
+        "default_preset": "default",
+        "presets": {
+            "default": {},
+            "review": {},
+        },
+    }
+}
+
+
+def _mock_runtime():
+    return {
+        "api_key": "moa-virtual-provider",
+        "base_url": "moa://local",
+        "api_mode": "chat_completions",
+        "provider": "moa",
+    }
+
+
+def test_explicit_moa_global_switch_is_rejected():
+    with patch("hermes_cli.config.load_config", return_value=_MOA_CFG), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=_mock_runtime()), \
+         patch("hermes_cli.models.validate_requested_model", return_value={"accepted": True, "persist": True, "recognized": True, "message": None}), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None):
+        result = switch_model(
+            raw_input="default",
+            current_provider="openrouter",
+            current_model="anthropic/claude-opus-4.8",
+            is_global=True,
+            explicit_provider="moa",
+        )
+
+    assert result.success is False
+    assert "cannot be persisted" in (result.error_message or "")
+    assert "--session" in (result.error_message or "")
+
+
+def test_explicit_moa_session_switch_still_works():
+    with patch("hermes_cli.config.load_config", return_value=_MOA_CFG), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=_mock_runtime()), \
+         patch("hermes_cli.models.validate_requested_model", return_value={"accepted": True, "persist": True, "recognized": True, "message": None}), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None):
+        result = switch_model(
+            raw_input="default",
+            current_provider="openrouter",
+            current_model="anthropic/claude-opus-4.8",
+            is_global=False,
+            explicit_provider="moa",
+        )
+
+    assert result.success is True
+    assert result.target_provider == "moa"
+    assert result.new_model == "default"
+
+
+def test_bare_preset_name_no_longer_implicitly_switches_to_moa():
+    with patch("hermes_cli.config.load_config", return_value=_MOA_CFG), \
+         patch("hermes_cli.model_switch.resolve_alias", return_value=None), \
+         patch("hermes_cli.model_switch.list_provider_models", return_value=[]), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={"api_key": "test", "base_url": "https://openrouter.ai/api/v1", "api_mode": "chat_completions", "provider": "openrouter"}), \
+         patch("hermes_cli.models.validate_requested_model", return_value={"accepted": False, "persist": False, "recognized": False, "message": "Model `review` was not found."}), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=None):
+        result = switch_model(
+            raw_input="review",
+            current_provider="openrouter",
+            current_model="anthropic/claude-opus-4.8",
+            is_global=False,
+            explicit_provider="",
+        )
+
+    assert result.success is False
+    assert result.target_provider != "moa"
+    assert "not found" in (result.error_message or "").lower()

--- a/tests/hermes_cli/test_web_server_moa_policy.py
+++ b/tests/hermes_cli/test_web_server_moa_policy.py
@@ -22,3 +22,23 @@ def test_apply_main_model_assignment_rejects_moa_persistence(monkeypatch):
 
     assert exc.value.status_code == 400
     assert "cannot be saved as the default model/provider" in str(exc.value.detail)
+
+
+def test_apply_auxiliary_model_assignment_rejects_moa_persistence(monkeypatch):
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(web_server, "load_config", lambda: {"auxiliary": {}})
+    monkeypatch.setattr(web_server, "save_config", lambda cfg: None)
+
+    with pytest.raises(HTTPException) as exc:
+        web_server._apply_model_assignment_sync(
+            scope="auxiliary",
+            provider="moa",
+            model="default",
+            task="vision",
+            base_url="",
+            api_key="",
+        )
+
+    assert exc.value.status_code == 400
+    assert "cannot be saved as an auxiliary/default model route" in str(exc.value.detail)

--- a/tests/hermes_cli/test_web_server_moa_policy.py
+++ b/tests/hermes_cli/test_web_server_moa_policy.py
@@ -1,0 +1,24 @@
+"""Web-server policy tests for restricting MoA as a persisted default model."""
+
+import pytest
+from fastapi import HTTPException
+
+
+def test_apply_main_model_assignment_rejects_moa_persistence(monkeypatch):
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(web_server, "load_config", lambda: {})
+    monkeypatch.setattr(web_server, "save_config", lambda cfg: None)
+
+    with pytest.raises(HTTPException) as exc:
+        web_server._apply_model_assignment_sync(
+            scope="main",
+            provider="moa",
+            model="default",
+            task="",
+            base_url="",
+            api_key="",
+        )
+
+    assert exc.value.status_code == 400
+    assert "cannot be saved as the default model/provider" in str(exc.value.detail)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2690,6 +2690,11 @@ def _apply_model_switch(
         if persist_override is not None
         else resolve_persist_behavior(is_global_flag, is_session)
     )
+    if (explicit_provider or "").strip().lower() == "moa" and not is_global_flag:
+        # MoA is manual-interactive only. A plain explicit MoA switch stays
+        # session-scoped unless the caller explicitly asked for `--global` — in
+        # which case switch_model() rejects it with a clear error.
+        persist_global = False
     if not model_input:
         raise ValueError("model value required")
 


### PR DESCRIPTION
## Summary
This PR keeps MoA in the manual interactive lane by preventing persisted default or auxiliary switches onto `provider: moa`, while preserving legitimate one-shot/session-scoped use and hardening the new guard against `explicit_provider = None` inputs.

## What changed
- stop bare preset names from implicitly switching onto the MoA provider
- reject attempts to persist MoA as the default provider/model route
- reject attempts to persist MoA as an auxiliary/default task route in the web server
- keep explicit MoA switches session-scoped/manual-only unless a caller explicitly requests a global switch, which is then rejected with a targeted error
- harden the TUI/CLI MoA guards so `explicit_provider` may be `None` or empty without crashing
- add focused policy coverage for the persisted-default rejection and web-server enforcement

## Why
The standing requirement for this lane is that MoA should remain **manual interactive only**, not become an unattended default route. The rebased split package enforces that policy directly and fixes the null-guard regression surfaced by CI in the combined branch.

## Scope
Files in this lane:
- `cli.py`
- `hermes_cli/model_switch.py`
- `hermes_cli/web_server.py`
- `tui_gateway/server.py`
- `tests/hermes_cli/test_model_switch_moa_policy.py`
- `tests/hermes_cli/test_web_server_moa_policy.py`

This package is intentionally split out of the earlier combined local branch/PR work so the MoA policy change can be reviewed independently of the image-generation override fixes.

## Testing
Run:
```bash
python -m pytest -q tests/tui_gateway/test_make_agent_provider.py::test_apply_model_switch_does_not_leak_process_env tests/hermes_cli/test_model_switch_moa_policy.py tests/hermes_cli/test_web_server_moa_policy.py tests/tui_gateway/test_goal_command.py::test_moa_bare_returns_usage tests/tui_gateway/test_goal_command.py::test_moa_arg_is_always_one_shot -o addopts=''
```

Observed locally after rebasing onto current `origin/main`:
- `8 passed`

## Related work
- Replaces the MoA portion of #57293 with a narrower split package.
- Adjacent to #59493 (`fix(desktop): keep model picker switches session-scoped`), but this diff is specifically about preventing MoA from becoming a persisted default route across CLI/TUI/web-server entry points.
