### PR TITLE
fix: guard unread streaming errors and desktop ctrl-c

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5773,7 +5773,11 @@ def cmd_gui(args: argparse.Namespace):
 
     if source_mode:
         print("→ Launching Hermes Desktop from source build...")
-        launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
+        try:
+            launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
+        except KeyboardInterrupt:
+            print("\nInterrupted while Hermes Desktop was running.")
+            sys.exit(130)
         sys.exit(launch_result.returncode)
 
     if packaged_executable is None:
@@ -5791,7 +5795,11 @@ def cmd_gui(args: argparse.Namespace):
 
     launch_command.extend(config_electron_flags)
     print(f"→ Launching packaged Hermes Desktop: {' '.join(launch_command)}")
-    launch_result = subprocess.run(launch_command, cwd=desktop_dir, env=env, check=False)
+    try:
+        launch_result = subprocess.run(launch_command, cwd=desktop_dir, env=env, check=False)
+    except KeyboardInterrupt:
+        print("\nInterrupted while Hermes Desktop was running.")
+        sys.exit(130)
     sys.exit(launch_result.returncode)
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2143,7 +2143,10 @@ class AIAgent:
         # widens exposure vs the old empty-body "HTTP 400" string).
         response = getattr(error, "response", None)
         if response is not None:
-            snippet = (getattr(response, "text", None) or "").strip()
+            try:
+                snippet = (getattr(response, "text", None) or "").strip()
+            except Exception:
+                snippet = ""
             if snippet:
                 status_code = getattr(error, "status_code", None)
                 prefix = f"HTTP {status_code}: " if status_code else ""

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -153,6 +153,22 @@ def test_gui_skip_build_launches_existing_packaged_app_without_npm(tmp_path, mon
     assert mock_run.call_args.args[0] == [str(packaged_exe)]
 
 
+def test_gui_skip_build_handles_ctrl_c_cleanly(tmp_path, monkeypatch, capsys):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+
+    with patch("hermes_cli.main.shutil.which", return_value=None), \
+         patch("hermes_cli.main._run_npm_install_deterministic") as mock_install, \
+         patch("hermes_cli.main.subprocess.run", side_effect=KeyboardInterrupt), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(skip_build=True))
+
+    assert exc.value.code == 130
+    mock_install.assert_not_called()
+    assert "Interrupted while Hermes Desktop was running." in capsys.readouterr().out
+
+
 def test_gui_linux_configures_sandbox_before_launch(tmp_path, monkeypatch):
     root = _make_desktop_tree(tmp_path)
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)

--- a/tests/run_agent/test_summarize_api_error.py
+++ b/tests/run_agent/test_summarize_api_error.py
@@ -12,6 +12,10 @@ provider error. This is a diagnostic improvement and is platform-agnostic.
 
 from types import SimpleNamespace
 
+from typing import Any
+
+import httpx
+
 from run_agent import AIAgent
 
 
@@ -53,4 +57,26 @@ def test_empty_body_fallback_redacts_secrets(monkeypatch):
     )
     summary = AIAgent._summarize_api_error(err)
     assert "sk-proj-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdef" not in summary
+
+
+def test_unread_streaming_response_does_not_crash_and_falls_back_to_exception_message():
+    """Unread streaming responses must not replace the real provider error."""
+
+    class _StreamingError(Exception):
+        def __init__(self):
+            super().__init__("Gemini HTTP 429: quota exceeded")
+            self.status_code = 429
+            self.response: Any = None
+
+    err = _StreamingError()
+
+    class _UnreadStreamingResponse:
+        @property
+        def text(self):
+            raise httpx.ResponseNotRead()
+
+    err.response = _UnreadStreamingResponse()
+    summary = AIAgent._summarize_api_error(err)
+    assert "HTTP 429" in summary
+    assert "Gemini HTTP 429: quota exceeded" in summary
 


### PR DESCRIPTION
Fixes two small user-facing failure modes:

1. Guard `_summarize_api_error()` against unread streaming `httpx.Response` objects so provider errors like Gemini quota 429s do not get replaced by `httpx.ResponseNotRead`.
2. Catch `KeyboardInterrupt` in `hermes desktop` launch paths so Ctrl-C exits cleanly with code 130 instead of printing a traceback.

What changed:
- wrap `response.text` access in `_summarize_api_error()` with a defensive `try/except`
- add regression test for unread streaming responses
- catch Ctrl-C around both source and packaged desktop launch subprocesses
- add regression test for clean Ctrl-C handling in packaged launch mode

Verification:
- `pytest -q tests/run_agent/test_summarize_api_error.py tests/hermes_cli/test_gui_command.py`
