### PR TITLE
fix(tui): stop kill() from letting a stale respawn race a dying gateway child

### DIFF
--- a/ui-tui/src/__tests__/gatewayClientSpawn.test.ts
+++ b/ui-tui/src/__tests__/gatewayClientSpawn.test.ts
@@ -1,0 +1,231 @@
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Regression coverage for the spawn/kill lifecycle race: a killed
+// `tui_gateway.entry` child can stay alive for a real, observable window
+// (its own Python-side shutdown grace period — see
+// `tui_gateway/entry.py::_shutdown_grace_seconds`, ~1s by default) after
+// `GatewayClient.kill()` sends SIGTERM. Before the fix, anything that called
+// `request()` (or `start()` directly, e.g. the app-level crash-recovery exit
+// handler) during that window treated the not-yet-exited child as "gone" and
+// spawned a second one — producing two live gateway processes at once, with
+// a request potentially written straight into the half-dead child's stdin
+// and never answered (silently hanging until the RPC timeout).
+//
+// The existing `gatewayClient.test.ts` suite only exercises the websocket
+// *attach* mode, so the default *spawn* mode (`startSpawnedGateway`) had no
+// coverage at all prior to this file.
+
+const { FakeChildProcess, spawnMock } = vi.hoisted(() => {
+  class FakeChildProcess {
+    static instances: FakeChildProcess[] = []
+    private static nextPid = 1000
+
+    exitCode: null | number = null
+    killed = false
+    pid = FakeChildProcess.nextPid++
+    signalCode: null | string = null
+    stderr = new PassThrough()
+    stdin = new PassThrough()
+    stdout = new PassThrough()
+
+    private listeners = new Map<string, ((...args: any[]) => void)[]>()
+
+    static reset() {
+      FakeChildProcess.instances = []
+    }
+
+    on(event: string, cb: (...args: any[]) => void) {
+      const entries = this.listeners.get(event) ?? []
+
+      entries.push(cb)
+      this.listeners.set(event, entries)
+
+      return this
+    }
+
+    // Mirrors Node's real semantics: `.kill()` flips `killed` synchronously
+    // and returns whether the signal was delivered — it does NOT mean the
+    // process has actually exited yet. The OS-level 'exit' event only fires
+    // later, via `simulateExit()` in these tests (or never, if a test wants
+    // to model a still-shutting-down child).
+    kill() {
+      if (this.killed || this.exitCode !== null) {
+        return false
+      }
+
+      this.killed = true
+
+      return true
+    }
+
+    // Test-only helper: simulate the child actually terminating at the OS
+    // level, asynchronously, some time after kill() was called.
+    simulateExit(code: null | number = 0, signal: null | string = null) {
+      this.exitCode = code
+      this.signalCode = signal
+      const entries = this.listeners.get('exit') ?? []
+
+      for (const cb of entries) {
+        cb(code, signal)
+      }
+    }
+  }
+
+  const spawnMock = vi.fn(() => {
+    const proc = new FakeChildProcess()
+
+    FakeChildProcess.instances.push(proc)
+
+    return proc
+  })
+
+  return { FakeChildProcess, spawnMock }
+})
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+import { GatewayClient } from '../gatewayClient.js'
+
+describe('GatewayClient spawn mode — kill/respawn lifecycle', () => {
+  let originalAttachUrl: string | undefined
+
+  beforeEach(() => {
+    originalAttachUrl = process.env.HERMES_TUI_GATEWAY_URL
+    delete process.env.HERMES_TUI_GATEWAY_URL
+    FakeChildProcess.reset()
+    spawnMock.mockClear()
+  })
+
+  afterEach(() => {
+    if (originalAttachUrl === undefined) {
+      delete process.env.HERMES_TUI_GATEWAY_URL
+    } else {
+      process.env.HERMES_TUI_GATEWAY_URL = originalAttachUrl
+    }
+  })
+
+  it('spawns exactly one child on start() and resolves a request end to end', async () => {
+    const gw = new GatewayClient()
+
+    gw.start()
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+
+    const proc = FakeChildProcess.instances[0]!
+    const req = gw.request<{ ok: boolean }>('session.create', { cols: 80 })
+
+    await vi.waitFor(() => {
+      const written = proc.stdin.read()
+
+      expect(written).not.toBeNull()
+    })
+
+    // Re-read isn't possible after consuming above; re-issue a fresh request
+    // to capture the frame cleanly for shape assertions.
+    const frames: Buffer[] = []
+
+    proc.stdin.on('data', chunk => frames.push(chunk))
+
+    const req2 = gw.request<{ ok: boolean }>('session.create', { cols: 80 })
+
+    await vi.waitFor(() => expect(frames.length).toBeGreaterThan(0))
+    const frame = JSON.parse(frames[0]!.toString('utf8')) as { id: string; method: string }
+
+    expect(frame.method).toBe('session.create')
+    proc.stdout.write(JSON.stringify({ id: frame.id, jsonrpc: '2.0', result: { ok: true } }) + '\n')
+    await expect(req2).resolves.toEqual({ ok: true })
+
+    // The first request's own promise is irrelevant to this assertion; avoid
+    // an unhandled rejection warning if it never settles in this test.
+    req.catch(() => {})
+    gw.kill()
+  })
+
+  it('does NOT spawn a second child while the killed one is still alive (mid graceful-exit)', async () => {
+    const gw = new GatewayClient()
+
+    gw.start()
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+
+    const firstProc = FakeChildProcess.instances[0]!
+
+    gw.kill('graceful-exit-cleanup')
+    expect(firstProc.killed).toBe(true)
+    // Crucially: the child has NOT actually exited yet — no simulateExit()
+    // call — modeling the up-to-~1s Python-side shutdown grace window.
+    expect(firstProc.exitCode).toBeNull()
+
+    // A request lands in that window (e.g. a stray poll timer, or the
+    // app-level auto-recovery handler reacting to a late 'exit' forward).
+    const late = gw.request('model.options', {})
+
+    await expect(late).rejects.toThrow(/shutting down/)
+
+    // The core regression assertion: no second gateway child was spawned
+    // while the first was still alive.
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    expect(FakeChildProcess.instances).toHaveLength(1)
+  })
+
+  it('start() called again after kill() (e.g. the exit-handler auto-recovery path) is a no-op', async () => {
+    const gw = new GatewayClient()
+
+    gw.start()
+    const firstProc = FakeChildProcess.instances[0]!
+
+    gw.kill('graceful-exit-cleanup')
+    expect(firstProc.exitCode).toBeNull()
+
+    // useMainApp.ts's crash-recovery exit handler calls gw.start() directly
+    // (not through request()) when it believes the gateway died unexpectedly.
+    gw.start()
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    expect(gw.getLogTail(20)).toContain('start() ignored — client is shutting down')
+  })
+
+  it('rejects immediately (not after the RPC timeout) once shutting down', async () => {
+    const gw = new GatewayClient()
+
+    gw.start()
+    gw.kill()
+
+    const start = Date.now()
+    const req = gw.request('model.options', {})
+
+    await expect(req).rejects.toThrow(/shutting down/)
+    // Should settle well under a second — nowhere near REQUEST_TIMEOUT_MS
+    // (30s floor / 120s default) — proving this is an immediate, explicit
+    // rejection and not a silent hang that happens to resolve later.
+    expect(Date.now() - start).toBeLessThan(1000)
+  })
+
+  it('a still-registered late response from the half-dead child is safely ignored, not misdelivered', async () => {
+    const gw = new GatewayClient()
+
+    gw.start()
+    const firstProc = FakeChildProcess.instances[0]!
+
+    const inFlight = gw.request('model.options', {})
+
+    await vi.waitFor(() => expect(firstProc.stdin.readableLength >= 0).toBe(true))
+
+    // Session closes mid-flight.
+    gw.kill('graceful-exit-cleanup')
+    await expect(inFlight).rejects.toThrow(/gateway closed/)
+
+    // The old child (still alive, per the grace window) finally finishes
+    // its abandoned work and writes the response it was computing when
+    // SIGTERM landed. Nothing should throw, and it must not resolve/reject
+    // the already-settled promise above (asserted implicitly: the earlier
+    // `await expect(inFlight).rejects` already proved the client-side
+    // settlement happened before this late write).
+    expect(() => {
+      firstProc.stdout.write(JSON.stringify({ id: 'r1', jsonrpc: '2.0', result: { models: [] } }) + '\n')
+    }).not.toThrow()
+
+    firstProc.simulateExit(0)
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -149,6 +149,21 @@ export class GatewayClient extends EventEmitter {
   private drainGeneration = 0
   private stdoutRl: ReturnType<typeof createInterface> | null = null
   private stderrRl: ReturnType<typeof createInterface> | null = null
+  // One-way latch set by kill(). A killed child can take a real, observable
+  // amount of time to actually exit (the Python side's own shutdown grace
+  // window — see tui_gateway/entry.py's `_shutdown_grace_seconds`, ~1s by
+  // default — during which it is still alive and doing real work). Every
+  // start() call site (request()'s auto-respawn, the websocket
+  // attach-reconnect path, and the app-level "unexpected exit" crash
+  // recovery in useMainApp.ts) previously treated `proc.killed` as "already
+  // gone, safe to replace" and spawned a brand-new child immediately —
+  // producing two live `tui_gateway.entry` processes for the same terminal
+  // at once, with no guarantee which one a subsequent request would land on.
+  // kill() is only ever invoked as part of intentionally ending this
+  // client's lifecycle (graceful-exit cleanup, die()/dieWithCode()), so once
+  // set there is no legitimate reason for this same instance to spin up a
+  // replacement child — start() below is a permanent no-op afterward.
+  private shuttingDown = false
 
   constructor() {
     super()
@@ -521,6 +536,16 @@ export class GatewayClient extends EventEmitter {
   }
 
   start() {
+    if (this.shuttingDown) {
+      // See the `shuttingDown` field comment: kill() already fired for this
+      // instance, so a subsequent respawn attempt (from any of the four
+      // call sites) would race a child that may still be mid-graceful-exit.
+      // No-op rather than spawn a second, uncoordinated child.
+      this.lifecycle('[lifecycle] start() ignored — client is shutting down (kill() already called)')
+
+      return
+    }
+
     const root = process.env.HERMES_PYTHON_SRC_ROOT ?? resolve(import.meta.dirname, '../../')
     const attachUrl = resolveGatewayAttachUrl()
     const sidecarUrl = resolveSidecarUrl()
@@ -666,6 +691,10 @@ export class GatewayClient extends EventEmitter {
   }
 
   private async ensureAttachedWebSocket(method: string): Promise<WebSocket> {
+    if (this.shuttingDown) {
+      throw new Error('gateway is shutting down')
+    }
+
     if (!this.attachUrl) {
       throw new Error('gateway not running')
     }
@@ -722,6 +751,19 @@ export class GatewayClient extends EventEmitter {
   }
 
   request<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+    if (this.shuttingDown) {
+      // Fail fast and explicitly rather than falling through to the
+      // stdin-write below: `this.proc` can still be a non-null, non-exited
+      // child here (kill() intentionally leaves it in place so its own late
+      // exit/close events are still identity-matched), so without this
+      // guard a request issued after kill() would be written straight to a
+      // half-dead child's stdin — a write that may never be read (the child
+      // is unwinding its own shutdown, not servicing new RPCs) and would
+      // otherwise silently hang the caller until REQUEST_TIMEOUT_MS instead
+      // of failing immediately.
+      return Promise.reject(new Error('gateway is shutting down'))
+    }
+
     const attachUrl = resolveGatewayAttachUrl()
 
     if (attachUrl) {
@@ -741,7 +783,7 @@ export class GatewayClient extends EventEmitter {
       this.start()
     }
 
-    if (!this.proc?.stdin) {
+    if (!this.proc?.stdin || this.proc.killed || this.proc.exitCode !== null) {
       return Promise.reject(new Error('gateway not running'))
     }
 
@@ -776,6 +818,14 @@ export class GatewayClient extends EventEmitter {
   }
 
   kill(reason = 'requested') {
+    // Set BEFORE anything else: a signal-forwarded child can take up to its
+    // own shutdown grace window to actually exit (still alive, still doing
+    // real work), so anything that runs synchronously below — or any
+    // request()/start() call that lands in the gap before this client's own
+    // process actually terminates — must see this instance as done for good
+    // rather than eligible for an implicit respawn.
+    this.shuttingDown = true
+
     const proc = this.proc
     const killed = proc?.kill()
 


### PR DESCRIPTION
## What does this PR do?

Fixes a race in `GatewayClient` (`ui-tui/src/gatewayClient.ts`) where `kill()` sends `SIGTERM` to the Python `tui_gateway.entry` child but never marks the client itself as shutting down, and `start()` treats `proc.killed === true` as "already gone, safe to replace." A killed child is not instantly dead — `tui_gateway/entry.py`'s shutdown path runs a real sequence (writing a crash log, closing sessions) bounded by a grace window (~1s by default) before it actually exits.

Any `request()` call issued in that window — a stray poll timer, the websocket attach-reconnect path, or the app-level "unexpected exit" crash-recovery handler, all of which funnel through `start()` — saw `proc.killed === true` and silently spawned a brand-new gateway child, producing two live `tui_gateway.entry` processes for the same terminal at once. A request that reached the old, half-dead child could hang until the RPC timeout waiting for a response that was never coming — this is the same class of symptom previously reported as a lost `model.options` reply making the model picker hang.

## Related Issue

No existing issue found describing this exact kill()-then-respawn race (searched "gateway respawn", "double spawn", "two gateway processes", "gateway kill race", "proc.killed", "broken pipe", "orphan gateway", "stdin EOF"). Two related-but-distinct issues, for context, not fixed by this PR: #39013 (a different bug in the same auto-recovery mechanism — session-not-found after rapid successive messages) and the now-closed #44560 (a different root cause — synchronous per-provider HTTP calls — for similar-sounding "model.options hangs" symptom language).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/gatewayClient.ts`: added a one-way `shuttingDown` latch, set at the start of `kill()`. `start()` becomes a permanent no-op once set, covering every call site that could trigger a respawn. `request()` and `ensureAttachedWebSocket()` now reject immediately with a clear "gateway is shutting down" error instead of falling through to a stdin write on a child that may never answer. Also tightened `request()`'s post-`start()` liveness check to also account for `.killed`/`.exitCode !== null`, closing a related gap where a still-referenced-but-dead `proc` could be written to.
- `ui-tui/src/__tests__/gatewayClientSpawn.test.ts` (new, 5 tests): the existing suite only covered websocket attach mode — default spawn mode had zero coverage before this. Mocks `child_process.spawn` with a fake `ChildProcess` that mirrors real Node `kill()`/`killed`/`exitCode` semantics (`killed=true` does not mean exited).

`kill()` is only ever invoked as part of intentionally ending a client's lifecycle (graceful-exit cleanup before `process.exit()`, and the app's `die()`/`dieWithCode()`) — all immediately followed by process exit, so there's no legitimate case where the same instance should spin up a replacement child afterward. This is a pure JS bookkeeping change; no new OS-specific process/signal logic (uses only already-cross-platform Node `ChildProcess` flags), equally correct on Windows, macOS, and Linux.

## How to Test

1. `cd ui-tui && npx vitest run src/__tests__/gatewayClientSpawn.test.ts` — 5/5 pass.
2. Revert just `gatewayClient.ts` and rerun — 3 of 5 fail: one records `spawn` called twice (the double-spawn), two time out waiting on a promise that never settles (the silent-hang symptom) — reproducing the exact two failure modes.
3. `npm run typecheck && npx eslint src/gatewayClient.ts src/__tests__/gatewayClientSpawn.test.ts && npx prettier --check src/gatewayClient.ts src/__tests__/gatewayClientSpawn.test.ts` — all clean.
4. Full `ui-tui` suite — 1113 pass, 3 pre-existing failures in `statusRule.test.ts`/`virtualHeights.test.ts` confirmed unrelated (reproduce identically on unmodified `main`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tui): ...`)
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate — none found; related-but-distinct #39013/#44560 noted above
- [x] My PR contains only changes related to this fix (2 files)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this diff touches zero Python files (only `ui-tui/src/gatewayClient.ts` and a new test file)
- [x] I've added tests for my changes — new regression test, verified fail-then-pass against the real bug
- [x] I've tested on my platform: macOS. This is a pure JS bookkeeping fix using only cross-platform Node `ChildProcess` flags (`.killed`/`.exitCode`) — no signals or process-group APIs touched, so behavior is identical on Windows/Linux.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, internal client lifecycle fix, no user-facing behavior change
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — see above; no OS-specific code paths added or touched
- [x] I've updated tool descriptions/schemas — N/A
