### PR TITLE
feat(unbroker): browser backends (Portal-or-keys) + browser_vision + cheap-read scan rung

### DIFF
--- a/optional-skills/security/unbroker/SKILL.md
+++ b/optional-skills/security/unbroker/SKILL.md
@@ -66,13 +66,26 @@ verifying re-scan.
   one it detects, reading credentials from the shell env **and from `$HERMES_HOME/.env`** so keys
   Hermes already loads for its own tools are picked up without re-exporting - each one converts a
   class of human tasks into agent actions):
-  - **Cloud browser (recommended default): `BROWSERBASE_API_KEY`.** `setup --auto` selects it
-    whenever the key is present, and it is the intended baseline: a real residential-IP cloud
-    browser **clears soft/managed CAPTCHAs (Cloudflare Turnstile, hCaptcha/reCAPTCHA checkbox) as
-    normal operation**, so those brokers stay automated (T1) instead of becoming human tasks. This
-    is not CAPTCHA "solving" - no solver service, no fingerprint spoofing; only interactive/behavioral
-    ("hard") challenges the browser genuinely cannot pass fall back to a human task. Without the key,
-    the plain agent browser is used and soft-CAPTCHA brokers drop to T2 (human).
+  - **A stealth browser (recommended default).** A real residential-IP / anti-detect browser
+    **clears soft/managed CAPTCHAs (Cloudflare Turnstile, hCaptcha/reCAPTCHA checkbox) as normal
+    operation**, so those brokers stay automated (T1) instead of becoming human tasks. This is not
+    CAPTCHA "solving" - no solver service; only interactive/behavioral ("hard") challenges fall back
+    to a human. `setup --auto` turns it on when configured. Hermes provides several backends (any one
+    works; see the Hermes docs → Features → Browser, and `references/methods.md` → "Browser backends"):
+    - **Browserbase, two ways (recommended):** it is a built-in Hermes browser tool, so it works via
+      **either** a **Nous Portal subscription** (the Tool Gateway provides it with **no keys** -
+      `hermes setup --portal`; easiest) **or** **direct credentials** - set **BOTH**
+      `BROWSERBASE_API_KEY` **and** `BROWSERBASE_PROJECT_ID` in `~/.hermes/.env` (the key alone will not
+      run). Either path gives residential proxies + CAPTCHA solving by default.
+    - **Browser Use** (`BROWSER_USE_API_KEY`) or **Firecrawl** (`FIRECRAWL_API_KEY`): alternative
+      managed cloud browsers.
+    - **Camofox** (`CAMOFOX_URL`): local anti-detect Firefox, no cloud cost.
+    - **Your own Chrome over CDP:** `/browser connect` in the Hermes CLI (auto-launches at
+      `127.0.0.1:9222`), or run `$PDD cdp` to launch the dedicated debug profile and set
+      `browser.cdp_url`. Best for Phase-2 webmail + session-bound gates.
+    Without any of these, the plain local browser is used and soft-CAPTCHA brokers drop to T2. For
+    reading a **static distorted-text or arithmetic** CAPTCHA on the subject's own opt-out, use
+    `browser_vision` (screenshot + AI); never defeat behavioral/token/slider challenges.
   - Email automation, two credential-free-or-not options:
     - **Browser mode (no password): `setup --email-mode browser`.** The agent sends opt-out/CCPA
       emails and opens verification links through the operator's **logged-in webmail** using

--- a/optional-skills/security/unbroker/references/methods.md
+++ b/optional-skills/security/unbroker/references/methods.md
@@ -70,8 +70,18 @@ URLs.
    (b) a broad `"First Last" <ZIP OR unique-address>` search (no `site:`) surfaces **brokers not yet in
    your DB** (e.g. information.com, peoplefinders.com) - record those as bonus exposures. Note: empty
    `site:` results are INCONCLUSIVE (many broker pages aren't indexed / are `noindex`), not `not_found`.
+1c. **Cheap public-route reads before a browser (the insane-search idea).** When `web_extract` hits a
+   403 / WAF wall, try the site's *other* public routes before spinning up a browser: a `/rss` or
+   syndication feed, a mobile or `.json` URL variant, an OGP / JSON-LD block in the partial HTML, or the
+   internal JSON API the page's own frontend calls (watch the network tab once in a browser, then reuse
+   that endpoint). These are faster and cheaper than a full browser and often return the listing text
+   outright. This is the escalation pattern of the `insane-search` project (a Claude Code plugin: public
+   API/feed readers -> TLS impersonation -> headless browser); its browser rung is redundant with
+   Hermes' native stealth backends (rung 3), but the **public-endpoint/feed/JSON-reuse rungs are worth
+   borrowing**. It is a READER only (helps this scan phase, never the opt-out) and stops at logins.
 2. If the page is JS-rendered or returns nothing useful, `browser_navigate` + `browser_snapshot`
