### PR TITLE
feat(approval): owner/user permission tier — non-admins can't self-approve dangerous commands

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1937,6 +1937,12 @@ class BasePlatformAdapter(ABC):
         self._owner_profile: Optional[str] = None
         # Registered by GatewayRunner (see set_authorization_check).
         self._authorization_check: Optional[Callable[[str, Optional[str], Optional[str]], bool]] = None
+        # Optional admin-tier check, registered by GatewayRunner per adapter
+        # instance (profile-bound at registration time -- see
+        # set_admin_policy_check's docstring). Used by adapters that gate
+        # owner/admin-only inline-button actions (e.g. Telegram's
+        # exec-approval Allow button).
+        self._admin_policy_check: Optional[Callable[[SessionSource], bool]] = None
         # Auto-TTS on voice input: ``voice.auto_tts`` default plus per-chat /voice on|tts / off.
         self._auto_tts_default: bool = False
         self._auto_tts_enabled_chats, self._auto_tts_disabled_chats = set(), set()
@@ -2291,6 +2297,42 @@ class BasePlatformAdapter(ABC):
         """Register ``(user_id, chat_type, chat_id) -> bool``; adapters pulling external context
         (Slack thread replies) use it to flag non-allowlisted senders as unverified background."""
         self._authorization_check = callback
+
+    def set_admin_policy_check(
+        self,
+        callback: Optional[Callable[[SessionSource], bool]],
+    ) -> None:
+        """Register a profile-bound admin-tier check for this adapter instance.
+
+        The callback signature is ``(source: SessionSource) -> bool``,
+        returning whether *source*'s user is admin-tier
+        (``slash_access.policy_for_source().is_admin()``). GatewayRunner
+        builds and injects this callback at adapter-registration time, bound
+        to the correct profile's config -- so gated inline-button actions
+        (e.g. Telegram's exec-approval Allow button) resolve the right
+        profile's ``allow_admin_from`` even for a secondary multiplexed
+        adapter, instead of introspecting ``_message_handler.__self__``
+        (which is None for a multiplexed adapter's closure-based handler).
+        """
+        self._admin_policy_check = callback
+
+    def _is_admin_for_gated_action(self, source: SessionSource) -> Optional[bool]:
+        """Return whether *source*'s user is admin-tier, if a check is registered.
+
+        Returns ``None`` when no check is registered (caller should fall back
+        to "no tier configured" / permissive behavior, same convention as
+        :meth:`_is_sender_authorized`).
+        """
+        if self._admin_policy_check is None:
+            return None
+        try:
+            return bool(self._admin_policy_check(source))
+        except Exception:
+            logger.warning(
+                "[%s] Admin policy check raised for %s; treating as unknown",
+                self.name, source, exc_info=True,
+            )
+            return None
 
     def _is_sender_authorized(self, user_id: Optional[str], chat_type: Optional[str] = None,
                               chat_id: Optional[str] = None, *, is_bot: bool = False,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -763,6 +763,57 @@ def _clarify_send_then_wait(fut, *, clarify_id: str, session_key: str, clarify_m
     return response
 
 
+def _resolve_approval_session_is_guest(status_adapter: Any, status_chat_id: Any) -> bool:
+    """Return whether *status_chat_id* is currently a guest-mode (non-member)
+    chat, per *status_adapter*'s own ``_is_guest_chat`` predicate.
+
+    A no-op (always False) until an adapter defines ``_is_guest_chat`` --
+    today none does; the Telegram Bot API 10.0 guest-mode work (see
+    plugins/platforms/telegram/adapter.py's ``_pending_guest_queries`` /
+    ``_guest_only_chats``) supplies the real predicate. Extracted to its own
+    function so this wiring is testable against that concrete adapter
+    contract independent of driving a full gateway turn.
+    """
+    is_guest_chat_fn = getattr(status_adapter, "_is_guest_chat", None)
+    return bool(callable(is_guest_chat_fn) and is_guest_chat_fn(status_chat_id))
+
+
+def _resolve_approval_session_is_non_admin(source: Any, base_config: Any) -> bool:
+    """Return whether *source*'s user is a non-admin (tier-restricted) caller
+    per the SAME ``slash_access.policy_for_source().is_admin()`` that gates
+    admin-only typed slash commands.
+
+    ``base_config`` is the caller's ``GatewayRunner.config`` (the PRIMARY
+    profile's config). For a non-multiplexed gateway that's already correct
+    -- there's only one profile, so it's used directly with zero extra cost
+    (no disk I/O on the turn-dispatch hot path, matching original behavior
+    and every test's existing mocking of ``self.config``).
+
+    Only when ``base_config.multiplex_profiles`` is set does this pay for a
+    fresh ``gateway.config.load_gateway_config()`` call: this function runs
+    from ``_run_agent_inner``, which for a multiplexed secondary-profile turn
+    already executes inside that profile's ``_profile_runtime_scope`` (set up
+    by the ``_run_agent`` wrapper) -- so ``HERMES_HOME`` is contextvar-
+    overridden to the secondary profile's home by the time this executes, and
+    ``base_config`` would still be the PRIMARY profile's parsed config
+    (loaded once at startup), silently applying the wrong profile's
+    ``allow_admin_from`` tier. This mirrors ``_connect_profile_platforms``'s
+    own ``with _profile_runtime_scope(profile_home): load_gateway_config()``
+    -- multiplex-only cost, same as that existing call site.
+    """
+    try:
+        from gateway.slash_access import policy_for_source
+
+        gateway_config = base_config
+        if getattr(base_config, "multiplex_profiles", False):
+            from gateway.config import load_gateway_config
+            gateway_config = load_gateway_config()
+        policy = policy_for_source(gateway_config, source)
+        return bool(policy.enabled and not policy.is_admin(getattr(source, "user_id", None)))
+    except Exception:
+        return False
+
+
 def _resolve_progress_thread_id(
     platform: Any, source_thread_id: Any, event_message_id: Any, *, reply_in_thread: bool = True
 ) -> Optional[str]:

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -1005,7 +1005,9 @@ class GatewayAdapterLifecycleMixin:
                 credential_claim, claimed, profile_name, platform, "credential"
             ) or self._refuse_duplicate_claim(listener_claim, claimed, profile_name, platform, "listener"):
                 continue
-            self._configure_profile_adapter(adapter, profile_name, platform)
+            self._configure_profile_adapter(
+                adapter, profile_name, platform, profile_home=profile_home
+            )
             try:
                 with _profile_runtime_scope(profile_home, hydrate_secrets=False):
                     success = await self._connect_initial_adapter_with_timeout(adapter, platform)
@@ -1032,7 +1034,7 @@ class GatewayAdapterLifecycleMixin:
     def _wire_adapter_handlers(
         self, adapter: BasePlatformAdapter, *, message_handler=None, fatal_error_handler=None,
         busy_session_handler=None, authorization_check=None, platform_event_handler=None,
-        busy_text_mode: Optional[str] = None,
+        admin_policy_check=None, busy_text_mode: Optional[str] = None,
     ) -> None:
         """Install the runner callbacks every adapter needs (defaults = primary handlers;
         secondary wiring passes profile-scoped variants). ``set_reaction_handler`` is optional."""
@@ -1048,10 +1050,12 @@ class GatewayAdapterLifecycleMixin:
             authorization_check or self._make_adapter_auth_check(adapter.platform)
         )
         adapter.set_platform_event_handler(platform_event_handler or self._primary_platform_event_handler())
+        adapter.set_admin_policy_check(admin_policy_check or self._make_adapter_admin_policy_check())
         adapter._busy_text_mode = (self._busy_text_mode if busy_text_mode is None else busy_text_mode)
 
     def _configure_profile_adapter(
-        self, adapter: BasePlatformAdapter, profile_name: str, platform: Platform
+        self, adapter: BasePlatformAdapter, profile_name: str, platform: Platform,
+        *, profile_home: Optional["Path"] = None,
     ) -> None:
         """Install the profile-scoped handlers shared by startup and reconnect."""
         # Runtime status is process-scoped: key on profile:platform so health shows WHICH secondary failed.
@@ -1071,6 +1075,7 @@ class GatewayAdapterLifecycleMixin:
             busy_session_handler=self._make_profile_busy_session_handler(profile_name),
             authorization_check=self._make_adapter_auth_check(platform, profile_name=profile_name),
             platform_event_handler=self._make_profile_platform_event_handler(profile_name),
