### PR TITLE
fix(cli): show subprocess exit code when post-setup stderr is empty

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -966,6 +966,8 @@ def _run_post_setup(post_setup_key: str):
                 _print_warning(f"    npm install failed - run manually: cd {display_hermes_home()}/hermes-agent && npm install --workspaces=false")
                 if result.stderr:
                     _print_info(f"      {result.stderr.strip()[:200]}")
+                else:
+                    _print_info(f"      subprocess exited with code {result.returncode}")
         elif not node_modules.exists():
             _print_warning("    Node.js not found - browser tools require: npm install (in hermes-agent directory)")
             return
@@ -1069,6 +1071,10 @@ def _run_post_setup(post_setup_key: str):
                 _print_success("    Camofox installed")
             else:
                 _print_warning("    npm install failed - run manually: npm install --workspaces=false")
+                if result.stderr:
+                    _print_info(f"      {result.stderr.strip()[:200]}")
+                else:
+                    _print_info(f"      subprocess exited with code {result.returncode}")
         if camofox_dir.exists():
             _print_info("    Start the Camofox server:")
             _print_info("      npx @askjo/camofox-browser")


### PR DESCRIPTION
Two failure paths in `_run_post_setup` print "npm install failed" with no diagnostic when stderr is empty (e.g. OOM-killed subprocess, or exit 127 from a missing binary on the npm side). The camofox path printed nothing at all on failure. Both now fall back to the exit code so e.g. exit 127 (command not found) is visible rather than silently ignored.

Fixes #56566.