### PR TITLE
fix(gemini): pin explicit thinkingBudget for gemini-2.5 to prevent empty completions

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -19,6 +19,45 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
+# Effort → thinkingBudget (tokens) for Gemini 2.5 models. See
+# ``_gemini_25_thinking_budget`` for why an explicit budget is required.
+_GEMINI_25_EFFORT_BUDGET = {
+    "minimal": 512,
+    "low": 2048,
+    "medium": 8192,
+    "high": 16384,
+    "xhigh": 24576,
+}
+
+
+def _gemini_25_thinking_budget(normalized_model: str, effort: str, *, disabled: bool) -> int:
+    """Pick an explicit Gemini 2.5 ``thinkingBudget`` (tokens).
+
+    Gemini 2.5 models default to "dynamic" thinking (budget ``-1``) when the
+    field is omitted. In that mode the model can silently consume its entire
+    output allowance as internal thinking tokens and return ``finish_reason
+    "stop"`` with **zero** completion tokens — surfaced to the user as
+    "empty content after retries" (a documented, otherwise-intermittent
+    gemini-2.5-flash failure). Always pinning a budget makes completions
+    deterministic. Budgets are clamped to each family's documented range:
+
+      * gemini-2.5-pro:        128..32768 (thinking cannot be disabled)
+      * gemini-2.5-flash-lite: 0 (off) or 512..24576
+      * gemini-2.5-flash:      0 (off) or up to 24576
+    """
+    budget = 0 if disabled else _GEMINI_25_EFFORT_BUDGET.get(effort, 8192)
+
+    if "pro" in normalized_model:
+        # Pro can't turn thinking off; keep it within [128, 32768].
+        return max(128, min(budget or 128, 32768))
+    if "flash-lite" in normalized_model:
+        if budget <= 0:
+            return 0
+        return max(512, min(budget, 24576))
+    # flash (and any other 2.5 family): 0 disables, else up to 24576.
+    return max(0, min(budget, 24576))
+
+
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
     """Translate Hermes/OpenRouter-style reasoning config to Gemini thinkingConfig."""
     if reasoning_config is None or not isinstance(reasoning_config, dict):
@@ -39,18 +78,31 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if reasoning_config.get("enabled") is False:
         # Gemini can hide thought parts even when internal thinking still
         # happens; omit thinkingLevel to avoid model-specific validation quirks.
-        return {"includeThoughts": False}
+        disabled_config: Dict[str, Any] = {"includeThoughts": False}
+        if normalized_model.startswith("gemini-2.5-"):
+            disabled_config["thinkingBudget"] = _gemini_25_thinking_budget(
+                normalized_model, "none", disabled=True
+            )
+        return disabled_config
 
     effort = str(reasoning_config.get("effort", "medium") or "medium").strip().lower()
     if effort == "none":
-        return {"includeThoughts": False}
+        disabled_config = {"includeThoughts": False}
+        if normalized_model.startswith("gemini-2.5-"):
+            disabled_config["thinkingBudget"] = _gemini_25_thinking_budget(
+                normalized_model, "none", disabled=True
+            )
+        return disabled_config
 
     thinking_config: Dict[str, Any] = {"includeThoughts": True}
 
-    # Gemini 2.5 accepts thinkingBudget; don't guess a budget from Hermes'
-    # coarse effort levels. ``includeThoughts`` alone is enough to surface
-    # thought parts without risking request validation errors.
+    # Gemini 2.5 requires an EXPLICIT thinkingBudget — left unset it uses
+    # dynamic thinking and can return zero-token empty completions (see
+    # _gemini_25_thinking_budget). Pin an effort-scaled, family-clamped budget.
     if normalized_model.startswith("gemini-2.5-"):
+        thinking_config["thinkingBudget"] = _gemini_25_thinking_budget(
+            normalized_model, effort, disabled=False
+        )
         return thinking_config
 
     if effort not in {"minimal", "low", "medium", "high", "xhigh"}:
@@ -433,6 +485,15 @@ class ChatCompletionsTransport(ProviderTransport):
             if _is_gemini_openai_compat_base_url(base_url):
                 thinking_config = _snake_case_gemini_thinking_config(raw_thinking_config)
                 if thinking_config:
