### PR TITLE
fix(codex): surface commentary as interim assistant prose

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -596,6 +596,33 @@ def _item_field(item: Any, name: str, default: Any = None) -> Any:
     return value if value is not None else default
 
 
+def _commentary_messages_from_output(output: Any) -> List[tuple[Any, str]]:
+    """Extract completed Harmony commentary messages from a concrete response."""
+    messages: List[tuple[Any, str]] = []
+    if not isinstance(output, list):
+        return messages
+    for output_index, item in enumerate(output):
+        if _item_field(item, "type", "") != "message":
+            continue
+        phase = _item_field(item, "phase", None)
+        if not isinstance(phase, str) or phase.strip().lower() != "commentary":
+            continue
+        chunks: List[str] = []
+        content = _item_field(item, "content", [])
+        if isinstance(content, list):
+            for part in content:
+                if _item_field(part, "type", "") != "output_text":
+                    continue
+                text = _item_field(part, "text", "")
+                if isinstance(text, str):
+                    chunks.append(text)
+        text = "".join(chunks).strip()
+        if text:
+            item_id = _item_field(item, "id", None)
+            messages.append((item_id if item_id is not None else output_index, text))
+    return messages
+
+
 def _raise_stream_error(event: Any) -> None:
     """Raise a ``_StreamErrorEvent`` from a ``type=error`` SSE frame.
 
@@ -617,6 +644,8 @@ def _consume_codex_event_stream(
     model: str,
     on_text_delta=None,
     on_reasoning_delta=None,
+    on_commentary_message=None,
+    commentary_emitted_keys=None,
     on_first_delta=None,
     on_event=None,
     interrupt_check=None,
@@ -648,7 +677,12 @@ def _consume_codex_event_stream(
     * ``on_text_delta(str)`` — fires per ``response.output_text.delta``, suppressed
       once a function_call event is seen (so tool-call turns don't bleed text
       into the chat).
-    * ``on_reasoning_delta(str)`` — fires per ``response.reasoning.*.delta``.
+    * ``on_reasoning_delta(str)`` — fires per ``response.reasoning.*.delta`` and
+      per Harmony ``analysis`` message deltas.
+    * ``on_commentary_message(str)`` — fires once per assembled Harmony
+      ``commentary`` message. Commentary is user-facing mid-turn narration; it
+      must not be merged into final assistant text, but it should remain visible
+      through the interim-assistant channel when one exists.
     * ``on_first_delta()`` — one-shot, fires on the first text delta only.
     * ``on_event(event)`` — fires for every event before any other processing.
       Used for watchdog activity, debug logging, anything wire-shape-agnostic.
@@ -656,15 +690,94 @@ def _consume_codex_event_stream(
     """
     collected_output_items: List[Any] = []
     collected_text_deltas: List[str] = []
+    if commentary_emitted_keys is None:
+        commentary_emitted_keys = set()
     has_tool_calls = False
     first_delta_fired = False
-    active_message_phase: str | None = None
+    active_message_state: Dict[str, Any] | None = None
+    message_states: List[Dict[str, Any]] = []
+    message_state_by_alias: Dict[tuple[str, Any], Dict[str, Any]] = {}
     terminal_status: str = "completed"
     terminal_usage: Any = None
     terminal_response_id: str = None
     terminal_incomplete_details: Any = None
     terminal_error: Any = None
     saw_terminal = False
