### PR TITLE
fix: preserve Photon iMessage reply context

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -816,6 +816,12 @@ class PhotonAdapter(BasePlatformAdapter):
         # preview artwork as separate image attachments immediately after the
         # URL bubble; this lets us coalesce those artifacts.
         self._recent_richlinks_by_chat: Dict[str, float] = {}
+        # Text preview for messages we sent, keyed by platform message id.
+        # Spectrum/iMessage sometimes emits reply targets as stubs: the target
+        # id is present but target.content is custom/empty, so the sidecar can't
+        # hydrate `reply_to_text`. Persisting send-time text lets replies still
+        # carry useful context when the target object comes through blank.
+        self._sent_message_text: Dict[str, str] = {}
         # Last time we sent a typing indicator per chat, for cooldown gating.
         self._typing_last_sent: Dict[str, float] = {}
 
@@ -1274,6 +1280,10 @@ class PhotonAdapter(BasePlatformAdapter):
                 reply_to_is_own_message = True
             elif target_direction == "inbound":
                 reply_to_is_own_message = False
+            if not reply_to_text and reply_to_message_id:
+                reply_to_text = self._lookup_sent_message_text(
+                    space_id, reply_to_message_id
+                )
             content = content.get("content") or {}
             ctype = content.get("type")
 
@@ -2171,6 +2181,8 @@ class PhotonAdapter(BasePlatformAdapter):
 
     _SENT_IDS_MAX = 1000
     _LAST_INBOUND_CHATS_MAX = 200
+    _SENT_TEXT_MAX = 1000
+    _SENT_TEXT_CHARS = 2000
 
     def _record_sent_message(self, message_id: Optional[str]) -> None:
         if not message_id:
@@ -2182,6 +2194,56 @@ class PhotonAdapter(BasePlatformAdapter):
         if len(sent) > self._SENT_IDS_MAX:
             for old in list(sent.keys())[: len(sent) - self._SENT_IDS_MAX]:
                 del sent[old]
+
+    def _record_sent_message_text(
+        self, chat_id: Optional[str], message_id: Optional[str], text: Optional[str]
+    ) -> None:
+        if not chat_id or not message_id or not text:
+            return
+        preview = text[: self._SENT_TEXT_CHARS]
+        cache = self._sent_message_text
+        if message_id in cache:
+            del cache[message_id]  # refresh insertion order
+        cache[message_id] = preview
+        if len(cache) > self._SENT_TEXT_MAX:
+            for old in list(cache.keys())[: len(cache) - self._SENT_TEXT_MAX]:
+                del cache[old]
+
+        # Shared durable index already used by Telegram/WhatsApp for reply
+        # hydration. It is best-effort and swallows errors, so send delivery
+        # never depends on this cache write succeeding.
+        try:
+            from gateway import rich_sent_store
+
+            rich_sent_store.record(chat_id, message_id, preview)
+            normalized = self._normalize_chat_key(str(chat_id))
+            if normalized != str(chat_id):
+                rich_sent_store.record(normalized, message_id, preview)
+        except Exception:
+            pass
+
+    def _lookup_sent_message_text(
+        self, chat_id: Optional[str], message_id: Optional[str]
+    ) -> Optional[str]:
+        if not message_id:
+            return None
+        text = self._sent_message_text.get(message_id)
+        if text:
+            return text
+        if not chat_id:
+            return None
+        try:
+            from gateway import rich_sent_store
+
+            text = rich_sent_store.lookup(chat_id, message_id)
+            if text:
+                return text
+            normalized = self._normalize_chat_key(str(chat_id))
+            if normalized != str(chat_id):
+                return rich_sent_store.lookup(normalized, message_id)
+        except Exception:
+            return None
+        return None
 
     # A DM space is addressable two ways — the chat GUID (`any;-;+1555...`)
     # that inbound events carry, and the bare E.164 phone that home-channel
@@ -2551,6 +2613,7 @@ class PhotonAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
         self._record_sent_message(data.get("messageId"))
+        self._record_sent_message_text(space_id, data.get("messageId"), text)
         return SendResult(success=True, message_id=data.get("messageId"))
 
     async def _sidecar_send_attachment(

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1268,24 +1268,49 @@ class PhotonAdapter(BasePlatformAdapter):
             )
 
         ctype = content.get("type")
-        reply_to_message_id = None
-        reply_to_text = None
-        reply_to_is_own_message = False
+        # Spectrum 8.2 can expose reply context either as a normalized
+        # ``content.type == reply`` wrapper or as envelope fields hydrated by
+        # the sidecar from iMessage's reply GUID. Accept both shapes: outbound
+        # targets commonly need the envelope lookup because they were never in
+        # the sidecar's inbound-only message cache.
+        reply_to_message_id = event.get("replyToMessageId") or None
+        reply_to_text = event.get("replyToText") or None
+        reply_to_is_own_message = event.get("replyToIsOwnMessage") is True
+        target_direction = None
 
         if ctype == "reply":
