### PR TITLE
fix(slack): avoid duplicated bang command block text

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -207,6 +207,35 @@ def _extract_text_from_slack_blocks(blocks: list) -> str:
     return "\n".join(parts)
 
 
+def _blocks_text_duplicates_plain_text(
+    blocks_text: str,
+    plain_text: str,
+    *,
+    bang_command_rewritten: bool = False,
+) -> bool:
+    """Return True when Slack block text only mirrors the plain-text field.
+
+    Slack's rich_text composer often duplicates ``text`` in ``blocks``.  When
+    the adapter rewrites a leading ``!known-cmd`` to ``/known-cmd``, blocks
+    still contain the original ``!`` form, so a naive substring check would
+    append a duplicate line.
+    """
+    stripped_blocks = blocks_text.strip()
+    stripped_plain = plain_text.strip()
+    if not stripped_blocks:
+        return True
+    if stripped_blocks == stripped_plain or stripped_blocks in stripped_plain:
+        return True
+    if (
+        bang_command_rewritten
+        and stripped_blocks.startswith("!")
+        and stripped_plain.startswith("/")
+        and stripped_blocks[1:] == stripped_plain[1:]
+    ):
+        return True
+    return False
+
+
 def _serialize_slack_blocks_for_agent(blocks: list, max_chars: int = 6000) -> str:
     """Return a compact, redacted JSON view of the current message's Block Kit payload."""
     if not blocks:
@@ -2628,6 +2657,7 @@ class SlackAdapter(BasePlatformAdapter):
         # gateway dispatcher) handles it like a normal slash command.  Only
         # rewrite when the first token resolves to a known gateway command
         # so casual messages like "!nice work" pass through unchanged.
+        bang_command_rewritten = False
         if original_text.startswith("!"):
             try:
                 from hermes_cli.commands import is_gateway_known_command
@@ -2642,6 +2672,7 @@ class SlackAdapter(BasePlatformAdapter):
                     and is_gateway_known_command(cmd_name)
                 ):
                     original_text = "/" + original_text[1:]
+                    bang_command_rewritten = True
             except Exception:  # pragma: no cover - defensive
                 pass
 
@@ -2658,14 +2689,17 @@ class SlackAdapter(BasePlatformAdapter):
             if blocks_text:
                 # Only append if the blocks contain text not already present
                 # in the plain text field (avoids duplication).
-                stripped_blocks = blocks_text.strip()
-                if stripped_blocks and stripped_blocks not in text.strip():
+                if not _blocks_text_duplicates_plain_text(
+                    blocks_text,
+                    text,
+                    bang_command_rewritten=bang_command_rewritten,
+                ):
                     logger.debug(
                         "Slack: extracted additional text from blocks "
                         "(likely quoted/forwarded content): %s",
-                        stripped_blocks[:300],
+                        blocks_text.strip()[:300],
                     )
-                    text = (text.strip() + "\n" + stripped_blocks).strip()
+                    text = (text.strip() + "\n" + blocks_text.strip()).strip()
 
             blocks_payload = _serialize_slack_blocks_for_agent(blocks)
             if blocks_payload:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1129,7 +1129,7 @@ class TestBangPrefixCommands:
     command before downstream processing.
     """
 
-    def _make_event(self, text, thread_ts=None, channel_type="im", channel="D123"):
+    def _make_event(self, text, thread_ts=None, channel_type="im", channel="D123", blocks=None):
         evt = {
             "text": text,
             "user": "U_USER",
@@ -1139,7 +1139,23 @@ class TestBangPrefixCommands:
         }
         if thread_ts:
             evt["thread_ts"] = thread_ts
+        if blocks is not None:
+            evt["blocks"] = blocks
         return evt
+
+    def _rich_text_command_blocks(self, command_text: str) -> list:
+        """Slack rich_text blocks mirroring a typed ``!cmd`` message."""
+        return [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [{"type": "text", "text": command_text}],
+                    }
+                ],
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_bang_known_command_is_rewritten_to_slash(self, adapter):
@@ -1199,6 +1215,60 @@ class TestBangPrefixCommands:
         msg_event = adapter.handle_message.call_args[0][0]
         assert msg_event.text.startswith("/queue")
         assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_bang_known_command_with_blocks_no_duplicate(self, adapter):
+        """``!model`` rewritten to ``/model`` must not re-append block ``!model`` line."""
+        command = "!model glm-5.2-nu176"
+        await adapter._handle_slack_message(
+            self._make_event(
+                command,
+                blocks=self._rich_text_command_blocks(command),
+            )
+        )
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/model glm-5.2-nu176"
+        assert msg_event.message_type == MessageType.COMMAND
+        assert "!model" not in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_bang_unknown_with_blocks_still_extracts_extra(self, adapter):
+        """``!nice work`` is not rewritten; quoted block content is still merged."""
+        await adapter._handle_slack_message(
+            self._make_event(
+                "!nice work",
+                blocks=[
+                    {
+                        "type": "rich_text",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {"type": "text", "text": "!nice work"},
+                                ],
+                            },
+                            {
+                                "type": "rich_text_quote",
+                                "elements": [
+                                    {
+                                        "type": "rich_text_section",
+                                        "elements": [
+                                            {"type": "text", "text": "quoted context"},
+                                        ],
+                                    }
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            )
+        )
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text.startswith("!nice work")
+        assert msg_event.message_type != MessageType.COMMAND
+        assert "> quoted context" in msg_event.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Prevent Slack rich_text blocks from duplicating bang-prefixed known commands after `!command` is rewritten to `/command`
- Preserve existing block extraction for unknown bang text and quoted/forwarded Slack content
- Add regression coverage for `!model glm-5.2-nu176` so it reaches the gateway as a single `/model glm-5.2-nu176` command

## Root cause
Slack sends both a plain `text` field and mirrored `rich_text` blocks. The adapter rewrites known `!command` messages to `/command` for Slack thread compatibility, but the mirrored block text still contains the original bang form. The old dedupe check compared `/model ...` to `!model ...`, treated them as different, and appended a second line. Gateway `/model` then parsed a multiline argument and failed with `Model names cannot contain spaces.`

## Test plan
- `python -m pytest tests/gateway/test_slack.py::TestBangPrefixCommands tests/gateway/test_slack.py::TestIncomingDocumentHandling::test_rich_text_blocks_do_not_duplicate_plain_text tests/gateway/test_slack.py::TestIncomingDocumentHandling::test_rich_text_quotes_and_lists_are_extracted tests/gateway/test_model_command_custom_providers.py tests/gateway/test_model_switch_persistence.py -q -o 'addopts='`

Related: #22716, #43140