+
+    def _message_aliases(event: Any, item: Any = None) -> List[tuple[str, Any]]:
+        aliases: List[tuple[str, Any]] = []
+        item_id = _event_field(event, "item_id", None)
+        if item_id is None and item is not None:
+            item_id = _item_field(item, "id", None)
+        if item_id is not None:
+            aliases.append(("item_id", item_id))
+        output_index = _event_field(event, "output_index", None)
+        if output_index is not None:
+            aliases.append(("output_index", output_index))
+        return aliases
+
+    def _message_state(
+        event: Any,
+        item: Any = None,
+        *,
+        create: bool = False,
+        force_new: bool = False,
+    ) -> Dict[str, Any] | None:
+        nonlocal active_message_state
+        aliases = _message_aliases(event, item)
+        state = next((message_state_by_alias[a] for a in aliases if a in message_state_by_alias), None)
+        if state is None and not aliases and not force_new:
+            state = active_message_state
+        if state is None and create:
+            state = {
+                "phase": None,
+                "parts": [],
+                "emitted": False,
+                "done": False,
+                "aliases": set(),
+            }
+            message_states.append(state)
+        if state is not None:
+            for alias in aliases:
+                message_state_by_alias[alias] = state
+                state["aliases"].add(alias)
+        return state
+
+    def _completed_message_text(item: Any) -> str:
+        chunks: List[str] = []
+        content = _item_field(item, "content", [])
+        if not isinstance(content, list):
+            return ""
+        for part in content:
+            if _item_field(part, "type", "") != "output_text":
+                continue
+            text = _item_field(part, "text", "")
+            if isinstance(text, str):
+                chunks.append(text)
+        return "".join(chunks).strip()
+
+    def _flush_commentary_state(state: Dict[str, Any] | None) -> None:
+        if state is None or state.get("phase") != "commentary" or state.get("emitted"):
+            return
+        text = "".join(state.get("parts") or []).strip()
+        if not text:
+            return
+        aliases = tuple(sorted(state.get("aliases") or (), key=repr))
+        emission_key = (aliases or (("text", text),), text)
+        state["emitted"] = True
+        if emission_key in commentary_emitted_keys:
+            return
+        commentary_emitted_keys.add(emission_key)
+        if on_commentary_message is None:
+            return
+        try:
+            on_commentary_message(text)
+        except Exception:
+            logger.debug("Codex stream on_commentary_message raised", exc_info=True)
+
+    def _flush_all_commentary_states() -> None:
+        for state in message_states:
+            _flush_commentary_state(state)
 
     for event in event_iter:
         if on_event is not None:
