### PR TITLE
fix(desktop): add NSContactsUsageDescription to macOS entitlements and Info.plist

### DIFF
--- a/apps/desktop/electron/entitlements.mac.inherit.plist
+++ b/apps/desktop/electron/entitlements.mac.inherit.plist
@@ -10,5 +10,7 @@
   <true/>
   <key>com.apple.security.device.audio-input</key>
   <true/>
+  <key>com.apple.security.personal-information.addressbook</key>
+  <true/>
 </dict>
 </plist>

--- a/apps/desktop/electron/entitlements.mac.plist
+++ b/apps/desktop/electron/entitlements.mac.plist
@@ -10,5 +10,7 @@
   <true/>
   <key>com.apple.security.device.audio-input</key>
   <true/>
+  <key>com.apple.security.personal-information.addressbook</key>
+  <true/>
 </dict>
 </plist>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -204,6 +204,7 @@
         "CFBundleExecutable": "Hermes",
         "CFBundleName": "Hermes",
         "NSAudioCaptureUsageDescription": "Hermes uses audio capture for voice conversations.",
+        "NSContactsUsageDescription": "Hermes accesses your contacts to read and manage contact information through MCP tools and integrations.",
         "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations."
       },
       "gatekeeperAssess": false,


### PR DESCRIPTION
## Summary

Adds the missing `NSContactsUsageDescription` key to both the hardened runtime entitlements and the Info.plist `extendInfo` section for the macOS desktop app.

## Problem

Without this key, macOS silently denies Contacts access instead of showing the standard permission prompt, causing tools that read Apple Contacts via `Contacts.framework` to fail with a denied error. This works in CLI because permission is granted to the terminal, but the desktop app has no entitlement.

## Changes

- **`entitlements.mac.plist`**: Added `com.apple.security.personal-information.addressbook` entitlement
- **`entitlements.mac.inherit.plist`**: Same entitlement for child processes  
- **`package.json`**: Added `NSContactsUsageDescription` to electron-builder `extendInfo` so it appears in `Info.plist`

## Testing

- Verified the plist XML is well-formed
- Verified the entitlements include the new key
- Issue reporter confirmed this resolves the silent denial

Fixes #59482