### PR TITLE
Add wide preview control to Desktop

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { $paneStates } from '@/store/panes'
 import { $connection } from '@/store/session'
 
 import { PreviewPane } from './preview-pane'
@@ -15,6 +16,7 @@ describe('PreviewPane console state', () => {
 
   afterEach(() => {
     cleanup()
+    $paneStates.set({})
     $connection.set(null)
     vi.unstubAllGlobals()
   })
@@ -80,5 +82,44 @@ describe('PreviewPane console state', () => {
     })
 
     expect(setTitlebarToolGroup).toHaveBeenCalledTimes(initialCalls)
+  })
+
+  it('widens web previews near full width and restores the default width', () => {
+    vi.stubGlobal('innerWidth', 1600)
+    const setTitlebarToolGroup = vi.fn()
+
+    render(
+      <PreviewPane
+        setTitlebarToolGroup={setTitlebarToolGroup}
+        target={{
+          kind: 'url',
+          label: 'Preview',
+          source: 'http://localhost:5174',
+          url: 'http://localhost:5174'
+        }}
+      />
+    )
+
+    const tools = setTitlebarToolGroup.mock.calls.at(-1)?.[1] ?? []
+    const wideTool = tools.find((tool: { id: string }) => tool.id === 'preview-wide')
+
+    expect(wideTool?.label).toBe('Maximize preview width')
+
+    act(() => {
+      wideTool?.onSelect()
+    })
+
+    expect($paneStates.get().preview?.widthOverride).toBe(1440)
+
+    const updatedTools = setTitlebarToolGroup.mock.calls.at(-1)?.[1] ?? []
+    const restoreTool = updatedTools.find((tool: { id: string }) => tool.id === 'preview-wide')
+
+    expect(restoreTool?.label).toBe('Restore preview width')
+
+    act(() => {
+      restoreTool?.onSelect()
+    })
+
+    expect($paneStates.get().preview?.widthOverride).toBeUndefined()
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -121,8 +121,8 @@ function PreviewLoadError({
 }
 
 const TITLEBAR_GROUP_ID = 'preview'
-const WIDE_PREVIEW_RATIO = 0.72
-const WIDE_PREVIEW_CHAT_RESERVE_PX = 320
+const WIDE_PREVIEW_RATIO = 0.9
+const WIDE_PREVIEW_CHAT_RESERVE_PX = 160
 const WIDE_PREVIEW_MIN_WIDTH_PX = 720
 
 function widePreviewWidth() {
@@ -327,7 +327,7 @@ export function PreviewPane({
               active: widePreviewActive,
               icon: <Maximize />,
               id: `${TITLEBAR_GROUP_ID}-wide`,
-              label: widePreviewActive ? 'Restore preview width' : 'Widen preview',
+              label: widePreviewActive ? copy.restorePreviewWidth : copy.maximizePreviewWidth,
               onSelect: toggleWidePreview
             },
             {

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -6,9 +6,11 @@ import type { SetTitlebarToolGroup, TitlebarTool } from '@/app/shell/titlebar-co
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
-import { Bug } from '@/lib/icons'
+import { Bug, Maximize } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { PREVIEW_PANE_ID } from '@/store/layout'
 import { notify, notifyError } from '@/store/notifications'
+import { $paneWidthOverride, setPaneWidthOverride } from '@/store/panes'
 import { $previewServerRestart, failPreviewServerRestart, type PreviewTarget } from '@/store/preview'
 
 import {
@@ -119,6 +121,25 @@ function PreviewLoadError({
 }
 
 const TITLEBAR_GROUP_ID = 'preview'
+const WIDE_PREVIEW_RATIO = 0.72
+const WIDE_PREVIEW_CHAT_RESERVE_PX = 320
+const WIDE_PREVIEW_MIN_WIDTH_PX = 720
+
+function widePreviewWidth() {
+  const viewport = typeof window === 'undefined' ? 1440 : window.innerWidth
+  const maxWithoutCrushingChat = Math.max(WIDE_PREVIEW_MIN_WIDTH_PX, viewport - WIDE_PREVIEW_CHAT_RESERVE_PX)
+
+  return Math.round(Math.min(viewport * WIDE_PREVIEW_RATIO, maxWithoutCrushingChat))
+}
+
+function isWidePreviewWidth(width: number | undefined) {
+  if (width === undefined) {
+    return false
+  }
+
+  return Math.abs(width - widePreviewWidth()) <= 16
+}
+
 
 export function PreviewPane({
   embedded = false,
@@ -140,6 +161,8 @@ export function PreviewPane({
   const previewServerRestart = useStore($previewServerRestart)
   const consoleHeight = useStore(consoleState.$height)
   const consoleOpen = useStore(consoleState.$open)
+  const previewPaneWidthOverride = useStore($paneWidthOverride(PREVIEW_PANE_ID))
+  const widePreviewActive = isWidePreviewWidth(previewPaneWidthOverride)
   const [currentUrl, setCurrentUrl] = useState(target.url)
   const [devtoolsOpen, setDevtoolsOpen] = useState(false)
   const [loading, setLoading] = useState(true)
@@ -282,6 +305,16 @@ export function PreviewPane({
     setDevtoolsOpen(true)
   }, [])
 
+  const toggleWidePreview = useCallback(() => {
+    if (widePreviewActive) {
+      setPaneWidthOverride(PREVIEW_PANE_ID, undefined)
+
+      return
+    }
+
+    setPaneWidthOverride(PREVIEW_PANE_ID, widePreviewWidth())
+  }, [widePreviewActive])
+
   useEffect(() => {
     if (!setTitlebarToolGroup) {
       return
@@ -290,6 +323,13 @@ export function PreviewPane({
     const tools: TitlebarTool[] = [
       ...(isWebPreview
         ? [
+            {
+              active: widePreviewActive,
+              icon: <Maximize />,
+              id: `${TITLEBAR_GROUP_ID}-wide`,
+              label: widePreviewActive ? 'Restore preview width' : 'Widen preview',
+              onSelect: toggleWidePreview
+            },
             {
               active: consoleOpen,
               icon: <PreviewConsoleTitlebarIcon consoleState={consoleState} />,
@@ -311,7 +351,7 @@ export function PreviewPane({
     setTitlebarToolGroup(TITLEBAR_GROUP_ID, tools)
 
     return () => setTitlebarToolGroup(TITLEBAR_GROUP_ID, [])
-  }, [consoleOpen, consoleState, copy, devtoolsOpen, isWebPreview, setTitlebarToolGroup, toggleDevTools])
+  }, [consoleOpen, consoleState, copy, devtoolsOpen, isWebPreview, setTitlebarToolGroup, toggleDevTools, toggleWidePreview, widePreviewActive])
 
   useEffect(() => {
     if (!consoleOpen) {

--- a/apps/desktop/src/app/chat/right-rail/preview.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview.tsx
@@ -36,7 +36,7 @@ import { $dirtyPreviewUrls } from '@/store/preview-edit'
 import { PreviewPane } from './preview-pane'
 
 export const PREVIEW_RAIL_MIN_WIDTH = '18rem'
-export const PREVIEW_RAIL_MAX_WIDTH = '72vw'
+export const PREVIEW_RAIL_MAX_WIDTH = '90vw'
 
 const INTRINSIC = `clamp(${PREVIEW_RAIL_MIN_WIDTH}, 36vw, 32rem)`
 

--- a/apps/desktop/src/app/chat/right-rail/preview.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview.tsx
@@ -36,7 +36,7 @@ import { $dirtyPreviewUrls } from '@/store/preview-edit'
 import { PreviewPane } from './preview-pane'
 
 export const PREVIEW_RAIL_MIN_WIDTH = '18rem'
-export const PREVIEW_RAIL_MAX_WIDTH = '38rem'
+export const PREVIEW_RAIL_MAX_WIDTH = '72vw'
 
 const INTRINSIC = `clamp(${PREVIEW_RAIL_MIN_WIDTH}, 36vw, 32rem)`
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2189,6 +2189,8 @@ export const en: Translations = {
       restartFailed: 'Server restart failed',
       hideConsole: 'Hide preview console',
       showConsole: 'Show preview console',
+      maximizePreviewWidth: 'Maximize preview width',
+      restorePreviewWidth: 'Restore preview width',
       hideDevTools: 'Hide preview DevTools',
       openDevTools: 'Open preview DevTools',
       finishedRestarting: message => `Hermes finished restarting the preview server${message ? `: ${message}` : ''}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2167,6 +2167,8 @@ export const ja = defineLocale({
       restartFailed: 'サーバーの再起動に失敗しました',
       hideConsole: 'プレビューコンソールを非表示',
       showConsole: 'プレビューコンソールを表示',
+      maximizePreviewWidth: 'プレビュー幅を最大化',
+      restorePreviewWidth: 'プレビュー幅を戻す',
       hideDevTools: 'プレビュー DevTools を非表示',
       openDevTools: 'プレビュー DevTools を開く',
       finishedRestarting: message =>

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1829,6 +1829,8 @@ export interface Translations {
       restartFailed: string
       hideConsole: string
       showConsole: string
+      maximizePreviewWidth: string
+      restorePreviewWidth: string
       hideDevTools: string
       openDevTools: string
       finishedRestarting: (message?: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2104,6 +2104,8 @@ export const zhHant = defineLocale({
       restartFailed: '伺服器重新啟動失敗',
       hideConsole: '隱藏預覽主控台',
       showConsole: '顯示預覽主控台',
+      maximizePreviewWidth: '最大化預覽寬度',
+      restorePreviewWidth: '還原預覽寬度',
       hideDevTools: '隱藏預覽 DevTools',
       openDevTools: '開啟預覽 DevTools',
       finishedRestarting: message => `Hermes 已完成預覽伺服器重新啟動${message ? `：${message}` : ''}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2356,6 +2356,8 @@ export const zh: Translations = {
       restartFailed: '服务器重启失败',
       hideConsole: '隐藏预览控制台',
       showConsole: '显示预览控制台',
+      maximizePreviewWidth: '最大化预览宽度',
+      restorePreviewWidth: '恢复预览宽度',
       hideDevTools: '隐藏预览 DevTools',
       openDevTools: '打开预览 DevTools',
       finishedRestarting: message => `Hermes 已完成预览服务器重启${message ? `: ${message}` : ''}`,


### PR DESCRIPTION
## Summary

- Raises the Hermes Desktop preview rail max width so website previews can be stretched close to full-window width (`90vw` instead of the old `38rem` cap).
- Adds a preview titlebar action that toggles `Maximize preview width` / `Restore preview width`; the maximize preset now targets 90% of the viewport while leaving a small chat column visible.
- Keeps the existing preview console and DevTools titlebar actions intact.
- Moves the new titlebar labels into the Desktop i18n dictionaries instead of hardcoding English in the component.

## Why

Desktop capped the preview rail at `38rem`, and even the first wide-preview preset could still feel constrained on large screens. Website/browser QA needs a Codex-style wide working surface where the preview can occupy most of the window while the chat remains available for steering.

## Validation

Ran from the repo root:

```text
npm ci
npm --workspace apps/desktop run test:ui -- src/app/chat/right-rail/preview-pane.test.tsx
npm --workspace apps/desktop run typecheck
npm --workspace apps/desktop run lint
npm --workspace apps/desktop run build
python scripts/check-windows-footguns.py $(git diff --name-only origin/main...HEAD)
```

Notes:
- Targeted preview-pane tests: 3 passed.
- Desktop lint passes with one pre-existing warning in `apps/desktop/src/app/settings/model-settings.tsx` about `setConfig` hook deps.
- Build passes; Vite still emits pre-existing CSS/barrel/chunk-size warnings.