+            admin_policy_check=self._make_adapter_admin_policy_check(profile_home=profile_home),
             busy_text_mode=(
                 text_modes.get(profile_name, self._busy_text_mode)
                 if isinstance(text_modes, dict)
@@ -1116,7 +1121,9 @@ class GatewayAdapterLifecycleMixin:
                 )
                 return None, None
             try:
-                self._configure_profile_adapter(adapter, profile_name, platform)
+                self._configure_profile_adapter(
+                    adapter, profile_name, platform, profile_home=profile_home
+                )
                 success = await self._connect_adapter_with_timeout(adapter, platform, is_reconnect=True)
             except BaseException:
                 # Caller never sees this adapter; release its partial resources here.
@@ -1497,4 +1504,52 @@ class GatewayAdapterLifecycleMixin:
             if not self._stamp_routed_profile(source):
                 return False  # fail-closed, like the ``_handle_message`` ingress gate
             return self._is_user_authorized_for_source(source)
+        return check
+
+    def _make_adapter_admin_policy_check(
+        self,
+        profile_home: Optional["Path"] = None,
+    ) -> Callable[[SessionSource], bool]:
+        """Build a profile-bound admin-tier callback for adapter use.
+
+        Registered via :meth:`BasePlatformAdapter.set_admin_policy_check` so
+        gated inline-button actions (Telegram's exec-approval Allow button)
+        resolve ``allow_admin_from`` for the RIGHT profile -- not just the
+        primary one -- without the adapter needing to introspect its own
+        message-handler binding.
+
+        ``profile_home`` is ``None`` for the primary (non-multiplexed)
+        adapter: ``self.config`` is already that profile's config, no scoping
+        needed. For a secondary multiplexed adapter, ``profile_home`` is the
+        Path captured from the same per-profile connection loop that builds
+        the adapter's message handler (``_make_profile_message_handler``) --
+        each adapter instance gets its own closure bound to its own profile,
+        mirroring ``_connect_profile_platforms``'s
+        ``with _profile_runtime_scope(profile_home): load_gateway_config()``.
+        """
+        def check(source: SessionSource) -> bool:
+            from gateway.run import _profile_runtime_scope
+            from gateway.slash_access import policy_for_source
+            try:
+                if profile_home is None:
+                    gateway_config = self.config
+                else:
+                    from gateway.config import load_gateway_config
+                    with _profile_runtime_scope(profile_home):
+                        gateway_config = load_gateway_config()
+                policy = policy_for_source(gateway_config, source)
+                return bool(
+                    not policy.enabled or policy.is_admin(getattr(source, "user_id", None))
+                )
+            except Exception:
+                # Fail toward existing behavior: an unresolvable tier policy
+                # must not newly lock out an already-authorized approver.
+                # Never silently, though — an operator who configured
+                # allow_admin_from needs to know the tier wasn't applied.
+                logger.warning(
+                    "Admin-tier policy resolution failed for %s (profile_home=%s); "
+                    "treating caller as admin (pre-tier behavior)",
+                    source, profile_home, exc_info=True,
+                )
+                return True
         return check

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1412,13 +1412,52 @@ class TurnRunner:
                                         persist_user_message_override, persist_user_timestamp_override):
         """Run the turn with the per-session gateway approval callback registered: dangerous-command
         approval blocks the agent thread (mirrors CLI input()); the callback bridges sync→async."""
-        from gateway.run import _wrap_current_message_with_observed_context
-        from tools.approval import register_gateway_notify, unregister_gateway_notify
+        from gateway.run import (
+            _resolve_approval_session_is_guest,
+            _resolve_approval_session_is_non_admin,
+            _wrap_current_message_with_observed_context,
+        )
+        from tools.approval import (
+            mark_session_approval_blocked,
+            register_gateway_notify,
+            unmark_session_approval_blocked,
+            unregister_gateway_notify,
+        )
         from tools.approval_context import reset_current_session_key, set_current_session_key
         ctx = self._ctx
         session_key = ctx.session_key or ""
         token = set_current_session_key(session_key)
         register_gateway_notify(session_key, self._approval_notify_sync)
+        # Guest-mode Telegram chats (Bot API 10.0 @mention from a chat the
+        # bot isn't a member of) can never present or resolve an
+        # interactive approval prompt -- mark the session so a dangerous
+        # command denies immediately (tools/approval.py's
+        # _await_gateway_decision short-circuit) instead of blocking the
+        # agent thread for the full gateway_timeout on an approval that
+        # can structurally never arrive.
+        _session_is_guest = _resolve_approval_session_is_guest(
+            ctx._status_adapter, ctx._status_chat_id
+        )
+        # Non-admin tier: an authorized-but-non-admin user (the
+        # allow_admin_from slash-access tier) approves nothing -- only the
+        # owner/admin can grant a dangerous-command approval, same trust
+        # level as a group/guest chat. Resolved via the SAME
+        # policy_for_source().is_admin() that gates admin-only slash
+        # commands, so "who is admin" has one definition enforced across
+        # both surfaces. Guest takes precedence (a guest is in a group and
+        # has its own carve-out); the policy is a no-op (is_admin -> True)
+        # until an operator actually sets allow_admin_from, so existing
+        # single-tier installs are unaffected.
+        _session_is_non_admin = (
+            False if _session_is_guest
+            else _resolve_approval_session_is_non_admin(
+                ctx.source, getattr(self._runner, "config", None)
+            )
+        )
+        if _session_is_guest:
+            mark_session_approval_blocked(session_key, "guest")
+        elif _session_is_non_admin:
+            mark_session_approval_blocked(session_key, "non_admin")
         try:
             api_message = _wrap_current_message_with_observed_context(self._native_image_run_message(), observed_group_context)
             kwargs = {"conversation_history": agent_history, "task_id": ctx.session_id}
@@ -1441,6 +1480,8 @@ class TurnRunner:
             return agent.run_conversation(api_message, **kwargs)
         finally:
             unregister_gateway_notify(session_key)
+            if _session_is_guest or _session_is_non_admin:
+                unmark_session_approval_blocked(session_key)
             # Cancel pending clarify entries so blocked agent threads don't hang past the end of the
             # run (interrupt, completion, gateway shutdown). Idempotent.
             with suppress(Exception):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -778,6 +778,59 @@ class TelegramAdapter(BasePlatformAdapter):
             return _scoped_gate_env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
         return decision
 
+    def _is_callback_user_admin(
+        self,
+        user_id: str,
+        *,
+        chat_id: Optional[str] = None,
+        chat_type: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        user_name: Optional[str] = None,
+    ) -> bool:
+        """Return whether a Telegram inline-button caller is an admin for gated
+        actions that only the owner/admin may take (e.g. approving a dangerous
+        command via the exec-approval buttons).
+
+        Resolved via ``self._is_admin_for_gated_action`` (``BasePlatformAdapter``),
+        which delegates to a profile-bound ``slash_access.policy_for_source()
+        .is_admin()`` callback GatewayRunner registers per adapter instance at
+        connection time (:meth:`set_admin_policy_check`) -- so the button and
+        the typed ``/approve`` share one definition of "is this user an admin"
+        (closing the gap where a button click skipped the admin gate the typed
+        command enforced), and a SECONDARY multiplexed adapter resolves ITS
+        OWN profile's ``allow_admin_from`` rather than introspecting
+        ``_message_handler.__self__`` (which is ``None`` for a multiplexed
+        adapter's closure-based handler, and would silently apply the
+        primary profile's tier or none at all). When the operator hasn't
+        configured ``allow_admin_from`` for the scope the policy is disabled
+        and ``is_admin`` returns True for every authorized user -- so
+        single-tier installs keep today's behavior (any authorized user may
+        approve). Caller must already have passed
+        :meth:`_is_callback_user_authorized`.
+        """
+        normalized_user_id = str(user_id or "").strip()
+        if not normalized_user_id:
+            return False
+
+        from gateway.session import SessionSource
+
+        normalized_chat_type = self._normalize_chat_type(chat_type, is_forum=thread_id is not None)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=str(chat_id or normalized_user_id),
+            chat_type=normalized_chat_type,
+            user_id=normalized_user_id,
+            user_name=str(user_name).strip() if user_name else None,
+            thread_id=str(thread_id) if thread_id is not None else None,
+        )
+        result = self._is_admin_for_gated_action(source)
+        if result is None:
+            # No admin-policy check registered (e.g. bare-adapter test
+            # paths) -- fall back to "authorized == allowed", no tier to
+            # enforce, matching the pre-existing single-tier behavior.
+            return True
+        return result
+
     def _source_from_message_for_auth(self, message: Message):
         """Build the SessionSource the gateway auth path expects; identity comes from ``from_user``,
         falling back to ``sender_chat`` for channel posts so an unauthorized channel can't inject."""