-            reply_to_message_id = content.get("targetMessageId") or None
-            reply_to_text = content.get("targetText") or None
+            reply_to_message_id = (
+                content.get("targetMessageId") or reply_to_message_id
+            )
+            reply_to_text = content.get("targetText") or reply_to_text
             target_direction = content.get("targetDirection")
             if target_direction == "outbound":
                 reply_to_is_own_message = True
             elif target_direction == "inbound":
                 reply_to_is_own_message = False
-            if not reply_to_text and reply_to_message_id:
-                reply_to_text = self._lookup_sent_message_text(
-                    space_id, reply_to_message_id
-                )
             content = content.get("content") or {}
             ctype = content.get("type")
+
+        sent_text_fallback = None
+        if not reply_to_text and reply_to_message_id:
+            sent_text_fallback = self._lookup_sent_message_text(
+                space_id, reply_to_message_id
+            )
+            reply_to_text = sent_text_fallback
+
+        # Spectrum's unresolved reply target is a stub with an id but no
+        # direction. The id/text caches are the durable signal that this was
+        # one of our outbound messages; do not let the sidecar's envelope
+        # ``false`` for an unknown direction hide that fallback.
+        if (
+            reply_to_message_id
+            and target_direction not in {"outbound", "inbound"}
+            and (
+                reply_to_message_id in self._sent_message_ids
+                or sent_text_fallback is not None
+            )
+        ):
+            reply_to_is_own_message = True
 
         if ctype == "reaction":
             # Route only tapbacks on messages WE sent — those are implicitly
