### PR TITLE
fix(security): redact secrets in background process notifications

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1840,3 +1840,69 @@ class TestHandleProcessRedaction:
         monkeypatch.setattr(pr, "process_registry", reg)
         out = json.loads(pr._handle_process({"action": "log", "session_id": sess.id}))
         assert "zzzopaque1234567890abcdef" in out["output"]
+
+
+class TestNotificationRedaction:
+    """Background-process notification delivery (completion_queue) applies the
+    same redaction as the explicit process tool — issue #43025 gap.
+
+    The _move_to_finished() and _check_watch_patterns() paths enqueue raw
+    output into the completion_queue.  After the fix, _redact_process_result()
+    is called before enqueueing so secrets are masked in the [IMPORTANT: ...]
+    messages delivered to the LLM.
+    """
+
+    def test_completion_notification_redacts_secret(self, monkeypatch):
+        """_move_to_finished completion notification redacts API keys."""
+        import agent.redact as _r
+        monkeypatch.setattr(_r, "_REDACT_ENABLED", True)
+        from tools import process_registry as pr
+
+        reg = ProcessRegistry()
+        sess = _make_session(sid="proc_notif1", command="env")
+        sess.output_buffer = "OPENAI_API_KEY=sk-proj-secret123\nHOME=/home/u"
+        sess.notify_on_complete = True
+        sess.exited = True
+        sess.exit_code = 0
+        reg._running[sess.id] = sess
+        monkeypatch.setattr(pr, "process_registry", reg)
+
+        reg._move_to_finished(sess)
+
+        # Drain and check the notification
+        results = reg.drain_notifications()
+        assert len(results) == 1
+        _evt, text = results[0]
+        assert "sk-proj-secret123" not in text
+        assert "REDACTED" in text or "sk-proj" not in text
+
+    def test_watch_match_notification_redacts_secret(self, monkeypatch):
+        """_check_watch_patterns watch_match notification redacts secrets."""
+        import agent.redact as _r
+        monkeypatch.setattr(_r, "_REDACT_ENABLED", True)
+        from tools import process_registry as pr
+
+        reg = ProcessRegistry()
+        sess = _make_session(sid="proc_notif2", command="python server.py")
+        sess.output_buffer = "Server started\nAPI_TOKEN=ghp_abc123def456\nListening on :8080"
+        sess.watch_patterns = ["API_TOKEN"]
+        sess._watch_disabled = False
+        sess._watch_hits = 0
+        sess._watch_suppressed = 0
+        sess.watcher_platform = None
+        sess.watcher_chat_id = None
+        sess.watcher_user_id = None
+        sess.watcher_user_name = None
+        sess.watcher_thread_id = None
+        sess.watcher_message_id = None
+        sess.exited = False
+        reg._running[sess.id] = sess
+        monkeypatch.setattr(pr, "process_registry", reg)
+
+        reg._check_watch_patterns(sess, ["API_TOKEN=ghp_abc123def456"], "API_TOKEN")
+
+        results = reg.drain_notifications()
+        assert len(results) == 1
+        _evt, text = results[0]
+        assert "ghp_abc123def456" not in text
+        assert "ghp_" not in text or "REDACTED" in text

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -337,7 +337,7 @@ class ProcessRegistry:
         if not self._global_watch_admit(now):
             return
 
-        self.completion_queue.put({
+        notification = {
             "session_id": session.id,
             "session_key": session.session_key,
             "command": session.command,
@@ -351,7 +351,9 @@ class ProcessRegistry:
             "user_name": session.watcher_user_name,
             "thread_id": session.watcher_thread_id,
             "message_id": session.watcher_message_id,
-        })
+        }
+        _redact_process_result(notification)
+        self.completion_queue.put(notification)
 
     def _global_watch_admit(self, now: float) -> bool:
         """Return True if this watch_match event is allowed through the global breaker.
@@ -1082,7 +1084,7 @@ class ProcessRegistry:
         if was_running and session.notify_on_complete:
             from tools.ansi_strip import strip_ansi
             output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
-            self.completion_queue.put({
+            notification = {
                 "type": "completion",
                 "session_id": session.id,
                 "session_key": session.session_key,
@@ -1091,7 +1093,9 @@ class ProcessRegistry:
                 "completion_reason": session.completion_reason,
                 "termination_source": session.termination_source,
                 "output": output_tail,
-            })
+            }
+            _redact_process_result(notification)
+            self.completion_queue.put(notification)
 
     # ----- Query Methods -----
 


### PR DESCRIPTION
## Summary

Apply `_redact_process_result()` to background process completion and watch_match notifications before enqueuing them in the `completion_queue`. Previously these notifications only applied `strip_ansi()`, leaving API keys, tokens, and other secrets in process output unmasked when injected into the LLM conversation.

## The bug

Two code paths deliver background process output to the LLM:

1. **Explicit `process` tool** (`poll`/`log`/`wait`) — calls `_redact_process_result()` which applies `redact_terminal_output()` ✅
2. **Automatic notifications** (`notify_on_complete`, `watch_patterns`) — only applies `strip_ansi()` ❌

When a background process finishes or matches a watch pattern, its raw output is formatted as `[IMPORTANT: ...]` and injected as a user message to the LLM. If that output contains API keys, tokens, passwords, or other secrets, they reach the model context unmasked.

## Example

A background `env` or `printenv` command completes with `notify_on_complete=true`. The process output contains `OPENAI_API_KEY=sk-...`. The explicit `process(action='poll')` path would redact this to `OPENAI_API_KEY=REDACTED`. The notification path injects `OPENAI_API_KEY=sk-...` verbatim into the LLM context.

## Fix

`tools/process_registry.py` — 2 changes:

- `_move_to_finished()` (line ~1085): Extract notification dict to variable, apply `_redact_process_result()`, then enqueue
- `_check_watch_patterns()` (line ~340): Same pattern — extract, redact, enqueue

Both paths now match the explicit `process` tool behavior. 8 lines added, 4 removed.

## Tests

`tests/tools/test_process_registry.py` — 2 new tests:

- `test_completion_notification_redacts_secret` — verifies `_move_to_finished` redacts API keys in completion notifications
- `test_watch_match_notification_redacts_secret` — verifies `_check_watch_patterns` redacts secrets in watch_match notifications