@@ -693,28 +806,51 @@ def _consume_codex_event_stream(
             _raise_stream_error(event)
 
         # Track the phase of the active streamed message item.  Codex/Harmony
-        # ``commentary``/``analysis`` text is mid-turn preamble/progress
-        # narration, never the final answer.  We still collect completed output
-        # items for replay, but route those deltas to the reasoning callback so
-        # they display like thinking text instead of assistant content.
+        # ``commentary`` text is user-facing mid-turn preamble/progress
+        # narration; route it to the interim-assistant channel in one assembled
+        # chunk so WebUI/gateway users understand why tools are being used.
+        # ``analysis`` remains private reasoning and must not become visible
+        # assistant text.  Neither phase is part of the final answer.
         if event_type == "response.output_item.added":
             item = _event_field(event, "item")
             item_type = _item_field(item, "type", "")
             if item_type == "message":
+                state = _message_state(event, item, create=True, force_new=True)
                 phase = _item_field(item, "phase", None)
-                active_message_phase = phase.strip().lower() if isinstance(phase, str) else None
+                state["phase"] = phase.strip().lower() if isinstance(phase, str) else None
+                active_message_state = state
             else:
-                active_message_phase = None
-            if "function_call" in str(item_type):
-                has_tool_calls = True
+                if "function_call" in str(item_type):
+                    has_tool_calls = True
+                active_message_state = None
             continue
 
-        if "output_text.delta" in event_type or event_type == "response.output_text.delta":
+        if event_type == "response.output_text.delta":
             delta_text = _event_field(event, "delta", "")
-            is_commentary_delta = active_message_phase in {"commentary", "analysis"}
-            if delta_text and is_commentary_delta:
-                # Commentary streams through the reasoning channel, not the
-                # visible answer stream (and stays out of output_text).
+            aliases = _message_aliases(event)
+            state = _message_state(event)
+            unresolved_states = [s for s in message_states if not s.get("done")]
+            # If several message items are still open and the delta carries no
+            # identity, correlation is impossible. Fail closed through the
+            # private reasoning lane rather than risk exposing analysis as final
+            # text or interim commentary.
+            ambiguous_unidentified = (
+                not aliases
+                and bool(unresolved_states)
+                and (state is None or len(unresolved_states) > 1)
+            )
+            if delta_text and ambiguous_unidentified:
+                if on_reasoning_delta is not None:
+                    try:
+                        on_reasoning_delta(delta_text)
+                    except Exception:
+                        logger.debug("Codex stream on_reasoning_delta raised", exc_info=True)
+                continue
+            phase = state.get("phase") if state is not None else None
+            if delta_text and phase == "commentary":
+                if not state.get("emitted"):
+                    state["parts"].append(delta_text)
+            elif delta_text and phase == "analysis":
                 if on_reasoning_delta is not None:
                     try:
                         on_reasoning_delta(delta_text)
@@ -737,6 +873,14 @@ def _consume_codex_event_stream(
                             logger.debug("Codex stream on_text_delta raised", exc_info=True)
             continue
 
+        if event_type == "response.output_text.done":
+            state = _message_state(event)
+            if state is not None and state.get("phase") == "commentary" and not state.get("parts"):
+                text = _event_field(event, "text", "")
+                if isinstance(text, str) and text:
+                    state["parts"].append(text)
+            continue
+
         if "function_call" in event_type:
             has_tool_calls = True
             # fall through — function_call items still get added on output_item.done
@@ -752,11 +896,26 @@ def _consume_codex_event_stream(
 
         if event_type == "response.output_item.done":
             done_item = _event_field(event, "item")
+            is_message = _item_field(done_item, "type", "") == "message"
+            state = _message_state(event, done_item, create=is_message)
+            if state is not None and state.get("phase") is None:
+                phase = _item_field(done_item, "phase", None)
+                state["phase"] = phase.strip().lower() if isinstance(phase, str) else None
+            if state is not None and state.get("phase") == "commentary" and not state.get("parts"):
+                completed_text = _completed_message_text(done_item)
+                if completed_text:
+                    state["parts"].append(completed_text)
+            _flush_commentary_state(state)
+            if state is not None:
+                state["done"] = True
             if done_item is not None:
                 collected_output_items.append(done_item)
+            if state is active_message_state:
+                active_message_state = None
             continue
 
         if event_type in _TERMINAL_EVENT_TYPES:
+            _flush_all_commentary_states()
             saw_terminal = True
             resp_obj = _event_field(event, "response")
             if resp_obj is not None:
@@ -788,6 +947,10 @@ def _consume_codex_event_stream(
                 terminal_status = terminal_status or "failed"
             # Stop on terminal event.
             break
+
+    # If the stream ended without a normal item boundary, still surface any
+    # assembled user-facing commentary before we inspect the final output.
+    _flush_all_commentary_states()
 
     # Build the final output list.  Prefer items observed via output_item.done;
     # if none arrived but we streamed plain text deltas (no tool calls), synthesize
@@ -846,6 +1009,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     max_stream_retries = 1
     # Accumulate streamed text so callers / compat shims can read it.
     agent._codex_streamed_text_parts: list = []
+    # A transport retry replays the same response item ids/output indexes. Keep
+    # commentary delivery idempotent across attempts while preserving distinct
+    # messages within one response.
+    commentary_emitted_keys = set()
 
     def _on_text_delta(text: str) -> None:
         agent._codex_streamed_text_parts.append(text)
@@ -853,6 +1020,9 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
     def _on_reasoning_delta(text: str) -> None:
         agent._fire_reasoning_delta(text)
+
+    def _on_commentary_message(text: str) -> None:
+        agent._emit_interim_assistant_message({"role": "assistant", "content": text})
 
     def _on_event(event: Any) -> None:
         # TTFB watchdog and activity touch — runs once per SSE event.
@@ -883,8 +1053,15 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
         try:
             # Compatibility: some mocks/providers return a concrete response
-            # instead of an iterable.  Pass it straight through.
+            # instead of an iterable. Surface explicit commentary message items
+            # through the same interim-assistant path before returning it.
             if hasattr(event_stream, "output") and not hasattr(event_stream, "__iter__"):
+                for item_key, text in _commentary_messages_from_output(event_stream.output):
+                    emission_key = (("item_id", item_key), text)
+                    if emission_key in commentary_emitted_keys:
+                        continue
+                    commentary_emitted_keys.add(emission_key)
+                    _on_commentary_message(text)
                 return event_stream
 
             try:
@@ -893,6 +1070,8 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     model=api_kwargs.get("model"),
                     on_text_delta=_on_text_delta,
                     on_reasoning_delta=_on_reasoning_delta,
+                    on_commentary_message=_on_commentary_message,
+                    commentary_emitted_keys=commentary_emitted_keys,
                     on_first_delta=on_first_delta,
                     on_event=_on_event,
                     interrupt_check=_interrupt_check,

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -629,7 +629,7 @@ def test_run_codex_stream_returns_collected_items_when_stream_ends_without_termi
     assert response.output == [output_item]
 
 
-def test_consume_codex_stream_routes_commentary_phase_deltas_to_reasoning(monkeypatch):
+def test_consume_codex_stream_routes_commentary_phase_deltas_to_interim(monkeypatch):
     from agent.codex_runtime import _consume_codex_event_stream
 
     commentary_item = SimpleNamespace(
@@ -647,6 +647,7 @@ def test_consume_codex_stream_routes_commentary_phase_deltas_to_reasoning(monkey
     )
     streamed = []
     reasoning_streamed = []
+    interim_commentary = []
 
     response = _consume_codex_event_stream(
         _FakeCreateStream([
@@ -667,11 +668,317 @@ def test_consume_codex_stream_routes_commentary_phase_deltas_to_reasoning(monkey
         model="gpt-5-codex",
         on_text_delta=streamed.append,
         on_reasoning_delta=reasoning_streamed.append,
+        on_commentary_message=interim_commentary.append,
     )
 
     assert streamed == []
-    assert reasoning_streamed == ["I’ll call the tool now."]
+    assert reasoning_streamed == []
+    assert interim_commentary == ["I’ll call the tool now."]
     assert response.output == [commentary_item, function_item]
+    assert response.output_text == ""
+
+
+def test_consume_codex_stream_uses_output_text_done_as_commentary_fallback(monkeypatch):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    commentary_item = SimpleNamespace(
+        type="message",
+        id="msg_commentary",
+        phase="commentary",
+        content=[SimpleNamespace(type="output_text", text="I’ll inspect the logs.")],
+    )
+    interim_commentary = []
+
+    _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(type="message", id="msg_commentary", phase="commentary"),
+            ),
+            SimpleNamespace(
+                type="response.output_text.done",
+                item_id="msg_commentary",
+                output_index=0,
+                text="I’ll inspect the logs.",
+            ),
+            SimpleNamespace(type="response.output_item.done", output_index=0, item=commentary_item),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+        ]),
+        model="gpt-5-codex",
+        on_commentary_message=interim_commentary.append,
+    )
+
+    assert interim_commentary == ["I’ll inspect the logs."]
+
+
+def test_consume_codex_stream_uses_completed_item_as_commentary_fallback(monkeypatch):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    commentary_item = SimpleNamespace(
+        type="message",
+        id="msg_commentary",
+        phase="commentary",
+        content=[SimpleNamespace(type="output_text", text="I’ll inspect the logs.")],
+    )
+    interim_commentary = []
+
+    _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(type="response.output_item.done", output_index=0, item=commentary_item),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+        ]),
+        model="gpt-5-codex",
+        on_commentary_message=interim_commentary.append,
+    )
+
+    assert interim_commentary == ["I’ll inspect the logs."]
+
+
+def test_consume_codex_stream_tracks_interleaved_message_items(monkeypatch):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    commentary_item = SimpleNamespace(
+        type="message",
+        id="msg_commentary",
+        phase="commentary",
+        content=[SimpleNamespace(type="output_text", text="I’ll inspect the logs now.")],
+    )
+    final_item = SimpleNamespace(
+        type="message",
+        id="msg_final",
+        phase="final_answer",
+        content=[SimpleNamespace(type="output_text", text="Final answer.")],
+    )
+    interim_commentary = []
+    visible_text = []
+    reasoning_text = []
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(type="message", id="msg_commentary", phase="commentary"),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_commentary",
+                output_index=0,
+                delta="I’ll inspect ",
+            ),
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=1,
+                item=SimpleNamespace(type="message", id="msg_final", phase="final_answer"),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_final",
+                output_index=1,
+                delta="Final answer.",
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_commentary",
+                output_index=0,
+                delta="the logs now.",
+            ),
+            SimpleNamespace(
+                type="response.reasoning_summary_text.delta",
+                delta="Validated the event routing.",
+            ),
+            SimpleNamespace(type="response.output_item.done", output_index=0, item=commentary_item),
+            SimpleNamespace(type="response.output_item.done", output_index=1, item=final_item),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+        ]),
+        model="gpt-5-codex",
+        on_text_delta=visible_text.append,
+        on_reasoning_delta=reasoning_text.append,
+        on_commentary_message=interim_commentary.append,
+    )
+
+    assert interim_commentary == ["I’ll inspect the logs now."]
+    assert visible_text == ["Final answer."]
+    assert reasoning_text == ["Validated the event routing."]
+    assert response.output_text == "Final answer."
+
+
+def test_run_codex_stream_deduplicates_commentary_across_transport_retry(monkeypatch):
+    import httpx
+
+    agent = _build_agent(monkeypatch)
+    interim_commentary = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: interim_commentary.append(text)
+    )
+    commentary_item = SimpleNamespace(
+        type="message",
+        id="msg_commentary",
+        phase="commentary",
+        content=[SimpleNamespace(type="output_text", text="I’ll inspect the logs.")],
+    )
+    calls = {"create": 0}
+
+    class _FailAfterCommentary:
+        def __iter__(self):
+            yield SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(type="message", id="msg_commentary", phase="commentary"),
+            )
+            yield SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_commentary",
+                output_index=0,
+                delta="I’ll inspect the logs.",
+            )
+            yield SimpleNamespace(type="response.output_item.done", output_index=0, item=commentary_item)
+            raise httpx.RemoteProtocolError("stream disconnected")
+
+        def close(self):
+            pass
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        if calls["create"] == 1:
+            return _FailAfterCommentary()
+        return _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(type="message", id="msg_commentary", phase="commentary"),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_commentary",
+                output_index=0,
+                delta="I’ll inspect the logs.",
+            ),
+            SimpleNamespace(type="response.output_item.done", output_index=0, item=commentary_item),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+        ])
+
+    agent.client = SimpleNamespace(responses=SimpleNamespace(create=_create))
+
+    agent._run_codex_stream(_codex_request_kwargs())
+
+    assert calls["create"] == 2
+    assert interim_commentary == ["I’ll inspect the logs."]
+
+
+def test_run_codex_stream_surfaces_commentary_from_concrete_response(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    interim_commentary = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: interim_commentary.append(text)
+    )
+    response = SimpleNamespace(
+        output=[SimpleNamespace(
+            type="message",
+            id="msg_commentary",
+            phase="commentary",
+            content=[SimpleNamespace(type="output_text", text="I’ll inspect the logs.")],
+        )],
+        output_text="",
+        status="completed",
+    )
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: response)
+    )
+
+    returned = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert returned is response
+    assert interim_commentary == ["I’ll inspect the logs."]
+
+
+def test_consume_codex_stream_waits_for_commentary_after_interleaved_function_call(monkeypatch):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    commentary_item = SimpleNamespace(
+        type="message",
+        id="msg_commentary",
+        phase="commentary",
+        content=[SimpleNamespace(type="output_text", text="First second")],
+    )
+    function_item = SimpleNamespace(
+        type="function_call",
+        id="call_1",
+        name="terminal",
+        arguments="{}",
+    )
+    commentary = []
+
+    _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(type="message", id="msg_commentary", phase="commentary"),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_commentary",
+                output_index=0,
+                delta="First ",
+            ),
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=1,
+                item=SimpleNamespace(type="function_call", id="call_1"),
+            ),
+            SimpleNamespace(
+                type="response.output_text.delta",
+                item_id="msg_commentary",
+                output_index=0,
+                delta="second",
+            ),
+            SimpleNamespace(type="response.output_item.done", output_index=0, item=commentary_item),
+            SimpleNamespace(type="response.output_item.done", output_index=1, item=function_item),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+        ]),
+        model="gpt-5-codex",
+        on_commentary_message=commentary.append,
+    )
+
+    assert commentary == ["First second"]
+
+
+def test_consume_codex_stream_fails_closed_for_unidentified_interleaved_delta(monkeypatch):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    commentary = []
+    reasoning = []
+    visible = []
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", phase="commentary"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta="Public preface."),
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", phase="analysis"),
+            ),
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="function_call"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta="PRIVATE"),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+        ]),
+        model="gpt-5-codex",
+        on_text_delta=visible.append,
+        on_reasoning_delta=reasoning.append,
+        on_commentary_message=commentary.append,
+    )
+
+    assert commentary == ["Public preface."]
+    assert reasoning == ["PRIVATE"]
+    assert visible == []
     assert response.output_text == ""
 
 
