### PR TITLE
fix(ollama-cloud): preserve :cloud tags for local-daemon proxy in model catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3625,17 +3625,48 @@ def fetch_api_models(
 _OLLAMA_CLOUD_CACHE_TTL = 3600  # 1 hour
 
 
-def _strip_ollama_cloud_suffix(model_id: str) -> str:
-    """Strip :cloud / -cloud suffixes that models.dev appends to Ollama Cloud IDs.
+def _ollama_cloud_suffix_key(model_id: str) -> str:
+    """Return a stable dedup key for Ollama Cloud model IDs.
 
-    The live API uses clean IDs (e.g. 'kimi-k2.6') while models.dev sometimes
-    returns them as 'kimi-k2.6:cloud'. Normalising before the dedup merge
-    prevents duplicate entries in the merged model list.
+    Ollama Cloud IDs are endpoint-shaped: the direct hosted OpenAI endpoint may
+    list/use bare IDs, while the local Ollama daemon's cloud proxy uses Ollama
+    tags such as ``kimi-k2.7-code:cloud`` and ``qwen3-coder:480b-cloud``.  Use
+    this key only for equivalence checks; never save it as the actual model ID.
     """
+    key = model_id
     for suffix in (":cloud", "-cloud"):
-        if model_id.endswith(suffix):
-            return model_id[: -len(suffix)]
-    return model_id
+        if key.endswith(suffix):
+            return key[: -len(suffix)]
+    return key
+
+
+def _ollama_cloud_base_is_local_proxy(base_url: str | None) -> bool:
+    """True when Ollama Cloud is routed through a local Ollama daemon."""
+    if not base_url:
+        return False
+    try:
+        parsed = urllib.parse.urlparse(base_url)
+    except Exception:
+        return False
+    host = (parsed.hostname or "").lower()
+    return host in {"localhost", "127.0.0.1", "::1"} or host.endswith(".local")
+
+
+def _ollama_cloud_model_for_endpoint(model_id: str, base_url: str | None) -> str:
+    """Return ``model_id`` in the shape expected by the configured endpoint.
+
+    For the local Ollama cloud proxy, cloud models need Ollama tag suffixes:
+    ``name`` -> ``name:cloud`` and ``name:tag`` -> ``name:tag-cloud``.  Already
+    suffixed IDs are passed through.  For the hosted ``ollama.com/v1`` endpoint,
+    preserve the catalog ID as-is.
+    """
+    if not model_id or not _ollama_cloud_base_is_local_proxy(base_url):
+        return model_id
+    if model_id.endswith(":cloud") or model_id.endswith("-cloud"):
+        return model_id
+    if ":" in model_id:
+        return f"{model_id}-cloud"
+    return f"{model_id}:cloud"
 
 
 def _ollama_cloud_cache_path() -> Path:
@@ -3724,19 +3755,27 @@ def fetch_ollama_cloud_models(
     except Exception:
         pass
 
-    # 4. Merge: live first, then models.dev additions (deduped, order-preserving)
+    # 4. Merge: live first, then models.dev additions (deduped, order-preserving).
+    # Keep the actual model IDs intact; use a suffix-stripped key only to avoid
+    # duplicate bare/suffixed variants when both sources mention the same model.
     if live_models or mdev_models:
-        seen: set[str] = set()
+        seen_keys: set[str] = set()
         merged: list[str] = []
         for m in live_models:
-            if m and m not in seen:
-                seen.add(m)
+            if not m:
+                continue
+            key = _ollama_cloud_suffix_key(m)
+            if key not in seen_keys:
+                seen_keys.add(key)
                 merged.append(m)
         for m in mdev_models:
-            normalized = _strip_ollama_cloud_suffix(m)
-            if normalized and normalized not in seen:
-                seen.add(normalized)
-                merged.append(normalized)
+            if not m:
+                continue
+            endpoint_model = _ollama_cloud_model_for_endpoint(m, base_url)
+            key = _ollama_cloud_suffix_key(endpoint_model)
+            if key not in seen_keys:
+                seen_keys.add(key)
+                merged.append(endpoint_model)
         if merged:
             _save_ollama_cloud_cache(merged)
             return merged

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -400,17 +400,18 @@ class TestOllamaCloudProvidersNew:
         assert pdef.transport == "openai_chat"
 
 
-# ── Cloud Suffix Stripping ──
+# ── Cloud Suffix Deduplication ──
 
-class TestOllamaCloudSuffixStripping:
-    """models.dev appends :cloud / -cloud suffixes that the live API omits.
+class TestOllamaCloudSuffixDeduplication:
+    """Ollama Cloud IDs may be bare or suffixed depending on endpoint/source.
 
-    fetch_ollama_cloud_models() must normalise these before the dedup merge so
-    users never see broken IDs like 'kimi-k2.6:cloud' in the model picker.
+    fetch_ollama_cloud_models() must never rewrite the ID it returns to the
+    picker. It only uses a suffix-stripped comparison key to dedupe equivalent
+    live/models.dev entries.
     """
 
-    def test_strips_colon_cloud_suffix(self, tmp_path, monkeypatch):
-        """:cloud suffix from models.dev is stripped before merge."""
+    def test_preserves_colon_cloud_suffix_from_models_dev(self, tmp_path, monkeypatch):
+        """:cloud suffix from models.dev is preserved when no live equivalent exists."""
         from hermes_cli.models import fetch_ollama_cloud_models
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -424,11 +425,11 @@ class TestOllamaCloudSuffixStripping:
         with patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
             result = fetch_ollama_cloud_models(force_refresh=True)
 
-        assert "kimi-k2.6" in result
-        assert "kimi-k2.6:cloud" not in result
+        assert "kimi-k2.6:cloud" in result
+        assert "kimi-k2.6" not in result
 
-    def test_strips_dash_cloud_suffix(self, tmp_path, monkeypatch):
-        """-cloud suffix from models.dev is stripped before merge."""
+    def test_preserves_dash_cloud_suffix_from_models_dev(self, tmp_path, monkeypatch):
+        """models.dev-only -cloud IDs are preserved because they may be required by Ollama."""
         from hermes_cli.models import fetch_ollama_cloud_models
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -442,11 +443,11 @@ class TestOllamaCloudSuffixStripping:
         with patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
             result = fetch_ollama_cloud_models(force_refresh=True)
 
-        assert "qwen3-coder:480b" in result
-        assert "qwen3-coder:480b-cloud" not in result
+        assert "qwen3-coder:480b-cloud" in result
+        assert "qwen3-coder:480b" not in result
 
     def test_no_duplicate_when_live_clean_and_mdev_suffixed(self, tmp_path, monkeypatch):
-        """Live API returns clean ID; mdev has :cloud variant — result has exactly one entry."""
+        """Live API wins; suffix variants from mdev are deduped without rewriting live IDs."""
         from hermes_cli.models import fetch_ollama_cloud_models
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -464,13 +465,34 @@ class TestOllamaCloudSuffixStripping:
              patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
             result = fetch_ollama_cloud_models(force_refresh=True)
 
-        assert result.count("kimi-k2.6") == 1
-        assert result.count("glm-5.1") == 1
-        assert "kimi-k2.6:cloud" not in result
-        assert "glm-5.1:cloud" not in result
+        assert result == ["kimi-k2.6", "glm-5.1"]
+
+    def test_models_dev_bare_ids_are_suffixed_for_local_proxy(self, tmp_path, monkeypatch):
+        """Local Ollama cloud proxy needs :cloud / -cloud tags for models.dev additions."""
+        from hermes_cli.models import fetch_ollama_cloud_models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {
+                    "minimax-m2.7": {"tool_call": True},
+                    "qwen3-coder:480b": {"tool_call": True},
+                }
+            }
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+
+        assert "minimax-m2.7:cloud" in result
+        assert "qwen3-coder:480b-cloud" in result
+        assert "minimax-m2.7" not in result
+        assert "qwen3-coder:480b" not in result
 
     def test_unsuffixed_model_id_unchanged(self, tmp_path, monkeypatch):