@@ -2540,8 +2565,10 @@ class PhotonAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             return SendResult(success=False, error=str(e))
-        self._record_sent_message(data.get("messageId"))
-        return SendResult(success=True, message_id=data.get("messageId"))
+        message_id = data.get("messageId")
+        self._record_sent_message(message_id)
+        self._record_sent_message_text(space_id, message_id, url)
+        return SendResult(success=True, message_id=message_id)
 
     async def _sidecar_send(
         self,
@@ -2586,8 +2613,10 @@ class PhotonAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             return SendResult(success=False, error=str(e))
-        self._record_sent_message(data.get("messageId"))
-        return SendResult(success=True, message_id=data.get("messageId"))
+        message_id = data.get("messageId")
+        self._record_sent_message(message_id)
+        self._record_sent_message_text(space_id, message_id, text)
+        return SendResult(success=True, message_id=message_id)
 
     async def _sidecar_send_poll(
         self, space_id: str, title: str, options: list,
@@ -2612,9 +2641,10 @@ class PhotonAdapter(BasePlatformAdapter):
             data = await self._sidecar_call("/send-poll", body)
         except Exception as e:
             return SendResult(success=False, error=str(e))
-        self._record_sent_message(data.get("messageId"))
-        self._record_sent_message_text(space_id, data.get("messageId"), text)
-        return SendResult(success=True, message_id=data.get("messageId"))
+        message_id = data.get("messageId")
+        self._record_sent_message(message_id)
+        self._record_sent_message_text(space_id, message_id, body["title"])
+        return SendResult(success=True, message_id=message_id)
 
     async def _sidecar_send_attachment(
         self,
@@ -2901,6 +2931,23 @@ async def _standalone_send(
                     if not data.get("ok"):
                         return _standalone_error(resp)
                     last_message_id = data.get("messageId")
+
+                # `hermes send` talks to the running sidecar directly rather
+                # than through PhotonAdapter.send(), so persist the same
+                # reply-hydration fallback here as the in-gateway send path.
+                if last_message_id:
+                    try:
+                        from gateway import rich_sent_store
+
+                        preview = message[: PhotonAdapter._SENT_TEXT_CHARS]
+                        rich_sent_store.record(chat_id, last_message_id, preview)
+                        normalized = PhotonAdapter._normalize_chat_key(str(chat_id))
+                        if normalized != str(chat_id):
+                            rich_sent_store.record(
+                                normalized, last_message_id, preview
+                            )
+                    except Exception:
+                        pass
 
             # 2. Each attachment as a separate /send-attachment call.
             #    media_files is List[Tuple[path, is_voice]] (see

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1262,6 +1262,21 @@ class PhotonAdapter(BasePlatformAdapter):
             )
 
         ctype = content.get("type")
+        reply_to_message_id = None
+        reply_to_text = None
+        reply_to_is_own_message = False
+
+        if ctype == "reply":
+            reply_to_message_id = content.get("targetMessageId") or None
+            reply_to_text = content.get("targetText") or None
+            target_direction = content.get("targetDirection")
+            if target_direction == "outbound":
+                reply_to_is_own_message = True
+            elif target_direction == "inbound":
+                reply_to_is_own_message = False
+            content = content.get("content") or {}
+            ctype = content.get("type")
+
         if ctype == "reaction":
             # Route only tapbacks on messages WE sent — those are implicitly
             # addressed to the bot (feishu precedent: synthetic text event).
@@ -1447,6 +1462,9 @@ class PhotonAdapter(BasePlatformAdapter):
             message_type=mtype,
             source=source,
             message_id=event.get("messageId"),
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
+            reply_to_is_own_message=reply_to_is_own_message,
             raw_message=event,
             timestamp=timestamp,
             media_urls=media_urls,

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -493,6 +493,10 @@ function messagePreviewText(target) {
   let text = null;
   if (c.type === "text") {
     text = c.text;
+  } else if (c.type === "markdown") {
+    // Spectrum caches outbound markdown in its authored form. A reply can hit
+    // that cache before iMessage rehydrates the bubble as inbound `text`.
+    text = c.markdown;
   } else if (c.type === "richlink") {
     text = c.url;
   } else if (c.type === "group") {
@@ -500,6 +504,10 @@ function messagePreviewText(target) {
       const ic = item && typeof item === "object" ? item.content : null;
       if (ic && ic.type === "text" && ic.text) {
         text = ic.text;
+        break;
+      }
+      if (ic && ic.type === "markdown" && ic.markdown) {
+        text = ic.markdown;
         break;
       }
       if (ic && ic.type === "richlink" && ic.url) {
@@ -599,8 +607,49 @@ async function normalizeEvent(space, message) {
   try {
     const msgSpace = message.space || {};
     const ts = message.timestamp;
+    const normalizedContent = await normalizeContent(message.content);
+    const replyTargetId =
+      message.replyTargetGuid ?? message.reply_to_guid ??
+      message.threadOriginatorGuid ?? message.threadRootMessageId ??
+      (normalizedContent.type === "reply"
+        ? normalizedContent.targetMessageId
+        : null);
+    // Reply targets are often Hermes' outbound messages, so they are not in
+    // knownMessages (which is populated from inbound events only). Hydrate a
+    // cache miss through Spectrum so the adapter can preserve quoted context.
+    let replyTarget = replyTargetId
+      ? knownMessages.get(replyTargetId)
+      : null;
+    if (replyTargetId && !replyTarget && typeof space.getMessage === "function") {
+      try {
+        replyTarget = await space.getMessage(replyTargetId);
+        if (replyTarget) rememberKnownMessage(replyTarget);
+      } catch (e) {
+        console.error(
+          `photon-sidecar: failed to hydrate reply target ${replyTargetId}: ` +
+            (e && e.message ? e.message : String(e))
+        );
+      }
+    }
+    const replyTargetText =
+      (normalizedContent.type === "reply"
+        ? normalizedContent.targetText
+        : null) ?? messagePreviewText(replyTarget);
+    const replyTargetDirection =
+      (normalizedContent.type === "reply"
+        ? normalizedContent.targetDirection
+        : null) ?? replyTarget?.direction ??
+      (replyTarget?.isFromMe === true ? "outbound" : null);
+    if (normalizedContent.type === "reply") {
+      normalizedContent.targetMessageId = replyTargetId;
+      normalizedContent.targetText = replyTargetText;
+      normalizedContent.targetDirection = replyTargetDirection;
+    }
     return {
       messageId: message.id ?? null,
+      replyToMessageId: replyTargetId,
+      replyToText: replyTargetText,
+      replyToIsOwnMessage: replyTargetDirection === "outbound",
       platform: message.platform || space.__platform || "iMessage",
       space: {
         id: space.id ?? msgSpace.id ?? null,
@@ -609,7 +658,7 @@ async function normalizeEvent(space, message) {
         phone: space.phone ?? msgSpace.phone ?? null,
       },
       sender: { id: message.sender ? message.sender.id : null },
-      content: await normalizeContent(message.content),
+      content: normalizedContent,
       timestamp:
         ts instanceof Date ? ts.toISOString() : ts ? String(ts) : null,
     };

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -480,15 +480,14 @@ async function normalizeBinaryContent(content) {
   return meta;
 }
 
-// Best-effort text preview of a reaction's resolved target Message, so the
-// Python adapter can populate the gateway's `reply_to_text` (context: WHAT was
-// tapped back). The SDK only emits a reaction once it has resolved the full
-// target Message (toReactionMessages bails otherwise), so `target.content` is
-// hydrated here — no extra round trip. Handles plain text and our patched mixed
-// text+attachment groups (first text child); null for attachment/voice-only
-// targets. Capped so one long bubble can't balloon the NDJSON line.
-const REACTION_TARGET_TEXT_CAP = 2000;
-function reactionTargetText(target) {
+// Best-effort text preview of a resolved target Message, so the Python adapter
+// can populate the gateway's `reply_to_text` for reactions and replies. The SDK
+// hydrates reaction/reply targets when possible; stub reply targets have custom
+// content and return null. Handles plain text and mixed text+attachment groups
+// (first text child); null for attachment/voice-only targets. Capped so one long
+// bubble can't balloon the NDJSON line.
+const MESSAGE_PREVIEW_TEXT_CAP = 2000;
+function messagePreviewText(target) {
   const c = target && typeof target === "object" ? target.content : null;
   if (!c || typeof c !== "object") return null;
   let text = null;
@@ -510,8 +509,8 @@ function reactionTargetText(target) {
     }
   }
   if (typeof text !== "string" || !text) return null;
-  return text.length > REACTION_TARGET_TEXT_CAP
-    ? text.slice(0, REACTION_TARGET_TEXT_CAP)
+  return text.length > MESSAGE_PREVIEW_TEXT_CAP
+    ? text.slice(0, MESSAGE_PREVIEW_TEXT_CAP)
     : text;
 }
 
@@ -545,6 +544,16 @@ async function normalizeContent(content) {
     }
     return { type: "group", items };
   }
+  if (content.type === "reply") {
+    const target = content.target || null;
+    return {
+      type: "reply",
+      content: await normalizeContent(content.content),
+      targetMessageId: target?.id ?? null,
+      targetDirection: target?.direction ?? null,
+      targetText: messagePreviewText(target),
+    };
+  }
   if (content.type === "reaction") {
     const target = content.target;
     return {
@@ -557,7 +566,7 @@ async function normalizeContent(content) {
       targetDirection: target?.direction ?? null,
       // Text of the reacted-to message, so Python can correlate the tapback to
       // the gateway's reply_to_text. Null for attachment/voice-only targets.
-      targetText: reactionTargetText(target),
+      targetText: messagePreviewText(target),
     };
   }
   // A user tapping a poll choice arrives as `poll_option` carrying the chosen

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
-        "spectrum-ts": "8.0.0"
+        "spectrum-ts": "8.2.2"
       },
       "engines": {
         "node": ">=18.17"
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
-      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.9.0.tgz",
+      "integrity": "sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -211,6 +211,55 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.219.0.tgz",
+      "integrity": "sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.219.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.29.0.tgz",
+      "integrity": "sha512-SnA+0XgGc595jtnwFVfWy7Vgfr5hle4D5YKIlm0U4z8aK9YoCZVUn1xAkVZ2evaJyykiDF50FBzr1XZ0uj8CPA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/semantic-conventions": "^1.24.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz",
+      "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@opentelemetry/otlp-exporter-base": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
@@ -311,12 +360,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/core": "2.9.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -422,14 +471,32 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
-      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -440,9 +507,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.42.0.tgz",
+      "integrity": "sha512-icc5xCzndZfhuJMy5oqk5AvloWquR7jtae74qzpkKkhGp8BivK+oCcEXgGnjCdTfp8hA44l+w8gE8yYJbocJJw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -497,9 +564,9 @@
       }
     },
     "node_modules/@photon-ai/otel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-1.1.0.tgz",
-      "integrity": "sha512-v6Ai5Anws+gkjzZQirXpuF6VtS4DmSnpx9o208R2mhwqONNp2iqwQx4400C6r8oyqv7mz65tkkTd083kG5/kng==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-3.1.0.tgz",
+      "integrity": "sha512-8PvN7o3rySHlMk6+a/5X/F5/w1RqGJkFuvcdaSinhdXYCsuO24AALSFV0g8KY4jNtVDs7L3I6v6QsL7WxZECjw==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
@@ -515,6 +582,10 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/instrumentation-undici": "^0.29.0"
       },
       "peerDependencies": {
         "typescript": "^5 || ^6.0.0"
@@ -557,9 +628,9 @@
       }
     },
     "node_modules/@photon-ai/whatsapp-business": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@photon-ai/whatsapp-business/-/whatsapp-business-0.1.1.tgz",
-      "integrity": "sha512-JAf/gHh92+H6h/7AMOQ6l+WFYBWdeRH5fZ+tvOUYJJnX1C4aJPDFa23VTH4ndhKPgA5bK/h++cxUZx2lMubvYQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/whatsapp-business/-/whatsapp-business-0.2.0.tgz",
+      "integrity": "sha512-FL5hKSZcgXCiZO1hVbu2A2Bd226ZfDEcbvlVWCEJUukWPUL7Gcs0RSwsJm57FnF0J/KhZ1DiwMWLoSL06N+fGw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
         "long": "^5.3.2",
@@ -578,12 +649,12 @@
       "license": "MIT"
     },
     "node_modules/@spectrum-ts/core": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/core/-/core-8.0.0.tgz",
-      "integrity": "sha512-qcMcx1Vf/hVKzyGkbNfrVf6q7t4Zsnr65Riq843W1ButJQnUf8MhCPwnSOavWYkd8IVXL4XSndqMMdOP9xPJeg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/core/-/core-8.2.2.tgz",
+      "integrity": "sha512-QG4axwo0ydyl5wg8hfp2GDrXrzeGdfi/knfuW9XTl18p7EY5m/DGoOdK0ESqZLSFsXqvLOem4IAQTKuQPv2jng==",
       "license": "MIT",
       "dependencies": {
-        "@photon-ai/otel": "^1.0.0",
+        "@photon-ai/otel": "^3.1.0",
         "@photon-ai/proto": "^0.2.4",
         "@repeaterjs/repeater": "^3.0.6",
         "marked": "^18.0.5",
@@ -603,14 +674,14 @@
       }
     },
     "node_modules/@spectrum-ts/imessage": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/imessage/-/imessage-8.0.0.tgz",
-      "integrity": "sha512-HjWoAZqXxuRsiY33aiJs4g6u/R8HE4V0/rtDd0wE2b+Hq/U0owDuc6T0+cLjrM/rC03jvVkTCnKSMeJWF+mYUA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/imessage/-/imessage-8.2.2.tgz",
+      "integrity": "sha512-5izXpXg3PmppfN7c0Iru39l7+ytSwUYNnSCYZnlmV8WoGBcnm7Izy1LaKnFdgwfe0YhE0/dZ0P00t8RiI3RioQ==",
       "license": "MIT",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.12.0",
         "@photon-ai/imessage-kit": "^3.0.0",
-        "@photon-ai/otel": "^1.0.0",
+        "@photon-ai/otel": "^3.1.0",
         "lru-cache": "^11.0.0",
         "marked": "^18.0.5",
         "zod": "^4.2.1"
@@ -621,9 +692,9 @@
       }
     },
     "node_modules/@spectrum-ts/slack": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/slack/-/slack-8.0.0.tgz",
-      "integrity": "sha512-UHLL0xxThDUBPYGbT2ms9Xq5B8dSQy3SoRZX88a04i649UebnjKg9cPU2amxA8gzRcARkQrfLFtq0CFz1jXcfw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/slack/-/slack-8.2.2.tgz",
+      "integrity": "sha512-5e9jG+bKfZsiWAfHl/4JD7C1EMw25c13zRFzHWqCiKyZqkYXWUkKG6pUkYFCiNSLTDza+I27x/7lWpsuy6+duw==",
       "license": "MIT",
       "dependencies": {
         "@photon-ai/slack": "^0.2.0",
@@ -635,9 +706,9 @@
       }
     },
     "node_modules/@spectrum-ts/telegram": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/telegram/-/telegram-8.0.0.tgz",
-      "integrity": "sha512-pvF9LrXdcewDthh89viu2lQxcxmmeXfu8MZpymIJSpP66SjCbTwhIbWkVFQbrJbBjLcB3UdyXdQv3dNoquEcRQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/telegram/-/telegram-8.2.2.tgz",
+      "integrity": "sha512-5XOZY8J+ZQV+d+gBCz9En3PqPucMKLAZxDpuwYbesdl4zdfshtbH7Mi3WgSaiaVq7mDY4gaGno43en3uq7ysYg==",
       "license": "MIT",
       "dependencies": {
         "@photon-ai/telegram-ts": "10.0.0",
@@ -650,9 +721,9 @@
       }
     },
     "node_modules/@spectrum-ts/terminal": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/terminal/-/terminal-8.0.0.tgz",
