### PR TITLE
fix(desktop): keep assistant URLs visible

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -16,7 +16,7 @@ describe('preprocessMarkdown', () => {
 
     expect(output).not.toContain('```')
     expect(output).toContain("Here's your scene:")
-    expect(output).not.toContain('http://localhost:8812/')
+    expect(output).toContain('<http://localhost:8812/>')
     expect(output).toContain('- **Multicolored cube**')
   })
 
@@ -33,11 +33,11 @@ describe('preprocessMarkdown', () => {
     const output = preprocessMarkdown(input)
 
     expect(output).not.toContain('```')
-    expect(output).not.toContain('http://localhost:8812/')
+    expect(output).toContain('<http://localhost:8812/>')
     expect(output).toContain('- **Scroll wheel** - zoom')
   })
 
-  it('drops fences around a preview-only URL block', () => {
+  it('drops fences around a localhost-only URL block while keeping the URL visible', () => {
     const fence = '```'
     const input = ['Server is back.', '', fence, 'http://localhost:8812/', fence].join('\n')
 
@@ -45,7 +45,7 @@ describe('preprocessMarkdown', () => {
 
     expect(output).toContain('Server is back.')
     expect(output).not.toContain('```')
-    expect(output).not.toContain('http://localhost:8812/')
+    expect(output).toContain('<http://localhost:8812/>')
   })
 
   it('demotes prose sentence masquerading as fence info', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -549,6 +549,21 @@ describe('assistant-ui streaming renderer', () => {
     expect(screen.getByRole('alert').textContent).toContain('OpenRouter rejected the request (403).')
   })
 
+  it('renders assistant message URLs as visible links', async () => {
+    const { container } = render(
+      <MessageHarness
+        message={assistantMessage('Open http://localhost:5173/ or https://example.com/docs for details.', false)}
+      />
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('a[href="http://localhost:5173/"]')).toBeTruthy()
+      expect(container.querySelector('a[href="https://example.com/docs"]')).toBeTruthy()
+    })
+    expect(container.textContent).toContain('localhost')
+    expect(container.textContent).toContain('Docs')
+  })
+
   it('omits the dismiss control when no onDismissError handler is supplied', () => {
     render(<MessageHarness message={assistantErrorMessage('OpenRouter rejected the request (403).')} />)
 

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -22,8 +22,6 @@ const CUSTOM_DISPLAY_MATH_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \
 // and keeps the emphasis run intact. Other trailing punctuation is still peeled
 // off by the final `[^\s<>"'`*.,;:!?]` class.
 const RAW_URL_RE = /https?:\/\/[^\s<>"'`*]+[^\s<>"'`*.,;:!?]/g
-const LOCAL_PREVIEW_URL_RE = /(^|\s)https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?[^\s<>"'`]*/gi
-const LOCAL_PREVIEW_ONLY_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?$/i
 const URL_ONLY_LINE_RE = /^\s*https?:\/\/\S+\s*$/i
 const CITATION_MARKER_RE = /(?<=[\p{L}\p{N})\].,!?:;"'”’])\[(?:\d+(?:\s*,\s*\d+)*)\](?!\()/gu
 
@@ -150,11 +148,7 @@ function normalizeVisibleProse(text: string): string {
     .map(part =>
       part.startsWith('`')
         ? part
-        : linkifySessionRefs(
-            autoLinkRawUrls(
-              part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
-            )
-          )
+        : linkifySessionRefs(autoLinkRawUrls(part.replace(/`{3,}/g, '').replace(CITATION_MARKER_RE, '')))
     )
     .join('')
 }
@@ -402,12 +396,6 @@ function normalizeFenceBlocks(text: string): string {
     const body = bodyLines.join('\n')
 
     if (closeIndex !== -1 && !body.trim()) {
-      index = closeIndex + 1
-
-      continue
-    }
-
-    if (closeIndex !== -1 && LOCAL_PREVIEW_ONLY_RE.test(body.trim())) {
       index = closeIndex + 1
 
       continue


### PR DESCRIPTION
## Summary
- stop stripping localhost URLs from assistant markdown prose
- keep localhost-only fenced URL blocks visible so they autolink like external URLs
- add a desktop thread regression that verifies localhost and external URLs render as anchors

Fixes #59649

## Validation
- npm run test:ui -- src/components/assistant-ui/markdown-text.test.ts src/components/assistant-ui/thread/streaming.test.tsx
- npm exec eslint -- src/lib/markdown-preprocess.ts src/components/assistant-ui/markdown-text.test.ts src/components/assistant-ui/thread/streaming.test.tsx
- npm exec prettier -- --check src/lib/markdown-preprocess.ts src/components/assistant-ui/markdown-text.test.ts src/components/assistant-ui/thread/streaming.test.tsx
- git diff --check

## Platforms
- macOS local validation; issue reported on Windows desktop