-   (and `browser_type`/`browser_click` to run the site's search box).
+   (and `browser_type`/`browser_click` to run the site's search box; `browser_vision` to read a static
+   image/text CAPTCHA or a visual layout the accessibility tree misses).
 3. If blocked by stealth/Cloudflare, use the `scrapling` skill via `terminal`. **If the broker record
    has `search.antibot` set (e.g. `datadome`), results are behind a device-check CAPTCHA**: a
    cloud/stealth browser (Browserbase) or `scrapling` may get through; if none is available, do **not**
@@ -266,13 +276,17 @@ T2 and become human tasks. **Never use a third-party CAPTCHA-defeating service.*
 Two different jobs need two different browsers. Getting this wrong is the single biggest cause of a
 run stalling in Phase 2.
 
-- **Phase 1 (scan, read-only):** a cloud stealth browser (Browserbase) or the `scrapling` skill is
-  ideal. On a residential IP with a real fingerprint it passes managed challenges (Cloudflare
-  Turnstile, hCaptcha checkbox) and reads anti-bot people-search pages that `web_extract` and the
-  proxyless agent browser cannot. This is what the skill's `browser_backend` setting governs
-  (`auto` picks Browserbase when `BROWSERBASE_API_KEY` is present - now also read from
-  `$HERMES_HOME/.env`, not just the shell env, so `doctor`/`setup --auto` detect the key Hermes
-  already loads for its own tools).
+- **Phase 1 (scan, read-only):** a stealth browser reads anti-bot people-search pages that
+  `web_extract` and the proxyless browser cannot. Any of Hermes' stealth backends works (see the Hermes
+  docs → Features → Browser): **Browserbase** (a built-in gateway tool - available via a **Nous Portal
+  subscription with NO keys**, or direct with BOTH `BROWSERBASE_API_KEY` and `BROWSERBASE_PROJECT_ID`),
+  **Browser Use** (`BROWSER_USE_API_KEY`), **Firecrawl** (`FIRECRAWL_API_KEY`), or **Camofox**
+  (`CAMOFOX_URL`, local anti-detect Firefox). On a
+  residential IP / real fingerprint they pass managed challenges (Turnstile, hCaptcha checkbox). The
+  skill's `browser_backend` (`auto` picks up any of these creds, read from the shell env AND
+  `$HERMES_HOME/.env`) only governs the Phase-1 scan browser and captcha tiering; the `scrapling` skill
+  is a further option. For a static image/arithmetic CAPTCHA on the subject's own opt-out, read it with
+  `browser_vision`; never defeat behavioral/token/slider challenges.
 - **Phase 2 (execute: opt-out forms, webmail sends, session-bound multi-step gates):** the work must
   run in the **operator's own everyday browser** - real fingerprint, residential IP, AND the
   operator's logged-in sessions. A headless cloud browser is the WRONG default here for two reasons:
@@ -294,6 +308,13 @@ run stalling in Phase 2.
   endpoint (`webSocketDebuggerUrl`). `pdd.py cdp --check` reports whether a debug browser is already
   live (and never launches a second one); `pdd.py cdp --print` just emits the exact command for the
   operator to run themselves. Point the browser tools at the `endpoint` it returns.
+  **Hermes-native attach:** in the interactive Hermes CLI, `/browser connect` does this officially - it
+  auto-launches a Chromium-family browser at `127.0.0.1:9222` (same `--user-data-dir` recipe) or
+  attaches to a given CDP endpoint; or set `browser.cdp_url` in `config.yaml`. Note `/browser connect`
+  is a CLI-only slash command (not dispatched by the gateway), so for a gateway-driven run use
+  `pdd.py cdp` to launch the browser and set `browser.cdp_url`. Once attached over CDP, `browser_cdp`
+  (raw DevTools passthrough) and `browser_dialog` (native JS dialogs) become available for the fiddly
+  multi-step gates.
 - **Always-available fallback:** if no CDP browser is wired up, use the operator-in-the-loop path
   (scan ladder 3b) - hand over paste-ready URLs and field-by-field least-disclosure guidance, pausing
   before submit. It never fails; it just needs a human present.

