### PR TITLE
fix(desktop): anchor streaming replies on run start

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -25,6 +25,7 @@ import {
 import { isSecondaryWindow } from '@/store/windows'
 
 import { MessageRenderBoundary } from '../message-render-boundary'
+import { createRunStartAnchor } from './scroll-anchor'
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
@@ -177,8 +178,25 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   useEffect(() => onThreadEditOpen(beginEditHold), [beginEditHold])
   useEffect(() => onThreadEditClose(endEditHold), [endEditHold])
   useEffect(() => () => endEditHold(), [endEditHold])
-  // New run → snap to the latest turn.
-  useAuiEvent('thread.runStart', () => void scrollToBottom())
+  const runStartAnchorRef = useRef<ReturnType<typeof createRunStartAnchor> | null>(null)
+
+  useEffect(() => {
+    const anchor = createRunStartAnchor({ scrollToBottom, stopScroll })
+    runStartAnchorRef.current = anchor
+
+    return () => {
+      anchor.cancel()
+
+      if (runStartAnchorRef.current === anchor) {
+        runStartAnchorRef.current = null
+      }
+    }
+  }, [scrollToBottom, stopScroll])
+
+  // New run -> reveal the new assistant turn once, then release resize-follow
+  // so streamed token growth cannot keep pulling the viewport away from what
+  // the user is reading. The jump button remains the explicit tail-follow path.
+  useAuiEvent('thread.runStart', () => runStartAnchorRef.current?.anchor())
 
   // Reset the cap and pin to bottom on mount + every session switch (messages
   // swap in place on a long-lived runtime, so sessionKey is the only signal).

--- a/apps/desktop/src/components/assistant-ui/thread/scroll-anchor.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/scroll-anchor.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createRunStartAnchor } from './scroll-anchor'
+
+function createDeferred<T>() {
+  let resolve: ((value: T) => void) | undefined
+
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise
+  })
+
+  return {
+    promise,
+    resolve: (value: T) => resolve?.(value)
+  }
+}
+
+describe('createRunStartAnchor', () => {
+  it('anchors the new assistant turn once, then releases sticky resize-follow', async () => {
+    const callbacks: Array<() => void> = []
+    const scrollToBottom = vi.fn()
+    const stopScroll = vi.fn()
+
+    const anchor = createRunStartAnchor({
+      cancelFrame: vi.fn(),
+      requestFrame: callback => {
+        callbacks.push(callback)
+
+        return callbacks.length
+      },
+      scrollToBottom,
+      stopScroll
+    })
+
+    anchor.anchor()
+
+    expect(scrollToBottom).not.toHaveBeenCalled()
+    expect(stopScroll).not.toHaveBeenCalled()
+
+    callbacks[0]()
+
+    expect(scrollToBottom).toHaveBeenCalledTimes(1)
+    expect(scrollToBottom).toHaveBeenCalledWith('instant')
+    expect(stopScroll).not.toHaveBeenCalled()
+
+    await Promise.resolve()
+
+    expect(stopScroll).toHaveBeenCalledTimes(1)
+    expect(stopScroll.mock.invocationCallOrder[0]).toBeGreaterThan(
+      scrollToBottom.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('coalesces repeated run-start events to the latest frame', () => {
+    const callbacks: Array<() => void> = []
+    const cancelFrame = vi.fn()
+
+    const anchor = createRunStartAnchor({
+      cancelFrame,
+      requestFrame: callback => {
+        callbacks.push(callback)
+
+        return callbacks.length
+      },
+      scrollToBottom: vi.fn(),
+      stopScroll: vi.fn()
+    })
+
+    anchor.anchor()
+    anchor.anchor()
+
+    expect(cancelFrame).toHaveBeenCalledTimes(1)
+    expect(cancelFrame).toHaveBeenCalledWith(1)
+  })
+
+  it('releases after the latest deferred scroll completes', async () => {
+    const callbacks: Array<() => void> = []
+    const firstScroll = createDeferred<boolean>()
+    const latestScroll = createDeferred<boolean>()
+
+    const scrollToBottom = vi.fn()
+      .mockReturnValueOnce(firstScroll.promise)
+      .mockReturnValueOnce(latestScroll.promise)
+
+    const stopScroll = vi.fn()
+
+    const anchor = createRunStartAnchor({
+      requestFrame: callback => {
+        callbacks.push(callback)
+
+        return callbacks.length
+      },
+      scrollToBottom,
+      stopScroll
+    })
+
+    anchor.anchor()
+    callbacks[0]()
+
+    expect(stopScroll).not.toHaveBeenCalled()
+
+    anchor.anchor()
+    callbacks[1]()
+    firstScroll.resolve(true)
+    await firstScroll.promise
+
+    expect(stopScroll).not.toHaveBeenCalled()
+
+    latestScroll.resolve(true)
+    await latestScroll.promise
+
+    expect(stopScroll).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels a pending frame on cleanup', () => {
+    const cancelFrame = vi.fn()
+
+    const anchor = createRunStartAnchor({
+      cancelFrame,
+      requestFrame: () => 7,
+      scrollToBottom: vi.fn(),
+      stopScroll: vi.fn()
+    })
+
+    anchor.anchor()
+    anchor.cancel()
+    anchor.cancel()
+
+    expect(cancelFrame).toHaveBeenCalledTimes(1)
+    expect(cancelFrame).toHaveBeenCalledWith(7)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/scroll-anchor.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/scroll-anchor.ts
@@ -1,0 +1,72 @@
+type FrameCallback = () => void
+type FrameHandle = ReturnType<typeof setTimeout> | number
+
+interface FrameScheduler {
+  cancelFrame: (handle: FrameHandle) => void
+  requestFrame: (callback: FrameCallback) => FrameHandle
+}
+
+interface RunStartAnchorOptions extends Partial<FrameScheduler> {
+  scrollToBottom: (behavior?: 'instant') => boolean | Promise<boolean>
+  stopScroll: () => void
+}
+
+const defaultRequestFrame = (callback: FrameCallback): FrameHandle => {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    return globalThis.requestAnimationFrame(() => callback())
+  }
+
+  return setTimeout(callback, 0)
+}
+
+const defaultCancelFrame = (handle: FrameHandle) => {
+  if (typeof globalThis.cancelAnimationFrame === 'function' && typeof handle === 'number') {
+    globalThis.cancelAnimationFrame(handle)
+
+    return
+  }
+
+  clearTimeout(handle)
+}
+
+export function createRunStartAnchor({
+  cancelFrame = defaultCancelFrame,
+  requestFrame = defaultRequestFrame,
+  scrollToBottom,
+  stopScroll
+}: RunStartAnchorOptions) {
+  let pendingFrame: FrameHandle | null = null
+  let generation = 0
+
+  const cancel = () => {
+    generation += 1
+
+    if (pendingFrame !== null) {
+      cancelFrame(pendingFrame)
+      pendingFrame = null
+    }
+  }
+
+  const anchor = () => {
+    cancel()
+    const anchorGeneration = generation
+
+    pendingFrame = requestFrame(() => {
+      if (generation !== anchorGeneration) {
+        return
+      }
+
+      pendingFrame = null
+
+      const release = () => {
+        if (generation === anchorGeneration) {
+          stopScroll()
+        }
+      }
+
+      void Promise.resolve(scrollToBottom('instant')).then(release, release)
+    })
+  }
+
+  return { anchor, cancel }
+}


### PR DESCRIPTION
## What does this PR do?

Anchors Hermes Desktop streaming replies at the start of the new assistant turn instead of keeping sticky resize-follow armed for the whole token stream.

## Shared root cause

- `ThreadMessageList` is the Desktop transcript scroll owner through `use-stick-to-bottom`.
- On `thread.runStart`, it previously called `scrollToBottom()` and left resize-follow locked, so each streamed layout growth could keep moving the viewport even after the user tried to read earlier text.
- The coordinated fix schedules one instant reveal after the optimistic assistant row can render, then calls `stopScroll()` so token growth no longer pulls the viewport away from the reader. The existing jump-to-bottom button remains the explicit opt-in path to follow the live tail.

## How this fixes each issue

- #37549: prevents streaming transcript flicker and repeated position capture by releasing the sticky resize-follow loop after the new turn is revealed.
- #53231: keeps the beginning of a long streamed assistant reply readable because the viewport is no longer forced downward as more tokens arrive.

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added a small run-start scroll anchor helper for Desktop thread scrolling.
- Updated `ThreadMessageList` so `thread.runStart` reveals the new assistant turn once and then releases sticky resize-follow.
- Added unit coverage for one-shot anchoring, frame coalescing, and cleanup cancellation.

## How to Test

1. Start Hermes Desktop and submit a prompt that streams a long assistant response.
2. When the assistant starts responding, begin reading from the top of the new reply.
3. Confirm streamed token growth does not keep dragging the viewport downward; use the existing jump-to-bottom button when you want to follow the tail.

Local verification attempted:

- `git diff --check` passed.
- `python3 scripts/check-windows-footguns.py apps/desktop/src/components/assistant-ui/thread/list.tsx apps/desktop/src/components/assistant-ui/thread/scroll-anchor.ts apps/desktop/src/components/assistant-ui/thread/scroll-anchor.test.ts` reported no findings, though the script only scans Python footgun patterns and therefore scanned 0 TS files.
- Required suite `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` aborted during collection before reaching this change because `fastapi`/`uvicorn` are missing and the lazy install is blocked by the externally managed Python environment.
- Desktop checks could not run in this worktree because JS dependencies are not installed: `vitest`, `tsc`, and `eslint` are missing from PATH and there is no `node_modules` tree.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass - blocked locally by missing optional dashboard dependencies and PEP 668 lazy-install failure
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS darwin-arm64, static/local command checks only due missing Node dependencies

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas update N/A

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #37549
Refs #53231

<!-- autocontrib:worker-id=pr-spanning-caa13a00 kind=pr-open -->