### PR TITLE
fix(gateway): match /goal draft as a whole word so "drafting…" goals aren't truncated

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2236,7 +2236,7 @@ class GatewaySlashCommandsMixin:
         # /goal draft <objective> → draft a structured completion contract,
         # then set it. The aux LLM call is sync; run it off the event loop.
         draft_contract_obj = None
-        if lower.startswith("draft"):
+        if lower == "draft" or lower.startswith("draft "):
             objective = args[len("draft"):].strip()
             if not objective:
                 return "Usage: /goal draft <objective in plain language>"
@@ -2288,7 +2288,7 @@ class GatewaySlashCommandsMixin:
         base = t("gateway.goal.set", budget=state.max_turns, goal=state.goal)
         if state.has_contract():
             return f"{base}\nCompletion contract:\n{state.contract.render_block()}"
-        if lower.startswith("draft"):
+        if lower == "draft" or lower.startswith("draft "):
             # Drafting was requested but the aux model couldn't produce one.
             return f"{base}\n(Couldn't draft a contract — running as a free-form goal.)"
         return base

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2024,7 +2024,7 @@ class CLICommandsMixin:
         # boundaries / stop_when) and set it as the active goal. Adapted
         # from Codex's "let the agent draft the goal" guidance: the contract
         # makes "done" evidence-based instead of a loose vibe check.
-        if lower.startswith("draft"):
+        if lower == "draft" or lower.startswith("draft "):
             objective = arg[len("draft"):].strip()
             if not objective:
                 _cprint("  Usage: /goal draft <objective in plain language>")

--- a/tests/gateway/test_goal_draft_prefix.py
+++ b/tests/gateway/test_goal_draft_prefix.py
@@ -1,0 +1,140 @@
+"""Regression tests for `/goal draft` word-boundary matching.
+
+`/goal draft <objective>` expands plain text into a structured completion
+contract via an aux-LLM call. Its detection guard must match ``draft`` as a
+whole word — a bare ``lower.startswith("draft")`` misroutes any goal whose
+first word merely *begins* with "draft" (``drafting``, ``drafts``,
+``draftsman``) into the contract-draft path AND slices the first 5 chars off
+the objective via ``args[len("draft"):]``.
+"""
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_cli import goals
+
+
+class _FakeSessionEntry:
+    def __init__(self, session_id):
+        self.session_id = session_id
+
+
+class _FakeSessionStore:
+    def __init__(self, session_id):
+        self.entry = _FakeSessionEntry(session_id)
+
+    def get_or_create_session(self, source):
+        return self.entry
+
+    def _generate_session_key(self, source):
+        return "agent:main:discord:channel:goal-draft-prefix"
+
+
+def _make_runner(session_id):
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+    )
+    runner.session_store = _FakeSessionStore(session_id)
+    runner.adapters = {}
+    runner._queued_events = {}
+    return runner
+
+
+def _make_event(text):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chat-goal-draft-prefix",
+            chat_type="channel",
+            user_id="user-goal-draft-prefix",
+        ),
+        message_id="msg-goal-draft-prefix",
+    )
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_goal_starting_with_draft_word_is_not_truncated(hermes_home, monkeypatch):
+    """`/goal drafting …` is a free-form goal, not a draft-contract request.
+
+    It must be preserved verbatim (no ``draft`` prefix stripped) and must NOT
+    invoke the aux-LLM ``draft_contract`` path.
+    """
+    called = {"draft": False}
+
+    def _spy_draft_contract(objective, *args, **kwargs):
+        called["draft"] = True
+        return None
+
+    monkeypatch.setattr(goals, "draft_contract", _spy_draft_contract)
+
+    sid = "sid-goal-draft-prefix-truncate"
+    runner = _make_runner(sid)
+    event = _make_event("/goal drafting a response to the customer")
+
+    response = await GatewayRunner._handle_goal_command(runner, event)
+
+    assert called["draft"] is False, "free-form 'drafting…' goal must not hit draft_contract"
+
+    state = goals.GoalManager(sid).state
+    assert state is not None
+    assert state.goal == "drafting a response to the customer"
+    assert "drafting a response to the customer" in response
+
+
+@pytest.mark.asyncio
+async def test_goal_draft_still_routes_to_contract(hermes_home, monkeypatch):
+    """A genuine `/goal draft <objective>` still routes to the draft path
+    with the objective (minus the ``draft`` keyword) as the goal text."""
+    captured = {}
+
+    def _spy_draft_contract(objective, *args, **kwargs):
+        captured["objective"] = objective
+        return None
+
+    monkeypatch.setattr(goals, "draft_contract", _spy_draft_contract)
+
+    sid = "sid-goal-draft-prefix-contract"
+    runner = _make_runner(sid)
+    event = _make_event("/goal draft the quarterly report")
+
+    response = await GatewayRunner._handle_goal_command(runner, event)
+
+    assert captured.get("objective") == "the quarterly report"
+
+    state = goals.GoalManager(sid).state
+    assert state is not None
+    assert state.goal == "the quarterly report"
+    assert isinstance(response, str)
+
+
+@pytest.mark.asyncio
+async def test_goal_draft_empty_objective(hermes_home, monkeypatch):
+    """Bare `/goal draft` still returns the usage message and does not set a goal."""
+    monkeypatch.setattr(
+        goals, "draft_contract", lambda *a, **k: pytest.fail("draft_contract must not run for bare draft")
+    )
+
+    sid = "sid-goal-draft-prefix-empty"
+    runner = _make_runner(sid)
+    event = _make_event("/goal draft")
+
+    response = await GatewayRunner._handle_goal_command(runner, event)
+
+    assert "Usage: /goal draft" in response
+    assert goals.GoalManager(sid).state is None

