### PR TITLE
fix(agent): stop concatenated tool-call args in Gemini native streaming

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -661,7 +661,7 @@ def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
                 yield payload
 
 
-def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices: Dict[str, Dict[str, Any]]) -> List[_GeminiStreamChunk]:
+def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices: Dict[str, List[Dict[str, Any]]]) -> List[_GeminiStreamChunk]:
     candidates = event.get("candidates") or []
     if not candidates:
         return []
@@ -693,16 +693,31 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
                 },
                 sort_keys=True,
             )
-            slot = tool_call_indices.get(call_key)
-            if slot is None:
+            # part_index resets to 0 on every SSE event (each event usually
+            # carries a single part), so (part_index, name, thought_signature)
+            # collides when the model issues two calls to the same tool in
+            # one turn — e.g. discord_read_messages for two channel IDs.
+            # tool_call_indices maps call_key -> the chain of call slots that
+            # have shared that key over the stream, most recent last, so a
+            # non-continuing args_str starts a fresh slot instead of being
+            # appended to the previous call's buffer (which produced
+            # concatenated/invalid JSON args downstream).
+            slots = tool_call_indices.setdefault(call_key, [])
+            slot = slots[-1] if slots else None
+            last_arguments = str(slot.get("last_arguments") or "") if slot else ""
+            is_continuation = slot is not None and (
+                args_str == last_arguments or args_str.startswith(last_arguments)
+            )
+            if not is_continuation:
+                total_slots = sum(len(v) for v in tool_call_indices.values())
                 slot = {
-                    "index": len(tool_call_indices),
+                    "index": total_slots,
                     "id": f"call_{uuid.uuid4().hex[:12]}",
                     "last_arguments": "",
                 }
-                tool_call_indices[call_key] = slot
+                slots.append(slot)
+                last_arguments = ""
             emitted_arguments = args_str
-            last_arguments = str(slot.get("last_arguments") or "")
             if last_arguments:
                 if args_str == last_arguments:
                     emitted_arguments = ""
@@ -974,7 +989,7 @@ class GeminiNativeClient:
                     if response.status_code != 200:
                         body_text = read_streaming_error_body(response)
                         raise gemini_http_error(response, body_text=body_text)
-                    tool_call_indices: Dict[str, Dict[str, Any]] = {}
+                    tool_call_indices: Dict[str, List[Dict[str, Any]]] = {}
                     for event in _iter_sse_events(response):
                         for chunk in translate_stream_event(event, model, tool_call_indices):
                             yield chunk

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -420,6 +420,54 @@ def test_stream_event_translation_keeps_identical_calls_in_distinct_parts():
     assert tool_chunks[0].choices[0].delta.tool_calls[0].id != tool_chunks[1].choices[0].delta.tool_calls[0].id
 
 
+def test_stream_event_translation_separates_distinct_calls_across_events():
+    # Regression test: two DIFFERENT calls to the same tool, delivered in
+    # separate SSE events, both land at part_index 0 (each event carries one
+    # part). Before the fix, the second call's full arguments were appended
+    # to the first call's buffer instead of starting a new slot, producing
+    # concatenated/invalid JSON args (e.g. two discord_read_messages calls
+    # for different channel IDs in one turn).
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices = {}
+    first_event = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "discord_read_messages", "args": {"channelId": "111", "limit": 15}}}
+                    ]
+                },
+            }
+        ]
+    }
+    second_event = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "discord_read_messages", "args": {"channelId": "222", "limit": 5}}}
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ]
+    }
+
+    first = translate_stream_event(first_event, model="gemini-3.1-pro-preview", tool_call_indices=tool_call_indices)
+    second = translate_stream_event(second_event, model="gemini-3.1-pro-preview", tool_call_indices=tool_call_indices)
+
+    first_call = first[0].choices[0].delta.tool_calls[0]
+    second_call = second[0].choices[0].delta.tool_calls[0]
+
+    assert first_call.index != second_call.index
+    assert first_call.id != second_call.id
+    assert json.loads(first_call.function.arguments) == {"channelId": "111", "limit": 15}
+    # The second call must be its own complete, valid JSON object — not a
+    # suffix concatenated onto the first call's arguments.
+    assert json.loads(second_call.function.arguments) == {"channelId": "222", "limit": 5}
+
+
 def test_system_instruction_includes_role_field_and_stays_out_of_contents():
     from agent.gemini_native_adapter import build_gemini_request
 


### PR DESCRIPTION
## What changed and why

`translate_stream_event()` in `agent/gemini_native_adapter.py` keys each
in-flight function-call slot by `(part_index, name, thought_signature)`.
`part_index` is only unique within a single SSE event, and each event
typically carries a single part, so it resets to `0` on every event.

When the model calls the **same tool twice in one turn** (e.g. two
`discord_read_messages` calls for two different channel IDs), both calls
land on the same `call_key`. The second call's full arguments get treated
as a continuation of the first and are appended to its buffer instead of
starting a new slot — producing concatenated, invalid JSON such as:

```
{"channelId": "1234567890", "limit": 15}{"channelId": "0987654321...
```

Downstream, this fails JSON sanitization/repair and gets replaced with an
empty tool-call object, so the call fails (e.g. missing required
`channelId`), the model retries, and the loop repeats — in the case that
surfaced this, it ran long enough to exhaust the model's output budget and
finish with `finish_reason='length'`.

## Fix

Track a chain of slots per `call_key` (most recent last) instead of a
single slot. New arguments are only treated as a continuation of the
previous call when they extend its last-seen arguments (equal or a
prefix-extension); otherwise a fresh slot is allocated. This mirrors the
existing "Ollama reuses index 0" workaround in
`chat_completion_helpers.py`, applied to Gemini's content-keyed slot
lookup instead of an id-keyed one.

## How to test

Added `test_stream_event_translation_separates_distinct_calls_across_events`
in `tests/agent/test_gemini_native_adapter.py`, which reproduces two
different calls to the same tool name arriving in separate SSE events
(each at `part_index=0`) and asserts they land in distinct slots with
independently valid JSON arguments. Confirmed this test fails on the
pre-fix code (`assert 0 != 0`, both calls collapse to the same id) and
passes with the fix.

Ran:
```
scripts/run_tests.sh tests/agent/test_gemini_native_adapter.py \
  tests/agent/test_gemini_fast_fallback.py tests/agent/test_gemini_schema.py \
  tests/agent/test_gemini_free_tier_gate.py
```
61 passed, 0 failed.

## Platforms tested

Linux (Ubuntu). No platform-specific code touched (pure Python
streaming-response translation logic).