### PR TITLE
fix: preserve Photon reply context

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -960,6 +960,9 @@ class PhotonAdapter(BasePlatformAdapter):
         # gateway death of ANY kind — including SIGKILL, where disconnect()
         # never runs — can't leave it orphaned on the port.
         env["PHOTON_SIDECAR_WATCH_STDIN"] = "1"
+        # Temporary opt-in safe shape logging for Photon reply-context debugging.
+        # The sidecar redacts all string values to lengths and logs only once.
+        env.setdefault("PHOTON_DEBUG_INBOUND_SHAPE", "1")
 
         try:
             patch = subprocess.run(  # noqa: S603

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -808,6 +808,19 @@ class PhotonAdapter(BasePlatformAdapter):
             user_id=sender_id,
             user_name=sender_id or None,
         )
+        reply_to = event.get("replyTo") or {}
+        reply_to_message_id = None
+        reply_to_text = None
+        reply_to_author_id = None
+        reply_to_is_own_message = False
+        if isinstance(reply_to, dict):
+            reply_to_message_id = reply_to.get("messageId") or None
+            reply_to_text = reply_to.get("text") or None
+            reply_to_author_id = reply_to.get("senderId") or None
+            reply_to_is_own_message = reply_to.get("direction") == "outbound" or (
+                bool(reply_to_message_id)
+                and str(reply_to_message_id) in self._sent_message_ids
+            )
         message_event = MessageEvent(
             text=text,
             message_type=mtype,
@@ -817,6 +830,10 @@ class PhotonAdapter(BasePlatformAdapter):
             timestamp=timestamp,
             media_urls=media_urls,
             media_types=media_types,
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
+            reply_to_author_id=reply_to_author_id,
+            reply_to_is_own_message=reply_to_is_own_message,
         )
         await self.handle_message(message_event)
 

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -412,8 +412,8 @@ async function normalizeBinaryContent(content) {
 // hydrated here — no extra round trip. Handles plain text and our patched mixed
 // text+attachment groups (first text child); null for attachment/voice-only
 // targets. Capped so one long bubble can't balloon the NDJSON line.
-const REACTION_TARGET_TEXT_CAP = 2000;
-function reactionTargetText(target) {
+const MESSAGE_PREVIEW_TEXT_CAP = 2000;
+function messagePreviewText(target) {
   const c = target && typeof target === "object" ? target.content : null;
   if (!c || typeof c !== "object") return null;
   let text = null;
@@ -429,9 +429,19 @@ function reactionTargetText(target) {
     }
   }
   if (typeof text !== "string" || !text) return null;
-  return text.length > REACTION_TARGET_TEXT_CAP
-    ? text.slice(0, REACTION_TARGET_TEXT_CAP)
+  return text.length > MESSAGE_PREVIEW_TEXT_CAP
+    ? text.slice(0, MESSAGE_PREVIEW_TEXT_CAP)
     : text;
+}
+
+function reactionTargetText(target) {
+  return messagePreviewText(target);
+}
+
+function parentMessageFor(message) {
+  const parentId = message?.parentId;
+  if (!parentId || typeof parentId !== "string") return null;
+  return knownMessages.get(parentId) || null;
 }
 
 async function normalizeContent(content) {
@@ -476,6 +486,7 @@ async function normalizeEvent(space, message) {
   try {
     const msgSpace = message.space || {};
     const ts = message.timestamp;
+    const parent = parentMessageFor(message);
     return {
       messageId: message.id ?? null,
       platform: message.platform || space.__platform || "iMessage",
@@ -487,6 +498,14 @@ async function normalizeEvent(space, message) {
       },
       sender: { id: message.sender ? message.sender.id : null },
       content: await normalizeContent(message.content),
+      replyTo: message.parentId
+        ? {
+            messageId: message.parentId,
+            text: messagePreviewText(parent),
+            senderId: parent?.sender?.id ?? null,
+            direction: parent?.direction ?? null,
+          }
+        : null,
       timestamp:
         ts instanceof Date ? ts.toISOString() : ts ? String(ts) : null,
     };

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -444,6 +444,37 @@ function parentMessageFor(message) {
   return knownMessages.get(parentId) || null;
 }
 
+let debugShapeLogged = false;
+function debugInboundShape(message) {
+  if (debugShapeLogged || process.env.PHOTON_DEBUG_INBOUND_SHAPE !== "1") return;
+  debugShapeLogged = true;
+  const seen = new WeakSet();
+  const scrub = (value, depth = 0) => {
+    if (value === null || value === undefined) return value;
+    if (typeof value === "string") return value.length > 0 ? `[string:${value.length}]` : "";
+    if (typeof value === "number" || typeof value === "boolean") return value;
+    if (typeof value === "function") return `[function:${value.name || "anonymous"}]`;
+    if (typeof value !== "object") return `[${typeof value}]`;
+    if (seen.has(value)) return "[circular]";
+    if (depth >= 3) return Array.isArray(value) ? `[array:${value.length}]` : `[object:${Object.keys(value).join(",")}]`;
+    seen.add(value);
+    if (Array.isArray(value)) return value.slice(0, 5).map((item) => scrub(item, depth + 1));
+    const out = {};
+    for (const key of Object.keys(value).sort()) {
+      out[key] = scrub(value[key], depth + 1);
+    }
+    return out;
+  };
+  try {
+    console.error(
+      "photon-sidecar: debug inbound message shape " +
+        JSON.stringify(scrub(message), null, 2)
+    );
+  } catch (e) {
+    console.error("photon-sidecar: failed to log inbound shape: " + String(e));
+  }
+}
+
 async function normalizeContent(content) {
   if (!content || typeof content !== "object") {
     return { type: "unknown" };
@@ -559,6 +590,7 @@ function inboundStreamErrorMessage(e) {
         }
         rememberInboundSpace(space, message);
         rememberKnownMessage(message);
+        debugInboundShape(message);
         const event = await normalizeEvent(space, message);
         if (!event) continue;
         await deliver(JSON.stringify(event));

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -74,12 +74,62 @@ async def test_dispatch_group_type(monkeypatch: pytest.MonkeyPatch) -> None:
     event = {
         "messageId": "spc-msg-grp",
         "space": {"id": "group-guid-xyz", "type": "group", "phone": None},
-        "sender": {"id": "+15551234567"},
+        "sender": {"id": "+155****4567"},
         "content": {"type": "text", "text": "hi group"},
         "timestamp": "2026-05-14T19:06:32.000Z",
     }
     await adapter._dispatch_inbound(event)
     assert captured[0].source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_text_preserves_reply_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _dm_event("Ahaha i meant the dhl email silly", msg_id="spc-reply-1")
+    event["replyTo"] = {
+        "messageId": "spc-parent-1",
+        "text": "This is an old package at MYPUP so can be archived.",
+        "senderId": "+155****4567",
+        "direction": "inbound",
+    }
+
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert ev.text == "Ahaha i meant the dhl email silly"
+    assert ev.reply_to_message_id == "spc-parent-1"
+    assert ev.reply_to_text == "This is an old package at MYPUP so can be archived."
+    assert ev.reply_to_author_id == "+155****4567"
+    assert ev.reply_to_is_own_message is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_text_marks_outbound_reply_context_as_own(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _dm_event("I agree with your recommendation!", msg_id="spc-reply-2")
+    event["replyTo"] = {
+        "messageId": "spc-parent-2",
+        "text": "I would archive the informational emails.",
+        "senderId": None,
+        "direction": "outbound",
+    }
+
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert ev.reply_to_message_id == "spc-parent-2"
+    assert ev.reply_to_text == "I would archive the informational emails."
+    assert ev.reply_to_is_own_message is True
 
 
 # A real 1x1 transparent PNG (passes base.py's _looks_like_image magic check).


### PR DESCRIPTION
## Summary
- propagate iMessage reply/quote parent context from the Photon sidecar when Spectrum exposes `parentId`
- hydrate quoted text/sender/direction from the sidecar's known-message cache
- map Photon `replyTo` metadata onto Hermes `MessageEvent` reply fields so the agent can tell what a user replied to
- temporarily add one-shot redacted inbound message shape logging (`PHOTON_DEBUG_INBOUND_SHAPE=1`) to verify where/if Spectrum exposes iMessage reply metadata in live events

## Current live-test status
A post-restart iMessage reply still logged with `reply_to_id=None`, so `parentId` may not be the quote/reply field for this provider. The latest commit adds redacted shape logging to inspect the live Spectrum message object without logging message text/secrets.

## Tests
- `python -m py_compile plugins/platforms/photon/adapter.py`
- `node --check plugins/platforms/photon/sidecar/index.mjs`
- `python -m pytest tests/plugins/platforms/photon/test_inbound.py tests/plugins/platforms/photon/test_reactions.py -q` → 28 passed
