### PR TITLE
fix(supermemory): forget hybrid results by backing document

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import threading
+import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -277,6 +278,37 @@ def _is_trivial_message(text: str) -> bool:
     return bool(_TRIVIAL_RE.match((text or "").strip()))
 
 
+def _is_supermemory_not_found_error(exc: Exception) -> bool:
+    """Return True only for confirmed Supermemory 404/not-found failures."""
+    try:
+        from supermemory import NotFoundError
+    except Exception:
+        NotFoundError = None  # type: ignore[assignment]
+
+    if NotFoundError is not None and isinstance(exc, NotFoundError):
+        return True
+
+    status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
+    if status is None:
+        response = getattr(exc, "response", None)
+        status = getattr(response, "status_code", None)
+    if status == 404:
+        return True
+
+    text = str(exc).lower()
+    return "404" in text and "not found" in text
+
+
+def _is_supermemory_processing_conflict(exc: Exception) -> bool:
+    """Return True when document deletion is blocked while indexing finishes."""
+    status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
+    if status is None:
+        response = getattr(exc, "response", None)
+        status = getattr(response, "status_code", None)
+    text = str(exc).lower()
+    return status == 409 and "processing" in text
+
+
 class _SupermemoryClient:
     def __init__(self, api_key: str, timeout: float, container_tag: str,
                  search_mode: str = "hybrid", base_url: str = ""):
@@ -345,9 +377,36 @@ class _SupermemoryClient:
         response = self._client.search.memories(**kwargs)
         results = []
         for item in (getattr(response, "results", None) or []):
