### PR TITLE
Enable token analytics by default

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1870,21 +1870,19 @@ DEFAULT_CONFIG = {
     # Web dashboard settings
     "dashboard": {
         "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
-        # Hide the token/cost analytics surfaces (Analytics page, token bars and
-        # cost figures on the Models page) by default.  The numbers shown there
-        # are a local debug estimate: they only count successful main-agent
-        # responses with a usable ``response.usage``, and silently exclude every
-        # auxiliary call (context compression, title generation, vision,
-        # session search, web extract, smart approval, MCP routing, plugin LLM
-        # access) plus provider-side retries, fallback attempts, and any call
-        # whose usage block didn't come back.  Cache writes are also missing
-        # from the API response.  On models with heavy auxiliary traffic
-        # (Kimi K2.6, MiniMax M2.7) the local total can be 10x-100x lower than
-        # the provider bill, which is worse than hiding the numbers entirely
-        # because they look precise enough to compare against the provider.
-        # Set this to True to re-enable the surfaces with the understanding
-        # that the numbers are a local lower-bound estimate, not billing.
-        "show_token_analytics": False,
+        # Show the token/cost analytics surfaces (Analytics page, token bars
+        # and cost figures on the Models page) by default.  The numbers shown
+        # there are a local debug estimate: they only count successful
+        # main-agent responses with a usable ``response.usage``, and silently
+        # exclude every auxiliary call (context compression, title generation,
+        # vision, session search, web extract, smart approval, MCP routing,
+        # plugin LLM access) plus provider-side retries, fallback attempts,
+        # and any call whose usage block didn't come back.  Cache writes are
+        # also missing from the API response.  On models with heavy auxiliary
+        # traffic (Kimi K2.6, MiniMax M2.7) the local total can be 10x-100x
+        # lower than the provider bill, which is still a lower-bound estimate
+        # rather than billing.
+        "show_token_analytics": True,
         # OAuth gate configuration (engaged when ``--host`` is set and
         # ``--insecure`` is not). The bundled Nous Portal plugin reads
         # both keys at startup; they are the canonical surface for these

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -408,7 +408,7 @@ export default function AnalyticsPage() {
   const [data, setData] = useState<AnalyticsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  // Gated on `dashboard.show_token_analytics` (default off).  When off the
+  // Gated on `dashboard.show_token_analytics` (default on).  When off the
   // page renders an explanation card instead of fetching analytics — the
   // local token counts exclude auxiliary calls and provider retries, so
   // they diverge from provider billing in ways that mislead users.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2027,7 +2027,7 @@ Configuration for the [web dashboard](/user-guide/features/web-dashboard) — vi
 ```yaml
 dashboard:
   theme: "default"            # "default" | "midnight" | "ember" | "mono" | "cyberpunk" | "rose"
-  show_token_analytics: false # Re-enable the (local-estimate-only) token/cost analytics surfaces
+  show_token_analytics: true  # Token/cost analytics surfaces are on by default (local-estimate-only)
   public_url: ""              # Full public authority for OAuth redirect_uri (env: HERMES_DASHBOARD_PUBLIC_URL)
   oauth:                      # Portal OAuth gate (engaged with --host and not --insecure)
     client_id: ""             # agent:{instance_id} — Portal provisions this
@@ -2044,6 +2044,6 @@ dashboard:
 ```
 
 - `theme` — dashboard visual theme.
-- `show_token_analytics` — off by default. The Analytics page and token/cost figures are a **local lower-bound estimate** (they exclude auxiliary calls, retries, fallbacks, and cache writes), so they can read far below the provider bill. Set `true` only if you understand they're not billing.
+- `show_token_analytics` — on by default. The Analytics page and token/cost figures are a **local lower-bound estimate** (they exclude auxiliary calls, retries, fallbacks, and cache writes), so they can read far below the provider bill. Set `false` only if you want to hide the surfaces.
 - `public_url` — when set, this is the complete authority (scheme + host + optional path prefix) the OAuth `redirect_uri` is built from. Set it for deploys behind reverse proxies that don't reliably forward `X-Forwarded-*` headers. Leave empty to use proxy-header reconstruction.
 - `oauth` / `basic_auth` / `drain_auth` — auth provider config read by the bundled dashboard-auth plugins. The drain secret itself is **not** set here; it's provisioned via the `HERMES_DASHBOARD_DRAIN_SECRET` env var. See [Web Dashboard](/user-guide/features/web-dashboard) for full auth setup.


### PR DESCRIPTION
Flip dashboard.show_token_analytics to true in the Hermes defaults, update the dashboard config docs, and align the Analytics page comment with the new default.