@@ -2124,6 +2431,74 @@ def test_stream_delta_preserves_code_fence_newlines(monkeypatch):
     combined = "".join(observed)
     assert "```python\n" in combined
     assert combined.startswith("Here is the code:\n```python\n")
+
+
+def test_codex_stream_commentary_phase_emits_interim_not_reasoning(monkeypatch):
+    """Codex Harmony commentary is user-facing progress narration.
+
+    It must be visible as one interim-assistant message, but must not be routed
+    through final answer deltas or the private reasoning stream.
+    """
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    commentary = []
+    reasoning = []
+    visible_text = []
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(type="message", phase="commentary"),
+        ),
+        SimpleNamespace(type="response.output_text.delta", delta="Je vais vérifier "),
+        SimpleNamespace(type="response.output_text.delta", delta="la WebUI."),
+        SimpleNamespace(type="response.output_item.done", item=SimpleNamespace(type="message", phase="commentary")),
+        SimpleNamespace(type="response.output_item.added", item=SimpleNamespace(type="function_call")),
+        SimpleNamespace(type="response.function_call_arguments.delta", delta='{}'),
+        SimpleNamespace(
+            type="response.output_item.done",
+            item=SimpleNamespace(type="function_call", name="terminal", arguments="{}"),
+        ),
+        SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+    ]
+
+    _consume_codex_event_stream(
+        events,
+        model="gpt-5-codex",
+        on_text_delta=visible_text.append,
+        on_reasoning_delta=reasoning.append,
+        on_commentary_message=commentary.append,
+    )
+
+    assert commentary == ["Je vais vérifier la WebUI."]
+    assert reasoning == []
+    assert visible_text == []
+
+
+def test_codex_stream_analysis_phase_stays_reasoning(monkeypatch):
+    """Codex Harmony analysis is private reasoning and must not become interim prose."""
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    commentary = []
+    reasoning = []
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(type="message", phase="analysis"),
+        ),
+        SimpleNamespace(type="response.output_text.delta", delta="private deliberation"),
+        SimpleNamespace(type="response.output_item.done", item=SimpleNamespace(type="message", phase="analysis")),
+        SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed")),
+    ]
+
+    _consume_codex_event_stream(
+        events,
+        model="gpt-5-codex",
+        on_reasoning_delta=reasoning.append,
+        on_commentary_message=commentary.append,
+    )
+
+    assert commentary == []
+    assert reasoning == ["private deliberation"]
 
 
 def test_run_conversation_codex_continues_after_commentary_phase_message(monkeypatch):


### PR DESCRIPTION
## Summary

- route Codex/Harmony `commentary` phase deltas to the `interim_assistant` channel as one assembled message
- keep Codex/Harmony `analysis` phase deltas in the private reasoning path
- keep commentary out of final assistant text / `output_text`, preserving the existing final-answer behavior

## Why

Recent Codex runtime changes correctly stopped treating commentary as final assistant text, but routed both `commentary` and `analysis` through the reasoning callback. In WebUI and gateway surfaces where raw reasoning is hidden, that removed the useful high-level “why I’m doing this next” narration and left users with only tool cards or generic tool labels.

`commentary` is intended as user-facing mid-turn narration; `analysis` is private reasoning. This patch restores that distinction.

## Tests

- `python3 -m py_compile agent/codex_runtime.py`
- `python3 -m pytest tests/run_agent/test_run_agent_codex_responses.py -q`
