### PR TITLE
fix(cron): normalize absolute skill paths before skill_view (#59824)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -143,37 +143,9 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
 
     try:
         from tools.skills_tool import SKILLS_DIR, skill_view
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import normalize_skill_lookup_name
 
-        identifier_path = Path(raw_identifier).expanduser()
-        if identifier_path.is_absolute():
-            normalized = None
-            trusted_roots = [SKILLS_DIR]
-            try:
-                trusted_roots.extend(get_external_skills_dirs())
-            except Exception:
-                pass
-
-            # Prefer the lexical path under a trusted skill root before
-            # resolving symlinks.  Slash-command discovery can legitimately
-            # find a skill via ~/.hermes/skills/<name> where <name> is a
-            # symlink to a checked-out skill elsewhere.  Resolving first turns
-            # that trusted visible path into an arbitrary absolute path that
-            # skill_view() refuses to load.
-            for root in trusted_roots:
-                try:
-                    normalized = str(identifier_path.relative_to(root))
-                    break
-                except ValueError:
-                    continue
-
-            if normalized is None:
-                try:
-                    normalized = str(identifier_path.resolve().relative_to(SKILLS_DIR.resolve()))
-                except Exception:
-                    normalized = raw_identifier
-        else:
-            normalized = raw_identifier.lstrip("/")
+        normalized = normalize_skill_lookup_name(raw_identifier)
 
         loaded_skill = json.loads(
             skill_view(normalized, task_id=task_id, preprocess=False)

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -507,6 +507,46 @@ def get_all_skills_dirs() -> List[Path]:
     return dirs
 
 
+def normalize_skill_lookup_name(identifier: str) -> str:
+    """Normalize a skill identifier to a ``skill_view()``-safe relative path.
+
+    Slash commands and cron jobs may store absolute paths to skills that live
+    under ``~/.hermes/skills/`` (including via symlinks) or configured
+    ``skills.external_dirs``. ``skill_view()`` rejects absolute names for
+    security, so callers must translate trusted absolute paths to their
+    relative form first.
+    """
+    raw_identifier = (identifier or "").strip()
+    if not raw_identifier:
+        return raw_identifier
+
+    identifier_path = Path(raw_identifier).expanduser()
+    if not identifier_path.is_absolute():
+        return raw_identifier.lstrip("/")
+
+    trusted_roots = [get_skills_dir()]
+    try:
+        trusted_roots.extend(get_external_skills_dirs())
+    except Exception:
+        pass
+
+    # Prefer the lexical path under a trusted skill root before resolving
+    # symlinks. Slash-command discovery can legitimately find a skill via
+    # ~/.hermes/skills/<name> where <name> is a symlink to a checked-out
+    # skill elsewhere. Resolving first turns that trusted visible path into
+    # an arbitrary absolute path that skill_view() refuses to load.
+    for root in trusted_roots:
+        try:
+            return str(identifier_path.relative_to(root))
+        except ValueError:
+            continue
+
+    try:
+        return str(identifier_path.resolve().relative_to(get_skills_dir().resolve()))
+    except Exception:
+        return raw_identifier
+
+
 def _resolve_for_skill_ownership(path) -> Path:
     path_obj = path if isinstance(path, Path) else Path(str(path))
     try:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2195,6 +2195,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     from tools.skills_tool import skill_view
     from tools.skill_usage import bump_use
     from agent.skill_bundles import build_bundle_invocation_message, resolve_bundle_command_key
+    from agent.skill_utils import normalize_skill_lookup_name
 
     parts = []
     skipped: list[str] = []
@@ -2225,7 +2226,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
             continue
 
         try:
-            loaded = json.loads(skill_view(skill_name))
+            loaded = json.loads(skill_view(normalize_skill_lookup_name(skill_name)))
         except (json.JSONDecodeError, TypeError):
             logger.warning("Cron job '%s': skill '%s' returned invalid JSON, skipping", job.get("name", job.get("id")), skill_name)
             skipped.append(skill_name)

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -333,3 +333,42 @@ class TestSkillMatchesPlatformTermux:
             "agent.skill_utils.is_termux", return_value=False
         ):
             assert skill_matches_platform(fm) is True
+
+
+class TestNormalizeSkillLookupName:
+    def test_relative_path_unchanged(self, tmp_path, monkeypatch):
+        from agent.skill_utils import normalize_skill_lookup_name
+
+        monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: tmp_path / "skills")
+        assert normalize_skill_lookup_name("foo/bar") == "foo/bar"
+
+    def test_absolute_under_skills_dir_becomes_relative(self, tmp_path, monkeypatch):
+        from agent.skill_utils import normalize_skill_lookup_name
+
+        skills_dir = tmp_path / "skills"
+        skill_dir = skills_dir / "category" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: skills_dir)
+        assert normalize_skill_lookup_name(str(skill_dir)) == "category/my-skill"
+
+    def test_absolute_via_symlink_uses_lexical_relative_path(self, tmp_path, monkeypatch):
+        from agent.skill_utils import normalize_skill_lookup_name
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        external = tmp_path / "external" / "my-skill"
+        external.mkdir(parents=True)
+        link = skills_dir / "my-skill"
+        try:
+            link.symlink_to(external)
+        except OSError:
+            pytest.skip("Symlinks not supported")
+        monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: skills_dir)
+        assert normalize_skill_lookup_name(str(link)) == "my-skill"
+
+    def test_untrusted_absolute_returned_unchanged(self, tmp_path, monkeypatch):
+        from agent.skill_utils import normalize_skill_lookup_name
+
+        monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: tmp_path / "skills")
+        outside = str(tmp_path / "outside" / "skill")
+        assert normalize_skill_lookup_name(outside) == outside

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2885,6 +2885,31 @@ class TestBuildJobPromptMissingSkill:
         assert "go" in result
 
 
+class TestBuildJobPromptAbsoluteSkillPath:
+    """Cron jobs may store absolute skill paths; normalize before skill_view."""
+
+    def test_absolute_skill_path_normalized_before_skill_view(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        skill_dir = skills_dir / "alpha-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Alpha\nDo alpha.")
+        absolute_path = str(skill_dir)
+        seen_names: list[str] = []
+
+        def _skill_view(name: str) -> str:
+            seen_names.append(name)
+            if name == "alpha-skill":
+                return json.dumps({"success": True, "content": "# Alpha\nDo alpha."})
+            return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
+
+        with patch("agent.skill_utils.get_skills_dir", return_value=skills_dir), \
+             patch("tools.skills_tool.skill_view", side_effect=_skill_view):
+            result = _build_job_prompt({"skills": [absolute_path], "prompt": "go"})
+
+        assert seen_names == ["alpha-skill"]
+        assert "Do alpha." in result
+
+
 class TestBuildJobPromptBumpUse:
     """Verify that cron jobs bump skill usage counters so the curator sees them as active."""
 


### PR DESCRIPTION
## Summary
- Extract `normalize_skill_lookup_name()` from the slash-command loader into `agent.skill_utils`
- Cron scheduler now normalizes absolute skill paths under trusted skills roots before calling `skill_view()`
- Fixes silent cron skill-load failures when `jobs.json` stores absolute paths (e.g. `/home/hermes/.../SKILLS/category/skill/`)

Fixes #59824

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_skill_utils.py -k NormalizeSkillLookupName`
- [x] `scripts/run_tests.sh tests/cron/test_scheduler.py -k AbsoluteSkillPath`