### PR TITLE
docs(cli): document oneshot usage reports

### DIFF
--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -49,6 +49,9 @@ hermes chat --verbose
 # Isolated git worktree (for running multiple agents in parallel)
 hermes -w                         # Interactive mode in worktree
 hermes -w -z "Fix issue #123"     # Single query in worktree
+
+# Write a JSON usage report for one-shot automation
+hermes -z "Summarize this repository" --usage-file usage.json
 ```
 
 ## Interface Layout
@@ -88,7 +91,7 @@ The bar adapts to terminal width — full layout at ≥ 76 columns, compact at 5
 | Orange | 80–95% | Approaching limit |
 | Red | ≥ 95% | Near overflow — consider `/compress` |
 
-Use `/usage` for a detailed breakdown including per-category costs (input vs output tokens).
+Use `/usage` for a detailed breakdown including per-category costs (input vs output tokens). For non-interactive `-z` runs, `--usage-file <path>` writes a JSON report with estimated cost, token counts, model/provider, API call count, and completion or failure status.
 
 ### Session Resume Display
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/cli.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/cli.md
@@ -45,6 +45,9 @@ hermes chat --verbose
 # 隔离的 git worktree（用于并行运行多个 agent）
 hermes -w                         # 在 worktree 中以交互模式运行
 hermes -w -z "Fix issue #123"     # 在 worktree 中以单次查询模式运行
+
+# 为单次自动化运行写入 JSON 用量报告
+hermes -z "Summarize this repository" --usage-file usage.json
 ```
 
 ## 界面布局
@@ -84,7 +87,7 @@ hermes -w -z "Fix issue #123"     # 在 worktree 中以单次查询模式运行
 | 橙色 | 80–95% | 接近上限 |
 | 红色 | ≥ 95% | 即将溢出——考虑使用 `/compress` |
 
-使用 `/usage` 查看详细分解，包括各类别费用（输入 vs 输出 token）。
+使用 `/usage` 查看详细分解，包括各类别费用（输入 vs 输出 token）。对于非交互式 `-z` 运行，`--usage-file <path>` 会写入 JSON 报告，包含预估费用、token 数量、模型/提供商、API 调用次数以及完成或失败状态。
 
 ### 会话恢复显示
 


### PR DESCRIPTION
## Summary

Document `hermes -z --usage-file <path>` in the CLI guide and zh-Hans mirror.

This flag was added for one-shot automation so batch callers can capture JSON usage data without scraping terminal output. The new docs show the command and summarize the report fields: estimated cost, token counts, model/provider, API call count, and completion/failure status.

## Checks

- Source-checked `hermes_cli/_parser.py` and `hermes_cli/oneshot.py`
- Docs-only change
