### PR TITLE
feat(telegram): allow opt-in CJK rich messages

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -519,6 +519,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # can leave Bot API 10.1 rich draft frames visually overlaid until the
         # chat is redrawn, while final rich messages remain useful.
         self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
+        # Current Telegram Desktop/macOS builds can garble CJK text in Bot API
+        # 10.1 rich rendering. Keep the safe default, but let users who prefer
+        # native rich tables for Chinese/Japanese/Korean opt in explicitly.
+        self._allow_cjk_rich_messages: bool = self._coerce_bool_extra(
+            "allow_cjk_rich_messages", False
+        )
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
@@ -1331,6 +1337,8 @@ class TelegramAdapter(BasePlatformAdapter):
         The legacy MarkdownV2 path renders the same text cleanly, so skip rich
         delivery up front until affected clients age out.
         """
+        if getattr(self, "_allow_cjk_rich_messages", False):
+            return False
         return bool(content and self._RICH_CJK_RE.search(content))
 
     def _needs_rich_rendering(self, content: str) -> bool:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1337,8 +1337,6 @@ class TelegramAdapter(BasePlatformAdapter):
         The legacy MarkdownV2 path renders the same text cleanly, so skip rich
         delivery up front until affected clients age out.
         """
-        if getattr(self, "_allow_cjk_rich_messages", False):
-            return False
         return bool(content and self._RICH_CJK_RE.search(content))
 
     def _needs_rich_rendering(self, content: str) -> bool:
@@ -1407,7 +1405,10 @@ class TelegramAdapter(BasePlatformAdapter):
             and content.strip()
             and self._needs_rich_rendering(content)
             and not self._has_telegram_desktop_details_math_crash_shape(content)
-            and not self._has_telegram_desktop_cjk_rich_garble_shape(content)
+            and (
+                getattr(self, "_allow_cjk_rich_messages", False)
+                or not self._has_telegram_desktop_cjk_rich_garble_shape(content)
+            )
             and self._content_fits_rich_limits(content)
             and self._bot_supports_rich()
         )
@@ -1755,7 +1756,10 @@ class TelegramAdapter(BasePlatformAdapter):
             and content
             and content.strip()
             and not self._has_telegram_desktop_details_math_crash_shape(content)
-            and not self._has_telegram_desktop_cjk_rich_garble_shape(content)
+            and (
+                getattr(self, "_allow_cjk_rich_messages", False)
+                or not self._has_telegram_desktop_cjk_rich_garble_shape(content)
+            )
             and self._content_fits_rich_limits(content)
             and self._bot_supports_rich()
         )

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -191,6 +191,36 @@ async def test_astral_cjk_rich_content_skips_rich_send_to_avoid_tdesktop_garble(
 
 
 @pytest.mark.asyncio
+async def test_cjk_rich_content_opt_in_uses_rich_send():
+    adapter = _make_adapter(extra={"allow_cjk_rich_messages": True})
+
+    result = await adapter.send("12345", CJK_RICH_CONTENT)
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_awaited_once()
+    api_kwargs = _rich_api_kwargs(adapter)
+    assert api_kwargs["rich_message"]["markdown"] == CJK_RICH_CONTENT
+    bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_astral_cjk_rich_content_opt_in_uses_rich_send():
+    adapter = _make_adapter(extra={"allow_cjk_rich_messages": True})
+
+    result = await adapter.send("12345", ASTRAL_CJK_RICH_CONTENT)
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_awaited_once()
+    api_kwargs = _rich_api_kwargs(adapter)
+    assert api_kwargs["rich_message"]["markdown"] == ASTRAL_CJK_RICH_CONTENT
+    bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_rich_messages_opt_out_uses_legacy_send_path():
     adapter = _make_adapter(extra={"rich_messages": False})
 

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -191,6 +191,17 @@ async def test_astral_cjk_rich_content_skips_rich_send_to_avoid_tdesktop_garble(
 
 
 @pytest.mark.asyncio
+async def test_cjk_rich_content_explicit_opt_out_uses_legacy_send():
+    adapter = _make_adapter(extra={"allow_cjk_rich_messages": False})
+
+    result = await adapter.send("12345", CJK_RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_cjk_rich_content_opt_in_uses_rich_send():
     adapter = _make_adapter(extra={"allow_cjk_rich_messages": True})
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -974,9 +974,14 @@ gateway:
       extra:
         rich_messages: true
         rich_drafts: false
+        allow_cjk_rich_messages: false
 ```
 
-This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. `rich_drafts` controls the experimental rich draft preview path during Telegram DM streaming and stays off by default because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
+This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. `rich_drafts` controls the experimental rich draft preview path during Telegram DM streaming and stays off by default because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws.
+
+CJK content (Chinese, Japanese, and Korean) stays on the legacy MarkdownV2 path by default because affected Telegram Desktop/macOS clients have rendered Bot API rich messages with overlapping glyph artifacts. If you prefer native rich tables/task lists for CJK content and accept that client-rendering risk, set `allow_cjk_rich_messages: true` together with `rich_messages: true`.
+
+If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
 
 **Link previews.** Telegram auto-generates link previews for URLs in bot messages. If you'd rather suppress those (long `/tools` output, agent reply that mentions ten links, etc.):
 


### PR DESCRIPTION
## Summary
- Adds a Telegram `allow_cjk_rich_messages` extra flag so users can explicitly opt CJK content into Bot API rich rendering.
- Keeps the existing safe default: CJK rich messages are still blocked unless the new flag is enabled.
- Documents the opt-in and adds regression coverage for both BMP and astral CJK content.

## Rationale
Hermes currently skips rich rendering for Chinese/Japanese/Korean text to avoid known Telegram Desktop/macOS glyph overlay artifacts. Some users still prefer native rich tables for CJK content and are willing to accept that client-rendering risk. This makes that trade-off explicit and configurable without changing the default behavior.

## Test Plan
- [x] `scripts/run_tests.sh tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_rich_newlines.py tests/gateway/test_stream_consumer.py -k 'telegram_rich or rich or fresh_final' -q`
- [x] `git diff --check`
- [x] `python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_rich_messages.py`
