### PR TITLE
fix(telegram): commit streamed final when preview may disappear

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -982,6 +982,36 @@ class GatewayStreamConsumer:
         continuation = self._continuation_text(final_text)
         self._fallback_final_send = False
         if not continuation.strip():
+            # Telegram Desktop/macOS can lose a streamed preview after the
+            # cosmetic final edit fails. Opt-in adapters commit the answer with
+            # a fresh final send instead of treating the preview as durable
+            # delivery (#58958); other platforms keep the legacy suppression.
+            if (
+                final_text.strip()
+                and final_text == self._visible_prefix()
+                and getattr(
+                    self.adapter,
+                    "RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK",
+                    False,
+                ) is True
+            ):
+                empty_fallback_result = await self._send_empty_fallback_final(final_text)
+                if empty_fallback_result == "delivered":
+                    return
+                self._already_sent = True
+                self._fallback_prefix = ""
+                self._fallback_preserve_partial_messages = False
+                if empty_fallback_result == "ambiguous":
+                    # Timeout-style failures may already have reached Telegram;
+                    # keep suppressing gateway's full resend to avoid duplicates.
+                    self._final_content_delivered = True
+                else:
+                    # The commit send failed safely. Clear any earlier cosmetic
+                    # delivery flag so gateway/run.py can attempt its normal
+                    # final send instead of suppressing the answer.
+                    self._final_response_sent = False
+                    self._final_content_delivered = False
+                return
             # Nothing new to send — the visible partial already matches final text.
             # BUT: if final_text itself has meaningful content (e.g. a timeout
             # message after a long tool call), the prefix-based continuation