-        """Model IDs without :cloud / -cloud suffix are passed through unchanged."""
+        """Model IDs without :cloud / -cloud suffix are passed through unchanged for hosted API."""
         from hermes_cli.models import fetch_ollama_cloud_models
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -486,12 +508,15 @@ class TestOllamaCloudSuffixStripping:
 
         assert "nemotron-3-nano:30b" in result
 
-    def test_strip_suffix_helper(self):
-        """Unit test for the _strip_ollama_cloud_suffix helper."""
-        from hermes_cli.models import _strip_ollama_cloud_suffix
+    def test_suffix_key_helper(self):
+        """Unit test for the _ollama_cloud_suffix_key helper."""
+        from hermes_cli.models import _ollama_cloud_model_for_endpoint, _ollama_cloud_suffix_key
 
-        assert _strip_ollama_cloud_suffix("kimi-k2.6:cloud") == "kimi-k2.6"
-        assert _strip_ollama_cloud_suffix("glm-5.1:cloud") == "glm-5.1"
-        assert _strip_ollama_cloud_suffix("qwen3-coder:480b-cloud") == "qwen3-coder:480b"
-        assert _strip_ollama_cloud_suffix("nemotron-3-nano:30b") == "nemotron-3-nano:30b"
-        assert _strip_ollama_cloud_suffix("") == ""
+        assert _ollama_cloud_suffix_key("kimi-k2.6:cloud") == "kimi-k2.6"
+        assert _ollama_cloud_suffix_key("glm-5.1:cloud") == "glm-5.1"
+        assert _ollama_cloud_suffix_key("qwen3-coder:480b-cloud") == "qwen3-coder:480b"
+        assert _ollama_cloud_suffix_key("nemotron-3-nano:30b") == "nemotron-3-nano:30b"
+        assert _ollama_cloud_suffix_key("") == ""
+        assert _ollama_cloud_model_for_endpoint("minimax-m2.7", "http://localhost:11434/v1") == "minimax-m2.7:cloud"
+        assert _ollama_cloud_model_for_endpoint("qwen3-coder:480b", "http://localhost:11434/v1") == "qwen3-coder:480b-cloud"
+        assert _ollama_cloud_model_for_endpoint("minimax-m2.7", "https://ollama.com/v1") == "minimax-m2.7"


