### PR TITLE
fix(config): warn on unsafe Hermes home mode

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 # so concurrent CLI/gateway loads of a broken config.yaml don't spam stderr
 # every time. Cleared automatically when the file changes (different mtime).
 _CONFIG_PARSE_WARNED: set = set()
+_HERMES_HOME_MODE_WARNED: set = set()
 
 
 def _backup_corrupt_config(config_path: Path) -> Optional[Path]:
@@ -745,6 +746,29 @@ def _chown_to_hermes_uid(path) -> None:
         pass
 
 
+def _warn_unsafe_hermes_home_mode(mode: int, mode_str: str) -> None:
+    """Warn once when HERMES_HOME_MODE exposes directory contents to others."""
+    if mode & 0o066 == 0:
+        return
+    if mode in _HERMES_HOME_MODE_WARNED:
+        return
+    _HERMES_HOME_MODE_WARNED.add(mode)
+
+    rendered_mode = f"{mode:04o}"
+    msg = (
+        f"HERMES_HOME_MODE={mode_str or rendered_mode} grants group/other read "
+        f"or write access ({rendered_mode}). HERMES_HOME may contain secrets; "
+        "use execute-only traversal bits such as 0711/0701 when a web server "
+        "only needs to traverse the directory."
+    )
+    logger.warning(msg)
+    try:
+        sys.stderr.write(f"⚠️  hermes config: {msg}\n")
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+
 def _secure_dir(path):
     """Set directory to owner-only access (0700 by default). No-op on Windows.
 
@@ -770,6 +794,9 @@ def _secure_dir(path):
         mode = int(mode_str, 8) if mode_str else 0o700
     except ValueError:
         mode = 0o700
+        mode_str = ""
+    if mode_str:
+        _warn_unsafe_hermes_home_mode(mode, mode_str)
     try:
         os.chmod(path, mode)
     except (OSError, NotImplementedError):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -106,6 +106,50 @@ class TestEnsureHermesHome:
                 ensure_hermes_home()
         assert not profile_home.exists()
 
+    def test_warns_once_for_readable_hermes_home_mode(self, tmp_path, caplog, capsys):
+        import logging
+        from hermes_cli import config as cfg_mod
+
+        cfg_mod._HERMES_HOME_MODE_WARNED.clear()
+
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(tmp_path), "HERMES_HOME_MODE": "0755"},
+        ):
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+                ensure_hermes_home()
+                ensure_hermes_home()
+
+        messages = [
+            rec.message
+            for rec in caplog.records
+            if "HERMES_HOME_MODE=0755" in rec.message
+        ]
+        assert len(messages) == 1
+        assert "group/other read or write access" in messages[0]
+        assert "0711/0701" in messages[0]
+
+        captured = capsys.readouterr()
+        assert captured.err.count("HERMES_HOME_MODE=0755") == 1
+
+    def test_execute_only_hermes_home_mode_does_not_warn(
+        self, tmp_path, caplog, capsys
+    ):
+        import logging
+        from hermes_cli import config as cfg_mod
+
+        cfg_mod._HERMES_HOME_MODE_WARNED.clear()
+
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(tmp_path), "HERMES_HOME_MODE": "0711"},
+        ):
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+                ensure_hermes_home()
+
+        assert not any("HERMES_HOME_MODE=0711" in rec.message for rec in caplog.records)
+        assert "HERMES_HOME_MODE=0711" not in capsys.readouterr().err
+
 
 class TestLoadConfigDefaults:
     def test_returns_defaults_when_no_file(self, tmp_path):


### PR DESCRIPTION
## Summary
- warn once when HERMES_HOME_MODE grants group/other read or write access
- keep execute-only traversal modes such as 0711/0701 quiet
- add regression coverage for warning de-duplication and execute-only mode

Fixes #59695

## Validation
- ./scripts/run_tests.sh tests/hermes_cli/test_config.py -q
- git diff --check

## Platforms
- macOS