### PR TITLE
fix(desktop): prevent bootstrap stale commit repin

### DIFF
--- a/apps/desktop/electron/bootstrap-runner.cjs
+++ b/apps/desktop/electron/bootstrap-runner.cjs
@@ -85,10 +85,6 @@ function bootstrapCacheDir(hermesHome) {
   return path.join(hermesHome, 'bootstrap-cache')
 }
 
-// The install.sh / install.ps1 that ships inside the already-installed agent
-// checkout under ~/.hermes/hermes-agent. Used as a last-resort fallback when
-// the pinned commit can't be fetched from GitHub (e.g. a locally-built desktop
-// app stamped to an unpushed HEAD).
 function installedAgentInstallScript(hermesHome) {
   if (!hermesHome) return null
   const candidate = path.join(hermesHome, 'hermes-agent', 'scripts', installScriptName())
@@ -97,6 +93,15 @@ function installedAgentInstallScript(hermesHome) {
     return candidate
   } catch {
     return null
+  }
+}
+
+function hasExistingGitCheckout(activeRoot) {
+  if (!activeRoot) return false
+  try {
+    return fs.existsSync(path.join(activeRoot, '.git'))
+  } catch {
+    return false
   }
 }
 
@@ -451,12 +456,13 @@ function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome 
 // Manifest + stage dispatch
 // ---------------------------------------------------------------------------
 