--- a/optional-skills/security/unbroker/scripts/config.py
+++ b/optional-skills/security/unbroker/scripts/config.py
@@ -82,6 +82,45 @@ def dotenv_env() -> dict:
     return merged
 
 
+# Env vars that indicate a configured stealth/cloud browser backend (Hermes browser feature). Any of
+# these clears soft/managed CAPTCHAs, so any one shifts a captcha-gated broker T2 -> T1.
+_CLOUD_BROWSER_ENV = ("BROWSERBASE_API_KEY", "BROWSER_USE_API_KEY", "FIRECRAWL_API_KEY", "CAMOFOX_URL")
+
+
+def _has_cloud_browser(env: dict) -> bool:
+    return any(env.get(k) for k in _CLOUD_BROWSER_ENV)
+
+
+def hermes_browser_configured() -> bool:
+    """Best-effort: does Hermes ALREADY have a stealth browser wired up (no skill env keys needed)?
+
+    Two no-key paths the env alone can't see (see the Hermes browser docs):
+      - a provider selected in `$HERMES_HOME/config.yaml` (`browser.cloud_provider`, e.g. browserbase,
+        browser-use, firecrawl, or the Nous Subscription gateway);
+      - a Nous Portal subscriber token in `$HERMES_HOME/auth.json` (the Tool Gateway then provides the
+        browser -- Browserbase is a built-in gateway tool, so Portal auth works instead of an API key).
+    Defensive: any read error just returns the env-only picture.
+    """
+    home = paths.hermes_home()
+    try:
+        cfg_text = (home / "config.yaml").read_text(encoding="utf-8", errors="replace")
+        for line in cfg_text.splitlines():
+            s = line.strip()
+            if s.startswith("cloud_provider:"):
+                val = s.split(":", 1)[1].strip().strip('"').strip("'")
+                if val and not val.startswith("#"):
+                    return True
+    except OSError:
+        pass
+    try:
+        auth_text = (home / "auth.json").read_text(encoding="utf-8", errors="replace").lower()
+        if "nous" in auth_text and "access_token" in auth_text:
+            return True
+    except OSError:
+        pass
+    return False
+
+
 def detect_capabilities(env: dict | None = None) -> dict:
     """Report which opt-in upgrades are available without extra setup."""
     env = os.environ if env is None else env
