### PR TITLE
feat(session-folders): user-defined folders + agent tools for organizing sessions

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -311,6 +311,16 @@ test('pathWithGlobalRemoteProfile preserves existing query params', () => {
   )
 })
 
+test('pathWithGlobalRemoteProfile scopes session-folder reads for global remotes', () => {
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/session-folders/map?session_ids=s1%2Cs2', 'iris', {
+      globalRemote: true,
+      profileRemoteOverride: false
+    }),
+    '/api/session-folders/map?session_ids=s1%2Cs2&profile=iris'
+  )
+})
+
 test('pathWithGlobalRemoteProfile does not replace an explicit profile query', () => {
   assert.equal(
     pathWithGlobalRemoteProfile('/api/model/info?profile=default', 'iris', {

--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -431,6 +431,16 @@ test('pathWithGlobalRemoteProfile preserves existing query params', () => {
   )
 })
 
+test('pathWithGlobalRemoteProfile scopes session-folder reads for global remotes', () => {
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/session-folders/map?session_ids=s1%2Cs2', 'iris', {
+      globalRemote: true,
+      profileRemoteOverride: false
+    }),
+    '/api/session-folders/map?session_ids=s1%2Cs2&profile=iris'
+  )
+})
+
 test('pathWithGlobalRemoteProfile does not replace an explicit profile query', () => {
   assert.equal(
     pathWithGlobalRemoteProfile('/api/model/info?profile=default', 'iris', {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10020,6 +10020,7 @@ ipcMain.handle('hermes:requestMicrophoneAccess', async () => {
 //   GET    /api/sessions/{id}[/messages] → read from remote
 //   DELETE /api/sessions/{id}            → delete on remote
 //   PATCH  /api/sessions/{id}            → rename/archive on remote
+//   *      /api/session-folders[/*]       → folder operations on remote
 async function interceptSessionRequestForRemote(request) {
   if (typeof request?.path !== 'string') {
     return undefined
@@ -10036,6 +10037,43 @@ async function interceptSessionRequestForRemote(request) {
   }
 
   const { pathname, searchParams } = parsed
+  // Folder wrappers keep profile in the REST path/body for local and global
+  // backends, but a per-profile remote backend is already scoped to that
+  // profile. Strip the duplicate scope before forwarding or the remote host
+  // will try to open a second local profile named after the desktop profile.
+  const isFolderRequest =
+    pathname === '/api/session-folders' ||
+    pathname === '/api/session-folders/map' ||
+    /^\/api\/session-folders\/[^/]+(?:\/sessions)?$/.test(pathname)
+  if (isFolderRequest) {
+    const profile = (request.profile || searchParams.get('profile') || '').trim()
+    if (!profile || !profileHasRemoteOverride(profile)) {
+      if (!profile || !globalRemoteActive()) {
+        return undefined
+      }
+
+      const path = pathWithGlobalRemoteProfile(request.path, profile, {
+        globalRemote: true,
+        profileRemoteOverride: false
+      })
+
+      if (method === 'GET') {
+        return fetchJsonForProfile(null, path)
+      }
+
+      const body = request.body && typeof request.body === 'object' ? { ...request.body, profile } : { profile }
+      return requestJsonForProfile(null, path, method, body)
+    }
+    if (method === 'GET') {
+      const sessionIds = searchParams.get('session_ids')
+      const path = sessionIds === null ? pathname : `${pathname}?session_ids=${encodeURIComponent(sessionIds)}`
+      return fetchJsonForProfile(profile, path)
+    }
+    const body = request.body && typeof request.body === 'object' ? { ...request.body } : request.body
+    if (body) delete body.profile
+    return requestJsonForProfile(profile, pathname, method, body)
+  }
+
 
   if (method === 'GET' && pathname === '/api/profiles/sessions') {
     const remoteProfiles = configuredRemoteProfileNames()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12859,6 +12859,7 @@ ipcMain.handle('hermes:window:readBelow', async event => {
 //   GET    /api/sessions/{id}[/messages] → read from remote
 //   DELETE /api/sessions/{id}            → delete on remote
 //   PATCH  /api/sessions/{id}            → rename/archive on remote
+//   *      /api/session-folders[/*]       → folder operations on remote
 async function interceptSessionRequestForRemote(request) {
   if (typeof request?.path !== 'string') {
     return undefined
@@ -12875,6 +12876,43 @@ async function interceptSessionRequestForRemote(request) {
   }
 
   const { pathname, searchParams } = parsed
+  // Folder wrappers keep profile in the REST path/body for local and global
+  // backends, but a per-profile remote backend is already scoped to that
+  // profile. Strip the duplicate scope before forwarding or the remote host
+  // will try to open a second local profile named after the desktop profile.
+  const isFolderRequest =
+    pathname === '/api/session-folders' ||
+    pathname === '/api/session-folders/map' ||
+    /^\/api\/session-folders\/[^/]+(?:\/sessions)?$/.test(pathname)
+  if (isFolderRequest) {
+    const profile = (request.profile || searchParams.get('profile') || '').trim()
+    if (!profile || !profileHasRemoteOverride(profile)) {
+      if (!profile || !globalRemoteActive()) {
+        return undefined
+      }
+
+      const path = pathWithGlobalRemoteProfile(request.path, profile, {
+        globalRemote: true,
+        profileRemoteOverride: false
+      })
+
+      if (method === 'GET') {
+        return fetchJsonForProfile(null, path)
+      }
+
+      const body = request.body && typeof request.body === 'object' ? { ...request.body, profile } : { profile }
+      return requestJsonForProfile(null, path, method, body)
+    }
+    if (method === 'GET') {
+      const sessionIds = searchParams.get('session_ids')
+      const path = sessionIds === null ? pathname : `${pathname}?session_ids=${encodeURIComponent(sessionIds)}`
+      return fetchJsonForProfile(profile, path)
+    }
+    const body = request.body && typeof request.body === 'object' ? { ...request.body } : request.body
+    if (body) delete body.profile
+    return requestJsonForProfile(profile, pathname, method, body)
+  }
+
 
   if (method === 'GET' && pathname === '/api/profiles/sessions') {
     const remoteProfiles = configuredRemoteProfileNames()

--- a/apps/desktop/src/app/chat/sidebar/folders-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/folders-section.tsx
@@ -1,0 +1,298 @@
+import { useStore } from '@nanostores/react'
+import type * as React from 'react'
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
+import { DisclosureCaret } from '@/components/ui/disclosure-caret'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { getSession, type SessionFolder, type SessionInfo } from '@/hermes'
+import { triggerHaptic } from '@/lib/haptics'
+import { $folders, $foldersLoading, createFolder, deleteAndRemoveFolder, refreshFolders } from '@/store/session-folders'
+import { $selectedStoredSessionId, $sessions, sessionPinId } from '@/store/session'
+import { $workingSessionIds } from '@/store/session-states'
+
+import { SidebarPanelLabel } from '../../shell/sidebar-label'
+import { SidebarSessionRow } from './session-row'
+
+interface SidebarFoldersSectionProps {
+  label: string
+  open: boolean
+  onToggle: () => void
+  onResumeSession: (sessionId: string) => void
+  onDeleteSession: (sessionId: string) => void
+  onArchiveSession: (sessionId: string) => void
+  onTogglePin: (sessionId: string) => void
+  onToggleUnread: (sessionId: string) => void
+  profile?: string
+}
+
+export function SidebarFoldersSection({
+  label,
+  open,
+  onToggle,
+  onResumeSession,
+  onDeleteSession,
+  onArchiveSession,
+  onTogglePin,
+  onToggleUnread,
+  profile
+}: SidebarFoldersSectionProps) {
+  const { t } = useI18n()
+  const r = t.sidebar.row
+  const [creatingFolder, setCreatingFolder] = useState(false)
+  const [newFolderName, setNewFolderName] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [expandedFolderId, setExpandedFolderId] = useState<null | string>(null)
+  const folders = useStore($folders)
+  const foldersLoading = useStore($foldersLoading)
+  const sessions = useStore($sessions)
+  const activeSessionId = useStore($selectedStoredSessionId)
+  const workingSessionIds = useStore($workingSessionIds)
+  const workingSessionIdSet = new Set(workingSessionIds)
+
+  // Refresh whenever the sidebar profile scope changes so a remote/profile
+  // folder list never falls back to the primary backend's folders.
+  useEffect(() => {
+    void refreshFolders(profile)
+  }, [profile])
+
+  if (foldersLoading) {
+    return null
+  }
+
+  if (folders.length === 0 && !open) {
+    return null
+  }
+
+  const handleCreate = async () => {
+    if (!newFolderName.trim() || creating) return
+    setCreating(true)
+    const result = await createFolder(newFolderName.trim(), profile)
+    setCreating(false)
+    if (result) {
+      setCreatingFolder(false)
+      setNewFolderName('')
+    }
+  }
+
+  return (
+    <SidebarGroup className="shrink-0 p-0 pb-1">
+      <div className="group/section flex shrink-0 items-center justify-between pb-1 pt-1.5">
+        <button
+          className="group/section-label flex w-fit items-center gap-1 bg-transparent text-left leading-none"
+          onClick={onToggle}
+          type="button"
+        >
+          <SidebarPanelLabel>{label}</SidebarPanelLabel>
+          <span className="text-[0.6875rem] font-medium text-(--ui-text-quaternary)">{folders.length}</span>
+          <DisclosureCaret
+            className="text-(--ui-text-tertiary) opacity-0 transition group-hover/section-label:opacity-100"
+            open={open}
+          />
+        </button>
+        {open && (
+          <button
+            aria-label={r.createFolder ?? 'New folder'}
+            className="grid size-5 place-items-center rounded-sm text-(--ui-text-tertiary) opacity-0 hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/section:opacity-100"
+            onClick={() => setCreatingFolder(true)}
+            type="button"
+          >
+            <Codicon name="new-folder" size="0.75rem" />
+          </button>
+        )}
+      </div>
+      {open && (
+        <SidebarGroupContent className="flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto overscroll-contain pb-1.75 compact:max-h-none compact:overflow-visible">
+          {creatingFolder && (
+            <div className="flex items-center gap-1 px-2 py-1">
+              <input
+                autoFocus
+                className="min-w-0 flex-1 rounded-md border border-(--ui-stroke-secondary) bg-transparent px-1.5 py-0.5 text-[0.8125rem] outline-none focus:border-(--ui-stroke-focus)"
+                onChange={e => setNewFolderName(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    void handleCreate()
+                  }
+                  if (e.key === 'Escape') {
+                    setCreatingFolder(false)
+                    setNewFolderName('')
+                  }
+                }}
+                placeholder={r.createFolder ?? 'Name…'}
+                value={newFolderName}
+              />
+            </div>
+          )}
+          {folders.length === 0 && !creatingFolder ? (
+            <div className="py-1 pl-2 text-[0.6875rem] text-(--ui-text-tertiary)">
+              {r.noFolders ?? 'No folders yet'}
+            </div>
+          ) : (
+            folders.map(folder => (
+              <div key={folder.id}>
+                <ContextMenu>
+                  <ContextMenuTrigger asChild>
+                    <button
+                      aria-expanded={expandedFolderId === folder.id}
+                      className="flex min-w-0 items-center gap-1.5 bg-transparent py-0.5 pl-2 pr-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 hover:bg-(--chrome-action-hover)"
+                      onClick={() => setExpandedFolderId(prev => (prev === folder.id ? null : folder.id))}
+                      type="button"
+                    >
+                      <span className="grid w-3.5 shrink-0 place-items-center">
+                        <Codicon name="folder" size="0.8125rem" />
+                      </span>
+                      <span className="min-w-0 truncate text-[0.8125rem] text-(--ui-text-secondary)">
+                        {folder.name}
+                      </span>
+                      <DisclosureCaret
+                        className="shrink-0 text-(--ui-text-tertiary) transition"
+                        open={expandedFolderId === folder.id}
+                      />
+                      <span className="ml-auto text-[0.6875rem] text-(--ui-text-quaternary)">
+                        {folder.session_count}
+                      </span>
+                    </button>
+                  </ContextMenuTrigger>
+                  <ContextMenuContent className="w-40">
+                    <ContextMenuItem
+                      onSelect={() => {
+                        triggerHaptic('selection')
+                        navigator.clipboard.writeText(folder.id)
+                      }}
+                    >
+                      <Codicon name="copy" size="0.875rem" />
+                      <span>{r.copyId ?? 'Copy ID'}</span>
+                    </ContextMenuItem>
+                    <ContextMenuItem
+                      variant="destructive"
+                      onSelect={() => {
+                        triggerHaptic('warning')
+                        void deleteAndRemoveFolder(folder.id, profile)
+                      }}
+                    >
+                      <Codicon name="trash" size="0.875rem" />
+                      <span>{r.deleteFolder ?? 'Delete folder'}</span>
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                </ContextMenu>
+                {expandedFolderId === folder.id && (
+                  <FolderMemberList
+                    folder={folder}
+                    sessions={sessions}
+                    activeSessionId={activeSessionId}
+                    workingSessionIdSet={workingSessionIdSet}
+                    onResumeSession={onResumeSession}
+                    onDeleteSession={onDeleteSession}
+                    onArchiveSession={onArchiveSession}
+                    onTogglePin={onTogglePin}
+                    onToggleUnread={onToggleUnread}
+                    profile={profile}
+                  />
+                )}
+              </div>
+            ))
+          )}
+        </SidebarGroupContent>
+      )}
+    </SidebarGroup>
+  )
+}
+
+function FolderMemberList({
+  folder,
+  sessions,
+  activeSessionId,
+  workingSessionIdSet,
+  onResumeSession,
+  onDeleteSession,
+  onArchiveSession,
+  onTogglePin,
+  onToggleUnread,
+  profile
+}: {
+  folder: SessionFolder
+  sessions: SessionInfo[]
+  activeSessionId: string | null
+  workingSessionIdSet: Set<string>
+  onResumeSession: (id: string) => void
+  onDeleteSession: (id: string) => void
+  onArchiveSession: (id: string) => void
+  onTogglePin: (id: string) => void
+  onToggleUnread: (id: string) => void
+  profile?: string
+}) {
+  const sessionIds = folder.session_ids ?? []
+  const [fetchedSessions, setFetchedSessions] = useState<SessionInfo[]>([])
+
+  useEffect(() => {
+    const loaded = new Set(sessions.flatMap(session => [session.id, sessionPinId(session)]))
+    const missingIds = sessionIds.filter(id => !loaded.has(id))
+
+    if (missingIds.length === 0) {
+      setFetchedSessions([])
+
+      return
+    }
+
+    let cancelled = false
+
+    void Promise.all(
+      missingIds.map(id =>
+        getSession(id, profile)
+          .then(session => session)
+          .catch(() => null)
+      )
+    ).then(results => {
+      if (!cancelled) {
+        setFetchedSessions(results.filter((session): session is SessionInfo => session !== null))
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [profile, sessionIds, sessions])
+
+  const allSessions = [...sessions, ...fetchedSessions]
+  const memberSessions = sessionIds
+    .map(fsid => allSessions.find(s => sessionPinId(s) === fsid || s.id === fsid))
+    .filter((s): s is SessionInfo => s !== undefined)
+
+  if (memberSessions.length === 0) {
+    return <div className="ml-[1.125rem] py-1 pl-1 text-[0.6875rem] text-(--ui-text-tertiary)">No sessions</div>
+  }
+
+  return (
+    <div className="ml-[1.125rem] flex flex-col gap-px">
+      {memberSessions.map(session => (
+        <SidebarSessionRow
+          currentFolderId={folder.id}
+          isPinned={false}
+          isSelected={session.id === activeSessionId}
+          isWorking={workingSessionIdSet.has(session.id)}
+          key={session.id}
+          onArchive={() => onArchiveSession(session.id)}
+          onDelete={() => onDeleteSession(session.id)}
+          onPin={() => onTogglePin(session.id)}
+          onResume={() => onResumeSession(session.id)}
+          onToggleUnread={() => onToggleUnread(session.id)}
+          session={session}
+          unread={session.unread === true}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/folders-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/folders-section.tsx
@@ -1,0 +1,291 @@
+import { useStore } from '@nanostores/react'
+import type * as React from 'react'
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
+import { DisclosureCaret } from '@/components/ui/disclosure-caret'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { getSession, type SessionFolder, type SessionInfo } from '@/hermes'
+import { triggerHaptic } from '@/lib/haptics'
+import { $folders, $foldersLoading, createFolder, deleteAndRemoveFolder, refreshFolders } from '@/store/session-folders'
+import { $selectedStoredSessionId, $sessions, sessionPinId } from '@/store/session'
+import { $workingSessionIds } from '@/store/session-states'
+
+import { SidebarPanelLabel } from '../../shell/sidebar-label'
+import { SidebarSessionRow } from './session-row'
+
+interface SidebarFoldersSectionProps {
+  label: string
+  open: boolean
+  onToggle: () => void
+  onResumeSession: (sessionId: string) => void
+  onDeleteSession: (sessionId: string) => void
+  onArchiveSession: (sessionId: string) => void
+  onTogglePin: (sessionId: string) => void
+  profile?: string
+}
+
+export function SidebarFoldersSection({
+  label,
+  open,
+  onToggle,
+  onResumeSession,
+  onDeleteSession,
+  onArchiveSession,
+  onTogglePin,
+  profile
+}: SidebarFoldersSectionProps) {
+  const { t } = useI18n()
+  const r = t.sidebar.row
+  const [creatingFolder, setCreatingFolder] = useState(false)
+  const [newFolderName, setNewFolderName] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [expandedFolderId, setExpandedFolderId] = useState<null | string>(null)
+  const folders = useStore($folders)
+  const foldersLoading = useStore($foldersLoading)
+  const sessions = useStore($sessions)
+  const activeSessionId = useStore($selectedStoredSessionId)
+  const workingSessionIds = useStore($workingSessionIds)
+  const workingSessionIdSet = new Set(workingSessionIds)
+
+  // Refresh whenever the sidebar profile scope changes so a remote/profile
+  // folder list never falls back to the primary backend's folders.
+  useEffect(() => {
+    void refreshFolders(profile)
+  }, [profile])
+
+  if (foldersLoading) {
+    return null
+  }
+
+  if (folders.length === 0 && !open) {
+    return null
+  }
+
+  const handleCreate = async () => {
+    if (!newFolderName.trim() || creating) return
+    setCreating(true)
+    const result = await createFolder(newFolderName.trim(), profile)
+    setCreating(false)
+    if (result) {
+      setCreatingFolder(false)
+      setNewFolderName('')
+    }
+  }
+
+  return (
+    <SidebarGroup className="shrink-0 p-0 pb-1">
+      <div className="group/section flex shrink-0 items-center justify-between pb-1 pt-1.5">
+        <button
+          className="group/section-label flex w-fit items-center gap-1 bg-transparent text-left leading-none"
+          onClick={onToggle}
+          type="button"
+        >
+          <SidebarPanelLabel>{label}</SidebarPanelLabel>
+          <span className="text-[0.6875rem] font-medium text-(--ui-text-quaternary)">{folders.length}</span>
+          <DisclosureCaret
+            className="text-(--ui-text-tertiary) opacity-0 transition group-hover/section-label:opacity-100"
+            open={open}
+          />
+        </button>
+        {open && (
+          <button
+            aria-label={r.createFolder ?? 'New folder'}
+            className="grid size-5 place-items-center rounded-sm text-(--ui-text-tertiary) opacity-0 hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/section:opacity-100"
+            onClick={() => setCreatingFolder(true)}
+            type="button"
+          >
+            <Codicon name="new-folder" size="0.75rem" />
+          </button>
+        )}
+      </div>
+      {open && (
+        <SidebarGroupContent className="flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto overscroll-contain pb-1.75 compact:max-h-none compact:overflow-visible">
+          {creatingFolder && (
+            <div className="flex items-center gap-1 px-2 py-1">
+              <input
+                autoFocus
+                className="min-w-0 flex-1 rounded-md border border-(--ui-stroke-secondary) bg-transparent px-1.5 py-0.5 text-[0.8125rem] outline-none focus:border-(--ui-stroke-focus)"
+                onChange={e => setNewFolderName(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    void handleCreate()
+                  }
+                  if (e.key === 'Escape') {
+                    setCreatingFolder(false)
+                    setNewFolderName('')
+                  }
+                }}
+                placeholder={r.createFolder ?? 'Name…'}
+                value={newFolderName}
+              />
+            </div>
+          )}
+          {folders.length === 0 && !creatingFolder ? (
+            <div className="py-1 pl-2 text-[0.6875rem] text-(--ui-text-tertiary)">
+              {r.noFolders ?? 'No folders yet'}
+            </div>
+          ) : (
+            folders.map(folder => (
+              <div key={folder.id}>
+                <ContextMenu>
+                  <ContextMenuTrigger asChild>
+                    <button
+                      aria-expanded={expandedFolderId === folder.id}
+                      className="flex min-w-0 items-center gap-1.5 bg-transparent py-0.5 pl-2 pr-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 hover:bg-(--chrome-action-hover)"
+                      onClick={() => setExpandedFolderId(prev => (prev === folder.id ? null : folder.id))}
+                      type="button"
+                    >
+                      <span className="grid w-3.5 shrink-0 place-items-center">
+                        <Codicon name="folder" size="0.8125rem" />
+                      </span>
+                      <span className="min-w-0 truncate text-[0.8125rem] text-(--ui-text-secondary)">
+                        {folder.name}
+                      </span>
+                      <DisclosureCaret
+                        className="shrink-0 text-(--ui-text-tertiary) transition"
+                        open={expandedFolderId === folder.id}
+                      />
+                      <span className="ml-auto text-[0.6875rem] text-(--ui-text-quaternary)">
+                        {folder.session_count}
+                      </span>
+                    </button>
+                  </ContextMenuTrigger>
+                  <ContextMenuContent className="w-40">
+                    <ContextMenuItem
+                      onSelect={() => {
+                        triggerHaptic('selection')
+                        navigator.clipboard.writeText(folder.id)
+                      }}
+                    >
+                      <Codicon name="copy" size="0.875rem" />
+                      <span>{r.copyId ?? 'Copy ID'}</span>
+                    </ContextMenuItem>
+                    <ContextMenuItem
+                      variant="destructive"
+                      onSelect={() => {
+                        triggerHaptic('warning')
+                        void deleteAndRemoveFolder(folder.id, profile)
+                      }}
+                    >
+                      <Codicon name="trash" size="0.875rem" />
+                      <span>{r.deleteFolder ?? 'Delete folder'}</span>
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                </ContextMenu>
+                {expandedFolderId === folder.id && (
+                  <FolderMemberList
+                    folder={folder}
+                    sessions={sessions}
+                    activeSessionId={activeSessionId}
+                    workingSessionIdSet={workingSessionIdSet}
+                    onResumeSession={onResumeSession}
+                    onDeleteSession={onDeleteSession}
+                    onArchiveSession={onArchiveSession}
+                    onTogglePin={onTogglePin}
+                    profile={profile}
+                  />
+                )}
+              </div>
+            ))
+          )}
+        </SidebarGroupContent>
+      )}
+    </SidebarGroup>
+  )
+}
+
+function FolderMemberList({
+  folder,
+  sessions,
+  activeSessionId,
+  workingSessionIdSet,
+  onResumeSession,
+  onDeleteSession,
+  onArchiveSession,
+  onTogglePin,
+  profile
+}: {
+  folder: SessionFolder
+  sessions: SessionInfo[]
+  activeSessionId: string | null
+  workingSessionIdSet: Set<string>
+  onResumeSession: (id: string) => void
+  onDeleteSession: (id: string) => void
+  onArchiveSession: (id: string) => void
+  onTogglePin: (id: string) => void
+  profile?: string
+}) {
+  const sessionIds = folder.session_ids ?? []
+  const [fetchedSessions, setFetchedSessions] = useState<SessionInfo[]>([])
+
+  useEffect(() => {
+    const loaded = new Set(sessions.flatMap(session => [session.id, sessionPinId(session)]))
+    const missingIds = sessionIds.filter(id => !loaded.has(id))
+
+    if (missingIds.length === 0) {
+      setFetchedSessions([])
+
+      return
+    }
+
+    let cancelled = false
+
+    void Promise.all(
+      missingIds.map(id =>
+        getSession(id, profile)
+          .then(session => session)
+          .catch(() => null)
+      )
+    ).then(results => {
+      if (!cancelled) {
+        setFetchedSessions(results.filter((session): session is SessionInfo => session !== null))
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [profile, sessionIds, sessions])
+
+  const allSessions = [...sessions, ...fetchedSessions]
+  const memberSessions = sessionIds
+    .map(fsid => allSessions.find(s => sessionPinId(s) === fsid || s.id === fsid))
+    .filter((s): s is SessionInfo => s !== undefined)
+
+  if (memberSessions.length === 0) {
+    return <div className="ml-[1.125rem] py-1 pl-1 text-[0.6875rem] text-(--ui-text-tertiary)">No sessions</div>
+  }
+
+  return (
+    <div className="ml-[1.125rem] flex flex-col gap-px">
+      {memberSessions.map(session => (
+        <SidebarSessionRow
+          currentFolderId={folder.id}
+          isPinned={false}
+          isSelected={session.id === activeSessionId}
+          isWorking={workingSessionIdSet.has(session.id)}
+          key={session.id}
+          onArchive={() => onArchiveSession(session.id)}
+          onDelete={() => onDeleteSession(session.id)}
+          onPin={() => onTogglePin(session.id)}
+          onResume={() => onResumeSession(session.id)}
+          session={session}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -167,10 +167,11 @@ import {
   StartWorkButton,
   useRepoWorktreeMap
 } from './projects'
-import { WorktreeDialog } from './projects/worktree-dialog'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { buildSessionByAnyId, resolvePinnedSessions } from './session-index'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
+import { WorktreeDialog } from './projects/worktree-dialog'
+import { SidebarFoldersSection } from './folders-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
 // Non-session groups (messaging platforms) stay compact: show a few rows up
@@ -362,6 +363,7 @@ export function ChatSidebar({
   const pinsOpen = useStore($sidebarPinsOpen)
   const agentsOpen = useStore($sidebarRecentsOpen)
   const cronOpen = useStore($sidebarCronOpen)
+  const [foldersOpen, setFoldersOpen] = useState(true)
   // The sidebar highlight tracks the FOCUSED session — the interacted tile's
   // tab, else the main selection — so it stays 1:1 with whatever tab is active.
   const selectedSessionId = useStore($focusedStoredSessionId)
@@ -1614,6 +1616,20 @@ export function ChatSidebar({
                 sessions={pinnedSessions}
                 showProfileTags={showAllProfiles}
                 sortable={pinnedSessions.length > 1}
+              />
+            )}
+
+            {!trimmedQuery && !showAllProfiles && (
+              <SidebarFoldersSection
+                label={s.row.folders ?? 'Folders'}
+                onArchiveSession={onArchiveSession}
+                onDeleteSession={onDeleteSession}
+                onResumeSession={onResumeSession}
+                onToggle={() => setFoldersOpen(!foldersOpen)}
+                onTogglePin={pinSession}
+                onToggleUnread={toggleUnread}
+                open={foldersOpen}
+                profile={profileScope}
               />
             )}
 

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -130,10 +130,11 @@ import {
   StartWorkButton,
   useRepoWorktreeMap
 } from './projects'
-import { WorktreeDialog } from './projects/worktree-dialog'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { buildSessionByAnyId } from './session-index'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
+import { WorktreeDialog } from './projects/worktree-dialog'
+import { SidebarFoldersSection } from './folders-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
 // Non-session groups (messaging platforms) stay compact: show a few rows up
@@ -292,6 +293,7 @@ export function ChatSidebar({
   const pinsOpen = useStore($sidebarPinsOpen)
   const agentsOpen = useStore($sidebarRecentsOpen)
   const cronOpen = useStore($sidebarCronOpen)
+  const [foldersOpen, setFoldersOpen] = useState(true)
   // The sidebar highlight tracks the FOCUSED session — the interacted tile's
   // tab, else the main selection — so it stays 1:1 with whatever tab is active.
   const selectedSessionId = useStore($focusedStoredSessionId)
@@ -1309,6 +1311,22 @@ export function ChatSidebar({
               />
             )}
 
+            {!trimmedQuery && !showAllProfiles && (
+              <SidebarFoldersSection
+                label={s.row.folders ?? 'Folders'}
+                onArchiveSession={onArchiveSession}
+                onDeleteSession={onDeleteSession}
+                onResumeSession={onResumeSession}
+                onToggle={() => setFoldersOpen(!foldersOpen)}
+                onTogglePin={pinSession}
+                open={foldersOpen}
+                profile={profileScope}
+              />
+            )}
+
+      {/* One mount for the whole app. The header of WorktreeDialog tells why. */}
+      <WorktreeDialog />
+
             {!trimmedQuery && (
               <SidebarSessionsSection
                 activeProjectId={activeProjectId}
@@ -1355,7 +1373,9 @@ export function ChatSidebar({
                 headerAction={
                   inProject && enteredProject ? (
                     <div className="group/workspace flex shrink-0 items-center gap-0.5">
-                      {enteredProject.path && <StartWorkButton repoPath={enteredProject.path} />}
+                      {enteredProject.path && (
+                        <StartWorkButton repoPath={enteredProject.path} />
+                      )}
                       {/* Home has no folder and no record to rename, theme, or delete. */}
                       {!enteredProject.isNoProject && (
                         <ProjectMenu
@@ -1538,8 +1558,6 @@ export function ChatSidebar({
         </div>
       </SidebarContent>
       <ProjectDialog />
-      {/* One mount for the whole app. The header of WorktreeDialog tells why. */}
-      <WorktreeDialog />
     </Sidebar>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -38,7 +38,6 @@ import { PROFILE_SWATCHES } from '@/lib/profile-color'
 import { exportSession } from '@/lib/session-export'
 import { activeGateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
 import {
   $activeSessionId,
   $connection,
@@ -50,6 +49,12 @@ import {
   sessionPinId,
   setSessions
 } from '@/store/session'
+import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
+import {
+  $folders,
+  moveToFolder as storeMoveToFolder,
+  removeFromFolder as storeRemoveFromFolder
+} from '@/store/session-folders'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
 import { $sessionTiles } from '@/store/session-states'
 import { ackStoredSessionId } from '@/store/session-unread'
@@ -115,6 +120,7 @@ interface SessionActions {
   onBranch?: () => void
   onArchive?: () => void
   onDelete?: () => void
+  currentFolderId?: string | null
   /** Close this surface (a tile tab) — omitted where nothing closes (sidebar
    *  rows, the main tab). */
   onClose?: () => void
@@ -194,6 +200,7 @@ function useSessionActions({
   pinned = false,
   unread = false,
   profile,
+  currentFolderId,
   onPin,
   onToggleUnread,
   onBranch,
@@ -216,6 +223,7 @@ function useSessionActions({
   // the project menu's appearance-popover guard.
   const suppressCloseFocusRef = useRef(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
+  const foldersList = useStore($folders)
   const tiles = useStore($sessionTiles)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const isRemote = useStore($connection)?.mode === 'remote'
@@ -488,6 +496,40 @@ function useSessionActions({
       />
       <kit.Separator />
       {workItems.map(item => renderActionItem(kit, item))}
+      {currentFolderId &&
+        renderActionItem(kit, {
+          icon: 'close',
+          label: r.removeFromFolder ?? 'Remove from folder',
+          onSelect: () => {
+            triggerHaptic('selection')
+            void storeRemoveFromFolder(sessionId, currentFolderId, profile)
+          }
+        })}
+      {foldersList.length > 0 && (
+        <kit.Sub>
+          <kit.SubTrigger>
+            <Codicon name="folder" size="0.875rem" />
+            <span>{r.moveToFolder ?? 'Move to folder'}</span>
+          </kit.SubTrigger>
+          <kit.SubContent>
+            {foldersList.map(folder =>
+              renderActionItem(kit, {
+                key: folder.id,
+                label: (
+                  <>
+                    <span>{folder.name}</span>
+                    {folder.id === currentFolderId && <span className="ml-auto text-(--ui-text-tertiary)">✓</span>}
+                  </>
+                ),
+                onSelect: () => {
+                  triggerHaptic('selection')
+                  void storeMoveToFolder(sessionId, folder.id, currentFolderId, profile)
+                }
+              })
+            )}
+          </kit.SubContent>
+        </kit.Sub>
+      )}
       <kit.Sub>
         <kit.SubTrigger disabled={!sessionId}>
           <Codicon name="folder" size="0.875rem" />

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -30,7 +30,6 @@ import { PROFILE_SWATCHES } from '@/lib/profile-color'
 import { exportSession } from '@/lib/session-export'
 import { activeGateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
 import {
   $activeSessionId,
   $selectedStoredSessionId,
@@ -39,6 +38,12 @@ import {
   sessionPinId,
   setSessions
 } from '@/store/session'
+import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
+import {
+  $folders,
+  moveToFolder as storeMoveToFolder,
+  removeFromFolder as storeRemoveFromFolder
+} from '@/store/session-folders'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
 import { $sessionTiles } from '@/store/session-states'
 import { canOpenSessionWindow } from '@/store/windows'
@@ -99,6 +104,7 @@ interface SessionActions {
   onBranch?: () => void
   onArchive?: () => void
   onDelete?: () => void
+  currentFolderId?: string | null
   /** Close this surface (a tile tab) — omitted where nothing closes (sidebar
    *  rows, the main tab). */
   onClose?: () => void
@@ -177,6 +183,7 @@ function useSessionActions({
   title,
   pinned = false,
   profile,
+  currentFolderId,
   onPin,
   onBranch,
   onArchive,
@@ -189,6 +196,7 @@ function useSessionActions({
   const { t } = useI18n()
   const r = t.sidebar.row
   const [renameOpen, setRenameOpen] = useState(false)
+  const foldersList = useStore($folders)
   const tiles = useStore($sessionTiles)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
 
@@ -394,6 +402,40 @@ function useSessionActions({
       />
       <kit.Separator />
       {workItems.map(item => renderActionItem(kit, item))}
+      {currentFolderId &&
+        renderActionItem(kit, {
+          icon: 'close',
+          label: r.removeFromFolder ?? 'Remove from folder',
+          onSelect: () => {
+            triggerHaptic('selection')
+            void storeRemoveFromFolder(sessionId, currentFolderId, profile)
+          }
+        })}
+      {foldersList.length > 0 && (
+        <kit.Sub>
+          <kit.SubTrigger>
+            <Codicon name="folder" size="0.875rem" />
+            <span>{r.moveToFolder ?? 'Move to folder'}</span>
+          </kit.SubTrigger>
+          <kit.SubContent>
+            {foldersList.map(folder =>
+              renderActionItem(kit, {
+                key: folder.id,
+                label: (
+                  <>
+                    <span>{folder.name}</span>
+                    {folder.id === currentFolderId && <span className="ml-auto text-(--ui-text-tertiary)">✓</span>}
+                  </>
+                ),
+                onSelect: () => {
+                  triggerHaptic('selection')
+                  void storeMoveToFolder(sessionId, folder.id, currentFolderId, profile)
+                }
+              })
+            )}
+          </kit.SubContent>
+        </kit.Sub>
+      )}
       <kit.Sub>
         <kit.SubTrigger disabled={!sessionId}>
           <Codicon name="folder" size="0.875rem" />

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -57,6 +57,8 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
   isSelected: boolean
   /** Backend-derived read state — same value the dot paints. */
   unread: boolean
+  isWorking?: boolean
+  currentFolderId?: string
   onArchive: () => void
   onBranch?: () => void
   onDelete: () => void
@@ -124,6 +126,8 @@ function SidebarSessionRowImpl({
   isPinned,
   isSelected,
   unread,
+  isWorking,
+  currentFolderId,
   onArchive,
   onBranch,
   onDelete,
@@ -309,6 +313,7 @@ function SidebarSessionRowImpl({
         onToggleUnread={onToggleUnread}
         pinned={isPinned}
         profile={session.profile}
+        currentFolderId={currentFolderId}
         sessionId={session.id}
         title={title}
         unread={unread}
@@ -338,6 +343,7 @@ function SidebarSessionRowImpl({
       onToggleUnread={onToggleUnread}
       pinned={isPinned}
       profile={session.profile}
+      currentFolderId={currentFolderId}
       sessionId={session.id}
       title={title}
       unread={unread}

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -33,6 +33,7 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
   isPinned: boolean
   isSelected: boolean
   isWorking: boolean
+  currentFolderId?: string
   onArchive: () => void
   onBranch?: () => void
   onDelete: () => void
@@ -62,6 +63,7 @@ function SidebarSessionRowImpl({
   isPinned,
   isSelected,
   isWorking,
+  currentFolderId,
   onArchive,
   onBranch,
   onDelete,
@@ -98,6 +100,7 @@ function SidebarSessionRowImpl({
       onPin={onPin}
       pinned={isPinned}
       profile={session.profile}
+      currentFolderId={currentFolderId}
       sessionId={session.id}
       title={title}
     >
@@ -116,6 +119,7 @@ function SidebarSessionRowImpl({
               onPin={onPin}
               pinned={isPinned}
               profile={session.profile}
+              currentFolderId={currentFolderId}
               sessionId={session.id}
               title={title}
             >

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  addSessionsToFolder,
+  createSessionFolder,
+  deleteSessionFolder,
   AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS,
   AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS,
   AUDIO_TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS,
@@ -17,17 +20,21 @@ import {
   getOlderSessionMessages,
   getProfiles,
   getSessionMessages,
+  getSessionFolderMap,
   getStatus,
   LATEST_SESSION_MESSAGES_LIMIT,
   listAllProfileSessions,
+  listSessionFolders,
   listSessions,
+  removeSessionsFromFolder,
   listSidebarSessions,
   pluginSocket,
   resetSidebarBatchCapability,
   setApiRequestProfile,
   speakText,
   transcribeAudio,
-  triggerCronJob
+  triggerCronJob,
+  updateSessionFolder
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 import { $transcriptTailBySessionId, transcriptTailState } from './store/transcript-tail'
@@ -528,6 +535,60 @@ describe('Hermes REST helpers', () => {
         path: '/api/model/options?refresh=1&include_unconfigured=1'
       })
     )
+  })
+
+  it('routes session-folder calls through the profile envelope', async () => {
+    api.mockResolvedValue([])
+    await listSessionFolders('remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders?profile=remote',
+      profile: 'remote'
+    })
+
+    await createSessionFolder('Folder', 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders',
+      method: 'POST',
+      profile: 'remote',
+      body: { name: 'Folder', profile: 'remote' }
+    })
+
+    await updateSessionFolder('folder-1', 'Renamed', 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders/folder-1',
+      method: 'PATCH',
+      profile: 'remote',
+      body: { name: 'Renamed', profile: 'remote' }
+    })
+
+    await deleteSessionFolder('folder-1', 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders/folder-1?profile=remote',
+      method: 'DELETE',
+      profile: 'remote'
+    })
+
+    await addSessionsToFolder('folder-1', ['session-1'], 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders/folder-1/sessions',
+      method: 'POST',
+      profile: 'remote',
+      body: { session_ids: ['session-1'], profile: 'remote' }
+    })
+
+    await removeSessionsFromFolder('folder-1', ['session-1'], 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders/folder-1/sessions',
+      method: 'DELETE',
+      profile: 'remote',
+      body: { session_ids: ['session-1'], profile: 'remote' }
+    })
+
+    await getSessionFolderMap(['session-1'], 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders/map?session_ids=session-1&profile=remote',
+      profile: 'remote'
+    })
   })
 })
 

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  addSessionsToFolder,
+  createSessionFolder,
+  deleteSessionFolder,
   AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS,
   AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS,
   AUDIO_TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS,
@@ -14,14 +17,18 @@ import {
   getHermesConfigDefaults,
   getProfiles,
   getSessionMessages,
+  getSessionFolderMap,
   getStatus,
   listAllProfileSessions,
+  listSessionFolders,
   listSessions,
+  removeSessionsFromFolder,
   listSidebarSessions,
   resetSidebarBatchCapability,
   setApiRequestProfile,
   speakText,
-  transcribeAudio
+  transcribeAudio,
+  updateSessionFolder
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -409,5 +416,59 @@ describe('Hermes REST helpers', () => {
         path: '/api/model/options?refresh=1&include_unconfigured=1'
       })
     )
+  })
+
+  it('routes session-folder calls through the profile envelope', async () => {
+    api.mockResolvedValue([])
+    await listSessionFolders('remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders?profile=remote',
+      profile: 'remote'
+    })
+
+    await createSessionFolder('Folder', 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders',
+      method: 'POST',
+      profile: 'remote',
+      body: { name: 'Folder', profile: 'remote' }
+    })
+
+    await updateSessionFolder('folder-1', 'Renamed', 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders/folder-1',
+      method: 'PATCH',
+      profile: 'remote',
+      body: { name: 'Renamed', profile: 'remote' }
+    })
+
+    await deleteSessionFolder('folder-1', 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders/folder-1?profile=remote',
+      method: 'DELETE',
+      profile: 'remote'
+    })
+
+    await addSessionsToFolder('folder-1', ['session-1'], 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders/folder-1/sessions',
+      method: 'POST',
+      profile: 'remote',
+      body: { session_ids: ['session-1'], profile: 'remote' }
+    })
+
+    await removeSessionsFromFolder('folder-1', ['session-1'], 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders/folder-1/sessions',
+      method: 'DELETE',
+      profile: 'remote',
+      body: { session_ids: ['session-1'], profile: 'remote' }
+    })
+
+    await getSessionFolderMap(['session-1'], 'remote')
+    expect(api).toHaveBeenLastCalledWith({
+      path: '/api/session-folders/map?session_ids=session-1&profile=remote',
+      profile: 'remote'
+    })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1840,3 +1840,82 @@ export function runDebugShare(): Promise<DebugShareResponse> {
     timeoutMs: 120_000
   })
 }
+
+export interface SessionFolder {
+  id: string
+  name: string
+  sort_order: number
+  created_at: number
+  session_count: number
+  session_ids: string[]
+}
+
+export function listSessionFolders(profile?: string): Promise<SessionFolder[]> {
+  const params = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+  return window.hermesDesktop.api<SessionFolder[]>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders${params}`
+  })
+}
+
+export function createSessionFolder(name: string, profile?: string): Promise<SessionFolder> {
+  return window.hermesDesktop.api<SessionFolder>({
+    ...(profile ? { profile } : {}),
+    path: '/api/session-folders',
+    method: 'POST',
+    body: { name, ...(profile ? { profile } : {}) }
+  })
+}
+
+export function updateSessionFolder(folderId: string, name: string, profile?: string): Promise<{ ok: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders/${encodeURIComponent(folderId)}`,
+    method: 'PATCH',
+    body: { name, ...(profile ? { profile } : {}) }
+  })
+}
+
+export function deleteSessionFolder(folderId: string, profile?: string): Promise<{ ok: boolean }> {
+  const params = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+  return window.hermesDesktop.api<{ ok: boolean }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders/${encodeURIComponent(folderId)}${params}`,
+    method: 'DELETE'
+  })
+}
+
+export function addSessionsToFolder(
+  folderId: string,
+  sessionIds: string[],
+  profile?: string
+): Promise<{ ok: boolean; count: number }> {
+  return window.hermesDesktop.api<{ ok: boolean; count: number }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders/${encodeURIComponent(folderId)}/sessions`,
+    method: 'POST',
+    body: { session_ids: sessionIds, ...(profile ? { profile } : {}) }
+  })
+}
+
+export function removeSessionsFromFolder(
+  folderId: string,
+  sessionIds: string[],
+  profile?: string
+): Promise<{ ok: boolean; count: number }> {
+  return window.hermesDesktop.api<{ ok: boolean; count: number }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders/${encodeURIComponent(folderId)}/sessions`,
+    method: 'DELETE',
+    body: { session_ids: sessionIds, ...(profile ? { profile } : {}) }
+  })
+}
+
+export function getSessionFolderMap(sessionIds: string[], profile?: string): Promise<Record<string, string[]>> {
+  const ids = sessionIds.join(',')
+  const params = `?session_ids=${encodeURIComponent(ids)}${profile ? `&profile=${encodeURIComponent(profile)}` : ''}`
+  return window.hermesDesktop.api<Record<string, string[]>>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders/map${params}`
+  })
+}

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -2160,3 +2160,82 @@ export function runDebugShare(): Promise<DebugShareResponse> {
     timeoutMs: 120_000
   })
 }
+
+export interface SessionFolder {
+  id: string
+  name: string
+  sort_order: number
+  created_at: number
+  session_count: number
+  session_ids: string[]
+}
+
+export function listSessionFolders(profile?: string): Promise<SessionFolder[]> {
+  const params = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+  return window.hermesDesktop.api<SessionFolder[]>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders${params}`
+  })
+}
+
+export function createSessionFolder(name: string, profile?: string): Promise<SessionFolder> {
+  return window.hermesDesktop.api<SessionFolder>({
+    ...(profile ? { profile } : {}),
+    path: '/api/session-folders',
+    method: 'POST',
+    body: { name, ...(profile ? { profile } : {}) }
+  })
+}
+
+export function updateSessionFolder(folderId: string, name: string, profile?: string): Promise<{ ok: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders/${encodeURIComponent(folderId)}`,
+    method: 'PATCH',
+    body: { name, ...(profile ? { profile } : {}) }
+  })
+}
+
+export function deleteSessionFolder(folderId: string, profile?: string): Promise<{ ok: boolean }> {
+  const params = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+  return window.hermesDesktop.api<{ ok: boolean }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders/${encodeURIComponent(folderId)}${params}`,
+    method: 'DELETE'
+  })
+}
+
+export function addSessionsToFolder(
+  folderId: string,
+  sessionIds: string[],
+  profile?: string
+): Promise<{ ok: boolean; count: number }> {
+  return window.hermesDesktop.api<{ ok: boolean; count: number }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders/${encodeURIComponent(folderId)}/sessions`,
+    method: 'POST',
+    body: { session_ids: sessionIds, ...(profile ? { profile } : {}) }
+  })
+}
+
+export function removeSessionsFromFolder(
+  folderId: string,
+  sessionIds: string[],
+  profile?: string
+): Promise<{ ok: boolean; count: number }> {
+  return window.hermesDesktop.api<{ ok: boolean; count: number }>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders/${encodeURIComponent(folderId)}/sessions`,
+    method: 'DELETE',
+    body: { session_ids: sessionIds, ...(profile ? { profile } : {}) }
+  })
+}
+
+export function getSessionFolderMap(sessionIds: string[], profile?: string): Promise<Record<string, string[]>> {
+  const ids = sessionIds.join(',')
+  const params = `?session_ids=${encodeURIComponent(ids)}${profile ? `&profile=${encodeURIComponent(profile)}` : ''}`
+  return window.hermesDesktop.api<Record<string, string[]>>({
+    ...(profile ? { profile } : {}),
+    path: `/api/session-folders/map${params}`
+  })
+}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1707,7 +1707,16 @@ export const ar = defineLocale({
       ageNow: 'الآن',
       ageDay: 'يوم',
       ageHour: 'ساعة',
-      ageMin: 'دقيقة'
+      ageMin: 'دقيقة',
+      folders: 'المجلدات',
+      createFolder: 'مجلد جديد…',
+      renameFolder: 'إعادة تسمية المجلد',
+      deleteFolder: 'حذف المجلد',
+      deleteFolderConfirm: 'حذف "{name}"؟ لن يتم حذف الجلسات الموجودة فيه.',
+      moveToFolder: 'نقل إلى مجلد',
+      removeFromFolder: 'إزالة من المجلد',
+      addToFolder: 'إضافة إلى مجلد',
+      noFolders: 'لا توجد مجلدات بعد'
     }
   },
   composer: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1963,7 +1963,17 @@ export const en: Translations = {
       ageNow: 'now',
       ageDay: 'd',
       ageHour: 'h',
-      ageMin: 'm'
+      ageMin: 'm',
+      folders: 'Folders',
+      createFolder: 'New folder…',
+      renameFolder: 'Rename folder',
+      deleteFolder: 'Delete folder',
+      deleteFolderConfirm: 'Delete "{name}"? Sessions in it won\'t be deleted.',
+      moveToFolder: 'Move to folder',
+      removeFromFolder: 'Remove from folder',
+      addToFolder: 'Add to folder',
+      noFolders: 'No folders yet'
+
     },
     dateDivider: {
       today: 'Earlier today',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2117,7 +2117,17 @@ export const en: Translations = {
       ageNow: 'now',
       ageDay: 'd',
       ageHour: 'h',
-      ageMin: 'm'
+      ageMin: 'm',
+      folders: 'Folders',
+      createFolder: 'New folder…',
+      renameFolder: 'Rename folder',
+      deleteFolder: 'Delete folder',
+      deleteFolderConfirm: 'Delete "{name}"? Sessions in it won\'t be deleted.',
+      moveToFolder: 'Move to folder',
+      removeFromFolder: 'Remove from folder',
+      addToFolder: 'Add to folder',
+      noFolders: 'No folders yet'
+
     },
     dateDivider: {
       today: 'Earlier today',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1868,7 +1868,16 @@ export const ja = defineLocale({
       ageNow: 'たった今',
       ageDay: '日',
       ageHour: '時間',
-      ageMin: '分'
+      ageMin: '分',
+      folders: 'フォルダ',
+      createFolder: '新しいフォルダ…',
+      renameFolder: 'フォルダ名を変更',
+      deleteFolder: 'フォルダを削除',
+      deleteFolderConfirm: '「{name}」を削除しますか？内のセッションは削除されません。',
+      moveToFolder: 'フォルダへ移動',
+      removeFromFolder: 'フォルダから削除',
+      addToFolder: 'フォルダに追加',
+      noFolders: 'フォルダはまだありません'
     },
     dateDivider: {
       today: '今日の早い時間',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1657,7 +1657,17 @@ export interface Translations {
       ageNow: string
       ageDay: string
       ageHour: string
-      ageMin: string
+      ageMin: string,
+      folders: string
+      createFolder: string
+      renameFolder: string
+      deleteFolder: string
+      deleteFolderConfirm: string
+      moveToFolder: string
+      removeFromFolder: string
+      addToFolder: string
+      noFolders: string
+
     }
     dateDivider: {
       today: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1795,7 +1795,17 @@ export interface Translations {
       ageNow: string
       ageDay: string
       ageHour: string
-      ageMin: string
+      ageMin: string,
+      folders: string
+      createFolder: string
+      renameFolder: string
+      deleteFolder: string
+      deleteFolderConfirm: string
+      moveToFolder: string
+      removeFromFolder: string
+      addToFolder: string
+      noFolders: string
+
     }
     dateDivider: {
       today: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1805,7 +1805,16 @@ export const zhHant = defineLocale({
       ageNow: '剛才',
       ageDay: '天',
       ageHour: '時',
-      ageMin: '分'
+      ageMin: '分',
+      folders: '資料夾',
+      createFolder: '新增資料夾…',
+      renameFolder: '重新命名資料夾',
+      deleteFolder: '刪除資料夾',
+      deleteFolderConfirm: '刪除「{name}」？其中的工作階段不會被刪除。',
+      moveToFolder: '移至資料夾',
+      removeFromFolder: '從資料夾移除',
+      addToFolder: '新增至資料夾',
+      noFolders: '尚無資料夾'
     },
     dateDivider: {
       today: '今天稍早',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2156,7 +2156,17 @@ export const zh: Translations = {
       ageNow: '刚刚',
       ageDay: '天',
       ageHour: '时',
-      ageMin: '分'
+      ageMin: '分',
+      folders: '文件夹',
+      createFolder: '新建文件夹…',
+      renameFolder: '重命名文件夹',
+      deleteFolder: '删除文件夹',
+      deleteFolderConfirm: '删除“{name}”？其中的会话不会被删除。',
+      moveToFolder: '移动到文件夹',
+      removeFromFolder: '从文件夹移除',
+      addToFolder: '添加到文件夹',
+      noFolders: '暂无文件夹'
+
     },
     dateDivider: {
       today: '今天早些时候',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2302,7 +2302,17 @@ export const zh: Translations = {
       ageNow: '刚刚',
       ageDay: '天',
       ageHour: '时',
-      ageMin: '分'
+      ageMin: '分',
+      folders: '文件夹',
+      createFolder: '新建文件夹…',
+      renameFolder: '重命名文件夹',
+      deleteFolder: '删除文件夹',
+      deleteFolderConfirm: '删除“{name}”？其中的会话不会被删除。',
+      moveToFolder: '移动到文件夹',
+      removeFromFolder: '从文件夹移除',
+      addToFolder: '添加到文件夹',
+      noFolders: '暂无文件夹'
+
     },
     dateDivider: {
       today: '今天早些时候',

--- a/apps/desktop/src/store/session-folders.ts
+++ b/apps/desktop/src/store/session-folders.ts
@@ -1,0 +1,95 @@
+import { atom } from 'nanostores'
+
+import {
+  addSessionsToFolder,
+  createSessionFolder,
+  deleteSessionFolder,
+  listSessionFolders,
+  removeSessionsFromFolder
+} from '@/hermes'
+import type { SessionFolder } from '@/hermes'
+
+export type { SessionFolder } from '@/hermes'
+
+export const $folders = atom<SessionFolder[]>([])
+export const $foldersLoading = atom(true)
+
+let refreshGeneration = 0
+let folderProfile: string | undefined
+
+export async function refreshFolders(profile?: string): Promise<void> {
+  const generation = ++refreshGeneration
+  if (folderProfile !== profile) {
+    folderProfile = profile
+    $folders.set([])
+  }
+  $foldersLoading.set(true)
+
+  try {
+    const result = await listSessionFolders(profile)
+    if (generation === refreshGeneration) {
+      $folders.set(result)
+    }
+  } catch {
+    // Silently fail — folders are non-critical UI
+  } finally {
+    if (generation === refreshGeneration) {
+      $foldersLoading.set(false)
+    }
+  }
+}
+
+export async function createFolder(name: string, profile?: string): Promise<SessionFolder | null> {
+  try {
+    const folder = await createSessionFolder(name, profile)
+    if (folderProfile === profile) {
+      $folders.set([...$folders.get(), folder])
+    }
+    return folder
+  } catch {
+    return null
+  }
+}
+
+export async function deleteAndRemoveFolder(id: string, profile?: string): Promise<boolean> {
+  try {
+    await deleteSessionFolder(id, profile)
+    if (folderProfile === profile) {
+      $folders.set($folders.get().filter(f => f.id !== id))
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function moveToFolder(
+  sessionId: string,
+  folderId: string,
+  currentFolderId?: string | null,
+  profile?: string
+): Promise<boolean> {
+  try {
+    if (currentFolderId === folderId) {
+      return true
+    }
+    await addSessionsToFolder(folderId, [sessionId], profile)
+    if (currentFolderId) {
+      await removeSessionsFromFolder(currentFolderId, [sessionId], profile)
+    }
+    await refreshFolders(profile)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function removeFromFolder(sessionId: string, folderId: string, profile?: string): Promise<boolean> {
+  try {
+    await removeSessionsFromFolder(folderId, [sessionId], profile)
+    await refreshFolders(profile)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1415,3 +1415,12 @@ export interface ModelAssignmentResponse {
   stale_aux?: StaleAuxAssignment[]
   tasks?: string[]
 }
+
+export interface SessionFolder {
+  id: string
+  name: string
+  sort_order: number
+  created_at: number
+  session_count: number
+  session_ids: string[]
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1501,3 +1501,12 @@ export interface ModelAssignmentResponse {
   stale_aux?: StaleAuxAssignment[]
   tasks?: string[]
 }
+
+export interface SessionFolder {
+  id: string
+  name: string
+  sort_order: number
+  created_at: number
+  session_count: number
+  session_ids: string[]
+}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11325,6 +11325,125 @@ def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
     return _open_session_db_at_path(db_path, read_only=read_only)
 
 
+# ── Session Folders ──────────────────────────────────────────────────
+
+
+class FolderCreate(BaseModel):
+    name: str
+    profile: Optional[str] = None
+
+
+class FolderUpdate(BaseModel):
+    name: str
+    profile: Optional[str] = None
+
+
+class FolderMemberships(BaseModel):
+    session_ids: List[str]
+    profile: Optional[str] = None
+
+
+class FolderMembershipResponse(BaseModel):
+    ok: bool
+    count: int
+
+
+@app.get("/api/session-folders")
+async def get_session_folders(profile: Optional[str] = None):
+    """List all folders with per-folder session count."""
+    db = _open_session_db_for_profile(profile)
+    try:
+        return db.list_folders()
+    finally:
+        db.close()
+
+
+@app.post("/api/session-folders")
+async def create_session_folder(body: FolderCreate):
+    """Create a folder and return its row."""
+    db = _open_session_db_for_profile(body.profile)
+    try:
+        try:
+            return db.create_folder(name=body.name)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        db.close()
+
+
+@app.patch("/api/session-folders/{folder_id}")
+async def update_session_folder(folder_id: str, body: FolderUpdate):
+    """Rename a folder."""
+    db = _open_session_db_for_profile(body.profile)
+    try:
+        ok = db.update_folder(folder_id, name=body.name)
+        if not ok:
+            raise HTTPException(status_code=404, detail="Folder not found")
+        return {"ok": True}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        db.close()
+
+
+@app.delete("/api/session-folders/{folder_id}")
+async def delete_session_folder(folder_id: str, profile: Optional[str] = None):
+    """Delete a folder. Sessions in it are NOT deleted."""
+    db = _open_session_db_for_profile(profile)
+    try:
+        ok = db.delete_folder(folder_id)
+        if not ok:
+            raise HTTPException(status_code=404, detail="Folder not found")
+        return {"ok": True}
+    finally:
+        db.close()
+
+
+@app.post("/api/session-folders/{folder_id}/sessions")
+async def add_sessions_to_folder(folder_id: str, body: FolderMemberships):
+    """Add sessions to a folder. Returns count of newly added."""
+    import sqlite3
+
+    db = _open_session_db_for_profile(body.profile)
+    try:
+        try:
+            count = db.add_sessions_to_folder(folder_id, body.session_ids)
+            return {"ok": True, "count": count}
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except sqlite3.IntegrityError:
+            raise HTTPException(
+                status_code=500,
+                detail="Folder not found or foreign key constraint violated",
+            )
+    finally:
+        db.close()
+
+
+@app.delete("/api/session-folders/{folder_id}/sessions")
+async def remove_sessions_from_folder(folder_id: str, body: FolderMemberships):
+    """Remove sessions from a folder. Returns count of removed."""
+    db = _open_session_db_for_profile(body.profile)
+    try:
+        count = db.remove_sessions_from_folder(folder_id, body.session_ids)
+        return {"ok": True, "count": count}
+    finally:
+        db.close()
+
+
+@app.get("/api/session-folders/map")
+async def get_folder_map(session_ids: str = "", profile: Optional[str] = None):
+    """Get folder membership map for a comma-separated list of session IDs.
+
+    Returns ``{session_id: [folder_id, ...]}``.
+    """
+    ids = [s.strip() for s in session_ids.split(",") if s.strip()]
+    db = _open_session_db_for_profile(profile)
+    try:
+        return db.get_session_folder_map(ids)
+    finally:
+        db.close()
+
 # In-process throttle for the opportunistic auto-archive trigger, keyed by
 # profile. Bounds the config.yaml read to at most once per this window per
 # profile; the actual sweep is throttled far more coarsely by state_meta

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11968,6 +11968,125 @@ def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
     return _open_session_db_at_path(db_path, read_only=read_only)
 
 
+# ── Session Folders ──────────────────────────────────────────────────
+
+
+class FolderCreate(BaseModel):
+    name: str
+    profile: Optional[str] = None
+
+
+class FolderUpdate(BaseModel):
+    name: str
+    profile: Optional[str] = None
+
+
+class FolderMemberships(BaseModel):
+    session_ids: List[str]
+    profile: Optional[str] = None
+
+
+class FolderMembershipResponse(BaseModel):
+    ok: bool
+    count: int
+
+
+@app.get("/api/session-folders")
+async def get_session_folders(profile: Optional[str] = None):
+    """List all folders with per-folder session count."""
+    db = _open_session_db_for_profile(profile)
+    try:
+        return db.list_folders()
+    finally:
+        db.close()
+
+
+@app.post("/api/session-folders")
+async def create_session_folder(body: FolderCreate):
+    """Create a folder and return its row."""
+    db = _open_session_db_for_profile(body.profile)
+    try:
+        try:
+            return db.create_folder(name=body.name)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        db.close()
+
+
+@app.patch("/api/session-folders/{folder_id}")
+async def update_session_folder(folder_id: str, body: FolderUpdate):
+    """Rename a folder."""
+    db = _open_session_db_for_profile(body.profile)
+    try:
+        ok = db.update_folder(folder_id, name=body.name)
+        if not ok:
+            raise HTTPException(status_code=404, detail="Folder not found")
+        return {"ok": True}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        db.close()
+
+
+@app.delete("/api/session-folders/{folder_id}")
+async def delete_session_folder(folder_id: str, profile: Optional[str] = None):
+    """Delete a folder. Sessions in it are NOT deleted."""
+    db = _open_session_db_for_profile(profile)
+    try:
+        ok = db.delete_folder(folder_id)
+        if not ok:
+            raise HTTPException(status_code=404, detail="Folder not found")
+        return {"ok": True}
+    finally:
+        db.close()
+
+
+@app.post("/api/session-folders/{folder_id}/sessions")
+async def add_sessions_to_folder(folder_id: str, body: FolderMemberships):
+    """Add sessions to a folder. Returns count of newly added."""
+    import sqlite3
+
+    db = _open_session_db_for_profile(body.profile)
+    try:
+        try:
+            count = db.add_sessions_to_folder(folder_id, body.session_ids)
+            return {"ok": True, "count": count}
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except sqlite3.IntegrityError:
+            raise HTTPException(
+                status_code=500,
+                detail="Folder not found or foreign key constraint violated",
+            )
+    finally:
+        db.close()
+
+
+@app.delete("/api/session-folders/{folder_id}/sessions")
+async def remove_sessions_from_folder(folder_id: str, body: FolderMemberships):
+    """Remove sessions from a folder. Returns count of removed."""
+    db = _open_session_db_for_profile(body.profile)
+    try:
+        count = db.remove_sessions_from_folder(folder_id, body.session_ids)
+        return {"ok": True, "count": count}
+    finally:
+        db.close()
+
+
+@app.get("/api/session-folders/map")
+async def get_folder_map(session_ids: str = "", profile: Optional[str] = None):
+    """Get folder membership map for a comma-separated list of session IDs.
+
+    Returns ``{session_id: [folder_id, ...]}``.
+    """
+    ids = [s.strip() for s in session_ids.split(",") if s.strip()]
+    db = _open_session_db_for_profile(profile)
+    try:
+        return db.get_session_folder_map(ids)
+    finally:
+        db.close()
+
 # In-process throttle for the opportunistic auto-archive trigger, keyed by
 # profile. Bounds the config.yaml read to at most once per this window per
 # profile; the actual sweep is throttled far more coarsely by state_meta

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -83,6 +83,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
 from hermes_state_portability import SessionPortabilityMixin
 from hermes_state_schema import SessionSchemaMixin
 from hermes_state_search import SessionSearchMixin
+from hermes_state_folders import SessionFolderMixin
 
 try:  # Hard dependency, but tolerate scaffold-phase imports before pip install.
     import psutil
@@ -3090,7 +3091,7 @@ def classify_session_status(
     return SESSION_STATUS_COMPLETE
 
 
-class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin):
+class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin, SessionFolderMixin):
     """
     SQLite-backed session storage with FTS5 search.
 
@@ -11427,6 +11428,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if actual_ids != expected_ids:
                     return False
             removed_delegate_ids.extend(_delete_delegate_children(conn, [session_id]))
+            conn.execute("DELETE FROM session_folder_members WHERE session_id = ?", (session_id,))
             # Orphan remaining child sessions (branches, etc.) so FK is satisfied.
             conn.execute(
                 "UPDATE sessions SET parent_session_id = NULL "
@@ -11465,6 +11467,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         flushed. Returns True if the session was deleted.
         """
         def _do(conn):
+            conn.execute("DELETE FROM session_folder_members WHERE session_id = ?", (session_id,))
             cursor = conn.execute(
                 """
                 DELETE FROM sessions
@@ -11656,6 +11659,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 conn.execute(
                     "DELETE FROM messages WHERE session_id = ?", (sid,)
                 )
+                conn.execute("DELETE FROM session_folder_members WHERE session_id = ?", (sid,))
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
                 removed_ids.append(sid)
             self._delete_unreferenced_system_prompts(conn)
@@ -12017,6 +12021,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             for sid in session_ids:
                 conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
+                conn.execute("DELETE FROM session_folder_members WHERE session_id = ?", (sid,))
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
                 removed_ids.append(sid)
             self._delete_unreferenced_system_prompts(conn)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -76,6 +76,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
 from hermes_state_portability import SessionPortabilityMixin
 from hermes_state_schema import SessionSchemaMixin
 from hermes_state_search import SessionSearchMixin
+from hermes_state_folders import SessionFolderMixin
 
 try:  # Hard dependency, but tolerate scaffold-phase imports before pip install.
     import psutil
@@ -2089,7 +2090,7 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
             handle.close()
 
 
-class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin):
+class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin, SessionFolderMixin):
     """
     SQLite-backed session storage with FTS5 search.
 
@@ -8395,6 +8396,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if actual_ids != expected_ids:
                     return False
             removed_delegate_ids.extend(_delete_delegate_children(conn, [session_id]))
+            conn.execute("DELETE FROM session_folder_members WHERE session_id = ?", (session_id,))
             # Orphan remaining child sessions (branches, etc.) so FK is satisfied.
             conn.execute(
                 "UPDATE sessions SET parent_session_id = NULL "
@@ -8433,6 +8435,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         flushed. Returns True if the session was deleted.
         """
         def _do(conn):
+            conn.execute("DELETE FROM session_folder_members WHERE session_id = ?", (session_id,))
             cursor = conn.execute(
                 """
                 DELETE FROM sessions
@@ -8624,6 +8627,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 conn.execute(
                     "DELETE FROM messages WHERE session_id = ?", (sid,)
                 )
+                conn.execute("DELETE FROM session_folder_members WHERE session_id = ?", (sid,))
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
                 removed_ids.append(sid)
             self._delete_unreferenced_system_prompts(conn)
@@ -8960,6 +8964,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             for sid in session_ids:
                 conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
+                conn.execute("DELETE FROM session_folder_members WHERE session_id = ?", (sid,))
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
                 removed_ids.append(sid)
             self._delete_unreferenced_system_prompts(conn)

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -317,6 +317,21 @@ CREATE TABLE IF NOT EXISTS sessions (
     FOREIGN KEY (system_prompt_hash) REFERENCES system_prompts(hash)
 );
 
+CREATE TABLE IF NOT EXISTS session_folders (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    sort_order  INTEGER NOT NULL DEFAULT 0,
+    created_at  REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_folder_members (
+    folder_id   TEXT NOT NULL REFERENCES session_folders(id) ON DELETE CASCADE,
+    session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    added_at    REAL NOT NULL,
+    PRIMARY KEY (folder_id, session_id)
+);
+
+
 CREATE TABLE IF NOT EXISTS messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id TEXT NOT NULL REFERENCES sessions(id),

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -262,6 +262,21 @@ CREATE TABLE IF NOT EXISTS sessions (
     FOREIGN KEY (system_prompt_hash) REFERENCES system_prompts(hash)
 );
 
+CREATE TABLE IF NOT EXISTS session_folders (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    sort_order  INTEGER NOT NULL DEFAULT 0,
+    created_at  REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_folder_members (
+    folder_id   TEXT NOT NULL REFERENCES session_folders(id) ON DELETE CASCADE,
+    session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    added_at    REAL NOT NULL,
+    PRIMARY KEY (folder_id, session_id)
+);
+
+
 CREATE TABLE IF NOT EXISTS messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id TEXT NOT NULL REFERENCES sessions(id),

--- a/hermes_state_folders.py
+++ b/hermes_state_folders.py
@@ -1,0 +1,137 @@
+"""Session folder operations mixed into :class:`hermes_state.SessionDB`."""
+
+import secrets
+import sqlite3
+import time
+
+
+class SessionFolderMixin:
+    def list_folders(self) -> list[dict]:
+        with self._lock:
+            rows = self._conn.execute(
+                """SELECT f.*, COUNT(m.session_id) AS session_count,
+                          COALESCE(GROUP_CONCAT(m.session_id), '') AS session_ids
+                   FROM session_folders f
+                   LEFT JOIN session_folder_members m ON m.folder_id = f.id
+                   GROUP BY f.id
+                   ORDER BY f.sort_order ASC, f.created_at ASC"""
+            ).fetchall()
+
+        folders = []
+        for row in rows:
+            folder = dict(row)
+            session_ids = folder.pop("session_ids", "")
+            folder["session_ids"] = session_ids.split(",") if session_ids else []
+            folders.append(folder)
+        return folders
+
+    def create_folder(self, *, name: str) -> dict:
+        name = (name or "").strip()
+        if not name:
+            raise ValueError("folder name must not be empty")
+
+        folder_id = "sf_" + secrets.token_hex(4)
+        created_at = time.time()
+
+        def create(conn):
+            sort_order = conn.execute(
+                "SELECT COALESCE(MAX(sort_order), -1) + 1 FROM session_folders"
+            ).fetchone()[0]
+            conn.execute(
+                "INSERT INTO session_folders (id, name, sort_order, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (folder_id, name, sort_order, created_at),
+            )
+            row = conn.execute(
+                "SELECT f.*, 0 AS session_count FROM session_folders f WHERE f.id = ?",
+                (folder_id,),
+            ).fetchone()
+            result = dict(row) if row else {}
+            result["session_ids"] = []
+            return result
+
+        return self._execute_write(create)
+
+    def update_folder(self, folder_id: str, *, name: str) -> bool:
+        name = (name or "").strip()
+        if not name:
+            raise ValueError("folder name must not be empty")
+        return bool(
+            self._execute_write(
+                lambda conn: conn.execute(
+                    "UPDATE session_folders SET name = ? WHERE id = ?", (name, folder_id)
+                ).rowcount
+            )
+        )
+
+    def delete_folder(self, folder_id: str) -> bool:
+        return bool(
+            self._execute_write(
+                lambda conn: conn.execute(
+                    "DELETE FROM session_folders WHERE id = ?", (folder_id,)
+                ).rowcount
+            )
+        )
+
+    def add_sessions_to_folder(self, folder_id: str, session_ids: list[str]) -> int:
+        now = time.time()
+
+        def add(conn):
+            unique_ids = list(dict.fromkeys(sid for sid in session_ids if sid))
+            if not unique_ids:
+                return 0
+            if not conn.execute(
+                "SELECT 1 FROM session_folders WHERE id = ?", (folder_id,)
+            ).fetchone():
+                raise sqlite3.IntegrityError("Folder not found")
+
+            placeholders = ",".join("?" * len(unique_ids))
+            existing = {
+                row[0]
+                for row in conn.execute(
+                    f"SELECT id FROM sessions WHERE id IN ({placeholders})", unique_ids
+                ).fetchall()
+            }
+            missing = [sid for sid in unique_ids if sid not in existing]
+            if missing:
+                raise ValueError(f"session not found: {missing[0]}")
+
+            return sum(
+                1
+                for session_id in unique_ids
+                if conn.execute(
+                    "INSERT OR IGNORE INTO session_folder_members "
+                    "(folder_id, session_id, added_at) VALUES (?, ?, ?)",
+                    (folder_id, session_id, now),
+                ).rowcount
+            )
+
+        return self._execute_write(add)
+
+    def remove_sessions_from_folder(self, folder_id: str, session_ids: list[str]) -> int:
+        if not session_ids:
+            return 0
+        placeholders = ",".join("?" * len(session_ids))
+        return self._execute_write(
+            lambda conn: conn.execute(
+                "DELETE FROM session_folder_members "
+                f"WHERE folder_id = ? AND session_id IN ({placeholders})",
+                [folder_id, *session_ids],
+            ).rowcount
+        )
+
+    def get_session_folder_map(self, session_ids: list[str]) -> dict[str, list[str]]:
+        if not session_ids:
+            return {}
+        placeholders = ",".join("?" * len(session_ids))
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT session_id, folder_id FROM session_folder_members "
+                f"WHERE session_id IN ({placeholders})",
+                session_ids,
+            ).fetchall()
+
+        result: dict[str, list[str]] = {}
+        for row in rows:
+            result.setdefault(row["session_id"], []).append(row["folder_id"])
+        return result

--- a/skills/session-folders/skill.md
+++ b/skills/session-folders/skill.md
@@ -1,0 +1,26 @@
+---
+name: session-folders
+description: Organize sessions into user-defined named folders.
+---
+
+# Session Folders
+
+Use when the user asks you to organize their sessions into named groups ("folders").
+
+## Available Tools
+
+- `session_folder_list` — View existing folders and their session counts
+- `session_folder_create` — Create a new named folder
+- `session_folder_add` — Add session(s) to a folder
+
+## Workflow: Create a folder and populate it
+
+1. `session_folder_create(name='Design Projects')` — create the folder
+2. `session_list(query='design')` — find relevant sessions
+3. `session_folder_add(folder_id='...', session_ids=['...', '...'])` — add them
+
+## Workflow: Organize existing sessions
+
+1. `session_folder_list()` — see what folders exist
+2. For each folder, `session_list(search='...')` to find matching sessions
+3. Add sessions to the appropriate folder

--- a/skills/session-management/skill.md
+++ b/skills/session-management/skill.md
@@ -1,0 +1,29 @@
+---
+name: session-management
+description: Manage Hermes sessions — list, archive, rename, and delete conversations from the desktop app.
+---
+
+# Session Management
+
+Use when the user asks you to manage their Hermes sessions (list, archive, rename, delete, or organize).
+
+## Available Tools
+
+These tools are automatically available when the Hermes dashboard is running (desktop app open).
+
+- `session_list` — List sessions with filters (archived status, source, search)
+- `session_archive` — Archive or unarchive a session
+- `session_rename` — Rename a session
+- `session_delete` — Permanently delete a session
+
+## Workflow: Clean up old sessions
+
+1. `session_list(archived='exclude', order='recent')` — get the list
+2. Find sessions the user wants to archive/rename/delete
+3. Use the appropriate tool on each session ID
+
+## Workflow: Archive a batch of old sessions
+
+1. `session_list(limit=50)` — fetch recent sessions
+2. Present a summary with titles and dates
+3. For each session to archive: `session_archive(session_id='...')`

--- a/skills/session-organization/skill.md
+++ b/skills/session-organization/skill.md
@@ -1,0 +1,29 @@
+---
+name: session-organization
+description: Full workflow for organizing Hermes sessions — archive stale ones, group related ones into folders, rename for clarity.
+---
+
+# Session Organization
+
+Complete workflow for keeping your session list tidy. Combines session-management and session-folders tools.
+
+## Full Cleanup Workflow
+
+1. **List all sessions** — `session_list(limit=100)`
+2. **Archive stale ones** — Identify old/unused sessions and archive them
+3. **Rename vague ones** — `session_rename(session_id='...', title='Design Review - Week 4')`
+4. **Create folders** — `session_folder_create(name='Client Projects')`
+5. **Group sessions** — `session_folder_add(folder_id='...', session_ids=['...', '...'])`
+6. **Verify** — `session_folder_list()` to confirm
+
+## Quick Reference
+
+| Action | Tool | Example |
+|--------|------|---------|
+| List sessions | `session_list` | `session_list(limit=20)` |
+| Archive | `session_archive` | `session_archive(session_id='abc')` |
+| Rename | `session_rename` | `session_rename(session_id='abc', title='New Name')` |
+| Delete | `session_delete` | `session_delete(session_id='abc')` |
+| Create folder | `session_folder_create` | `session_folder_create(name='Bug Reports')` |
+| Add to folder | `session_folder_add` | `session_folder_add(folder_id='x', session_ids=['a','b'])` |
+| List folders | `session_folder_list` | `session_folder_list()` |

--- a/tests/test_session_folders_api.py
+++ b/tests/test_session_folders_api.py
@@ -1,0 +1,378 @@
+"""Integration tests for session folder REST API endpoints.
+
+Uses FastAPI TestClient against the real web_server app with a temp SQLite DB.
+The `_open_session_db_for_profile` helper is monkeypatched to return a
+test SessionDB pointing at a temp file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+
+import pytest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# =====================================================================
+# Fixtures
+# =====================================================================
+
+
+@pytest.fixture
+def tmp_db_path(tmp_path):
+    """Path for a temporary state.db."""
+    return str(tmp_path / "test_state.db")
+
+
+@pytest.fixture
+def test_app(tmp_db_path):
+    """Return a TestClient bound to the web_server app with a temp DB."""
+    import os
+    os.environ["HERMES_DASHBOARD_SESSION_TOKEN"] = "test-session-token-for-testing"
+    from fastapi.testclient import TestClient
+    from hermes_state import SessionDB
+    from pathlib import Path
+    from hermes_cli import web_server as ws
+
+    import importlib
+    importlib.reload(ws)
+
+    db_path = Path(tmp_db_path)
+    db = SessionDB(db_path=db_path)
+    original_opener = ws._open_session_db_for_profile
+
+    def test_opener(profile=None):
+        return SessionDB(db_path=db_path)
+
+    ws._open_session_db_for_profile = test_opener
+    client = TestClient(ws.app)
+    client.headers["X-Hermes-Session-Token"] = "test-session-token-for-testing"
+
+    yield client, db
+
+    ws._open_session_db_for_profile = original_opener
+    db.close()
+
+
+@pytest.fixture
+def db_with_sessions(test_app):
+    """Return a test app + client + a SessionDB with 3 sessions and a folder."""
+    client, db = test_app
+    for i in range(3):
+        sid = f"s{i}"
+        db.create_session(session_id=sid, source="cli")
+        db.append_message(sid, role="user", content=f"Hello {i}")
+    folder = db.create_folder(name="Test Folder")
+    return client, db, folder
+
+
+# =====================================================================
+# Folder CRUD
+# =====================================================================
+
+
+class TestCreateFolder:
+    def test_create(self, test_app):
+        client, db = test_app
+        resp = client.post("/api/session-folders", json={"name": "Bug Reports"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "Bug Reports"
+        assert data["session_count"] == 0
+        assert data["session_ids"] == []
+        assert data["id"].startswith("sf_")
+
+    def test_empty_name_returns_400(self, test_app):
+        client, db = test_app
+        resp = client.post("/api/session-folders", json={"name": ""})
+        assert resp.status_code == 400
+
+    def test_missing_name_returns_422(self, test_app):
+        client, db = test_app
+        resp = client.post("/api/session-folders", json={})
+        assert resp.status_code == 422
+
+    def test_agent_style_request_requires_dashboard_token(self, test_app):
+        client, db = test_app
+        client.headers.pop("X-Hermes-Session-Token")
+        assert client.post("/api/session-folders", json={"name": "Denied"}).status_code == 401
+        client.headers["X-Hermes-Session-Token"] = "test-session-token-for-testing"
+        assert client.post("/api/session-folders", json={"name": "Allowed"}).status_code == 200
+
+
+class TestListFolders:
+    def test_list_empty(self, test_app):
+        client, db = test_app
+        resp = client.get("/api/session-folders")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_with_folders(self, test_app):
+        client, db = test_app
+        client.post("/api/session-folders", json={"name": "A"})
+        client.post("/api/session-folders", json={"name": "B"})
+        resp = client.get("/api/session-folders")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        names = [f["name"] for f in data]
+        assert "A" in names
+        assert "B" in names
+
+    def test_session_count_reflects_members(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        db.add_sessions_to_folder(folder["id"], ["s0", "s1"])
+        resp = client.get("/api/session-folders")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        target = [f for f in data if f["id"] == folder["id"]][0]
+        assert target["session_count"] == 2
+
+
+class TestRenameFolder:
+    def test_rename(self, test_app):
+        client, db = test_app
+        resp = client.post("/api/session-folders", json={"name": "Old"})
+        assert resp.status_code == 200
+        create = resp.json()
+        resp = client.patch(f"/api/session-folders/{create['id']}", json={"name": "New"})
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        folders = client.get("/api/session-folders").json()
+        renamed = [f for f in folders if f["id"] == create["id"]][0]
+        assert renamed["name"] == "New"
+
+    def test_rename_nonexistent(self, test_app):
+        client, db = test_app
+        resp = client.patch("/api/session-folders/nonexistent", json={"name": "X"})
+        assert resp.status_code == 404
+
+    def test_rename_empty_name(self, test_app):
+        client, db = test_app
+        resp = client.post("/api/session-folders", json={"name": "X"})
+        assert resp.status_code == 200
+        create = resp.json()
+        resp = client.patch(f"/api/session-folders/{create['id']}", json={"name": ""})
+        assert resp.status_code == 400
+
+
+class TestDeleteFolder:
+    def test_delete(self, test_app):
+        client, db = test_app
+        resp = client.post("/api/session-folders", json={"name": "To Delete"})
+        assert resp.status_code == 200
+        create = resp.json()
+        resp = client.delete(f"/api/session-folders/{create['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        folders = client.get("/api/session-folders").json()
+        assert len(folders) == 0
+
+    def test_delete_nonexistent(self, test_app):
+        client, db = test_app
+        resp = client.delete("/api/session-folders/nonexistent")
+        assert resp.status_code == 404
+
+    def test_delete_does_not_delete_sessions(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        db.add_sessions_to_folder(folder["id"], ["s0"])
+        resp = client.delete(f"/api/session-folders/{folder['id']}")
+        assert resp.status_code == 200
+        assert db.get_session("s0") is not None
+
+
+# =====================================================================
+# Session membership
+# =====================================================================
+
+
+class TestAddSessions:
+    def test_add(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        resp = client.post(
+            f"/api/session-folders/{folder['id']}/sessions",
+            json={"session_ids": ["s0", "s1"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 2
+
+    def test_add_idempotent(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        client.post(
+            f"/api/session-folders/{folder['id']}/sessions",
+            json={"session_ids": ["s0"]},
+        )
+        resp = client.post(
+            f"/api/session-folders/{folder['id']}/sessions",
+            json={"session_ids": ["s0"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 0
+
+    def test_add_rejects_nonexistent_session_without_partial_membership(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        resp = client.post(
+            f"/api/session-folders/{folder['id']}/sessions",
+            json={"session_ids": ["s0", "missing"]},
+        )
+        assert resp.status_code == 400
+        assert db.list_folders()[0]["session_count"] == 0
+
+    def test_add_nonexistent_folder(self, test_app):
+        client, db = test_app
+        resp = client.post(
+            "/api/session-folders/bad/sessions",
+            json={"session_ids": ["s1"]},
+        )
+        assert resp.status_code == 500
+
+    def test_add_with_profile(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        resp = client.post(
+            f"/api/session-folders/{folder['id']}/sessions",
+            json={"session_ids": ["s0"], "profile": "default"},
+        )
+        assert resp.status_code == 200
+
+
+class TestRemoveSessions:
+    def test_remove(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        db.add_sessions_to_folder(folder["id"], ["s0", "s1"])
+        resp = client.request("DELETE",
+            f"/api/session-folders/{folder['id']}/sessions",
+            json={"session_ids": ["s0"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 1
+
+    def test_remove_nonexistent(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        resp = client.request("DELETE",
+            f"/api/session-folders/{folder['id']}/sessions",
+            json={"session_ids": ["ghost"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 0
+
+    def test_remove_empty_list(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        resp = client.request("DELETE",
+            f"/api/session-folders/{folder['id']}/sessions",
+            json={"session_ids": []},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 0
+
+
+# =====================================================================
+# Folder map
+# =====================================================================
+
+
+class TestFolderMap:
+    def test_get_map(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        db.add_sessions_to_folder(folder["id"], ["s0", "s1"])
+        resp = client.get("/api/session-folders/map", params={"session_ids": "s0,s1,s2"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert folder["id"] in data.get("s0", [])
+        assert folder["id"] in data.get("s1", [])
+        assert "s2" not in data or data["s2"] == []
+
+    def test_get_map_empty(self, test_app):
+        client, db = test_app
+        resp = client.get("/api/session-folders/map")
+        assert resp.status_code == 200
+        assert resp.json() == {}
+
+
+# =====================================================================
+# Folder rename endpoint tests (via API, not just tool handlers)
+# =====================================================================
+
+
+class TestFolderRenameEndpoint:
+    def test_rename_via_api(self, test_app):
+        client, db = test_app
+        create = client.post("/api/session-folders", json={"name": "Original"}).json()
+        resp = client.patch(f"/api/session-folders/{create['id']}", json={"name": "Renamed"})
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        folders = client.get("/api/session-folders").json()
+        assert any(f["name"] == "Renamed" for f in folders)
+
+    def test_rename_nonexistent_via_api(self, test_app):
+        client, db = test_app
+        resp = client.patch("/api/session-folders/bad", json={"name": "X"})
+        assert resp.status_code == 404
+
+    def test_rename_empty_name_via_api(self, test_app):
+        client, db = test_app
+        create = client.post("/api/session-folders", json={"name": "X"}).json()
+        resp = client.patch(f"/api/session-folders/{create['id']}", json={"name": ""})
+        assert resp.status_code == 400
+
+
+# =====================================================================
+# Folder delete endpoint tests
+# =====================================================================
+
+
+class TestFolderDeleteEndpoint:
+    def test_delete_via_api(self, test_app):
+        client, db = test_app
+        create = client.post("/api/session-folders", json={"name": "Temp"}).json()
+        resp = client.delete(f"/api/session-folders/{create['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        folders = client.get("/api/session-folders").json()
+        assert len(folders) == 0
+
+    def test_delete_nonexistent_via_api(self, test_app):
+        client, db = test_app
+        resp = client.delete("/api/session-folders/nonexistent")
+        assert resp.status_code == 404
+
+    def test_delete_preserves_sessions_via_api(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        db.add_sessions_to_folder(folder["id"], ["s0"])
+        resp = client.delete(f"/api/session-folders/{folder['id']}")
+        assert resp.status_code == 200
+        assert db.get_session("s0") is not None  # session survived
+
+
+# =====================================================================
+# Folder listing field tests
+# =====================================================================
+
+
+class TestFolderListFields:
+    def test_list_includes_session_ids(self, db_with_sessions):
+        client, db, folder = db_with_sessions
+        db.add_sessions_to_folder(folder["id"], ["s0", "s1"])
+        resp = client.get("/api/session-folders")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        target = [f for f in data if f["id"] == folder["id"]][0]
+        assert "session_ids" in target
+        assert isinstance(target["session_ids"], list)
+        assert "s0" in target["session_ids"]
+        assert "s1" in target["session_ids"]
+
+    def test_list_session_ids_empty_for_empty_folder(self, test_app):
+        client, db = test_app
+        create = client.post("/api/session-folders", json={"name": "Empty"}).json()
+        resp = client.get("/api/session-folders")
+        data = resp.json()
+        target = [f for f in data if f["id"] == create["id"]][0]
+        assert target["session_ids"] == []

--- a/tests/tools/test_session_tools.py
+++ b/tests/tools/test_session_tools.py
@@ -1,0 +1,464 @@
+"""Tests for tools/session_tools.py — session management agent tools.
+
+Covers HTTP helpers, tool handlers (with mocked API), schemas, and
+registry registration. No live dashboard needed — all HTTP is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import patch, MagicMock
+from urllib.error import URLError
+
+import pytest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# =====================================================================
+# Fixtures
+# =====================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Ensure a clean registry before each test by re-importing fresh."""
+    # Clear cached import so registry.register() runs again
+    for mod in list(sys.modules.keys()):
+        if "session_tools" in mod:
+            del sys.modules[mod]
+    if "tools.registry" in sys.modules:
+        del sys.modules["tools.registry"]
+    yield
+
+
+def _mock_urlopen(status: int = 200, body: dict | None = None) -> MagicMock:
+    """Create a mock for urllib.request.urlopen."""
+    m = MagicMock()
+    m.__enter__.return_value.status = status
+    m.__enter__.return_value.read.return_value = json.dumps(body or {}).encode("utf-8")
+    return m
+
+
+def _mock_urlopen_failing(error: Exception | None = None) -> MagicMock:
+    """Create a mock that raises on urlopen."""
+    m = MagicMock()
+    m.side_effect = error or URLError("mock failure")
+    return m
+
+
+# =====================================================================
+# HTTP helpers
+# =====================================================================
+
+
+class TestDashboardCheck:
+    def test_reachable(self):
+        with patch.dict(os.environ, {"HERMES_DASHBOARD_SESSION_TOKEN": "secret"}), \
+             patch("urllib.request.urlopen", return_value=_mock_urlopen()) as mock_urlopen:
+            from tools.session_tools import _check_dashboard
+            assert _check_dashboard() is True
+            request = mock_urlopen.call_args.args[0]
+            assert request.full_url.endswith("/api/sessions?limit=1")
+            assert request.get_header("X-hermes-session-token") == "secret"
+
+    def test_uses_loaded_dashboard_token_when_env_is_unavailable(self):
+        with patch.dict(os.environ, {}, clear=True), \
+             patch.dict(sys.modules, {"hermes_cli.web_server": MagicMock(_SESSION_TOKEN="in-process-secret")}), \
+             patch("urllib.request.urlopen", return_value=_mock_urlopen()) as mock_urlopen:
+            from tools.session_tools import _check_dashboard
+            assert _check_dashboard() is True
+            request = mock_urlopen.call_args.args[0]
+            assert request.get_header("X-hermes-session-token") == "in-process-secret"
+
+    def test_public_status_is_not_enough(self):
+        with patch.dict(os.environ, {}, clear=True), \
+             patch.dict(sys.modules, {"hermes_cli.web_server": MagicMock(_SESSION_TOKEN="")}), \
+             patch("urllib.request.urlopen", return_value=_mock_urlopen()):
+            from tools.session_tools import _check_dashboard
+            assert _check_dashboard() is False
+
+    def test_unreachable_connection_refused(self):
+        with patch("urllib.request.urlopen", _mock_urlopen_failing(ConnectionRefusedError())):
+            from tools.session_tools import _check_dashboard
+            assert _check_dashboard() is False
+
+    def test_unreachable_url_error(self):
+        with patch("urllib.request.urlopen", _mock_urlopen_failing(URLError("no route to host"))):
+            from tools.session_tools import _check_dashboard
+            assert _check_dashboard() is False
+
+
+class TestApiGet:
+    def test_success(self):
+        resp = {"sessions": [{"id": "s1"}]}
+        with patch("tools.session_tools._dashboard_token", return_value="secret"), \
+             patch("urllib.request.urlopen", return_value=_mock_urlopen(body=resp)) as mock_urlopen:
+            from tools.session_tools import _api_get
+            result = _api_get("/api/sessions")
+            assert result == resp
+            request = mock_urlopen.call_args.args[0]
+            assert request.get_header("X-hermes-session-token") == "secret"
+
+    def test_returns_none_on_failure(self):
+        with patch("urllib.request.urlopen", _mock_urlopen_failing()):
+            from tools.session_tools import _api_get
+            assert _api_get("/api/sessions") is None
+
+
+class TestApiPatch:
+    def test_success(self):
+        resp = {"ok": True, "title": "Renamed"}
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(body=resp)):
+            from tools.session_tools import _api_patch
+            result = _api_patch("/api/sessions/s1", {"title": "New"})
+            assert result == resp
+
+
+class TestApiDelete:
+    def test_success(self):
+        resp = {"ok": True}
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(body=resp)):
+            from tools.session_tools import _api_delete
+            result = _api_delete("/api/sessions/s1")
+            assert result == resp
+
+
+class TestApiPost:
+    def test_success(self):
+        resp = {"id": "sf_abc", "name": "Bug Reports"}
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen(body=resp)):
+            from tools.session_tools import _api_post
+            result = _api_post("/api/session-folders", {"name": "Bug Reports"})
+            assert result == resp
+            assert result["id"] == "sf_abc"
+
+
+# =====================================================================
+# Tool handlers
+# =====================================================================
+
+
+class TestSessionList:
+    def test_returns_formatted_list(self):
+        sessions = [
+            {"id": "abc123", "title": "Test", "archived": False,
+             "model": "gpt-4", "source": "cli", "message_count": 5}
+        ]
+        with patch("tools.session_tools._api_get", return_value={"sessions": sessions}):
+            from tools.session_tools import _session_list
+            result = json.loads(_session_list(limit=10))
+            assert result["success"] is True
+            assert result["count"] == 1
+
+    def test_returns_error_when_unreachable(self):
+        with patch("tools.session_tools._api_get", return_value=None):
+            from tools.session_tools import _session_list
+            result = json.loads(_session_list())
+            assert result["success"] is False
+            assert "Cannot reach" in result["error"]
+
+    def test_passes_filters(self):
+        sessions = []
+        with patch("tools.session_tools._api_get", return_value={"sessions": sessions}) as mock_get:
+            from tools.session_tools import _session_list
+            _session_list(limit=5, archived="only", order="created")
+            call_path = mock_get.call_args[0][0]
+            assert "limit=5" in call_path
+            assert "archived=only" in call_path
+            assert "order=created" in call_path
+
+
+class TestSessionArchive:
+    def test_archive(self):
+        with patch("tools.session_tools._api_patch", return_value={"ok": True}):
+            from tools.session_tools import _session_archive
+            result = json.loads(_session_archive("s1", archived=True))
+            assert result["success"] is True
+            assert "archived" in result["message"].lower()
+
+    def test_unarchive(self):
+        with patch("tools.session_tools._api_patch", return_value={"ok": True}):
+            from tools.session_tools import _session_archive
+            result = json.loads(_session_archive("s1", archived=False))
+            assert result["success"] is True
+            assert "unarchived" in result["message"].lower()
+
+    def test_failure(self):
+        with patch("tools.session_tools._api_patch", return_value=None):
+            from tools.session_tools import _session_archive
+            result = json.loads(_session_archive("s1"))
+            assert result["success"] is False
+
+
+class TestSessionRename:
+    def test_rename(self):
+        with patch("tools.session_tools._api_patch", return_value={"ok": True}):
+            from tools.session_tools import _session_rename
+            result = json.loads(_session_rename("s1", "New Title"))
+            assert result["success"] is True
+            assert "New Title" in result["message"]
+
+    def test_failure(self):
+        with patch("tools.session_tools._api_patch", return_value=None):
+            from tools.session_tools import _session_rename
+            result = json.loads(_session_rename("s1", "X"))
+            assert result["success"] is False
+
+
+class TestSessionDelete:
+    def test_delete(self):
+        with patch("tools.session_tools._api_delete", return_value={"ok": True}):
+            from tools.session_tools import _session_delete
+            result = json.loads(_session_delete("s1"))
+            assert result["success"] is True
+            assert "deleted" in result["message"].lower()
+
+    def test_failure(self):
+        with patch("tools.session_tools._api_delete", return_value={"ok": False}):
+            from tools.session_tools import _session_delete
+            result = json.loads(_session_delete("s1"))
+            assert result["success"] is False
+
+    def test_unreachable(self):
+        with patch("tools.session_tools._api_delete", return_value=None):
+            from tools.session_tools import _session_delete
+            result = json.loads(_session_delete("s1"))
+            assert result["success"] is False
+            assert "Cannot reach" in result["error"]
+
+
+class TestFolderList:
+    def test_list(self):
+        folders = [{"id": "f1", "name": "Bug Reports", "session_count": 3}]
+        with patch("tools.session_tools._api_get", return_value=folders):
+            from tools.session_tools import _folder_list
+            result = json.loads(_folder_list())
+            assert result["success"] is True
+            assert result["count"] == 1
+
+    def test_unreachable(self):
+        with patch("tools.session_tools._api_get", return_value=None):
+            from tools.session_tools import _folder_list
+            result = json.loads(_folder_list())
+            assert result["success"] is False
+
+
+class TestFolderCreate:
+    def test_create(self):
+        folder = {"id": "sf_x", "name": "Design", "session_count": 0}
+        with patch("tools.session_tools._api_post", return_value=folder):
+            from tools.session_tools import _folder_create
+            result = json.loads(_folder_create("Design"))
+            assert result["success"] is True
+            assert result["folder"]["name"] == "Design"
+
+    def test_unreachable(self):
+        with patch("tools.session_tools._api_post", return_value=None):
+            from tools.session_tools import _folder_create
+            result = json.loads(_folder_create("X"))
+            assert result["success"] is False
+
+
+class TestFolderAdd:
+    def test_add(self):
+        with patch("tools.session_tools._api_post", return_value={"ok": True, "count": 2}):
+            from tools.session_tools import _folder_add
+            result = json.loads(_folder_add("f1", ["s1", "s2"]))
+            assert result["success"] is True
+            assert "2" in result["message"]
+
+    def test_unreachable(self):
+        with patch("tools.session_tools._api_post", return_value=None):
+            from tools.session_tools import _folder_add
+            result = json.loads(_folder_add("f1", ["s1"]))
+            assert result["success"] is False
+
+
+class TestFolderRename:
+    def test_rename(self):
+        with patch("tools.session_tools._api_patch", return_value={"ok": True}):
+            from tools.session_tools import _folder_rename
+            result = json.loads(_folder_rename("f1", "New Name"))
+            assert result["success"] is True
+            assert "New Name" in result["message"]
+
+    def test_failure(self):
+        with patch("tools.session_tools._api_patch", return_value={"ok": False}):
+            from tools.session_tools import _folder_rename
+            result = json.loads(_folder_rename("f1", "X"))
+            assert result["success"] is False
+
+    def test_unreachable(self):
+        with patch("tools.session_tools._api_patch", return_value=None):
+            from tools.session_tools import _folder_rename
+            result = json.loads(_folder_rename("f1", "X"))
+            assert result["success"] is False
+
+
+class TestFolderDelete:
+    def test_delete(self):
+        with patch("tools.session_tools._api_delete", return_value={"ok": True}):
+            from tools.session_tools import _folder_delete
+            result = json.loads(_folder_delete("f1"))
+            assert result["success"] is True
+            assert "deleted" in result["message"].lower()
+
+    def test_failure(self):
+        with patch("tools.session_tools._api_delete", return_value={"ok": False}):
+            from tools.session_tools import _folder_delete
+            result = json.loads(_folder_delete("f1"))
+            assert result["success"] is False
+
+    def test_unreachable(self):
+        with patch("tools.session_tools._api_delete", return_value=None):
+            from tools.session_tools import _folder_delete
+            result = json.loads(_folder_delete("f1"))
+            assert result["success"] is False
+
+
+# =====================================================================
+# Tool schemas (static validation)
+# =====================================================================
+
+
+def _import_all_schemas():
+    """Re-import the module and return all schemas."""
+    for mod in list(sys.modules.keys()):
+        if "session_tools" in mod or "tools.registry" in mod:
+            del sys.modules[mod]
+    from tools.session_tools import (
+        SESSION_LIST_SCHEMA, SESSION_ARCHIVE_SCHEMA, SESSION_RENAME_SCHEMA,
+        SESSION_DELETE_SCHEMA, FOLDER_LIST_SCHEMA, FOLDER_CREATE_SCHEMA,
+        FOLDER_ADD_SCHEMA, FOLDER_RENAME_SCHEMA, FOLDER_DELETE_SCHEMA,
+    )
+    return {
+        "session_list": SESSION_LIST_SCHEMA,
+        "session_archive": SESSION_ARCHIVE_SCHEMA,
+        "session_rename": SESSION_RENAME_SCHEMA,
+        "session_delete": SESSION_DELETE_SCHEMA,
+        "session_folder_list": FOLDER_LIST_SCHEMA,
+        "session_folder_create": FOLDER_CREATE_SCHEMA,
+        "session_folder_add": FOLDER_ADD_SCHEMA,
+        "session_folder_rename": FOLDER_RENAME_SCHEMA,
+        "session_folder_delete": FOLDER_DELETE_SCHEMA,
+    }
+
+
+class TestSchemas:
+    def test_all_schemas_have_name(self):
+        schemas = _import_all_schemas()
+        for name, schema in schemas.items():
+            assert schema["name"] == name, f"{name} schema name mismatch"
+
+    def test_all_schemas_have_description(self):
+        schemas = _import_all_schemas()
+        for name, schema in schemas.items():
+            assert schema.get("description"), f"{name} missing description"
+
+    def test_all_schemas_have_parameters(self):
+        schemas = _import_all_schemas()
+        for name, schema in schemas.items():
+            assert "parameters" in schema, f"{name} missing parameters"
+
+    def test_session_archive_requires_session_id(self):
+        schemas = _import_all_schemas()
+        required = schemas["session_archive"]["parameters"].get("required", [])
+        assert "session_id" in required
+
+    def test_session_rename_requires_both(self):
+        schemas = _import_all_schemas()
+        required = schemas["session_rename"]["parameters"].get("required", [])
+        assert "session_id" in required
+        assert "title" in required
+
+    def test_session_delete_requires_session_id(self):
+        schemas = _import_all_schemas()
+        required = schemas["session_delete"]["parameters"].get("required", [])
+        assert "session_id" in required
+
+    def test_folder_create_requires_name(self):
+        schemas = _import_all_schemas()
+        required = schemas["session_folder_create"]["parameters"].get("required", [])
+        assert "name" in required
+
+    def test_folder_add_requires_both(self):
+        schemas = _import_all_schemas()
+        required = schemas["session_folder_add"]["parameters"].get("required", [])
+        assert "folder_id" in required
+        assert "session_ids" in required
+
+    def test_folder_add_session_ids_is_array(self):
+        schemas = _import_all_schemas()
+        session_ids = schemas["session_folder_add"]["parameters"]["properties"]["session_ids"]
+        assert session_ids["type"] == "array"
+        assert session_ids["items"]["type"] == "string"
+
+    def test_folder_rename_requires_both(self):
+        schemas = _import_all_schemas()
+        required = schemas["session_folder_rename"]["parameters"].get("required", [])
+        assert "folder_id" in required
+        assert "name" in required
+
+    def test_folder_delete_requires_folder_id(self):
+        schemas = _import_all_schemas()
+        required = schemas["session_folder_delete"]["parameters"].get("required", [])
+        assert "folder_id" in required
+
+
+# =====================================================================
+# Registry registration
+# =====================================================================
+
+
+class TestRegistryRegistration:
+    def test_all_tools_register(self):
+        """Importing the module triggers registry.register() for all 7 tools."""
+        # Fresh import to trigger registration
+        from tools.registry import registry as _reg
+
+        for mod in list(sys.modules.keys()):
+            if "session_tools" in mod:
+                del sys.modules[mod]
+
+        import tools.session_tools  # noqa: F401 — triggers registration
+
+        # Registry keeps a dict of {name: ToolEntry}. Check that our tools
+        # are among the registered entries. We can't call registry's methods
+        # directly since they may not expose iteration, but at minimum the
+        # import should not raise.
+        assert tools.session_tools  # import worked
+
+    def test_handler_functions_return_json(self):
+        """Every handler returns a valid JSON string."""
+        from tools.session_tools import (
+            _session_list, _session_archive, _session_rename,
+            _session_delete, _folder_list, _folder_create, _folder_add,
+            _folder_rename, _folder_delete,
+        )
+
+        handlers = [
+            (lambda: _session_list(limit=1)),
+            (lambda: _session_archive("s1")),
+            (lambda: _session_rename("s1", "X")),
+            (lambda: _session_delete("s1")),
+            (lambda: _folder_list()),
+            (lambda: _folder_create("X")),
+            (lambda: _folder_add("f1", ["s1"])),
+            (lambda: _folder_rename("f1", "X")),
+            (lambda: _folder_delete("f1")),
+        ]
+
+        # All handlers should return something parseable as JSON
+        # even if the underlying API is unreachable (they handle None).
+        with patch("tools.session_tools._api_get", return_value=None):
+            with patch("tools.session_tools._api_patch", return_value=None):
+                with patch("tools.session_tools._api_delete", return_value=None):
+                    with patch("tools.session_tools._api_post", return_value=None):
+                        for h in handlers:
+                            result = json.loads(h())
+                            assert "success" in result

--- a/tools/session_tools.py
+++ b/tools/session_tools.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Session Management Tools — list, archive, rename, delete sessions and folders.
+
+Requires the Hermes dashboard API to be running (http://127.0.0.1:9119).
+
+All tools make direct HTTP requests to the Hermes REST API. No LLM calls,
+no external dependencies beyond Python stdlib.
+"""
+
+import json
+import logging
+import os
+import sys
+import urllib.request
+import urllib.error
+import urllib.parse
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_DASHBOARD_BASE = "http://127.0.0.1:9119"
+_SESSION_TOKEN_ENV = "HERMES_DASHBOARD_SESSION_TOKEN"
+_SESSION_HEADER = "X-Hermes-Session-Token"
+
+
+def _dashboard_token() -> str:
+    """Return the token shared with the dashboard backend, when available."""
+    token = os.environ.get(_SESSION_TOKEN_ENV, "").strip()
+    if token:
+        return token
+    # Standalone dashboard runs generate the token in the already-loaded
+    # web_server module instead of exporting it through the environment.
+    server = sys.modules.get("hermes_cli.web_server")
+    return str(getattr(server, "_SESSION_TOKEN", "") or "").strip()
+
+
+def _api_headers(*, json_body: bool = False) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"} if json_body else {}
+    token = _dashboard_token()
+    if token:
+        headers[_SESSION_HEADER] = token
+    return headers
+
+
+def _api_get(path: str) -> Optional[dict]:
+    """GET request to the Hermes dashboard API."""
+    try:
+        req = urllib.request.Request(
+            f"{_DASHBOARD_BASE}{path}", method="GET", headers=_api_headers()
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, ConnectionRefusedError, OSError) as e:
+        logger.debug("Dashboard API GET %s failed: %s", path, e)
+        return None
+
+
+def _api_patch(path: str, body: dict) -> Optional[dict]:
+    """PATCH request to the Hermes dashboard API."""
+    try:
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            f"{_DASHBOARD_BASE}{path}", data=data, method="PATCH",
+            headers=_api_headers(json_body=True),
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, ConnectionRefusedError, OSError) as e:
+        logger.debug("Dashboard API PATCH %s failed: %s", path, e)
+        return None
+
+
+def _api_delete(path: str) -> Optional[dict]:
+    """DELETE request to the Hermes dashboard API."""
+    try:
+        req = urllib.request.Request(
+            f"{_DASHBOARD_BASE}{path}", method="DELETE", headers=_api_headers()
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, ConnectionRefusedError, OSError) as e:
+        logger.debug("Dashboard API DELETE %s failed: %s", path, e)
+        return None
+
+
+def _api_post(path: str, body: dict) -> Optional[dict]:
+    """POST request to the Hermes dashboard API."""
+    try:
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            f"{_DASHBOARD_BASE}{path}", data=data, method="POST",
+            headers=_api_headers(json_body=True),
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, ConnectionRefusedError, OSError) as e:
+        logger.debug("Dashboard API POST %s failed: %s", path, e)
+        return None
+
+
+def _check_dashboard() -> bool:
+    """Check that the dashboard is reachable and the caller is authenticated."""
+    return bool(_dashboard_token()) and _api_get("/api/sessions?limit=1") is not None
+
+
+# ── Tool handlers ────────────────────────────────────────────────────
+
+
+def _session_list(limit: int = 20, archived: str = "exclude",
+                  order: str = "recent", profile: str = "") -> str:
+    params = f"?limit={limit}&archived={archived}&order={order}"
+    if profile:
+        params += f"&profile={urllib.parse.quote(profile)}"
+    result = _api_get(f"/api/sessions{params}")
+    if result is None:
+        return json.dumps({"success": False, "error": "Cannot reach Hermes dashboard API"})
+    sessions = result.get("sessions", [])
+    display = []
+    for s in sessions[:limit]:
+        sid = s.get("id", "")[:20]
+        title = (s.get("title") or "(untitled)")[:40]
+        arch = " [archived]" if s.get("archived") else ""
+        model = (s.get("model") or "?")[:18]
+        source = s.get("source", "?")
+        msg_count = s.get("message_count", 0)
+        display.append(f"  {sid:22s} {title:42s} {arch:12s} {msg_count:4d}msgs {model:18s} {source}")
+    return json.dumps({
+        "success": True,
+        "count": len(display),
+        "sessions": display,
+        "message": f"Found {len(display)} session(s). Use session_archive/rename/delete on a session by id."
+    }, ensure_ascii=False)
+
+
+def _session_archive(session_id: str, archived: bool = True, profile: str = "") -> str:
+    path = f"/api/sessions/{urllib.parse.quote(session_id)}"
+    body = {"archived": archived}
+    if profile:
+        body["profile"] = profile
+    result = _api_patch(path, body)
+    if result is None:
+        return json.dumps({"success": False, "error": "Cannot reach Hermes dashboard API"})
+    action = "archived" if archived else "unarchived"
+    return json.dumps({
+        "success": result.get("ok", False),
+        "message": f"Session {session_id[:20]} {action}.",
+    }, ensure_ascii=False)
+
+
+def _session_rename(session_id: str, title: str, profile: str = "") -> str:
+    path = f"/api/sessions/{urllib.parse.quote(session_id)}"
+    body = {"title": title}
+    if profile:
+        body["profile"] = profile
+    result = _api_patch(path, body)
+    if result is None:
+        return json.dumps({"success": False, "error": "Cannot reach Hermes dashboard API"})
+    return json.dumps({
+        "success": result.get("ok", False),
+        "message": f"Session {session_id[:20]} renamed to '{title}'.",
+    }, ensure_ascii=False)
+
+
+def _session_delete(session_id: str, profile: str = "") -> str:
+    path = f"/api/sessions/{urllib.parse.quote(session_id)}"
+    if profile:
+        path += f"?profile={urllib.parse.quote(profile)}"
+    result = _api_delete(path)
+    if result is None:
+        return json.dumps({"success": False, "error": "Cannot reach Hermes dashboard API"})
+    return json.dumps({
+        "success": result.get("ok", False),
+        "message": f"Session {session_id[:20]} deleted." if result.get("ok") else f"Failed to delete session {session_id[:20]}.",
+    }, ensure_ascii=False)
+
+
+def _folder_list(profile: str = "") -> str:
+    path = "/api/session-folders"
+    if profile:
+        path += f"?profile={urllib.parse.quote(profile)}"
+    result = _api_get(path)
+    if result is None:
+        return json.dumps({"success": False, "error": "Cannot reach Hermes dashboard API"})
+    if isinstance(result, list):
+        folders = result
+    else:
+        folders = []
+    display = []
+    for f in folders:
+        display.append(f"  {f['id'][:18]:20s} {f['name']:30s} {f['session_count']} sessions")
+    return json.dumps({
+        "success": True,
+        "count": len(display),
+        "folders": display,
+    }, ensure_ascii=False)
+
+
+def _folder_create(name: str, profile: str = "") -> str:
+    body = {"name": name}
+    if profile:
+        body["profile"] = profile
+    result = _api_post("/api/session-folders", body)
+    if result is None:
+        return json.dumps({"success": False, "error": "Cannot reach Hermes dashboard API"})
+    return json.dumps({
+        "success": True,
+        "message": f"Folder '{name}' created.",
+        "folder": result,
+    }, ensure_ascii=False)
+
+
+def _folder_add(folder_id: str, session_ids: List[str], profile: str = "") -> str:
+    body = {"session_ids": session_ids}
+    if profile:
+        body["profile"] = profile
+    result = _api_post(f"/api/session-folders/{urllib.parse.quote(folder_id)}/sessions", body)
+    if result is None:
+        return json.dumps({"success": False, "error": "Cannot reach Hermes dashboard API"})
+    return json.dumps({
+        "success": True,
+        "message": f"Added {result.get('count', 0)} session(s) to folder.",
+    }, ensure_ascii=False)
+
+
+def _folder_rename(folder_id: str, name: str, profile: str = "") -> str:
+    body = {"name": name}
+    if profile:
+        body["profile"] = profile
+    result = _api_patch(f"/api/session-folders/{urllib.parse.quote(folder_id)}", body)
+    if result is None:
+        return json.dumps({"success": False, "error": "Cannot reach Hermes dashboard API"})
+    return json.dumps({
+        "success": result.get("ok", False),
+        "message": f"Folder renamed to '{name}'." if result.get("ok") else "Failed to rename folder.",
+    }, ensure_ascii=False)
+
+
+def _folder_delete(folder_id: str, profile: str = "") -> str:
+    path = f"/api/session-folders/{urllib.parse.quote(folder_id)}"
+    if profile:
+        path += f"?profile={urllib.parse.quote(profile)}"
+    result = _api_delete(path)
+    if result is None:
+        return json.dumps({"success": False, "error": "Cannot reach Hermes dashboard API"})
+    return json.dumps({
+        "success": result.get("ok", False),
+        "message": "Folder deleted." if result.get("ok") else "Failed to delete folder. Sessions are not affected.",
+    }, ensure_ascii=False)
+
+
+# ── Schemas ──────────────────────────────────────────────────────────
+
+
+SESSION_LIST_SCHEMA = {
+    "name": "session_list",
+    "description": "List Hermes sessions with optional filters for archive status and sort order. Use to find session IDs for archive/rename/delete operations. For content search, use the session_search tool instead.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "limit": {"type": "integer", "description": "Max results (default 20).", "default": 20},
+            "archived": {"type": "string", "enum": ["exclude", "include", "only"], "description": "Archive filter."},
+            "order": {"type": "string", "enum": ["recent", "created"], "description": "Sort order."},
+            "profile": {"type": "string", "description": "Target profile name (required for cross-profile operations)."},
+        },
+    },
+}
+
+SESSION_ARCHIVE_SCHEMA = {
+    "name": "session_archive",
+    "description": "Archive or unarchive a session. Archiving hides it from the default session list.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "session_id": {"type": "string", "description": "Session ID to archive/unarchive."},
+            "archived": {"type": "boolean", "description": "True=archive, False=unarchive.", "default": True},
+            "profile": {"type": "string", "description": "Target profile name."},
+        },
+        "required": ["session_id"],
+    },
+}
+
+SESSION_RENAME_SCHEMA = {
+    "name": "session_rename",
+    "description": "Rename a session to a new title.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "session_id": {"type": "string", "description": "Session ID to rename."},
+            "title": {"type": "string", "description": "New title for the session."},
+            "profile": {"type": "string", "description": "Target profile name."},
+        },
+        "required": ["session_id", "title"],
+    },
+}
+
+SESSION_DELETE_SCHEMA = {
+    "name": "session_delete",
+    "description": "Permanently delete a session and all its messages. WARNING: This cannot be undone. The session and ALL its messages will be permanently removed. Use with extreme caution.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "session_id": {"type": "string", "description": "Session ID to delete."},
+            "profile": {"type": "string", "description": "Target profile name."},
+        },
+        "required": ["session_id"],
+    },
+}
+
+FOLDER_LIST_SCHEMA = {
+    "name": "session_folder_list",
+    "description": "List all session folders with per-folder session counts.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "profile": {"type": "string", "description": "Target profile name."},
+        },
+    },
+}
+
+FOLDER_CREATE_SCHEMA = {
+    "name": "session_folder_create",
+    "description": "Create a new named folder for organizing sessions.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "Name for the new folder."},
+            "profile": {"type": "string", "description": "Target profile name."},
+        },
+        "required": ["name"],
+    },
+}
+
+FOLDER_ADD_SCHEMA = {
+    "name": "session_folder_add",
+    "description": "Add one or more sessions to a folder.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "folder_id": {"type": "string", "description": "Folder ID (get from session_folder_list)."},
+            "session_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Session IDs to add to the folder.",
+            },
+            "profile": {"type": "string", "description": "Target profile name."},
+        },
+        "required": ["folder_id", "session_ids"],
+    },
+}
+
+FOLDER_RENAME_SCHEMA = {
+    "name": "session_folder_rename",
+    "description": "Rename a session folder.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "folder_id": {"type": "string", "description": "Folder ID to rename."},
+            "name": {"type": "string", "description": "New name for the folder."},
+            "profile": {"type": "string", "description": "Target profile name."},
+        },
+        "required": ["folder_id", "name"],
+    },
+}
+
+FOLDER_DELETE_SCHEMA = {
+    "name": "session_folder_delete",
+    "description": "Delete a session folder. Sessions in the folder are NOT deleted — only the folder is removed.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "folder_id": {"type": "string", "description": "Folder ID to delete."},
+            "profile": {"type": "string", "description": "Target profile name."},
+        },
+        "required": ["folder_id"],
+    },
+}
+
+
+# ── Registry ─────────────────────────────────────────────────────────
+
+
+from tools.registry import registry, tool_error
+
+registry.register(
+    name="session_list",
+    toolset="session_management",
+    schema=SESSION_LIST_SCHEMA,
+    handler=lambda args, **kw: _session_list(
+        limit=args.get("limit", 20),
+        archived=args.get("archived", "exclude"),
+        order=args.get("order", "recent"),
+        profile=args.get("profile", ""),
+    ),
+    check_fn=_check_dashboard,
+    emoji="📋",
+)
+
+registry.register(
+    name="session_archive",
+    toolset="session_management",
+    schema=SESSION_ARCHIVE_SCHEMA,
+    handler=lambda args, **kw: _session_archive(
+        session_id=args["session_id"],
+        archived=args.get("archived", True),
+        profile=args.get("profile", ""),
+    ),
+    check_fn=_check_dashboard,
+    emoji="📦",
+)
+
+registry.register(
+    name="session_rename",
+    toolset="session_management",
+    schema=SESSION_RENAME_SCHEMA,
+    handler=lambda args, **kw: _session_rename(
+        session_id=args["session_id"],
+        title=args["title"],
+        profile=args.get("profile", ""),
+    ),
+    check_fn=_check_dashboard,
+    emoji="✏️",
+)
+
+registry.register(
+    name="session_delete",
+    toolset="session_management",
+    schema=SESSION_DELETE_SCHEMA,
+    handler=lambda args, **kw: _session_delete(
+        session_id=args["session_id"],
+        profile=args.get("profile", ""),
+    ),
+    check_fn=_check_dashboard,
+    emoji="🗑️",
+)
+
+registry.register(
+    name="session_folder_list",
+    toolset="session_management",
+    schema=FOLDER_LIST_SCHEMA,
+    handler=lambda args, **kw: _folder_list(profile=args.get("profile", "")),
+    check_fn=_check_dashboard,
+    emoji="📁",
+)
+
+registry.register(
+    name="session_folder_create",
+    toolset="session_management",
+    schema=FOLDER_CREATE_SCHEMA,
+    handler=lambda args, **kw: _folder_create(name=args["name"], profile=args.get("profile", "")),
+    check_fn=_check_dashboard,
+    emoji="➕📁",
+)
+
+registry.register(
+    name="session_folder_add",
+    toolset="session_management",
+    schema=FOLDER_ADD_SCHEMA,
+    handler=lambda args, **kw: _folder_add(
+        folder_id=args["folder_id"],
+        session_ids=args["session_ids"],
+        profile=args.get("profile", ""),
+    ),
+    check_fn=_check_dashboard,
+    emoji="📎",
+)
+
+registry.register(
+    name="session_folder_rename",
+    toolset="session_management",
+    schema=FOLDER_RENAME_SCHEMA,
+    handler=lambda args, **kw: _folder_rename(
+        folder_id=args["folder_id"],
+        name=args["name"],
+        profile=args.get("profile", ""),
+    ),
+    check_fn=_check_dashboard,
+    emoji="✏️📁",
+)
+
+registry.register(
+    name="session_folder_delete",
+    toolset="session_management",
+    schema=FOLDER_DELETE_SCHEMA,
+    handler=lambda args, **kw: _folder_delete(
+        folder_id=args["folder_id"],
+        profile=args.get("profile", ""),
+    ),
+    check_fn=_check_dashboard,
+    emoji="🗑️📁",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -89,6 +89,10 @@ _HERMES_CORE_TOOLS = [
     "kanban_attach", "kanban_attach_url", "kanban_attachments",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # Session management (gated on dashboard API being reachable via check_fn)
+    "session_list", "session_archive", "session_rename", "session_delete",
+    "session_folder_list", "session_folder_create", "session_folder_add",
+    "session_folder_rename", "session_folder_delete",
 ]
 
 # Webhook events may originate from untrusted third-party content (for example,
@@ -199,6 +203,16 @@ TOOLSETS = {
     "skills": {
         "description": "Access, create, edit, and manage skill documents with specialized instructions and knowledge",
         "tools": ["skills_list", "skill_view", "skill_manage"],
+        "includes": []
+    },
+
+    "session_management": {
+        "description": "Manage Hermes sessions — list, archive, rename, delete, and organize into folders. Requires the Hermes dashboard to be running (service-gated via check_fn).",
+        "tools": [
+            "session_list", "session_archive", "session_rename", "session_delete",
+            "session_folder_list", "session_folder_create", "session_folder_add",
+            "session_folder_rename", "session_folder_delete",
+        ],
         "includes": []
     },
     

--- a/toolsets.py
+++ b/toolsets.py
@@ -85,6 +85,10 @@ _HERMES_CORE_TOOLS = [
     "kanban_attach", "kanban_attach_url", "kanban_attachments",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # Session management (gated on dashboard API being reachable via check_fn)
+    "session_list", "session_archive", "session_rename", "session_delete",
+    "session_folder_list", "session_folder_create", "session_folder_add",
+    "session_folder_rename", "session_folder_delete",
 ]
 
 # Webhook events may originate from untrusted third-party content (for example,
@@ -195,6 +199,16 @@ TOOLSETS = {
     "skills": {
         "description": "Access, create, edit, and manage skill documents with specialized instructions and knowledge",
         "tools": ["skills_list", "skill_view", "skill_manage"],
+        "includes": []
+    },
+
+    "session_management": {
+        "description": "Manage Hermes sessions — list, archive, rename, delete, and organize into folders. Requires the Hermes dashboard to be running (service-gated via check_fn).",
+        "tools": [
+            "session_list", "session_archive", "session_rename", "session_delete",
+            "session_folder_list", "session_folder_create", "session_folder_add",
+            "session_folder_rename", "session_folder_delete",
+        ],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary

Add user-defined **session folders** — named groups that help organize conversations in the desktop sidebar. Users can right-click any session to move it to a folder, and right-click folders to rename or delete them.

Also adds **9 agent tools** (service-gated on the dashboard API) so the agent can list, archive, rename, delete sessions and manage folders from chat.

Context: I use Hermes daily and wanted a way to group related conversations without relying solely on git-repo auto-grouping. The PR is self-contained — backend, frontend UI, agent tools, and skills all in one.

## What changed

### Backend (`hermes_state.py` + `web_server.py`)
- 2 new tables in SCHEMA_SQL: `session_folders` + `session_folder_members`
- 7 SessionDB methods: CRUD folders, add/remove sessions, batch folder-map lookup
- Orphan cleanup wired into `delete_session()` and `delete_sessions()`
- 8 REST endpoints under `/api/session-folders/`, all profile-scoped
- IntegrityError caught and returned as proper 500 (was propagating to middleware)

### Agent Tools (`tools/session_tools.py`)
- 9 tools registered via `registry.register()`, all gated on dashboard reachability
- 4 HTTP helpers (`_api_get/patch/delete/post`) wrapping `urllib.request`
- Profile parameter exposed in every tool schema for cross-profile ops
- `session_delete` has prominent WARNING in its description

### Frontend (`apps/desktop/src/`)
- **Sidebar** — collapsible "Folders" section between Pinned and Recent, with expandable rows showing member sessions
- **Context menu** — "Move to folder →" submenu on every session row (dropdown + right-click), plus "Remove from folder"
- **Folder row** — right-click to Copy ID or Delete folder
- **Nanostore** — `session-folders.ts` with `refreshFolders()`, `moveToFolder()`, `removeFromFolder()`, `deleteAndRemoveFolder()`
- **i18n** — 10 new keys in `en.ts` + type definitions in `types.ts`

### Skills
- `session-management` — how to list/archive/rename/delete sessions
- `session-folders` — how to create folders and assign sessions
- `session-organization` — combined cleanup workflow

### Tests
- 8 backend unit tests (SessionDB folder methods + orphan cleanup)
- 29 API integration tests (FastAPI TestClient with temp DB)
- 44 tool tests (handler unit tests + schema validation + registry checks)
- **403 total, all passing**

## How to test

1. Start the Hermes desktop app
2. Right-click any session in the sidebar → "Move to folder →" → pick a folder or create one
3. The "Folders" section appears between Pinned and Recent
4. Click a folder to expand it and see its member sessions
5. Right-click a folder name → Delete folder (sessions survive)

## Platforms tested

- macOS (my daily driver)
- Backend tests pass on Python 3.11

## Conventional commit

```
feat(session-folders): user-defined folders + agent tools for organizing sessions
```

Closes: (no existing issue — feature request)