### PR TITLE
docs(community): add know-fast to the Community list

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🔌 [know-fast](https://github.com/j-s/know-fast-hermes) — Community [know.fast](https://know.fast/agent.txt) plugin: turns a URL (article, video, podcast, PDF) into a compact knowledge packet via `know`/`know_status` tools and a web-extract backend. Paid service, flat $0.01 per link.
 
 ---
 


### PR DESCRIPTION
Adds one entry to the README **Community** list for [know-fast](https://github.com/j-s/know-fast-hermes) — a standalone plugin repo for [know.fast](https://know.fast/agent.txt) (URL → compact knowledge packet; `know`/`know_status` tools + a web-extract backend; paid, flat $0.01 per link).

Shipped as its own repo per CONTRIBUTING.md §Third-Party Product Integrations (no core changes; installs with `hermes plugins install j-s/know-fast-hermes`). Entry follows the existing format and neutral wording of the neighboring community entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)