### PR TITLE
fix(compression): preserve gateway origin on continuation

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -432,6 +432,27 @@ def _ensure_compressed_has_user_turn(original_messages: list, compressed: list) 
     })
 
 
+_GATEWAY_ORIGIN_SESSION_FIELDS = (
+    "user_id",
+    "session_key",
+    "chat_id",
+    "chat_type",
+    "thread_id",
+    "cwd",
+)
+
+
+def _session_origin_kwargs(row: Optional[dict]) -> dict:
+    """Return parent session metadata that must survive session rotation."""
+    if not row:
+        return {}
+    return {
+        field: row.get(field)
+        for field in _GATEWAY_ORIGIN_SESSION_FIELDS
+        if row.get(field) is not None
+    }
+
+
 def compress_context(
     agent: Any,
     messages: list,
@@ -743,6 +764,11 @@ def compress_context(
                         pass  # best-effort — don't block compression on a flush error
                     # Propagate title to the new session with auto-numbering
                     old_title = agent._session_db.get_session_title(agent.session_id)
+                    old_session_row = None
+                    try:
+                        old_session_row = agent._session_db.get_session(agent.session_id)
+                    except Exception:
+                        pass
                     agent._session_db.end_session(agent.session_id, "compression")
                     old_session_id = agent.session_id
                     agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
@@ -773,10 +799,15 @@ def compress_context(
                     try:
                         agent._session_db.create_session(
                             session_id=agent.session_id,
-                            source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                            source=(
+                                (old_session_row or {}).get("source")
+                                or agent.platform
+                                or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+                            ),
                             model=agent.model,
                             model_config=agent._session_init_model_config,
                             parent_session_id=old_session_id,
+                            **_session_origin_kwargs(old_session_row),
                         )
                     except Exception as _cs_err:
                         # The child row could not be created (e.g. FK constraint,

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -130,3 +130,33 @@ class TestPlatformForwardedAtBoundary:
         kwargs = calls[-1].kwargs
         assert kwargs.get("platform") == "telegram"
         assert kwargs.get("boundary_reason") == "compression"
+
+
+class TestGatewayOriginMigratesOnRotation:
+    def test_gateway_origin_metadata_follows_compression_rotation(self, tmp_path: Path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_GATEWAY_ORIGIN_ROT"
+        db.create_session(
+            parent,
+            source="telegram",
+            user_id="U_TELEGRAM",
+            session_key="agent:main:telegram:dm:C_TELEGRAM:U_TELEGRAM",
+            chat_id="C_TELEGRAM",
+            chat_type="dm",
+            thread_id="T_THREAD",
+            cwd="/workspace",
+        )
+        agent = _build_agent_with_db(db, parent, platform="telegram")
+
+        agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+        child = db.get_session(agent.session_id)
+
+        assert child is not None
+        assert child["parent_session_id"] == parent
+        assert child["source"] == "telegram"
+        assert child["user_id"] == "U_TELEGRAM"
+        assert child["session_key"] == "agent:main:telegram:dm:C_TELEGRAM:U_TELEGRAM"
+        assert child["chat_id"] == "C_TELEGRAM"
+        assert child["chat_type"] == "dm"
+        assert child["thread_id"] == "T_THREAD"
+        assert child["cwd"] == "/workspace"


### PR DESCRIPTION
## Problem

Fixes #59527.

Gateway sessions persist ownership/routing metadata (`session_key`, `user_id`, `chat_id`, `chat_type`, `thread_id`) so `/sessions` and `/resume` can scope rows to the caller's platform/chat. Legacy context-compression rotation ended the parent and created a continuation child with only `source`, `model`, `model_config`, and `parent_session_id`, so the child could become `source=telegram` with no persisted origin metadata.

That leaves the continuation hidden from `/sessions` and blocked by `/resume` because the persisted row cannot prove it belongs to the same gateway caller.

## Root Cause

`agent/conversation_compression.py` rotated the session id and called `SessionDB.create_session()` without copying the parent row's gateway origin fields. The stricter resume/listing guards in `gateway/slash_commands.py` correctly fail closed when those fields are missing.

## Fix

Before ending the parent, read its session row and pass the durable origin fields through when creating the compression child:

- `user_id`
- `session_key`
- `chat_id`
- `chat_type`
- `thread_id`
- `cwd`

The child also prefers the parent's persisted `source` when present, keeping the database row aligned with the original gateway route.

## Tests

- `scripts/run_tests.sh tests/agent/test_compression_rotation_state.py -q`
- `scripts/run_tests.sh tests/gateway/test_resume_command.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check agent/conversation_compression.py tests/agent/test_compression_rotation_state.py`