-      "integrity": "sha512-VOyirdioTMAuR7+QNsWt708hG2ZVwt4qhyn/6CXbhnqM/V2FbEu5vNkbOlrxNj4o3y4Lr1mWMih2Fb3udJd+Nw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/terminal/-/terminal-8.2.2.tgz",
+      "integrity": "sha512-FfTtZjv8ehece6iPBa4u3BOeGuzw2QVll/EL/DqyyStz+nh/AF0JrdksXoHPGWPx7/wHyBCQrkfJnpL28uGThw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.2.1"
@@ -663,12 +734,12 @@
       }
     },
     "node_modules/@spectrum-ts/whatsapp-business": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/whatsapp-business/-/whatsapp-business-8.0.0.tgz",
-      "integrity": "sha512-O4mlJi/YtFpnNsiqMo5aReC/nKg66voPp0botJW+MUWZpMlon4/tJ8uVXTUwzQFwOmNRjifVTSD+R/Tll3Kvaw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/whatsapp-business/-/whatsapp-business-8.2.2.tgz",
+      "integrity": "sha512-z1sD+MwTClKbxrPpppjW1/tLTWcljnmLKCs0608azi9MmHXVJ1Hh+kWy7bXPFKmCbGAeRtXVtB/oDYU3QvjKCQ==",
       "license": "MIT",
       "dependencies": {
-        "@photon-ai/whatsapp-business": "^0.1.1",
+        "@photon-ai/whatsapp-business": "^0.2.0",
         "mime-types": "^3.0.1",
         "zod": "^4.2.1"
       },
