### PR TITLE
fix(tui): render absolute-positioned children of a zero-height parent

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -545,7 +545,17 @@ function renderNodeToOutput(
     // can give a box h=0 while still leaving a row for it (next sibling at
     // y+1, not y). HelpV2's third shortcuts column hits this — skipping
     // unconditionally drops "ctrl + z to suspend" from /help output.
-    if (height === 0 && siblingSharesY(node, yogaNode)) {
+    //
+    // hasAbsoluteChild exception: a node with no normal-flow content (h=0)
+    // but a position='absolute' child (e.g. the composer's FloatingOverlays
+    // wrapper when the input row is hidden behind an open overlay) still has
+    // real, off-flow content to paint. Skipping here marks it clean with a
+    // cached rect, so every later frame takes the blit-fast-path above and
+    // never descends into renderChildren again — the overlay (model picker,
+    // pager, sessions switcher, pet/skills/plugins hub, completions menu)
+    // mounts, its own effects/RPCs resolve, but it never actually paints.
+    // Falling through here lets the absolute child render on its own terms.
+    if (height === 0 && siblingSharesY(node, yogaNode) && !hasAbsoluteChild(node)) {
       nodeCache.set(node, { x, y, width, height, top: yogaTop })
       node.dirty = false
 
@@ -1388,6 +1398,20 @@ function clipsBothAxes(node: DOMElement): boolean {
   const oy = node.style.overflowY ?? node.style.overflow
 
   return (ox === 'hidden' || ox === 'scroll') && (oy === 'hidden' || oy === 'scroll')
+}
+
+// A node squeezed to h=0 can still have position='absolute' children —
+// Yoga excludes absolutely-positioned children from a parent's intrinsic
+// height, so h===0 only means "no normal-flow content", not "nothing to
+// paint" (see the h===0 && siblingSharesY skip above, which this guards).
+function hasAbsoluteChild(node: DOMElement): boolean {
+  for (const child of node.childNodes) {
+    if ((child as DOMElement).style?.position === 'absolute') {
+      return true
+    }
+  }
+
+  return false
 }
 
 // When Yoga squeezes a box to h=0, the ghost only happens if a sibling

--- a/ui-tui/packages/hermes-ink/src/ink/zero-height-absolute-overlay.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/zero-height-absolute-overlay.test.ts
@@ -1,0 +1,103 @@
+import { EventEmitter } from 'events'
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import Box from './components/Box.js'
+import Text from './components/Text.js'
+import Ink from './ink.js'
+
+// Regression: the bare `/model` slash command (and any other
+// FloatingOverlays-based overlay — pager, sessions switcher, pet/skills/
+// plugins hub, completions menu) silently failed to paint. React committed
+// the overlay correctly (state set, component mounted, RPC resolved), but
+// nothing ever appeared on screen.
+//
+// Root cause: the ui-tui composer wraps its floating overlays in a plain
+// <Box position="relative"> that has NO other normal-flow children while an
+// overlay is open (the input row is hidden behind it) — its only child is
+// the overlay's own <Box position="absolute" bottom="100%">. Yoga excludes
+// absolutely-positioned children from a parent's intrinsic height, so that
+// wrapper computes height=0. render-node-to-output.ts has an optimization
+// that SKIPS rendering (and marks clean) any node with height=0 whose next/
+// previous sibling lands on the same row — added to stop a genuine ghosting
+// bug (HelpV2's shortcuts column) where a squeezed, genuinely-empty box
+// could leave stale characters behind. But it doesn't distinguish "empty"
+// from "zero-height parent of an absolute-positioned child with real
+// content" — so it discarded the whole overlay subtree and marked the
+// wrapper clean, meaning every subsequent frame took the blit-fast-path and
+// never descended into it again. The overlay was mounted forever, invisible
+// forever.
+class FakeTty extends EventEmitter {
+  chunks: string[] = []
+  columns = 20
+  rows = 6
+  isTTY = true
+
+  write(chunk: string | Uint8Array, cb?: (err?: Error | null) => void): boolean {
+    this.chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'))
+    cb?.()
+
+    return true
+  }
+}
+
+const makeInk = () => {
+  const stdout = new FakeTty()
+  const stdin = new EventEmitter() as unknown as NodeJS.ReadStream
+  const stderr = new FakeTty()
+
+  const ink = new Ink({
+    exitOnCtrlC: false,
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  return { ink, stdout }
+}
+
+describe('zero-height node with an absolute-positioned child', () => {
+  it('still paints the absolute child even when squeezed to h=0 and sharing a row with a sibling', () => {
+    const { ink, stdout } = makeInk()
+
+    // Structurally mirrors ComposerPane's <Box position="relative"> wrapper
+    // around <FloatingOverlays/>: a column of siblings where the middle box
+    // has ONLY an absolute-positioned child (so Yoga gives it h=0), landing
+    // it on the same row as the sibling below — the exact trigger for the
+    // h===0 && siblingSharesY skip.
+    const tree = React.createElement(
+      Box,
+      { flexDirection: 'column' },
+      React.createElement(Text, { key: 'before' }, 'before'),
+      // Blank spacer row: the absolute overlay's bottom='100%' extends
+      // upward from the h=0 wrapper's top edge by the overlay's own
+      // content height (1 line), landing here rather than on 'before'.
+      React.createElement(Box, { flexShrink: 0, height: 1, key: 'spacer' }),
+      React.createElement(
+        Box,
+        { key: 'wrapper', position: 'relative' },
+        React.createElement(
+          Box,
+          { bottom: '100%', left: 0, position: 'absolute', right: 0 },
+          React.createElement(Text, null, 'OVERLAY-CONTENT')
+        )
+      ),
+      React.createElement(Text, { key: 'after' }, 'after')
+    )
+
+    ink.render(tree)
+    ink.onRender()
+
+    const out = stdout.chunks.join('')
+
+    expect(out).toContain('before')
+    expect(out).toContain('after')
+    // This is the assertion that fails without the hasAbsoluteChild guard:
+    // the overlay's own text never reaches the terminal at all.
+    expect(out).toContain('OVERLAY-CONTENT')
+
+    ink.unmount()
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes the bare `/model` slash command (and every other `FloatingOverlays`-based overlay — `/resume`, `/pager`, the sessions switcher, pet/skills/plugins hub, the completions menu) silently doing nothing in the TUI: the command echoes to the transcript, the busy-guard correctly passes, `$overlayState` correctly flips, the overlay component correctly mounts, its RPC correctly resolves — and nothing ever paints to the terminal. No error, no spinner, indefinitely.

**Root cause:** the composer wraps `FloatingOverlays` in a plain `<Box position="relative">` that has no other normal-flow children while an overlay is open (the input row is hidden). Yoga excludes `position: absolute` children from a parent's intrinsic height, so that wrapper computes `height=0`. `render-node-to-output.ts` has an optimization that skips rendering (and marks the node clean) for any zero-height node whose sibling shares its row — added earlier to prevent a real text-ghosting bug in HelpV2's shortcuts column. It doesn't distinguish "genuinely empty" from "zero-height parent of a real, off-flow absolute child," so it discards the whole overlay subtree on the very first frame and caches the wrapper as clean. Every subsequent frame then takes the blit fast-path and never descends into it again — the overlay is mounted forever, invisible forever.

This is why the fix in #48045 (anchor swap for `tui_statusbar: bottom`) doesn't touch this: that's a different precondition in the same fragile area (overlay positioning relative to a sibling), not the zero-height-skip itself. I tested #47978's exact repro against unpatched `main` and it does **not** reproduce this bug's complete blackout — it shows a different, milder rendering artifact — so this PR doesn't claim to fix #47978, only #14907.

## Related Issue

Fixes #14907

(That issue's thread stalled after a contributor correctly identified the precondition — *"the parent Box in ComposerPane can now collapse to zero height when isBlocked hides the input subtree"* — but never found the actual mechanism inside the renderer that turns that precondition into a permanent invisible render. This PR is that missing piece.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts`: added a `hasAbsoluteChild(node)` helper and guarded the existing zero-height skip with `&& !hasAbsoluteChild(node)`, so a node is only skipped when it's genuinely empty, not when its only content is a `position: absolute` child waiting to paint. The original HelpV2 ghost-prevention behavior is unchanged for every node without an absolute child.
- `ui-tui/packages/hermes-ink/src/ink/zero-height-absolute-overlay.test.ts` (new): renders a tree structurally equivalent to the composer's overlay wrapper through the real Ink+Yoga pipeline and asserts the absolute child's text actually reaches the captured terminal output. Verified it fails without the guard and passes with it (TDD).

## How to Test

1. On unpatched `main`, run the TUI (`HERMES_TUI=1 hermes`), type `/model`, press Enter. The command echoes to the transcript, the status bar stays "ready," and nothing else happens — no picker, no error.
2. Apply this patch, relaunch, repeat the same steps. The provider picker overlay renders immediately, fully populated.
3. `cd ui-tui && npm run typecheck && npm run lint && npx prettier --check packages/hermes-ink/src/ink/render-node-to-output.ts packages/hermes-ink/src/ink/zero-height-absolute-overlay.test.ts` — all clean.
4. `cd ui-tui && npx vitest run packages/hermes-ink/src/ink/zero-height-absolute-overlay.test.ts` — passes; temporarily reverting the `hasAbsoluteChild` guard makes it fail with the predicted symptom (overlay content missing from captured output).
5. Full `hermes-ink` package suite (`cd ui-tui/packages/hermes-ink && npx vitest run`) — 119 passed, 1 skipped, no regressions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tui): ...`)
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate — found #14907 (this fixes it), #47978/#48045 (related but distinct, does not conflict), #15094 (closed, earlier instance of this bug family, unrelated fix)
- [x] My PR contains only changes related to this fix (2 files, +128/-1)
- [ ] I've run `pytest tests/ -q` and all tests pass — **N/A: this diff touches zero Python files** (only `ui-tui/packages/hermes-ink/src/ink/*`); the Python suite is unaffected. TypeScript-side verification instead: `npm run typecheck`, `npm run lint`, `prettier --check`, and the full `hermes-ink` vitest suite all pass clean (see above).
- [x] I've added tests for my changes — new regression test, TDD-verified fail-then-pass
- [x] I've tested on my platform: macOS (Sequoia, Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing docs describe this internal rendering behavior
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture/workflow change
- [x] I've considered cross-platform impact — N/A, Ink's render pipeline is terminal-based and platform-independent; the bug and fix are in Yoga layout math, not OS-specific code
- [x] I've updated tool descriptions/schemas — N/A, no tool behavior changed

## Screenshots / Logs

Before (unpatched `main`, `tui_statusbar` default):
```
❯ · /model
─ ready │ opus 4.8 xhigh │ 8m 10s │ voice off │ 1 session
```
(nothing else — no picker, no error, indefinitely)

After (this patch):
```
╔══════════════════════════════════════════════╗
║ Select provider (step 1/2)                    ║
║ Full model IDs on the next step · Enter to... ║
║ Current: claude-opus-4-8                      ║
║ ...39 providers listed, fully interactive...  ║
╚══════════════════════════════════════════════╝
```