### PR DESCRIPTION
## Problem

When Ollama Cloud is routed through the **local Ollama daemon** (`base_url` host `localhost` / `127.0.0.1` / `::1` / `*.local`), cloud models must keep their Ollama tag suffixes:

- `kimi-k2.6` → `kimi-k2.6:cloud`
- `qwen3-coder:480b` → `qwen3-coder:480b-cloud`

`fetch_ollama_cloud_models()` merged the live list with the models.dev catalog and ran every models.dev ID through `_strip_ollama_cloud_suffix()`, which **unconditionally** removed `:cloud`/`-cloud`. The merged/cached list (and therefore the `hermes model` picker) then offered bare IDs that the local proxy cannot serve.

## Fix

Replace the unconditional strip with intent-separated helpers:

- **`_ollama_cloud_suffix_key()`** — suffix-agnostic value used **only** as a dedup equivalence key (never saved as a model ID).
- **`_ollama_cloud_base_is_local_proxy()`** — detects local-daemon routing.
- **`_ollama_cloud_model_for_endpoint()`** — re-tags catalog IDs for the local proxy (`name` → `name:cloud`, `name:tag` → `name:tag-cloud`) while preserving hosted `ollama.com/v1` IDs as-is.

The merge keeps the real, tagged IDs and uses the stripped value only for equivalence, so bare/suffixed duplicates still collapse to one entry.

## Tests

Extends `tests/hermes_cli/test_ollama_cloud_provider.py` (45 passing locally).