### PR TITLE
fix(desktop): scope cron API calls to the active gateway profile

### DIFF
--- a/apps/desktop/src/hermes-cron-scope.test.ts
+++ b/apps/desktop/src/hermes-cron-scope.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createCronJob,
+  deleteCronJob,
+  getCronJob,
+  getCronJobRuns,
+  getCronJobs,
+  pauseCronJob,
+  resumeCronJob,
+  setApiRequestProfile,
+  triggerCronJob,
+  updateCronJob
+} from './hermes'
+
+// Contract: every cron helper must carry the active gateway profile, so a
+// multi-profile / remote user's cron list, runs, and mutations hit the backend
+// they're actually on — not the primary/default. Without it, selecting a remote
+// profile still showed the local primary's jobs (the "remote cron jobs don't
+// show up" bug), the counterpart to the backend-action-helper fix in
+// hermes-profile-scope.test.ts.
+describe('cron helpers are profile-scoped', () => {
+  const api = vi.fn(async (_req: { path: string; profile?: string }) => ({}) as never)
+
+  beforeEach(() => {
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = { api }
+    api.mockClear()
+  })
+
+  afterEach(() => {
+    setApiRequestProfile(null)
+    delete (window as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  const lastProfile = () => api.mock.calls.at(-1)?.[0].profile
+
+  it('omits profile when none is active (single-profile users unaffected)', () => {
+    void getCronJobs()
+    expect(lastProfile()).toBeUndefined()
+  })
+
+  it('forwards the active profile to every cron helper', () => {
+    setApiRequestProfile('coder')
+
+    void getCronJobs()
+    void getCronJob('job-1')
+    void getCronJobRuns('job-1')
+    void createCronJob({ name: 'nightly', prompt: 'run', schedule: '0 3 * * *' } as never)
+    void updateCronJob('job-1', { enabled: false } as never)
+    void pauseCronJob('job-1')
+    void resumeCronJob('job-1')
+    void triggerCronJob('job-1')
+    void deleteCronJob('job-1')
+
+    for (const call of api.mock.calls) {
+      expect(call[0].profile).toBe('coder')
+    }
+  })
+})

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -749,6 +749,7 @@ export function testMessagingPlatform(platformId: string): Promise<MessagingPlat
 
 export function getCronJobs(): Promise<CronJob[]> {
   return window.hermesDesktop.api<CronJob[]>({
+    ...profileScoped(),
     path: '/api/cron/jobs',
     timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
@@ -756,12 +757,14 @@ export function getCronJobs(): Promise<CronJob[]> {
 
 export function getCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}`
   })
 }
 
 export async function getCronJobRuns(jobId: string, limit = 20): Promise<SessionInfo[]> {
   const { runs } = await window.hermesDesktop.api<{ runs: SessionInfo[] }>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}/runs?limit=${limit}`
   })
 
@@ -770,6 +773,7 @@ export async function getCronJobRuns(jobId: string, limit = 20): Promise<Session
 
 export function createCronJob(body: CronJobCreatePayload): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: '/api/cron/jobs',
     method: 'POST',
     body
@@ -778,6 +782,7 @@ export function createCronJob(body: CronJobCreatePayload): Promise<CronJob> {
 
 export function updateCronJob(jobId: string, updates: CronJobUpdates): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
     method: 'PUT',
     body: { updates }
@@ -786,6 +791,7 @@ export function updateCronJob(jobId: string, updates: CronJobUpdates): Promise<C
 
 export function pauseCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}/pause`,
     method: 'POST'
   })
@@ -793,6 +799,7 @@ export function pauseCronJob(jobId: string): Promise<CronJob> {
 
 export function resumeCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}/resume`,
     method: 'POST'
   })
@@ -800,6 +807,7 @@ export function resumeCronJob(jobId: string): Promise<CronJob> {
 
 export function triggerCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}/trigger`,
     method: 'POST'
   })
@@ -807,6 +815,7 @@ export function triggerCronJob(jobId: string): Promise<CronJob> {
 
 export function deleteCronJob(jobId: string): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
     method: 'DELETE'
   })


### PR DESCRIPTION
## What & why

The cron helpers in `apps/desktop/src/hermes.ts` — `getCronJobs`, `getCronJob`,
`getCronJobRuns`, `createCronJob`, `updateCronJob`, `pauseCronJob`,
`resumeCronJob`, `triggerCronJob`, `deleteCronJob` — did **not** include
`...profileScoped()` in their request objects. Every other backend-targeted
helper in this file (settings, sessions, backend actions) carries it, which is
what lets Electron's `hermes:api` handler route the call to the selected
profile's backend via `request.profile`.

Because the cron helpers omitted it, `request.profile` was always `null`, so
`ensureBackend()` fell through to the primary/default backend regardless of the
profile the user had selected.

**Symptom:** on a multi-profile / remote setup, selecting a remote profile
correctly showed *that profile's sessions* (session helpers are already
profile-routed), but the **Cron jobs** section kept listing the local primary
profile's jobs. The remote profile's scheduled jobs never appeared — cron was
silently desynced from the rest of the UI, which had switched profiles.

## Fix

Add `...profileScoped()` to all nine cron helpers, matching the existing pattern
used throughout the file. No call-site changes are needed: the cron sidebar
section and the Cron page already refetch when `profileScope` changes, so
switching profiles now re-lists the selected profile's jobs. For a per-profile
remote override this routes through `ensureBackend` →
`resolveRemoteBackend(profile)` to the remote host (OAuth-aware path included).

## How to test

Reproduction requires a remote (or second) profile configured in the desktop
app (`connection.json` `profiles[<name>].mode: "remote"`), with cron jobs that
live on that remote backend.

- **Before:** select the remote profile → its sessions show, but the Cron jobs
  section still shows the local primary profile's jobs.
- **After:** select the remote profile → the Cron jobs section lists the remote
  profile's jobs; switching back re-lists the local ones.

Automated: `apps/desktop/src/hermes-cron-scope.test.ts` (added here, mirrors
`hermes-profile-scope.test.ts`) asserts every cron helper forwards the active
profile and omits it when none is active.

```
vitest run --environment jsdom src/hermes-cron-scope.test.ts
```

## Platforms tested

macOS (Apple Silicon). The change is pure renderer TypeScript with no
platform-specific code paths.
