### PR TITLE
fix: suppress quiet gmail cron responses

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -253,6 +253,15 @@ SILENT_MARKER = "[SILENT]"
 # "I considered staying [SILENT] but here is the summary…" must deliver).
 _CRON_SILENCE_TOKENS = frozenset({"[SILENT]", "SILENT", "NO_REPLY", "NO REPLY"})
 
+# Back-compat for existing Gmail Inbox Zero cron prompts that predate the
+# [SILENT] contract and returned a human no-op line.  Treat these as silence
+# only when they are the whole final response; a report that merely mentions
+# the phrase still delivers.
+_CRON_WHOLE_RESPONSE_SILENCE_PHRASES = frozenset({
+    "GMAIL: НОВЫХ ДЕЙСТВИЙ НЕТ",
+    "GMAIL: NO NEW ACTIONS",
+})
+
 
 def _is_cron_silence_response(text: str) -> bool:
     """Return True when a cron final response should suppress delivery.
@@ -274,6 +283,9 @@ def _is_cron_silence_response(text: str) -> bool:
 
     # Whole response is exactly a token.
     if _is_token(stripped):
+        return True
+    normalized_whole = " ".join(stripped.upper().rstrip(".!。 ").split())
+    if normalized_whole in _CRON_WHOLE_RESPONSE_SILENCE_PHRASES:
         return True
     # Marker on its own first or last line (trailing/leading note on a
     # separate line — e.g. "2 deals filtered\n\n[SILENT]").

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2521,10 +2521,13 @@ class TestSilentDelivery:
         assert sil("NO_REPLY")
         assert sil("NO REPLY")
         assert sil("Summary.\nSILENT")
+        assert sil("Gmail: новых действий нет.")
+        assert sil(" gmail: no new actions ")
         # Deliver: real content, mid-sentence quotes, bare words, junk.
         assert not sil("Daily report: 4 PRs merged.")
         assert not sil("I stayed [SILENT] but here is the report: 3 items.")
         assert not sil("Silent retry succeeded after 2 attempts.")
+        assert not sil("Processed 2 emails. Gmail: новых действий нет.")
         assert not sil("[SILENT")  # malformed open-bracket is not the sentinel
         assert not sil("")
         assert not sil("   \n\t ")


### PR DESCRIPTION
## Summary
- Suppress legacy Gmail no-action cron responses as silent output
- Add coverage for Gmail no-action silence phrases

## Test Plan
- uv pip install pytest
- uv run pytest tests/cron/test_scheduler.py -k "silence_response_contract or silent_response_suppresses_delivery or silent_with_note_suppresses_delivery or silent_trailing_suppresses_delivery or bracketless_silent_variants_suppress"