@@ -4262,11 +4315,32 @@ class TelegramAdapter(BasePlatformAdapter):
         except (ValueError, IndexError):
             await query.answer(text="Invalid approval data.")
             return
+        # Peek (no pop yet): the admin-tier check below must run BEFORE the
+        # entry is removed from _approval_state. Popping first and denying on
+        # the admin check would silently discard the pending approval — a
+        # later legitimate admin tap on the same button would then see
+        # "already resolved" even though resolve_gateway_approval() never ran.
         session_key = await self._claim_callback_state(
             query, cb, self._approval_state, approval_id, "⛔ You are not authorized to approve commands.",
-            "This approval has already been resolved.")
+            "This approval has already been resolved.", pop=False)
         if not session_key:
             return
+        # ...and, when a permission tier is configured, only an admin.
+        # The typed /approve command is already admin-gated via
+        # slash_access; the button must share that gate so a non-admin
+        # can't self-approve their own dangerous command by tapping the
+        # inline button instead of typing the command. No-op (allows
+        # every authorized user) until allow_admin_from is set.
+        if not self._is_callback_user_admin(
+            str(getattr(query.from_user, "id", "")),
+            chat_id=cb["chat_id"],
+            chat_type=str(cb["chat_type"]) if cb["chat_type"] is not None else None,
+            thread_id=str(cb["thread_id"]) if cb["thread_id"] is not None else None,
+            user_name=cb["user_name"],
+        ):
+            await query.answer(text="⛔ Only an admin can approve commands here.")
+            return
+        self._approval_state.pop(approval_id, None)
         user_display = getattr(query.from_user, "first_name", "User")
         # Resolve FIRST (unblocks the agent thread), render after: a tap landing after the wait timed out
         # (count == 0) must NOT claim "Approved" — the command was already denied.