+                    # Google's OpenAI-compat endpoint expects the thinking config
+                    # under a top-level field literally named `extra_body`
+                    # (`{"extra_body": {"google": {"thinking_config": ...}}}` on
+                    # the wire). Since the OpenAI SDK merges api_kwargs["extra_body"]
+                    # into the top-level body, we must nest it once more here so the
+                    # wire ends up with that top-level `extra_body` field. This
+                    # "double nesting" is REQUIRED — verified against the live API: top-level
+                    # `google` → HTTP 400 "Unknown name 'google'"; top-level
+                    # `extra_body.google` → HTTP 200.
                     openai_compat_extra = extra_body.get("extra_body", {})
                     google_extra = openai_compat_extra.get("google", {})
                     google_extra["thinking_config"] = thinking_config

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -21,8 +21,23 @@ class GeminiProfile(ProviderProfile):
     def build_extra_body(
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:
-        """Emit extra_body.thinking_config (native) or extra_body.extra_body.google.thinking_config
-        (OpenAI-compat /openai subpath), mirroring the legacy path's behavior.
+        """Emit the thinking_config the resolved endpoint expects.
+
+        The returned dict is merged into the transport's ``extra_body`` dict and
+        assigned to ``api_kwargs["extra_body"]``; the OpenAI SDK then merges *that
+        dict's contents* into the top-level JSON request body.
+
+        For Google's OpenAI-compat endpoint (`/v1beta/openai`) the thinking
+        config must arrive as a top-level field **literally named** ``extra_body``
+        (Google's documented compat extension), i.e. the wire body must contain::
+
+            {"model": …, "messages": …, "extra_body": {"google": {"thinking_config": …}}}
+
+        To make the SDK emit that top-level ``extra_body`` field, we must pass
+        ``extra_body={"extra_body": {"google": …}}`` here — the extra nesting is
+        REQUIRED, not a bug. (Verified against the live API: top-level ``google`` → HTTP 400
+        "Unknown name 'google'"; top-level ``extra_body.google`` → HTTP 200.) The
+        native REST endpoint instead speaks ``thinking_config`` directly.
         """
         from agent.transports.chat_completions import (
             _build_gemini_thinking_config,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -353,7 +353,9 @@ class TestChatCompletionsBuildKwargs:
             "thinking_level": "high",
         }
 
-    def test_gemini_native_25_reasoning_only_enables_visible_thoughts(self, transport):
+    def test_gemini_native_25_reasoning_sets_explicit_thinking_budget(self, transport):
+        # Gemini 2.5 must always send an explicit thinkingBudget — left unset it
+        # uses dynamic thinking and can return zero-token empty completions.
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
             model="gemini-2.5-flash",
@@ -364,6 +366,43 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["thinking_config"] == {
             "includeThoughts": True,
+            "thinkingBudget": 16384,
+        }
+
+    def test_gemini_openai_compat_25_disabled_reasoning_sets_budget_zero(self, transport):
+        # Regression guard for the "empty content after retries" bug: on the
+        # OpenAI-compat endpoint, disabled reasoning on gemini-2.5-flash must
+        # pin thinking_budget=0 (fully disable thinking) so the model can't burn
+        # its whole output allowance thinking and return a zero-token completion.
+        # The wire shape must stay double-nested (extra_body.google.*) — Google's
+        # compat endpoint 400s on a top-level `google` field.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-2.5-flash",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": False},
+        )
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": False,
+            "thinking_budget": 0,
+        }
+
+    def test_gemini_25_pro_cannot_disable_thinking_budget_clamped(self, transport):
+        # gemini-2.5-pro cannot turn thinking off (min budget 128); a disabled
+        # request must clamp up to the minimum, never send 0.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-2.5-pro",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+            reasoning_config={"enabled": False},
+        )
+        assert kw["extra_body"]["thinking_config"] == {
+            "includeThoughts": False,
+            "thinkingBudget": 128,
         }
 
     def test_gemini_openai_compat_pro_reasoning_clamps_to_supported_levels(self, transport):

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -487,3 +487,65 @@ class TestBaseProfile:
         eb, tl = p.build_api_kwargs_extras()
         assert eb == {}
         assert tl == {}
+
+
+class TestGeminiProfileExtraBody:
+    """Guards for the Gemini provider profile's build_extra_body.
+
+    Known providers route through _build_kwargs_from_profile, so the Gemini
+    plugin's build_extra_body — not the legacy transport inline builder — is what
+    actually shapes live requests. Regression guards for two issues:
+      1. wire shape MUST be extra_body.google.* (top-level `google` → HTTP 400)
+      2. gemini-2.5 MUST carry an explicit thinking_budget (unset → empty completion)
+    """
+
+    OPENAI_COMPAT = "https://generativelanguage.googleapis.com/v1beta/openai"
+    NATIVE = "https://generativelanguage.googleapis.com/v1beta"
+
+    def test_openai_compat_shape_is_double_nested(self):
+        p = get_provider_profile("gemini")
+        body = p.build_extra_body(
+            model="gemini-2.5-flash",
+            reasoning_config={"enabled": False},
+            base_url=self.OPENAI_COMPAT,
+        )
+        # Google's OpenAI-compat endpoint wants a top-level field literally named
+        # `extra_body`; the SDK merges api_kwargs["extra_body"] to top level, so
+        # this must stay double-nested. A top-level `google` key would 400.
+        assert body == {
+            "extra_body": {
+                "google": {
+                    "thinking_config": {
+                        "include_thoughts": False,
+                        "thinking_budget": 0,
+                    }
+                }
+            }
+        }
+        assert "google" not in body
+
+    def test_openai_compat_enabled_reasoning_carries_budget(self):
+        p = get_provider_profile("gemini")
+        body = p.build_extra_body(
+            model="gemini-2.5-flash",
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url=self.OPENAI_COMPAT,
+        )
+        tc = body["extra_body"]["google"]["thinking_config"]
+        assert tc["thinking_budget"] == 8192
+        assert tc["include_thoughts"] is True
+
+    def test_native_shape_uses_thinking_config_directly(self):
+        p = get_provider_profile("gemini")
+        body = p.build_extra_body(
+            model="gemini-2.5-flash",
+            reasoning_config={"enabled": True, "effort": "low"},
+            base_url=self.NATIVE,
+        )
+        assert body == {
+            "thinking_config": {"includeThoughts": True, "thinkingBudget": 2048}
+        }
+
+    def test_no_reasoning_config_returns_empty(self):
+        p = get_provider_profile("gemini")
+        assert p.build_extra_body(model="gemini-2.5-flash") == {}


### PR DESCRIPTION
## Problem

Gemini 2.5 models (`flash`, `flash-lite`, `pro`) default to **dynamic thinking** (`thinkingBudget = -1`) when the field is omitted. In that mode the model can silently consume its entire output allowance as internal thinking tokens and return `finish_reason: "stop"` with **zero completion tokens**. Hermes surfaces this as `"empty content after retries"` — an intermittent, hard-to-diagnose failure that reproduces especially on tool-calling prompts.

`_build_gemini_thinking_config` previously emitted only `{"includeThoughts": ...}` for the gemini-2.5 family, deliberately leaving `thinkingBudget` unset (a comment even said "don't guess a budget"). Unfortunately "unset" is exactly what triggers the empty-completion behavior.

## Fix

Adds `_gemini_25_thinking_budget()`, which **always pins an explicit budget** for gemini-2.5:

- `0` disables thinking (flash / flash-lite) for the disabled / `effort=none` case
- otherwise an effort-scaled budget (`minimal` 512 → `xhigh` 24576)
- clamped to each family's documented range:
  - `gemini-2.5-pro`: `128..32768` (thinking cannot be disabled)
  - `gemini-2.5-flash-lite`: `0` (off) or `512..24576`
  - `gemini-2.5-flash`: `0` (off) or up to `24576`

`gemini-3` behavior is unchanged.

## Also

Documents (in comments) why the gemini OpenAI-compat thinking config is intentionally nested under a top-level field literally named `extra_body` (Google's compat extension point). Verified against the live API:

| wire shape | result |
|---|---|
| top-level `extra_body: {"google": {"thinking_config": …}}` | **HTTP 200** |
| top-level `google: {"thinking_config": …}` | **HTTP 400** `Unknown name "google"` |

This is easy to mistake for a double-nesting bug and "fix" into a 400, so the comment + a wire-shape regression test lock it in.

## Tests

Adds regression tests for the explicit budgets, the pro-cannot-disable clamp, and the double-nested wire shape on the provider-profile path. All existing gemini transport/provider tests pass; one prior test that asserted the budget-less shape was updated to expect the new explicit budget.

## Verification

Live-verified end-to-end: a previously-failing tool-calling prompt against `gemini-2.5-flash` (which returned empty completions) now returns a proper grounded response after this change.