### PR TITLE
feat(desktop): present MCP catalog as connectors

### DIFF
--- a/apps/desktop/src/app/settings/index.tsx
+++ b/apps/desktop/src/app/settings/index.tsx
@@ -6,7 +6,7 @@ import { Tip } from '@/components/ui/tooltip'
 import { getHermesConfigDefaults, getHermesConfigRecord, saveHermesConfig } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
-import { Archive, Bell, Download, Globe, Info, KeyRound, RefreshCw, Settings2, Upload, Wrench, Zap } from '@/lib/icons'
+import { Archive, Bell, Download, Globe, Info, KeyRound, Link2, RefreshCw, Settings2, Upload, Wrench, Zap } from '@/lib/icons'
 import { notifyError } from '@/store/notifications'
 
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -185,6 +185,13 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
       id: 'keys',
       label: t.settings.nav.apiKeys,
       onSelect: () => setActiveView('keys')
+    },
+    {
+      active: false,
+      icon: Link2,
+      id: 'mcp',
+      label: t.settings.nav.mcp,
+      onSelect: () => navigate(`${SKILLS_ROUTE}?tab=mcp`)
     },
     {
       active: activeView === 'sessions',

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -76,6 +76,14 @@ afterEach(() => {
   queryClient.clear()
 })
 
+describe('SkillsView navigation', () => {
+  it('keeps MCP visible in the connector tab label', async () => {
+    await renderSkills()
+
+    expect(await screen.findByRole('button', { name: /MCP Connectors/i })).toBeTruthy()
+  })
+})
+
 describe('SkillsView toolset management', () => {
   it('renders a switch for each toolset and toggles it off', async () => {
     await renderSkills()

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -37,7 +37,7 @@ import {
   testMcpServer
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
-import { connectorDisplayName, connectorPrimaryActionKind } from '@/lib/mcp-catalog'
+import { connectorDisplayName, connectorPrimaryActionKind, connectorSetupSummary } from '@/lib/mcp-catalog'
 import { countEnabledTools, isToolEnabled, toggleToolInServer } from '@/lib/mcp-tool-filter'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -1376,6 +1376,7 @@ function McpCatalog({
       {entries.map(entry => {
         const draft = envDrafts[entry.name] ?? {}
         const actionKind = connectorPrimaryActionKind(entry)
+        const setupSummary = connectorSetupSummary(entry)
 
         return (
           <div className="rounded-md px-2 py-2" key={entry.name}>
@@ -1404,6 +1405,24 @@ function McpCatalog({
                   )}
                 </div>
                 <p className="mt-0.5 line-clamp-2 text-[0.68rem] text-muted-foreground/70">{entry.description}</p>
+                {setupSummary && (
+                  <div className="mt-1 flex items-center gap-1.5 text-[0.62rem] text-(--ui-text-tertiary)">
+                    <Codicon name="pass" size="0.7rem" />
+                    <span>{setupSummary}</span>
+                  </div>
+                )}
+                {entry.setup_steps.length > 0 && (
+                  <div className="mt-2 grid gap-1 rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-2">
+                    {entry.setup_steps.slice(0, 3).map((step, index) => (
+                      <div className="flex gap-2 text-[0.62rem] leading-relaxed text-(--ui-text-tertiary)" key={step}>
+                        <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-(--ui-bg-tertiary) text-[0.55rem] text-(--ui-text-secondary)">
+                          {index + 1}
+                        </span>
+                        <span>{step}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
                 {entry.capabilities.length > 0 && (
                   <div className="mt-1 flex flex-wrap gap-1">
                     {entry.capabilities.slice(0, 3).map(capability => (

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -8,6 +8,7 @@ import {
   SiSentry,
   SiStripe,
   SiSupabase,
+  SiUnrealengine,
   SiVercel
 } from '@icons-pack/react-simple-icons'
 import { useStore } from '@nanostores/react'
@@ -37,7 +38,7 @@ import {
   testMcpServer
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
-import { connectorDisplayName, connectorPrimaryActionKind, connectorSetupSummary } from '@/lib/mcp-catalog'
+import { connectorDisplayName, connectorIdentityKey, connectorPrimaryActionKind, connectorSetupSummary } from '@/lib/mcp-catalog'
 import { countEnabledTools, isToolEnabled, toggleToolInServer } from '@/lib/mcp-tool-filter'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -1377,20 +1378,22 @@ function McpCatalog({
         const draft = envDrafts[entry.name] ?? {}
         const actionKind = connectorPrimaryActionKind(entry)
         const setupSummary = connectorSetupSummary(entry)
+        const identityKey = connectorIdentityKey(entry)
 
         return (
-          <div className="rounded-md px-2 py-2" key={entry.name}>
-            <div className="flex items-start gap-2">
-              {/* 2px nudge so the start-aligned avatar sits where McpRow's
-                  center-aligned one does — no jump when flipping Servers⇄Catalog. */}
+          <div
+            className="group/connector rounded-xl border border-(--ui-stroke-tertiary) bg-linear-to-br from-(--ui-bg-secondary) to-(--ui-bg-tertiary)/60 px-3 py-3 shadow-sm transition-colors hover:border-(--ui-stroke-secondary) hover:bg-(--ui-bg-tertiary)"
+            key={entry.name}
+          >
+            <div className="flex items-start gap-3">
               <McpAvatar
-                className="mt-0.5"
-                name={entry.name}
+                className="mt-0.5 size-9 rounded-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] ring-1 ring-(--ui-stroke-tertiary)"
+                name={identityKey}
                 status={entry.installed ? (entry.enabled ? 'ok' : 'off') : 'unknown'}
               />
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-1.5">
-                  <span className="truncate text-[0.78rem] font-medium text-foreground/85">
+                  <span className="truncate text-[0.86rem] font-semibold tracking-tight text-foreground/90">
                     {connectorDisplayName(entry)}
                   </span>
                   {entry.category && <CatalogTag>{entry.category}</CatalogTag>}
@@ -1577,6 +1580,8 @@ const MCP_BRAND_ICONS: Record<string, { Icon: ComponentType<SVGProps<SVGSVGEleme
   gitlab: { Icon: SiGitlab, color: '#FC6D26' },
   linear: { Icon: SiLinear, color: '#5E6AD2' },
   notion: { Icon: SiNotion, color: '#000000' },
+  'unreal-engine': { Icon: SiUnrealengine, color: '#0E1128' },
+  unrealengine: { Icon: SiUnrealengine, color: '#0E1128' },
   postgres: { Icon: SiPostgresql, color: '#4169E1' },
   postgresql: { Icon: SiPostgresql, color: '#4169E1' },
   sentry: { Icon: SiSentry, color: '#362D59' },
@@ -1609,7 +1614,7 @@ function McpAvatar({ className, name, status }: { className?: string; name: stri
       style={brand ? { backgroundColor: `color-mix(in srgb, ${brand.color} 16%, transparent)` } : undefined}
     >
       {brand ? (
-        <brand.Icon aria-hidden className="size-3.5" style={{ color: brand.color }} />
+        <brand.Icon aria-hidden className="size-[58%]" style={{ color: brand.color }} />
       ) : (
         name.charAt(0).toUpperCase()
       )}

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -37,6 +37,7 @@ import {
   testMcpServer
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
+import { connectorDisplayName, connectorPrimaryActionKind } from '@/lib/mcp-catalog'
 import { countEnabledTools, isToolEnabled, toggleToolInServer } from '@/lib/mcp-tool-filter'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
@@ -1374,6 +1375,7 @@ function McpCatalog({
     <div className="flex flex-col">
       {entries.map(entry => {
         const draft = envDrafts[entry.name] ?? {}
+        const actionKind = connectorPrimaryActionKind(entry)
 
         return (
           <div className="rounded-md px-2 py-2" key={entry.name}>
@@ -1388,8 +1390,9 @@ function McpCatalog({
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-1.5">
                   <span className="truncate text-[0.78rem] font-medium text-foreground/85">
-                    {prettyName(entry.name)}
+                    {connectorDisplayName(entry)}
                   </span>
+                  {entry.category && <CatalogTag>{entry.category}</CatalogTag>}
                   <CatalogTag>{entry.transport}</CatalogTag>
                   {entry.auth_type === 'oauth' && <CatalogTag>OAuth</CatalogTag>}
                   {entry.auth_type === 'api_key' && <CatalogTag>API key</CatalogTag>}
@@ -1401,6 +1404,21 @@ function McpCatalog({
                   )}
                 </div>
                 <p className="mt-0.5 line-clamp-2 text-[0.68rem] text-muted-foreground/70">{entry.description}</p>
+                {entry.capabilities.length > 0 && (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {entry.capabilities.slice(0, 3).map(capability => (
+                      <span
+                        className="rounded bg-(--ui-bg-quinary) px-1.5 py-0.5 text-[0.6rem] text-(--ui-text-tertiary)"
+                        key={capability}
+                      >
+                        {capability}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {entry.danger_notes.length > 0 && (
+                  <p className="mt-1 text-[0.62rem] text-amber-400/90">{entry.danger_notes[0]}</p>
+                )}
                 {envOpenFor === entry.name && entry.required_env.length > 0 && (
                   <div className="mt-2 grid gap-2">
                     {entry.required_env.map(env => (
@@ -1434,9 +1452,11 @@ function McpCatalog({
               >
                 {installing === entry.name
                   ? m.catalogInstalling
-                  : entry.installed
+                  : actionKind === 'installed'
                     ? m.catalogInstalled
-                    : m.catalogInstall}
+                    : actionKind === 'connect'
+                      ? m.catalogConnect
+                      : m.catalogInstall}
               </Button>
             </div>
           </div>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -307,7 +307,7 @@ export const en: Translations = {
       apiKeys: 'Tools & Keys',
       keysTools: 'Tools',
       keysSettings: 'Settings',
-      mcp: 'MCP',
+      mcp: 'MCP Connectors',
       archivedChats: 'Archived Chats',
       about: 'About',
       notifications: 'Notifications'
@@ -775,7 +775,7 @@ export const en: Translations = {
   skills: {
     tabSkills: 'Skills',
     tabToolsets: 'Tools',
-    tabMcp: 'Connectors',
+    tabMcp: 'MCP Connectors',
     tabHub: 'Browse Hub',
     all: 'All',
     searchSkills: 'Search skills...',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -627,6 +627,7 @@ export const en: Translations = {
       catalogEnabled: 'Enabled',
       catalogNeedsInstall: 'Needs build',
       catalogInstall: 'Install',
+      catalogConnect: 'Connect',
       catalogInstalling: 'Installing...',
       catalogInstallStarted: name => `Installing ${name}... applies to new sessions when done.`,
       catalogInstallFailed: name => `Failed to install ${name}`,
@@ -774,7 +775,7 @@ export const en: Translations = {
   skills: {
     tabSkills: 'Skills',
     tabToolsets: 'Tools',
-    tabMcp: 'MCP',
+    tabMcp: 'Connectors',
     tabHub: 'Browse Hub',
     all: 'All',
     searchSkills: 'Search skills...',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -538,6 +538,7 @@ export interface Translations {
       catalogEnabled: string
       catalogNeedsInstall: string
       catalogInstall: string
+      catalogConnect: string
       catalogInstalling: string
       catalogInstallStarted: (name: string) => string
       catalogInstallFailed: (name: string) => string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -816,6 +816,7 @@ export const zh: Translations = {
       catalogEnabled: '已启用',
       catalogNeedsInstall: '需要构建',
       catalogInstall: '安装',
+      catalogConnect: '连接',
       catalogInstalling: '安装中…',
       catalogInstallStarted: name => `正在安装 ${name}… 完成后对新会话生效。`,
       catalogInstallFailed: name => `安装 ${name} 失败`,

--- a/apps/desktop/src/lib/mcp-catalog.test.ts
+++ b/apps/desktop/src/lib/mcp-catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { connectorDisplayName, connectorPrimaryActionKind } from './mcp-catalog'
+import { connectorDisplayName, connectorPrimaryActionKind, connectorSetupSummary } from './mcp-catalog'
 
 const entry = (overrides = {}) => ({
   name: 'github-enterprise',
@@ -53,5 +53,25 @@ describe('connectorPrimaryActionKind', () => {
 
   it('returns installed once the entry is already installed', () => {
     expect(connectorPrimaryActionKind(entry({ installed: true, enabled: true }))).toBe('installed')
+  })
+})
+
+describe('connectorSetupSummary', () => {
+  it('describes OAuth HTTP connectors as browser sign-in flows', () => {
+    expect(connectorSetupSummary(entry({ setup_steps: ['Sign in', 'Pick tools'] }))).toBe(
+      '2 setup steps · Browser OAuth'
+    )
+  })
+
+  it('describes api-key connectors as credential setup flows', () => {
+    expect(
+      connectorSetupSummary(
+        entry({ auth_type: 'api_key', required_env: [{ name: 'API_KEY', prompt: 'API key', required: true }] })
+      )
+    ).toBe('1 setup step · Requires credentials')
+  })
+
+  it('describes local build connectors without setup steps', () => {
+    expect(connectorSetupSummary(entry({ auth_type: 'none', needs_install: true, setup_steps: [] }))).toBe('Local build')
   })
 })

--- a/apps/desktop/src/lib/mcp-catalog.test.ts
+++ b/apps/desktop/src/lib/mcp-catalog.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { connectorDisplayName, connectorPrimaryActionKind } from './mcp-catalog'
+
+const entry = (overrides = {}) => ({
+  name: 'github-enterprise',
+  description: 'GitHub connector',
+  source: 'https://example.com',
+  transport: 'http',
+  auth_type: 'oauth',
+  required_env: [],
+  command: null,
+  args: [],
+  url: 'https://example.com/mcp',
+  install_url: null,
+  install_ref: null,
+  bootstrap: [],
+  default_enabled: null,
+  post_install: '',
+  display_name: '',
+  category: '',
+  icon: '',
+  tags: [],
+  capabilities: [],
+  setup_steps: [],
+  danger_notes: [],
+  needs_install: false,
+  installed: false,
+  enabled: false,
+  ...overrides
+})
+
+describe('connectorDisplayName', () => {
+  it('uses manifest display_name when present', () => {
+    expect(connectorDisplayName(entry({ display_name: 'GitHub Enterprise' }))).toBe('GitHub Enterprise')
+  })
+
+  it('falls back to a readable name for legacy manifests', () => {
+    expect(connectorDisplayName(entry())).toBe('Github Enterprise')
+  })
+})
+
+describe('connectorPrimaryActionKind', () => {
+  it('treats uninstalled OAuth HTTP catalog entries as connect actions', () => {
+    expect(connectorPrimaryActionKind(entry())).toBe('connect')
+  })
+
+  it('keeps local stdio catalog entries as install actions', () => {
+    expect(connectorPrimaryActionKind(entry({ transport: 'stdio', auth_type: 'none', command: 'npx', url: null }))).toBe(
+      'install'
+    )
+  })
+
+  it('returns installed once the entry is already installed', () => {
+    expect(connectorPrimaryActionKind(entry({ installed: true, enabled: true }))).toBe('installed')
+  })
+})

--- a/apps/desktop/src/lib/mcp-catalog.test.ts
+++ b/apps/desktop/src/lib/mcp-catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { connectorDisplayName, connectorPrimaryActionKind, connectorSetupSummary } from './mcp-catalog'
+import { connectorDisplayName, connectorIdentityKey, connectorPrimaryActionKind, connectorSetupSummary } from './mcp-catalog'
 
 const entry = (overrides = {}) => ({
   name: 'github-enterprise',
@@ -37,6 +37,16 @@ describe('connectorDisplayName', () => {
 
   it('falls back to a readable name for legacy manifests', () => {
     expect(connectorDisplayName(entry())).toBe('Github Enterprise')
+  })
+})
+
+describe('connectorIdentityKey', () => {
+  it('prefers the curated icon key over the config name', () => {
+    expect(connectorIdentityKey(entry({ icon: 'unreal-engine', name: 'ue-local' }))).toBe('unreal-engine')
+  })
+
+  it('falls back to the entry name for legacy manifests', () => {
+    expect(connectorIdentityKey(entry({ icon: '' }))).toBe('github-enterprise')
   })
 })
 

--- a/apps/desktop/src/lib/mcp-catalog.test.ts
+++ b/apps/desktop/src/lib/mcp-catalog.test.ts
@@ -55,6 +55,10 @@ describe('connectorPrimaryActionKind', () => {
     expect(connectorPrimaryActionKind(entry())).toBe('connect')
   })
 
+  it('treats uninstalled OAuth SSE catalog entries as connect actions', () => {
+    expect(connectorPrimaryActionKind(entry({ transport: 'sse' }))).toBe('connect')
+  })
+
   it('keeps local stdio catalog entries as install actions', () => {
     expect(connectorPrimaryActionKind(entry({ transport: 'stdio', auth_type: 'none', command: 'npx', url: null }))).toBe(
       'install'

--- a/apps/desktop/src/lib/mcp-catalog.ts
+++ b/apps/desktop/src/lib/mcp-catalog.ts
@@ -2,6 +2,10 @@ import type { McpCatalogEntry } from '@/types/hermes'
 
 export type ConnectorPrimaryActionKind = 'connect' | 'install' | 'installed'
 
+export function connectorIdentityKey(entry: Pick<McpCatalogEntry, 'icon' | 'name'>): string {
+  return entry.icon?.trim() || entry.name
+}
+
 export function connectorDisplayName(entry: Pick<McpCatalogEntry, 'display_name' | 'name'>): string {
   const displayName = entry.display_name?.trim()
 

--- a/apps/desktop/src/lib/mcp-catalog.ts
+++ b/apps/desktop/src/lib/mcp-catalog.ts
@@ -25,3 +25,24 @@ export function connectorPrimaryActionKind(
 
   return entry.auth_type === 'oauth' && entry.transport === 'http' ? 'connect' : 'install'
 }
+
+export function connectorSetupSummary(
+  entry: Pick<McpCatalogEntry, 'auth_type' | 'needs_install' | 'required_env' | 'setup_steps' | 'transport'>
+): string {
+  const parts: string[] = []
+  const stepCount = entry.setup_steps.length || entry.required_env.filter(env => env.required).length
+
+  if (stepCount > 0) {
+    parts.push(`${stepCount} setup step${stepCount === 1 ? '' : 's'}`)
+  }
+
+  if (entry.auth_type === 'oauth' && entry.transport === 'http') {
+    parts.push('Browser OAuth')
+  } else if (entry.auth_type === 'api_key' || entry.required_env.length > 0) {
+    parts.push('Requires credentials')
+  } else if (entry.needs_install) {
+    parts.push('Local build')
+  }
+
+  return parts.join(' · ')
+}

--- a/apps/desktop/src/lib/mcp-catalog.ts
+++ b/apps/desktop/src/lib/mcp-catalog.ts
@@ -27,7 +27,7 @@ export function connectorPrimaryActionKind(
     return 'installed'
   }
 
-  return entry.auth_type === 'oauth' && entry.transport === 'http' ? 'connect' : 'install'
+  return entry.auth_type === 'oauth' && ['http', 'sse'].includes(entry.transport) ? 'connect' : 'install'
 }
 
 export function connectorSetupSummary(

--- a/apps/desktop/src/lib/mcp-catalog.ts
+++ b/apps/desktop/src/lib/mcp-catalog.ts
@@ -1,0 +1,27 @@
+import type { McpCatalogEntry } from '@/types/hermes'
+
+export type ConnectorPrimaryActionKind = 'connect' | 'install' | 'installed'
+
+export function connectorDisplayName(entry: Pick<McpCatalogEntry, 'display_name' | 'name'>): string {
+  const displayName = entry.display_name?.trim()
+
+  if (displayName) {
+    return displayName
+  }
+
+  return entry.name
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export function connectorPrimaryActionKind(
+  entry: Pick<McpCatalogEntry, 'auth_type' | 'installed' | 'transport'>
+): ConnectorPrimaryActionKind {
+  if (entry.installed) {
+    return 'installed'
+  }
+
+  return entry.auth_type === 'oauth' && entry.transport === 'http' ? 'connect' : 'install'
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1010,6 +1010,13 @@ export interface McpCatalogEntry {
   bootstrap: string[]
   default_enabled: string[] | null
   post_install: string
+  display_name: string
+  category: string
+  icon: string
+  tags: string[]
+  capabilities: string[]
+  setup_steps: string[]
+  danger_notes: string[]
   needs_install: boolean
   installed: boolean
   enabled: boolean

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -72,7 +72,7 @@ class AuthSpec:
 
 @dataclass
 class TransportSpec:
-    type: str  # "stdio" | "http"
+    type: str  # "stdio" | "http" | "sse"
     command: Optional[str] = None
     args: List[str] = field(default_factory=list)
     url: Optional[str] = None
@@ -230,8 +230,8 @@ def _parse_manifest(path: Path) -> CatalogEntry:
     if not isinstance(transport_raw, dict):
         raise CatalogError(f"{path}: 'transport' must be a mapping")
     t_type = transport_raw.get("type")
-    if t_type not in ("stdio", "http"):
-        raise CatalogError(f"{path}: transport.type must be 'stdio' or 'http'")
+    if t_type not in ("stdio", "http", "sse"):
+        raise CatalogError(f"{path}: transport.type must be 'stdio', 'http', or 'sse'")
     args = transport_raw.get("args") or []
     if not isinstance(args, list):
         raise CatalogError(f"{path}: transport.args must be a list")
@@ -244,8 +244,8 @@ def _parse_manifest(path: Path) -> CatalogEntry:
     )
     if t_type == "stdio" and not transport.command:
         raise CatalogError(f"{path}: stdio transport requires 'command'")
-    if t_type == "http" and not transport.url:
-        raise CatalogError(f"{path}: http transport requires 'url'")
+    if t_type in ("http", "sse") and not transport.url:
+        raise CatalogError(f"{path}: {t_type} transport requires 'url'")
 
     auth_raw = data.get("auth") or {"type": "none"}
     if not isinstance(auth_raw, dict):
@@ -521,8 +521,10 @@ def _build_server_config(
         cfg["command"] = _expand_install_dir(t.command or "", install_dir)
         if t.args:
             cfg["args"] = [_expand_install_dir(a, install_dir) for a in t.args]
-    elif t.type == "http":
+    elif t.type in ("http", "sse"):
         cfg["url"] = t.url
+        if t.type == "sse":
+            cfg["transport"] = "sse"
         if entry.auth.type == "oauth":
             cfg["auth"] = "oauth"
     return cfg

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -106,6 +106,25 @@ class ToolsSpec:
 
 
 @dataclass
+class ConnectorUiSpec:
+    """Presentation metadata for connector-first catalog surfaces.
+
+    These fields are optional so existing ``manifest_version: 1`` catalog
+    manifests stay valid. They let desktop/dashboard UIs present entries as
+    user-facing connectors instead of raw MCP transport blocks, while the
+    runtime config remains the same ``mcp_servers`` shape.
+    """
+
+    display_name: str = ""
+    category: str = ""
+    icon: str = ""
+    tags: List[str] = field(default_factory=list)
+    capabilities: List[str] = field(default_factory=list)
+    setup_steps: List[str] = field(default_factory=list)
+    danger_notes: List[str] = field(default_factory=list)
+
+
+@dataclass
 class CatalogEntry:
     name: str
     description: str
@@ -113,6 +132,7 @@ class CatalogEntry:
     transport: TransportSpec
     auth: AuthSpec
     tools: ToolsSpec = field(default_factory=ToolsSpec)
+    ui: ConnectorUiSpec = field(default_factory=ConnectorUiSpec)
     install: Optional[InstallSpec] = None
     post_install: str = ""
     manifest_path: Path = field(default_factory=Path)
@@ -144,6 +164,37 @@ def _parse_env_spec(raw: Any) -> EnvVarSpec:
         required=bool(raw.get("required", True)),
         secret=bool(raw.get("secret", True)),
         default=str(raw.get("default") or ""),
+    )
+
+
+def _parse_string_list(raw: Any, *, path: Path, key: str) -> List[str]:
+    """Parse an optional UI list field as ``list[str]``."""
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise CatalogError(f"{path}: ui.{key} must be a list of strings")
+    return list(raw)
+
+
+def _parse_ui_spec(path: Path, raw: Any) -> ConnectorUiSpec:
+    if raw is None:
+        return ConnectorUiSpec()
+    if not isinstance(raw, dict):
+        raise CatalogError(f"{path}: 'ui' must be a mapping")
+    return ConnectorUiSpec(
+        display_name=str(raw.get("display_name") or ""),
+        category=str(raw.get("category") or ""),
+        icon=str(raw.get("icon") or ""),
+        tags=_parse_string_list(raw.get("tags"), path=path, key="tags"),
+        capabilities=_parse_string_list(
+            raw.get("capabilities"), path=path, key="capabilities"
+        ),
+        setup_steps=_parse_string_list(
+            raw.get("setup_steps"), path=path, key="setup_steps"
+        ),
+        danger_notes=_parse_string_list(
+            raw.get("danger_notes"), path=path, key="danger_notes"
+        ),
     )
 
 
@@ -226,6 +277,7 @@ def _parse_manifest(path: Path) -> CatalogEntry:
                 f"{path}: tools.default_enabled must be a list of strings"
             )
     tools_spec = ToolsSpec(default_enabled=default_enabled)
+    ui_spec = _parse_ui_spec(path, data.get("ui"))
 
     install: Optional[InstallSpec] = None
     install_raw = data.get("install")
@@ -256,6 +308,7 @@ def _parse_manifest(path: Path) -> CatalogEntry:
         transport=transport,
         auth=auth,
         tools=tools_spec,
+        ui=ui_spec,
         install=install,
         post_install=str(data.get("post_install") or ""),
         manifest_path=path,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9342,6 +9342,7 @@ async def list_mcp_catalog(profile: Optional[str] = None):
             auth = entry.auth
             transport = entry.transport
             install = entry.install
+            ui = entry.ui
             entries.append({
                 "name": entry.name,
                 "description": entry.description,
@@ -9369,6 +9370,13 @@ async def list_mcp_catalog(profile: Optional[str] = None):
                 if entry.tools.default_enabled is not None
                 else None,
                 "post_install": entry.post_install or "",
+                "display_name": ui.display_name,
+                "category": ui.category,
+                "icon": ui.icon,
+                "tags": list(ui.tags),
+                "capabilities": list(ui.capabilities),
+                "setup_steps": list(ui.setup_steps),
+                "danger_notes": list(ui.danger_notes),
                 "needs_install": entry.install is not None,
                 "installed": installed_state.get(entry.name, (False, False))[0],
                 "enabled": installed_state.get(entry.name, (False, False))[1],

--- a/optional-mcps/actively/manifest.yaml
+++ b/optional-mcps/actively/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: actively
+description: 1:1 account agents for GTM teams
+source: https://claude.com/connectors/actively
+ui:
+  display_name: Actively
+  category: Sales & CRM
+  icon: actively
+  tags:
+  - crm
+  capabilities:
+  - 1:1 account agents for GTM teams
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.actively.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Actively.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure actively\n"

--- a/optional-mcps/adisinsight/manifest.yaml
+++ b/optional-mcps/adisinsight/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: adisinsight
+description: Pharmaceutical drug & clinical trial intelligence
+source: https://claude.com/connectors/adisinsight
+ui:
+  display_name: AdisInsight
+  category: Analytics
+  icon: adisinsight
+  tags:
+  - analytics
+  capabilities:
+  - Pharmaceutical drug & clinical trial intelligence
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://adisinsight-mcp.springer.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with AdisInsight.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure adisinsight\n"

--- a/optional-mcps/adobe-cja/manifest.yaml
+++ b/optional-mcps/adobe-cja/manifest.yaml
@@ -1,0 +1,26 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: adobe-cja
+description: Run reports using your metrics, dimensions, and segments
+source: https://claude.com/connectors/adobe-cja
+ui:
+  display_name: Adobe Customer Journey Analytics
+  category: Analytics
+  icon: adobe-cja
+  tags:
+  - crm
+  - analytics
+  capabilities:
+  - Run reports using your metrics, dimensions, and segments
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://cja-mcp.adobe.io/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Adobe Customer Journey Analytics.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure adobe-cja\n"

--- a/optional-mcps/adobe-creativity/manifest.yaml
+++ b/optional-mcps/adobe-creativity/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: adobe-creativity
+description: Ideate, create, and deliver with Adobe pro tools
+source: https://claude.com/connectors/adobe-creativity
+ui:
+  display_name: Adobe for creativity
+  category: Business tools
+  icon: adobe-creativity
+  tags:
+  - connector
+  capabilities:
+  - Ideate, create, and deliver with Adobe pro tools
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://adobe-creativity.adobe.io/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Adobe for creativity.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure adobe-creativity\n"

--- a/optional-mcps/adobe-experience-manager/manifest.yaml
+++ b/optional-mcps/adobe-experience-manager/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: adobe-experience-manager
+description: Manage your Adobe Experience Manager content
+source: https://claude.com/connectors/adobe-experience-manager
+ui:
+  display_name: Adobe Experience Manager
+  category: Business tools
+  icon: adobe-experience-manager
+  tags:
+  - connector
+  capabilities:
+  - Manage your Adobe Experience Manager content
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.adobeaemcloud.com/adobe/mcp/aem
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Adobe Experience Manager.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure adobe-experience-manager\n"

--- a/optional-mcps/adobe-journey-optimizer/manifest.yaml
+++ b/optional-mcps/adobe-journey-optimizer/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: adobe-journey-optimizer
+description: Understand and troubleshoot your Journeys and Campaigns
+source: https://claude.com/connectors/adobe-journey-optimizer
+ui:
+  display_name: Adobe Journey Optimizer
+  category: Business tools
+  icon: adobe-journey-optimizer
+  tags:
+  - connector
+  capabilities:
+  - Understand and troubleshoot your Journeys and Campaigns
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://ajo-mcp.adobe.io/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Adobe Journey Optimizer.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure adobe-journey-optimizer\n"

--- a/optional-mcps/adobe-marketing-agent/manifest.yaml
+++ b/optional-mcps/adobe-marketing-agent/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: adobe-marketing-agent
+description: Marketing campaign and audience insights from Adobe
+source: https://claude.com/connectors/adobe-marketing-agent
+ui:
+  display_name: Adobe Marketing Agent
+  category: Analytics
+  icon: adobe-marketing-agent
+  tags:
+  - analytics
+  capabilities:
+  - Marketing campaign and audience insights from Adobe
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://aep-ai-ama.adobe.io/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Adobe Marketing Agent.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure adobe-marketing-agent\n"

--- a/optional-mcps/adobe-workfront/manifest.yaml
+++ b/optional-mcps/adobe-workfront/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: adobe-workfront
+description: Manage planning, projects, tasks, and approvals
+source: https://claude.com/connectors/adobe-workfront
+ui:
+  display_name: Adobe Workfront
+  category: Business tools
+  icon: adobe-workfront
+  tags:
+  - project-management
+  capabilities:
+  - Manage planning, projects, tasks, and approvals
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.workfront.adobe.com/mcp/v1/workfront
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Adobe Workfront.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure adobe-workfront\n"

--- a/optional-mcps/affinity/manifest.yaml
+++ b/optional-mcps/affinity/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: affinity
+description: Search, update, and prep deals without switching tabs.
+source: https://claude.com/connectors/affinity
+ui:
+  display_name: Affinity
+  category: Business tools
+  icon: affinity
+  tags:
+  - connector
+  capabilities:
+  - Search, update, and prep deals without switching tabs.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.affinity.co/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Affinity.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure affinity\n"

--- a/optional-mcps/ahrefs/manifest.yaml
+++ b/optional-mcps/ahrefs/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: ahrefs
+description: SEO & AI search analytics
+source: https://claude.com/connectors/ahrefs
+ui:
+  display_name: Ahrefs
+  category: Analytics
+  icon: ahrefs
+  tags:
+  - analytics
+  capabilities:
+  - SEO & AI search analytics
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.ahrefs.com/mcp/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Ahrefs.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure ahrefs\n"

--- a/optional-mcps/airops/manifest.yaml
+++ b/optional-mcps/airops/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: airops
+description: Craft content that wins AI search
+source: https://claude.com/connectors/airops
+ui:
+  display_name: AirOps
+  category: Business tools
+  icon: airops
+  tags:
+  - connector
+  capabilities:
+  - Craft content that wins AI search
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://app.airops.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with AirOps.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure airops\n"

--- a/optional-mcps/airtable/manifest.yaml
+++ b/optional-mcps/airtable/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: airtable
+description: Bring your structured data to Claude
+source: https://claude.com/connectors/airtable
+ui:
+  display_name: Airtable
+  category: Analytics
+  icon: airtable
+  tags:
+  - analytics
+  capabilities:
+  - Bring your structured data to Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.airtable.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Airtable.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure airtable\n"

--- a/optional-mcps/airwallex-developer/manifest.yaml
+++ b/optional-mcps/airwallex-developer/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: airwallex-developer
+description: Integrate with the Airwallex Platform using Claude
+source: https://claude.com/connectors/airwallex
+ui:
+  display_name: Airwallex
+  category: Business tools
+  icon: airwallex-developer
+  tags:
+  - connector
+  capabilities:
+  - Integrate with the Airwallex Platform using Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp-demo.airwallex.com/developer
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Airwallex.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure airwallex-developer\n"

--- a/optional-mcps/aiwyn-tax/manifest.yaml
+++ b/optional-mcps/aiwyn-tax/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: aiwyn-tax
+description: Estimate your federal & state taxes with Aiwyn's tax engine
+source: https://claude.com/connectors/aiwyn-tax
+ui:
+  display_name: Aiwyn Tax
+  category: Business tools
+  icon: aiwyn-tax
+  tags:
+  - connector
+  capabilities:
+  - Estimate your federal & state taxes with Aiwyn's tax engine
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.columnapi.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Aiwyn Tax.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure aiwyn-tax\n"

--- a/optional-mcps/alltrails/manifest.yaml
+++ b/optional-mcps/alltrails/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: alltrails
+description: Find your next hike
+source: https://claude.com/connectors/alltrails
+ui:
+  display_name: AllTrails
+  category: Business tools
+  icon: alltrails
+  tags:
+  - connector
+  capabilities:
+  - Find your next hike
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://www.alltrails.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with AllTrails.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure alltrails\n"

--- a/optional-mcps/alma/manifest.yaml
+++ b/optional-mcps/alma/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: alma
+description: Your nutrition data, inside every Claude conversation.
+source: https://claude.com/connectors/alma
+ui:
+  display_name: Alma
+  category: Analytics
+  icon: alma
+  tags:
+  - analytics
+  capabilities:
+  - Your nutrition data, inside every Claude conversation.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.alma.food
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Alma.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure alma\n"

--- a/optional-mcps/alphaxiv/manifest.yaml
+++ b/optional-mcps/alphaxiv/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: alphaxiv
+description: Fast search and full-text access over arXiv pre-prints
+source: https://claude.com/connectors/alphaxiv
+ui:
+  display_name: alphaXiv
+  category: Business tools
+  icon: alphaxiv
+  tags:
+  - connector
+  capabilities:
+  - Fast search and full-text access over arXiv pre-prints
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: sse
+  url: https://api.alphaxiv.org/mcp/v1
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with alphaXiv.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure alphaxiv\n"

--- a/optional-mcps/amplitude/manifest.yaml
+++ b/optional-mcps/amplitude/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: amplitude
+description: Give your teams powerful behavioral insights
+source: https://claude.com/connectors/amplitude
+ui:
+  display_name: Amplitude
+  category: Analytics
+  icon: amplitude
+  tags:
+  - analytics
+  capabilities:
+  - Give your teams powerful behavioral insights
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.amplitude.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Amplitude.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure amplitude\n"

--- a/optional-mcps/appfolio-realm-x/manifest.yaml
+++ b/optional-mcps/appfolio-realm-x/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: appfolio-realm-x
+description: Operate your portfolio directly from Claude
+source: https://claude.com/connectors/appfolio-realm-x
+ui:
+  display_name: AppFolio Realm-X
+  category: Business tools
+  icon: appfolio-realm-x
+  tags:
+  - connector
+  capabilities:
+  - Operate your portfolio directly from Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.appfolio.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with AppFolio Realm-X.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure appfolio-realm-x\n"

--- a/optional-mcps/asana/manifest.yaml
+++ b/optional-mcps/asana/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: asana
+description: Connect to Asana to coordinate tasks, projects, and goals
+source: https://claude.com/connectors/asana
+ui:
+  display_name: Asana
+  category: Business tools
+  icon: asana
+  tags:
+  - project-management
+  capabilities:
+  - Connect to Asana to coordinate tasks, projects, and goals
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: sse
+  url: https://mcp.asana.com/sse
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Asana.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure asana\n"

--- a/optional-mcps/atlassian/manifest.yaml
+++ b/optional-mcps/atlassian/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: atlassian
+description: Access Jira & Confluence from Claude
+source: https://claude.com/connectors/atlassian
+ui:
+  display_name: Atlassian Rovo
+  category: Business tools
+  icon: atlassian
+  tags:
+  - connector
+  capabilities:
+  - Access Jira & Confluence from Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: sse
+  url: https://mcp.atlassian.com/v1/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Atlassian Rovo.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure atlassian\n"

--- a/optional-mcps/attention/manifest.yaml
+++ b/optional-mcps/attention/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: attention
+description: Search, analyze, and act on client conversations
+source: https://claude.com/connectors/attention
+ui:
+  display_name: Attention
+  category: Business tools
+  icon: attention
+  tags:
+  - connector
+  capabilities:
+  - Search, analyze, and act on client conversations
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: sse
+  url: https://api.attention.tech/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Attention.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure attention\n"

--- a/optional-mcps/attio/manifest.yaml
+++ b/optional-mcps/attio/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: attio
+description: Search, manage, and update your Attio CRM from Claude
+source: https://claude.com/connectors/attio
+ui:
+  display_name: Attio
+  category: Sales & CRM
+  icon: attio
+  tags:
+  - crm
+  capabilities:
+  - Search, manage, and update your Attio CRM from Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.attio.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Attio.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure attio\n"

--- a/optional-mcps/audible/manifest.yaml
+++ b/optional-mcps/audible/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: audible
+description: Ask for audiobook recommendations & preview audiobooks
+source: https://claude.com/connectors/audible
+ui:
+  display_name: Audible
+  category: Business tools
+  icon: audible
+  tags:
+  - connector
+  capabilities:
+  - Ask for audiobook recommendations & preview audiobooks
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.audible.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Audible.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure audible\n"

--- a/optional-mcps/auraintelligence/manifest.yaml
+++ b/optional-mcps/auraintelligence/manifest.yaml
@@ -1,0 +1,26 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: auraintelligence
+description: Company intelligence & workforce analytics
+source: https://claude.com/connectors/aura
+ui:
+  display_name: Aura
+  category: Analytics
+  icon: auraintelligence
+  tags:
+  - project-management
+  - analytics
+  capabilities:
+  - Company intelligence & workforce analytics
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.auraintelligence.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Aura.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure auraintelligence\n"

--- a/optional-mcps/aurora/manifest.yaml
+++ b/optional-mcps/aurora/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: aurora
+description: Search your Consilio matters, docs, and more.
+source: https://claude.com/connectors/aurora
+ui:
+  display_name: Aurora
+  category: Business tools
+  icon: aurora
+  tags:
+  - connector
+  capabilities:
+  - Search your Consilio matters, docs, and more.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.ai.consilio.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Aurora.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure aurora\n"

--- a/optional-mcps/autodesk-product-help/manifest.yaml
+++ b/optional-mcps/autodesk-product-help/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: autodesk-product-help
+description: Securely access Autodesk's help documentation
+source: https://claude.com/connectors/autodesk-product-help
+ui:
+  display_name: Autodesk Product Help
+  category: Business tools
+  icon: autodesk-product-help
+  tags:
+  - connector
+  capabilities:
+  - Securely access Autodesk's help documentation
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://developer.api.autodesk.com/knowledge/public/v1/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Autodesk Product Help.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure autodesk-product-help\n"

--- a/optional-mcps/aws-marketplace/manifest.yaml
+++ b/optional-mcps/aws-marketplace/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: aws-marketplace
+description: Discover, evaluate, and buy solutions for the cloud
+source: https://claude.com/connectors/aws-marketplace
+ui:
+  display_name: AWS Marketplace
+  category: Business tools
+  icon: aws-marketplace
+  tags:
+  - connector
+  capabilities:
+  - Discover, evaluate, and buy solutions for the cloud
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://marketplace-mcp.us-east-1.api.aws/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with AWS Marketplace.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure aws-marketplace\n"

--- a/optional-mcps/bigdata/manifest.yaml
+++ b/optional-mcps/bigdata/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: bigdata
+description: Access real-time financial data
+source: https://claude.com/connectors/bigdata
+ui:
+  display_name: Bigdata.com
+  category: Analytics
+  icon: bigdata
+  tags:
+  - analytics
+  capabilities:
+  - Access real-time financial data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.bigdata.com/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Bigdata.com.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure bigdata\n"

--- a/optional-mcps/bigquery/manifest.yaml
+++ b/optional-mcps/bigquery/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: bigquery
+description: 'BigQuery: Advanced analytical insights for agents'
+source: https://claude.com/connectors/bigquery
+ui:
+  display_name: Google Cloud BigQuery
+  category: Analytics
+  icon: bigquery
+  tags:
+  - analytics
+  capabilities:
+  - 'BigQuery: Advanced analytical insights for agents'
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://bigquery.googleapis.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Google Cloud BigQuery.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure bigquery\n"

--- a/optional-mcps/biomni-lab/manifest.yaml
+++ b/optional-mcps/biomni-lab/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: biomni-lab
+description: Biomni Lab by Phylo — the Integrated Biology Environment for AI-native research
+source: https://claude.com/connectors/biomni-lab
+ui:
+  display_name: Biomni Lab
+  category: Business tools
+  icon: biomni-lab
+  tags:
+  - connector
+  capabilities:
+  - Biomni Lab by Phylo — the Integrated Biology Environment for AI-native research
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.phylo.bio/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Biomni Lab.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure biomni-lab\n"

--- a/optional-mcps/blockscout/manifest.yaml
+++ b/optional-mcps/blockscout/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: blockscout
+description: Access and analyze blockchain data
+source: https://claude.com/connectors/blockscout
+ui:
+  display_name: Blockscout
+  category: Analytics
+  icon: blockscout
+  tags:
+  - analytics
+  capabilities:
+  - Access and analyze blockchain data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.blockscout.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Blockscout.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure blockscout\n"

--- a/optional-mcps/boardwise/manifest.yaml
+++ b/optional-mcps/boardwise/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: boardwise
+description: Calm board-defense guidance for licensed pros.
+source: https://claude.com/connectors/boardwise
+ui:
+  display_name: BoardWise
+  category: Business tools
+  icon: boardwise
+  tags:
+  - connector
+  capabilities:
+  - Calm board-defense guidance for licensed pros.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://uakozrqrztgrgwoywxkx.supabase.co/functions/v1/mcp-server
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with BoardWise.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure boardwise\n"

--- a/optional-mcps/boltz-api/manifest.yaml
+++ b/optional-mcps/boltz-api/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: boltz-api
+description: Predict molecular structures and binding interactions, screen libraries, and design binders with the Boltz API.
+source: https://claude.com/connectors/boltz-api
+ui:
+  display_name: Boltz API
+  category: Developer tools
+  icon: boltz-api
+  tags:
+  - developer-tools
+  capabilities:
+  - Predict molecular structures and binding interactions, screen libraries, and design binders with the Boltz API.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.boltz.bio/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Boltz API.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure boltz-api\n"

--- a/optional-mcps/booking/manifest.yaml
+++ b/optional-mcps/booking/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: booking
+description: Find hotels, homes and more
+source: https://claude.com/connectors/booking
+ui:
+  display_name: Booking.com
+  category: Business tools
+  icon: booking
+  tags:
+  - connector
+  capabilities:
+  - Find hotels, homes and more
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://demandapi-mcp.booking.com/v1/mcp/8132308
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Booking.com.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure booking\n"

--- a/optional-mcps/brevo/manifest.yaml
+++ b/optional-mcps/brevo/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: brevo
+description: Analyze campaigns, know your audience and create drafts
+source: https://claude.com/connectors/brevo
+ui:
+  display_name: Brevo
+  category: Business tools
+  icon: brevo
+  tags:
+  - connector
+  capabilities:
+  - Analyze campaigns, know your audience and create drafts
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.brevo.com/v1/anthropic/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Brevo.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure brevo\n"

--- a/optional-mcps/brighthire/manifest.yaml
+++ b/optional-mcps/brighthire/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: brighthire
+description: Search, summarize and analyze hiring data
+source: https://claude.com/connectors/brighthire
+ui:
+  display_name: BrightHire
+  category: Analytics
+  icon: brighthire
+  tags:
+  - analytics
+  capabilities:
+  - Search, summarize and analyze hiring data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://app.brighthire.ai/mcp/v1
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with BrightHire.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure brighthire\n"

--- a/optional-mcps/brisk-teaching/manifest.yaml
+++ b/optional-mcps/brisk-teaching/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: brisk-teaching
+description: Build classroom activities, lessons, & more with Brisk
+source: https://claude.com/connectors/brisk-teaching
+ui:
+  display_name: Brisk Teaching
+  category: Business tools
+  icon: brisk-teaching
+  tags:
+  - connector
+  capabilities:
+  - Build classroom activities, lessons, & more with Brisk
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.briskteaching.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Brisk Teaching.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure brisk-teaching\n"

--- a/optional-mcps/canary-data/manifest.yaml
+++ b/optional-mcps/canary-data/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: canary-data
+description: Perform world-class investment analysis
+source: https://claude.com/connectors/canary-data
+ui:
+  display_name: Canary Data
+  category: Analytics
+  icon: canary-data
+  tags:
+  - analytics
+  capabilities:
+  - Perform world-class investment analysis
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.canary-data.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Canary Data.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure canary-data\n"

--- a/optional-mcps/canva/manifest.yaml
+++ b/optional-mcps/canva/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: canva
+description: Search, create, autofill, and export Canva designs from a prompt
+source: https://claude.com/connectors/canva
+ui:
+  display_name: Canva
+  category: Business tools
+  icon: canva
+  tags:
+  - connector
+  capabilities:
+  - Search, create, autofill, and export Canva designs from a prompt
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.canva.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Canva.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure canva\n"

--- a/optional-mcps/cargoai/manifest.yaml
+++ b/optional-mcps/cargoai/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: cargoai
+description: Instant air cargo rates, quotes & tracking
+source: https://claude.com/connectors/cargoai
+ui:
+  display_name: CargoAi
+  category: Business tools
+  icon: cargoai
+  tags:
+  - connector
+  capabilities:
+  - Instant air cargo rates, quotes & tracking
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.cargoai.co/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with CargoAi.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure cargoai\n"

--- a/optional-mcps/carta/manifest.yaml
+++ b/optional-mcps/carta/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: carta
+description: The connected ERP for private capital
+source: https://claude.com/connectors/carta
+ui:
+  display_name: Carta
+  category: Developer tools
+  icon: carta
+  tags:
+  - developer-tools
+  capabilities:
+  - The connected ERP for private capital
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.app.carta.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Carta.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure carta\n"

--- a/optional-mcps/cash-app/manifest.yaml
+++ b/optional-mcps/cash-app/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: cash-app
+description: Discover local food spots and order with a conversation
+source: https://claude.com/connectors/cash-app
+ui:
+  display_name: Order by Cash App
+  category: Business tools
+  icon: cash-app
+  tags:
+  - connector
+  capabilities:
+  - Discover local food spots and order with a conversation
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://connect.squareup.com/v2/mcp/cash-app
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Order by Cash App.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure cash-app\n"

--- a/optional-mcps/cb-insights/manifest.yaml
+++ b/optional-mcps/cb-insights/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: cb-insights
+description: Predictive intelligence on private companies
+source: https://claude.com/connectors/cb-insights
+ui:
+  display_name: CB Insights
+  category: Analytics
+  icon: cb-insights
+  tags:
+  - analytics
+  capabilities:
+  - Predictive intelligence on private companies
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.cbinsights.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with CB Insights.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure cb-insights\n"

--- a/optional-mcps/chronograph/manifest.yaml
+++ b/optional-mcps/chronograph/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: chronograph
+description: Interact with your Chronograph data directly in Claude
+source: https://claude.com/connectors/chronograph
+ui:
+  display_name: Chronograph
+  category: Analytics
+  icon: chronograph
+  tags:
+  - analytics
+  capabilities:
+  - Interact with your Chronograph data directly in Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://ai.chronograph.pe/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Chronograph.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure chronograph\n"

--- a/optional-mcps/clarify/manifest.yaml
+++ b/optional-mcps/clarify/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: clarify
+description: Query your CRM. Create records. Ask anything.
+source: https://claude.com/connectors/clarify
+ui:
+  display_name: Clarify
+  category: Sales & CRM
+  icon: clarify
+  tags:
+  - crm
+  capabilities:
+  - Query your CRM. Create records. Ask anything.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.clarify.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Clarify.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure clarify\n"

--- a/optional-mcps/clarity-ai/manifest.yaml
+++ b/optional-mcps/clarity-ai/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: clarity-ai
+description: Simulate fund classifications under proposed SFDR 2.0
+source: https://claude.com/connectors/clarity-ai
+ui:
+  display_name: Clarity AI
+  category: Business tools
+  icon: clarity-ai
+  tags:
+  - connector
+  capabilities:
+  - Simulate fund classifications under proposed SFDR 2.0
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://clarity-sfdr20-mcp.pro.clarity.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Clarity AI.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure clarity-ai\n"

--- a/optional-mcps/clarivate-compumark/manifest.yaml
+++ b/optional-mcps/clarivate-compumark/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: clarivate-compumark
+description: Trusted Trademark Intelligence from Clarivate CompuMark
+source: https://claude.com/connectors/clarivate-compumark
+ui:
+  display_name: Clarivate IPOne CompuMark Trademarks
+  category: Business tools
+  icon: clarivate-compumark
+  tags:
+  - connector
+  capabilities:
+  - Trusted Trademark Intelligence from Clarivate CompuMark
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://ipone.clarivate.com/trademarks/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Clarivate IPOne CompuMark Trademarks.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure clarivate-compumark\n"

--- a/optional-mcps/clerk/manifest.yaml
+++ b/optional-mcps/clerk/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: clerk
+description: Add authentication, organizations, and billing
+source: https://claude.com/connectors/clerk
+ui:
+  display_name: Clerk
+  category: Business tools
+  icon: clerk
+  tags:
+  - connector
+  capabilities:
+  - Add authentication, organizations, and billing
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.clerk.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Clerk.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure clerk\n"

--- a/optional-mcps/clickup/manifest.yaml
+++ b/optional-mcps/clickup/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: clickup
+description: Project management & collaboration for teams & agents
+source: https://claude.com/connectors/clickup
+ui:
+  display_name: ClickUp
+  category: Business tools
+  icon: clickup
+  tags:
+  - project-management
+  capabilities:
+  - Project management & collaboration for teams & agents
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.clickup.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with ClickUp.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure clickup\n"

--- a/optional-mcps/clockwise/manifest.yaml
+++ b/optional-mcps/clockwise/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: clockwise
+description: Advanced scheduling and time management for work.
+source: https://claude.com/connectors/clockwise
+ui:
+  display_name: Clockwise
+  category: Business tools
+  icon: clockwise
+  tags:
+  - project-management
+  capabilities:
+  - Advanced scheduling and time management for work.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.getclockwise.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Clockwise.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure clockwise\n"

--- a/optional-mcps/cloudflare/manifest.yaml
+++ b/optional-mcps/cloudflare/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: cloudflare
+description: Build applications with compute, storage, and AI
+source: https://claude.com/connectors/cloudflare
+ui:
+  display_name: Cloudflare
+  category: Business tools
+  icon: cloudflare
+  tags:
+  - connector
+  capabilities:
+  - Build applications with compute, storage, and AI
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://bindings.mcp.cloudflare.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Cloudflare.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure cloudflare\n"

--- a/optional-mcps/cloudinary/manifest.yaml
+++ b/optional-mcps/cloudinary/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: cloudinary
+description: Manage, transform and deliver your images & videos
+source: https://claude.com/connectors/cloudinary
+ui:
+  display_name: Cloudinary
+  category: Business tools
+  icon: cloudinary
+  tags:
+  - connector
+  capabilities:
+  - Manage, transform and deliver your images & videos
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://asset-management.mcp.cloudinary.com/sse
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Cloudinary.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure cloudinary\n"

--- a/optional-mcps/cognito-forms/manifest.yaml
+++ b/optional-mcps/cognito-forms/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: cognito-forms
+description: Manage entries, analyze submissions, and download files
+source: https://claude.com/connectors/cognito-forms
+ui:
+  display_name: Cognito Forms
+  category: Business tools
+  icon: cognito-forms
+  tags:
+  - connector
+  capabilities:
+  - Manage entries, analyze submissions, and download files
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.cognitoforms.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Cognito Forms.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure cognito-forms\n"

--- a/optional-mcps/coindesk/manifest.yaml
+++ b/optional-mcps/coindesk/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: coindesk
+description: Access Live & Historical Crypto Data, Indices
+source: https://claude.com/connectors/coindesk
+ui:
+  display_name: CoinDesk
+  category: Analytics
+  icon: coindesk
+  tags:
+  - analytics
+  capabilities:
+  - Access Live & Historical Crypto Data, Indices
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.coindesk.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with CoinDesk.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure coindesk\n"

--- a/optional-mcps/consensus/manifest.yaml
+++ b/optional-mcps/consensus/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: consensus
+description: Explore scientific research
+source: https://claude.com/connectors/consensus
+ui:
+  display_name: Consensus
+  category: Business tools
+  icon: consensus
+  tags:
+  - connector
+  capabilities:
+  - Explore scientific research
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.consensus.app/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Consensus.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure consensus\n"

--- a/optional-mcps/contentsquare/manifest.yaml
+++ b/optional-mcps/contentsquare/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: contentsquare
+description: Experience analytics platform for digital businesses
+source: https://claude.com/connectors/contentsquare
+ui:
+  display_name: Contentsquare
+  category: Analytics
+  icon: contentsquare
+  tags:
+  - analytics
+  capabilities:
+  - Experience analytics platform for digital businesses
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.contentsquare.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Contentsquare.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure contentsquare\n"

--- a/optional-mcps/context7/manifest.yaml
+++ b/optional-mcps/context7/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: context7
+description: Up-to-date docs for LLMs and AI code editors
+source: https://claude.com/connectors/context7
+ui:
+  display_name: Context7
+  category: Developer tools
+  icon: context7
+  tags:
+  - developer-tools
+  capabilities:
+  - Up-to-date docs for LLMs and AI code editors
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.context7.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Context7.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure context7\n"

--- a/optional-mcps/coupler/manifest.yaml
+++ b/optional-mcps/coupler/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: coupler
+description: Access business data from hundreds of sources
+source: https://claude.com/connectors/coupler-io
+ui:
+  display_name: Coupler.io
+  category: Analytics
+  icon: coupler
+  tags:
+  - analytics
+  capabilities:
+  - Access business data from hundreds of sources
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.coupler.io/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Coupler.io.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure coupler\n"

--- a/optional-mcps/coursera/manifest.yaml
+++ b/optional-mcps/coursera/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: coursera
+description: Transform your prompts into active skill-building
+source: https://claude.com/connectors/coursera
+ui:
+  display_name: Coursera
+  category: Business tools
+  icon: coursera
+  tags:
+  - connector
+  capabilities:
+  - Transform your prompts into active skill-building
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.coursera.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Coursera.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure coursera\n"

--- a/optional-mcps/courtlistener/manifest.yaml
+++ b/optional-mcps/courtlistener/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: courtlistener
+description: Legal research across millions of court records
+source: https://claude.com/connectors/courtlistener
+ui:
+  display_name: CourtListener
+  category: Business tools
+  icon: courtlistener
+  tags:
+  - connector
+  capabilities:
+  - Legal research across millions of court records
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.courtlistener.com/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with CourtListener.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure courtlistener\n"

--- a/optional-mcps/courtroom5/manifest.yaml
+++ b/optional-mcps/courtroom5/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: courtroom5
+description: Civil legal guidance for self-represented litigants
+source: https://claude.com/connectors/courtroom5
+ui:
+  display_name: Courtroom5
+  category: Business tools
+  icon: courtroom5
+  tags:
+  - connector
+  capabilities:
+  - Civil legal guidance for self-represented litigants
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.courtroom5.com/v1
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Courtroom5.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure courtroom5\n"

--- a/optional-mcps/craft/manifest.yaml
+++ b/optional-mcps/craft/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: craft
+description: Notes & second brain
+source: https://claude.com/connectors/craft
+ui:
+  display_name: Craft
+  category: Business tools
+  icon: craft
+  tags:
+  - connector
+  capabilities:
+  - Notes & second brain
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.craft.do/my/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Craft.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure craft\n"

--- a/optional-mcps/crossbeam/manifest.yaml
+++ b/optional-mcps/crossbeam/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: crossbeam
+description: Explore partner data and ecosystem insights in Claude
+source: https://claude.com/connectors/crossbeam
+ui:
+  display_name: Crossbeam
+  category: Analytics
+  icon: crossbeam
+  tags:
+  - analytics
+  capabilities:
+  - Explore partner data and ecosystem insights in Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.crossbeam.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Crossbeam.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure crossbeam\n"

--- a/optional-mcps/crypto-com/manifest.yaml
+++ b/optional-mcps/crypto-com/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: crypto-com
+description: Real time prices, orders, charts, and more for crypto
+source: https://claude.com/connectors/crypto-com
+ui:
+  display_name: Crypto.com
+  category: Business tools
+  icon: crypto-com
+  tags:
+  - connector
+  capabilities:
+  - Real time prices, orders, charts, and more for crypto
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.crypto.com/market-data/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Crypto.com.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure crypto-com\n"

--- a/optional-mcps/daloopa/manifest.yaml
+++ b/optional-mcps/daloopa/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: daloopa
+description: Financial fundamental data and KPIs with hyperlinks
+source: https://claude.com/connectors/daloopa
+ui:
+  display_name: Daloopa
+  category: Analytics
+  icon: daloopa
+  tags:
+  - analytics
+  capabilities:
+  - Financial fundamental data and KPIs with hyperlinks
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.daloopa.com/server/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Daloopa.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure daloopa\n"

--- a/optional-mcps/datadog/manifest.yaml
+++ b/optional-mcps/datadog/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: datadog
+description: Debug and resolve issues using Datadog telemetry
+source: https://claude.com/connectors/datadog
+ui:
+  display_name: Datadog
+  category: Business tools
+  icon: datadog
+  tags:
+  - connector
+  capabilities:
+  - Debug and resolve issues using Datadog telemetry
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=all
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Datadog.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure datadog\n"

--- a/optional-mcps/datahub/manifest.yaml
+++ b/optional-mcps/datahub/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: datahub
+description: Connect AI agents to enterprise data & context
+source: https://claude.com/connectors/datahub
+ui:
+  display_name: DataHub
+  category: Analytics
+  icon: datahub
+  tags:
+  - analytics
+  capabilities:
+  - Connect AI agents to enterprise data & context
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.datahub.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with DataHub.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure datahub\n"

--- a/optional-mcps/datasite/manifest.yaml
+++ b/optional-mcps/datasite/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: datasite
+description: Manage your M&A data room from Claude
+source: https://claude.com/connectors/datasite
+ui:
+  display_name: Datasite
+  category: Analytics
+  icon: datasite
+  tags:
+  - analytics
+  capabilities:
+  - Manage your M&A data room from Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.global.datasite.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Datasite.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure datasite\n"

--- a/optional-mcps/day-ai/manifest.yaml
+++ b/optional-mcps/day-ai/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: day-ai
+description: Know everything about your prospects & customers with CRMx
+source: https://claude.com/connectors/day-ai
+ui:
+  display_name: Day AI
+  category: Sales & CRM
+  icon: day-ai
+  tags:
+  - crm
+  capabilities:
+  - Know everything about your prospects & customers with CRMx
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://day.ai/api/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Day AI.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure day-ai\n"

--- a/optional-mcps/definely/manifest.yaml
+++ b/optional-mcps/definely/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: definely
+description: Structured contract review tools for legal teams
+source: https://claude.com/connectors/definely
+ui:
+  display_name: Definely
+  category: Business tools
+  icon: definely
+  tags:
+  - connector
+  capabilities:
+  - Structured contract review tools for legal teams
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.app.definely.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Definely.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure definely\n"

--- a/optional-mcps/descript/manifest.yaml
+++ b/optional-mcps/descript/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: descript
+description: Import, edit, or create video with prompts
+source: https://claude.com/connectors/descript
+ui:
+  display_name: Descript
+  category: Business tools
+  icon: descript
+  tags:
+  - connector
+  capabilities:
+  - Import, edit, or create video with prompts
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.descript.com/v2/mcp/claude
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Descript.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure descript\n"

--- a/optional-mcps/descrybe/manifest.yaml
+++ b/optional-mcps/descrybe/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: descrybe
+description: Ground your work in clean, structured U.S. primary law
+source: https://claude.com/connectors/descrybe-legal-engine
+ui:
+  display_name: Descrybe Legal Engine
+  category: Business tools
+  icon: descrybe
+  tags:
+  - project-management
+  capabilities:
+  - Ground your work in clean, structured U.S. primary law
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.descrybe.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Descrybe Legal Engine.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure descrybe\n"

--- a/optional-mcps/dhs-program/manifest.yaml
+++ b/optional-mcps/dhs-program/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: dhs-program
+description: Data from The Demographic and Health Surveys Program
+source: https://claude.com/connectors/dhs-program
+ui:
+  display_name: Demographic and Health Surveys
+  category: Analytics
+  icon: dhs-program
+  tags:
+  - analytics
+  capabilities:
+  - Data from The Demographic and Health Surveys Program
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.dhsprogram.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Demographic and Health Surveys.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure dhs-program\n"

--- a/optional-mcps/digits/manifest.yaml
+++ b/optional-mcps/digits/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: digits
+description: Track and analyze your finances with Digits
+source: https://claude.com/connectors/digits
+ui:
+  display_name: Digits
+  category: Business tools
+  icon: digits
+  tags:
+  - connector
+  capabilities:
+  - Track and analyze your finances with Digits
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.digits.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Digits.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure digits\n"

--- a/optional-mcps/directbooker/manifest.yaml
+++ b/optional-mcps/directbooker/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: directbooker
+description: Compare hotels, then book direct
+source: https://claude.com/connectors/directbooker
+ui:
+  display_name: DirectBooker
+  category: Business tools
+  icon: directbooker
+  tags:
+  - connector
+  capabilities:
+  - Compare hotels, then book direct
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://www.directbooker.ai/claude
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with DirectBooker.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure directbooker\n"

--- a/optional-mcps/dnb-risk-analytics/manifest.yaml
+++ b/optional-mcps/dnb-risk-analytics/manifest.yaml
@@ -1,0 +1,26 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: dnb-risk-analytics
+description: Execute risk workflows powered by the D&B Commercial Graph™
+source: https://claude.com/connectors/dnb-risk-analytics
+ui:
+  display_name: D&B Risk Analytics
+  category: Analytics
+  icon: dnb-risk-analytics
+  tags:
+  - project-management
+  - analytics
+  capabilities:
+  - Execute risk workflows powered by the D&B Commercial Graph™
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://agents.riskanalytics.dnb.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with D&B Risk Analytics.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure dnb-risk-analytics\n"

--- a/optional-mcps/doordash/manifest.yaml
+++ b/optional-mcps/doordash/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: doordash
+description: Food delivery & Reservations
+source: https://claude.com/connectors/doordash
+ui:
+  display_name: DoorDash
+  category: Business tools
+  icon: doordash
+  tags:
+  - connector
+  capabilities:
+  - Food delivery & Reservations
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://openapi.doordash.com/mcp/consumer
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with DoorDash.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure doordash\n"

--- a/optional-mcps/dovetail/manifest.yaml
+++ b/optional-mcps/dovetail/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: dovetail
+description: Turn scattered feedback into decisions grounded in customer evidence
+source: https://claude.com/connectors/dovetail
+ui:
+  display_name: Dovetail
+  category: Sales & CRM
+  icon: dovetail
+  tags:
+  - crm
+  capabilities:
+  - Turn scattered feedback into decisions grounded in customer evidence
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://dovetail.com/api/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Dovetail.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure dovetail\n"

--- a/optional-mcps/dropbox/manifest.yaml
+++ b/optional-mcps/dropbox/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: dropbox
+description: Search, organize, and take action on your Dropbox content
+source: https://claude.com/connectors/dropbox
+ui:
+  display_name: Dropbox
+  category: Business tools
+  icon: dropbox
+  tags:
+  - connector
+  capabilities:
+  - Search, organize, and take action on your Dropbox content
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.dropbox.com/claude_app_mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Dropbox.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure dropbox\n"

--- a/optional-mcps/eden-basecamp-research/manifest.yaml
+++ b/optional-mcps/eden-basecamp-research/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: eden-basecamp-research
+description: Design antibiotics and prioritise vaccine targets against drug-resistant pathogens using EDEN, Basecamp Research's biological foundation model.
+source: https://claude.com/connectors/eden-basecamp-research
+ui:
+  display_name: EDEN by Basecamp Research
+  category: Business tools
+  icon: eden-basecamp-research
+  tags:
+  - connector
+  capabilities:
+  - Design antibiotics and prioritise vaccine targets against drug-resistant pathogens using EDEN, Basecamp Research's biolo
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp-public.basecamp-research.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with EDEN by Basecamp Research.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure eden-basecamp-research\n"

--- a/optional-mcps/egnyte/manifest.yaml
+++ b/optional-mcps/egnyte/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: egnyte
+description: Securely access and analyze Egnyte content.
+source: https://claude.com/connectors/egnyte
+ui:
+  display_name: Egnyte
+  category: Business tools
+  icon: egnyte
+  tags:
+  - connector
+  capabilities:
+  - Securely access and analyze Egnyte content.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp-server.egnyte.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Egnyte.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure egnyte\n"

--- a/optional-mcps/embat/manifest.yaml
+++ b/optional-mcps/embat/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: embat
+description: Ask Embat about cash, debt, payments, and accounting
+source: https://claude.com/connectors/embat
+ui:
+  display_name: Embat
+  category: Business tools
+  icon: embat
+  tags:
+  - connector
+  capabilities:
+  - Ask Embat about cash, debt, payments, and accounting
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://tellme.embat.io/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Embat.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure embat\n"

--- a/optional-mcps/enterpret-wisdom/manifest.yaml
+++ b/optional-mcps/enterpret-wisdom/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: enterpret-wisdom
+description: Get answers from unified feedback of your customers.
+source: https://claude.com/connectors/enterpret
+ui:
+  display_name: Enterpret
+  category: Sales & CRM
+  icon: enterpret-wisdom
+  tags:
+  - crm
+  capabilities:
+  - Get answers from unified feedback of your customers.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://wisdom-api.enterpret.com/server/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Enterpret.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure enterpret-wisdom\n"

--- a/optional-mcps/era-context/manifest.yaml
+++ b/optional-mcps/era-context/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: era-context
+description: Manage your personal finances using Claude
+source: https://claude.com/connectors/era-context
+ui:
+  display_name: Era Context
+  category: Business tools
+  icon: era-context
+  tags:
+  - connector
+  capabilities:
+  - Manage your personal finances using Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://context.era.app
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Era Context.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure era-context\n"

--- a/optional-mcps/eraser/manifest.yaml
+++ b/optional-mcps/eraser/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: eraser
+description: Generate, manage, and update Eraser diagrams and files
+source: https://claude.com/connectors/eraser
+ui:
+  display_name: Eraser
+  category: Business tools
+  icon: eraser
+  tags:
+  - connector
+  capabilities:
+  - Generate, manage, and update Eraser diagrams and files
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://app.eraser.io/api/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Eraser.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure eraser\n"

--- a/optional-mcps/euler/manifest.yaml
+++ b/optional-mcps/euler/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: euler
+description: Manage your partner program and access your Partner Data Lake with Claude.
+source: https://claude.com/connectors/euler
+ui:
+  display_name: EULER
+  category: Analytics
+  icon: euler
+  tags:
+  - analytics
+  capabilities:
+  - Manage your partner program and access your Partner Data Lake with Claude.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.eulerapp.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with EULER.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure euler\n"

--- a/optional-mcps/everlaw/manifest.yaml
+++ b/optional-mcps/everlaw/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: everlaw
+description: Search and explore your Everlaw database in Claude.
+source: https://claude.com/connectors/everlaw
+ui:
+  display_name: Everlaw
+  category: Analytics
+  icon: everlaw
+  tags:
+  - analytics
+  capabilities:
+  - Search and explore your Everlaw database in Claude.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.everlaw.com/v1/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Everlaw.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure everlaw\n"

--- a/optional-mcps/exa/manifest.yaml
+++ b/optional-mcps/exa/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: exa
+description: Web Search + Code Docs Search
+source: https://claude.com/connectors/exa
+ui:
+  display_name: Exa
+  category: Developer tools
+  icon: exa
+  tags:
+  - developer-tools
+  capabilities:
+  - Web Search + Code Docs Search
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.exa.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Exa.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure exa\n"

--- a/optional-mcps/excalidraw-app-demo/manifest.yaml
+++ b/optional-mcps/excalidraw-app-demo/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: excalidraw-app-demo
+description: MCP for creating interactive hand-drawn diagrams in Excalidraw
+source: https://claude.com/connectors/excalidraw-app-demo
+ui:
+  display_name: Excalidraw
+  category: Business tools
+  icon: excalidraw-app-demo
+  tags:
+  - connector
+  capabilities:
+  - MCP for creating interactive hand-drawn diagrams in Excalidraw
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://excalidraw-mcp-app.vercel.app/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Excalidraw.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure excalidraw-app-demo\n"

--- a/optional-mcps/expedia/manifest.yaml
+++ b/optional-mcps/expedia/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: expedia
+description: Plan trips, flights and hotels
+source: https://claude.com/connectors/expedia
+ui:
+  display_name: Expedia
+  category: Business tools
+  icon: expedia
+  tags:
+  - connector
+  capabilities:
+  - Plan trips, flights and hotels
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://www.expedia.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Expedia.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure expedia\n"

--- a/optional-mcps/fathom/manifest.yaml
+++ b/optional-mcps/fathom/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: fathom
+description: Your meetings, now part of every Claude conversation
+source: https://claude.com/connectors/fathom
+ui:
+  display_name: Fathom
+  category: Productivity
+  icon: fathom
+  tags:
+  - productivity
+  capabilities:
+  - Your meetings, now part of every Claude conversation
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.fathom.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Fathom.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure fathom\n"

--- a/optional-mcps/felt-maps/manifest.yaml
+++ b/optional-mcps/felt-maps/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: felt-maps
+description: Map and analyze your geospatial data
+source: https://claude.com/connectors/felt-maps
+ui:
+  display_name: Felt Maps
+  category: Analytics
+  icon: felt-maps
+  tags:
+  - analytics
+  capabilities:
+  - Map and analyze your geospatial data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://felt.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Felt Maps.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure felt-maps\n"

--- a/optional-mcps/fever-event-discovery/manifest.yaml
+++ b/optional-mcps/fever-event-discovery/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: fever-event-discovery
+description: Discover live entertainment events worldwide
+source: https://claude.com/connectors/fever-event-discovery
+ui:
+  display_name: Fever Event Discovery
+  category: Business tools
+  icon: fever-event-discovery
+  tags:
+  - connector
+  capabilities:
+  - Discover live entertainment events worldwide
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://data-search.apigw.feverup.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Fever Event Discovery.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure fever-event-discovery\n"

--- a/optional-mcps/fiscal-ai/manifest.yaml
+++ b/optional-mcps/fiscal-ai/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: fiscal-ai
+description: Clean Public Equity Fundamental Data
+source: https://claude.com/connectors/fiscal-ai
+ui:
+  display_name: Fiscal.ai
+  category: Analytics
+  icon: fiscal-ai
+  tags:
+  - analytics
+  capabilities:
+  - Clean Public Equity Fundamental Data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: sse
+  url: https://api.fiscal.ai/mcp/sse
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Fiscal.ai.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure fiscal-ai\n"

--- a/optional-mcps/fitch-solutions/manifest.yaml
+++ b/optional-mcps/fitch-solutions/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: fitch-solutions
+description: Fitch credit intelligence, inside your AI workflow
+source: https://claude.com/connectors/fitch-solutions
+ui:
+  display_name: Fitch Solutions
+  category: Business tools
+  icon: fitch-solutions
+  tags:
+  - project-management
+  capabilities:
+  - Fitch credit intelligence, inside your AI workflow
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.fitch.group/nexus/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Fitch Solutions.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure fitch-solutions\n"

--- a/optional-mcps/fmp/manifest.yaml
+++ b/optional-mcps/fmp/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: fmp
+description: Comprehensive financial datasets
+source: https://claude.com/connectors/fmp
+ui:
+  display_name: FMP
+  category: Analytics
+  icon: fmp
+  tags:
+  - analytics
+  capabilities:
+  - Comprehensive financial datasets
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://financialmodelingprep.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with FMP.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure fmp\n"

--- a/optional-mcps/fyxer/manifest.yaml
+++ b/optional-mcps/fyxer/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: fyxer
+description: Search your inbox, and draft replies in your voice
+source: https://claude.com/connectors/fyxer
+ui:
+  display_name: Fyxer
+  category: Business tools
+  icon: fyxer
+  tags:
+  - connector
+  capabilities:
+  - Search your inbox, and draft replies in your voice
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://app.fyxer.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Fyxer.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure fyxer\n"

--- a/optional-mcps/gainsight-staircase-ai/manifest.yaml
+++ b/optional-mcps/gainsight-staircase-ai/manifest.yaml
@@ -1,0 +1,27 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: gainsight-staircase-ai
+description: Power AI Workflows with Customer Context
+source: https://claude.com/connectors/gainsight-staircase-ai
+ui:
+  display_name: Gainsight (Staircase AI)
+  category: Analytics
+  icon: gainsight-staircase-ai
+  tags:
+  - crm
+  - project-management
+  - analytics
+  capabilities:
+  - Power AI Workflows with Customer Context
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.staircase.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Gainsight (Staircase AI).\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure gainsight-staircase-ai\n"

--- a/optional-mcps/github/manifest.yaml
+++ b/optional-mcps/github/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: github
+description: The Official GitHub MCP Server
+source: https://claude.com/connectors/github
+ui:
+  display_name: GitHub MCP
+  category: Developer tools
+  icon: github
+  tags:
+  - developer-tools
+  capabilities:
+  - The Official GitHub MCP Server
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.githubcopilot.com/mcp/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with GitHub MCP.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure github\n"

--- a/optional-mcps/gitlab/manifest.yaml
+++ b/optional-mcps/gitlab/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: gitlab
+description: Connect AI tools securely to your GitLab data
+source: https://claude.com/connectors/gitlab
+ui:
+  display_name: GitLab
+  category: Analytics
+  icon: gitlab
+  tags:
+  - analytics
+  capabilities:
+  - Connect AI tools securely to your GitLab data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://gitlab.com/api/v4/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with GitLab.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure gitlab\n"

--- a/optional-mcps/glovo/manifest.yaml
+++ b/optional-mcps/glovo/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: glovo
+description: Anything delivered in minutes
+source: https://claude.com/connectors/glovo
+ui:
+  display_name: Glovo
+  category: Business tools
+  icon: glovo
+  tags:
+  - connector
+  capabilities:
+  - Anything delivered in minutes
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.glovoapp.com/discovery-mcp/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Glovo.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure glovo\n"

--- a/optional-mcps/gocardless/manifest.yaml
+++ b/optional-mcps/gocardless/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: gocardless
+description: Ask about your payments, customers, and payouts
+source: https://claude.com/connectors/gocardless
+ui:
+  display_name: GoCardless
+  category: Sales & CRM
+  icon: gocardless
+  tags:
+  - crm
+  capabilities:
+  - Ask about your payments, customers, and payouts
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.gocardless.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with GoCardless.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure gocardless\n"

--- a/optional-mcps/godaddy/manifest.yaml
+++ b/optional-mcps/godaddy/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: godaddy
+description: Search domains and check availability
+source: https://claude.com/connectors/godaddy
+ui:
+  display_name: GoDaddy
+  category: Business tools
+  icon: godaddy
+  tags:
+  - connector
+  capabilities:
+  - Search domains and check availability
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.godaddy.com/v1/domains/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with GoDaddy.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure godaddy\n"

--- a/optional-mcps/goodnotes/manifest.yaml
+++ b/optional-mcps/goodnotes/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: goodnotes
+description: Turn AI insights into documents
+source: https://claude.com/connectors/goodnotes
+ui:
+  display_name: Goodnotes
+  category: Analytics
+  icon: goodnotes
+  tags:
+  - analytics
+  capabilities:
+  - Turn AI insights into documents
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://claude-mcp-api.ml.goodnotes.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Goodnotes.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure goodnotes\n"

--- a/optional-mcps/govtribe/manifest.yaml
+++ b/optional-mcps/govtribe/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: govtribe
+description: Search government procurement & spending data
+source: https://claude.com/connectors/govtribe
+ui:
+  display_name: GovTribe
+  category: Analytics
+  icon: govtribe
+  tags:
+  - analytics
+  capabilities:
+  - Search government procurement & spending data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://govtribe.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with GovTribe.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure govtribe\n"

--- a/optional-mcps/grain/manifest.yaml
+++ b/optional-mcps/grain/manifest.yaml
@@ -1,0 +1,26 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: grain
+description: Put your meetings to work
+source: https://claude.com/connectors/grain
+ui:
+  display_name: Grain
+  category: Productivity
+  icon: grain
+  tags:
+  - project-management
+  - productivity
+  capabilities:
+  - Put your meetings to work
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.grain.com/_/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Grain.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure grain\n"

--- a/optional-mcps/granola/manifest.yaml
+++ b/optional-mcps/granola/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: granola
+description: The AI notepad for meetings
+source: https://claude.com/connectors/granola
+ui:
+  display_name: Granola
+  category: Productivity
+  icon: granola
+  tags:
+  - productivity
+  capabilities:
+  - The AI notepad for meetings
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.granola.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Granola.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure granola\n"

--- a/optional-mcps/granted/manifest.yaml
+++ b/optional-mcps/granted/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: granted
+description: Discover every grant opportunity in existence.
+source: https://claude.com/connectors/granted
+ui:
+  display_name: Granted
+  category: Business tools
+  icon: granted
+  tags:
+  - connector
+  capabilities:
+  - Discover every grant opportunity in existence.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://grantedai.com/api/mcp/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Granted.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure granted\n"

--- a/optional-mcps/graphos-tools/manifest.yaml
+++ b/optional-mcps/graphos-tools/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: graphos-tools
+description: Search Apollo docs, specs, and best practices
+source: https://claude.com/connectors/graphos-tools
+ui:
+  display_name: GraphOS MCP Tools
+  category: Business tools
+  icon: graphos-tools
+  tags:
+  - connector
+  capabilities:
+  - Search Apollo docs, specs, and best practices
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.apollographql.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with GraphOS MCP Tools.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure graphos-tools\n"

--- a/optional-mcps/grasshopper-bank/manifest.yaml
+++ b/optional-mcps/grasshopper-bank/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: grasshopper-bank
+description: Query and analyze your financial data
+source: https://claude.com/connectors/grasshopper-bank
+ui:
+  display_name: Grasshopper Bank
+  category: Analytics
+  icon: grasshopper-bank
+  tags:
+  - analytics
+  capabilities:
+  - Query and analyze your financial data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://grasshopper-mcp.prd.narmitech.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Grasshopper Bank.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure grasshopper-bank\n"

--- a/optional-mcps/guidepoint/manifest.yaml
+++ b/optional-mcps/guidepoint/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: guidepoint
+description: Real-time access to trusted expert knowledge
+source: https://claude.com/connectors/guidepoint
+ui:
+  display_name: Guidepoint
+  category: Business tools
+  icon: guidepoint
+  tags:
+  - connector
+  capabilities:
+  - Real-time access to trusted expert knowledge
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://clapi.guidepoint.io/mcp-server/v1/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Guidepoint.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure guidepoint\n"

--- a/optional-mcps/guru/manifest.yaml
+++ b/optional-mcps/guru/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: guru
+description: Search and interact with your company knowledge
+source: https://claude.com/connectors/guru
+ui:
+  display_name: Guru
+  category: Business tools
+  icon: guru
+  tags:
+  - connector
+  capabilities:
+  - Search and interact with your company knowledge
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.api.getguru.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Guru.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure guru\n"

--- a/optional-mcps/harmonic/manifest.yaml
+++ b/optional-mcps/harmonic/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: harmonic
+description: Discover, research, and enrich companies and people
+source: https://claude.com/connectors/harmonic
+ui:
+  display_name: Harmonic
+  category: Business tools
+  icon: harmonic
+  tags:
+  - connector
+  capabilities:
+  - Discover, research, and enrich companies and people
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.api.harmonic.ai
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Harmonic.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure harmonic\n"

--- a/optional-mcps/harness/manifest.yaml
+++ b/optional-mcps/harness/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: harness
+description: Build, Ship and Secure your apps on Harness Platform
+source: https://claude.com/connectors/harness
+ui:
+  display_name: Harness.io
+  category: Business tools
+  icon: harness
+  tags:
+  - connector
+  capabilities:
+  - Build, Ship and Secure your apps on Harness Platform
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.harness.io/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Harness.io.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure harness\n"

--- a/optional-mcps/helix-genosphere/manifest.yaml
+++ b/optional-mcps/helix-genosphere/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: helix-genosphere
+description: Query human genomics & longitudinal clinical data
+source: https://claude.com/connectors/helix-genosphere
+ui:
+  display_name: Helix GenoSphere
+  category: Analytics
+  icon: helix-genosphere
+  tags:
+  - analytics
+  capabilities:
+  - Query human genomics & longitudinal clinical data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.hrn-production.helix.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Helix GenoSphere.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure helix-genosphere\n"

--- a/optional-mcps/hex/manifest.yaml
+++ b/optional-mcps/hex/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: hex
+description: Answer questions with the Hex agent
+source: https://claude.com/connectors/hex
+ui:
+  display_name: Hex
+  category: Business tools
+  icon: hex
+  tags:
+  - connector
+  capabilities:
+  - Answer questions with the Hex agent
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://app.hex.tech/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Hex.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure hex\n"

--- a/optional-mcps/honeycomb/manifest.yaml
+++ b/optional-mcps/honeycomb/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: honeycomb
+description: Query and explore observability data and SLOs
+source: https://claude.com/connectors/honeycomb
+ui:
+  display_name: Honeycomb
+  category: Analytics
+  icon: honeycomb
+  tags:
+  - analytics
+  capabilities:
+  - Query and explore observability data and SLOs
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.honeycomb.io/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Honeycomb.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure honeycomb\n"

--- a/optional-mcps/hugging-face/manifest.yaml
+++ b/optional-mcps/hugging-face/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: hugging-face
+description: Access the HF Hub and thousands of Gradio Apps
+source: https://claude.com/connectors/hugging-face
+ui:
+  display_name: Hugging Face
+  category: Business tools
+  icon: hugging-face
+  tags:
+  - connector
+  capabilities:
+  - Access the HF Hub and thousands of Gradio Apps
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://huggingface.co/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Hugging Face.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure hugging-face\n"

--- a/optional-mcps/hyperframes/manifest.yaml
+++ b/optional-mcps/hyperframes/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: hyperframes
+description: Build animated slides and motion graphics with HTML
+source: https://claude.com/connectors/hyperframes-heygen
+ui:
+  display_name: HyperFrames by HeyGen
+  category: Business tools
+  icon: hyperframes
+  tags:
+  - connector
+  capabilities:
+  - Build animated slides and motion graphics with HTML
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.heygen.com/mcp/hyperframes
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with HyperFrames by HeyGen.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure hyperframes\n"

--- a/optional-mcps/ibisworld/manifest.yaml
+++ b/optional-mcps/ibisworld/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: ibisworld
+description: Financials, risk data and analysis on 50,000 industries
+source: https://claude.com/connectors/ibisworld
+ui:
+  display_name: IBISWorld
+  category: Analytics
+  icon: ibisworld
+  tags:
+  - analytics
+  capabilities:
+  - Financials, risk data and analysis on 50,000 industries
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.ibisworld.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with IBISWorld.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure ibisworld\n"

--- a/optional-mcps/ifttt/manifest.yaml
+++ b/optional-mcps/ifttt/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: ifttt
+description: Connect, control, and automate 1,000+ apps with IFTTT
+source: https://claude.com/connectors/ifttt
+ui:
+  display_name: IFTTT
+  category: Business tools
+  icon: ifttt
+  tags:
+  - connector
+  capabilities:
+  - Connect, control, and automate 1,000+ apps with IFTTT
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://ifttt.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with IFTTT.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure ifttt\n"

--- a/optional-mcps/imanage/manifest.yaml
+++ b/optional-mcps/imanage/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: imanage
+description: Governed knowledge. AI ready.
+source: https://claude.com/connectors/imanage
+ui:
+  display_name: iManage Work
+  category: Business tools
+  icon: imanage
+  tags:
+  - project-management
+  capabilities:
+  - Governed knowledge. AI ready.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://cloudimanage.com/mcp/work
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with iManage Work.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure imanage\n"

--- a/optional-mcps/inductive-bio/manifest.yaml
+++ b/optional-mcps/inductive-bio/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: inductive-bio
+description: State-of-the-art ADMET prediction models for drug discovery
+source: https://claude.com/connectors/inductive-bio
+ui:
+  display_name: Inductive Bio
+  category: Business tools
+  icon: inductive-bio
+  tags:
+  - connector
+  capabilities:
+  - State-of-the-art ADMET prediction models for drug discovery
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.inductive.bio/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Inductive Bio.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure inductive-bio\n"

--- a/optional-mcps/insider-one/manifest.yaml
+++ b/optional-mcps/insider-one/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: insider-one
+description: Query Insider One CDP and APIs using natural language
+source: https://claude.com/connectors/insider-one
+ui:
+  display_name: Insider One
+  category: Developer tools
+  icon: insider-one
+  tags:
+  - developer-tools
+  capabilities:
+  - Query Insider One CDP and APIs using natural language
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.insiderone.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Insider One.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure insider-one\n"

--- a/optional-mcps/instacart/manifest.yaml
+++ b/optional-mcps/instacart/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: instacart
+description: Groceries and more delivered as fast as 30 minutes
+source: https://claude.com/connectors/instacart
+ui:
+  display_name: Instacart
+  category: Business tools
+  icon: instacart
+  tags:
+  - connector
+  capabilities:
+  - Groceries and more delivered as fast as 30 minutes
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://fig-mcp.instacart.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Instacart.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure instacart\n"

--- a/optional-mcps/instrumentl/manifest.yaml
+++ b/optional-mcps/instrumentl/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: instrumentl
+description: Find, evaluate, and manage your grants
+source: https://claude.com/connectors/instrumentl
+ui:
+  display_name: Instrumentl
+  category: Business tools
+  icon: instrumentl
+  tags:
+  - connector
+  capabilities:
+  - Find, evaluate, and manage your grants
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.instrumentl.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Instrumentl.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure instrumentl\n"

--- a/optional-mcps/interactive-brokers/manifest.yaml
+++ b/optional-mcps/interactive-brokers/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: interactive-brokers
+description: Trade, invest, analyze, and manage global markets
+source: https://claude.com/connectors/interactive-brokers
+ui:
+  display_name: Interactive Brokers (IBKR)
+  category: Business tools
+  icon: interactive-brokers
+  tags:
+  - connector
+  capabilities:
+  - Trade, invest, analyze, and manage global markets
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.ibkr.com/v1/api/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Interactive Brokers (IBKR).\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure interactive-brokers\n"

--- a/optional-mcps/intercom/manifest.yaml
+++ b/optional-mcps/intercom/manifest.yaml
@@ -1,0 +1,26 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: intercom
+description: AI access to Intercom data for better customer insights
+source: https://claude.com/connectors/intercom
+ui:
+  display_name: Intercom
+  category: Analytics
+  icon: intercom
+  tags:
+  - crm
+  - analytics
+  capabilities:
+  - AI access to Intercom data for better customer insights
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.intercom.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Intercom.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure intercom\n"

--- a/optional-mcps/ironclad/manifest.yaml
+++ b/optional-mcps/ironclad/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: ironclad
+description: Plain language search for faster contract answers
+source: https://claude.com/connectors/ironclad-contracts
+ui:
+  display_name: Ironclad Contracts
+  category: Business tools
+  icon: ironclad
+  tags:
+  - connector
+  capabilities:
+  - Plain language search for faster contract answers
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.na1.ironcladapp.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Ironclad Contracts.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure ironclad\n"

--- a/optional-mcps/jam/manifest.yaml
+++ b/optional-mcps/jam/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: jam
+description: Record screen and collect automatic context for issues
+source: https://claude.com/connectors/jam
+ui:
+  display_name: Jam
+  category: Business tools
+  icon: jam
+  tags:
+  - project-management
+  capabilities:
+  - Record screen and collect automatic context for issues
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.jam.dev/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Jam.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure jam\n"

--- a/optional-mcps/jotform/manifest.yaml
+++ b/optional-mcps/jotform/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: jotform
+description: Create forms & analyze submissions inside Claude
+source: https://claude.com/connectors/jotform
+ui:
+  display_name: Jotform
+  category: Business tools
+  icon: jotform
+  tags:
+  - connector
+  capabilities:
+  - Create forms & analyze submissions inside Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.jotform.com/mcp-app
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Jotform.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure jotform\n"

--- a/optional-mcps/ketryx/manifest.yaml
+++ b/optional-mcps/ketryx/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: ketryx
+description: Search and explore regulated software lifecycle data
+source: https://claude.com/connectors/ketryx
+ui:
+  display_name: Ketryx
+  category: Analytics
+  icon: ketryx
+  tags:
+  - analytics
+  capabilities:
+  - Search and explore regulated software lifecycle data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://app.ketryx.com/api/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Ketryx.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure ketryx\n"

--- a/optional-mcps/kindora-funder-discovery/manifest.yaml
+++ b/optional-mcps/kindora-funder-discovery/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: kindora-funder-discovery
+description: Find funders who support causes like yours
+source: https://claude.com/connectors/kindora-funder-discovery
+ui:
+  display_name: Kindora Funder Discovery
+  category: Business tools
+  icon: kindora-funder-discovery
+  tags:
+  - connector
+  capabilities:
+  - Find funders who support causes like yours
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://kindora-mcp.azurewebsites.net/mcp/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Kindora Funder Discovery.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure kindora-funder-discovery\n"

--- a/optional-mcps/kpler/manifest.yaml
+++ b/optional-mcps/kpler/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: kpler
+description: Explore Kpler's maritime and commodities intelligence
+source: https://claude.com/connectors/kpler
+ui:
+  display_name: Kpler
+  category: Business tools
+  icon: kpler
+  tags:
+  - connector
+  capabilities:
+  - Explore Kpler's maritime and commodities intelligence
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://claude.mcp.kpler.com/v1/mcp/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Kpler.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure kpler\n"

--- a/optional-mcps/krisp/manifest.yaml
+++ b/optional-mcps/krisp/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: krisp
+description: Add your meetings context via transcripts and notes
+source: https://claude.com/connectors/krisp
+ui:
+  display_name: Krisp
+  category: Productivity
+  icon: krisp
+  tags:
+  - productivity
+  capabilities:
+  - Add your meetings context via transcripts and notes
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.krisp.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Krisp.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure krisp\n"

--- a/optional-mcps/latchbio/manifest.yaml
+++ b/optional-mcps/latchbio/manifest.yaml
@@ -1,0 +1,26 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: latchbio
+description: Analyze data and launch bioinformatics workflows
+source: https://claude.com/connectors/latchbio
+ui:
+  display_name: LatchBio
+  category: Analytics
+  icon: latchbio
+  tags:
+  - project-management
+  - analytics
+  capabilities:
+  - Analyze data and launch bioinformatics workflows
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.latch.bio/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with LatchBio.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure latchbio\n"

--- a/optional-mcps/lawve-ai/manifest.yaml
+++ b/optional-mcps/lawve-ai/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: lawve-ai
+description: Discover expert-written skills for legal work
+source: https://claude.com/connectors/lawve-ai
+ui:
+  display_name: Lawve AI
+  category: Business tools
+  icon: lawve-ai
+  tags:
+  - project-management
+  capabilities:
+  - Discover expert-written skills for legal work
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.lawve.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Lawve AI.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure lawve-ai\n"

--- a/optional-mcps/legal-data-hunter/manifest.yaml
+++ b/optional-mcps/legal-data-hunter/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: legal-data-hunter
+description: Search 23M+ legal docs in 160+ jurisdictions.
+source: https://claude.com/connectors/legal-data-hunter
+ui:
+  display_name: Legal Data Hunter
+  category: Analytics
+  icon: legal-data-hunter
+  tags:
+  - analytics
+  capabilities:
+  - Search 23M+ legal docs in 160+ jurisdictions.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://legaldatahunter.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Legal Data Hunter.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure legal-data-hunter\n"

--- a/optional-mcps/lightfield/manifest.yaml
+++ b/optional-mcps/lightfield/manifest.yaml
@@ -1,0 +1,26 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: lightfield
+description: CRM that remembers everything and works for you.
+source: https://claude.com/connectors/lightfield
+ui:
+  display_name: Lightfield
+  category: Sales & CRM
+  icon: lightfield
+  tags:
+  - crm
+  - project-management
+  capabilities:
+  - CRM that remembers everything and works for you.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.lightfield.app/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Lightfield.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure lightfield\n"

--- a/optional-mcps/lilt/manifest.yaml
+++ b/optional-mcps/lilt/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: lilt
+description: High-quality translation with human verification
+source: https://claude.com/connectors/lilt
+ui:
+  display_name: LILT
+  category: Business tools
+  icon: lilt
+  tags:
+  - connector
+  capabilities:
+  - High-quality translation with human verification
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.lilt.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with LILT.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure lilt\n"

--- a/optional-mcps/linear/manifest.yaml
+++ b/optional-mcps/linear/manifest.yaml
@@ -6,6 +6,21 @@ name: linear
 description: Find, create, and update Linear issues, projects, and comments.
 source: https://linear.app/docs/mcp
 
+ui:
+  display_name: Linear
+  category: Project management
+  icon: linear
+  tags: [issues, projects, comments]
+  capabilities:
+    - Find and inspect issues
+    - Create and update Linear work
+    - Manage projects and comments
+  setup_steps:
+    - Connect your Linear account in the browser.
+    - Choose which tools Hermes may use after discovery.
+  danger_notes:
+    - Write tools can create or update issues, projects, and comments.
+
 # Linear ships a remote MCP server with native OAuth 2.1 + Dynamic Client
 # Registration over Streamable HTTP. Hermes's MCP client + mcp_oauth_manager
 # handle discovery, PKCE, token exchange, and refresh — nothing to install

--- a/optional-mcps/listen-labs/manifest.yaml
+++ b/optional-mcps/listen-labs/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: listen-labs
+description: Analyze user insights from Listen Labs
+source: https://claude.com/connectors/listen-labs
+ui:
+  display_name: Listen Labs
+  category: Analytics
+  icon: listen-labs
+  tags:
+  - analytics
+  capabilities:
+  - Analyze user insights from Listen Labs
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://listenlabs.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Listen Labs.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure listen-labs\n"

--- a/optional-mcps/local-falcon/manifest.yaml
+++ b/optional-mcps/local-falcon/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: local-falcon
+description: AI visibility and local search intelligence platform
+source: https://claude.com/connectors/local-falcon
+ui:
+  display_name: Local Falcon
+  category: Business tools
+  icon: local-falcon
+  tags:
+  - connector
+  capabilities:
+  - AI visibility and local search intelligence platform
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: sse
+  url: https://mcp.localfalcon.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Local Falcon.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure local-falcon\n"

--- a/optional-mcps/lorikeet/manifest.yaml
+++ b/optional-mcps/lorikeet/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: lorikeet
+description: A universal concierge for complex businesses
+source: https://claude.com/connectors/lorikeet
+ui:
+  display_name: Lorikeet
+  category: Business tools
+  icon: lorikeet
+  tags:
+  - connector
+  capabilities:
+  - A universal concierge for complex businesses
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.lorikeetcx.ai/v1/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Lorikeet.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure lorikeet\n"

--- a/optional-mcps/lovable/manifest.yaml
+++ b/optional-mcps/lovable/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: lovable
+description: Build, iterate, inspect, and deploy Lovable apps
+source: https://claude.com/connectors/lovable
+ui:
+  display_name: Lovable
+  category: Business tools
+  icon: lovable
+  tags:
+  - connector
+  capabilities:
+  - Build, iterate, inspect, and deploy Lovable apps
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.lovable.dev
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Lovable.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure lovable\n"

--- a/optional-mcps/lucid/manifest.yaml
+++ b/optional-mcps/lucid/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: lucid
+description: Ideate, diagram, and align teams
+source: https://claude.com/connectors/lucid
+ui:
+  display_name: Lucid
+  category: Business tools
+  icon: lucid
+  tags:
+  - connector
+  capabilities:
+  - Ideate, diagram, and align teams
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.lucid.app/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Lucid.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure lucid\n"

--- a/optional-mcps/lumin/manifest.yaml
+++ b/optional-mcps/lumin/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: lumin
+description: Manage documents, send signature requests, and convert Markdown to PDF
+source: https://claude.com/connectors/lumin
+ui:
+  display_name: Lumin
+  category: Business tools
+  icon: lumin
+  tags:
+  - connector
+  capabilities:
+  - Manage documents, send signature requests, and convert Markdown to PDF
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.luminpdf.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Lumin.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure lumin\n"

--- a/optional-mcps/lusha/manifest.yaml
+++ b/optional-mcps/lusha/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: lusha
+description: Find and enrich B2B contacts and companies
+source: https://claude.com/connectors/lusha
+ui:
+  display_name: Lusha
+  category: Business tools
+  icon: lusha
+  tags:
+  - connector
+  capabilities:
+  - Find and enrich B2B contacts and companies
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.lusha.com/mcp/claude
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Lusha.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure lusha\n"

--- a/optional-mcps/magic-patterns/manifest.yaml
+++ b/optional-mcps/magic-patterns/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: magic-patterns
+description: Discuss and iterate on Magic Patterns designs
+source: https://claude.com/connectors/magic-patterns
+ui:
+  display_name: Magic Patterns
+  category: Business tools
+  icon: magic-patterns
+  tags:
+  - connector
+  capabilities:
+  - Discuss and iterate on Magic Patterns designs
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.magicpatterns.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Magic Patterns.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure magic-patterns\n"

--- a/optional-mcps/mailerlite/manifest.yaml
+++ b/optional-mcps/mailerlite/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: mailerlite
+description: Turn Claude into your email marketing assistant
+source: https://claude.com/connectors/mailerlite
+ui:
+  display_name: MailerLite
+  category: Productivity
+  icon: mailerlite
+  tags:
+  - productivity
+  capabilities:
+  - Turn Claude into your email marketing assistant
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.mailerlite.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with MailerLite.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure mailerlite\n"

--- a/optional-mcps/make/manifest.yaml
+++ b/optional-mcps/make/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: make
+description: Run Make scenarios and manage your Make account
+source: https://claude.com/connectors/make
+ui:
+  display_name: Make
+  category: Business tools
+  icon: make
+  tags:
+  - connector
+  capabilities:
+  - Run Make scenarios and manage your Make account
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.make.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Make.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure make\n"

--- a/optional-mcps/malwarebytes/manifest.yaml
+++ b/optional-mcps/malwarebytes/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: malwarebytes
+description: Check links, phones, and emails for scams
+source: https://claude.com/connectors/malwarebytes
+ui:
+  display_name: Malwarebytes
+  category: Productivity
+  icon: malwarebytes
+  tags:
+  - productivity
+  capabilities:
+  - Check links, phones, and emails for scams
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://scamguard.malwarebytes.com/claude/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Malwarebytes.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure malwarebytes\n"

--- a/optional-mcps/melon/manifest.yaml
+++ b/optional-mcps/melon/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: melon
+description: Browse music charts & your personalized music picks
+source: https://claude.com/connectors/melon
+ui:
+  display_name: Melon
+  category: Business tools
+  icon: melon
+  tags:
+  - connector
+  capabilities:
+  - Browse music charts & your personalized music picks
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.melon.com/mcp/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Melon.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure melon\n"

--- a/optional-mcps/mem/manifest.yaml
+++ b/optional-mcps/mem/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: mem
+description: The AI notebook for everything on your mind
+source: https://claude.com/connectors/mem
+ui:
+  display_name: Mem
+  category: Business tools
+  icon: mem
+  tags:
+  - connector
+  capabilities:
+  - The AI notebook for everything on your mind
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.mem.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Mem.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure mem\n"

--- a/optional-mcps/mermaidchart/manifest.yaml
+++ b/optional-mcps/mermaidchart/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: mermaidchart
+description: Validates Mermaid syntax, renders diagrams as high-quality SVG, and displays them instantly in an interactive UI where users can preview, zoom, and iterate in real time.
+source: https://claude.com/connectors/mermaid-chart
+ui:
+  display_name: Mermaid Chart
+  category: Productivity
+  icon: mermaidchart
+  tags:
+  - productivity
+  capabilities:
+  - Validates Mermaid syntax, renders diagrams as high-quality SVG, and displays them instantly in an interactive UI where u
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.mermaid.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Mermaid Chart.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure mermaidchart\n"

--- a/optional-mcps/metaview/manifest.yaml
+++ b/optional-mcps/metaview/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: metaview
+description: The AI platform for recruiting.
+source: https://claude.com/connectors/metaview
+ui:
+  display_name: Metaview
+  category: Business tools
+  icon: metaview
+  tags:
+  - connector
+  capabilities:
+  - The AI platform for recruiting.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.metaview.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Metaview.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure metaview\n"

--- a/optional-mcps/microsoft-learn/manifest.yaml
+++ b/optional-mcps/microsoft-learn/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: microsoft-learn
+description: Search trusted Microsoft docs to power your development
+source: https://claude.com/connectors/microsoft-learn
+ui:
+  display_name: Microsoft Learn
+  category: Business tools
+  icon: microsoft-learn
+  tags:
+  - connector
+  capabilities:
+  - Search trusted Microsoft docs to power your development
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://learn.microsoft.com/api/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Microsoft Learn.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure microsoft-learn\n"

--- a/optional-mcps/midpage/manifest.yaml
+++ b/optional-mcps/midpage/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: midpage
+description: Conduct legal research and create work product
+source: https://claude.com/connectors/midpage
+ui:
+  display_name: Midpage Legal Research
+  category: Business tools
+  icon: midpage
+  tags:
+  - project-management
+  capabilities:
+  - Conduct legal research and create work product
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://app.midpage.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Midpage Legal Research.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure midpage\n"

--- a/optional-mcps/mintlify/manifest.yaml
+++ b/optional-mcps/mintlify/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: mintlify
+description: Search, read, and edit your documentation
+source: https://claude.com/connectors/mintlify
+ui:
+  display_name: Mintlify
+  category: Business tools
+  icon: mintlify
+  tags:
+  - connector
+  capabilities:
+  - Search, read, and edit your documentation
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.mintlify.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Mintlify.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure mintlify\n"

--- a/optional-mcps/miro/manifest.yaml
+++ b/optional-mcps/miro/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: miro
+description: From a single prompt, build workshops, visualize complex ideas, search across boards, and act on feedback agentically
+source: https://claude.com/connectors/miro
+ui:
+  display_name: Miro
+  category: Business tools
+  icon: miro
+  tags:
+  - project-management
+  capabilities:
+  - From a single prompt, build workshops, visualize complex ideas, search across boards, and act on feedback agentically
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.miro.com/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Miro.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure miro\n"

--- a/optional-mcps/mixpanel/manifest.yaml
+++ b/optional-mcps/mixpanel/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: mixpanel
+description: Analyze, query, and manage your Mixpanel data
+source: https://claude.com/connectors/mixpanel
+ui:
+  display_name: Mixpanel
+  category: Analytics
+  icon: mixpanel
+  tags:
+  - analytics
+  capabilities:
+  - Analyze, query, and manage your Mixpanel data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.mixpanel.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Mixpanel.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure mixpanel\n"

--- a/optional-mcps/monday/manifest.yaml
+++ b/optional-mcps/monday/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: monday
+description: Manage projects, boards, and workflows in monday.com
+source: https://claude.com/connectors/monday
+ui:
+  display_name: Monday
+  category: Business tools
+  icon: monday
+  tags:
+  - project-management
+  capabilities:
+  - Manage projects, boards, and workflows in monday.com
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.monday.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Monday.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure monday\n"

--- a/optional-mcps/monte-carlo/manifest.yaml
+++ b/optional-mcps/monte-carlo/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: monte-carlo
+description: Data & AI observability
+source: https://claude.com/connectors/monte-carlo
+ui:
+  display_name: Monte Carlo
+  category: Analytics
+  icon: monte-carlo
+  tags:
+  - analytics
+  capabilities:
+  - Data & AI observability
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://integrations.getmontecarlo.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Monte Carlo.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure monte-carlo\n"

--- a/optional-mcps/motion/manifest.yaml
+++ b/optional-mcps/motion/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: motion
+description: Analyze your Meta ad creative & competitor ad libraries
+source: https://claude.com/connectors/motion
+ui:
+  display_name: Motion Creative Analytics
+  category: Analytics
+  icon: motion
+  tags:
+  - analytics
+  capabilities:
+  - Analyze your Meta ad creative & competitor ad libraries
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://projects.motionapp.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Motion Creative Analytics.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure motion\n"

--- a/optional-mcps/n8n/manifest.yaml
+++ b/optional-mcps/n8n/manifest.yaml
@@ -8,6 +8,21 @@ name: n8n
 description: Manage and inspect n8n workflows from Hermes (stdio bridge, no public port).
 source: https://github.com/CyberSamuraiX/hermes-n8n-mcp
 
+ui:
+  display_name: n8n
+  category: Automation
+  icon: n8n
+  tags: [workflows, automations, executions]
+  capabilities:
+    - Inspect workflows and executions
+    - Export workflow definitions
+    - Review recent workflow failures
+  setup_steps:
+    - Enter your n8n base URL.
+    - Generate and paste an n8n API key.
+  danger_notes:
+    - Optional mutating tools can activate or deactivate live workflows.
+
 # How to launch the server once installed. The keys here map 1:1 to the
 # `mcp_servers.<name>` block written into ~/.hermes/config.yaml by the
 # existing `_save_mcp_server()` helper in hermes_cli/mcp_config.py.

--- a/optional-mcps/netdocuments/manifest.yaml
+++ b/optional-mcps/netdocuments/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: netdocuments
+description: Securely access your documents in NetDocuments
+source: https://claude.com/connectors/netdocuments
+ui:
+  display_name: NetDocuments
+  category: Business tools
+  icon: netdocuments
+  tags:
+  - connector
+  capabilities:
+  - Securely access your documents in NetDocuments
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://web-api.us.netdocuments.app/connect/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with NetDocuments.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure netdocuments\n"

--- a/optional-mcps/netlify/manifest.yaml
+++ b/optional-mcps/netlify/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: netlify
+description: Create, deploy, manage, and secure websites on Netlify
+source: https://claude.com/connectors/netlify
+ui:
+  display_name: Netlify
+  category: Business tools
+  icon: netlify
+  tags:
+  - connector
+  capabilities:
+  - Create, deploy, manage, and secure websites on Netlify
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://netlify-mcp.netlify.app/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Netlify.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure netlify\n"

--- a/optional-mcps/nimble/manifest.yaml
+++ b/optional-mcps/nimble/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: nimble
+description: Real-time web search & extraction for AI agents
+source: https://claude.com/connectors/nimble
+ui:
+  display_name: Nimble
+  category: Business tools
+  icon: nimble
+  tags:
+  - connector
+  capabilities:
+  - Real-time web search & extraction for AI agents
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.nimbleway.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Nimble.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure nimble\n"

--- a/optional-mcps/notion/manifest.yaml
+++ b/optional-mcps/notion/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: notion
+description: Connect your Notion workspace to search, update, and power workflows across tools
+source: https://claude.com/connectors/notion
+ui:
+  display_name: Notion
+  category: Business tools
+  icon: notion
+  tags:
+  - project-management
+  capabilities:
+  - Connect your Notion workspace to search, update, and power workflows across tools
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.notion.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Notion.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure notion\n"

--- a/optional-mcps/omni-analytics/manifest.yaml
+++ b/optional-mcps/omni-analytics/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: omni-analytics
+description: Query your data using natural language through Omni's semantic model
+source: https://claude.com/connectors/omni-analytics
+ui:
+  display_name: Omni Analytics
+  category: Analytics
+  icon: omni-analytics
+  tags:
+  - analytics
+  capabilities:
+  - Query your data using natural language through Omni's semantic model
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://callbacks.omniapp.co/callback/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Omni Analytics.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure omni-analytics\n"

--- a/optional-mcps/ontra/manifest.yaml
+++ b/optional-mcps/ontra/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: ontra
+description: Query your Ontra data directly from any AI tool
+source: https://claude.com/connectors/ontra
+ui:
+  display_name: Ontra
+  category: Analytics
+  icon: ontra
+  tags:
+  - analytics
+  capabilities:
+  - Query your Ontra data directly from any AI tool
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.ontra.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Ontra.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure ontra\n"

--- a/optional-mcps/orion/manifest.yaml
+++ b/optional-mcps/orion/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: orion
+description: Get insights from your autonomous AI analyst
+source: https://claude.com/connectors/orion
+ui:
+  display_name: Orion by Gravity
+  category: Analytics
+  icon: orion
+  tags:
+  - analytics
+  capabilities:
+  - Get insights from your autonomous AI analyst
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://g.runorion.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Orion by Gravity.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure orion\n"

--- a/optional-mcps/otter-ai/manifest.yaml
+++ b/optional-mcps/otter-ai/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: otter-ai
+description: Unlock your meeting intelligence
+source: https://claude.com/connectors/otter-ai
+ui:
+  display_name: Otter.ai
+  category: Productivity
+  icon: otter-ai
+  tags:
+  - productivity
+  capabilities:
+  - Unlock your meeting intelligence
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.otter.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Otter.ai.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure otter-ai\n"

--- a/optional-mcps/otto-travel/manifest.yaml
+++ b/optional-mcps/otto-travel/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: otto-travel
+description: Plan, book, and manage business travel
+source: https://claude.com/connectors/otto-travel
+ui:
+  display_name: Otto Travel
+  category: Business tools
+  icon: otto-travel
+  tags:
+  - connector
+  capabilities:
+  - Plan, book, and manage business travel
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.ottotheagent.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Otto Travel.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure otto-travel\n"

--- a/optional-mcps/outreach/manifest.yaml
+++ b/optional-mcps/outreach/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: outreach
+description: Unleash your team's best performance with Outreach AI
+source: https://claude.com/connectors/outreach
+ui:
+  display_name: Outreach
+  category: Business tools
+  icon: outreach
+  tags:
+  - connector
+  capabilities:
+  - Unleash your team's best performance with Outreach AI
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.outreach.io/mcp/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Outreach.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure outreach\n"

--- a/optional-mcps/pandadoc/manifest.yaml
+++ b/optional-mcps/pandadoc/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: pandadoc
+description: Create, send, sign and track documents
+source: https://claude.com/connectors/pandadoc
+ui:
+  display_name: PandaDoc
+  category: Business tools
+  icon: pandadoc
+  tags:
+  - connector
+  capabilities:
+  - Create, send, sign and track documents
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.pandadoc.com/v1/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with PandaDoc.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure pandadoc\n"

--- a/optional-mcps/paypal/manifest.yaml
+++ b/optional-mcps/paypal/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: paypal
+description: Access PayPal payments platform
+source: https://claude.com/connectors/paypal
+ui:
+  display_name: PayPal
+  category: Business tools
+  icon: paypal
+  tags:
+  - connector
+  capabilities:
+  - Access PayPal payments platform
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.paypal.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with PayPal.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure paypal\n"

--- a/optional-mcps/paytm-for-business/manifest.yaml
+++ b/optional-mcps/paytm-for-business/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: paytm-for-business
+description: Make Claude your Paytm Payments assistant
+source: https://claude.com/connectors/paytm-for-business
+ui:
+  display_name: Paytm for Business
+  category: Business tools
+  icon: paytm-for-business
+  tags:
+  - connector
+  capabilities:
+  - Make Claude your Paytm Payments assistant
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.paytmpayments.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Paytm for Business.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure paytm-for-business\n"

--- a/optional-mcps/peec-ai/manifest.yaml
+++ b/optional-mcps/peec-ai/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: peec-ai
+description: Analyze your brand's visibility across LLMs
+source: https://claude.com/connectors/peec-ai
+ui:
+  display_name: Peec AI
+  category: Business tools
+  icon: peec-ai
+  tags:
+  - connector
+  capabilities:
+  - Analyze your brand's visibility across LLMs
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.peec.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Peec AI.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure peec-ai\n"

--- a/optional-mcps/pg-aiguide/manifest.yaml
+++ b/optional-mcps/pg-aiguide/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: pg-aiguide
+description: Search pg and Tiger docs, learn database skills
+source: https://claude.com/connectors/pg-aiguide
+ui:
+  display_name: pg-aiguide
+  category: Analytics
+  icon: pg-aiguide
+  tags:
+  - analytics
+  capabilities:
+  - Search pg and Tiger docs, learn database skills
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.tigerdata.com/docs
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with pg-aiguide.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure pg-aiguide\n"

--- a/optional-mcps/phoenix/manifest.yaml
+++ b/optional-mcps/phoenix/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: phoenix
+description: AI-powered B2B data intelligence & analytics
+source: https://claude.com/connectors/phoenix
+ui:
+  display_name: Phoenix by HG Insights
+  category: Analytics
+  icon: phoenix
+  tags:
+  - analytics
+  capabilities:
+  - AI-powered B2B data intelligence & analytics
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://phoenix.hginsights.com/api/ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Phoenix by HG Insights.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure phoenix\n"

--- a/optional-mcps/planetscale/manifest.yaml
+++ b/optional-mcps/planetscale/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: planetscale
+description: Authenticated access to your Postgres and MySQL DBs
+source: https://claude.com/connectors/planetscale
+ui:
+  display_name: PlanetScale
+  category: Business tools
+  icon: planetscale
+  tags:
+  - connector
+  capabilities:
+  - Authenticated access to your Postgres and MySQL DBs
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.pscale.dev/mcp/planetscale\n
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with PlanetScale.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure planetscale\n"

--- a/optional-mcps/polar-analytics/manifest.yaml
+++ b/optional-mcps/polar-analytics/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: polar-analytics
+description: Bring all your data in one place & connect it to Claude
+source: https://claude.com/connectors/polar-analytics
+ui:
+  display_name: Polar Analytics
+  category: Analytics
+  icon: polar-analytics
+  tags:
+  - analytics
+  capabilities:
+  - Bring all your data in one place & connect it to Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.polaranalytics.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Polar Analytics.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure polar-analytics\n"

--- a/optional-mcps/pophive/manifest.yaml
+++ b/optional-mcps/pophive/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: pophive
+description: Yale's harmonized US public health surveillance data
+source: https://claude.com/connectors/pophive
+ui:
+  display_name: PopHIVE
+  category: Analytics
+  icon: pophive
+  tags:
+  - analytics
+  capabilities:
+  - Yale's harmonized US public health surveillance data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.pophive.org/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with PopHIVE.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure pophive\n"

--- a/optional-mcps/portio/manifest.yaml
+++ b/optional-mcps/portio/manifest.yaml
@@ -1,0 +1,26 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: portio
+description: Build and query your developer portal and trigger developer workflows
+source: https://claude.com/connectors/port-io
+ui:
+  display_name: Port IO
+  category: Developer tools
+  icon: portio
+  tags:
+  - project-management
+  - developer-tools
+  capabilities:
+  - Build and query your developer portal and trigger developer workflows
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.port.io/v1
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Port IO.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure portio\n"

--- a/optional-mcps/postman/manifest.yaml
+++ b/optional-mcps/postman/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: postman
+description: Give API context to your coding agents
+source: https://claude.com/connectors/postman
+ui:
+  display_name: Postman
+  category: Developer tools
+  icon: postman
+  tags:
+  - developer-tools
+  capabilities:
+  - Give API context to your coding agents
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.postman.com/minimal
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Postman.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure postman\n"

--- a/optional-mcps/privacy/manifest.yaml
+++ b/optional-mcps/privacy/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: privacy
+description: Manage virtual cards and track your spending patterns
+source: https://claude.com/connectors/privacy
+ui:
+  display_name: Privacy.com
+  category: Business tools
+  icon: privacy
+  tags:
+  - connector
+  capabilities:
+  - Manage virtual cards and track your spending patterns
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.privacy.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Privacy.com.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure privacy\n"

--- a/optional-mcps/profound/manifest.yaml
+++ b/optional-mcps/profound/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: profound
+description: Pull Profound Visibility, Citation, & AI Bot Visit Data
+source: https://claude.com/connectors/profound
+ui:
+  display_name: Profound
+  category: Analytics
+  icon: profound
+  tags:
+  - analytics
+  capabilities:
+  - Pull Profound Visibility, Citation, & AI Bot Visit Data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.tryprofound.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Profound.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure profound\n"

--- a/optional-mcps/pylon/manifest.yaml
+++ b/optional-mcps/pylon/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: pylon
+description: Search and manage Pylon support issues
+source: https://claude.com/connectors/pylon
+ui:
+  display_name: Pylon
+  category: Business tools
+  icon: pylon
+  tags:
+  - project-management
+  capabilities:
+  - Search and manage Pylon support issues
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.usepylon.com/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Pylon.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure pylon\n"

--- a/optional-mcps/qonto/manifest.yaml
+++ b/optional-mcps/qonto/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: qonto
+description: Manage your Qonto business finances from Claude
+source: https://claude.com/connectors/qonto
+ui:
+  display_name: Qonto
+  category: Business tools
+  icon: qonto
+  tags:
+  - connector
+  capabilities:
+  - Manage your Qonto business finances from Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.qonto.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Qonto.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure qonto\n"

--- a/optional-mcps/quartr/manifest.yaml
+++ b/optional-mcps/quartr/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: quartr
+description: Financial data and AI infrastructure for company research.
+source: https://claude.com/connectors/quartr
+ui:
+  display_name: Quartr
+  category: Analytics
+  icon: quartr
+  tags:
+  - analytics
+  capabilities:
+  - Financial data and AI infrastructure for company research.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.quartr.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Quartr.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure quartr\n"

--- a/optional-mcps/quicknode/manifest.yaml
+++ b/optional-mcps/quicknode/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: quicknode
+description: Manage blockchain infrastructure right in Claude
+source: https://claude.com/connectors/quicknode
+ui:
+  display_name: QuickNode
+  category: Business tools
+  icon: quicknode
+  tags:
+  - connector
+  capabilities:
+  - Manage blockchain infrastructure right in Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.quicknode.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with QuickNode.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure quicknode\n"

--- a/optional-mcps/quo/manifest.yaml
+++ b/optional-mcps/quo/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: quo
+description: Surface call insights and missed opportunities
+source: https://claude.com/connectors/quo
+ui:
+  display_name: Quo
+  category: Analytics
+  icon: quo
+  tags:
+  - analytics
+  capabilities:
+  - Surface call insights and missed opportunities
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.quo.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Quo.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure quo\n"

--- a/optional-mcps/ramp-data/manifest.yaml
+++ b/optional-mcps/ramp-data/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: ramp-data
+description: Search and analyze Ramp spend across 50,000+ businesses
+source: https://claude.com/connectors/ramp-data
+ui:
+  display_name: Ramp Data
+  category: Analytics
+  icon: ramp-data
+  tags:
+  - analytics
+  capabilities:
+  - Search and analyze Ramp spend across 50,000+ businesses
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.ramp.com/ramp-data/anthropic/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Ramp Data.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure ramp-data\n"

--- a/optional-mcps/ramp/manifest.yaml
+++ b/optional-mcps/ramp/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: ramp
+description: Search, access, and analyze your Ramp financial data
+source: https://claude.com/connectors/ramp
+ui:
+  display_name: Ramp
+  category: Analytics
+  icon: ramp
+  tags:
+  - analytics
+  capabilities:
+  - Search, access, and analyze your Ramp financial data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://ramp-mcp-remote.ramp.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Ramp.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure ramp\n"

--- a/optional-mcps/read-ai/manifest.yaml
+++ b/optional-mcps/read-ai/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: read-ai
+description: Bring your meetings into Claude
+source: https://claude.com/connectors/read-ai
+ui:
+  display_name: Read AI
+  category: Productivity
+  icon: read-ai
+  tags:
+  - productivity
+  capabilities:
+  - Bring your meetings into Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.read.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Read AI.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure read-ai\n"

--- a/optional-mcps/replit/manifest.yaml
+++ b/optional-mcps/replit/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: replit
+description: Turn ideas into apps and websites instantly
+source: https://claude.com/connectors/replit
+ui:
+  display_name: Replit
+  category: Business tools
+  icon: replit
+  tags:
+  - connector
+  capabilities:
+  - Turn ideas into apps and websites instantly
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://replit-mcp.com/anthropic/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Replit.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure replit\n"

--- a/optional-mcps/resy/manifest.yaml
+++ b/optional-mcps/resy/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: resy
+description: Find and book restaurants instantly
+source: https://claude.com/connectors/resy
+ui:
+  display_name: Resy
+  category: Business tools
+  icon: resy
+  tags:
+  - connector
+  capabilities:
+  - Find and book restaurants instantly
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://apigw.americanexpress.com/dining/v1/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Resy.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure resy\n"

--- a/optional-mcps/rillet/manifest.yaml
+++ b/optional-mcps/rillet/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: rillet
+description: Query your live GL and financials in plain English
+source: https://claude.com/connectors/rillet
+ui:
+  display_name: Rillet
+  category: Business tools
+  icon: rillet
+  tags:
+  - connector
+  capabilities:
+  - Query your live GL and financials in plain English
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.rillet.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Rillet.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure rillet\n"

--- a/optional-mcps/salesloft/manifest.yaml
+++ b/optional-mcps/salesloft/manifest.yaml
@@ -1,0 +1,26 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: salesloft
+description: Query live data about deals, engagement, and pipeline
+source: https://claude.com/connectors/salesloft
+ui:
+  display_name: Salesloft
+  category: Analytics
+  icon: salesloft
+  tags:
+  - crm
+  - analytics
+  capabilities:
+  - Query live data about deals, engagement, and pipeline
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: sse
+  url: https://mcp.salesloft.com/sse
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Salesloft.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure salesloft\n"

--- a/optional-mcps/sanity/manifest.yaml
+++ b/optional-mcps/sanity/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: sanity
+description: Create, query, and manage structured content in Sanity
+source: https://claude.com/connectors/sanity
+ui:
+  display_name: Sanity
+  category: Business tools
+  icon: sanity
+  tags:
+  - connector
+  capabilities:
+  - Create, query, and manage structured content in Sanity
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.sanity.io
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Sanity.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure sanity\n"

--- a/optional-mcps/scite/manifest.yaml
+++ b/optional-mcps/scite/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: scite
+description: Evidence-based answers grounded in research
+source: https://claude.com/connectors/scite
+ui:
+  display_name: Scite
+  category: Business tools
+  icon: scite
+  tags:
+  - connector
+  capabilities:
+  - Evidence-based answers grounded in research
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.scite.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Scite.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure scite\n"

--- a/optional-mcps/semrush/manifest.yaml
+++ b/optional-mcps/semrush/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: semrush
+description: SEO, competitor research, and traffic analysis
+source: https://claude.com/connectors/semrush
+ui:
+  display_name: Semrush
+  category: Business tools
+  icon: semrush
+  tags:
+  - connector
+  capabilities:
+  - SEO, competitor research, and traffic analysis
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.semrush.com/claude/v1/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Semrush.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure semrush\n"

--- a/optional-mcps/send/manifest.yaml
+++ b/optional-mcps/send/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: send
+description: Create shareable documents, one-pagers, and decks
+source: https://claude.com/connectors/send
+ui:
+  display_name: Send
+  category: Business tools
+  icon: send
+  tags:
+  - connector
+  capabilities:
+  - Create shareable documents, one-pagers, and decks
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://www.send.co/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Send.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure send\n"

--- a/optional-mcps/sentry/manifest.yaml
+++ b/optional-mcps/sentry/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: sentry
+description: Search, query, and debug errors intelligently
+source: https://claude.com/connectors/sentry
+ui:
+  display_name: Sentry
+  category: Business tools
+  icon: sentry
+  tags:
+  - connector
+  capabilities:
+  - Search, query, and debug errors intelligently
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.sentry.dev/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Sentry.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure sentry\n"

--- a/optional-mcps/shapes/manifest.yaml
+++ b/optional-mcps/shapes/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: shapes
+description: Analyse your live people data, right in Claude
+source: https://claude.com/connectors/shapes
+ui:
+  display_name: Shapes
+  category: Analytics
+  icon: shapes
+  tags:
+  - analytics
+  capabilities:
+  - Analyse your live people data, right in Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.shapes.co/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Shapes.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure shapes\n"

--- a/optional-mcps/shopify/manifest.yaml
+++ b/optional-mcps/shopify/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: shopify
+description: Build, manage, and analyze your Shopify store
+source: https://claude.com/connectors/shopify
+ui:
+  display_name: Shopify
+  category: Business tools
+  icon: shopify
+  tags:
+  - connector
+  capabilities:
+  - Build, manage, and analyze your Shopify store
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://setup.shopify.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Shopify.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure shopify\n"

--- a/optional-mcps/similarweb/manifest.yaml
+++ b/optional-mcps/similarweb/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: similarweb
+description: Real time web, mobile app, and market data.
+source: https://claude.com/connectors/similarweb
+ui:
+  display_name: Similarweb
+  category: Analytics
+  icon: similarweb
+  tags:
+  - analytics
+  capabilities:
+  - Real time web, mobile app, and market data.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.similarweb.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Similarweb.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure similarweb\n"

--- a/optional-mcps/sketchup/manifest.yaml
+++ b/optional-mcps/sketchup/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: sketchup
+description: Create and iterate 3D models for use in SketchUp
+source: https://claude.com/connectors/sketchup
+ui:
+  display_name: Trimble SketchUp
+  category: Business tools
+  icon: sketchup
+  tags:
+  - connector
+  capabilities:
+  - Create and iterate 3D models for use in SketchUp
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.sketchup.com/mcp/v1/sketchup/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Trimble SketchUp.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure sketchup\n"

--- a/optional-mcps/slidesgpt/manifest.yaml
+++ b/optional-mcps/slidesgpt/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: slidesgpt
+description: Make presentations and slides, export to PowerPoint
+source: https://claude.com/connectors/slidesgpt
+ui:
+  display_name: Agentic Presentations by SlidesGPT
+  category: Business tools
+  icon: slidesgpt
+  tags:
+  - connector
+  capabilities:
+  - Make presentations and slides, export to PowerPoint
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://claude.slidesgpt.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Agentic Presentations by SlidesGPT.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure slidesgpt\n"

--- a/optional-mcps/solve-intelligence/manifest.yaml
+++ b/optional-mcps/solve-intelligence/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: solve-intelligence
+description: Search, draft, and chart patents
+source: https://claude.com/connectors/solve-intelligence
+ui:
+  display_name: Solve Intelligence
+  category: Business tools
+  icon: solve-intelligence
+  tags:
+  - connector
+  capabilities:
+  - Search, draft, and chart patents
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.solveintelligence.com/mcp/
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Solve Intelligence.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure solve-intelligence\n"

--- a/optional-mcps/spinach-ai/manifest.yaml
+++ b/optional-mcps/spinach-ai/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: spinach-ai
+description: The system of action for conversation data
+source: https://claude.com/connectors/spinach-ai
+ui:
+  display_name: Spinach AI
+  category: Analytics
+  icon: spinach-ai
+  tags:
+  - analytics
+  capabilities:
+  - The system of action for conversation data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.spinach.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Spinach AI.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure spinach-ai\n"

--- a/optional-mcps/splice/manifest.yaml
+++ b/optional-mcps/splice/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: splice
+description: Search Splice's sounds catalog, build stacks & more!
+source: https://claude.com/connectors/splice
+ui:
+  display_name: Splice
+  category: Business tools
+  icon: splice
+  tags:
+  - connector
+  capabilities:
+  - Search Splice's sounds catalog, build stacks & more!
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.splice.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Splice.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure splice\n"

--- a/optional-mcps/spotify/manifest.yaml
+++ b/optional-mcps/spotify/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: spotify
+description: Music and podcast recommendations, just for you.
+source: https://claude.com/connectors/spotify
+ui:
+  display_name: Spotify
+  category: Business tools
+  icon: spotify
+  tags:
+  - connector
+  capabilities:
+  - Music and podcast recommendations, just for you.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp-gateway-external-pilot.spotify.net/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Spotify.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure spotify\n"

--- a/optional-mcps/sprouts/manifest.yaml
+++ b/optional-mcps/sprouts/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: sprouts
+description: From query to qualified lead in seconds.
+source: https://claude.com/connectors/sprouts
+ui:
+  display_name: Sprouts Data Intelligence
+  category: Analytics
+  icon: sprouts
+  tags:
+  - analytics
+  capabilities:
+  - From query to qualified lead in seconds.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://sprouts-mcp-server.kartikay-dhar.workers.dev
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Sprouts Data Intelligence.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure sprouts\n"

--- a/optional-mcps/square/manifest.yaml
+++ b/optional-mcps/square/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: square
+description: Search and manage transaction, merchant, and payment data
+source: https://claude.com/connectors/square
+ui:
+  display_name: Square
+  category: Analytics
+  icon: square
+  tags:
+  - analytics
+  capabilities:
+  - Search and manage transaction, merchant, and payment data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: sse
+  url: https://mcp.squareup.com/sse
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Square.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure square\n"

--- a/optional-mcps/strava/manifest.yaml
+++ b/optional-mcps/strava/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: strava
+description: Analyze, summarize, and explore your Strava data
+source: https://claude.com/connectors/strava
+ui:
+  display_name: Strava
+  category: Analytics
+  icon: strava
+  tags:
+  - analytics
+  capabilities:
+  - Analyze, summarize, and explore your Strava data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.strava.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Strava.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure strava\n"

--- a/optional-mcps/stripe/manifest.yaml
+++ b/optional-mcps/stripe/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: stripe
+description: Payment processing and financial infrastructure tools
+source: https://claude.com/connectors/stripe
+ui:
+  display_name: Stripe
+  category: Business tools
+  icon: stripe
+  tags:
+  - connector
+  capabilities:
+  - Payment processing and financial infrastructure tools
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.stripe.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Stripe.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure stripe\n"

--- a/optional-mcps/stubhub/manifest.yaml
+++ b/optional-mcps/stubhub/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: stubhub
+description: Find tickets on the World's Largest Ticket Marketplace
+source: https://claude.com/connectors/stubhub
+ui:
+  display_name: StubHub
+  category: Business tools
+  icon: stubhub
+  tags:
+  - connector
+  capabilities:
+  - Find tickets on the World's Largest Ticket Marketplace
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://open-ai-app.stubhub.net/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with StubHub.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure stubhub\n"

--- a/optional-mcps/sumble/manifest.yaml
+++ b/optional-mcps/sumble/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: sumble
+description: Deep research any account's teams, tech, and people
+source: https://claude.com/connectors/sumble
+ui:
+  display_name: Sumble
+  category: Business tools
+  icon: sumble
+  tags:
+  - connector
+  capabilities:
+  - Deep research any account's teams, tech, and people
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.sumble.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Sumble.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure sumble\n"

--- a/optional-mcps/supabase/manifest.yaml
+++ b/optional-mcps/supabase/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: supabase
+description: Manage databases, authentication, and storage
+source: https://claude.com/connectors/supabase
+ui:
+  display_name: Supabase
+  category: Analytics
+  icon: supabase
+  tags:
+  - analytics
+  capabilities:
+  - Manage databases, authentication, and storage
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.supabase.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Supabase.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure supabase\n"

--- a/optional-mcps/superhuman-mail/manifest.yaml
+++ b/optional-mcps/superhuman-mail/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: superhuman-mail
+description: The most productive email app ever, for Gmail & Outlook
+source: https://claude.com/connectors/superhuman-mail
+ui:
+  display_name: Superhuman Mail
+  category: Productivity
+  icon: superhuman-mail
+  tags:
+  - productivity
+  capabilities:
+  - The most productive email app ever, for Gmail & Outlook
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.mail.superhuman.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Superhuman Mail.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure superhuman-mail\n"

--- a/optional-mcps/surveymonkey/manifest.yaml
+++ b/optional-mcps/surveymonkey/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: surveymonkey
+description: Design surveys, collect responses, and analyze results
+source: https://claude.com/connectors/surveymonkey
+ui:
+  display_name: SurveyMonkey
+  category: Business tools
+  icon: surveymonkey
+  tags:
+  - connector
+  capabilities:
+  - Design surveys, collect responses, and analyze results
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.surveymonkey.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with SurveyMonkey.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure surveymonkey\n"

--- a/optional-mcps/swagger/manifest.yaml
+++ b/optional-mcps/swagger/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: swagger
+description: Build, govern, and document APIs
+source: https://claude.com/connectors/swagger
+ui:
+  display_name: Swagger
+  category: Developer tools
+  icon: swagger
+  tags:
+  - developer-tools
+  capabilities:
+  - Build, govern, and document APIs
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://swagger.mcp.smartbear.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Swagger.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure swagger\n"

--- a/optional-mcps/synthesize-bio/manifest.yaml
+++ b/optional-mcps/synthesize-bio/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: synthesize-bio
+description: Generate gene expression from a virtual human
+source: https://claude.com/connectors/synthesize-bio
+ui:
+  display_name: Synthesize Bio
+  category: Business tools
+  icon: synthesize-bio
+  tags:
+  - connector
+  capabilities:
+  - Generate gene expression from a virtual human
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://app.synthesize.bio/api/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Synthesize Bio.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure synthesize-bio\n"

--- a/optional-mcps/taskrabbit/manifest.yaml
+++ b/optional-mcps/taskrabbit/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: taskrabbit
+description: Find & book local Taskrabbit services near you
+source: https://claude.com/connectors/taskrabbit
+ui:
+  display_name: Taskrabbit Booking Assistance
+  category: Business tools
+  icon: taskrabbit
+  tags:
+  - project-management
+  capabilities:
+  - Find & book local Taskrabbit services near you
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.taskrabbit.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Taskrabbit Booking Assistance.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure taskrabbit\n"

--- a/optional-mcps/tavily/manifest.yaml
+++ b/optional-mcps/tavily/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: tavily
+description: Connect your AI agents to the web
+source: https://claude.com/connectors/tavily
+ui:
+  display_name: Tavily
+  category: Business tools
+  icon: tavily
+  tags:
+  - connector
+  capabilities:
+  - Connect your AI agents to the web
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.tavily.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Tavily.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure tavily\n"

--- a/optional-mcps/third-bridge/manifest.yaml
+++ b/optional-mcps/third-bridge/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: third-bridge
+description: Expert-led enhanced insights
+source: https://claude.com/connectors/third-bridge
+ui:
+  display_name: Third Bridge
+  category: Analytics
+  icon: third-bridge
+  tags:
+  - analytics
+  capabilities:
+  - Expert-led enhanced insights
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://ai.thirdbridge.com/mcp/sse
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Third Bridge.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure third-bridge\n"

--- a/optional-mcps/thoughtspot-spotter/manifest.yaml
+++ b/optional-mcps/thoughtspot-spotter/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: thoughtspot-spotter
+description: Your AI data analyst, from question to trusted insights
+source: https://claude.com/connectors/thoughtspot-spotter
+ui:
+  display_name: ThoughtSpot Spotter
+  category: Analytics
+  icon: thoughtspot-spotter
+  tags:
+  - analytics
+  capabilities:
+  - Your AI data analyst, from question to trusted insights
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://agent.thoughtspot.app/mcp?api-version=latest
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with ThoughtSpot Spotter.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure thoughtspot-spotter\n"

--- a/optional-mcps/thumbtack/manifest.yaml
+++ b/optional-mcps/thumbtack/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: thumbtack
+description: Find and hire local pros in Claude
+source: https://claude.com/connectors/thumbtack
+ui:
+  display_name: Thumbtack
+  category: Business tools
+  icon: thumbtack
+  tags:
+  - connector
+  capabilities:
+  - Find and hire local pros in Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.thumbtack.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Thumbtack.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure thumbtack\n"

--- a/optional-mcps/tickettailor/manifest.yaml
+++ b/optional-mcps/tickettailor/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: tickettailor
+description: Event platform for managing tickets, orders & more
+source: https://claude.com/connectors/ticket-tailor
+ui:
+  display_name: Ticket Tailor
+  category: Business tools
+  icon: tickettailor
+  tags:
+  - connector
+  capabilities:
+  - Event platform for managing tickets, orders & more
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.tickettailor.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Ticket Tailor.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure tickettailor\n"

--- a/optional-mcps/tldv/manifest.yaml
+++ b/optional-mcps/tldv/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: tldv
+description: Fetch Transcripts & Notes from Meet, Zoom & Teams
+source: https://claude.com/connectors/tldv
+ui:
+  display_name: tldv
+  category: Productivity
+  icon: tldv
+  tags:
+  - productivity
+  capabilities:
+  - Fetch Transcripts & Notes from Meet, Zoom & Teams
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.tldv.io/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with tldv.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure tldv\n"

--- a/optional-mcps/todoist/manifest.yaml
+++ b/optional-mcps/todoist/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: todoist
+description: Search, complete, and manage your tasks in Todoist
+source: https://claude.com/connectors/todoist
+ui:
+  display_name: Todoist
+  category: Business tools
+  icon: todoist
+  tags:
+  - project-management
+  capabilities:
+  - Search, complete, and manage your tasks in Todoist
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://ai.todoist.net/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Todoist.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure todoist\n"

--- a/optional-mcps/tomtom-maps/manifest.yaml
+++ b/optional-mcps/tomtom-maps/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: tomtom-maps
+description: TomTom maps, routing, geocoding & traffic data
+source: https://claude.com/connectors/tomtom-maps
+ui:
+  display_name: TomTom Maps
+  category: Analytics
+  icon: tomtom-maps
+  tags:
+  - analytics
+  capabilities:
+  - TomTom maps, routing, geocoding & traffic data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.tomtom.com/maps
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with TomTom Maps.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure tomtom-maps\n"

--- a/optional-mcps/topcounsel/manifest.yaml
+++ b/optional-mcps/topcounsel/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: topcounsel
+description: Outside Counsel recommendations from Inhouse Counsel
+source: https://claude.com/connectors/topcounsel
+ui:
+  display_name: TopCounsel by The L Suite
+  category: Business tools
+  icon: topcounsel
+  tags:
+  - connector
+  capabilities:
+  - Outside Counsel recommendations from Inhouse Counsel
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.techgc.co/api/mcp/topcounsel
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with TopCounsel by The L Suite.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure topcounsel\n"

--- a/optional-mcps/trellis/manifest.yaml
+++ b/optional-mcps/trellis/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: trellis
+description: Claude for Trial Court Litigators
+source: https://claude.com/connectors/trellis
+ui:
+  display_name: Trellis
+  category: Business tools
+  icon: trellis
+  tags:
+  - connector
+  capabilities:
+  - Claude for Trial Court Litigators
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.trellis.law/anthropic
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Trellis.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure trellis\n"

--- a/optional-mcps/tripadvisor/manifest.yaml
+++ b/optional-mcps/tripadvisor/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: tripadvisor
+description: Find your perfect hotel based on Tripadvisor reviews
+source: https://claude.com/connectors/tripadvisor
+ui:
+  display_name: Tripadvisor
+  category: Business tools
+  icon: tripadvisor
+  tags:
+  - connector
+  capabilities:
+  - Find your perfect hotel based on Tripadvisor reviews
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://production.ai-mcp-extensibility-prd.tamg.cloud/ogMvjY4De1G7CiHanMOAgddl/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Tripadvisor.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure tripadvisor\n"

--- a/optional-mcps/trivago/manifest.yaml
+++ b/optional-mcps/trivago/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: trivago
+description: Find your ideal hotel at the best price.
+source: https://claude.com/connectors/trivago
+ui:
+  display_name: Trivago
+  category: Business tools
+  icon: trivago
+  tags:
+  - connector
+  capabilities:
+  - Find your ideal hotel at the best price.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.trivago.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Trivago.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure trivago\n"

--- a/optional-mcps/tropic/manifest.yaml
+++ b/optional-mcps/tropic/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: tropic
+description: Save money on Software + AI contracts
+source: https://claude.com/connectors/tropic
+ui:
+  display_name: Tropic
+  category: Business tools
+  icon: tropic
+  tags:
+  - connector
+  capabilities:
+  - Save money on Software + AI contracts
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://app.tropicapp.io/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Tropic.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure tropic\n"

--- a/optional-mcps/turkish-airlines/manifest.yaml
+++ b/optional-mcps/turkish-airlines/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: turkish-airlines
+description: Search flights, plan trips, and manage bookings
+source: https://claude.com/connectors/turkish-airlines
+ui:
+  display_name: Turkish Airlines
+  category: Business tools
+  icon: turkish-airlines
+  tags:
+  - connector
+  capabilities:
+  - Search flights, plan trips, and manage bookings
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp-app.turkishtechlab.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Turkish Airlines.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure turkish-airlines\n"

--- a/optional-mcps/turquoise/manifest.yaml
+++ b/optional-mcps/turquoise/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: turquoise
+description: Query Turquoise's proprietary healthcare pricing data
+source: https://claude.com/connectors/turquoise
+ui:
+  display_name: Turquoise
+  category: Analytics
+  icon: turquoise
+  tags:
+  - analytics
+  capabilities:
+  - Query Turquoise's proprietary healthcare pricing data
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.turquoise.health/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Turquoise.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure turquoise\n"

--- a/optional-mcps/twilio/manifest.yaml
+++ b/optional-mcps/twilio/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: twilio
+description: Build powerful communications and customer engagement
+source: https://claude.com/connectors/twilio
+ui:
+  display_name: Twilio
+  category: Sales & CRM
+  icon: twilio
+  tags:
+  - crm
+  capabilities:
+  - Build powerful communications and customer engagement
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.twilio.com/docs
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Twilio.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure twilio\n"

--- a/optional-mcps/uber-eats/manifest.yaml
+++ b/optional-mcps/uber-eats/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: uber-eats
+description: Explore restaurants and dishes
+source: https://claude.com/connectors/uber-eats
+ui:
+  display_name: Uber Eats
+  category: Business tools
+  icon: uber-eats
+  tags:
+  - connector
+  capabilities:
+  - Explore restaurants and dishes
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.ubereats.com/eats-claude/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Uber Eats.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure uber-eats\n"

--- a/optional-mcps/uber/manifest.yaml
+++ b/optional-mcps/uber/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: uber
+description: Get Uber price & time estimates for any ride option
+source: https://claude.com/connectors/uber
+ui:
+  display_name: Uber
+  category: Business tools
+  icon: uber
+  tags:
+  - connector
+  capabilities:
+  - Get Uber price & time estimates for any ride option
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.uber.com/claude/rides-3p/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Uber.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure uber\n"

--- a/optional-mcps/unreal-engine/manifest.yaml
+++ b/optional-mcps/unreal-engine/manifest.yaml
@@ -6,6 +6,21 @@ name: unreal-engine
 description: Drive the Unreal Engine 5.8 editor over its local MCP server.
 source: https://dev.epicgames.com/documentation/unreal-engine/unreal-mcp-in-unreal-editor
 
+ui:
+  display_name: Unreal Engine
+  category: Creative tools
+  icon: unreal-engine
+  tags: [game-dev, editor, local]
+  capabilities:
+    - Inspect and drive an Unreal Editor project
+    - Spawn actors and configure scene assets
+    - Run editor automation exposed by the plugin
+  setup_steps:
+    - Enable Epic's Unreal MCP plugin in the editor.
+    - Start the local MCP server before connecting Hermes.
+  danger_notes:
+    - Editor tool calls mutate the open Unreal project on the game thread.
+
 # Epic's official "Unreal MCP" plugin (internal id ModelContextProtocol)
 # embeds an MCP server inside the running Unreal Editor process and serves it
 # over local HTTP. There is nothing to install on the Hermes side — the user

--- a/optional-mcps/unthread/manifest.yaml
+++ b/optional-mcps/unthread/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: unthread
+description: Manage and automate your support tickets
+source: https://claude.com/connectors/unthread
+ui:
+  display_name: Unthread
+  category: Business tools
+  icon: unthread
+  tags:
+  - connector
+  capabilities:
+  - Manage and automate your support tickets
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://app.unthread.io/api/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Unthread.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure unthread\n"

--- a/optional-mcps/unwrap/manifest.yaml
+++ b/optional-mcps/unwrap/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: unwrap
+description: Search and analyze customer feedback
+source: https://claude.com/connectors/unwrap
+ui:
+  display_name: Unwrap
+  category: Sales & CRM
+  icon: unwrap
+  tags:
+  - crm
+  capabilities:
+  - Search and analyze customer feedback
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://nlp.api.production.unwrap.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Unwrap.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure unwrap\n"

--- a/optional-mcps/upwork/manifest.yaml
+++ b/optional-mcps/upwork/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: upwork
+description: Hire talent with confidence
+source: https://claude.com/connectors/upwork
+ui:
+  display_name: Upwork
+  category: Business tools
+  icon: upwork
+  tags:
+  - project-management
+  capabilities:
+  - Hire talent with confidence
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://edge.upwork.com/api/v4/upw-mcp-app/v3/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Upwork.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure upwork\n"

--- a/optional-mcps/vercel/manifest.yaml
+++ b/optional-mcps/vercel/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: vercel
+description: Analyze, debug, and manage projects and deployments
+source: https://claude.com/connectors/vercel
+ui:
+  display_name: Vercel
+  category: Business tools
+  icon: vercel
+  tags:
+  - project-management
+  capabilities:
+  - Analyze, debug, and manage projects and deployments
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.vercel.com
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Vercel.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure vercel\n"

--- a/optional-mcps/verisk-underwriting-intelligence/manifest.yaml
+++ b/optional-mcps/verisk-underwriting-intelligence/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: verisk-underwriting-intelligence
+description: Ask questions. Get underwriting insights from Verisk.
+source: https://claude.com/connectors/verisk-underwriting-intelligence
+ui:
+  display_name: Verisk Underwriting Intelligence
+  category: Analytics
+  icon: verisk-underwriting-intelligence
+  tags:
+  - analytics
+  capabilities:
+  - Ask questions. Get underwriting insights from Verisk.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://gatewaymcp.verisk.com/underwriting/intelligencemcp/v1
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Verisk Underwriting Intelligence.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure verisk-underwriting-intelligence\n"

--- a/optional-mcps/verisk-xactrestore/manifest.yaml
+++ b/optional-mcps/verisk-xactrestore/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: verisk-xactrestore
+description: Natural-language estimating for XactRestore
+source: https://claude.com/connectors/verisk-xactrestore
+ui:
+  display_name: Verisk XactRestore
+  category: Business tools
+  icon: verisk-xactrestore
+  tags:
+  - connector
+  capabilities:
+  - Natural-language estimating for XactRestore
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://xactrestore-xactremodelserver-usw2-prod.propsol.io/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Verisk XactRestore.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure verisk-xactrestore\n"

--- a/optional-mcps/viator/manifest.yaml
+++ b/optional-mcps/viator/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: viator
+description: Book travel experiences around the world
+source: https://claude.com/connectors/viator
+ui:
+  display_name: Viator
+  category: Business tools
+  icon: viator
+  tags:
+  - connector
+  capabilities:
+  - Book travel experiences around the world
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://exp-app-mcp.prod.ep.viator.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Viator.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure viator\n"

--- a/optional-mcps/webex-meetings/manifest.yaml
+++ b/optional-mcps/webex-meetings/manifest.yaml
@@ -1,0 +1,26 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: webex-meetings
+description: AI-powered workflows for Webex meetings
+source: https://claude.com/connectors/webex-meetings
+ui:
+  display_name: Webex Meetings
+  category: Productivity
+  icon: webex-meetings
+  tags:
+  - project-management
+  - productivity
+  capabilities:
+  - AI-powered workflows for Webex meetings
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.webexapis.com/mcp/webex-meeting
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Webex Meetings.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure webex-meetings\n"

--- a/optional-mcps/whimsical/manifest.yaml
+++ b/optional-mcps/whimsical/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: whimsical
+description: Create flowcharts, mindmaps, wireframes and diagrams
+source: https://claude.com/connectors/whimsical
+ui:
+  display_name: Whimsical
+  category: Business tools
+  icon: whimsical
+  tags:
+  - connector
+  capabilities:
+  - Create flowcharts, mindmaps, wireframes and diagrams
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.whimsical.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Whimsical.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure whimsical\n"

--- a/optional-mcps/wolfram/manifest.yaml
+++ b/optional-mcps/wolfram/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: wolfram
+description: Inject precise, real-time computation and knowledge
+source: https://claude.com/connectors/wolfram
+ui:
+  display_name: Wolfram
+  category: Business tools
+  icon: wolfram
+  tags:
+  - connector
+  capabilities:
+  - Inject precise, real-time computation and knowledge
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://agenttools.wolfram.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Wolfram.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure wolfram\n"

--- a/optional-mcps/wordpress-com/manifest.yaml
+++ b/optional-mcps/wordpress-com/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: wordpress-com
+description: Secure AI access to manage your WordPress.com sites
+source: https://claude.com/connectors/wordpress-com
+ui:
+  display_name: WordPress.com
+  category: Business tools
+  icon: wordpress-com
+  tags:
+  - connector
+  capabilities:
+  - Secure AI access to manage your WordPress.com sites
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://public-api.wordpress.com/wpcom/v2/mcp/v1
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with WordPress.com.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure wordpress-com\n"

--- a/optional-mcps/workable/manifest.yaml
+++ b/optional-mcps/workable/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: workable
+description: Your AI assistant for Hiring and HR — inside Workable
+source: https://claude.com/connectors/workable
+ui:
+  display_name: Workable
+  category: Business tools
+  icon: workable
+  tags:
+  - project-management
+  capabilities:
+  - Your AI assistant for Hiring and HR — inside Workable
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.workable.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Workable.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure workable\n"

--- a/optional-mcps/wrike/manifest.yaml
+++ b/optional-mcps/wrike/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: wrike
+description: Manage, update and move work forward from Claude
+source: https://claude.com/connectors/wrike
+ui:
+  display_name: Wrike
+  category: Business tools
+  icon: wrike
+  tags:
+  - project-management
+  capabilities:
+  - Manage, update and move work forward from Claude
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.wrike.com/app/mcp/stream
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Wrike.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure wrike\n"

--- a/optional-mcps/wyndham-hotels/manifest.yaml
+++ b/optional-mcps/wyndham-hotels/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: wyndham-hotels
+description: Discover the right Wyndham Hotel for you, faster
+source: https://claude.com/connectors/wyndham-hotels
+ui:
+  display_name: Wyndham Hotels and Resorts
+  category: Business tools
+  icon: wyndham-hotels
+  tags:
+  - connector
+  capabilities:
+  - Discover the right Wyndham Hotel for you, faster
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.wyndhamhotels.com/claude/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Wyndham Hotels and Resorts.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure wyndham-hotels\n"

--- a/optional-mcps/xero/manifest.yaml
+++ b/optional-mcps/xero/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: xero
+description: Access your Xero financials from any conversation
+source: https://claude.com/connectors/xero
+ui:
+  display_name: Xero
+  category: Business tools
+  icon: xero
+  tags:
+  - connector
+  capabilities:
+  - Access your Xero financials from any conversation
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.xero.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Xero.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure xero\n"

--- a/optional-mcps/yardi-matrix/manifest.yaml
+++ b/optional-mcps/yardi-matrix/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: yardi-matrix
+description: Real estate market intelligence from Yardi Matrix
+source: https://claude.com/connectors/yardi-matrix
+ui:
+  display_name: Yardi Matrix
+  category: Business tools
+  icon: yardi-matrix
+  tags:
+  - connector
+  capabilities:
+  - Real estate market intelligence from Yardi Matrix
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://matrixmcp.virtuoso.ai/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Yardi Matrix.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure yardi-matrix\n"

--- a/optional-mcps/ziprecruiter/manifest.yaml
+++ b/optional-mcps/ziprecruiter/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: ziprecruiter
+description: Job search made easy
+source: https://claude.com/connectors/ziprecruiter
+ui:
+  display_name: ZipRecruiter
+  category: Business tools
+  icon: ziprecruiter
+  tags:
+  - connector
+  capabilities:
+  - Job search made easy
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://api.ziprecruiter.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with ZipRecruiter.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure ziprecruiter\n"

--- a/optional-mcps/zocks/manifest.yaml
+++ b/optional-mcps/zocks/manifest.yaml
@@ -1,0 +1,25 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: zocks
+description: Analyze client conversations, patterns, and insights.
+source: https://claude.com/connectors/zocks
+ui:
+  display_name: Zocks
+  category: Analytics
+  icon: zocks
+  tags:
+  - analytics
+  capabilities:
+  - Analyze client conversations, patterns, and insights.
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.zocks.io/v1/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with Zocks.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure zocks\n"

--- a/optional-mcps/zoominfo/manifest.yaml
+++ b/optional-mcps/zoominfo/manifest.yaml
@@ -1,0 +1,26 @@
+# Nous-approved MCP catalog entry.
+# Generated from Anthropic Claude Connectors directory metadata.
+manifest_version: 1
+name: zoominfo
+description: Enrich contacts & accounts with GTM intelligence
+source: https://claude.com/connectors/zoominfo
+ui:
+  display_name: ZoomInfo
+  category: Productivity
+  icon: zoominfo
+  tags:
+  - crm
+  - productivity
+  capabilities:
+  - Enrich contacts & accounts with GTM intelligence
+  setup_steps:
+  - Connect your account in the browser.
+  - Choose which discovered tools Hermes may use.
+  danger_notes:
+  - Remote connector tools may read or modify data in the connected service depending on the tools you enable.
+transport:
+  type: http
+  url: https://mcp.zoominfo.com/mcp
+auth:
+  type: oauth
+post_install: "On first connection, Hermes will open a browser to authenticate with ZoomInfo.\nAfter auth, restart your Hermes session so the connector tools are loaded.\n\nYou can re-run the tool checklist any time with:\n  hermes mcp configure zoominfo\n"

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -113,6 +113,13 @@ class TestMcpEndpoints:
                 "bootstrap",
                 "default_enabled",
                 "post_install",
+                "display_name",
+                "category",
+                "icon",
+                "tags",
+                "capabilities",
+                "setup_steps",
+                "danger_notes",
             } <= set(e)
             # http entries expose a url; stdio entries expose a command.
             if e["transport"] == "http":

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -121,8 +121,8 @@ class TestMcpEndpoints:
                 "setup_steps",
                 "danger_notes",
             } <= set(e)
-            # http entries expose a url; stdio entries expose a command.
-            if e["transport"] == "http":
+            # http/sse entries expose a url; stdio entries expose a command.
+            if e["transport"] in {"http", "sse"}:
                 assert e["url"]
             elif e["transport"] == "stdio":
                 assert e["command"]

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -143,6 +143,43 @@ class TestManifestParsing:
         assert e.auth.env[1].required is False
         assert e.auth.env[1].secret is False
 
+    def test_connector_ui_metadata_is_optional_and_parsed(self, catalog_dir):
+        body = _basic_manifest(
+            ui={
+                "display_name": "Acme CRM",
+                "category": "sales",
+                "icon": "database",
+                "tags": ["crm", "customers"],
+                "capabilities": ["Search customers", "Create follow-up tasks"],
+                "setup_steps": ["Sign in to Acme", "Choose a workspace"],
+                "danger_notes": ["Can create tasks when write tools are enabled"],
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        e = list_catalog()[0]
+        assert e.ui.display_name == "Acme CRM"
+        assert e.ui.category == "sales"
+        assert e.ui.icon == "database"
+        assert e.ui.tags == ["crm", "customers"]
+        assert e.ui.capabilities == ["Search customers", "Create follow-up tasks"]
+        assert e.ui.setup_steps == ["Sign in to Acme", "Choose a workspace"]
+        assert e.ui.danger_notes == ["Can create tasks when write tools are enabled"]
+
+    def test_connector_ui_metadata_defaults_keep_existing_manifests_valid(self, catalog_dir):
+        _write_manifest(catalog_dir, "demo", _basic_manifest())
+        from hermes_cli.mcp_catalog import list_catalog
+
+        e = list_catalog()[0]
+        assert e.ui.display_name == ""
+        assert e.ui.category == ""
+        assert e.ui.icon == ""
+        assert e.ui.tags == []
+        assert e.ui.capabilities == []
+        assert e.ui.setup_steps == []
+        assert e.ui.danger_notes == []
+
     def test_install_block(self, catalog_dir):
         body = _basic_manifest(
             install={

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -180,6 +180,24 @@ class TestManifestParsing:
         assert e.ui.setup_steps == []
         assert e.ui.danger_notes == []
 
+    def test_sse_transport_writes_sse_config(self, catalog_dir):
+        body = _basic_manifest(
+            transport={"type": "sse", "url": "https://example.com/sse"},
+            auth={"type": "oauth"},
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import install_entry, list_catalog
+        from hermes_cli.config import load_config
+
+        e = list_catalog()[0]
+        assert e.transport.type == "sse"
+        install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["url"] == "https://example.com/sse"
+        assert server["transport"] == "sse"
+        assert server["auth"] == "oauth"
+
     def test_install_block(self, catalog_dir):
         body = _basic_manifest(
             install={
@@ -848,4 +866,4 @@ class TestShippedCatalog:
             entry = _parse_manifest(m)
             assert entry.name
             assert entry.description
-            assert entry.transport.type in ("stdio", "http")
+            assert entry.transport.type in ("stdio", "http", "sse")


### PR DESCRIPTION
## Summary\n- Presents the desktop MCP catalog as user-facing Connectors with display metadata, richer cards, setup summaries, and Connect/Install actions.\n- Adds optional connector UI metadata to MCP manifests and exposes it through the catalog API.\n- Imports installable remote MCP endpoints from the Claude Connectors directory where the page exposes a `claude mcp add` command; includes Streamable HTTP and SSE entries.\n\n## Validation\n- env -u PYTHONPATH uv run python -m pytest tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_dashboard_admin_endpoints.py::TestMcpEndpoints::test_catalog_lists_entries -q\n- cd apps/desktop && npm run test:ui -- src/lib/mcp-catalog.test.ts && npm run typecheck && npx eslint src/lib/mcp-catalog.ts src/lib/mcp-catalog.test.ts\n- cd apps/desktop && npm run build\n\n## Notes\n- The Claude directory currently exposes 400 connector cards. This PR adds the 262 new installable endpoints whose detail pages expose concrete MCP add commands, plus the existing curated entries already in Hermes. Directory cards with no endpoint command or placeholder URLs were not converted into manifests because Hermes requires a concrete transport target.