### PR TITLE
fix(hindsight): surface retain timeouts clearly

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import concurrent.futures
 import importlib
 import json
 import logging
@@ -271,14 +272,18 @@ def _get_loop() -> asyncio.AbstractEventLoop:
         return _loop
 
 
-def _run_sync(coro, timeout: float = _DEFAULT_TIMEOUT):
+def _run_sync(coro, timeout: float = _DEFAULT_TIMEOUT, operation_name: str = "hindsight operation"):
     """Schedule *coro* on the shared loop and block until done."""
     from agent.async_utils import safe_schedule_threadsafe
     loop = _get_loop()
     future = safe_schedule_threadsafe(coro, loop)
     if future is None:
         raise RuntimeError("Hindsight loop unavailable")
-    return future.result(timeout=timeout)
+    try:
+        return future.result(timeout=timeout)
+    except concurrent.futures.TimeoutError as exc:
+        future.cancel()
+        raise TimeoutError(f"{operation_name} timed out after {timeout}s") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -1062,9 +1067,9 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = Hindsight(**kwargs)
         return self._client
 
-    def _run_sync(self, coro):
+    def _run_sync(self, coro, operation_name: str = "hindsight operation"):
         """Schedule *coro* on the shared loop using the configured timeout."""
-        return _run_sync(coro, timeout=self._timeout)
+        return _run_sync(coro, timeout=self._timeout, operation_name=operation_name)
 
     def _is_retriable_embedded_connection_error(self, exc: Exception) -> bool:
         """Return True for stale embedded-daemon connection failures."""
@@ -1152,7 +1157,7 @@ class HindsightMemoryProvider(MemoryProvider):
         """Run an async Hindsight client operation, retrying once after idle shutdown."""
         client = self._get_client()
         try:
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), operation_name="hindsight client operation")
         except Exception as exc:
             if not self._is_retriable_embedded_connection_error(exc):
                 raise
@@ -1163,7 +1168,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client = None
             client = self._get_client()
             self._client = client
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), operation_name="hindsight client operation retry")
 
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
@@ -1713,10 +1718,12 @@ class HindsightMemoryProvider(MemoryProvider):
                     tags=args.get("tags"),
                 )
                 # aretain_batch takes bank_id/retain_async as call args, not item keys.
+                retain_async = item.pop("retain_async", None)
                 item.pop("bank_id", None)
-                item.pop("retain_async", None)
-                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                             self._bank_id, len(content), context)
+                logger.debug(
+                    "Tool hindsight_retain: bank=%s, url=%s, timeout=%s, async=%s, content_len=%d, context=%s",
+                    self._bank_id, self._api_url, self._timeout, retain_async, len(content), context,
+                )
                 self._run_hindsight_operation(
                     lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item])
                 )
@@ -1724,7 +1731,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 return json.dumps({"result": "Memory stored successfully."})
             except Exception as e:
                 logger.warning("hindsight_retain failed: %s", e, exc_info=True)
-                return tool_error(f"Failed to store memory: {e}")
+                detail = str(e) or type(e).__name__
+                return tool_error(f"Failed to store memory: {detail}")
 
         elif tool_name == "hindsight_recall":
             query = args.get("query", "")

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1153,11 +1153,11 @@ class HindsightMemoryProvider(MemoryProvider):
         except Exception as exc:
             logger.debug("Hindsight atexit shutdown failed: %s", exc)
 
-    def _run_hindsight_operation(self, operation):
+    def _run_hindsight_operation(self, operation, operation_name="hindsight client operation"):
         """Run an async Hindsight client operation, retrying once after idle shutdown."""
         client = self._get_client()
         try:
-            return self._run_sync(operation(client), operation_name="hindsight client operation")
+            return self._run_sync(operation(client), operation_name=operation_name)
         except Exception as exc:
             if not self._is_retriable_embedded_connection_error(exc):
                 raise
@@ -1168,7 +1168,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client = None
             client = self._get_client()
             self._client = client
-            return self._run_sync(operation(client), operation_name="hindsight client operation retry")
+            return self._run_sync(operation(client), operation_name=f"{operation_name} retry")
 
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
@@ -1688,7 +1688,8 @@ class HindsightMemoryProvider(MemoryProvider):
                     items=[item],
                     document_id=document_id,
                     retain_async=retain_async_flag,
-                )
+                ),
+                operation_name="hindsight retain",
             )
             logger.debug("Hindsight retain succeeded")
 
@@ -1725,7 +1726,8 @@ class HindsightMemoryProvider(MemoryProvider):
                     self._bank_id, self._api_url, self._timeout, retain_async, len(content), context,
                 )
                 self._run_hindsight_operation(
-                    lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item])
+                    lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item]),
+                    operation_name="hindsight retain",
                 )
                 logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})
@@ -1872,7 +1874,8 @@ class HindsightMemoryProvider(MemoryProvider):
                             items=[item],
                             document_id=old_document_id,
                             retain_async=self._retain_async,
-                        )
+                        ),
+                        operation_name="hindsight retain",
                     )
                 except Exception as e:
                     logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -5,6 +5,7 @@ prefetch (auto_recall, preamble, query truncation), sync_turn (auto_retain,
 turn counting, tags), and schema completeness.
 """
 
+import concurrent.futures
 import json
 import os
 import re
@@ -1777,6 +1778,30 @@ class TestSharedEventLoopLifecycle:
         assert hindsight_mod._run_sync(_still_working()) == 42
 
         provider_b.shutdown()
+
+    def test_run_sync_cancels_future_and_names_timeout(self, monkeypatch):
+        from plugins.memory import hindsight as hindsight_mod
+
+        class TimedOutFuture:
+            cancelled = False
+
+            def result(self, timeout=None):
+                raise concurrent.futures.TimeoutError()
+
+            def cancel(self):
+                self.cancelled = True
+
+        future = TimedOutFuture()
+        monkeypatch.setattr(hindsight_mod, "_get_loop", lambda: object())
+        monkeypatch.setattr(
+            "agent.async_utils.safe_schedule_threadsafe",
+            lambda coro, loop: future,
+        )
+
+        with pytest.raises(TimeoutError, match="hindsight retain timed out after 0.01s"):
+            hindsight_mod._run_sync(object(), timeout=0.01, operation_name="hindsight retain")
+
+        assert future.cancelled
 
     def test_client_aclose_called_on_cloud_mode_shutdown(self, provider):
         """Per-provider session cleanup still runs even though the shared

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -653,6 +653,17 @@ class TestToolHandlers:
         assert "bank_id" not in item
         assert "retain_async" not in item
 
+    def test_retain_timeout_uses_retain_specific_operation_name(self, provider, monkeypatch):
+        def _timeout(coro, *, operation_name):
+            coro.close()
+            raise TimeoutError(f"{operation_name} timed out after 0.01s")
+
+        monkeypatch.setattr(provider, "_run_sync", _timeout)
+
+        result = provider.handle_tool_call("hindsight_retain", {"content": "remember this"})
+
+        assert "hindsight retain timed out after 0.01s" in result
+
     def test_retain_with_tags(self, provider_with_config):
         p = provider_with_config(retain_tags=["pref", "ui"])
         p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})


### PR DESCRIPTION
Make Hindsight memory-provider **retain timeouts explicit** instead of failing silently, so a slow/unreachable retain surfaces a clear signal rather than a swallowed error.

### Testing
`pytest tests/plugins/memory/test_hindsight_provider.py` → 117 passed, on current `main`.