@@ -1111,6 +1141,86 @@ class GatewayStreamConsumer:
         self._last_sent_text = chunks[-1]
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
+
+    async def _send_empty_fallback_final(self, final_text: str) -> str:
+        """Commit a final answer even when the fallback tail is empty.
+
+        Returns ``"delivered"`` on confirmed fresh-send success, ``"failed"``
+        when a gateway-level final resend is safe, and ``"ambiguous"`` when a
+        timeout-like failure may already have reached Telegram.
+        """
+        stale_ids = set(self._preview_message_ids)
+        if self._message_id and self._message_id != "__no_edit__":
+            stale_ids.add(str(self._message_id))
+        result = None
+        for attempt in range(2):
+            try:
+                result = await self.adapter.send(
+                    chat_id=self.chat_id,
+                    content=final_text,
+                    metadata=self._metadata_for_send(final=True),
+                )
+            except Exception as e:
+                logger.debug("Empty fallback final send failed: %s", e)
+                return "ambiguous" if self._send_failure_may_have_delivered(e) else "failed"
+            if getattr(result, "success", False):
+                break
+            if attempt == 0 and self._is_flood_error(result):
+                delay = float(getattr(result, "retry_after", None) or 3.0)
+                logger.debug(
+                    "Flood control on empty fallback final send; retrying in %.1fs",
+                    delay,
+                )
+                await asyncio.sleep(delay)
+            else:
+                return (
+                    "ambiguous"
+                    if self._send_failure_may_have_delivered(result)
+                    else "failed"
+                )
+
+        new_message_id = getattr(result, "message_id", None)
+        if stale_ids:
+            delete_fn = getattr(self.adapter, "delete_message", None)
+            if delete_fn is not None:
+                for stale_id in stale_ids:
+                    if not stale_id or stale_id == new_message_id:
+                        continue
+                    try:
+                        await delete_fn(self.chat_id, stale_id)
+                    except Exception as e:
+                        logger.debug(
+                            "Empty fallback preview cleanup failed (%s): %s",
+                            stale_id,
+                            e,
+                        )
+
+        self._preview_message_ids = set()
+        self._message_id = new_message_id or "__no_edit__"
+        self._already_sent = True
+        self._final_response_sent = True
+        self._final_content_delivered = True
+        self._last_sent_text = final_text
+        self._fallback_prefix = ""
+        self._fallback_preserve_partial_messages = False
+        self._notify_new_message()
+        return "delivered"
+
+    @staticmethod
+    def _send_failure_may_have_delivered(result_or_exc) -> bool:
+        """Return True for timeout-style send failures where retrying may duplicate.
+
+        Telegram's ``TimedOut`` can mean the Bot API request reached Telegram but
+        the client did not receive the response.  Adapter results use
+        ``retryable=False`` for that ambiguous case; avoid treating every
+        non-retryable hard failure (e.g. missing anchor, not connected) as
+        possibly delivered by also checking the error text/class.
+        """
+        if getattr(result_or_exc, "retryable", True) is not False:
+            return False
+        err = str(getattr(result_or_exc, "error", None) or result_or_exc).lower()
+        name = result_or_exc.__class__.__name__.lower()
+        return "timeout" in err or "timed out" in err or "timeout" in name
 
     def _is_flood_error(self, result) -> bool:
         """Check if a SendResult failure is due to flood control / rate limiting."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -451,6 +451,14 @@ class TelegramAdapter(BasePlatformAdapter):
     # edit and the final edit, skipping the plain-text → MarkdownV2 conversion.
     # Fixes #25710.
     REQUIRES_EDIT_FINALIZE: bool = True
+    # If the final streaming edit fails after a complete preview was already
+    # visible, the generic stream consumer can otherwise treat the empty
+    # continuation as "already delivered" and suppress the gateway's normal
+    # final send. Telegram Desktop/macOS has been observed to briefly show and
+    # then remove that preview in this state (#58958), so Telegram asks the
+    # consumer to commit the answer with a fresh final send instead, followed by
+    # best-effort cleanup of the stale preview.
+    RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK: bool = True
 
     # Adaptive text-batch ingress: short messages need a tighter delay so the
     # first token reaches the agent fast.  Numbers tuned for "feels instant":

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1124,6 +1124,216 @@ class TestFinalContentDeliveredGuard:
         assert consumer._final_response_sent is True
 
     @pytest.mark.asyncio
+    async def test_empty_fallback_opt_in_resends_full_final_and_cleans_preview(self):
+        """Telegram/macOS regression #58958: when the finalize edit failed
+        after the complete preview was visible, an empty fallback tail must not
+        be treated as a durable final delivery for adapters that opt in. Commit
+        the answer with a fresh final send, then best-effort delete the preview.
+        """
+        adapter = MagicMock()
+        adapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK = True
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_2"),
+        )
+        adapter.delete_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "msg_1"
+        consumer._preview_message_ids = {"msg_0", "msg_1"}
+        consumer._already_sent = True
+        consumer._last_sent_text = "Final answer"
+        consumer._fallback_final_send = True
+
+        await consumer._send_fallback_final("Final answer")
+
+        adapter.send.assert_awaited_once()
+        assert adapter.send.await_args.kwargs["content"] == "Final answer"
+        assert adapter.send.await_args.kwargs["metadata"] == {"notify": True}
+        assert adapter.delete_message.await_count == 2
+        assert {call.args for call in adapter.delete_message.await_args_list} == {
+            ("chat_123", "msg_0"),
+            ("chat_123", "msg_1"),
+        }
+        assert consumer._message_id == "msg_2"
+        assert consumer._preview_message_ids == set()
+        assert consumer._final_response_sent is True
+        assert consumer._final_content_delivered is True
+
+    @pytest.mark.asyncio
+    async def test_empty_fallback_opt_in_failure_does_not_mark_final_delivered(self):
+        """If the fresh commit send fails, leave final-delivery flags false so
+        the gateway can attempt its normal final send instead of suppressing the
+        answer based on a non-durable Telegram preview (#58958)."""
+        adapter = MagicMock()
+        adapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK = True
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=False, error="network down"),
+        )
+        adapter.delete_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "msg_1"
+        consumer._already_sent = True
+        consumer._last_sent_text = "Final answer"
+        consumer._fallback_final_send = True
+        consumer._final_content_delivered = True  # set by a failed cosmetic final edit
+
+        await consumer._send_fallback_final("Final answer")
+
+        adapter.send.assert_awaited_once()
+        adapter.delete_message.assert_not_awaited()
+        assert consumer._final_response_sent is False
+        assert consumer._final_content_delivered is False
+        assert consumer._fallback_final_send is False
+
+    @pytest.mark.asyncio
+    async def test_empty_fallback_ambiguous_timeout_preserves_duplicate_suppression(self):
+        """A Telegram timeout may have reached the Bot API; do not invite a
+        gateway-level duplicate full resend for that ambiguous failure."""
+        adapter = MagicMock()
+        adapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK = True
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(
+                success=False,
+                error="Timed out",
+                retryable=False,
+            ),
+        )
+        adapter.delete_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "msg_1"
+        consumer._already_sent = True
+        consumer._last_sent_text = "Final answer"
+        consumer._fallback_final_send = True
+
+        await consumer._send_fallback_final("Final answer")
+
+        adapter.send.assert_awaited_once()
+        adapter.delete_message.assert_not_awaited()
+        assert consumer._final_response_sent is False
+        assert consumer._final_content_delivered is True
+
+    @pytest.mark.asyncio
+    async def test_empty_fallback_flood_retry_uses_retry_after(self, monkeypatch):
+        """Use Telegram's retry_after when the empty final commit hits flood
+        control, then mark final delivered after the retry succeeds."""
+        sleep = AsyncMock()
+        monkeypatch.setattr(asyncio, "sleep", sleep)
+
+        adapter = MagicMock()
+        adapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK = True
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=False, error="retry after", retry_after=7.0),
+            SimpleNamespace(success=True, message_id="msg_2"),
+        ])
+        adapter.delete_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "msg_1"
+        consumer._already_sent = True
+        consumer._last_sent_text = "Final answer"
+        consumer._fallback_final_send = True
+
+        await consumer._send_fallback_final("Final answer")
+
+        assert adapter.send.await_count == 2
+        sleep.assert_awaited_once_with(7.0)
+        assert consumer._final_response_sent is True
+        assert consumer._final_content_delivered is True
+
+    @pytest.mark.asyncio
+    async def test_empty_fallback_final_send_preserves_thread_metadata(self):
+        """Fresh final sends must keep Telegram topic/reply metadata while
+        adding notify=True."""
+        adapter = MagicMock()
+        adapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK = True
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_2"),
+        )
+        adapter.delete_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        metadata = {
+            "thread_id": "topic-77",
+            "telegram_reply_to_message_id": 42,
+            "telegram_dm_topic_reply_fallback": True,
+        }
+        consumer = GatewayStreamConsumer(adapter, "chat_123", metadata=metadata)
+        consumer._message_id = "msg_1"
+        consumer._already_sent = True
+        consumer._last_sent_text = "Final answer"
+        consumer._fallback_final_send = True
+
+        await consumer._send_fallback_final("Final answer")
+
+        assert adapter.send.await_args.kwargs["metadata"] == {
+            **metadata,
+            "notify": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_run_loop_failed_empty_commit_clears_prior_delivery_flag(self):
+        """Full run-loop regression: a failed final edit can set
+        final_content_delivered before empty fallback runs; a safe failure of
+        the fresh commit send must clear that stale flag so the gateway can send
+        the final answer normally (#58958)."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = True
+        adapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK = True
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=False, error="network down"),
+        ])
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=False, error="edit failed"),
+        )
+        adapter.delete_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5),
+        )
+        consumer.on_delta("Final answer")
+        consumer.finish()
+
+        await consumer.run()
+
+        assert adapter.send.await_count == 2
+        assert adapter.send.await_args_list[-1].kwargs["content"] == "Final answer"
+        assert consumer._final_response_sent is False
+        assert consumer._final_content_delivered is False
+
+    @pytest.mark.asyncio
+    async def test_empty_fallback_non_opt_in_preserves_legacy_suppression(self):
+        """Adapters that do not opt in keep the old empty-tail behavior: a
+        durable visible preview suppresses a duplicate final send."""
+        adapter = MagicMock()
+        adapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK = False
+        adapter.send = AsyncMock()
+        adapter.delete_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        consumer._message_id = "msg_1"
+        consumer._already_sent = True
+        consumer._last_sent_text = "Final answer"
+        consumer._fallback_final_send = True
+
+        await consumer._send_fallback_final("Final answer")
+
+        adapter.send.assert_not_awaited()
+        adapter.delete_message.assert_not_awaited()
+        assert consumer._final_response_sent is True
+        assert consumer._final_content_delivered is True
+
+    @pytest.mark.asyncio
     async def test_fallback_partial_send_does_not_mark_final_sent(self):
         """When fallback final send delivers only some chunks before failing,
         _final_response_sent must stay False so the gateway can still attempt


### PR DESCRIPTION
## Summary

Fixes #58958.

Telegram Desktop/macOS can briefly show a streamed assistant preview and then lose it after generation completes when the final/cosmetic edit fails. In that state, the stream consumer could treat the visible preview as durable final delivery, set final-delivery flags, and let the gateway suppress its normal final send — leaving the user with no final answer.

This PR adds a narrow Telegram opt-in for that empty-fallback case:

- Telegram opts in to committing an empty-tail fallback with a fresh final send.
- The fresh final send uses `notify=True` and preserves existing topic/reply metadata.
- Stale streamed preview messages are best-effort deleted after the fresh final send succeeds.
- Non-opt-in adapters keep the existing behavior, avoiding global duplicate-reply regressions.
- If the fresh final send safely fails, stale final-delivery flags are cleared so the gateway can still attempt its normal final send.
- If the fresh final send fails ambiguously with a timeout-like non-retryable Telegram result, duplicate suppression is preserved because the Bot API request may already have landed.
- Flood-control retry honors Telegram `retry_after` when present.

## Why

Hermes tracks two related concepts:

- `final_response_sent`: the final reply was durably sent/finalized.
- `final_content_delivered`: the final content was visible via streaming, even if a cosmetic final edit failed.

For most platforms, if the streamed preview already equals the final text and the fallback continuation is empty, it is safe to mark the response delivered and suppress a duplicate final send.

Telegram Desktop/macOS appears less durable in this specific failure mode: the preview may be visible during generation but disappear after finalization fails. This PR keeps the existing global behavior and only changes Telegram’s opted-in empty-fallback finalization path.

## Tests

Targeted regression tests:

    uv run python -m pytest tests/gateway/test_stream_consumer.py::TestFinalContentDeliveredGuard -q -o 'addopts='

Result:

    10 passed in 3.87s

Related gateway/Telegram streaming suites:

    uv run python -m pytest tests/gateway/test_stream_consumer.py tests/gateway/test_duplicate_reply_suppression.py tests/gateway/test_telegram_overflow_partial.py tests/gateway/test_stream_consumer_fresh_final.py tests/gateway/test_telegram_send_draft_format.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_send_path_health.py -q -o 'addopts='

Result:

    264 passed, 1 warning in 12.32s

Syntax/diff checks:

    git diff --check
    python3 -m py_compile gateway/stream_consumer.py plugins/platforms/telegram/adapter.py tests/gateway/test_stream_consumer.py

Result: both passed.

Broader Telegram suite check:

    uv run python -m pytest tests/gateway/test_telegram*.py -q -o 'addopts='

Result on this branch:

    1004 passed, 3 failed, 1 warning

The same 3 order-dependent failures reproduce on a clean `origin/main` worktree, and the failing tests pass when run directly:

    tests/gateway/test_telegram_thread_fallback.py::test_non_forum_group_reply_thread_id_does_not_fork_session_key
    tests/gateway/test_telegram_thread_fallback.py::test_forum_group_topic_message_preserves_thread_session_key
    tests/gateway/test_telegram_thread_fallback.py::test_forum_general_topic_without_message_thread_id_keeps_thread_context

So those broader-suite failures appear pre-existing and unrelated to this patch. They look like a separate test-order/global-state issue where a previous Telegram test causes later supergroup messages to be classified as `chat_type == "dm"` instead of `"group"`.