### PR TITLE
feat(gateway): fuzzy skill suggestions for unknown commands + Discord /skill

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -514,6 +514,78 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     return cmd_key if cmd_key in get_skill_commands() else None
 
 
+def suggest_skill_commands(
+    command: str,
+    limit: int = 3,
+    candidates: list[str] | None = None,
+) -> list[str]:
+    """Suggest close skill-command matches for an unresolved ``/command``.
+
+    Used by the gateway's unknown-command path (and the Discord ``/skill``
+    handler) to answer "did you mean …?" instead of a dead-end error.
+
+    Matching strategy, in priority order (mirrors the CLI's autocomplete
+    philosophy from #33822 — prefix beats substring beats fuzzy):
+
+    1. **Prefix** — ``pd`` → ``pdf`` (what the user started typing).
+    2. **Substring** — ``pdf`` → ``nano-pdf`` (they remember a fragment).
+    3. **Fuzzy** (``difflib``, cutoff 0.6) — ``pfd`` → ``pdf`` (typo).
+
+    Hyphen/underscore forms are treated interchangeably, matching
+    :func:`resolve_skill_command_key`.
+
+    Args:
+        command: The unresolved command (with or without leading slash).
+        limit: Maximum number of suggestions returned.
+        candidates: Optional explicit slug list to match against. When
+            omitted, the installed skill-command catalog from
+            :func:`get_skill_commands` is used. Callers with their own
+            (possibly narrower) catalog — e.g. the Discord ``/skill``
+            autocomplete entries — pass it here so suggestions never
+            name a skill the surface can't actually run.
+
+    Returns:
+        Up to *limit* command slugs WITHOUT the leading slash (e.g.
+        ``["nano-pdf", "brain-pdf"]``), best matches first. Empty list
+        when nothing plausible is found or *command* is empty.
+    """
+    if not command:
+        return []
+    from difflib import get_close_matches
+
+    normalized = command.lower().replace("_", "-").strip("/")
+    if not normalized:
+        return []
+
+    if candidates is None:
+        slugs = [key.lstrip("/") for key in get_skill_commands()]
+    else:
+        slugs = [c.lstrip("/") for c in candidates if c]
+    if not slugs:
+        return []
+
+    suggestions: list[str] = []
+
+    def _add(candidates: list[str]) -> None:
+        for slug in candidates:
+            if slug not in suggestions:
+                suggestions.append(slug)
+            if len(suggestions) >= limit:
+                return
+
+    # 1. Prefix matches (shortest first: the tightest completion wins).
+    _add(sorted((s for s in slugs if s.startswith(normalized)), key=len))
+    # 2. Substring matches, only for fragments long enough to be meaningful
+    #    (1–2 chars would match half the catalog).
+    if len(suggestions) < limit and len(normalized) >= 3:
+        _add(sorted((s for s in slugs if normalized in s), key=len))
+    # 3. Fuzzy typo matches.
+    if len(suggestions) < limit:
+        _add(get_close_matches(normalized, slugs, n=limit, cutoff=0.6))
+
+    return suggestions[:limit]
+
+
 def build_skill_invocation_message(
     cmd_key: str,
     user_instruction: str = "",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9988,8 +9988,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             command,
                             source.platform.value if source.platform else "?",
                         )