--- a/tests/gateway/test_admin_policy_multiplex_scope.py
+++ b/tests/gateway/test_admin_policy_multiplex_scope.py
@@ -1,0 +1,246 @@
+"""Regression tests for the multiplex-profile admin-tier scoping bugs
+sweeper flagged on PR #59857:
+
+1. ``plugins/platforms/telegram/adapter.py``'s exec-approval button gate
+   used to resolve the runner via ``_message_handler.__self__``, which is
+   ``None`` for a secondary multiplexed adapter (its handler is a closure
+   from ``_make_profile_message_handler``, not a bound method) -- silently
+   failing OPEN (any authorized user treated as admin) even when that
+   profile configured ``allow_admin_from``.
+
+2. ``gateway/run.py``'s turn-dispatch non-admin marking read ``self.config``,
+   which is the PRIMARY profile's config -- wrong for a secondary
+   multiplexed profile's turn, which runs inside that profile's OWN
+   ``_profile_runtime_scope``.
+
+Both are fixed by resolving the policy fresh (profile-bound closure /
+``load_gateway_config()``) instead of reading a cached attribute off
+whatever object happens to be reachable.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.run import GatewayRunner, _resolve_approval_session_is_non_admin
+from gateway.session import SessionSource
+
+
+def _tiered_config(admin_ids):
+    return GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True, token="***",
+                extra={"allow_admin_from": list(admin_ids)},
+            )
+        }
+    )
+
+
+def _source(user_id: str) -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id=user_id,
+    )
+
+
+def _make_runner(config) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    return runner
+
+
+class TestMakeAdapterAdminPolicyCheck:
+    """GatewayRunner._make_adapter_admin_policy_check -- the injected,
+    profile-bound resolver that replaces __self__ introspection."""
+
+    def test_profile_home_none_uses_self_config(self):
+        runner = _make_runner(_tiered_config(admin_ids=["999"]))
+        check = runner._make_adapter_admin_policy_check(profile_home=None)
+
+        assert check(_source("999")) is True
+        assert check(_source("12345")) is False
+
+    def test_profile_home_set_uses_scoped_config_not_self_config(self, monkeypatch):
+        """The exact bug: for a secondary profile, self.config must be
+        IGNORED entirely -- only the scoped load matters. Deliberately make
+        self.config say the opposite of the scoped config so a test that
+        accidentally reads self.config would be caught."""
+        # self.config would let user "12345" through (empty admin list == disabled).
+        runner = _make_runner(_tiered_config(admin_ids=[]))
+
+        scoped_config = _tiered_config(admin_ids=["999"])
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: scoped_config)
+
+        calls = []
+
+        def _fake_scope(profile_home):
+            calls.append(profile_home)
+            from contextlib import contextmanager
+
+            @contextmanager
+            def _cm():
+                yield
+            return _cm()
+
+        monkeypatch.setattr("gateway.run._profile_runtime_scope", _fake_scope)
+
+        check = runner._make_adapter_admin_policy_check(profile_home="/fake/profile/home")
+
+        # Scoped config's tier (admin=["999"]) applies, NOT self.config's
+        # (which would have let "12345" through as "no tier configured").
+        assert check(_source("999")) is True
+        assert check(_source("12345")) is False
+        assert calls == ["/fake/profile/home", "/fake/profile/home"]
+
+    def test_resolution_error_fails_toward_existing_behavior(self, monkeypatch):
+        """An unresolvable policy must not newly lock out an
+        already-authorized approver (matches the pre-existing __self__-path
+        fail-toward-permissive convention)."""
+        runner = _make_runner(_tiered_config(admin_ids=["999"]))
+        check = runner._make_adapter_admin_policy_check(profile_home="/fake")
+        monkeypatch.setattr(
+            "gateway.run._profile_runtime_scope",
+            MagicMock(side_effect=RuntimeError("boom")),
+        )
+        assert check(_source("12345")) is True
+
+    def test_resolution_error_is_logged_not_silent(self, monkeypatch, caplog):
+        """The fail-toward-permissive path must leave a trace: an operator
+        who configured allow_admin_from needs to know the tier silently
+        stopped applying (e.g. their profile config no longer loads), and a
+        bare ``except: return True`` in an authorization gate is invisible."""
+        import logging
+
+        runner = _make_runner(_tiered_config(admin_ids=["999"]))
+        check = runner._make_adapter_admin_policy_check(profile_home="/fake")
+        monkeypatch.setattr(
+            "gateway.run._profile_runtime_scope",
+            MagicMock(side_effect=RuntimeError("boom")),
+        )
+        with caplog.at_level(logging.WARNING, logger="gateway.run"):
+            assert check(_source("12345")) is True
+        assert any(
+            "Admin-tier policy resolution failed" in rec.message
+            for rec in caplog.records
+        ), "policy-resolution failure must be logged, not swallowed"
+
+
+class TestAdapterButtonGateUsesInjectedCheckNotHandlerIntrospection:
+    """The exact scenario sweeper described: a secondary multiplexed
+    adapter's _message_handler is a closure (no __self__). Before the fix,
+    TelegramAdapter._is_callback_user_admin's getattr(..., "__self__", None)
+    chain resolved to None -> runner_config None -> fail-open (return True)
+    even with allow_admin_from configured for that profile.
+    """
+
+    def _make_adapter(self):
+        import sys
+        from unittest.mock import MagicMock as _MM
+
+        if "telegram" not in sys.modules or not hasattr(sys.modules["telegram"], "__file__"):
+            mod = _MM()
+            mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+            mod.error.NetworkError = type("NetworkError", (OSError,), {})
+            mod.error.TimedOut = type("TimedOut", (OSError,), {})
+            mod.error.BadRequest = type("BadRequest", (Exception,), {})
+            for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+                sys.modules.setdefault(name, mod)
+            sys.modules.setdefault("telegram.error", mod.error)
+
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+        config = PlatformConfig(enabled=True, token="test-token")
+        adapter = TelegramAdapter(config)
+        adapter._bot = _MM()
+        adapter._app = _MM()
+        return adapter
+
+    def test_closure_handler_with_no_self_still_enforces_configured_tier(self):
+        """Regression: _message_handler with no __self__ (the secondary
+        multiplex shape) must not fail open once set_admin_policy_check has
+        been used to inject a real resolver."""
+        adapter = self._make_adapter()
+
+        async def _closure_handler(event):
+            return None
+        adapter._message_handler = _closure_handler
+        assert not hasattr(adapter._message_handler, "__self__")
+
+        runner = _make_runner(_tiered_config(admin_ids=["999"]))
+        adapter.set_admin_policy_check(runner._make_adapter_admin_policy_check())
+
+        assert adapter._is_callback_user_admin("12345", chat_id="12345") is False
+        assert adapter._is_callback_user_admin("999", chat_id="12345") is True
+
+    def test_no_admin_policy_check_registered_falls_back_to_permissive(self):
+        """Bare-adapter test paths (nothing injected at all) keep today's
+        single-tier behavior: any authorized user may approve."""
+        adapter = self._make_adapter()
+        assert adapter._is_callback_user_admin("12345", chat_id="12345") is True
+
+
+class TestResolveApprovalSessionIsNonAdmin:
+    """gateway.run._resolve_approval_session_is_non_admin.
+
+    Non-multiplex (the common case): base_config IS already correct, used
+    directly with zero extra disk I/O on the turn-dispatch hot path.
+
+    Multiplex active: loads config fresh via gateway.config.load_gateway_config()
+    instead of trusting base_config, since for a secondary profile's turn
+    (already inside that profile's _profile_runtime_scope) base_config is
+    still the PRIMARY profile's parsed config.
+    """
+
+    def test_admin_user_is_not_flagged_non_admin(self):
+        base_config = _tiered_config(admin_ids=["999"])
+        assert _resolve_approval_session_is_non_admin(_source("999"), base_config) is False
+
+    def test_non_admin_user_is_flagged(self):
+        base_config = _tiered_config(admin_ids=["999"])
+        assert _resolve_approval_session_is_non_admin(_source("12345"), base_config) is True
+
+    def test_no_tier_configured_is_a_no_op(self):
+        base_config = _tiered_config(admin_ids=[])
+        assert _resolve_approval_session_is_non_admin(_source("12345"), base_config) is False
+
+    def test_non_multiplex_never_calls_load_gateway_config(self, monkeypatch):
+        """Zero extra disk I/O for the common (non-multiplex) case -- base_config
+        is already correct, so the expensive fresh load must not fire at all."""
+        calls = []
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config",
+            lambda: calls.append(1) or _tiered_config(admin_ids=["999"]),
+        )
+        base_config = _tiered_config(admin_ids=["999"])
+        _resolve_approval_session_is_non_admin(_source("12345"), base_config)
+        assert calls == []
+
+    def test_multiplex_active_ignores_base_config_uses_fresh_scoped_load(self, monkeypatch):
+        """The exact bug: for a multiplexed secondary-profile turn,
+        base_config (the primary profile's config) must be IGNORED entirely.
+        Deliberately make base_config say the opposite of the freshly-loaded
+        scoped config so a test that accidentally reads base_config would be
+        caught."""
+        # base_config says "12345" is fine (disabled tier) -- the scoped
+        # config (what a multiplexed secondary profile's turn actually sees)
+        # says only "999" is admin. If the fix regresses to reading
+        # base_config, this user would wrongly NOT be flagged non-admin.
+        base_config = _tiered_config(admin_ids=[])
+        base_config.multiplex_profiles = True
+
+        scoped_config = _tiered_config(admin_ids=["999"])
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: scoped_config)
+
+        assert _resolve_approval_session_is_non_admin(_source("12345"), base_config) is True
+        assert _resolve_approval_session_is_non_admin(_source("999"), base_config) is False
+
+    def test_missing_base_config_is_a_safe_no_op_not_a_raise(self):
+        """Regression: the call site passes ``getattr(self, "config", None)``,
+        not a bare ``self.config`` -- a runner test fixture with no .config
+        attribute at all (test_reasoning_command.py's minimal GatewayRunner
+        double) must get a safe no-op here, not an AttributeError escaping
+        the call site (which has no enclosing try/except of its own; only
+        this function's internals do)."""
+        assert _resolve_approval_session_is_non_admin(_source("12345"), None) is False

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -210,6 +210,9 @@ class _SecondaryRecoveryAdapter:
     def set_platform_event_handler(self, handler):
         self.platform_event_handler = handler
 
+    def set_admin_policy_check(self, handler):
+        self.admin_policy_check = handler
+
 
 def _secondary_recovery_runner(*, running=True):
     runner = GatewayRunner.__new__(GatewayRunner)

--- a/tests/gateway/test_resolve_approval_session_is_guest.py
+++ b/tests/gateway/test_resolve_approval_session_is_guest.py
@@ -1,0 +1,202 @@
+"""gateway.run._resolve_approval_session_is_guest against the concrete Bot
+API 10.0 guest-mode adapter contract (plugins/platforms/telegram/adapter.py's
+``_is_guest_chat``, ``_pending_guest_queries``, ``_guest_only_chats`` — see
+the linked #56476 guest-mode PR), plus a regression test for the smart-
+approval bypass sweeper flagged: a guest session must deny BEFORE smart
+approval or cached per-session grants get a chance to auto-approve.
+
+Not theorized: no adapter on current main defines ``_is_guest_chat`` yet, so
+tests/tools/test_approval.py's own guest-mode tests exercise the approval
+short-circuit by calling ``mark_session_guest``/``unmark_session_guest``
+directly. The tests below instead build a stub adapter with the REAL shape
+#56476 ships (same attribute names, same ``str(chat_id)`` key normalization)
+and drive it through the actual ``getattr``-based wiring extracted from
+``gateway/run.py``, so the integration between that wiring and a real guest
+predicate is exercised — not just the approval module's internal state.
+"""
+from __future__ import annotations
+
+import os
+
+from unittest.mock import MagicMock
+
+from gateway.run import _resolve_approval_session_is_guest
+
+
+class _StubGuestAwareAdapter:
+    """Mirrors #56476's TelegramAdapter._is_guest_chat exactly:
+    True while a guest turn is in flight (_pending_guest_queries) or for
+    the remainder of processing after the query was consumed
+    (_guest_only_chats). Keys are normalized via str(chat_id).
+    """
+
+    def __init__(self):
+        self._pending_guest_queries: dict[str, object] = {}
+        self._guest_only_chats: set[str] = set()
+
+    def _is_guest_chat(self, chat_id) -> bool:
+        cid_str = str(chat_id)
+        return self._pending_guest_queries.get(cid_str) is not None or cid_str in self._guest_only_chats
+
+
+def test_false_when_neither_pending_nor_guest_only():
+    adapter = _StubGuestAwareAdapter()
+    assert _resolve_approval_session_is_guest(adapter, "12345") is False
+
+
+def test_true_when_chat_is_pending_guest_query():
+    adapter = _StubGuestAwareAdapter()
+    adapter._pending_guest_queries["12345"] = object()
+    assert _resolve_approval_session_is_guest(adapter, "12345") is True
+
+
+def test_true_when_chat_is_guest_only():
+    adapter = _StubGuestAwareAdapter()
+    adapter._guest_only_chats.add("12345")
+    assert _resolve_approval_session_is_guest(adapter, "12345") is True
+
+
+def test_normalizes_non_string_chat_id_like_the_real_predicate_does():
+    """gateway/run.py passes chat_id through as-is (may be int); the real
+    predicate's own str() conversion must still match a string-keyed entry."""
+    adapter = _StubGuestAwareAdapter()
+    adapter._guest_only_chats.add("12345")
+    assert _resolve_approval_session_is_guest(adapter, 12345) is True
+
+
+def test_false_for_adapter_without_is_guest_chat():
+    """Today's reality on main: no adapter defines _is_guest_chat at all --
+    must be a safe no-op, not an AttributeError."""
+    adapter = MagicMock(spec=[])  # no attributes at all
+    assert _resolve_approval_session_is_guest(adapter, "12345") is False
+
+
+def test_false_when_is_guest_chat_is_not_callable():
+    """Defensive: a plain attribute (not a method) must not be invoked."""
+    adapter = MagicMock()
+    adapter._is_guest_chat = "not callable"
+    assert _resolve_approval_session_is_guest(adapter, "12345") is False
+
+
+class TestGuestPredicateDrivesRealApprovalDenial:
+    """End-to-end: a real-shaped guest adapter resolving True, marked via
+    mark_session_guest (exactly as gateway/run.py's turn-dispatch wiring
+    does), must cause check_all_command_guards to deny a dangerous command
+    instantly and WITHOUT ever attempting to send an approval prompt -- both
+    in the default manual-approval flow AND when approvals.mode=smart would
+    otherwise auto-approve. The smart case is the regression this test suite
+    exists for: the guest check used to run only inside
+    _await_gateway_decision, which a smart-approve "approve" verdict never
+    reaches.
+    """
+
+    SESSION_KEY = "test-guest-predicate-session"
+
+    def setup_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._gateway_approval_blocked.clear()
+        mod._session_approved.clear()
+        mod._permanent_approved.clear()
+
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("HERMES_GATEWAY_SESSION", "HERMES_CRON_SESSION",
+                      "HERMES_YOLO_MODE", "HERMES_SESSION_KEY", "HERMES_INTERACTIVE")
+        }
+        os.environ.pop("HERMES_YOLO_MODE", None)
+        os.environ.pop("HERMES_INTERACTIVE", None)
+        os.environ.pop("HERMES_CRON_SESSION", None)
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY
+
+    def teardown_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._gateway_approval_blocked.clear()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _mark_guest_via_real_predicate(self) -> None:
+        from tools.approval import mark_session_guest
+
+        adapter = _StubGuestAwareAdapter()
+        adapter._guest_only_chats.add("999")
+        assert _resolve_approval_session_is_guest(adapter, "999") is True
+        mark_session_guest(self.SESSION_KEY)
+
+    def test_manual_mode_denies_without_notify(self):
+        from tools import approval as mod
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        self._mark_guest_via_real_predicate()
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == []
+
+    def test_smart_mode_approve_verdict_still_denies_guest(self, monkeypatch):
+        """The bug: smart approval's 'approve' verdict used to return
+        approved=True directly, before the guest check (which only lived in
+        _await_gateway_decision) ever ran. A guest session must deny even
+        when the aux LLM would have auto-approved."""
+        from tools import approval as mod
+
+        monkeypatch.setattr(mod.approval_context, "_get_approval_mode", lambda: "smart")
+        monkeypatch.setattr(mod, "_smart_verdict", lambda command, description, pattern_key, pattern_keys, session_key: "approve")
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        self._mark_guest_via_real_predicate()
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == [], "smart-approve must not reach notify_cb for a guest session"
+
+    def test_cached_session_grant_still_denies_guest(self, monkeypatch):
+        """The other half of the bug: a pattern already approved earlier in
+        the session (is_approved) used to skip straight to approved=True,
+        never reaching the guest check either."""
+        from tools import approval as mod
+
+        monkeypatch.setattr(mod.approval_context, "_get_approval_mode", lambda: "manual")
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        # Pre-approve the pattern this command will match, as if the user
+        # had approved it earlier in a non-guest turn on the same session.
+        _, pattern_key, _ = mod.detect_dangerous_command("rm -rf .git")
+        mod.approve_session(self.SESSION_KEY, pattern_key)
+        self._mark_guest_via_real_predicate()
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == []
+
+    def test_execute_code_smart_mode_approve_verdict_still_denies_guest(self, monkeypatch):
+        from tools import approval as mod
+
+        monkeypatch.setattr(mod.approval_context, "_get_approval_mode", lambda: "smart")
+        monkeypatch.setattr(mod, "_smart_verdict", lambda command, description, pattern_key, pattern_keys, session_key: "approve")
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        self._mark_guest_via_real_predicate()
+
+        result = mod.check_execute_code_guard("import os; os.system('rm -rf /')", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == []

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -330,3 +330,153 @@ class TestTelegramApprovalCallback:
         assert runner.last_source.platform == Platform.TELEGRAM
         assert runner.last_source.user_id == "222"
 
+    @pytest.mark.asyncio
+    async def test_update_prompt_callback_allows_authorized_user(self, tmp_path):
+        """Allowed Telegram users can still answer update prompt buttons."""
+        adapter = _make_adapter()
+
+        query = AsyncMock()
+        query.data = "update_prompt:n"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.id = 111
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+            with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "111"}):
+                await adapter._handle_callback_query(update, context)
+
+        query.answer.assert_called_once()
+        query.edit_message_text.assert_called_once()
+        assert (tmp_path / ".update_response").read_text() == "n"
+
+
+# ===========================================================================
+# Admin-tier gating of the exec-approval button (item 2 fix)
+#
+# The typed /approve command is admin-gated via slash_access; the inline
+# button must share that gate so a non-admin can't self-approve their own
+# dangerous command by tapping the button instead of typing the command.
+# No-op (any authorized user may approve) until allow_admin_from is set.
+# ===========================================================================
+
+class _TierRunner:
+    """Runner shim exposing both _is_user_authorized and a tiered config."""
+
+    def __init__(self, gateway_config):
+        self.config = gateway_config
+
+    async def _handle_message(self, event):
+        return None
+
+    def _is_user_authorized(self, source):
+        return True  # authorized to chat; admin-ness handled by slash_access
+
+
+def _wire_admin_policy_check(adapter, runner) -> None:
+    """Register the admin-tier check the same way GatewayRunner does at
+    adapter-connection time (set_admin_policy_check), rather than relying on
+    ``_message_handler.__self__`` introspection -- that path was removed
+    specifically because it fails open for a secondary multiplexed adapter
+    (closure-based handler, no ``__self__``). ``GatewayRunner``'s real
+    factory only reads ``self.config`` when ``profile_home`` is None, so
+    ``_TierRunner``'s lightweight ``.config`` duck-types fine here.
+    """
+    from gateway.run import GatewayRunner
+    adapter.set_admin_policy_check(GatewayRunner._make_adapter_admin_policy_check(runner))
+
+
+def _tiered_gateway_config(admin_ids):
+    """A gateway-config-like object policy_for_source can read."""
+    from gateway.config import Platform
+    telegram_cfg = PlatformConfig(
+        enabled=True, token="test-token",
+        extra={"allow_admin_from": list(admin_ids)},
+    )
+    return SimpleNamespace(platforms={Platform.TELEGRAM: telegram_cfg})
+
+
+def _make_ea_query(caller_id, approval_id):
+    query = AsyncMock()
+    query.data = f"ea:once:{approval_id}"
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.message.chat = MagicMock()
+    query.message.chat.type = "private"
+    query.message.message_thread_id = None
+    query.from_user = MagicMock()
+    query.from_user.first_name = "Norbert"
+    query.from_user.id = caller_id
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+    return update, query
+
+
+class TestApprovalButtonAdminGate:
+    @pytest.mark.asyncio
+    async def test_non_admin_click_is_rejected_and_does_not_resolve(self):
+        """With allow_admin_from set, a non-admin button click is refused and
+        never reaches resolve_gateway_approval."""
+        adapter = _make_adapter()
+        adapter._approval_state[41] = "agent:main:telegram:dm:12345:99"
+        runner = _TierRunner(_tiered_gateway_config(admin_ids=["999"]))
+        adapter._message_handler = runner._handle_message
+        _wire_admin_policy_check(adapter, runner)
+
+        update, query = _make_ea_query(caller_id="12345", approval_id=41)  # not admin
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_not_called()
+        # State must remain (not popped) so the real admin can still resolve.
+        assert 41 in adapter._approval_state
+        answer_text = query.answer.call_args.kwargs.get("text", "") if query.answer.call_args else ""
+        assert "admin" in answer_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_admin_click_resolves_normally(self):
+        adapter = _make_adapter()
+        adapter._approval_state[42] = "agent:main:telegram:dm:12345:99"
+        runner = _TierRunner(_tiered_gateway_config(admin_ids=["999"]))
+        adapter._message_handler = runner._handle_message
+        _wire_admin_policy_check(adapter, runner)
+
+        update, query = _make_ea_query(caller_id="999", approval_id=42)  # admin
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_called_once_with("agent:main:telegram:dm:12345:99", "once")
+        assert 42 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_no_tier_configured_any_authorized_user_may_approve(self):
+        """Backward compat: without allow_admin_from, the admin gate is a no-op."""
+        adapter = _make_adapter()
+        adapter._approval_state[43] = "agent:main:telegram:dm:12345:99"
+        runner = _TierRunner(_tiered_gateway_config(admin_ids=[]))  # tier disabled
+        adapter._message_handler = runner._handle_message
+        _wire_admin_policy_check(adapter, runner)
+
+        update, query = _make_ea_query(caller_id="12345", approval_id=43)
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_called_once()
+        assert 43 not in adapter._approval_state

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1403,7 +1403,8 @@ class TestApprovalTimeoutIsNotConsent:
         assert "BLOCKED" in msg
         assert "NOT consented" in msg
         assert "Silence is not consent" in msg
-        assert "retry" in msg.lower()
+        # Both forms of evasion must be named:
+        assert "do not retry" in msg.lower() or "Do NOT retry" in msg
         assert "rephrase" in msg.lower()
         assert "different command" in msg.lower()
 
@@ -1725,6 +1726,250 @@ class TestConcurrentApprovalCoalescing:
         t1.join(timeout=5)
         t2.join(timeout=5)
         assert all(r is not None and r["choice"] == "session" for r in results)
+
+
+class TestGuestModeApprovalShortCircuit:
+    """Guest-mode chats (Telegram Bot API 10.0 @mention, bot not a member)
+    can never present or resolve an interactive approval prompt -- mirrors
+    the existing slash-command carve-out (declines at the front door with a
+    canned message) instead of depending on approval-routing/delivery being
+    fixed first. Session marked guest -> immediate BLOCKED, no queue entry,
+    no notify_cb call, no wait.
+    """
+
+    SESSION_KEY = "test-guest-session"
+
+    def setup_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._gateway_approval_blocked.clear()
+        mod._session_approved.clear()
+        mod._permanent_approved.clear()
+        mod._pending.clear()
+
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("HERMES_GATEWAY_SESSION", "HERMES_CRON_SESSION",
+                      "HERMES_YOLO_MODE",
+                      "HERMES_SESSION_KEY", "HERMES_INTERACTIVE")
+        }
+        os.environ.pop("HERMES_YOLO_MODE", None)
+        os.environ.pop("HERMES_INTERACTIVE", None)
+        os.environ.pop("HERMES_CRON_SESSION", None)
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY
+
+    def teardown_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._gateway_approval_blocked.clear()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_mark_unmark_is_session_guest_roundtrip(self):
+        from tools import approval as mod
+        assert mod.is_session_guest(self.SESSION_KEY) is False
+        mod.mark_session_guest(self.SESSION_KEY)
+        assert mod.is_session_guest(self.SESSION_KEY) is True
+        mod.unmark_session_guest(self.SESSION_KEY)
+        assert mod.is_session_guest(self.SESSION_KEY) is False
+
+    def test_terminal_guard_denies_immediately_without_notify(self):
+        """Guest session: BLOCKED without ever calling notify_cb."""
+        from tools import approval as mod
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        mod.mark_session_guest(self.SESSION_KEY)
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == [], "notify_cb must never be called for a guest session"
+        assert mod._gateway_queues.get(self.SESSION_KEY) in (None, []), (
+            "no queue entry should be created for a guest session"
+        )
+
+    def test_terminal_guard_denial_message_tells_agent_context_not_supported(self):
+        from tools import approval as mod
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: None)
+        mod.mark_session_guest(self.SESSION_KEY)
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        msg = result["message"]
+        assert "BLOCKED" in msg
+        assert "isn't supported in this context" in msg
+        assert "do not retry" in msg.lower()
+
+    def test_terminal_guard_denial_is_fast_even_with_long_timeout(self, monkeypatch):
+        """Must not pay the gateway_timeout wait -- denies before ever queuing."""
+        from tools import approval as mod
+        monkeypatch.setattr(
+            approval_context, "_get_approval_config",
+            lambda: {"mode": "manual", "gateway_timeout": 300, "timeout": 300},
+        )
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: None)
+        mod.mark_session_guest(self.SESSION_KEY)
+
+        start = time.monotonic()
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+        elapsed = time.monotonic() - start
+
+        assert result["approved"] is False
+        assert elapsed < 2.0, f"guest denial took {elapsed:.2f}s -- should be near-instant"
+
+    def test_execute_code_guard_denies_immediately_without_notify(self):
+        from tools import approval as mod
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        mod.mark_session_guest(self.SESSION_KEY)
+
+        result = mod.check_execute_code_guard("import os; os.system('rm -rf /')", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "guest_unsupported"
+        assert notified == []
+
+    def test_non_guest_session_unaffected(self, monkeypatch):
+        """Sanity check: without the guest marker, existing timeout behavior is unchanged."""
+        from tools import approval as mod
+        monkeypatch.setattr(
+            approval_context, "_get_approval_config",
+            lambda: {"mode": "manual", "gateway_timeout": 1, "timeout": 1},
+        )
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        # Deliberately NOT marking the session as guest.
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "timeout"
+        assert len(notified) == 1, "notify_cb should fire normally for a non-guest session"
+
+
+class TestNonAdminApprovalShortCircuit:
+    """Authorized-but-non-admin users (the allow_admin_from slash-access tier)
+    cannot self-approve a dangerous command -- same immediate-deny mechanism as
+    guest chats, distinct 'ask the owner' messaging. The admin decision itself
+    is made in the gateway (slash_access.policy_for_source().is_admin()); the
+    approval layer only transports it via mark_session_approval_blocked().
+    """
+
+    SESSION_KEY = "test-non-admin-session"
+
+    def setup_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._gateway_approval_blocked.clear()
+        mod._session_approved.clear()
+        mod._permanent_approved.clear()
+        mod._pending.clear()
+
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("HERMES_GATEWAY_SESSION", "HERMES_CRON_SESSION",
+                      "HERMES_YOLO_MODE",
+                      "HERMES_SESSION_KEY", "HERMES_INTERACTIVE")
+        }
+        os.environ.pop("HERMES_YOLO_MODE", None)
+        os.environ.pop("HERMES_INTERACTIVE", None)
+        os.environ.pop("HERMES_CRON_SESSION", None)
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY
+
+    def teardown_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._gateway_approval_blocked.clear()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_block_reason_roundtrip(self):
+        from tools import approval as mod
+        assert mod.session_approval_block_reason(self.SESSION_KEY) is None
+        mod.mark_session_approval_blocked(self.SESSION_KEY, "non_admin")
+        assert mod.session_approval_block_reason(self.SESSION_KEY) == "non_admin"
+        # Guest wrapper reports False for a non_admin block (distinct reason).
+        assert mod.is_session_guest(self.SESSION_KEY) is False
+        mod.unmark_session_approval_blocked(self.SESSION_KEY)
+        assert mod.session_approval_block_reason(self.SESSION_KEY) is None
+
+    def test_guest_wrapper_still_maps_to_reason_guest(self):
+        from tools import approval as mod
+        mod.mark_session_guest(self.SESSION_KEY)
+        assert mod.session_approval_block_reason(self.SESSION_KEY) == "guest"
+        assert mod.is_session_guest(self.SESSION_KEY) is True
+
+    def test_terminal_guard_denies_non_admin_without_notify(self):
+        from tools import approval as mod
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        mod.mark_session_approval_blocked(self.SESSION_KEY, "non_admin")
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "non_admin_unsupported"
+        assert notified == [], "notify_cb must never fire for a non-admin session"
+        assert mod._gateway_queues.get(self.SESSION_KEY) in (None, [])
+
+    def test_non_admin_message_points_at_owner_not_generic_context(self):
+        from tools import approval as mod
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: None)
+        mod.mark_session_approval_blocked(self.SESSION_KEY, "non_admin")
+
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+
+        msg = result["message"].lower()
+        assert "blocked" in msg
+        assert "admin" in msg or "owner" in msg
+        assert "do not retry" in msg
+        # It must NOT reuse the guest "not supported in this context" wording.
+        assert "guest chat" not in msg
+
+    def test_non_admin_denial_is_fast_even_with_long_timeout(self, monkeypatch):
+        from tools import approval as mod
+        monkeypatch.setattr(
+            approval_context, "_get_approval_config",
+            lambda: {"mode": "manual", "gateway_timeout": 300, "timeout": 300},
+        )
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: None)
+        mod.mark_session_approval_blocked(self.SESSION_KEY, "non_admin")
+
+        start = time.monotonic()
+        result = mod.check_all_command_guards("rm -rf .git", "local")
+        elapsed = time.monotonic() - start
+
+        assert result["approved"] is False
+        assert elapsed < 2.0, f"non-admin denial took {elapsed:.2f}s -- should be near-instant"
+
+    def test_execute_code_guard_denies_non_admin(self):
+        from tools import approval as mod
+
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+        mod.mark_session_approval_blocked(self.SESSION_KEY, "non_admin")
+
+        result = mod.check_execute_code_guard("import os; os.system('rm -rf /')", "local")
+
+        assert result["approved"] is False
+        assert result.get("outcome") == "non_admin_unsupported"
+        assert notified == []
 
 
 class TestTirithImportErrorFailOpenPolicy:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -115,6 +115,27 @@ def _denial_breaker_addendum(session_key: str) -> str:
 # instead of only hearing "denied". Ported from qwibitai/nanoclaw#2832.
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+# session_key -> reason a session cannot grant an interactive approval, one of:
+#   "guest"     -- Telegram Bot API 10.0 @mention from a chat the bot isn't a
+#                  member of. No sendMessage/answerGuestQuery approval surface,
+#                  and slash commands (incl. /approve) are hard-blocked there.
+#   "non_admin" -- an authorized-but-non-admin user (the allow_admin_from
+#                  slash-access tier). The owner/admin approves dangerous
+#                  actions; a non-admin cannot self-approve, same trust level
+#                  as a group/guest chat.
+# In both cases _await_gateway_decision denies immediately -- no queue entry,
+# no notify_cb call, no wait, no approval hooks -- instead of blocking the
+# agent thread for the full gateway_timeout on an approval that will never
+# (guest) or must never (non_admin) arrive. This is independent of
+# send_exec_approval / approval-routing destination (home channel, etc.) --
+# the notify callback is never invoked.
+#
+# The admin/guest DECISION itself is resolved upstream in the gateway
+# (slash_access.policy_for_source().is_admin() and the adapter's
+# _is_guest_chat) -- this store only TRANSPORTS that decision into the
+# approval layer, which must not import gateway config. One source of truth
+# for "who is admin"; this is not a second place that re-decides it.
+_gateway_approval_blocked: dict[str, str] = {}
 
 
 def register_gateway_notify(session_key: str, cb) -> None:
@@ -132,6 +153,88 @@ def unregister_gateway_notify(session_key: str) -> None:
         entries = _gateway_queues.pop(session_key, [])
     for entry in entries:
         entry.event.set()
+
+
+def mark_session_approval_blocked(session_key: str, reason: str) -> None:
+    """Mark *session_key* as unable to grant an interactive approval this turn.
+
+    *reason* is ``"guest"`` or ``"non_admin"`` (see ``_gateway_approval_blocked``).
+    Call once per turn dispatch, alongside :func:`register_gateway_notify`.
+    """
+    with _lock:
+        _gateway_approval_blocked[session_key] = reason
+
+
+def unmark_session_approval_blocked(session_key: str) -> None:
+    """Clear the approval-blocked marker for *session_key* (turn teardown)."""
+    with _lock:
+        _gateway_approval_blocked.pop(session_key, None)
+
+
+def session_approval_block_reason(session_key: str) -> Optional[str]:
+    """Return why *session_key* can't grant approvals (``"guest"`` /
+    ``"non_admin"``), or ``None`` when it can."""
+    with _lock:
+        return _gateway_approval_blocked.get(session_key)
+
+
+# Backward-compatible guest-only surface (the original #59741 API). Guest is
+# just one reason a session is approval-blocked; these keep existing callers
+# and tests working while the general form above also covers the non_admin tier.
+def mark_session_guest(session_key: str) -> None:
+    """Mark *session_key* as a guest-mode chat (``reason="guest"``)."""
+    mark_session_approval_blocked(session_key, "guest")
+
+
+def unmark_session_guest(session_key: str) -> None:
+    """Clear the guest/approval-blocked marker for *session_key*."""
+    unmark_session_approval_blocked(session_key)
+
+
+def is_session_guest(session_key: str) -> bool:
+    """Return whether *session_key* is currently marked guest specifically."""
+    return session_approval_block_reason(session_key) == "guest"
+
+
+_APPROVAL_BLOCKED_MESSAGES = {
+    "guest": (
+        "BLOCKED: this action requires running a command that isn't "
+        "supported in this context (a guest chat the bot isn't a "
+        "member of has no way to grant approval). Do NOT retry this "
+        "command, do NOT rephrase it, and do NOT attempt the same "
+        "outcome via a different command -- there is no approval path "
+        "available here. Tell the user you can't do that in this context."
+    ),
+    "non_admin": (
+        "BLOCKED: this action requires approval to run a dangerous command, "
+        "and only the owner/an admin can grant it -- you are talking to a "
+        "non-admin user who cannot self-approve. Do NOT retry this command, "
+        "do NOT rephrase it, and do NOT attempt the same outcome via a "
+        "different command. Tell the user this action needs the owner to "
+        "run it or to grant them admin access."
+    ),
+}
+
+
+def _approval_blocked_result(reason: str, pattern_key: str, description: str) -> dict:
+    """The fixed BLOCKED result for a session that structurally cannot grant
+    an interactive approval this turn (``reason`` is ``"guest"`` or
+    ``"non_admin"`` -- see :func:`mark_session_approval_blocked`).
+
+    Shared by every approval-blocked denial site in both command-guard entry
+    points: the early check (before cached grants/smart approval get a
+    chance to run) and _await_gateway_decision's own ``guest_unsupported`` /
+    ``non_admin_unsupported`` result (reached for a command that wasn't
+    already caught early, e.g. a fresh pattern with no prior findings gate).
+    """
+    return {
+        "approved": False,
+        "message": _APPROVAL_BLOCKED_MESSAGES[reason],
+        "pattern_key": pattern_key,
+        "description": description,
+        "outcome": f"{reason}_unsupported",
+        "user_consent": False,
+    }
 
 
 def resolve_gateway_approval(session_key: str, choice: str,
@@ -718,6 +821,10 @@ def _human_decision(spec: _GateSpec, *, command: str, description: str,
             if smart_denied:
                 data["smart_denied"] = True
             decision = _await_gateway_decision(session_key, notify_cb, data, surface="gateway")
+            if decision.get("guest_unsupported"):
+                return _approval_blocked_result("guest", pattern_key, description)
+            if decision.get("non_admin_unsupported"):
+                return _approval_blocked_result("non_admin", pattern_key, description)
             if decision.get("notify_failed"):
                 return _denied(spec.notify_failed, pattern_key=pattern_key,
                                description=description, outcome="notify_failed")
@@ -1011,6 +1118,30 @@ def check_all_command_guards(command: str, env_type: str,
     is_dangerous, pattern_key, description = detect_dangerous_command(command)
     warnings = []
     session_key = get_current_session_key()
+
+    # A guest-mode or non-admin-tier session can never/must never present or
+    # resolve an interactive approval prompt (see
+    # mark_session_approval_blocked's docstring). Fail closed for ANY
+    # warning-worthy command HERE — before cached per-session grants
+    # (is_approved, below) or smart approval get a chance to run. Both would
+    # otherwise short-circuit straight to "approved": True without ever
+    # reaching _await_gateway_decision's own check further down in Phase 3,
+    # silently defeating the denial for the two paths that matter most: a
+    # pattern already approved earlier in the session, or an aux-LLM
+    # "approve" verdict.
+    _block_reason = session_approval_block_reason(session_key)
+    if _block_reason is not None and (
+        tirith_result["action"] in {"block", "warn"} or is_dangerous
+    ):
+        if tirith_result["action"] in {"block", "warn"}:
+            _blocked_desc = _format_tirith_description(tirith_result)
+            findings = tirith_result.get("findings") or []
+            _blocked_key = f"tirith:{findings[0].get('rule_id', 'unknown')}" if findings else "tirith:unknown"
+        else:
+            _blocked_desc = description
+            _blocked_key = pattern_key
+        return _approval_blocked_result(_block_reason, _blocked_key, _blocked_desc)
+
     if tirith_result["action"] in {"block", "warn"}:
         findings = tirith_result.get("findings") or []
         rule_id = findings[0].get("rule_id", "unknown") if findings else "unknown"
@@ -1093,6 +1224,16 @@ def check_execute_code_guard(code: str, env_type: str, has_host_access: bool = F
         return _approved()
 
     session_key = get_current_session_key()
+
+    # A guest-mode or non-admin-tier session can never/must never present or
+    # resolve an interactive approval prompt (see
+    # mark_session_approval_blocked's docstring). Fail closed here, before
+    # cached per-session grants (is_approved, below) or smart approval get a
+    # chance to auto-approve — same reasoning as check_all_command_guards.
+    _block_reason = session_approval_block_reason(session_key)
+    if _block_reason is not None:
+        return _approval_blocked_result(_block_reason, pattern_key, description)
+
     # Built only past the early-return gates so common paths don't copy a potentially-large script into this string.
     command = f"execute_code <<'PY'\n{code}\nPY"
 

--- a/tools/approval_gateway_wait.py
+++ b/tools/approval_gateway_wait.py
@@ -107,8 +107,13 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict, *,
     out. Shared by the terminal command guard, the execute_code guard, the plugin
     escalation gate, and MCP elicitation. Returns ``{"resolved", "choice",
     "reason"}`` or ``{"resolved": False, "choice": None, "notify_failed": True}``
-    when the notify callback raised. Persisting the choice and building the
-    tool-facing result stay with the caller.
+    when the notify callback raised, or ``{"resolved": True, "choice": None,
+    "guest_unsupported": True}`` / ``{"resolved": True, "choice": None,
+    "non_admin_unsupported": True}`` immediately if the session is
+    approval-blocked (see :func:`mark_session_approval_blocked`) -- no queue
+    entry, no notify_cb call, no wait, and no approval hooks fire for that
+    case. Persisting the choice and building the tool-facing result stay with
+    the caller.
 
     Identical concurrent approvals (same command text + pattern-key set) are
     coalesced: parallel tool calls would otherwise fire N identical prompts
@@ -116,6 +121,22 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict, *,
     the leader's ``session``/``always``/``deny``/timeout; a ``once`` covers only
     the leader, so the follower falls through to a fresh prompt."""
     from tools import approval as _approval
+
+    # Approval-blocked sessions (guest chats, or authorized-but-non-admin
+    # users -- see _gateway_approval_blocked docstring above) can never (guest)
+    # or must never (non_admin) resolve an interactive approval -- deny
+    # immediately, the same way the adapter already declines slash commands at
+    # the front door, instead of registering a queue entry and blocking the
+    # agent thread for the full gateway_timeout. Deliberately skips notify_cb
+    # and the pre/post approval hooks: this never becomes a real approval
+    # attempt, so nothing should observe it as one. Checked before the
+    # coalescing lookup below: a structurally-blocked session must never
+    # adopt another thread's in-flight decision either.
+    _block_reason = _approval.session_approval_block_reason(session_key)
+    if _block_reason == "guest":
+        return {"resolved": True, "choice": None, "guest_unsupported": True}
+    if _block_reason == "non_admin":
+        return {"resolved": True, "choice": None, "non_admin_unsupported": True}
 
     primary_key = approval_data.get("pattern_key", "")
     payload = {


### PR DESCRIPTION
## Summary

Adds the "user tier" half of a simple owner/user split for messaging platforms: an authorized-but-non-admin user can no longer approve a dangerous command — only the owner/admin can. This is the same trust level a group/guest chat already has, extended to known non-owner users.

**Stacked on #59741** (guest-mode approval fast-deny) — this branch contains #59741's commit plus this feature's commit, so the diff currently shows both. It will shrink to just this feature once #59741 merges into `main`.

## Design: reuse the shipped tier, no new config

The slash-command admin/user split (`allow_admin_from` / `user_allowed_commands`, PR #23373 — the salvaged, scoped-down landing of the larger #4443 tier work) already ships. This PR reuses it as the **single source of truth** rather than adding a parallel permission system:

- **Owner/admin = whoever is in `allow_admin_from`.** No new config key.
- Until an operator sets `allow_admin_from`, every check is a no-op (`is_admin → True` for all authorized users), so **existing single-tier installs are completely unaffected**.

## What changes

**One definition of "is admin", enforced on every approval surface:**

- **`tools/approval.py`** — generalize #59741's guest marker into an approval-blocked *reason* (`"guest"` | `"non_admin"`). `_await_gateway_decision` denies immediately for either — no queue entry, no `notify_cb` call, no wait, no approval hooks — with reason-specific messaging (guest: "not supported in this context"; non-admin: "ask the owner to run it or grant you access"). The `mark_session_guest` / `is_session_guest` functions stay as thin wrappers, so #59741's surface is unchanged.
- **`gateway/run.py`** — at turn dispatch, resolve non-admin via the **same** `slash_access.policy_for_source().is_admin()` that gates admin-only *typed* slash commands, and mark the session. Guest takes precedence (a guest is in a group and has its own carve-out).
- **`plugins/platforms/telegram/adapter.py`** — close a gap found while building this: the typed `/approve` command was already admin-gated via `slash_access`, but the inline exec-approval **button** (`ea:`) was gated only by "is this user allowed to chat," not "is this user an admin." So a non-admin could tap **Allow** to self-approve their own dangerous command even though typing `/approve` was blocked. The button now shares the same `policy_for_source().is_admin()` gate. No-op until `allow_admin_from` is set.

## Scope

Deliberately minimal, matching "same as group chats": non-admin users keep full agent access, they just can't approve dangerous commands (auto-denied) and can't run admin-only slash commands (already handled by #23373). **No tool-filtering / reduced toolset** — that's the larger #4443 territory and isn't needed for this ask. Denying outright also sidesteps the approval-routing / delegation subsystem (home-channel pinning, #47863) entirely, the same way #59741 did for guest mode.

## Test plan

- [x] `TestNonAdminApprovalShortCircuit` (6): reason roundtrip, guest wrapper still maps to `"guest"`, terminal + execute_code guards deny non-admin without calling `notify_cb`, owner-pointed messaging, near-instant denial under a 300s timeout.
- [x] `TestApprovalButtonAdminGate` (3): non-admin button click refused and approval state preserved (real admin can still resolve), admin click resolves normally, and no-tier-configured backward compat (any authorized user may approve).
- [x] `#59741`'s guest tests updated for the generalized internal store name; full `tests/tools/test_approval.py` + `tests/gateway/test_telegram_approval_buttons.py` + `tests/gateway/test_approve_deny_commands.py` green (361 passed). `tests/gateway/test_slash_access.py` green (21).

## Update: fixed two multiplex fail-open gaps (addresses hermes-sweeper review)

Also rebased onto the updated `#59741` (it landed a smart-approval/cached-grant bypass fix in the meantime; this branch now builds on that).

sweeper found that both new admin-tier checks resolved their config in a way that works for a single-profile gateway but fails open for a **secondary multiplexed profile**:

1. The exec-approval button gate (`plugins/platforms/telegram/adapter.py`) resolved the runner via `_message_handler.__self__` — `None` for a secondary profile's adapter (its handler is a closure from `_make_profile_message_handler`, not a bound method), so `runner_config` was `None` and the check fell back to "no tier to enforce" even with `allow_admin_from` configured for that profile.
2. The turn-dispatch marking (`gateway/run.py`) read `self.config` — the PRIMARY profile's config — while a secondary profile's turn runs inside that profile's own `_profile_runtime_scope`, so it could apply the wrong profile's tier.

Fix: added `BasePlatformAdapter.set_admin_policy_check()` (mirrors the existing `set_authorization_check`) and `GatewayRunner._make_adapter_admin_policy_check()`, which builds a profile-bound closure injected at adapter-connection time — no more handler introspection. Extracted `_resolve_approval_session_is_non_admin()` for the turn-dispatch side: uses the primary config directly for the common non-multiplex case (zero extra cost, matches every existing test's mocking of `self.config`), and only loads `gateway.config.load_gateway_config()` fresh when `multiplex_profiles` is actually set.

Also generalized `#59741`'s `_guest_unsupported_block_result` into `_approval_blocked_result(reason, ...)` so the early fail-closed checks in `check_all_command_guards`/`check_execute_code_guard` (which #59741 added to close its own smart-approval bypass) cover `non_admin` too — otherwise that exact bypass would still apply to non-admin sessions, just not guest ones.

Found and fixed two collateral issues while testing this against the full suite: an eager `load_gateway_config()` call was hanging a `tests/gateway/test_compression_failure_session_sync.py` test that doesn't isolate `HERMES_HOME` (now only loads fresh when multiplexing is active); and the call site was doing a bare `self.config` attribute access outside any try/except, which crashed `tests/gateway/test_reasoning_command.py`'s minimal runner fixture (fixed with `getattr(self, "config", None)`, matching the pre-existing code's implicit safety).

🤖 Generated with [Claude Code](https://claude.com/claude-code)