### PR TITLE
fix(dashboard): handle password auth login form

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -450,6 +450,13 @@ _PASSWORD_FORM_SCRIPT = """\
   }
   var forms = document.querySelectorAll('form.provider-form');
   for (var i = 0; i < forms.length; i++) { handle(forms[i]); }
+  var toggles = document.querySelectorAll('input[data-password-toggle]');
+  for (var j = 0; j < toggles.length; j++) {
+    toggles[j].addEventListener('change', function () {
+      var input = document.getElementById(this.getAttribute('data-password-toggle'));
+      if (input) { input.type = this.checked ? 'text' : 'password'; }
+    });
+  }
 })();
 </script>
 """
@@ -512,21 +519,29 @@ def _render_password_form(provider, next_path: str) -> str:
     pname = html.escape(provider.name, quote=True)
     plabel = html.escape(provider.display_name)
     safe_next = html.escape(next_path, quote=True) if next_path else ""
+    username_id = f"dashboard-{pname}-username"
+    password_id = f"dashboard-{pname}-password"
     return (
         f'      <form class="provider-form" data-provider="{pname}" '
-        f'autocomplete="on">\n'
+        f'action="/auth/password-login" method="post" autocomplete="on">\n'
         f'        <div class="form-title">Sign in with {plabel}</div>\n'
         f'        <input type="hidden" name="next" value="{safe_next}">\n'
-        f'        <label class="field">\n'
+        f'        <label class="field" for="{username_id}">\n'
         f'          <span class="field-label">Username</span>\n'
-        f'          <input class="field-input" type="text" name="username" '
+        f'          <input id="{username_id}" class="field-input" type="text" '
+        f'name="username" inputmode="text" '
         f'autocomplete="username" autocapitalize="none" '
-        f'autocorrect="off" spellcheck="false" required>\n'
+        f'autocorrect="off" spellcheck="false" required autofocus>\n'
         f'        </label>\n'
-        f'        <label class="field">\n'
+        f'        <label class="field" for="{password_id}">\n'
         f'          <span class="field-label">Password</span>\n'
-        f'          <input class="field-input" type="password" name="password" '
+        f'          <input id="{password_id}" class="field-input" '
+        f'type="password" name="password" '
         f'autocomplete="current-password" required>\n'
+        f'        </label>\n'
+        f'        <label class="show-password">\n'
+        f'          <input type="checkbox" data-password-toggle="{password_id}">\n'
+        f'          <span>Show password</span>\n'
         f'        </label>\n'
         f'        <div class="form-error" role="alert" hidden></div>\n'
         f'        <button class="provider-btn" type="submit">Sign in</button>\n'

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,13 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    if getattr(provider, "supports_password", False):
+        # Password-only providers (for example the bundled basic auth gate)
+        # do not implement the OAuth redirect handshake behind /auth/login.
+        # Let /login render the credential form instead of auto-bouncing into
+        # /auth/login and producing a 500 from start_login().
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -215,6 +215,18 @@ class TestProviderListFlag:
             web_server.app.state.auth_required = prev
 
 
+class TestPasswordOnlyGate:
+    def test_password_only_provider_renders_login_form_not_oauth_redirect(self, gated_app):
+        resp = gated_app.get("/", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login?next=%2F"
+
+        login = gated_app.get("/login")
+        assert login.status_code == 200
+        assert "Sign in with Test Password" in login.text
+        assert 'action="/auth/password-login"' in login.text
+
+
 # ---------------------------------------------------------------------------
 # /auth/password-login — end-to-end through the real middleware
 # ---------------------------------------------------------------------------
@@ -406,6 +418,12 @@ class TestLoginPageRender:
         try:
             html = render_login_html(next_path="/sessions")
             assert '<form class="provider-form" data-provider="testpw"' in html
+            assert 'action="/auth/password-login" method="post"' in html
+            assert 'autocomplete="on"' in html
+            assert 'autocomplete="username"' in html
+            assert 'autocomplete="current-password"' in html
+            assert 'data-password-toggle=' in html
+            assert "Show password" in html
             assert 'name="username"' in html
             assert 'name="password"' in html
             assert 'value="/sessions"' in html


### PR DESCRIPTION
## Summary
- make the password-provider login form submit to `/auth/password-login` with normal form metadata for password managers
- add stable username/password field IDs, username autofocus, and current-password autocomplete
- add a show-password checkbox wired into the existing password-login script
- keep dashboard auth status public while preserving the rest of the auth gate

## Test Plan
- `./venv/bin/python -m pytest tests/hermes_cli/test_dashboard_auth_password_login.py tests/hermes_cli/test_dashboard_auth_middleware.py` — 53 passed, 1 warning
- `./venv/bin/python -m pytest tests/hermes_cli/test_dashboard_auth_password_login.py tests/hermes_cli/test_dashboard_auth_middleware.py tests/plugins/dashboard_auth/test_basic_provider.py` — 75 passed, 1 warning
