### PR TITLE
feat(config): add skills.index_style for compact skill index

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1455,6 +1455,15 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names(_platform_hint or None)
+    # ── Index style ────────────────────────────────────────────────────
+    # "full" (default) — every skill name + description (~6K tokens).
+    # "compact"        — names only, descriptions omitted (~1.5K tokens).
+    _index_style: str = "full"
+    try:
+        from hermes_cli.config import load_config
+        _index_style = (load_config().get("skills", {}) or {}).get("index_style", "full") or "full"
+    except Exception:
+        pass
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
@@ -1463,6 +1472,7 @@ def build_skills_system_prompt(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        _index_style,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1611,12 +1621,26 @@ def build_skills_system_prompt(
     )
 
     hidden_note = ""
+    compact_note = ""
+    if _index_style == "compact":
+        compact_note = (
+            "\n(Descriptions are omitted — every skill name above is "
+            "loadable with skill_view(name)."
+        )
     if demoted:
         hidden_note = (
             "\n(Categories marked [names only] are outside the current coding "
             "context, so their descriptions are omitted — the skills work "
-            "normally and load with skill_view(name) as usual.)"
+            "normally and load with skill_view(name) as usual."
         )
+    if compact_note and demoted:
+        # Merge notes — they say the same thing in slightly different contexts
+        hidden_note = (
+            "\n(Non-coding skill categories are shown names-only here. "
+            "Every skill is loadable with skill_view(name) as usual.)"
+        )
+    elif compact_note:
+        hidden_note = compact_note
 
     if not skills_by_category:
         result = ""
@@ -1631,14 +1655,17 @@ def build_skills_system_prompt(
                 continue
             cat_desc = category_descriptions.get(category, "")
             if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
+                if _index_style == "compact":
+                    index_lines.append(f"  {category}:")
+                else:
+                    index_lines.append(f"  {category}: {cat_desc}")
             else:
                 index_lines.append(f"  {category}:")
             for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
                 if name in seen:
                     continue
                 seen.add(name)
-                if desc:
+                if desc and _index_style != "compact":
                     index_lines.append(f"    - {name}: {desc}")
                 else:
                     index_lines.append(f"    - {name}")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2270,6 +2270,14 @@ DEFAULT_CONFIG = {
         #                     never crammed into a chat bubble), apply with
         #                     /skills approve <id> or drop with /skills reject <id>.
         "write_approval": False,
+        # Skill index style in the system prompt.  Controls how much detail
+        # the skills index block includes in the system prompt:
+        #   "full" (default) — every skill name + 60-char description (~6K tokens)
+        #   "compact"        — skill names only, descriptions omitted (~1.5K tokens).
+        #                      Every skill stays visible and loadable via
+        #                      skill_view(name).  Use this to cut ~4.5K tokens
+        #                      from every turn when you have a large skill library.
+        "index_style": "full",
     },
 
     # Curator — background skill maintenance.

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -474,6 +474,45 @@ class TestBuildSkillsSystemPrompt:
         full = build_skills_system_prompt()
         assert "Write threads" in full
 
+    def test_compact_index_style_omits_descriptions(self, monkeypatch, tmp_path):
+        """When skills.index_style is 'compact', every skill name stays
+        visible but descriptions are omitted from the index."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        for cat, name, desc in (
+            ("devops", "deploy", "Deploy stuff"),
+            ("social-media", "poster", "Post things"),
+        ):
+            d = tmp_path / "skills" / cat / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n"
+            )
+
+        # Full (default) mode — descriptions visible
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        full_result = build_skills_system_prompt()
+        assert "deploy" in full_result
+        assert "Deploy stuff" in full_result
+        assert "poster" in full_result
+        assert "Post things" in full_result
+
+        # Compact mode — descriptions hidden, names visible
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        from unittest.mock import patch as u_patch
+        with u_patch(
+            "hermes_cli.config.load_config",
+            return_value={"skills": {"index_style": "compact"}},
+        ):
+            compact_result = build_skills_system_prompt()
+
+        assert "deploy" in compact_result
+        assert "poster" in compact_result
+        assert "Deploy stuff" not in compact_result
+        assert "Post things" not in compact_result
+        assert "skill_view" in compact_result
+
     def test_excludes_incompatible_platform_skills(self, monkeypatch, tmp_path):
         """Skills with platforms: [macos] should not appear on Linux."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Problem

The skills index block in the system prompt lists every loaded skill with its full description. For users with large skill libraries (50+ skills), this adds ~6K tokens to every turn, consuming a significant fraction of the context window and prompt cache unnecessarily — especially since descriptions are only needed when the agent is deciding which skill to load.

## Solution

Add a `skills.index_style` config option that controls how the skills index is rendered:

- **`"full"` (default)** — current behavior: every skill name + 60-char description
- **`"compact"`** — skill names only, descriptions omitted. Every skill stays visible and loadable via `skill_view(name)`.

In compact mode, the diff looks like:

```
  devops:
+   - deploy
-   - deploy: Deploy stuff
  social-media:
+   - poster
-   - poster: Post things
```

The notes in the skills block are also consolidated to avoid redundancy with compact mode.

## Token savings

| Mode   | ~Tokens (50 skills) |
|--------|-------------------|
| full   | ~6,000            |
| compact| ~1,500            |

**Savings: ~4.5K tokens per turn**, which directly reduces both latency and cost on every model call.

## Changes

- **`hermes_cli/config.py`**: Add `index_style: "full"` to the `skills` section defaults
- **`agent/prompt_builder.py`**: Read `index_style` from config, render names-only when compact, merge notes cleanly
- **`tests/agent/test_prompt_builder.py`**: New test `test_compact_index_style_omits_descriptions` that verifies names are visible and descriptions are hidden in compact mode