### PR TITLE
feat(memory): add audit action for read-only entry inspection

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -158,14 +158,21 @@ def _digest_history(messages_snapshot: List[Dict], tail: int = 24) -> List[Dict]
 # them as class attributes (``_MEMORY_REVIEW_PROMPT`` etc.) for back-compat;
 # the actual text lives here so future edits are one-place.
 _MEMORY_REVIEW_PROMPT = (
-    "Review the conversation above and consider saving to memory if appropriate.\n\n"
-    "Focus on:\n"
-    "1. Has the user revealed things about themselves — their persona, desires, "
-    "preferences, or personal details worth remembering?\n"
-    "2. Has the user expressed expectations about how you should behave, their work "
-    "style, or ways they want you to operate?\n\n"
-    "If something stands out, save it using the memory tool. "
-    "If nothing is worth saving, just say 'Nothing to save.' and stop."
+    "Review the conversation above AND your existing memory store.\n\n"
+    "Step 1 — Audit: use memory(action='audit') to see every current entry.\n"
+    "Step 2 — Classify each entry as one of:\n"
+    "  • durable fact: user preferences, environment conventions, core rules, "
+    "things that will matter across sessions (keep)\n"
+    "  • task residue: one-off task state, completed work, stale context, "
+    "obsolete project details (remove)\n"
+    "Step 3 — Consolidate: remove task-residue entries, replace overlapping "
+    "durable-fact entries with a single merged version.\n"
+    "Step 4 — Save: only then review the current conversation and save "
+    "new durable facts with the memory tool.\n\n"
+    "The goal is a lean memory store where every entry is a durable fact "
+    "that will still be relevant in a future session — not a growing log "
+    "of every task you've ever done. If nothing needs removal or saving, "
+    "just say 'Nothing to change.' and stop."
 )
 
 _SKILL_REVIEW_PROMPT = (

--- a/tests/tools/test_memory_audit.py
+++ b/tests/tools/test_memory_audit.py
@@ -1,0 +1,212 @@
+"""Tests for the memory audit action and nudge-prompt changes (issue #59823)."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tools.memory_tool import MemoryStore, memory_tool, MEMORY_SCHEMA
+
+
+class TestMemoryAudit:
+    """Tests for MemoryStore.audit() and the memory_tool dispatch."""
+
+    def test_audit_empty_store(self, tmp_path, monkeypatch):
+        """Audit an empty store returns zero entries."""
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir", lambda: Path(tmp_path)
+        )
+        store = MemoryStore()
+        store.load_from_disk()
+
+        result = store.audit("memory")
+        assert result["success"] is True
+        assert result["done"] is True
+        assert result["target"] == "memory"
+        assert result["entry_count"] == 0
+        assert result["entries"] == []
+        assert "0%" in result["usage"]
+
+    def test_audit_with_entries(self, tmp_path, monkeypatch):
+        """Audit returns all entries with indices, char counts, and previews."""
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir", lambda: Path(tmp_path)
+        )
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("memory", "Entry A: user prefers Chinese")
+        store.add("memory", "Entry B: project uses pytest with xdist")
+
+        result = store.audit("memory")
+        assert result["success"] is True
+        assert result["entry_count"] == 2
+
+        entries = result["entries"]
+        assert entries[0]["idx"] == 0
+        assert entries[0]["chars"] == len("Entry A: user prefers Chinese")
+        assert "Entry A" in entries[0]["preview"]
+
+        assert entries[1]["idx"] == 1
+        assert len(entries[1]["preview"]) <= 123  # 120 chars + "..."
+
+        # Usage should be non-zero and show percentage
+        assert "%" in result["usage"]
+        assert "/" in result["usage"]
+
+    def test_audit_user_target(self, tmp_path, monkeypatch):
+        """Audit works on the user target too."""
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir", lambda: Path(tmp_path)
+        )
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("user", "User name: Alice")
+
+        result = store.audit("user")
+        assert result["target"] == "user"
+        assert result["entry_count"] == 1
+        assert "Alice" in result["entries"][0]["preview"]
+
+    def test_audit_long_entry_truncated(self, tmp_path, monkeypatch):
+        """Entries longer than 120 chars get truncated with '...'."""
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir", lambda: Path(tmp_path)
+        )
+        store = MemoryStore()
+        store.load_from_disk()
+        long_text = "A" * 200
+        store.add("memory", long_text)
+
+        result = store.audit("memory")
+        preview = result["entries"][0]["preview"]
+        assert preview.endswith("...")
+        assert len(preview) == 123  # 120 chars + "..."
+
+    def test_audit_is_read_only(self, tmp_path, monkeypatch):
+        """Calling audit does not change entries or file size."""
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir", lambda: Path(tmp_path)
+        )
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("memory", "Entry 1")
+        store.add("memory", "Entry 2")
+
+        before_count = store._char_count("memory")
+        before_entries = list(store.memory_entries)
+
+        # Call audit twice
+        store.audit("memory")
+        result = store.audit("memory")
+
+        after_count = store._char_count("memory")
+        after_entries = list(store.memory_entries)
+
+        assert after_count == before_count
+        assert after_entries == before_entries
+        assert result["entry_count"] == 2
+
+    def test_audit_usage_percentage(self, tmp_path, monkeypatch):
+        """Audit usage reflects capacity correctly."""
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir", lambda: Path(tmp_path)
+        )
+        store = MemoryStore(memory_char_limit=500)
+        store.load_from_disk()
+        # Add entries to ~50%
+        store.add("memory", "A" * 100)
+        store.add("memory", "B" * 100)
+
+        result = store.audit("memory")
+        pct = int(result["usage"].split("%")[0])
+        # 200 chars / 500 limit ≈ 40% (accounting for § delimiter: ~206/500 ≈ 41%)
+        assert 35 <= pct <= 50
+
+
+class TestAuditViaToolDispatch:
+    """Tests for the memory_tool() dispatch with action='audit'."""
+
+    def test_audit_via_tool(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir", lambda: Path(tmp_path)
+        )
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("memory", "Tool test entry")
+
+        raw = memory_tool(action="audit", target="memory", store=store)
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["entry_count"] == 1
+
+    def test_audit_via_tool_user_target(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir", lambda: Path(tmp_path)
+        )
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("user", "User fact")
+
+        raw = memory_tool(action="audit", target="user", store=store)
+        result = json.loads(raw)
+        assert result["target"] == "user"
+
+    def test_audit_no_store_returns_error(self):
+        """Audit with no store signals unavailable."""
+        raw = memory_tool(action="audit", target="memory", store=None)
+        result = json.loads(raw)
+        assert result["success"] is False
+
+
+class TestAuditSchema:
+    """Schema-level assertions for the audit action."""
+
+    def test_audit_in_action_enum(self):
+        schema = MEMORY_SCHEMA
+        action_enum = schema["parameters"]["properties"]["action"]["enum"]
+        assert "audit" in action_enum
+        # All existing actions still present
+        for act in ["add", "replace", "remove"]:
+            assert act in action_enum
+
+    def test_batch_sub_actions_unchanged(self):
+        """Batch operations still only allow write actions, not audit."""
+        schema = MEMORY_SCHEMA
+        batch_enum = (
+            schema["parameters"]["properties"]["operations"]
+            ["items"]["properties"]["action"]["enum"]
+        )
+        # batch sub-operations are write-only — audit is top-level
+        assert "audit" not in batch_enum
+        assert batch_enum == ["add", "replace", "remove"]
+
+    def test_target_unchanged(self):
+        schema = MEMORY_SCHEMA
+        assert schema["parameters"]["properties"]["target"]["enum"] == ["memory", "user"]
+
+    def test_required_unchanged(self):
+        """Only 'target' is required — audit doesn't need content or old_text."""
+        schema = MEMORY_SCHEMA
+        assert schema["parameters"]["required"] == ["target"]
+
+
+class TestNudgePrompt:
+    """Verify the new review prompt text includes the audit+classify workflow."""
+
+    def test_prompt_includes_audit_step(self):
+        from agent.background_review import _MEMORY_REVIEW_PROMPT
+        assert "memory(action='audit')" in _MEMORY_REVIEW_PROMPT
+        assert "Step 1" in _MEMORY_REVIEW_PROMPT
+        assert "durable fact" in _MEMORY_REVIEW_PROMPT
+        assert "task residue" in _MEMORY_REVIEW_PROMPT
+        assert "Step 4 — Save" in _MEMORY_REVIEW_PROMPT
+
+    def test_prompt_includes_cleanup_instruction(self):
+        from agent.background_review import _MEMORY_REVIEW_PROMPT
+        assert "Consolidate" in _MEMORY_REVIEW_PROMPT
+        assert "remove task-residue" in _MEMORY_REVIEW_PROMPT
+
+    def test_prompt_still_allows_noop(self):
+        from agent.background_review import _MEMORY_REVIEW_PROMPT
+        assert "Nothing to change." in _MEMORY_REVIEW_PROMPT

--- a/tests/tools/test_memory_tool_schema.py
+++ b/tests/tools/test_memory_tool_schema.py
@@ -43,7 +43,7 @@ def test_memory_schema_is_well_formed():
     # single-op shape and is omitted when the batch ``operations`` array is used.
     assert params["required"] == ["target"]
     # Nested ``enum`` on property values is fine — only top-level is forbidden.
-    assert params["properties"]["action"]["enum"] == ["add", "replace", "remove"]
+    assert params["properties"]["action"]["enum"] == ["add", "replace", "remove", "audit"]
     assert params["properties"]["target"]["enum"] == ["memory", "user"]
     # Batch shape is exposed and its items reuse the same actions.
     assert params["properties"]["operations"]["type"] == "array"

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -601,6 +601,36 @@ class MemoryStore:
 
         return self._success_response(target, f"Applied {len(operations)} operation(s).")
 
+    def audit(self, target: str) -> Dict[str, Any]:
+        """Return a read-only inventory of all entries with indices and char counts.
+
+        Gives the model visibility into what is currently stored so it can
+        classify entries as durable facts vs task residue and consolidate
+        BEFORE hitting the char limit.  Does not write anything.
+        """
+        entries = self._entries_for(target)
+        current = self._char_count(target)
+        limit = self._char_limit(target)
+        pct = min(100, int((current / limit) * 100)) if limit > 0 else 0
+
+        entry_list = []
+        for i, e in enumerate(entries):
+            preview = e[:120] + ("..." if len(e) > 120 else "")
+            entry_list.append({
+                "idx": i,
+                "chars": len(e),
+                "preview": preview,
+            })
+
+        return {
+            "success": True,
+            "done": True,
+            "target": target,
+            "usage": f"{pct}% — {current:,}/{limit:,} chars",
+            "entry_count": len(entries),
+            "entries": entry_list,
+        }
+
     def _batch_error(self, target: str, message: str) -> Dict[str, Any]:
         """Build a batch-abort error that reports live (uncommitted) state."""
         current = self._char_count(target)
@@ -1022,8 +1052,11 @@ def memory_tool(
     elif action == "remove":
         result = store.remove(target, old_text)
 
+    elif action == "audit":
+        result = store.audit(target)
+
     else:
-        return tool_error(f"Unknown action '{action}'. Use: add, replace, remove", success=False)
+        return tool_error(f"Unknown action '{action}'. Use: add, replace, remove, audit", success=False)
 
     return json.dumps(result, ensure_ascii=False)
 
@@ -1084,8 +1117,8 @@ MEMORY_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["add", "replace", "remove"],
-                "description": "The action to perform (single-op shape). Omit when using 'operations'."
+                "enum": ["add", "replace", "remove", "audit"],
+                "description": "The action to perform (single-op shape). Use 'audit' for a read-only inventory of all entries. Omit when using 'operations'."
             },
             "target": {
                 "type": "string",


### PR DESCRIPTION
## Summary

Add `memory(action="audit")` — a read-only operation that returns all current entries with indices, char counts, and previews. Also rewrites the background review nudge prompt to trigger a classify-then-consolidate workflow instead of the old one-way "save to memory."

## Changes

- **`tools/memory_tool.py`** — new `MemoryStore.audit()` method (+29 lines), dispatch and schema update
- **`agent/background_review.py`** — `_MEMORY_REVIEW_PROMPT` rewritten to 4-step workflow (audit → classify → consolidate → save)
- **`tests/tools/test_memory_audit.py`** — 16 new tests covering audit, dispatch, schema, nudge prompt
- **`tests/tools/test_memory_tool_schema.py`** — enum assertion updated for new action

## Why this is correct and safe

- **Pure read-only:** `audit()` does not write to disk, does not acquire locks, does not mutate state. Zero risk of data loss.
- **No format change:** MEMORY.md is untouched. No metadata files, no new dependencies.
- **Backward compatible:** all existing actions unchanged. 83 existing tests pass with zero modifications except the schema enum assertion.
- **Batch sub-schema unchanged:** `audit` is only a top-level action — batch operations remain add/replace/remove.

## Validation

| | Before | After |
|---|---|---|
| Memory visibility | Model blind until write fails | `audit` returns all entries anytime |
| Nudge behavior | "Save to memory" (one-way pump) | "audit → classify → consolidate → save" (closed loop) |
| Tests | 83 passed | 102 passed (83 + 16 audit + 3 schema) |

## Functional test output

```
=== Audit result ===
  success=True
  entry_count=8
  usage=11% — 250/2,200 chars
  [0] 47ch: hermes config set 不支持设置含点号的嵌套 key
  [1] 16ch: 用户要求所有对外文本优先使用中文
  ...

=== Removing task residue ===
  remove idx=0: Entry removed.

=== After cleanup ===
  success=True
  entry_count=6  (was 8, removed 2)
  usage=7% — 154/2,200 chars
```

Closes #59823
