### PR TITLE
fix(desktop): handle KeyboardInterrupt cleanly in hermes desktop (#59848)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5767,7 +5767,11 @@ def cmd_gui(args: argparse.Namespace):
 
     if source_mode:
         print("→ Launching Hermes Desktop from source build...")
-        launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
+        try:
+            launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
+        except KeyboardInterrupt:
+            print("\n✓ Hermes Desktop closed (KeyboardInterrupt)")
+            sys.exit(0)
         sys.exit(launch_result.returncode)
 
     if packaged_executable is None:
@@ -5785,7 +5789,11 @@ def cmd_gui(args: argparse.Namespace):
 
     launch_command.extend(config_electron_flags)
     print(f"→ Launching packaged Hermes Desktop: {' '.join(launch_command)}")
-    launch_result = subprocess.run(launch_command, cwd=desktop_dir, env=env, check=False)
+    try:
+        launch_result = subprocess.run(launch_command, cwd=desktop_dir, env=env, check=False)
+    except KeyboardInterrupt:
+        print("\n✓ Hermes Desktop closed (KeyboardInterrupt)")
+        sys.exit(0)
     sys.exit(launch_result.returncode)
 
 


### PR DESCRIPTION
## Descrição

Quando o usuário executa `hermes desktop` e pressiona Ctrl-C para fechar o Electron, um `KeyboardInterrupt` não tratado propaga do `subprocess.run()`, resultando em um traceback feio.

Este PR envolve as duas chamadas de `subprocess.run()` no `cmd_gui()` (lançamento em modo source e modo empacotado) com `try/except KeyboardInterrupt`, exibindo uma mensagem limpa e saindo com código 0.

## Mudanças

- **`hermes_cli/main.py`**: Adicionado `try/except KeyboardInterrupt` em ambos os caminhos de lançamento do Electron desktop:
  - Linha 5770: Lançamento em modo source (`npm exec -- electron .`)
  - Linha 5788: Lançamento em modo empacotado (executável direto)

## Closes

Closes #59848