### PR TITLE
fix(tui): make logForDebugging() actually write debug output

### DIFF
--- a/ui-tui/packages/hermes-ink/src/utils/debug.test.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/debug.test.ts
@@ -1,0 +1,81 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { logForDebugging } from './debug.js'
+
+describe('logForDebugging', () => {
+  let dir: string
+  let logPath: string
+  let originalEnabled: string | undefined
+  let originalPath: string | undefined
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'hermes-ink-debug-test-'))
+    logPath = join(dir, 'nested', 'tui-debug.log')
+    originalEnabled = process.env.HERMES_INK_DEBUG_LOG
+    originalPath = process.env.HERMES_INK_DEBUG_LOG_PATH
+    process.env.HERMES_INK_DEBUG_LOG_PATH = logPath
+  })
+
+  afterEach(() => {
+    if (originalEnabled === undefined) {
+      delete process.env.HERMES_INK_DEBUG_LOG
+    } else {
+      process.env.HERMES_INK_DEBUG_LOG = originalEnabled
+    }
+
+    if (originalPath === undefined) {
+      delete process.env.HERMES_INK_DEBUG_LOG_PATH
+    } else {
+      process.env.HERMES_INK_DEBUG_LOG_PATH = originalPath
+    }
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('is a safe no-op and writes nothing when not explicitly enabled', () => {
+    delete process.env.HERMES_INK_DEBUG_LOG
+
+    logForDebugging('should not be written anywhere')
+
+    expect(existsSync(logPath)).toBe(false)
+  })
+
+  it('appends a timestamped line to the debug log file when enabled', () => {
+    process.env.HERMES_INK_DEBUG_LOG = '1'
+
+    logForDebugging('hello from the tui', { level: 'warn' })
+
+    expect(existsSync(logPath)).toBe(true)
+
+    const contents = readFileSync(logPath, 'utf8')
+
+    expect(contents).toContain('[warn] hello from the tui')
+    // ISO 8601 timestamp prefix, e.g. 2026-07-06T20:00:00.000Z
+    expect(contents).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z /)
+  })
+
+  it('appends multiple calls as separate lines rather than overwriting', () => {
+    process.env.HERMES_INK_DEBUG_LOG = '1'
+
+    logForDebugging('first message')
+    logForDebugging('second message')
+
+    const lines = readFileSync(logPath, 'utf8').trim().split('\n')
+
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toContain('first message')
+    expect(lines[1]).toContain('second message')
+  })
+
+  it('defaults to level "debug" when no level is given', () => {
+    process.env.HERMES_INK_DEBUG_LOG = '1'
+
+    logForDebugging('unlabeled message')
+
+    expect(readFileSync(logPath, 'utf8')).toContain('[debug] unlabeled message')
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/utils/debug.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/debug.ts
@@ -1,6 +1,43 @@
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+// Default destination lives alongside the other `~/.hermes/logs/*.log` files
+// (agent.log, errors.log, gateway.log) so `hermes logs` output and TUI-side
+// debug breadcrumbs sit in one place. Respects HERMES_HOME for profile-aware
+// installs, mirroring the resolution used by ui-tui/src/lib/parentLog.ts.
+const DEFAULT_LOG_PATH = join(process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes'), 'logs', 'tui-debug.log')
+
+/**
+ * Debug-only logging for the Ink TUI.
+ *
+ * A no-op unless HERMES_INK_DEBUG_LOG is set — this must never write to
+ * stdout/stderr, since patchConsole()/patchStderr() (ink.tsx) route through
+ * here while the alt-screen is mounted, and printing would corrupt the
+ * terminal buffer. When enabled, appends a timestamped line to a log file
+ * instead (default `~/.hermes/logs/tui-debug.log`, overridable with
+ * HERMES_INK_DEBUG_LOG_PATH) so in-TUI debugging has somewhere to look.
+ *
+ * Failures to write are swallowed: there's nowhere safe to report them from
+ * inside the alt-screen, and debug logging must never crash the TUI.
+ */
 export function logForDebugging(
-  _message: string,
-  _options: {
+  message: string,
+  options: {
     level?: string
   } = {}
-): void {}
+): void {
+  if (!process.env.HERMES_INK_DEBUG_LOG) {
+    return
+  }
+
+  try {
+    const path = process.env.HERMES_INK_DEBUG_LOG_PATH?.trim() || DEFAULT_LOG_PATH
+    const level = options.level ?? 'debug'
+
+    mkdirSync(dirname(path), { recursive: true })
+    appendFileSync(path, `${new Date().toISOString()} [${level}] ${message}\n`)
+  } catch {
+    // Best-effort — see doc comment above.
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes `logForDebugging()` in `ui-tui/packages/hermes-ink/src/utils/debug.ts`, which has a literal empty body — it silently swallows every `console.log`/`console.error` call and even raw `process.stderr.write` while Ink's alternate-screen TUI is mounted (it's routed through here via `patchConsole()`/`patchStderr()` in `ui-tui/packages/hermes-ink/src/ink/ink.tsx`). This makes any in-TUI debug logging invisible with no indication it's being dropped — a real footgun for anyone trying to debug this app, since normal `console.*` calls just silently vanish instead of erroring or warning.

## Related Issue

No existing issue found — searched issues/PRs for "logForDebugging", "debug.ts", "patchConsole debug", "console.log alt-screen", "debug logging swallowed"; no matches.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/packages/hermes-ink/src/utils/debug.ts`: `logForDebugging()` is now a true no-op (zero filesystem access) unless `HERMES_INK_DEBUG_LOG` is set, matching the existing env-gated pattern already used by the sibling `logError()` in `log.ts`. When enabled, it appends a timestamped, leveled line to a log file (default `~/.hermes/logs/tui-debug.log`, matching this repo's existing `~/.hermes/logs/` convention; overridable via `HERMES_INK_DEBUG_LOG_PATH`). It never writes to stdout/stderr — that would corrupt the very alt-screen buffer it's meant to help debug — and swallows its own write failures so it can never crash the TUI.
- `ui-tui/packages/hermes-ink/src/utils/debug.test.ts` (new): 4 tests — safe no-op when disabled, writes a timestamped+leveled line when enabled, appends multiple calls as separate lines, defaults level to "debug".

## How to Test

1. `cd ui-tui && npx vitest run packages/hermes-ink/src/utils/debug.test.ts` — 4/4 pass.
2. Temporarily revert to the original empty-body stub and rerun — 3 of 4 tests fail (the "no-op when disabled" test trivially still passes against an empty function), confirming the tests exercise real behavior.
3. `npm run typecheck && npx eslint packages/hermes-ink/src/utils/debug.ts packages/hermes-ink/src/utils/debug.test.ts && npx prettier --check packages/hermes-ink/src/utils/debug.ts packages/hermes-ink/src/utils/debug.test.ts` — all clean.
4. Full `hermes-ink` suite (`npx vitest run packages/hermes-ink`) — 20 files, 123 passed, 1 pre-existing skipped, 0 failures.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tui): ...`)
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate — none found
- [x] My PR contains only changes related to this fix (2 files)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this diff touches zero Python files (only `ui-tui/packages/hermes-ink/src/utils/*`)
- [x] I've added tests for my changes — new regression test, TDD-verified fail-then-pass
- [x] I've tested on my platform: macOS. This is a pure filesystem-logging change with no OS-specific APIs; nothing here is platform-dependent.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, internal debug utility, not user-facing
- [x] I've updated `cli-config.yaml.example` — N/A, env-var only, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — uses only `fs.mkdirSync`/`fs.appendFileSync` and `os.homedir()`-relative paths, no OS-specific behavior
- [x] I've updated tool descriptions/schemas — N/A
