### PR TITLE
fix: refresh Langfuse dependency after updates

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1384,17 +1384,25 @@ def _run_post_setup(post_setup_key: str):
             _print_info("    Run manually: hermes auth spotify")
 
     elif post_setup_key == "langfuse":
-        # Install the langfuse SDK.
+        # Install the Langfuse SDK through the managed lazy-dependency path so
+        # `hermes update` can also refresh it after venv rebuilds.
+        from tools import lazy_deps
+
+        feature = "observability.langfuse"
         try:
-            __import__("langfuse")
-            _print_success("    langfuse SDK already installed")
-        except ImportError:
-            _print_info("    Installing langfuse SDK...")
-            result = _pip_install(["langfuse", "--quiet"], timeout=120)
-            if result.returncode == 0:
+            missing = lazy_deps.feature_missing(feature)
+            if missing:
+                _print_info("    Installing langfuse SDK...")
+                lazy_deps.ensure(feature, prompt=False)
                 _print_success("    langfuse SDK installed")
             else:
-                _print_warning("    langfuse SDK install failed — run manually: uv pip install langfuse")
+                _print_success("    langfuse SDK already installed")
+        except lazy_deps.FeatureUnavailable as exc:
+            _print_warning(f"    langfuse SDK install failed: {exc.reason}")
+            _print_info(f"    Run manually: {lazy_deps.manual_install_hint(feature)}")
+        except Exception as exc:
+            _print_warning(f"    langfuse SDK install failed: {exc}")
+            _print_info(f"    Run manually: {lazy_deps.manual_install_hint(feature)}")
         # Opt the bundled observability/langfuse plugin into plugins.enabled.
         # The plugin ships in the repo but doesn't load until the user enables
         # it (standalone plugins are opt-in).

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -147,6 +147,35 @@ def test_configurable_toolsets_include_context_engine():
     assert any(ts_key == "context_engine" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 
 
+def test_langfuse_post_setup_installs_managed_lazy_dependency(monkeypatch, tmp_path):
+    """The documented Langfuse setup path should install the managed pin.
+
+    This keeps ``hermes tools -> Langfuse Observability`` aligned with the
+    lazy dependency refresh path that ``hermes update`` uses, instead of
+    installing an unpinned/manual package that update cannot reason about.
+    """
+    from hermes_cli import tools_config
+    from tools import lazy_deps
+
+    calls = []
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(lazy_deps, "feature_missing", lambda feature: ("langfuse==4.13.0",))
+    monkeypatch.setattr(
+        lazy_deps,
+        "ensure",
+        lambda feature, *, prompt=True: calls.append((feature, prompt)),
+    )
+    monkeypatch.setattr(
+        tools_config,
+        "_pip_install",
+        lambda *args, **kwargs: pytest.fail("Langfuse setup should use tools.lazy_deps.ensure"),
+    )
+
+    tools_config._run_post_setup("langfuse")
+
+    assert calls == [("observability.langfuse", False)]
+
+
 def test_get_platform_tools_active_context_engine_is_enabled_for_explicit_config():
     config = {
         "context": {"engine": "lcm"},

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -304,6 +304,27 @@ class TestActiveFeatures:
         monkeypatch.setattr(ld, "_is_present", lambda spec: False)
         assert ld.active_features() == []
 
+    def test_enabled_langfuse_plugin_counts_active_when_sdk_missing(self, tmp_path, monkeypatch):
+        """An enabled bundled plugin is active state even after its SDK vanishes.
+
+        ``hermes update`` refreshes active lazy features after rebuilding the
+        venv. If it only looks for packages still present on disk, a venv
+        refresh that removes ``langfuse`` has no breadcrumb left and cannot
+        reinstall it. The durable signal is ``plugins.enabled``.
+        """
+        home = tmp_path / "hermes-home"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "plugins:\n  enabled:\n    - observability/langfuse\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(ld, "_is_present", lambda spec: False)
+
+        active = ld.active_features()
+
+        assert "observability.langfuse" in active
+
     def test_finds_features_with_at_least_one_package_installed(self, monkeypatch):
         # Pretend only honcho-ai is installed; nothing else.
         monkeypatch.setattr(

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -138,6 +138,12 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Image generation backends ─────────────────────────────────────────
     "image.fal": ("fal-client==0.13.1",),
 
+    # ─── Observability plugins ─────────────────────────────────────────────
+    # The bundled Langfuse plugin is opt-in, while its SDK remains optional so
+    # base installs stay lean. Track the SDK here so `hermes update` can
+    # restore tracing after venv refreshes remove optional packages.
+    "observability.langfuse": ("langfuse==4.13.0",),
+
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.0.1",),
     "memory.hindsight": ("hindsight-client==0.6.1",),
@@ -722,6 +728,43 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
 # =============================================================================
 
 
+_ENABLED_PLUGIN_LAZY_FEATURES = {
+    # Canonical bundled plugin key.
+    "observability/langfuse": "observability.langfuse",
+    # Older setup/config paths may contain the bare plugin name.
+    "langfuse": "observability.langfuse",
+}
+
+
+def _features_from_enabled_plugins() -> list[str]:
+    """Return lazy features implied by enabled bundled plugins.
+
+    Most lazy features can be rediscovered by checking whether at least one of
+    their packages is still present in the venv. Enabled bundled plugins need a
+    second signal: after an update rebuilds the venv, their SDK can be gone
+    even though ``plugins.enabled`` still says the plugin should run. Use that
+    config state as the breadcrumb so update refreshes can rehydrate the SDK.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    except Exception:
+        return []
+
+    plugins_cfg = config.get("plugins") or {}
+    enabled = plugins_cfg.get("enabled") or []
+    if not isinstance(enabled, (list, tuple, set)):
+        return []
+
+    features: list[str] = []
+    for plugin_key in enabled:
+        feature = _ENABLED_PLUGIN_LAZY_FEATURES.get(str(plugin_key))
+        if feature and feature in LAZY_DEPS and feature not in features:
+            features.append(feature)
+    return features
+
+
 def feature_specs(feature: str) -> tuple[str, ...]:
     """Return the registered specs for a feature, or raise KeyError."""
     if feature not in LAZY_DEPS:
@@ -854,11 +897,13 @@ def feature_install_command(feature: str) -> Optional[str]:
 
 
 def active_features() -> list[str]:
-    """Return the list of features the user has ever lazy-installed.
+    """Return the list of lazy features the user has activated.
 
-    A feature counts as "active" if at least one of its declared packages
-    is currently installed in the venv (presence check, ignoring version).
-    Features the user has never enabled stay quiet.
+    A feature usually counts as active if at least one of its declared
+    packages is currently installed in the venv (presence check, ignoring
+    version). Enabled bundled plugins also count as active via
+    ``plugins.enabled`` so update can reinstall their SDK after a venv rebuild
+    removes optional packages.
 
     Used by ``hermes update`` to figure out which lazy backends need a
     refresh pass when pins move in :data:`LAZY_DEPS`.
@@ -866,6 +911,9 @@ def active_features() -> list[str]:
     active = []
     for feature, specs in LAZY_DEPS.items():
         if any(_is_present(s) for s in specs):
+            active.append(feature)
+    for feature in _features_from_enabled_plugins():
+        if feature not in active:
             active.append(feature)
     return active
 


### PR DESCRIPTION
## Summary

- Register the bundled Langfuse SDK as a managed lazy dependency: `observability.langfuse -> langfuse==4.13.0`.
- Route the `hermes tools` Langfuse post-setup path through `tools.lazy_deps.ensure(...)` instead of a one-off `uv pip install langfuse` call.
- Treat enabled `observability/langfuse` plugins as active lazy features even when the SDK is missing, so `hermes update` can rehydrate the dependency after a venv refresh.

Closes #59026.

## Why

The documented Langfuse setup can leave `plugins.enabled` and credentials intact while tracing silently stops if the active Hermes venv loses the `langfuse` SDK during update/venv refresh. Package-presence-only refresh detection cannot recover from that state because the package is already gone. The durable activation signal is the enabled plugin entry.

This keeps the fix narrow to the existing bundled Langfuse path and reuses the lazy dependency/update refresh infrastructure already used by optional backends.

## Test Plan

- [x] `HOME=/home/hermes scripts/run_tests.sh tests/tools/test_lazy_deps.py tests/hermes_cli/test_tools_config.py -k 'enabled_langfuse_plugin_counts_active_when_sdk_missing or langfuse_post_setup_installs_managed_lazy_dependency' -q`
- [x] `HOME=/home/hermes scripts/run_tests.sh tests/tools/test_lazy_deps.py tests/hermes_cli/test_tools_config.py -q`
- [x] `venv/bin/ruff check tools/lazy_deps.py hermes_cli/tools_config.py tests/tools/test_lazy_deps.py tests/hermes_cli/test_tools_config.py`
- [x] `python -m compileall -q tools/lazy_deps.py hermes_cli/tools_config.py tests/tools/test_lazy_deps.py tests/hermes_cli/test_tools_config.py`
- [ ] Full suite: attempted with `HOME=/home/hermes scripts/run_tests.sh -q`, but local environment is currently missing the `acp` test dependency and the run timed out after 600s. The observed failures before timeout were unrelated ACP/import failures and unrelated existing test failures, not Langfuse/lazy-deps failures.
