### PR TITLE
fix(slack): scope Socket Mode app token per profile

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -36,6 +36,7 @@ from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
+from agent.secret_scope import get_secret
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.base import (
@@ -960,7 +961,7 @@ class SlackAdapter(BasePlatformAdapter):
             return False
 
         raw_token = self.config.token
-        app_token = os.getenv("SLACK_APP_TOKEN")
+        app_token = get_secret("SLACK_APP_TOKEN")
 
         if not raw_token:
             logger.error("[Slack] SLACK_BOT_TOKEN not set")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, call
 
 import pytest
 
+import agent.secret_scope as secret_scope
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     MessageEvent,
@@ -257,6 +258,72 @@ class TestAppMentionHandler:
             assert slash_matcher.match(
                 expected
             ), f"Slack slash regex does not match {expected}"
+
+    @pytest.mark.asyncio
+    async def test_connect_uses_profile_scoped_app_token(self):
+        """Socket Mode must use the active profile's app token in multiplex mode."""
+        config = PlatformConfig(enabled=True, token="xoxb-profile")
+        adapter = SlackAdapter(config)
+
+        def _noop_decorator(_matcher):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+        mock_app = MagicMock()
+        mock_app.event = _noop_decorator
+        mock_app.command = _noop_decorator
+        mock_app.action = _noop_decorator
+        mock_app.client = AsyncMock()
+
+        mock_web_client = AsyncMock()
+        mock_web_client.auth_test = AsyncMock(
+            return_value={
+                "user_id": "U_PROFILE",
+                "user": "profilebot",
+                "team_id": "T_PROFILE",
+                "team": "ProfileTeam",
+            }
+        )
+
+        created_handlers = []
+
+        class FakeSocketModeHandler:
+            def __init__(self, app, app_token, proxy=None):
+                self.app = app
+                self.app_token = app_token
+                self.proxy = proxy
+                self.client = MagicMock(proxy=None)
+                created_handlers.append(self)
+
+            async def start_async(self):
+                return None
+
+            async def close_async(self):
+                return None
+
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope({"SLACK_APP_TOKEN": "xapp-profile"})
+        try:
+            with (
+                patch.object(_slack_mod, "AsyncApp", return_value=mock_app),
+                patch.object(_slack_mod, "AsyncWebClient", return_value=mock_web_client),
+                patch.object(
+                    _slack_mod, "AsyncSocketModeHandler", FakeSocketModeHandler
+                ),
+                patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-default"}),
+                patch("gateway.status.acquire_scoped_lock", return_value=(True, None)),
+                patch("asyncio.create_task", side_effect=_fake_create_task),
+            ):
+                result = await adapter.connect()
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+        assert result is True
+        assert created_handlers
+        assert created_handlers[0].app_token == "xapp-profile"
 
 
 class TestSlackConnectCleanup:


### PR DESCRIPTION
## Problem

Fixes #59739.

In multiplex gateway mode, each profile gets its own secret scope, but the Slack adapter still read `SLACK_APP_TOKEN` from process `os.environ` when opening Socket Mode. That lets secondary profiles authenticate their websocket with the default profile's app-level token while their bot token is correctly profile-scoped, so the adapter logs as connected but Slack delivers the secondary app's events to no gateway connection.

## Root Cause

`SlackAdapter.connect()` used the scoped `PlatformConfig.token` for the bot token but bypassed `agent.secret_scope` for the app token:

```python
app_token = os.getenv("SLACK_APP_TOKEN")
```

In a multiplexer, process env can hold another profile's secrets by design, and `_profile_runtime_scope()` installs the active profile's `.env` into `get_secret()` instead.

## Fix

Resolve the Socket Mode app token through `get_secret("SLACK_APP_TOKEN")`. This preserves legacy single-profile behavior because `get_secret()` falls back to `os.environ` when multiplexing is inactive, while making the active profile scope authoritative when multiplexing is on.

## Tests

- `scripts/run_tests.sh tests/gateway/test_slack.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py`