@@ -860,6 +931,13 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -918,6 +996,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -1064,6 +1160,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1151,9 +1254,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -1186,6 +1289,21 @@
       ],
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.0.tgz",
+      "integrity": "sha512-v4+k+PLt4z6g2ydEcXhfinTJxfgKJDWOW0v0GZNA5n2qToHFObpH4nGLhJdwnXnX4T14oREx/M62dS9GkpmSbQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -1298,6 +1416,20 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -1326,9 +1458,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1515,6 +1647,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1603,17 +1749,17 @@
       }
     },
     "node_modules/spectrum-ts": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-8.0.0.tgz",
-      "integrity": "sha512-MY/GeqWZ+aptIpG6q0385eSizxiqNo0bAEvEfSqI1ObifhsLTbxnak1ibOpfKIJF38+gR6x9hf50WXetPE36Xw==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-8.2.2.tgz",
+      "integrity": "sha512-e2+eypzhSWsZlFXURlduF6kZAk9FHfwz3WZQ/y3aRIPneSqKpY130zeta5xi8EC1VUTI8C7VzraGfFwpSpxDyw==",
       "license": "MIT",
       "dependencies": {
-        "@spectrum-ts/core": "8.0.0",
-        "@spectrum-ts/imessage": "8.0.0",
-        "@spectrum-ts/slack": "8.0.0",
-        "@spectrum-ts/telegram": "8.0.0",
-        "@spectrum-ts/terminal": "8.0.0",
-        "@spectrum-ts/whatsapp-business": "8.0.0"
+        "@spectrum-ts/core": "8.2.2",
+        "@spectrum-ts/imessage": "8.2.2",
+        "@spectrum-ts/slack": "8.2.2",
+        "@spectrum-ts/telegram": "8.2.2",
+        "@spectrum-ts/terminal": "8.2.2",
+        "@spectrum-ts/whatsapp-business": "8.2.2"
       }
     },
     "node_modules/string_decoder": {
@@ -1663,9 +1809,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -13,7 +13,7 @@
     "node": ">=18.17"
   },
   "dependencies": {
-    "spectrum-ts": "8.0.0"
+    "spectrum-ts": "8.2.2"
   },
   "overrides": {
     "protobufjs": "8.7.1",

--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -148,6 +148,14 @@ export function patchSpectrumTs(root = scriptDir()) {
         !original.includes("const rebuildFromAppleMessage = async")) {
       continue;
     }
+    // spectrum-ts >= 8 already preserves ordered mixed text + attachment
+    // payloads via buildUnwrappedContentMessage()/toOrderedParts(). The old
+    // patch anchors only match the pre-refactor mapper; treat the newer mapper
+    // as already fixed rather than failing Photon startup.
+    if (original.includes("const buildUnwrappedContentMessage = async") &&
+        original.includes("const parts = toOrderedParts(message.content.text, attachments);")) {
+      return { patched: false, file, reason: "upstream preserves mixed attachments" };
+    }
     let patched = original;
     patched = patchRebuild(patched);
     patched = patchInbound(patched);

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -244,3 +244,32 @@ async def test_dispatch_reply_context(monkeypatch: pytest.MonkeyPatch) -> None:
     assert message.reply_to_message_id == "bot-msg-123"
     assert message.reply_to_text == "DHL parcel notification"
     assert message.reply_to_is_own_message is True
+
+@pytest.mark.asyncio
+async def test_dispatch_reply_context_falls_back_to_sent_text_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+    adapter._record_sent_message_text(
+        "+155****4567", "bot-msg-blank-target", "Cached bot response text"
+    )
+
+    event = _dm_event("placeholder", msg_id="spc-reply-blank-target")
+    event["content"] = {
+        "type": "reply",
+        "content": {"type": "text", "text": "this is the reply"},
+        "targetMessageId": "bot-msg-blank-target",
+        "targetDirection": "outbound",
+        "targetText": None,
+    }
+
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    message = captured[0]
+    assert message.text == "this is the reply"
+    assert message.reply_to_message_id == "bot-msg-blank-target"
+    assert message.reply_to_text == "Cached bot response text"
+    assert message.reply_to_is_own_message is True
+

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -245,6 +245,33 @@ async def test_dispatch_reply_context(monkeypatch: pytest.MonkeyPatch) -> None:
     assert message.reply_to_text == "DHL parcel notification"
     assert message.reply_to_is_own_message is True
 
+
+@pytest.mark.asyncio
+async def test_dispatch_reply_context_from_hydrated_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _dm_event("this is the reply", msg_id="spc-envelope-reply")
+    event.update(
+        {
+            "replyToMessageId": "bot-msg-hydrated",
+            "replyToText": "Hydrated bot response text",
+            "replyToIsOwnMessage": True,
+        }
+    )
+
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    message = captured[0]
+    assert message.text == "this is the reply"
+    assert message.reply_to_message_id == "bot-msg-hydrated"
+    assert message.reply_to_text == "Hydrated bot response text"
+    assert message.reply_to_is_own_message is True
+
+
 @pytest.mark.asyncio
 async def test_dispatch_reply_context_falls_back_to_sent_text_cache(
     monkeypatch: pytest.MonkeyPatch,
@@ -260,7 +287,10 @@ async def test_dispatch_reply_context_falls_back_to_sent_text_cache(
         "type": "reply",
         "content": {"type": "text", "text": "this is the reply"},
         "targetMessageId": "bot-msg-blank-target",
-        "targetDirection": "outbound",
+        # Spectrum 8.2.2 emits an unresolved outbound target as a stub, so its
+        # direction and preview are both blank. The adapter must recover both
+        # ownership and text from its sent-message caches.
+        "targetDirection": None,
         "targetText": None,
     }
 

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -221,3 +221,26 @@ async def test_disconnect_cancels_pending_fffc_tasks(
     await adapter.disconnect()
 
     assert len(adapter._pending_fffc) == 0
+
+@pytest.mark.asyncio
+async def test_dispatch_reply_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _dm_event("placeholder", msg_id="spc-reply-msg")
+    event["content"] = {
+        "type": "reply",
+        "content": {"type": "text", "text": "this can be archived"},
+        "targetMessageId": "bot-msg-123",
+        "targetDirection": "outbound",
+        "targetText": "DHL parcel notification",
+    }
+
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    message = captured[0]
+    assert message.text == "this can be archived"
+    assert message.reply_to_message_id == "bot-msg-123"
+    assert message.reply_to_text == "DHL parcel notification"
+    assert message.reply_to_is_own_message is True

--- a/tests/plugins/platforms/photon/test_markdown.py
+++ b/tests/plugins/platforms/photon/test_markdown.py
@@ -103,3 +103,64 @@ async def test_standalone_send_includes_markdown_format(
 
     assert result.get("success") is True
     assert posted[0][1]["format"] == "markdown"
+    assert posted[0][1]["text"] == _MD
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_records_text_for_reply_hydration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gateway import rich_sent_store
+
+    monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "tok")
+
+    class _Resp:
+        status_code = 200
+
+        @staticmethod
+        def json() -> Dict[str, Any]:
+            return {"ok": True, "messageId": "m-reply"}
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url: str, json: Dict[str, Any], headers=None):
+            return _Resp()
+
+    monkeypatch.setattr(photon_adapter.httpx, "AsyncClient", _FakeClient)
+    cfg = PlatformConfig(enabled=True, token="", extra={})
+    chat_id = "any;-;+15551234567"
+
+    result = await photon_adapter._standalone_send(cfg, chat_id, _MD)
+
+    assert result.get("success") is True
+    assert rich_sent_store.lookup(chat_id, "m-reply") == _MD
+    assert rich_sent_store.lookup("+15551234567", "m-reply") == _MD
+
+@pytest.mark.asyncio
+async def test_adapter_send_records_text_for_stub_reply_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+
+    async def _fake_call(path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        assert path == "/send"
+        return {"ok": True, "messageId": "m-in-gateway"}
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_call)
+
+    result = await adapter.send("+155****4567", "Bot response kept for a reply")
+
+    assert result.success is True
+    assert adapter._sent_message_ids["m-in-gateway"]
+    assert (
+        adapter._sent_message_text["m-in-gateway"]
+        == "Bot response kept for a reply"
+    )

--- a/tests/plugins/platforms/photon/test_reply_context.py
+++ b/tests/plugins/platforms/photon/test_reply_context.py
@@ -1,0 +1,209 @@
+"""Sidecar reply-target normalization regression tests.
+
+These run the real Photon sidecar with a tiny Spectrum-compatible fake. They
+cover both Spectrum 8.2.2 target shapes: a hydrated target with direction and
+text, and the unresolved stub used when the target cannot be fetched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+_ROOT_SIDECAR = Path("plugins/platforms/photon/sidecar")
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _sidecar_env(port: int) -> dict[str, str]:
+    return {
+        **os.environ,
+        "PHOTON_PROJECT_ID": "test-project",
+        "PHOTON_PROJECT_SECRET": "test-secret",
+        "PHOTON_SIDECAR_PORT": str(port),
+        "PHOTON_SIDECAR_TOKEN": "test-token",
+        # The fixture intentionally leaves the stream open after one event.
+        "PHOTON_STREAM_SILENCE_PROBE_MS": "0",
+    }
+
+
+def _write_sidecar_fixture(tmp_path: Path, target_kind: str) -> Path:
+    sidecar = tmp_path / "sidecar"
+    sidecar.mkdir()
+    shutil.copyfile(_ROOT_SIDECAR / "index.mjs", sidecar / "index.mjs")
+    for helper in _ROOT_SIDECAR.glob("*.mjs"):
+        if helper.name in {"index.mjs", "patch-spectrum-mixed-attachments.mjs"}:
+            continue
+        shutil.copyfile(helper, sidecar / helper.name)
+    (sidecar / "patch-spectrum-mixed-attachments.mjs").write_text(
+        "export function patchSpectrumTs() { return { patched: false }; }\n",
+        encoding="utf-8",
+    )
+
+    target_id = f"target-{target_kind}"
+    target_text = "hydrated outbound text " + ("x" * 2100)
+    target_direction = 'direction: "outbound",' if target_kind == "hydrated" else ""
+    target_content = (
+        {"type": "text", "text": target_text}
+        if target_kind == "hydrated"
+        else {"type": "custom", "imessage_type": "reply-target", "stub": True}
+    )
+    fake_sdk = f"""
+const TARGET_KIND = {json.dumps(target_kind)};
+const target = {{
+  id: {json.dumps(target_id)},
+  {target_direction}
+  content: {json.dumps(target_content)},
+}};
+const space = {{
+  id: "space-1",
+  type: "dm",
+  phone: "+15555551212",
+  __platform: "iMessage",
+  async getMessage(id) {{
+    if (TARGET_KIND === "hydrated" && id === target.id) return target;
+    return undefined;
+  }},
+}};
+const message = {{
+  id: "inbound-reply",
+  direction: "inbound",
+  sender: {{ id: "+15555551212" }},
+  space,
+  timestamp: new Date("2026-08-05T12:00:00.000Z"),
+  content: {{
+    type: "reply",
+    content: {{ type: "text", text: "user reply" }},
+    target,
+  }},
+}};
+let emitted = false;
+const messages = {{
+  [Symbol.asyncIterator]() {{
+    return {{
+      async next() {{
+        if (!emitted) {{
+          emitted = true;
+          return {{ done: false, value: [space, message] }};
+        }}
+        await new Promise(() => {{}});
+      }},
+    }};
+  }},
+}};
+export async function Spectrum() {{
+  return {{ messages, stop: async () => undefined }};
+}}
+export const attachment = value => value;
+export const voice = value => value;
+export const text = value => value;
+export const markdown = value => value;
+export const richlink = value => value;
+export const typing = value => value;
+export const poll = value => value;
+"""
+    package = sidecar / "node_modules" / "spectrum-ts"
+    (package / "providers").mkdir(parents=True)
+    (package / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "spectrum-ts",
+                "type": "module",
+                "exports": {
+                    ".": "./index.js",
+                    "./providers/imessage": "./providers/imessage.js",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (package / "index.js").write_text(fake_sdk.lstrip(), encoding="utf-8")
+    (package / "providers" / "imessage.js").write_text(
+        "export function imessage() { return {}; }\nimessage.config = () => ({});\n",
+        encoding="utf-8",
+    )
+    return sidecar
+
+
+def _run_one_event(tmp_path: Path, target_kind: str) -> dict:
+    sidecar = _write_sidecar_fixture(tmp_path, target_kind)
+    port = _free_port()
+    proc = subprocess.Popen(
+        ["node", "index.mjs"],
+        cwd=sidecar,
+        env=_sidecar_env(port),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/inbound",
+        headers={"X-Hermes-Sidecar-Token": "test-token"},
+        method="GET",
+    )
+    response = None
+    try:
+        deadline = time.monotonic() + 5
+        while response is None:
+            try:
+                response = urllib.request.urlopen(request, timeout=0.5)
+            except (OSError, urllib.error.URLError):
+                if proc.poll() is not None or time.monotonic() >= deadline:
+                    raise
+        raw = response.readline()
+        if not raw:
+            raise AssertionError(
+                f"sidecar exited before emitting {target_kind} reply event"
+            )
+        return json.loads(raw)
+    finally:
+        if response is not None:
+            response.close()
+        proc.terminate()
+        try:
+            proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate(timeout=5)
+
+
+def test_sidecar_normalizes_hydrated_reply_target(tmp_path: Path) -> None:
+    event = _run_one_event(tmp_path, "hydrated")
+
+    content = event["content"]
+    assert event["replyToMessageId"] == "target-hydrated"
+    assert event["replyToIsOwnMessage"] is True
+    assert len(event["replyToText"]) == 2000
+    assert content["type"] == "reply"
+    assert content["targetMessageId"] == "target-hydrated"
+    assert content["targetDirection"] == "outbound"
+    assert content["targetText"] == event["replyToText"]
+    assert content["content"] == {"type": "text", "text": "user reply"}
+
+
+def test_sidecar_preserves_stub_reply_target_for_adapter_fallback(
+    tmp_path: Path,
+) -> None:
+    event = _run_one_event(tmp_path, "stub")
+
+    content = event["content"]
+    assert event["replyToMessageId"] == "target-stub"
+    assert event["replyToText"] is None
+    assert event["replyToIsOwnMessage"] is False
+    assert content["type"] == "reply"
+    assert content["targetMessageId"] == "target-stub"
+    assert content["targetDirection"] is None
+    assert content["targetText"] is None
+    assert content["content"] == {"type": "text", "text": "user reply"}


### PR DESCRIPTION
## Summary
- bump Photon sidecar `spectrum-ts` from 8.0.0 to 8.2.2, picking up upstream inbound iMessage reply preservation
- normalize Spectrum `reply` content in the Photon sidecar and pass target metadata/text previews to Python
- map Photon reply metadata into Hermes `MessageEvent.reply_to_*`
- make the old mixed-attachment Spectrum patch no-op when upstream already preserves ordered mixed parts
- add a regression test for inbound reply context

## Validation
- Live-tested on Photon/iMessage after gateway restart: explicit iMessage reply arrived with populated `reply_to_id` and `reply_to_text`
- `npm install` in `plugins/platforms/photon/sidecar` succeeds with the postinstall patch no-op on Spectrum 8.2.2
- `python -m py_compile plugins/platforms/photon/adapter.py`
- `node --check plugins/platforms/photon/sidecar/index.mjs`
- `python -m pytest tests/plugins/platforms/photon -q` → 112 passed