-// Build the install.ps1 pin args (-Commit / -Branch) from the install-stamp
-// so the repository stage clones the exact SHA the .exe was tested with
-// instead of falling back to install.ps1's default ($Branch = "main").
-function buildPinArgs(installStamp) {
+// Build the installer branch/pin args from the install stamp. The commit pin
+// is fresh-install only: once a managed checkout already exists, bootstrap is
+// a repair/update path and must not let an old packaged app detach the checkout
+// back to the commit baked into that app.
+function buildPinArgs(installStamp, { pinCommit = true } = {}) {
   const args = []
-  if (installStamp && installStamp.commit) {
+  if (pinCommit && installStamp && installStamp.commit) {
     args.push('-Commit', installStamp.commit)
   }
   if (installStamp && installStamp.branch) {
@@ -465,22 +471,22 @@ function buildPinArgs(installStamp) {
   return args
 }
 
-function buildPosixPinArgs({ installStamp, activeRoot, hermesHome }) {
+function buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit = true }) {
   const args = ['--dir', activeRoot, '--hermes-home', hermesHome]
   if (installStamp && installStamp.branch) {
     args.push('--branch', installStamp.branch)
   }
-  if (installStamp && installStamp.commit) {
+  if (pinCommit && installStamp && installStamp.commit) {
     args.push('--commit', installStamp.commit)
   }
   return args
 }
 
-async function fetchManifest({ scriptPath, installerKind, emit, hermesHome, activeRoot, installStamp }) {
+async function fetchManifest({ scriptPath, installerKind, emit, hermesHome, activeRoot, installStamp, pinCommit }) {
   const isPosix = installerKind === 'posix'
   const args = isPosix
-    ? ['--manifest', ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome })]
-    : ['-Manifest', ...buildPinArgs(installStamp)]
+    ? ['--manifest', ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit })]
+    : ['-Manifest', ...buildPinArgs(installStamp, { pinCommit })]
   const result = await (isPosix ? spawnBash : spawnPowerShell)(scriptPath, args, {
     emit,
     stageName: '__manifest__',
@@ -528,7 +534,17 @@ function parseStageResult(stdout) {
   return null
 }
 
-async function runStage({ scriptPath, installerKind, stage, emit, hermesHome, activeRoot, abortSignal, installStamp }) {
+async function runStage({
+  scriptPath,
+  installerKind,
+  stage,
+  emit,
+  hermesHome,
+  activeRoot,
+  abortSignal,
+  installStamp,
+  pinCommit
+}) {
   const startedAt = Date.now()
   emit({ type: 'stage', name: stage.name, state: 'running' })
 
@@ -539,9 +555,9 @@ async function runStage({ scriptPath, installerKind, stage, emit, hermesHome, ac
         stage.name,
         '--non-interactive',
         '--json',
-        ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome })
+        ...buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit })
       ]
-    : ['-Stage', stage.name, '-NonInteractive', '-Json', ...buildPinArgs(installStamp)]
+    : ['-Stage', stage.name, '-NonInteractive', '-Json', ...buildPinArgs(installStamp, { pinCommit })]
   const result = await (isPosix ? spawnBash : spawnPowerShell)(scriptPath, args, {
     emit,
     stageName: stage.name,
@@ -664,8 +680,25 @@ async function runBootstrap(opts) {
   })
 
   try {
+    const existingCheckout = hasExistingGitCheckout(activeRoot)
+    const pinCommit = !existingCheckout
+
+    if (existingCheckout && installStamp && installStamp.commit) {
+      emit({
+        type: 'log',
+        line:
+          `[bootstrap] existing checkout detected at ${activeRoot}; ` +
+          `not pinning to packaged install stamp ${installStamp.commit.slice(0, 12)}`
+      })
+    }
+
     // 1. Resolve the platform installer.
-    const scriptInfo = await resolveInstallScript({ installStamp, sourceRepoRoot, hermesHome, emit })
+    const scriptInfo = await resolveInstallScript({
+      installStamp,
+      sourceRepoRoot,
+      hermesHome,
+      emit
+    })
     const installerKind = scriptInfo.kind || 'powershell'
 
     // 2. Fetch manifest
@@ -675,7 +708,8 @@ async function runBootstrap(opts) {
       emit,
       hermesHome,
       activeRoot,
-      installStamp
+      installStamp,
+      pinCommit
     })
     emit({
       type: 'manifest',
@@ -700,7 +734,8 @@ async function runBootstrap(opts) {
         hermesHome,
         activeRoot,
         abortSignal,
-        installStamp
+        installStamp,
+        pinCommit
       })
       if (ev.state === 'failed') {
         emit({ type: 'failed', stage: stage.name, error: ev.error || 'stage failed' })
@@ -732,6 +767,9 @@ module.exports = {
   runBootstrap,
   // Exposed for testability
   parseStageResult,
+  buildPinArgs,
+  buildPosixPinArgs,
+  hasExistingGitCheckout,
   resolveLocalInstallScript,
   resolveInstallScript,
   installedAgentInstallScript,

--- a/apps/desktop/electron/bootstrap-runner.test.cjs
+++ b/apps/desktop/electron/bootstrap-runner.test.cjs
@@ -6,6 +6,9 @@ const path = require('node:path')
 
 const {
   runBootstrap,
+  buildPinArgs,
+  buildPosixPinArgs,
+  hasExistingGitCheckout,
   resolveInstallScript,
   installedAgentInstallScript,
   cachedScriptPath
@@ -55,6 +58,48 @@ test('installedAgentInstallScript resolves the installer in the agent checkout',
   } finally {
     fs.rmSync(home, { recursive: true, force: true })
   }
+})
+
+test('existing checkout detection requires git metadata', () => {
+  const home = mkTmpHome()
+  try {
+    const activeRoot = path.join(home, 'hermes-agent')
+    assert.equal(hasExistingGitCheckout(activeRoot), false)
+
+    fs.mkdirSync(path.join(activeRoot, '.git'), { recursive: true })
+    assert.equal(hasExistingGitCheckout(activeRoot), true)
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('fresh bootstrap args include the packaged commit pin', () => {
+  const installStamp = { commit: 'a'.repeat(40), branch: 'main' }
+
+  assert.deepEqual(buildPinArgs(installStamp), ['-Commit', installStamp.commit, '-Branch', 'main'])
+  assert.deepEqual(
+    buildPosixPinArgs({
+      installStamp,
+      activeRoot: '/tmp/hermes-agent',
+      hermesHome: '/tmp/hermes'
+    }),
+    ['--dir', '/tmp/hermes-agent', '--hermes-home', '/tmp/hermes', '--branch', 'main', '--commit', installStamp.commit]
+  )
+})
+
+test('existing-checkout bootstrap args keep branch but skip the packaged commit pin', () => {
+  const installStamp = { commit: 'a'.repeat(40), branch: 'main' }
+
+  assert.deepEqual(buildPinArgs(installStamp, { pinCommit: false }), ['-Branch', 'main'])
+  assert.deepEqual(
+    buildPosixPinArgs({
+      installStamp,
+      activeRoot: '/tmp/hermes-agent',
+      hermesHome: '/tmp/hermes',
+      pinCommit: false
+    }),
+    ['--dir', '/tmp/hermes-agent', '--hermes-home', '/tmp/hermes', '--branch', 'main']
+  )
 })
 
 test('resolveInstallScript prefers a cached script without touching the network', async () => {


### PR DESCRIPTION
## What does this PR do?

Prevents an old packaged Desktop app from downgrading an existing managed checkout during bootstrap repair.

The support logs show a Desktop app stamped at `acce1a245` / `0.15.1` re-entering bootstrap on July 6. Bootstrap updated the existing checkout to current `origin/main`, then immediately passed the old packaged `--commit acce1a245...` pin to the repository stage and detached the checkout back to the old May 29 commit.

This keeps commit pinning for fresh installs, but skips the packaged commit pin when `~/.hermes/hermes-agent` already exists as a git checkout. In that existing-checkout repair path, bootstrap still passes the stamped branch, so the installer can repair/update the checkout without repinning it to the old app bundle commit.

This is the same core fix shape as #39884, but that PR is stale/conflicting against current `main`. #39192 is broader install-stamp hardening and is also conflicting; this PR keeps the support-case fix narrow.

## Related Issue

Fixes #

Support thread: https://discord.com/channels/1053877538025386074/1523795011882188924

Related prior PRs:
- #39884
- #39192

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/electron/bootstrap-runner.cjs`
  - detect when the active Desktop-managed agent root already has git metadata
  - keep packaged commit pinning for fresh installs
  - skip only the packaged commit pin for existing-checkout bootstrap repair
  - keep branch args, installer script resolution, and bootstrap marker semantics otherwise unchanged
- `apps/desktop/electron/bootstrap-runner.test.cjs`
  - cover existing checkout detection
  - cover fresh install args retaining the commit pin
  - cover existing-checkout repair args keeping the branch while omitting the commit pin

## How to Test

1. `node --test apps/desktop/electron/bootstrap-runner.test.cjs`
2. `node --test apps/desktop/electron/windows-child-process.test.cjs`
3. `node --check apps/desktop/electron/bootstrap-runner.cjs`
4. `node --check apps/desktop/electron/bootstrap-runner.test.cjs`
5. `git diff --check -- apps/desktop/electron/bootstrap-runner.cjs apps/desktop/electron/bootstrap-runner.test.cjs`

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Linux/WSL focused Node tests

### Documentation & Housekeeping

- [x] I have updated relevant documentation — N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I have considered cross-platform impact — shared bootstrap args cover macOS/Linux/Windows runner behavior
- [x] I have updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Relevant customer log showed bootstrap using cached `install.sh` for `acce1a2452f8`, updating the existing checkout to current `origin/main`, then immediately pinning back to `acce1a2452f8b85343db1b057c1d98717c421522` from the packaged Desktop install stamp.