### PR TITLE
fix(setup): raise Python upper bound to support 3.14 (#59877)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,12 @@ readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's
 # Python from `requires-python`, and an inherited `UV_PYTHON` env var (or a
 # fresh distro whose newest interpreter uv auto-picks) will otherwise select
-# 3.14, where Rust-backed transitives (e.g. pydantic-core) have no cp314
-# wheel yet and fall back to a maturin source build that fails. Capping at
-# <3.14 makes uv refuse 3.14 with a clear error instead of attempting that
-# build. Raise the ceiling once our Rust transitives ship cp314 wheels.
-requires-python = ">=3.11,<3.14"
+# an unsupported Python version, where Rust-backed transitives (e.g.
+# pydantic-core) may lack a compatible wheel and fall back to a maturin
+# source build that fails. Capping the ceiling makes uv refuse the
+# version with a clear error instead of attempting that build. Raise the
+# ceiling once our Rust transitives ship wheels for the new Python.
+requires-python = ">=3.11,<3.15"
 authors = [{ name = "Nous Research" }]
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary

Raises  from  to  so that users on Python 3.14 can install hermes-agent.

## Problem

The  upper bound was originally set because pydantic-core lacked cp314 wheels, causing maturin source builds to fail. However, pydantic-core 2.46.4 (pinned via pydantic 2.13.4) now ships cp314 wheels for all major platforms (macOS x86_64/arm64, Linux x86_64/aarch64/armv7l/ppc64le/s390x, Windows x86_64/arm64, musl variants).

Users on distributions like Termux 0.118.3 (which ships Python 3.14.6) hit:



## Fix

- Raise  ceiling from  to 
- Update the comment to be version-agnostic (the original comment referenced 3.14 specifically)

## Verification

-  has cp314 wheels on PyPI for all platforms
- No other direct Rust-backed dependencies in  need cp314 verification (they are pure-Python or have cp314 wheels)

Closes #59877