@@ -93,7 +132,16 @@ def detect_capabilities(env: dict | None = None) -> dict:
     )
     mail = emailer.available(env)
     return {
+        # Browserbase needs BOTH the key and a project id to actually run (per the Hermes browser docs).
         "browserbase": bool(env.get("BROWSERBASE_API_KEY")),
+        "browserbase_ready": bool(env.get("BROWSERBASE_API_KEY") and env.get("BROWSERBASE_PROJECT_ID")),
+        # Other Hermes browser backends that also provide managed stealth (clear soft CAPTCHAs):
+        "browser_use": bool(env.get("BROWSER_USE_API_KEY")),
+        "firecrawl": bool(env.get("FIRECRAWL_API_KEY")),
+        "camofox": bool(env.get("CAMOFOX_URL")),
+        # Any configured stealth/cloud browser (Browserbase | Browser Use | Firecrawl | Camofox). Nous
+        # Portal subscribers also get the browser via the Tool Gateway with NO keys (not env-detectable).
+        "cloud_browser": _has_cloud_browser(env),
         "agentmail": bool(env.get("AGENTMAIL_API_KEY")),
         "email_imap_smtp": bool(env.get("EMAIL_ADDRESS") and env.get("EMAIL_PASSWORD")),
         "smtp_send": mail["smtp"],      # CLI can SEND opt-out emails itself
@@ -121,7 +169,10 @@ def auto_configure(env: dict | None = None) -> dict:
         cfg["email_mode"] = "alias"
     else:
         cfg["email_mode"] = "draft_only"
-    cfg["browser_backend"] = "browserbase" if caps["browserbase"] else "auto"
+    # Prefer an explicit stealth backend when its creds are present; else 'auto' (which still picks up
+    # a Browserbase/Browser Use/Firecrawl key, a Camofox URL, or the Nous Portal gateway at runtime).
+    cfg["browser_backend"] = ("browserbase" if caps["browserbase"]
+                              else "camofox" if caps["camofox"] else "auto")
     if caps["age"]:
         cfg["encryption"] = "age"
     return cfg
@@ -130,15 +181,17 @@ def auto_configure(env: dict | None = None) -> dict:
 def browser_clears_captcha(cfg: dict, env: dict | None = None) -> bool:
     """True if the chosen browser backend can clear soft CAPTCHAs (shifts T2 -> T1).
 
-    Browserbase is the recommended default: a real residential-IP cloud browser passes
-    soft/managed challenges (Turnstile, hCaptcha/reCAPTCHA checkbox) as normal operation.
-    This is NOT solving/spoofing - hard interactive challenges still escalate to a human.
-    `auto` inherits this whenever BROWSERBASE_API_KEY is present.
+    Any of Hermes' stealth backends qualifies: Browserbase / Browser Use / Firecrawl (managed cloud
+    browsers on residential IPs) or Camofox (local anti-detect Firefox) pass soft/managed challenges
+    (Turnstile, hCaptcha/reCAPTCHA checkbox) as normal operation. This is NOT solving/spoofing - hard
+    interactive challenges still escalate to a human. `auto` inherits this whenever any such backend is
+    configured; Nous Portal subscribers get it via the Tool Gateway (assume true if set up).
     """
     backend = cfg.get("browser_backend", "auto")
-    if backend == "browserbase":
+    if backend in ("browserbase", "camofox"):
         return True
     if backend == "auto":
         env = os.environ if env is None else env
-        return bool(env.get("BROWSERBASE_API_KEY"))
+        # env keys (direct) OR a browser Hermes already has via config/Portal (no skill keys needed).
+        return _has_cloud_browser(env) or hermes_browser_configured()
     return False

--- a/optional-skills/security/unbroker/scripts/pdd.py
+++ b/optional-skills/security/unbroker/scripts/pdd.py
@@ -126,6 +126,9 @@ def cmd_doctor(args) -> None:
 
     cfg = config_mod.load_config()
     caps = config_mod.detect_capabilities(config_mod.dotenv_env())  # see creds in $HERMES_HOME/.env too
+    # A browser can also come from Hermes itself with NO skill keys: a provider set in config.yaml, or a
+    # Nous Portal subscription (Browserbase is a built-in gateway tool). Fold that in.
+    browser_avail = caps["cloud_browser"] or config_mod.hermes_browser_configured()
     data = paths_mod.data_dir()
     writable = _check_writable(data)
     curated = len(brokers_mod._load_curated())
@@ -142,8 +145,10 @@ def cmd_doctor(args) -> None:
          + ("" if live else ", run `refresh-brokers` to expand to ~50") + ")",
          "", "Opt-in upgrades:"]
     rows = [
-        ("Cloud browser (Browserbase) *RECOMMENDED*", caps["browserbase"],
-         "default backend: clears soft CAPTCHAs (Turnstile/hCaptcha) -> more T1", "set BROWSERBASE_API_KEY"),
+        ("Stealth browser *RECOMMENDED*", browser_avail,
+         "clears soft CAPTCHAs (Turnstile/hCaptcha) -> more T1",
+         "Nous Portal subscription (no keys) / BROWSERBASE_API_KEY + BROWSERBASE_PROJECT_ID / "
+         "BROWSER_USE_API_KEY / FIRECRAWL_API_KEY / CAMOFOX_URL"),
         ("Email auto (AgentMail)", caps["agentmail"],
          "send + auto-verify, per-broker aliases (Mode B/C)", "install agentmail skill / set AGENTMAIL_API_KEY"),
         ("Email send (CLI SMTP)", caps["smtp_send"],
@@ -175,12 +180,20 @@ def cmd_doctor(args) -> None:
 
     L += ["", "Verdict:", "  Ready now in DRAFT mode (no setup needed): scan brokers, draft opt-out",
           "  emails for you to send, and track everything in the ledger."]
-    if caps["browserbase"]:
-        L.append("  Cloud browser ON (recommended default): soft/managed CAPTCHAs "
-                 "(Turnstile/hCaptcha) clear automatically -> those brokers stay T1.")
+    if browser_avail:
+        L.append("  Stealth browser ON: soft/managed CAPTCHAs (Turnstile/hCaptcha) clear "
+                 "automatically -> those brokers stay T1.")
+        if caps["browserbase"] and not caps["browserbase_ready"]:
+            L.append("  WARNING: BROWSERBASE_API_KEY is set but BROWSERBASE_PROJECT_ID is NOT - the "
+                     "Browserbase plugin needs BOTH (or use a Nous Portal subscription, which provides "
+                     "Browserbase via the Tool Gateway with no keys). Add BROWSERBASE_PROJECT_ID to ~/.hermes/.env.")
     else:
-        L.append("  No cloud browser: set BROWSERBASE_API_KEY (the recommended default) so soft "
-                 "CAPTCHAs clear automatically; without it those brokers drop to T2 (human tasks).")
+        L.append("  No stealth browser detected from env/config: soft-CAPTCHA brokers drop to T2. Turn "
+                 "one on (any of): a Nous Portal subscription (no keys - Browserbase via the Tool "
+                 "Gateway); BROWSERBASE_API_KEY + BROWSERBASE_PROJECT_ID; BROWSER_USE_API_KEY; "
+                 "FIRECRAWL_API_KEY; CAMOFOX_URL (local); or `/browser connect` in the Hermes CLI. "
+                 "(If you already use Portal or `/browser connect`, the browser IS available - this "
+                 "env check just can't see it.) See methods.md 'Browser backends'.")
     if cfg["email_mode"] == "draft_only":
         L.append("  Email is draft-only: you send drafts + click verify links. For hands-off email "
                  "WITHOUT storing a password, run `setup --email-mode browser` (agent sends + opens "
@@ -192,8 +205,10 @@ def cmd_doctor(args) -> None:
                  "--user-data-dir=~/.hermes/chrome-debug, signed into the webmail once); else it falls "
                  "back to drafts. Run `pdd.py cdp` to launch it (or `pdd.py cdp --print` for the command). "
                  "See methods.md 'Browser backends'.")
+        # Cloud backends (not local Camofox) can't hold the operator's webmail session.
         cloud_scan = cfg.get("browser_backend") == "browserbase" or (
-            cfg.get("browser_backend") == "auto" and caps.get("browserbase"))
+            cfg.get("browser_backend") == "auto"
+            and (caps["browserbase"] or caps["browser_use"] or caps["firecrawl"]))
         if cloud_scan:
             L.append("  NOTE: your scan backend is a cloud browser (Browserbase). It is great for "
                      "Phase-1 scanning but CANNOT be the browser that sends webmail (no inbox session) "

--- a/tests/skills/test_unbroker_skill.py
+++ b/tests/skills/test_unbroker_skill.py
@@ -108,11 +108,58 @@ def test_config_roundtrip_and_validation():
             raise AssertionError("invalid email_mode should raise")
 
 
+@contextlib.contextmanager
+def _empty_hermes_home():
+    """Isolate HERMES_HOME so hermes_browser_configured() sees no config.yaml/auth.json."""
+    prev = os.environ.get("HERMES_HOME")
+    with tempfile.TemporaryDirectory() as d:
+        os.environ["HERMES_HOME"] = d
+        try:
+            yield Path(d)
+        finally:
+            if prev is None:
+                os.environ.pop("HERMES_HOME", None)
+            else:
+                os.environ["HERMES_HOME"] = prev
+
+
 def test_browser_clears_captcha_logic():
-    assert config.browser_clears_captcha({"browser_backend": "browserbase"}) is True
-    assert config.browser_clears_captcha({"browser_backend": "agent-browser"}) is False
-    assert config.browser_clears_captcha({"browser_backend": "auto"}, env={}) is False
-    assert config.browser_clears_captcha({"browser_backend": "auto"}, env={"BROWSERBASE_API_KEY": "x"}) is True
+    with _empty_hermes_home():  # no Hermes-side browser configured, so 'auto' hinges on env keys
+        assert config.browser_clears_captcha({"browser_backend": "browserbase"}) is True
+        assert config.browser_clears_captcha({"browser_backend": "agent-browser"}) is False
+        assert config.browser_clears_captcha({"browser_backend": "auto"}, env={}) is False
+        assert config.browser_clears_captcha({"browser_backend": "auto"}, env={"BROWSERBASE_API_KEY": "x"}) is True
+        # Any Hermes stealth backend clears soft CAPTCHAs, not just Browserbase.
+        assert config.browser_clears_captcha({"browser_backend": "camofox"}) is True
+        assert config.browser_clears_captcha({"browser_backend": "auto"}, env={"BROWSER_USE_API_KEY": "x"}) is True
+        assert config.browser_clears_captcha({"browser_backend": "auto"}, env={"FIRECRAWL_API_KEY": "x"}) is True
+        assert config.browser_clears_captcha({"browser_backend": "auto"}, env={"CAMOFOX_URL": "http://x"}) is True
+
+
+def test_hermes_browser_available_via_portal_or_config_no_keys():
+    # Browserbase is a built-in gateway tool: Portal auth (auth.json token) OR a configured provider
+    # (config.yaml) means a browser is available with NO skill env keys.
+    with _empty_hermes_home() as home:
+        assert config.hermes_browser_configured() is False
+        assert config.browser_clears_captcha({"browser_backend": "auto"}, env={}) is False
+        (home / "config.yaml").write_text("browser:\n  cloud_provider: browserbase\n", encoding="utf-8")
+        assert config.hermes_browser_configured() is True
+        assert config.browser_clears_captcha({"browser_backend": "auto"}, env={}) is True  # no keys needed
+    with _empty_hermes_home() as home:
+        (home / "auth.json").write_text('{"providers": {"nous": {"access_token": "abc"}}}', encoding="utf-8")
+        assert config.hermes_browser_configured() is True   # Portal subscriber token
+
+
+def test_detect_capabilities_recognizes_all_browser_backends():
+    caps = config.detect_capabilities({"CAMOFOX_URL": "http://localhost:9377"})
+    assert caps["camofox"] and caps["cloud_browser"] and not caps["browserbase"]
+    caps = config.detect_capabilities({"BROWSER_USE_API_KEY": "x"})
+    assert caps["browser_use"] and caps["cloud_browser"]
+    # Browserbase needs BOTH the key and the project id to be "ready".
+    assert config.detect_capabilities({"BROWSERBASE_API_KEY": "x"})["browserbase_ready"] is False
+    ready = config.detect_capabilities({"BROWSERBASE_API_KEY": "x", "BROWSERBASE_PROJECT_ID": "p"})
+    assert ready["browserbase_ready"] is True and ready["cloud_browser"] is True
+    assert config.detect_capabilities({})["cloud_browser"] is False
 
 
 # --- storage ------------------------------------------------------------------


### PR DESCRIPTION
Aligns the unbroker skill's browser handling with the Hermes browser feature, and adds a cheap-read scan rung. Confined to `optional-skills/security/unbroker/` and its test — no core/tool/plugin changes.

### Browser backends (Portal **or** keys)
- **Browserbase is a built-in gateway tool**, so the skill now treats it as available via **either** a **Nous Portal subscription (no keys)** — detected from `~/.hermes/auth.json` / a `browser.cloud_provider` in `config.yaml` — **or** direct credentials. Previously the skill implied `BROWSERBASE_API_KEY` was required and would falsely report "no browser" for Portal subscribers; now Portal users get correct **T1** captcha tiering with no keys.
- Detects the other Hermes backends too: **Browser Use** (`BROWSER_USE_API_KEY`), **Firecrawl** (`FIRECRAWL_API_KEY`), **Camofox** (`CAMOFOX_URL`), plus a combined `cloud_browser` signal. `browser_clears_captcha` broadened to any stealth backend (was Browserbase-only).
- Fixes an under-documented gotcha: Browserbase needs **BOTH** `BROWSERBASE_API_KEY` **and** `BROWSERBASE_PROJECT_ID` — `doctor` now warns if only the key is set.

### Docs + tools alignment
- `doctor` / `SKILL.md` / `methods.md`: Browserbase = Portal or keys; `browser_vision` for reading static-text/arithmetic CAPTCHAs on a first-party opt-out (never behavioral/token/slider); `/browser connect` + `browser.cdp_url` + `browser_cdp`/`browser_dialog`; the existing `pdd.py cdp` helper composes with `/browser connect`.

### Cheap-read scan rung (`methods.md` 1c)
- Try public-route reads (RSS/feeds, `.json`/mobile variants, OGP/JSON-LD, a site's own internal JSON API) **before** spinning up a browser on a WAF/403-blocked page — the additive part of the [insane-search](https://github.com/fivetaku/insane-search) escalation. Documented as a **technique, not a dependency** (its headless-browser rung is already covered by Hermes' native stealth).

### Tests
`tests/skills/test_unbroker_skill.py`: 99 passing (+ all-backend detection, + Portal/config no-keys availability). `ruff` and `check-windows-footguns.py --all` clean.

### Coordination note
Deliberately **scoped to browser only**. UK/EU/GDPR coverage is deferred to #59806 (thanks @dodo-reach) to avoid duplication. This shares a few hunks with in-flight PRs (#59806, #58462) in different sections of `config.py`/`pdd.py`/`methods.md`/`SKILL.md`; happy to rebase whenever those land.
