### PR TITLE
fix(desktop): preserve profile for popped-out sessions

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5765,7 +5765,7 @@ function focusWindow(win) {
   win.focus()
 }
 
-function spawnSecondaryWindow({ sessionId, watch, newSession } = {}) {
+function spawnSecondaryWindow({ sessionId, profile, watch, newSession } = {}) {
   const icon = getAppIconPath()
   const win = new BrowserWindow({
     width: SESSION_WINDOW_MIN_WIDTH,
@@ -5808,6 +5808,7 @@ function spawnSecondaryWindow({ sessionId, watch, newSession } = {}) {
   win.loadURL(
     buildSessionWindowUrl(sessionId, {
       devServer: DEV_SERVER,
+      profile,
       rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
       watch,
       newSession
@@ -5818,8 +5819,11 @@ function spawnSecondaryWindow({ sessionId, watch, newSession } = {}) {
 }
 
 // Open (or focus) a standalone window for a single chat session.
-function createSessionWindow(sessionId, { watch = false } = {}) {
-  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, watch }))
+function createSessionWindow(sessionId, { profile, watch = false } = {}) {
+  const profileKey = typeof profile === 'string' ? profile.trim() : ''
+  const registryKey = profileKey ? `${profileKey}:${sessionId}` : sessionId
+
+  return sessionWindows.openOrFocus(registryKey, () => spawnSecondaryWindow({ sessionId, profile: profileKey, watch }))
 }
 
 // Open a fresh compact window on the new-session draft (#/). Not registry-keyed:
@@ -6148,7 +6152,7 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
     return { ok: false, error: 'invalid-session-id' }
   }
 
-  createSessionWindow(sessionId.trim(), { watch: opts?.watch === true })
+  createSessionWindow(sessionId.trim(), { profile: opts?.profile, watch: opts?.watch === true })
 
   return { ok: true }
 })

--- a/apps/desktop/electron/session-windows.cjs
+++ b/apps/desktop/electron/session-windows.cjs
@@ -42,17 +42,30 @@ function chatWindowWebPreferences(preloadPath) {
 // scratch window; `watch=1` marks a spectator window (e.g. a running subagent's
 // session): the renderer resumes it lazily so the gateway never builds an agent
 // just to stream into it.
-function buildSessionWindowUrl(sessionId, { devServer, rendererIndexPath, watch, newSession } = {}) {
-  const query = `?win=secondary${newSession ? '&new=1' : ''}${watch ? '&watch=1' : ''}`
+function buildSessionWindowUrl(sessionId, { devServer, rendererIndexPath, profile, watch, newSession } = {}) {
+  const query = new URLSearchParams({ win: 'secondary' })
+
+  if (profile) {
+    query.set('profile', profile)
+  }
+
+  if (newSession) {
+    query.set('new', '1')
+  }
+
+  if (watch) {
+    query.set('watch', '1')
+  }
+
   const route = newSession ? '#/' : `#/${encodeURIComponent(sessionId)}`
 
   if (devServer) {
     const base = devServer.endsWith('/') ? devServer.slice(0, -1) : devServer
 
-    return `${base}/${query}${route}`
+    return `${base}/?${query.toString()}${route}`
   }
 
-  return `${pathToFileURL(rendererIndexPath).toString()}${query}${route}`
+  return `${pathToFileURL(rendererIndexPath).toString()}?${query.toString()}${route}`
 }
 
 // A small registry keyed by sessionId that guarantees one window per chat:

--- a/apps/desktop/electron/session-windows.test.cjs
+++ b/apps/desktop/electron/session-windows.test.cjs
@@ -86,6 +86,18 @@ test('buildSessionWindowUrl adds the watch flag for spectator windows, before th
   assert.equal(url, 'http://localhost:5173/?win=secondary&watch=1#/abc')
 })
 
+test('buildSessionWindowUrl adds the profile flag before the hash', () => {
+  const url = buildSessionWindowUrl('abc', { devServer: 'http://localhost:5173', profile: 'rocky remote' })
+
+  assert.equal(url, 'http://localhost:5173/?win=secondary&profile=rocky+remote#/abc')
+})
+
+test('buildSessionWindowUrl keeps profile and watch flags before the hash', () => {
+  const url = buildSessionWindowUrl('abc', { devServer: 'http://localhost:5173', profile: 'rocky', watch: true })
+
+  assert.equal(url, 'http://localhost:5173/?win=secondary&profile=rocky&watch=1#/abc')
+})
+
 test('buildSessionWindowUrl routes new-session windows to the draft (#/)', () => {
   const url = buildSessionWindowUrl(null, { devServer: 'http://localhost:5173', newSession: true })
 

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -126,7 +126,7 @@ function useSessionActions({
             label: r.newWindow,
             onSelect: () => {
               triggerHaptic('selection')
-              void openSessionInNewWindow(sessionId)
+              void openSessionInNewWindow(sessionId, { profile })
             }
           }
         ]

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -171,7 +171,7 @@ export function SidebarSessionRow({
               event.preventDefault()
               event.stopPropagation()
               triggerHaptic('selection')
-              void openSessionInNewWindow(session.id)
+              void openSessionInNewWindow(session.id, { profile: session.profile })
 
               return
             }

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -24,7 +24,12 @@ import {
   touchSecondaryGateways
 } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $activeGatewayProfile, normalizeProfileKey, touchActiveGatewayBackend } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  initialWindowGatewayProfile,
+  normalizeProfileKey,
+  touchActiveGatewayBackend
+} from '@/store/profile'
 import {
   $activeSessionId,
   $attentionSessionIds,
@@ -333,7 +338,8 @@ export function useGatewayBoot({
 
     async function boot() {
       try {
-        const conn = await desktop.getConnection()
+        const requestedProfile = initialWindowGatewayProfile()
+        const conn = await desktop.getConnection(requestedProfile)
 
         if (cancelled) {
           return
@@ -361,8 +367,8 @@ export function useGatewayBoot({
         // same-profile resumes are no-op swaps and any reconnect targets the
         // right backend. Best-effort: a missing preference means "default".
         try {
-          const pref = await desktop.profile?.get?.()
-          const profileKey = (pref?.profile ?? '').trim() || 'default'
+          const pref = requestedProfile ? null : await desktop.profile?.get?.()
+          const profileKey = requestedProfile || (pref?.profile ?? '').trim() || 'default'
           $activeGatewayProfile.set(profileKey)
           setPrimaryGateway(gateway, profileKey)
           void ensureGatewayForProfile(profileKey)

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -30,7 +30,10 @@ declare global {
       // with an error code when the sessionId is empty/invalid. `watch` opens
       // a spectator window (lazy resume — no agent build) for live-streaming
       // a running subagent's session.
-      openSessionWindow: (sessionId: string, opts?: { watch?: boolean }) => Promise<{ ok: boolean; error?: string }>
+      openSessionWindow: (
+        sessionId: string,
+        opts?: { profile?: string | null; watch?: boolean }
+      ) => Promise<{ ok: boolean; error?: string }>
       // Open (or focus) a compact secondary window on the new-session draft.
       openNewSessionWindow: () => Promise<{ ok: boolean; error?: string }>
       // The pop-out pet overlay: a transparent always-on-top window hosting only

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -146,9 +146,37 @@ export async function switchProfile(name: string): Promise<void> {
 // gateway to that profile's backend (spawned on demand by the Electron pool).
 // A single-profile user never triggers a swap, so their path is unchanged.
 
+function initialSecondaryWindowProfile(): string | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    const params = new URLSearchParams(window.location.search)
+
+    if (params.get('win') !== 'secondary') {
+      return null
+    }
+
+    const profile = params.get('profile')?.trim()
+
+    return profile ? normalizeProfileKey(profile) : null
+  } catch {
+    return null
+  }
+}
+
+const initialGatewayProfile = initialSecondaryWindowProfile()
+
+export function initialWindowGatewayProfile(): string | null {
+  return initialGatewayProfile
+}
+
 // The profile the live gateway WebSocket is currently connected to. Initialized
-// to the primary (window) backend's profile on boot.
-export const $activeGatewayProfile = atom<string>('default')
+// to the primary (window) backend's profile on boot, except secondary session
+// windows opened from a profile-scoped row seed this from the URL so route resume
+// targets the session's owning backend before the first gateway connection.
+export const $activeGatewayProfile = atom<string>(initialGatewayProfile ?? 'default')
 
 // Profile for the NEXT new chat (chosen via the new-chat picker). null = primary
 // / default, so single-profile users are unaffected.

--- a/apps/desktop/src/store/windows.test.ts
+++ b/apps/desktop/src/store/windows.test.ts
@@ -89,6 +89,16 @@ describe('openSessionInNewWindow', () => {
     expect(notifyError).not.toHaveBeenCalled()
   })
 
+  it('forwards the session profile for profile-routed windows', async () => {
+    const open = vi.fn().mockResolvedValue({ ok: true })
+    installBridge(open)
+
+    await openSessionInNewWindow('s1', { profile: 'rocky' })
+
+    expect(open).toHaveBeenCalledWith('s1', { profile: 'rocky' })
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
   it('notifies on an ok:false result', async () => {
     installBridge(vi.fn().mockResolvedValue({ ok: false, error: 'invalid-session-id' }))
 

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -97,7 +97,10 @@ async function openWindow(call: () => Promise<WindowOpenResult>, failMessage: st
 // Open (or focus) a standalone OS window for a single chat session. No-ops
 // gracefully outside Electron so callers can wire it unconditionally.
 // `watch: true` opens a spectator window (lazy resume, live-mirror stream).
-export async function openSessionInNewWindow(sessionId: string, opts?: { watch?: boolean }): Promise<void> {
+export async function openSessionInNewWindow(
+  sessionId: string,
+  opts?: { profile?: string | null; watch?: boolean }
+): Promise<void> {
   if (!sessionId || !canOpenSessionWindow()) {
     return
   }


### PR DESCRIPTION
## Summary
- pass the owning session profile through Desktop pop-out window actions
- encode the profile in secondary window URLs before the hash route
- seed secondary-window gateway boot from the URL profile so route resume targets the right backend
- add regression coverage for profile-aware secondary window URLs and renderer bridge forwarding

## Test plan
- `node apps/desktop/electron/session-windows.test.cjs`
- `npm --workspace apps/desktop exec -- vitest run --environment jsdom src/store/windows.test.ts src/store/profile.test.ts src/app/session/hooks/use-route-resume.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run build`

## Notes
This fixes blank/loading secondary windows in multi-profile Desktop setups where opening a session by ID alone can connect the new renderer to the wrong profile/backend.