### PR TITLE
fix(bootstrap): enable Windows VT processing for ANSI escape codes

### DIFF
--- a/hermes_bootstrap.py
+++ b/hermes_bootstrap.py
@@ -118,6 +118,31 @@ def apply_windows_utf8_bootstrap() -> bool:
             except (OSError, ValueError):
                 pass
 
+    # 3. Enable Virtual Terminal Processing (ANSI escape codes) on the
+    #    console output handle so that hermes_cli/colors.py and Rich
+    #    color output renders correctly in Windows Terminal, CMD, and
+    #    PowerShell.  Without this, escape sequences like \033[35m are
+    #    printed as literal text.  ENABLE_VIRTUAL_TERMINAL_PROCESSING is
+    #    0x0004.  Non-fatal if it fails (e.g. redirected output, CI).
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        STD_OUTPUT_HANDLE = -11
+        handle = kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+        if handle and handle != -1:  # -1 is INVALID_HANDLE_VALUE
+            mode = wintypes.DWORD()
+            if kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+                ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+                new_mode = mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING
+                kernel32.SetConsoleMode(handle, new_mode)
+    except Exception:
+        # Non-fatal: if VT processing can't be enabled (old Windows,
+        # redirected output, CI), ANSI codes just won't render.  The
+        # CLI is still functional without color.
+        pass
+
     _bootstrap_applied = True
     return True
 


### PR DESCRIPTION
## Summary

Enables `ENABLE_VIRTUAL_TERMINAL_PROCESSING` on the Windows console output handle during the Hermes bootstrap phase, so that raw ANSI escape codes render correctly in Windows Terminal, CMD, and PowerShell.

## Problem

On Windows, ANSI escape sequences (like `\033[35m` for magenta) are printed as literal text instead of being interpreted as color codes. This affects `hermes setup`, `hermes model`, and other interactive wizards that use `hermes_cli/colors.py` raw ANSI codes. The terminal must have Virtual Terminal Processing enabled via the Win32 API before ANSI codes will be interpreted.

## Root Cause

`hermes_bootstrap.py` handles UTF-8 stdio setup on Windows but does not enable VT processing. The `hermes_cli/colors.py` module uses raw ANSI escape codes (`\033[...m`) and relies on the terminal being able to interpret them, but Windows terminals don't enable this by default.

## Fix

Added a Win32 `SetConsoleMode` call with `ENABLE_VIRTUAL_TERMINAL_PROCESSING` (0x0004) to `apply_windows_utf8_bootstrap()`. The call is wrapped in a try/except to be non-fatal on old Windows versions, redirected output, or CI environments.

## Testing

- Verified the ctypes call is syntactically correct on POSIX (guarded by _IS_WINDOWS)
- Verified the exception handling is robust (catches all exceptions)
- Issue reporter confirmed this is the correct fix path

Fixes #59397