+            documents = getattr(item, "documents", None) or []
+            document_id = (
+                getattr(item, "document_id", None)
+                or getattr(item, "documentId", None)
+                or ""
+            )
+            if not document_id and documents:
+                document = documents[0]
+                if isinstance(document, dict):
+                    document_id = (
+                        document.get("id")
+                        or document.get("document_id")
+                        or document.get("documentId")
+                        or ""
+                    )
+                else:
+                    document_id = (
+                        getattr(document, "id", None)
+                        or getattr(document, "document_id", None)
+                        or getattr(document, "documentId", None)
+                        or ""
+                    )
             results.append({
                 "id": getattr(item, "id", ""),
-                "memory": getattr(item, "memory", "") or "",
+                "document_id": document_id,
+                "memory": (
+                    getattr(item, "memory", "")
+                    or getattr(item, "chunk", "")
+                    or ""
+                ),
                 "similarity": getattr(item, "similarity", None),
                 "updated_at": getattr(item, "updated_at", None) or getattr(item, "updatedAt", None),
                 "metadata": getattr(item, "metadata", None),
@@ -383,17 +442,45 @@ class _SupermemoryClient:
         tag = container_tag or self._container_tag
         self._client.memories.forget(container_tag=tag, id=memory_id)
 
+    def _delete_document(self, document_id: str) -> None:
+        """Delete a backing document, retrying while Supermemory indexes it."""
+        for attempt in range(5):
+            try:
+                self._client.documents.delete(document_id)
+                return
+            except Exception as exc:
+                if not _is_supermemory_processing_conflict(exc) or attempt == 4:
+                    raise
+                time.sleep(1.0)
+
     def forget_by_query(self, query: str, *, container_tag: Optional[str] = None) -> dict:
         results = self.search_memories(query, limit=5, container_tag=container_tag)
         if not results:
             return {"success": False, "message": "No matching memory found to forget."}
         target = results[0]
         memory_id = target.get("id", "")
-        if not memory_id:
-            return {"success": False, "message": "Best matching memory has no id."}
-        self.forget_memory(memory_id, container_tag=container_tag)
+        document_id = target.get("document_id", "")
+        forgotten_id = memory_id or document_id
+        if not forgotten_id:
+            return {"success": False, "message": "Best matching memory has no deletable id."}
+
+        if memory_id:
+            try:
+                self.forget_memory(memory_id, container_tag=container_tag)
+            except Exception as exc:
+                if (
+                    not document_id
+                    or document_id == memory_id
+                    or not _is_supermemory_not_found_error(exc)
+                ):
+                    raise
+                self._delete_document(document_id)
+                forgotten_id = document_id
+        else:
+            self._delete_document(document_id)
+
         preview = (target.get("memory") or "")[:100]
-        return {"success": True, "message": f'Forgot: "{preview}"', "id": memory_id}
+        return {"success": True, "message": f'Forgot: "{preview}"', "id": forgotten_id}
 
     def ingest_conversation(self, session_id: str, messages: list[dict], metadata: dict | None = None) -> None:
         payload: dict = {

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -2,11 +2,13 @@ import json
 import os
 import stat
 import threading
+from types import SimpleNamespace
 
 import pytest
 
 from plugins.memory.supermemory import (
     SupermemoryMemoryProvider,
+    _SupermemoryClient,
     _clean_text_for_capture,
     _format_connection_summary,
     _format_prefetch_context,
@@ -225,6 +227,219 @@ def test_forget_tool_by_id(provider):
     result = json.loads(provider.handle_tool_call("supermemory_forget", {"id": "m1"}))
     assert result == {"forgotten": True, "id": "m1"}
     assert provider._client.forgotten_ids == ["m1"]
+
+
+class _FakeSupermemoryError(Exception):
+    def __init__(self, status_code: int, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class _FakeSearch:
+    def __init__(self, results):
+        self.results = results
+        self.calls = []
+
+    def memories(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(results=self.results)
+
+
+class _FakeMemories:
+    def __init__(self, error=None):
+        self.error = error
+        self.calls = []
+
+    def forget(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+
+
+class _FakeDocuments:
+    def __init__(self, errors=None):
+        self.errors = list(errors or [])
+        self.calls = []
+
+    def delete(self, document_id):
+        self.calls.append(document_id)
+        if self.errors:
+            error = self.errors.pop(0)
+            if error is not None:
+                raise error
+
+
+def _make_supermemory_client(search_results, *, memory_error=None, document_errors=None):
+    client = object.__new__(_SupermemoryClient)
+    client._container_tag = "test-container"
+    client._search_mode = "hybrid"
+    client._client = SimpleNamespace(
+        search=_FakeSearch(search_results),
+        memories=_FakeMemories(memory_error),
+        documents=_FakeDocuments(document_errors),
+    )
+    return client
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {"id": "doc-1"},
+        {"document_id": "doc-1"},
+        {"documentId": "doc-1"},
+        SimpleNamespace(documentId="doc-1"),
+    ],
+)
+def test_search_memories_preserves_chunk_and_backing_document_id(document):
+    item = SimpleNamespace(
+        id="chunk-1",
+        memory="",
+        chunk="Smoke marker content",
+        documents=[document],
+        similarity=0.9,
+        metadata={"source": "smoke"},
+    )
+    client = _make_supermemory_client([item])
+
+    result = client.search_memories("smoke marker")
+
+    assert result == [
+        {
+            "id": "chunk-1",
+            "document_id": "doc-1",
+            "memory": "Smoke marker content",
+            "similarity": 0.9,
+            "updated_at": None,
+            "metadata": {"source": "smoke"},
+        }
+    ]
+
+
+def test_forget_by_query_falls_back_to_backing_document_on_404():
+    item = SimpleNamespace(
+        id="chunk-1",
+        memory="",
+        chunk="Smoke marker content",
+        documents=[SimpleNamespace(id="doc-1")],
+    )
+    client = _make_supermemory_client(
+        [item],
+        memory_error=_FakeSupermemoryError(404, "Memory not found"),
+    )
+
+    result = client.forget_by_query("smoke marker")
+
+    assert client._client.memories.calls == [
+        {"container_tag": "test-container", "id": "chunk-1"}
+    ]
+    assert client._client.documents.calls == ["doc-1"]
+    assert result["id"] == "doc-1"
+    assert result["message"] == 'Forgot: "Smoke marker content"'
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _FakeSupermemoryError(401, "Authentication failed"),
+        _FakeSupermemoryError(403, "Forbidden"),
+        _FakeSupermemoryError(429, "Rate limited"),
+        _FakeSupermemoryError(500, "Server error"),
+        TimeoutError("Request timed out"),
+    ],
+    ids=["authentication", "forbidden", "rate-limit", "server", "timeout"],
+)
+def test_forget_by_query_does_not_fallback_on_non_404(error):
+    item = SimpleNamespace(
+        id="chunk-1",
+        memory="Smoke marker content",
+        documents=[SimpleNamespace(id="doc-1")],
+    )
+    client = _make_supermemory_client([item], memory_error=error)
+
+    with pytest.raises(type(error)) as exc_info:
+        client.forget_by_query("smoke marker")
+
+    assert exc_info.value is error
+    assert client._client.documents.calls == []
+
+
+def test_forget_by_query_keeps_successful_memory_delete():
+    item = SimpleNamespace(
+        id="memory-1",
+        memory="Smoke marker content",
+        documents=[SimpleNamespace(id="doc-1")],
+    )
+    client = _make_supermemory_client([item])
+
+    result = client.forget_by_query("smoke marker")
+
+    assert client._client.memories.calls == [
+        {"container_tag": "test-container", "id": "memory-1"}
+    ]
+    assert client._client.documents.calls == []
+    assert result["id"] == "memory-1"
+
+
+def test_forget_by_query_retries_document_delete_while_processing(monkeypatch):
+    item = SimpleNamespace(
+        id="chunk-1",
+        memory="Smoke marker content",
+        documents=[SimpleNamespace(id="doc-1")],
+    )
+    client = _make_supermemory_client(
+        [item],
+        memory_error=_FakeSupermemoryError(404, "Memory not found"),
+        document_errors=[
+            _FakeSupermemoryError(409, "Document is still processing"),
+            None,
+        ],
+    )
+    sleeps = []
+    monkeypatch.setattr("plugins.memory.supermemory.time.sleep", sleeps.append)
+
+    result = client.forget_by_query("smoke marker")
+
+    assert client._client.documents.calls == ["doc-1", "doc-1"]
+    assert sleeps == [1.0]
+    assert result["id"] == "doc-1"
+
+
+def test_forget_by_query_does_not_retry_unrelated_document_conflict(monkeypatch):
+    item = SimpleNamespace(
+        id="chunk-1",
+        memory="Smoke marker content",
+        documents=[SimpleNamespace(id="doc-1")],
+    )
+    error = _FakeSupermemoryError(409, "Document conflict")
+    client = _make_supermemory_client(
+        [item],
+        memory_error=_FakeSupermemoryError(404, "Memory not found"),
+        document_errors=[error],
+    )
+    sleeps = []
+    monkeypatch.setattr("plugins.memory.supermemory.time.sleep", sleeps.append)
+
+    with pytest.raises(_FakeSupermemoryError) as exc_info:
+        client.forget_by_query("smoke marker")
+
+    assert exc_info.value is error
+    assert client._client.documents.calls == ["doc-1"]
+    assert sleeps == []
+
+
+def test_forget_by_query_uses_document_when_search_id_is_missing():
+    item = SimpleNamespace(
+        id="",
+        memory="Smoke marker content",
+        documents=[SimpleNamespace(id="doc-1")],
+    )
+    client = _make_supermemory_client([item])
+
+    result = client.forget_by_query("smoke marker")
+
+    assert client._client.memories.calls == []
+    assert client._client.documents.calls == ["doc-1"]
+    assert result["id"] == "doc-1"
 
 
 def test_profile_tool_formats_sections(provider):


### PR DESCRIPTION
## Summary

`forget_by_query` can receive a hybrid search result whose generated `id` is not accepted by `memories.forget`, while the same result carries the authoritative backing document ID in `documents[0].id`. Supermemory may also expose the useful text in `chunk` rather than `memory`.

This update handles the query-path ID mismatch without using a broad content-based delete:

- Preserve `chunk` text when `memory` is empty.
- Normalize the backing document ID from top-level or nested SDK object/dict shapes (`id`, `document_id`, or `documentId`).
- Try the normal memory/search-result ID first.
- Only after a confirmed Supermemory 404, delete the distinct backing document ID.
- Retry backing-document deletion only for a narrow 409 "still processing" response.
- Re-raise authentication, rate-limit, timeout, connection, and server errors without issuing a second destructive delete.
- Return the ID that was actually deleted.

## Scope and relation to existing PRs

This remains a **query-path** fix. Direct `forget_memory(id=...)` behavior is unchanged, so the store-path document-ID work in #12341 and #45766 remains separate.

This supersedes the earlier version of this PR that forced `search_mode="memories"` and fell back to content-based deletion. The updated implementation keeps configured hybrid search behavior and uses the backing ID returned by the API instead.

## Maintainer feedback addressed

- Fallback is restricted to confirmed 404/not-found errors.
- Non-404 SDK errors re-raise without a second destructive operation.
- The successful backing document ID is returned.
- Regression coverage includes non-404 behavior and SDK object/dict response variants.

## Verification

- `pytest tests/plugins/memory/test_supermemory_provider.py -q -o 'addopts='` — 59 passed
- `pytest tests/plugins/memory -q -o 'addopts='` — 566 passed
- `ruff check .` — passed
- `py_compile` on changed Python files — passed
- `git diff --check` — passed