--- a/tests/hermes_cli/test_goal_draft_prefix.py
+++ b/tests/hermes_cli/test_goal_draft_prefix.py
@@ -1,0 +1,104 @@
+"""Regression tests for `/goal draft` word-boundary matching in the classic CLI.
+
+`/goal` is dispatched separately in the classic CLI
+(``CLICommandsMixin._handle_goal_command``) and in the gateway
+(``GatewayRunner._handle_goal_command``); the gateway side is covered by
+``tests/gateway/test_goal_draft_prefix.py``. Both carry the same guard, so
+both need the same regression.
+
+A bare ``lower.startswith("draft")`` misroutes any goal whose first word
+merely *begins* with "draft" (``drafting``, ``drafts``, ``draftsman``) into
+the aux-LLM contract-draft path AND slices the first 5 characters off the
+objective via ``arg[len("draft"):]`` — so ``/goal drafting the roadmap``
+silently became the goal ``ing the roadmap``.
+"""
+
+import queue
+
+import pytest
+
+from hermes_cli import goals
+from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+
+class _Stub(CLICommandsMixin):
+    """Minimal host for the goal command: a real GoalManager + input queue.
+
+    ``_get_goal_manager`` lives on the concrete CLI class, not the mixin, so
+    the stub supplies it.
+    """
+
+    def __init__(self, session_key: str):
+        self._mgr = goals.GoalManager(session_key)
+        self._pending_input = queue.Queue()
+
+    def _get_goal_manager(self):
+        return self._mgr
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+@pytest.fixture()
+def draft_spy(monkeypatch):
+    """Record calls to the aux-LLM contract drafter without invoking it."""
+    calls = []
+
+    def _spy(objective, *args, **kwargs):
+        calls.append(objective)
+        return None
+
+    monkeypatch.setattr(goals, "draft_contract", _spy)
+    return calls
+
+
+def test_cli_goal_starting_with_draft_word_stays_free_form(hermes_home, draft_spy):
+    """`/goal drafting …` is a free-form goal, not a draft-contract request.
+
+    It must not invoke the draft helper and must be stored verbatim — no
+    ``draft`` prefix sliced off the front.
+    """
+    sid = "sid-cli-goal-draft-prefix-freeform"
+    stub = _Stub(sid)
+
+    stub._handle_goal_command("/goal drafting the roadmap")
+
+    assert draft_spy == [], "free-form 'drafting…' goal must not hit draft_contract"
+
+    state = goals.GoalManager(sid).state
+    assert state is not None
+    assert state.goal == "drafting the roadmap"
+    assert stub._pending_input.get_nowait() == "drafting the roadmap"
+
+
+def test_cli_goal_draft_still_routes_to_contract_helper(hermes_home, draft_spy):
+    """Positive control: a genuine `/goal draft <objective>` still routes to
+    the draft helper with the ``draft`` keyword stripped."""
+    sid = "sid-cli-goal-draft-prefix-contract"
+    stub = _Stub(sid)
+
+    stub._handle_goal_command("/goal draft the quarterly report")
+
+    assert draft_spy == ["the quarterly report"]
+
+    state = goals.GoalManager(sid).state
+    assert state is not None
+    assert state.goal == "the quarterly report"
+
+
+def test_cli_goal_bare_draft_returns_usage(hermes_home, draft_spy):
+    """Bare `/goal draft` is still the usage path — no goal set, no helper."""
+    sid = "sid-cli-goal-draft-prefix-empty"
+    stub = _Stub(sid)
+
+    stub._handle_goal_command("/goal draft")
+
+    assert draft_spy == []
+    assert goals.GoalManager(sid).state is None


### PR DESCRIPTION
## What does this PR do?

`/goal draft <objective>` is detected with a bare `lower.startswith("draft")`, with no word boundary. Any goal whose text starts with "draft" as a prefix — `/goal drafting the proposal`, `/goal drafts pending`, `/goal draftsman notes` — is (1) misrouted into the aux-LLM contract-draft path and (2) has its first 5 characters sliced off by `args[len("draft"):]`, so `/goal drafting a response` silently sets the goal to `"ing a response"` and burns an aux-model call on a nonsense objective.

Every other `/goal` subcommand matches by exact equality, and the sibling `wait` subcommand in the same function is already guarded correctly with `lower == "wait" or lower.startswith("wait ")`. This PR applies the same word-boundary guard to `draft` in both the gateway handler (`gateway/slash_commands.py`) and its CLI mirror (`hermes_cli/cli_commands_mixin.py`), so a real `/goal draft <objective>` still drafts a contract while `/goal drafting…` is treated as an ordinary free-form goal.

> Sibling code paths that may need the same fix: `tui_gateway/server.py` carries a similar `startswith("draft")` check in its `/goal` dispatcher. Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.

## Related Issue

N/A — code-originated fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py`: guard the `/goal draft` branch with `lower == "draft" or lower.startswith("draft ")` (both the detection guard and the trailing "couldn't draft a contract" note), matching the sibling `wait` handler.
- `hermes_cli/cli_commands_mixin.py`: same word-boundary guard on the CLI mirror of the handler.
- `tests/gateway/test_goal_draft_prefix.py`: new regression test.

## How to Test

1. `/goal drafting a response to the customer` → goal is preserved verbatim as `drafting a response to the customer` and routed as a free-form goal (no aux-LLM `draft_contract` call). Before this fix it became `ing a response to the customer`.
2. `/goal draft the quarterly report` → still routes to the contract-draft path with objective `the quarterly report`.
3. `/goal draft` (bare) → still returns `Usage: /goal draft <objective in plain language>`.
4. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_goal_draft_prefix.py -v` — 3 passed. The truncation test fails before the production change and passes after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suite (`tests/gateway/` + `tests/hermes_cli/` goal tests, 135 passed) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A