+                        # Fuzzy-suggest close skill commands so a typo like
+                        # /nanopdf or /pfd gets a "did you mean" instead of
+                        # a dead end (mirrors CLI autocomplete, #33822).
+                        _did_you_mean = ""
+                        try:
+                            from agent.skill_commands import suggest_skill_commands
+                            _sugg = suggest_skill_commands(command)
+                            if _sugg:
+                                _did_you_mean = (
+                                    "Did you mean: "
+                                    + ", ".join(f"`/{s}`" for s in _sugg)
+                                    + "?\n"
+                                )
+                        except Exception:
+                            pass
                         return (
                             f"Unknown command `/{command}`. "
+                            f"{_did_you_mean}"
                             f"Type /commands to see what's available, "
                             f"or resend without the leading slash to send "
                             f"as a regular message."

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4330,20 +4330,49 @@ class DiscordAdapter(BasePlatformAdapter):
                     return []
                 q = (current or "").strip().lower()
                 choices: list = []
+
+                def _label(name: str, desc: str) -> str:
+                    label = f"{name} — {desc}" if desc else name
+                    # Discord's Choice.name is capped at 100 chars.
+                    if len(label) > 100:
+                        label = label[:97] + "..."
+                    return label
+
                 for name, desc, _key in self._skill_entries:
                     if not q or q in name.lower() or (desc and q in desc.lower()):
-                        if desc:
-                            label = f"{name} — {desc}"
-                        else:
-                            label = name
-                        # Discord's Choice.name is capped at 100 chars.
-                        if len(label) > 100:
-                            label = label[:97] + "..."
                         choices.append(
-                            discord.app_commands.Choice(name=label, value=name)
+                            discord.app_commands.Choice(
+                                name=_label(name, desc), value=name,
+                            )
                         )
                         if len(choices) >= 25:
                             break
+                # Fuzzy fallback: a typo like "pfd" or "humanzer" has no
+                # substring hit, but difflib still finds the intended
+                # skill. Only fires when substring matching came up short,
+                # so exact/substring results keep their priority order.
+                if q and len(choices) < 5:
+                    try:
+                        from difflib import get_close_matches
+                        shown = {c.value for c in choices}
+                        by_name = {
+                            n.lower(): (n, d) for n, d, _k in self._skill_entries
+                        }
+                        for m in get_close_matches(
+                            q, list(by_name), n=5, cutoff=0.6,
+                        ):
+                            name, desc = by_name[m]
+                            if name in shown:
+                                continue
+                            choices.append(
+                                discord.app_commands.Choice(
+                                    name=_label(name, desc), value=name,
+                                )
+                            )
+                            if len(choices) >= 25:
+                                break
+                    except Exception:
+                        pass
                 return choices
 
             @discord.app_commands.describe(
@@ -4362,11 +4391,30 @@ class DiscordAdapter(BasePlatformAdapter):
                     return
                 entry = self._skill_lookup.get(name)
                 if not entry:
-                    await interaction.response.send_message(
-                        f"Unknown skill: `{name}`. Start typing for "
-                        f"autocomplete suggestions.",
-                        ephemeral=True,
-                    )
+                    # Fuzzy-match against the catalog so a hand-typed or
+                    # stale-autocomplete name still resolves helpfully
+                    # (prefix > substring > difflib typo match).
+                    suggestions: list[str] = []
+                    try:
+                        from agent.skill_commands import suggest_skill_commands
+                        known = {n.lower(): n for n, _d, _k in self._skill_entries}
+                        for slug in suggest_skill_commands(
+                            name, candidates=list(known),
+                        ):
+                            match = known.get(slug.lower())
+                            if match and match not in suggestions:
+                                suggestions.append(match)
+                    except Exception:
+                        pass
+                    if suggestions:
+                        hint = " or ".join(f"`{s}`" for s in suggestions[:3])
+                        msg = f"Unknown skill: `{name}`. Did you mean {hint}?"
+                    else:
+                        msg = (
+                            f"Unknown skill: `{name}`. Start typing for "
+                            f"autocomplete suggestions."
+                        )
+                    await interaction.response.send_message(msg, ephemeral=True)
                     return
                 _desc, cmd_key = entry
                 await self._run_simple_slash(

--- a/tests/agent/test_skill_command_suggestions.py
+++ b/tests/agent/test_skill_command_suggestions.py
@@ -1,0 +1,93 @@
+"""Tests for agent.skill_commands.suggest_skill_commands — fuzzy skill
+suggestions used by the gateway unknown-command path and the Discord /skill
+handler.
+
+Contract: prefix matches outrank substring matches outrank difflib fuzzy
+matches; hyphen/underscore input forms are interchangeable; short fragments
+never trigger the substring pass; results are capped at *limit* and contain
+no duplicates.
+"""
+
+from unittest.mock import patch
+
+from agent.skill_commands import suggest_skill_commands
+
+_CATALOG = {
+    "/pdf": {},
+    "/nano-pdf": {},
+    "/brain-pdf": {},
+    "/humanizer": {},
+    "/docx": {},
+    "/xlsx": {},
+    "/ocr-and-documents": {},
+    "/blond-crm-eintrag": {},
+}
+
+
+def _suggest(command, **kwargs):
+    with patch(
+        "agent.skill_commands.get_skill_commands", return_value=_CATALOG
+    ):
+        return suggest_skill_commands(command, **kwargs)
+
+
+class TestPrefixMatches:
+    def test_prefix_match_wins(self):
+        # "pd" is a prefix of "pdf" only — must come back first.
+        assert _suggest("pd")[0] == "pdf"
+
+    def test_exactish_prefix_prefers_shortest(self):
+        # Both "pdf", "nano-pdf" contain pdf, but only "pdf" is a prefix.
+        result = _suggest("pdf")
+        assert result[0] == "pdf"
+
+
+class TestSubstringMatches:
+    def test_substring_fallback(self):
+        # Issue #33822's canonical example: "pdf" should surface nano-pdf.
+        result = _suggest("pdf")
+        assert "nano-pdf" in result
+
+    def test_substring_requires_three_chars(self):
+        # A 2-char fragment must not substring-match half the catalog.
+        result = _suggest("cr")
+        assert "ocr-and-documents" not in result
+        assert "blond-crm-eintrag" not in result
+
+    def test_ocr_example(self):
+        assert "ocr-and-documents" in _suggest("ocr")
+
+
+class TestFuzzyMatches:
+    def test_typo_match(self):
+        # Transposed typo with no prefix/substring hit.
+        assert "humanizer" in _suggest("humanzer")
+
+    def test_garbage_returns_empty(self):
+        assert _suggest("zzqqxxyy") == []
+
+
+class TestNormalization:
+    def test_underscores_treated_as_hyphens(self):
+        assert "nano-pdf" in _suggest("nano_pdf")
+
+    def test_leading_slash_stripped(self):
+        assert "pdf" in _suggest("/pdf")
+
+    def test_empty_input(self):
+        assert _suggest("") == []
+
+
+class TestLimits:
+    def test_limit_respected(self):
+        assert len(_suggest("pdf", limit=2)) == 2
+
+    def test_no_duplicates(self):
+        result = _suggest("pdf")
+        assert len(result) == len(set(result))
+
+    def test_empty_catalog(self):
+        with patch(
+            "agent.skill_commands.get_skill_commands", return_value={}
+        ):
+            assert suggest_skill_commands("pdf") == []

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -1047,3 +1047,64 @@ def test_register_skill_command_autocomplete_filters_by_name_and_description(ada
     # via direct function call in the real-discord integration path.
     assert skill_cmd.callback is not None
 
+
+
+def test_skill_command_unknown_name_suggests_close_match(adapter):
+    """A typo'd skill name should get a 'Did you mean' hint naming the
+    closest installed skill(s), sourced from the adapter's own catalog."""
+    with patch(
+        "hermes_cli.commands.discord_skill_commands_by_category",
+        return_value=(
+            {"media": [("gif-search", "GIFs", "/gif-search")]},
+            [("humanizer", "De-AI text", "/humanizer")],
+            0,
+        ),
+    ):
+        adapter._register_slash_commands()
+
+    skill_cmd = adapter._client.tree.commands["skill"]
+
+    sent: list[dict] = []
+
+    async def fake_send(text, ephemeral=False):
+        sent.append({"text": text, "ephemeral": ephemeral})
+
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(send_message=fake_send),
+    )
+
+    import asyncio
+    asyncio.run(skill_cmd.callback(interaction, name="humanzer"))
+
+    assert len(sent) == 1
+    assert "Unknown skill" in sent[0]["text"]
+    assert "Did you mean" in sent[0]["text"]
+    assert "humanizer" in sent[0]["text"]
+    assert sent[0]["ephemeral"] is True
+
+
+def test_skill_command_unknown_name_no_match_keeps_plain_error(adapter):
+    """Garbage input keeps the plain error — no bogus 'Did you mean'."""
+    with patch(
+        "hermes_cli.commands.discord_skill_commands_by_category",
+        return_value=({"media": [("gif-search", "GIFs", "/gif-search")]}, [], 0),
+    ):
+        adapter._register_slash_commands()
+
+    skill_cmd = adapter._client.tree.commands["skill"]
+
+    sent: list[dict] = []
+
+    async def fake_send(text, ephemeral=False):
+        sent.append({"text": text, "ephemeral": ephemeral})
+
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(send_message=fake_send),
+    )
+
+    import asyncio
+    asyncio.run(skill_cmd.callback(interaction, name="zzqqxxyyvv"))
+
+    assert len(sent) == 1
+    assert "Unknown skill" in sent[0]["text"]
+    assert "Did you mean" not in sent[0]["text"]

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -371,3 +371,69 @@ async def test_command_hook_rewrite_routes_to_plugin(monkeypatch):
     # First emit_collect fires on the original command; after rewrite the
     # dispatcher does NOT re-fire for the new command (one decision per turn).
     assert call_log == ["command:status"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_slash_command_suggests_close_skill(monkeypatch):
+    """A near-miss of an installed skill command must include a
+    "Did you mean" hint with the correct skill slug."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError(
+            "unknown slash command leaked through to the agent"
+        )
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    import agent.skill_commands as skill_commands_mod
+
+    monkeypatch.setattr(
+        skill_commands_mod,
+        "get_skill_commands",
+        lambda: {"/humanizer": {"name": "humanizer"}},
+    )
+
+    # Typo of an installed skill: no exact resolve, fuzzy should hit.
+    result = await runner._handle_message(_make_event("/humanzer"))
+
+    assert result is not None
+    assert "Unknown command" in result
+    assert "Did you mean" in result
+    assert "/humanizer" in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unknown_slash_command_without_close_match_has_no_hint(monkeypatch):
+    """Total garbage must keep the plain unknown-command message —
+    no empty/nonsense "Did you mean" line."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError(
+            "unknown slash command leaked through to the agent"
+        )
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    import agent.skill_commands as skill_commands_mod
+
+    monkeypatch.setattr(
+        skill_commands_mod,
+        "get_skill_commands",
+        lambda: {"/humanizer": {"name": "humanizer"}},
+    )
+
+    result = await runner._handle_message(_make_event("/zzqqxxyyvv"))
+
+    assert result is not None
+    assert "Unknown command" in result
+    assert "Did you mean" not in result
+    runner._run_agent.assert_not_called()


### PR DESCRIPTION
## Problem

Typos and near-misses of skill commands dead-end today on the gateway and on Discord:

- **Gateway (all platforms):** `/humanzer` → generic "Unknown command" with no pointer to the installed `humanizer` skill.
- **Discord `/skill` handler:** a hand-typed or stale-autocomplete name → "Unknown skill" with no pointer.
- **Discord `/skill` autocomplete:** substring-only matching, so a typo like `pfd` or `humanzer` shows zero choices while typing.

This extends the CLI-side idea from #33822 (prefix > substring for `/skill` autocomplete) to the gateway/Discord surface, with a fuzzy tier on top.

## Change

New helper `agent.skill_commands.suggest_skill_commands()`:

1. **Prefix** — `pd` → `pdf` (tightest completion first, shortest wins)
2. **Substring** (fragments ≥3 chars only, so 1–2 chars don't match half the catalog) — `pdf` → `nano-pdf`
3. **Fuzzy** (`difflib.get_close_matches`, cutoff 0.6) — `pfd` → `pdf`, `humanzer` → `humanizer`

Hyphen/underscore forms interchangeable (mirrors `resolve_skill_command_key`), results capped + deduped. Optional `candidates` parameter lets a caller match against its own (narrower) catalog.

Wired into three spots:

- **Gateway unknown-command notice** (`gateway/run.py`): appends `Did you mean: \`/humanizer\`?` when there's a plausible match. Best-effort and exception-safe — the existing guard behavior is unchanged when nothing matches or anything throws.
- **Discord `/skill` handler** (`plugins/platforms/discord/adapter.py`): "Unknown skill" reply now suggests close matches, sourced from the adapter's own `_skill_entries` catalog via `candidates` so it never names a skill that surface can't run.
- **Discord `/skill` autocomplete**: difflib fallback that only fires when substring matching returns <5 choices — exact/substring results keep priority, 25-choice cap preserved, fail-closed `[]` on error (authorization pre-check untouched).

No new tools, no new config, no cache impact — the suggestion only computes on the already-failing unknown-command path and inside Discord's dynamic autocomplete fetch.

## Tests

- `tests/agent/test_skill_command_suggestions.py` — suggester contract: priority order, 3-char substring gate, typo matching, normalization, limits, dedup, empty catalog.
- `tests/gateway/test_unknown_command.py` — did-you-mean on a near-miss; no bogus hint on garbage; agent never invoked.
- `tests/gateway/test_discord_slash_commands.py` — handler suggests close match from the adapter catalog; garbage keeps the plain ephemeral error.

`126 passed` across the touched suites (`test_skill_command_suggestions`, `test_skill_commands`, `test_unknown_command`, `test_discord_slash_commands`, `test_unavailable_skill_hint`, `test_reload_skills_discord_resync`).