### PR TITLE
fix(gateway): include ~/bin in generated service PATH

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2576,6 +2576,7 @@ def get_python_path() -> str:
 def _build_user_local_paths(home: Path, path_entries: list[str]) -> list[str]:
     """Return user-local bin dirs that exist and aren't already in *path_entries*."""
     candidates = [
+        str(home / "bin"),  # user-local bins (e.g. 1Password op CLI)
         str(home / ".local" / "bin"),  # uv, uvx, pip-installed CLIs
         str(home / ".cargo" / "bin"),  # Rust/cargo tools
         str(home / "go" / "bin"),  # Go tools

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -20,3 +20,33 @@ def test_service_path_includes_node_modules_when_present(tmp_path):
     assert str(nm_bin) in dirs
 
 
+def test_service_path_includes_hermes_home_node_modules(tmp_path):
+    """Service PATH should include ~/.hermes/node_modules/.bin when it exists."""
+    hermes_nm = tmp_path / ".hermes" / "node_modules" / ".bin"
+    hermes_nm.mkdir(parents=True)
+    from hermes_cli.gateway import _build_service_path_dirs
+    with patch("hermes_cli.gateway.get_hermes_home", return_value=tmp_path / ".hermes"):
+        dirs = _build_service_path_dirs(project_root=tmp_path)
+    assert str(hermes_nm) in dirs
+
+
+def test_user_local_paths_includes_home_bin_when_present(tmp_path):
+    """~/bin should be on the service PATH when it exists.
+
+    ~/bin is on the default Debian/Ubuntu login PATH and is where CLIs like
+    the 1Password `op` binary commonly live. Omitting it from the generated
+    systemd unit means `op://` secret references (e.g. TELEGRAM_BOT_TOKEN)
+    fail to resolve under the service even though they work in a login shell.
+    """
+    home_bin = tmp_path / "bin"
+    home_bin.mkdir()
+    from hermes_cli.gateway import _build_user_local_paths
+    result = _build_user_local_paths(tmp_path, [])
+    assert str(home_bin) in result
+
+
+def test_user_local_paths_skips_home_bin_when_absent(tmp_path):
+    """~/bin should not be added when it doesn't exist."""
+    from hermes_cli.gateway import _build_user_local_paths
+    result = _build_user_local_paths(tmp_path, [])
+    assert str(tmp_path / "bin") not in result


### PR DESCRIPTION
## Summary

The generated systemd/launchd service unit builds its `PATH` from a fixed list of user-local bin dirs — `~/.local/bin`, `~/.cargo/bin`, `~/go/bin`, `~/.npm-global/bin` — but **omits `~/bin`**, which is on the default Debian/Ubuntu login `PATH` (added by `~/.profile` when it exists).

A CLI installed to `~/bin` is therefore visible in an interactive login shell but **not** to the background gateway service.

## The concrete failure

The 1Password `op` CLI commonly lives at `~/bin/op`. When gateway secrets are configured as `op://` references (e.g. `TELEGRAM_BOT_TOKEN: op://...`), the gateway shells out to `op` to resolve them at startup. With `op` missing from the service `PATH`:

- `op` isn't found -> the `op://` reference resolves to empty
- the affected platform (Telegram, in our case) can't authenticate and silently stays `disconnected`
- other platforms that were already connected keep working, so it looks platform-specific rather than a secret-resolution problem

It works interactively (login shell has `~/bin`) but breaks under systemd — a confusing "works in my shell, not in the service" gap.

## Fix

Add `~/bin` as the first user-local candidate in `_build_user_local_paths()`. It remains guarded by the existing `Path.exists()` filter, so it's only added when the directory is actually present — no behavior change for users without a `~/bin`.

## Test plan

- [x] `test_user_local_paths_includes_home_bin_when_present` — `~/bin` included when it exists
- [x] `test_user_local_paths_skips_home_bin_when_absent` — `~/bin` skipped when absent
- [x] Existing `test_gateway_service_paths.py` tests still pass (5 passed)
