### PR TITLE
docs(skills): add environmental map forecast graphics skill

### DIFF
--- a/skills/productivity/environmental-map-and-forecast-graphics/SKILL.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: environmental-map-and-forecast-graphics
+description: "Use when creating polished environmental/geospatial graphics: KML/KMZ maps, GIS overlays, Florida sargassum/red tide/rainfall products, tide charts, and recurring coastal forecast image/email automation."
+version: 1.1.0
+author: Hermes Agent
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    tags: [maps, geospatial, kml, kmz, noaa, tides, rainfall, red-tide, sargassum, coastal, visualization]
+---
+
+# Environmental Map and Forecast Graphics
+
+## Overview
+
+Use this skill for user-facing environmental visualizations: static geospatial maps, GIS/KML/KMZ overlays, NOAA/FWC/Water Atlas coastal products, tide graphs, rainfall panels, and scheduled Florida/coastal forecast image packets. The class-level pattern is the same across these jobs: fetch authoritative data, render a polished visual artifact, visually QA it, then deliver the image or email.
+
+## When to Use
+
+- The user provides `.kml`, `.kmz`, `.zip`, Google Earth files, GIS layers, raster overlays, risk contours, or public ArcGIS/NOAA/FWC map layers.
+- The user asks for Florida/coastal maps such as sargassum, red tide, rainfall totals, radar, tropical outlooks, or local station maps.
+- The user asks for tide charts/graphs with daylight, high/low labels, or Telegram-ready delivery.
+- The user asks to automate daily/recurring environmental image packets or email reports.
+
+## Shared Workflow
+
+1. **Identify the source class**
+   - KML/KMZ/ZIP: inspect archive contents, parse KML, read `GroundOverlay` bounds and feature attributes.
+   - Public GIS/ArcGIS: query the REST layer directly when possible instead of scraping rendered map markers.
+   - NOAA/FWC/API graphics: fetch both image/API data and source metadata, including dates and station names.
+   - Tide charts: resolve the nearest relevant NOAA CO-OPS station and fetch both smooth predictions and high/low predictions.
+
+2. **Preserve data provenance**
+   - Put source name, data date/window, station/layer name, and important caveats in the title, legend, footer, or email copy.
+   - For modeled products, distinguish current-status sampling maps from forecasts/trajectory guidance and from health advisories.
+
+3. **Render in layers**
+   - Basemap or chart background.
+   - Raster overlays or filled regions.
+   - Vector features/contours/points.
+   - Custom labels, city markers, high/low tide callouts, or station values.
+   - Legend, title, source/date footer, disclaimers.
+
+4. **Use the right implementation level**
+   - Python + Pillow + NumPy is usually enough for custom static map/chart artifacts.
+   - Heavy GIS stacks are optional; do not require `geopandas`/`cartopy` for simple KML/raster or station-map rendering.
+   - For recurring work, place reusable scripts under `~/.hermes/scripts/` and schedule with Hermes cron using `no_agent=True` when the script emits the final fixed message/media.
+
+5. **Visually QA before delivery**
+   - Open or inspect the generated image before sending.
+   - Check label readability, legend size/placement, source/date text, overlap, color contrast, cropped footer/title, and whether all user-requested locations are present.
+   - If the visual artifact is clearly flawed, regenerate it before delivering.
+
+## KML/KMZ and GIS Overlay Maps
+
+- Treat `.kmz` as a ZIP archive; if upload ingestion rejects `.kmz`, ask for a `.zip` wrapper or extracted `.kml` plus assets.
+- KML coordinates are `longitude,latitude[,altitude]`.
+- Parse `Placemark`, `LineString`, `Polygon`, `Point`, `ExtendedData`, `GroundOverlay`, and style colors before deciding how to draw.
+- KML color strings are AABBGGRR, not RRGGBBAA.
+- For georeferenced rasters, map output pixels back to lon/lat and then into source-image coordinates from the overlay bounds.
+- Make near-white empty raster backgrounds transparent and keep current/vector rasters subtle enough that they do not become smudges.
+- See `references/sargassum-kmz-map-rendering.md` and `references/florida-sargassum-map-20260611.md` for concrete sargassum/KMZ lessons.
+
+## Basemaps, Labels, and Legends
+
+- If adding custom city labels, avoid basemaps with prominent built-in labels; duplicate labels look messy.
+- Use direct on-map text with white halos when the user wants labels on the map; use callout boxes only when collisions are otherwise unavoidable.
+- Legends should be large, readable, close to the mapped area, and not covering key labels/data.
+- Include the data date in the legend or footer.
+- For comparable risk categories, use same-size legend swatches rather than mixed line/box sizes.
+- If the user says the map is boring, try a more colorful topo/terrain/physical basemap while preserving label readability.
+
+## Florida/Coastal Product Patterns
+
+### Sargassum
+
+- Build NOAA/AOML KMZ URLs from `YYYYMMDD`: `https://cwcgom.aoml.noaa.gov/SIR/KMZ/Sargassum_risk_currents_FA_<YYYYMMDD>.kmz`.
+- For morning automation, try today then walk backward because newest KMZs may not be posted yet.
+- Use KML `GroundOverlay` bounds and `SimpleData name="date"` rather than hardcoding.
+- Default risk palette: low risk bright light blue/cyan, risk 1 yellow, risk 2 orange, risk 3 red.
+
+### Red tide
+
+- For Ron's Florida daily email, use the FWC current-status sampling map by default, not the USF trajectory composite.
+- If the user asks for prediction/forecast, use the USF/FWC short-term HAB trajectory workflow and clearly label it as model-based transport guidance.
+- See `references/fwc-red-tide-current-status-map.md` and `references/florida-red-tide-prediction-map.md`.
+
+### Sarasota/Manasota rainfall
+
+- Use `https://api.wateratlas.usf.edu/rainfall/latest/?s=8` behind the Sarasota Water Atlas rainfall page.
+- Render 24-hour, 7-day, and 31-day values from `total24h`, `total7d`, `total31d`.
+- Prefer Water Atlas-style station-box maps for user requests to match that page; use interpolated 3 km grids only when requested and label them as interpolated visualizations.
+- Preserve lower Manasota Key / Englewood station visibility.
+- See the Water Atlas references copied into this skill.
+
+### Tide charts
+
+- Resolve the NOAA CO-OPS station, fetch `product=predictions` with `interval=6` for the smooth curve and `interval=hilo` for high/low labels.
+- For one-day charts, set the x-axis from local midnight to next local midnight even if the final NOAA point is 23:54.
+- Shade daylight using the station/location latitude/longitude and local timezone; guard against UTC conversion making sunset appear before sunrise.
+- Render a high-resolution PNG with source station, datum, local time, high/low callouts, and footer/source text.
+- See `references/noaa-tide-graph-pattern.md`.
+
+## Automation and Delivery
+
+- Reusable scripts belong in `~/.hermes/scripts/`, not inside a one-off chat transcript.
+- Cron jobs that generate fixed image/email outputs should generally use `no_agent=True`; empty stdout should mean silent success when appropriate.
+- For Telegram/media delivery, include `MEDIA:/absolute/path/to/file.png` in the message.
+- For email packets, keep scripts quiet on success and print logs only on failure so cron does not spam status pings.
+
+### Polished environmental email packets
+
+- If a daily email includes multiple maps/charts, avoid a plain stack of images. Use a wide hero image plus clean individual card sections with concise human summary, then the authoritative map/chart.
+- For Ron's Florida daily email, do **not** use decorative photo headers inside each map/chart card; he redlined those out. Keep only the top hero image and the actual chart/map images.
+- Do not prefix Florida email section titles with ordering numbers like `1)` / `2)`; preserve order through layout only.
+- Source maps/charts should remain prominent and preserve provenance/date labels.
+- For Ron's Florida daily email, current added local forecast charts are generated inside `~/.hermes/scripts/florida-email-task.py` using Open-Meteo forecast and marine APIs for Manasota Key (`26.9241,-82.3600`): 7-day weather, 7-day wind, and 7-day swell. Treat them as daily-updating NOAA/NCEP model-derived guidance and label that source in chart footers. Render these charts at high resolution (currently 2200×1360) and keep rain/condition/date/legend zones physically separated; Ron specifically noticed rain percentages overlapping lows and high temps crowding condition callouts.
+- For Ron's Manasota Key Fun Pack email music section, use SWFLLive Englewood events (`https://swfllive.com/events?city=Englewood`) for a compact 5-day lineup organized by day/venue. Filter to Beachcomber Trading Post, SandBar Tiki & Grille, and White Elephant Pub. SWFLLive is a Next.js/RSC page; event rows can be parsed from the embedded escaped `tableRows` JSON payload. The email From/subject branding should be `Manasota Key Fun Pack`, not `Ara1bot Florida Fun Pack`.
+- When maintaining Ron's Manasota Key Fun Pack, load `references/manasota-key-fun-pack-email.md` for the durable workflow: branding, Gmail clipping/collapsing safeguards, forecast chart spacing pitfalls, SWFLLive entertainment parsing, Brave Search secret handling, and verification checklist.
+- Combine Sarasota Water Atlas 24-hour, 7-day, and 31-day rainfall maps into one side-by-side panel for email scanning; keep the individual map images available for source verification.
+- Optimize inline email image bytes before attaching (resize large maps/charts/photos and encode as progressive JPEG around quality 82–86). Verify total `.eml` image payload and make sure the large sargassum/rainfall products are no longer multi-MB attachments.
+- Verify generated `.eml` files by counting expected inline images/cards and visually previewing extracted HTML or a contact sheet; file existence is not enough.
+- See `references/florida-email-photo-led-map-cards.md` for the Florida daily email pattern and verification recipe.
+
+## Common Pitfalls
+
+1. **Skipping visual QA.** These tasks are visual deliverables; file existence is not enough.
+2. **Flattening KML/KMZ packages.** A KMZ may include rasters/assets that must move with the KML.
+3. **Wrong coordinate order.** KML is lon/lat, not lat/lon.
+4. **Duplicate labels.** Built-in basemap labels plus custom labels usually look bad.
+5. **Unclear product semantics.** Current-status sampling, model forecasts, radar, and health advisories are different; label them plainly.
+6. **Date/time mistakes.** Use tools for current dates, tide dates, and timezone-aware sunrise/sunset calculations.
+7. **Overcrowded title/legend/footer.** Move legends to footer or resize/regenerate when overlap appears.
+
+## Verification Checklist
+
+- [ ] Source/layer/station and date/window are visible.
+- [ ] Requested locations and labels are present and readable.
+- [ ] Legend is readable and not hiding important data.
+- [ ] Colors/line weights are visible against the basemap.
+- [ ] Footer/source/caveat text is not cropped.
+- [ ] Final image was visually inspected before delivery.
+
+## References
+
+This umbrella absorbed the previous `geospatial-map-rendering`, `geospatial-map-artifacts`, and `tide-forecast-graphics` skills. Their full prior SKILL.md files and supporting references/templates were preserved under this skill's `references/` directory.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/florida-email-photo-led-map-cards.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/florida-email-photo-led-map-cards.md
@@ -1,0 +1,38 @@
+# Florida Email Photo-Led Map Cards
+
+Session lesson from improving Ron's Florida daily email packet (`~/.hermes/scripts/florida-email-task.py`).
+
+## Pattern
+
+For recurring coastal/environmental email packets, make the message feel like a polished briefing instead of a stack of raw maps:
+
+- Use a wide hero photo at the top with a short dated briefing label.
+- Wrap each environmental product in a card: photo header, concise human summary, then the authoritative map/chart.
+- Use distinct photo themes per product so repeated sections do not feel generic:
+  - Sargassum: beach/shore condition photo.
+  - Tropical outlook: storm clouds/ocean sky photo.
+  - Radar: lightning/rain/storm photo.
+  - Rainfall totals: rain/water photo.
+  - Tide graph: shoreline/waves/tide photo.
+  - Red tide/current status: Gulf water/coastal water photo.
+- Keep the authoritative map/chart prominent; photos are visual lead-ins, not replacements for source products.
+- Label FWC red tide as current status, not trajectory/forecast, unless the actual forecast product is used.
+
+## Implementation notes
+
+- Cache downloaded public photo assets under the email task cache directory so repeated cron runs do not depend on re-fetching unchanged images unnecessarily.
+- Attach photos as inline CID images just like maps, and include all photo CIDs in the HTML alternative's `add_related` list.
+- If using dynamic photo providers, choose specific query terms per section; avoid reusing one generic photo for unrelated products.
+- In the footer, describe photos generically as cached public photos or visual section headers unless a specific provider/license is guaranteed.
+
+## Verification recipe
+
+After a dry run, parse the generated `.eml` and check:
+
+- Subject updated to match the improved theme.
+- HTML contains the expected number of map cards.
+- All CID images are present: hero photo, each section photo, and each authoritative map/chart.
+- Image payload sizes are non-trivial.
+- Browser-preview the extracted HTML with CIDs converted to local file URIs and visually inspect for broken images, huge whitespace, unreadable text, or repeated/wrong photos.
+
+Example expectations from this session: 8 map cards and 15 inline images (7 photos + 8 maps/charts).

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/florida-email-rainfall-integration.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/florida-email-rainfall-integration.md
@@ -1,0 +1,123 @@
+# Florida Email Task rainfall-map integration
+
+Session-derived notes for adding Sarasota Water Atlas rainfall maps to Ron's daily Florida email packet.
+
+## Goal
+
+Include Water Atlas-style rainfall visuals for Manasota Key / Englewood in the Florida Email Task, matching the page-like station-box map Ron preferred:
+
+- 24 Hour Total Rainfall
+- 7 Day Total Rainfall
+- 31 Day Total Rainfall
+
+Use the same screenshot-like visual language as the Sarasota Water Atlas rainfall page: white/teal header, pale basemap, blue station value boxes, left radio panel with the active period selected, and a bottom-left `3 km` scale marker.
+
+## Reusable renderer
+
+Script path:
+
+- `~/.hermes/scripts/sarasota-rainfall-wateratlas-maps.py`
+
+Data source:
+
+- API: `https://api.wateratlas.usf.edu/rainfall/latest/?s=8`
+- Page/source label: `https://sarasota.wateratlas.usf.edu/rainfall/latest/`
+
+Usage:
+
+```bash
+/usr/bin/python3 ~/.hermes/scripts/sarasota-rainfall-wateratlas-maps.py --period all
+```
+
+The script prints three `MEDIA:` paths in this order:
+
+1. `24h` map using `total24h`
+2. `7d` map using `total7d`
+3. `31d` map using `total31d`
+
+It caches OSM basemap tiles under `~/.hermes/cache/osm_tiles/` and writes generated maps under `~/.hermes/cache/sarasota_rainfall/`.
+
+## Viewport/style defaults
+
+Good screenshot-like viewport for lower Sarasota / Manasota Key / Englewood:
+
+- lon min/max: `-82.555, -82.125`
+- lat min/max: `26.835, 27.245`
+- canvas: `760 x 1230`
+- header: `112 px`
+- map area height: `1065 px`
+- Web Mercator tile zoom: `12`
+
+Basemap styling used to mimic Water Atlas:
+
+- OSM tiles, then `Color ~= 0.58`, `Contrast ~= 0.78`, `Brightness ~= 1.18`
+- station total boxes: pale blue fill, dark outline, large values
+- radio panel selects the requested period, with inactive options still visible
+
+Manual nudges are important for lower/congested labels such as Indian Mound Park, Lemon Bay Park, Lemon Bay Canal, FRK-1/FRK-2, GOT-1/GOT-2, and Jacaranda Bridge so the Englewood / Manasota lower stations stay visible.
+
+## Florida Email Task integration points
+
+Main script:
+
+- `~/.hermes/scripts/florida-email-task.py`
+
+Add or preserve:
+
+```python
+RAINFALL_SCRIPT = Path.home() / ".hermes" / "scripts" / "sarasota-rainfall-wateratlas-maps.py"
+```
+
+Add helper:
+
+```python
+def run_rainfall_maps():
+    cmd = [str(RAINFALL_SCRIPT), "--period", "all"]
+    proc = subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=240)
+    if proc.returncode != 0:
+        raise RuntimeError(f"Rainfall maps failed\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}")
+    media = [Path(line.replace("MEDIA:", "", 1).strip()) for line in proc.stdout.splitlines() if line.startswith("MEDIA:")]
+    if len(media) < 3:
+        raise RuntimeError(f"Expected 3 MEDIA paths from rainfall script, got {len(media)}\n{proc.stdout}")
+    for p in media[:3]:
+        if not p.exists() or p.stat().st_size < 1024:
+            raise RuntimeError(f"Missing/empty rainfall image: {p}")
+    return {"stdout": proc.stdout, "rainfall_24h": media[0], "rainfall_7d": media[1], "rainfall_31d": media[2]}
+```
+
+Then call it after the sargassum packet and before email construction:
+
+```python
+packet = run_sargassum_packet(args.date)
+packet.update(run_rainfall_maps())
+```
+
+Embed the three inline images in the HTML email with CIDs:
+
+- `rainfall_24h`
+- `rainfall_7d`
+- `rainfall_31d`
+
+Add them to the related image loop with filenames:
+
+- `sarasota-wateratlas-rainfall-24h.png`
+- `sarasota-wateratlas-rainfall-7d.png`
+- `sarasota-wateratlas-rainfall-31d.png`
+
+## Verification
+
+Run a dry build before relying on the cron job:
+
+```bash
+/usr/bin/python3 ~/.hermes/scripts/florida-email-task.py --to reisworth@gmail.com --dry-run
+```
+
+Verify the dry run prints all three rainfall image paths and that the preview `.eml` contains CIDs for `rainfall_24h`, `rainfall_7d`, and `rainfall_31d`.
+
+Visually QA at least the 24-hour and 7-day maps after creating the renderer or changing the viewport:
+
+- correct radio option selected
+- lower Manasota Key / Englewood station boxes visible
+- no severe crop or hidden station boxes
+- `3 km` scale marker visible
+- footer/source timestamp readable

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/florida-red-tide-prediction-map.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/florida-red-tide-prediction-map.md
@@ -1,0 +1,57 @@
+# Florida red tide prediction map workflow
+
+Session-derived workflow for making a Telegram-ready Florida red tide prediction map.
+
+## Best current data sources
+
+- USF Ocean Circulation Lab WFCOM HAB Tracking landing page:
+  - `https://ocl.marine.usf.edu/Models/WFCOM4/HAB_tracking/`
+- Current surface trajectories image:
+  - `https://ocl.marine.usf.edu/Models/WFCOM4/HAB_tracking/upper_R0.gif`
+- Current subsurface / near-bottom trajectories image:
+  - `https://ocl.marine.usf.edu/Models/WFCOM4/HAB_tracking/lower_R0.gif`
+- Current coastal concentration/forecast image:
+  - `https://ocl.marine.usf.edu/Models/WFCOM4/HAB_tracking/hab_coastal_WFS_R0.png`
+- FWC red tide statewide status page:
+  - `https://myfwc.com/research/redtide/statewide/`
+
+The FWC page includes current summary text such as:
+
+```text
+Short-term (3.5 day) forecasts provided by the USF-FWC Collaboration for Prediction of Red Tides predict ...
+```
+
+It also links current statewide maps/status files with dated filenames, e.g. `statewidemap0612.jpg` and tables/maps by region.
+
+## Recommended deliverable
+
+For a user asking “create a map showing the red tide prediction for Florida,” produce a polished composite rather than forwarding a raw source image:
+
+1. Download the current `upper_R0.gif` and `lower_R0.gif` images.
+2. Extract the current FWC forecast-summary sentence from the FWC page.
+3. Compose a single PNG with:
+   - title: “Florida Red Tide Prediction Map”
+   - subtitle: “USF–FWC short-term HAB trajectory forecast • surface and subsurface transport”
+   - two panels: “Surface water trajectories” and “Subsurface / near-bottom trajectories”
+   - forecast summary card using the FWC short-term forecast text
+   - “How to read the forecast” legend:
+     - X marks: sample/starting locations
+     - Colored lines: forecast transport by *K. brevis* category
+     - White line: present/drifter trajectory
+   - source footer naming USF OCL WFCOM HAB Tracking and FWC Red Tide Current Status
+   - note that this is model-based transport guidance, not a health advisory
+4. Visually inspect the final PNG before sending; ensure footer/source text is not cropped and summary text does not overlap the legend.
+
+## Implementation notes
+
+- Use Pillow directly; it worked reliably for composing the source GIF/PNG images into a clean Telegram-ready composite.
+- Source GIFs are 757×800 and can be resized into side-by-side panels.
+- Keep the raw map legends inside each source panel; add a simplified external legend only to explain the main visual cues.
+- The raw USF trajectory panels may show a time span like `From 2026-06-11 20 ET To 2026-06-11 20 ET`; preserve the source image as-is rather than rewriting its internal annotations.
+- The final composite size that worked well: about `1800×1360` pixels.
+
+## Pitfalls
+
+- Do not present this as a beach-health advisory. It is a model-based HAB transport forecast and local conditions can change quickly.
+- The FWC statewide status map is useful context, but the USF `upper_R0.gif`/`lower_R0.gif` trajectory images are better for a “prediction” map because they show forecast transport.
+- If using footer text from live pages, wrap it into a footer box; long source URLs can get cropped on the right edge if drawn as one line.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/florida-sargassum-map-20260611.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/florida-sargassum-map-20260611.md
@@ -1,0 +1,76 @@
+# Florida sargassum map session notes — 2026-06-11 source data
+
+## Source archive shape
+
+The user uploaded `Sargassum_risk_currents_FA_20260611.zip`, originally discussed as a `.kmz`-style Google Earth package. Contents included:
+
+- `risk_currents_FA.kml` — main KML, about 12.5 MB
+- `currents.png` — current data raster overlay
+- `FA_density.png` — sargassum/floating algae density raster overlay
+- logo and legend image assets under `images/`
+
+KML findings:
+
+- `GroundOverlay` bounds for both rasters were `west=-100`, `east=-50`, `south=2`, `north=35`.
+- The KML had many `LineString` placemarks with `ExtendedData` fields: `risk` and `date`.
+- Date field was `20260611`, rendered as `2026-06-11`.
+- Risk values observed: `0`, `1`, `2`, `3`.
+- KML style colors are AABBGGRR; `ffffffb2` corresponds to light blue/cyan and should be treated as low risk in this source family.
+
+## Map rendering technique that worked
+
+A static PNG was generated with Python, PIL, and NumPy:
+
+1. Fetch slippy-map tiles for the bounding box around Florida and the Gulf.
+2. Build a tile mosaic and crop it to the desired Web Mercator bounding box.
+3. For raster overlays, convert each output pixel to lon/lat and sample the source raster using the KML `GroundOverlay` bounds.
+4. Make near-white raster backgrounds transparent.
+5. Composite layers in this order:
+   - basemap
+   - density overlay, semi-transparent
+   - current overlay, very subtle
+   - risk lines/contours, bright high-contrast
+   - city labels, title, legend
+
+Useful bounding box for Florida + Gulf context:
+
+```python
+W, S, E, N = -88.8, 23.7, -79.6, 31.2
+ZOOM = 7
+```
+
+## User-driven visual preferences from the session
+
+The map improved through several corrections:
+
+- Initial city labels conflicted with built-in basemap labels. Fix: use a cleaner basemap or custom labels with halos/callouts.
+- The legend was too small/far away. Fix: make it large, place it near Florida but not over key data, and include the data date.
+- The user wanted `Manasota Key` added.
+- The user wanted a basemap that was less boring and showed Florida topology/terrain in different colors. Fix: switch from a no-label neutral basemap to a more colorful topo/terrain/physical basemap when visual richness is requested.
+- The user wanted city callouts directly on the map, not offshore callout boxes. Fix: place text near real city points using white halo text instead of opaque boxes.
+- Add major Atlantic-side cities for context: Jacksonville, St. Augustine, Daytona Beach, Cape Canaveral, Orlando, West Palm Beach, Fort Lauderdale, Miami.
+- Current lines/raster were too thick and smudgy. Fix: reduce current overlay opacity aggressively; keep it subtle.
+- Risk colors needed to be brighter. Fix: use bright cyan/yellow/orange/red and draw risk contours after current/density overlays.
+- Legend risk/category swatches should be same-size rectangles, not mixed line samples and different-sized blocks.
+
+## Final legend semantics used
+
+- Currents — yellow rectangle with arrow cue
+- Density — green rectangle
+- Low risk — bright light blue/cyan
+- Risk 1 — yellow
+- Risk 2 — orange
+- Risk 3 — red / highest
+
+## Verification checklist
+
+Before delivering a revised map:
+
+- Does the basemap match the requested style: clean/no-label vs topo/terrain?
+- Are requested Gulf and Atlantic cities present?
+- Is Manasota Key included when relevant?
+- Are labels readable without overwhelming the map?
+- Does the legend include the data date?
+- Are legend swatches uniform where categories are comparable?
+- Are current overlays subtle enough not to look like smudges?
+- Are risk colors bright and visible on top of the basemap?

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/fwc-red-tide-current-status-map.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/fwc-red-tide-current-status-map.md
@@ -1,0 +1,75 @@
+# FWC Red Tide Current Status Map
+
+Use this reference when the user asks to use the FWC interactive red tide map at `https://gis.myfwc.com/redtidecurrentstatus/`, or asks to include that current-status map in the Florida daily email.
+
+## Source
+
+- Public web app: `https://gis.myfwc.com/redtidecurrentstatus/`
+- ArcGIS web map item discovered from the app: `032578e992e04012a25db77499318ff9` — "Florida Red Tide Current Status Map"
+- Public feature layer:
+  `https://services2.arcgis.com/z6TmTIyYXEYhuNM0/arcgis/rest/services/HAB_Current_Web_Layer/FeatureServer/0`
+
+No credentials are required for the REST layer.
+
+## Query pattern
+
+Use ArcGIS REST `query` with JSON output and geometries:
+
+```text
+https://services2.arcgis.com/z6TmTIyYXEYhuNM0/arcgis/rest/services/HAB_Current_Web_Layer/FeatureServer/0/query
+  ?where=1%3D1
+  &outFields=*
+  &returnGeometry=true
+  &f=json
+  &returnExceededLimitFeatures=true
+```
+
+Useful fields observed:
+
+- `SampleDate_t` / `SAMPLE_DATE` — sample date fields
+- `LOCATION`
+- `COUNTY`
+- `LATITUDE`, `LONGITUDE`
+- `Abundance`
+- `SAMPLE_DEPTH`
+
+Abundance categories:
+
+- `not present/background (0-1,000)`
+- `very low (>1,000-10,000)`
+- `low (>10,000-100,000)`
+- `medium (>100,000-1,000,000)`
+- `high (>1,000,000)`
+
+## Rendering guidance
+
+- Treat this as a current-status sampling map, not a forward trajectory prediction model.
+- Query the layer directly instead of screenshotting the app; direct data access gives cleaner styling, reliable legends, and attachment-ready images.
+- Cache generated images under `~/.hermes/cache/red_tide/` for cron/email workflows.
+- A Pillow-only renderer is sufficient when geopandas/pyshp are unavailable:
+  - Use public state/county outline GeoJSON for context.
+  - Project lon/lat to the image with fixed Florida bounds, e.g. roughly `x=-87.9..-79.6`, `y=24.0..31.4`.
+  - Draw a light water/land basemap, state outline, and county outlines.
+  - Render sample points by abundance with readable dot sizes. For `not present/background`, mimic the FWC legend with a white/empty dot and dark outline.
+  - Add a local highlight ring for Manasota Key when the map is for Ron's Florida packet.
+- Include a date range in the subtitle or legend derived from the returned sample dates. The FWC app describes the data as the most recent eight days of sampling.
+- Add a clear note: "current-status sampling map, not a forward trajectory prediction model." This avoids conflating it with the USF/FWC HAB trajectory forecast.
+
+## Visual QA checklist
+
+- Title and subtitle are not cropped.
+- Dots are visible at email/Telegram size, including when all points are `not present/background`.
+- Legend includes all five abundance classes and counts.
+- Source/footer is readable and includes the FWC web map URL.
+- No important labels or west/east coast clusters are hidden by cards.
+- If all current points are background/no elevated samples, state that explicitly in the summary card so the mostly white/outlined markers do not look like missing data.
+
+## Florida daily email integration
+
+When integrating into `~/.hermes/scripts/florida-email-task.py`:
+
+1. Put the reusable renderer at `~/.hermes/scripts/florida-red-tide-map.py` with an absolute `/usr/bin/python3` shebang if it depends on system packages.
+2. Have the email task call the renderer and attach the output inline with a stable CID such as `red_tide_map`.
+3. Add an HTML section after the existing weather/coastal images with a short explanation and source link.
+4. Keep success silent in the cron wrapper; only print logs on failure.
+5. Dry-run by generating an `.eml` or sending a controlled test and verify the CID is present and the image displays inline.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/geospatial-map-artifacts-skill.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/geospatial-map-artifacts-skill.md
@@ -1,0 +1,91 @@
+---
+name: geospatial-map-artifacts
+description: "Create polished geospatial map artifacts from KML/KMZ/ZIP/raster overlays, with clear legends, labels, and visual verification."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [maps, geospatial, kml, kmz, zip, raster-overlays, cartography, legends, visualization]
+    created_by: agent
+---
+
+# Geospatial Map Artifacts
+
+## Trigger
+
+Use this skill when the user asks to process, visualize, improve, or create a map from:
+
+- `.kml`, `.kmz`, `.zip`, or Google Earth files
+- geospatial raster overlays such as `.png` images bundled with KML/KMZ
+- map layers with risk zones, currents, density, routes, city labels, placemarks, or polygons
+- iterative visual/cartographic edits: cleaner basemap, larger legend, label placement, colors, date/source attribution, etc.
+
+## Core workflow
+
+1. **Inspect the archive/layers first.**
+   - Treat `.kmz` as a ZIP archive.
+   - If the attachment was rejected before Hermes saved it, ask the user to resend as `.zip` or put the `.kmz` inside a `.zip`.
+   - If accessible, copy rather than destructively rename: `file.kmz` → sibling `file.zip`.
+   - Verify with Python `zipfile.is_zipfile()` and list archive contents.
+
+2. **Extract geospatial structure.**
+   - KML coordinate order is `longitude,latitude,altitude`, not `latitude,longitude`.
+   - Parse `GroundOverlay` bounds (`north/south/east/west`) for raster images.
+   - Count and classify KML elements: `Placemark`, `LineString`, `Polygon`, `Point`, `GroundOverlay`.
+   - Extract metadata such as date, risk fields, layer names, and style colors.
+
+3. **Choose a basemap appropriate to the requested visual style.**
+   - For clean custom labeling: use a no-label basemap such as CartoDB Positron no-label tiles.
+   - For a more colorful/interesting map: use topo/terrain tiles such as OpenTopoMap or another terrain/physical basemap.
+   - If the user complains the map is boring, switch to a more visually textured topo/terrain basemap.
+   - If the user wants the agent to add all labels manually, avoid basemaps with prominent built-in city labels when possible.
+
+4. **Render overlays carefully.**
+   - Raster overlays in KML may be geographic/equirectangular while web-map tiles are Web Mercator; resample by converting output pixels back to lon/lat before sampling source image pixels.
+   - Make near-white or empty raster backgrounds transparent.
+   - Keep density overlays semi-transparent so the basemap remains readable.
+   - Current/vector raster layers can look like broad smudges; reduce opacity aggressively and/or show them as subtle directional texture rather than dominant marks.
+   - Draw risk contours/lines after density/current overlays so they remain visible.
+
+5. **Legend and labels.**
+   - Legends should be large, readable, and placed near the mapped area without covering important data/city labels.
+   - Include the data date in the legend when the source contains a date.
+   - Use same-size legend swatches/rectangles for comparable categories.
+   - If low risk is represented by light blue/cyan in the source, explicitly include “Low risk = light blue” in the legend.
+   - Use bright, high-contrast risk colors when the user says risk colors are hard to see.
+   - For city labels, use either:
+     - callout boxes with leader lines when labels would collide with basemap text, or
+     - direct on-map text with a white halo when the user wants labels directly on the map.
+   - Add relevant contextual cities beyond the initial coast if requested (e.g., Atlantic-side cities for Florida maps).
+
+6. **Verify the generated artifact visually before delivery.**
+   - Use vision analysis or a screenshot/image review.
+   - Check: legend readability, data date, labels visible, overlays not obscuring basemap, requested cities included, color/line-size issues fixed.
+   - If a revision is clearly needed, fix and re-render before sending.
+
+## Implementation notes
+
+Python + PIL + NumPy is sufficient for many static map artifacts:
+
+- Fetch slippy map tiles by z/x/y.
+- Convert lon/lat to Web Mercator global pixels.
+- Crop the tile mosaic to the requested bounding box.
+- Resample KML `GroundOverlay` rasters by mapping each output pixel to lon/lat and then into the source raster.
+- Draw KML `LineString` risk contours with `ImageDraw.line`.
+- Draw city markers/text and legend on a final upscaled image.
+
+Prefer using existing installed libraries when available, but do not require heavy GIS stacks (`geopandas`, `cartopy`) for simple KML/raster overlay maps.
+
+## Pitfalls
+
+- Do not claim a `.kmz` was renamed if Hermes never received/saved the file.
+- Do not assume a KMZ has only `doc.kml`; list archive contents and find all `.kml` files.
+- Do not leave legends tiny or far from the relevant geography; map artifacts are visual deliverables, not just data dumps.
+- Do not let a basemap’s built-in city labels fight with custom labels. Switch basemap or use halos/callouts.
+- Do not make current/vector raster layers too opaque; they can read as smudges.
+- Do not make all risk categories line-width-coded if the user asked for same-size legend rectangles or equal visual weight.
+
+## Reference examples
+
+- `references/florida-sargassum-map-20260611.md` — session notes and implementation lessons from a Florida Gulf Coast sargassum KMZ/ZIP map, including legend/color/label iterations.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/geospatial-map-rendering-skill.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/geospatial-map-rendering-skill.md
@@ -1,0 +1,203 @@
+---
+name: geospatial-map-rendering
+description: "Render custom geospatial maps from KML/KMZ/ZIP files and public map/data layers with clean basemaps, overlays, labels, legends, and visual QA."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [maps, geospatial, kml, kmz, zip, overlays, cartography, visualization]
+    created_by: agent
+---
+
+# Geospatial Map Rendering
+
+## Trigger
+
+Use this skill when the user asks to turn geospatial files or map layers into a polished custom map image, especially when working with:
+
+- `.kml`, `.kmz`, or renamed `.zip` KMZ archives
+- Public GIS/ArcGIS REST layers that can be queried directly
+- Raster map overlays such as density/current PNGs
+- Risk/contour lines, polygons, or point sample layers
+- City/location labels, legends, basemaps, and iterative visual cleanup
+
+## Core workflow
+
+1. **Inspect the archive/layers first.**
+   - `.kmz` is ZIP-compatible; copy/rename to `.zip` if the file is already accessible locally.
+   - If the chat/document ingestion layer rejects `.kmz` before saving it, the agent cannot rename it yet; ask the user to upload the same KMZ renamed to `.zip`, upload a ZIP containing the KMZ, or extract/send the `.kml` plus assets.
+   - List archive contents and identify KML plus any raster overlays.
+   - Read KML metadata, `GroundOverlay` bounds, feature counts, and data dates.
+
+2. **Parse geospatial data directly.**
+   - KML coordinates are `longitude,latitude[,altitude]`.
+   - Extract `Placemark`, `LineString`, `Polygon`, `Point`, `ExtendedData`, and risk/date fields as needed.
+   - Do not infer risk classes from the picture alone when KML attributes exist.
+
+3. **Build the map in layers.**
+   Recommended order:
+   - Basemap.
+   - Georeferenced raster overlays, e.g. density/current PNGs.
+   - Vector features, e.g. KML risk contours/lines/polygons.
+   - Custom city/place labels and markers.
+   - Legend/title/source/date.
+
+4. **Choose basemaps for the labeling strategy.**
+   - If adding custom city labels, avoid basemaps with built-in city/road labels; duplicate labels look messy.
+   - Prefer no-label physical/topographic/terrain basemaps when the user wants custom callouts.
+      - Esri World Physical Map worked well for a more colorful Florida physical/topographic look while avoiding duplicate city callouts.
+      - Esri World Terrain Base avoided labels but looked too plain/gray for this use case.
+      - OpenTopoMap looked colorful but included built-in city labels, causing duplicate callouts.
+   - If a colorful topo basemap includes labels, switch to a no-label physical/terrain base and add only the desired labels manually.
+
+5. **Iterate visually.**
+   - Generate a PNG.
+   - Inspect it visually before sending.
+   - Fix overlap, muddy overlays, legend size/placement, missing labels, and color contrast.
+
+## Cartographic style preferences learned
+
+- For custom city labels, direct-on-map text with a white halo can look cleaner than offshore boxed callouts.
+- Include both sides of a region when context matters; for Florida sargassum maps, include Gulf coast cities and major Atlantic-side cities.
+- For Florida coast context, a good label set is: Pensacola, Destin, Panama City, Apalachicola, Cedar Key, Crystal River, Tampa, Clearwater, St. Petersburg, Sarasota, Venice, Manasota Key, Punta Gorda, Fort Myers, Naples, Marco Island, Key West, Fernandina Beach, Jacksonville, St. Augustine, Daytona Beach, Cape Canaveral, Melbourne, Orlando, Vero Beach, Port St. Lucie, West Palm Beach, Boca Raton, Fort Lauderdale, Miami.
+- Add user-requested local places explicitly, even if small, e.g. Manasota Key.
+- Legends should be large enough to read, near the mapped area, and should not cover key labels or risk areas.
+- Put the data date in the legend, not only in the title.
+- Use same-size legend swatches/rectangles for comparable risk classes.
+
+## Florida red tide maps
+
+For Ron's Florida daily email, use the FWC current-status map he specifically requested, not the USF trajectory composite:
+
+- Script: `~/.hermes/scripts/fwc-red-tide-current-status-map.py`
+- Public FWC app: `https://gis.myfwc.com/redtidecurrentstatus/`
+- ArcGIS web map item: `032578e992e04012a25db77499318ff9`
+- Feature layer: `https://services2.arcgis.com/z6TmTIyYXEYhuNM0/arcgis/rest/services/HAB_Current_Web_Layer/FeatureServer/0`
+- Output directory: `~/.hermes/cache/red_tide/`
+
+This renders a polished PNG from the FWC `HAB_Current_Web_Layer` sampling points, including city labels, Manasota Key marker, abundance legend, source/footer, and a clear note that the FWC app is a current-status sampling map for the most recent 8 days, not a forward trajectory prediction model.
+
+If the user explicitly asks for a red tide *prediction/forecast* map instead of the FWC current-status map, use the USF–FWC short-term HAB trajectory workflow in `references/florida-red-tide-prediction-map.md`:
+
+- Pull current USF OCL WFCOM HAB Tracking images: `upper_R0.gif` for surface trajectories and `lower_R0.gif` for subsurface / near-bottom trajectories.
+- Pull the current short-term forecast summary sentence from FWC Red Tide Current Status.
+- Compose a polished Telegram-ready PNG with two side-by-side panels, a FWC forecast summary card, a “how to read the forecast” legend, source footer, and a clear note that it is model-based transport guidance, not a health advisory.
+- Visually inspect the composite before delivery, especially footer/source wrapping and summary/legend overlap.
+
+## Sarasota Water Atlas rainfall maps
+
+For Ron's rainfall maps from `https://sarasota.wateratlas.usf.edu/rainfall/latest/`, use the workflow in `references/sarasota-water-atlas-rainfall-map.md`.
+
+Key defaults:
+
+- Query `https://api.wateratlas.usf.edu/rainfall/latest/?s=8` directly instead of scraping marker labels from the page.
+- For Manasota Key / Englewood 31-day maps, use `total31d`, a 3 km IDW visualization grid when requested, and prominent callouts for lower/coastal stations near Manasota Key including the Englewood / Indian Mound Park station.
+- If Ron asks to “go back to this map” or provides a screenshot of the Water Atlas page, recreate the **Water Atlas-style screenshot** rather than substituting the polished custom grid artifact: white Sarasota County Water Atlas header, pale OSM/Esri-like basemap, blue boxed station totals, left radio panel with “31 Day Total Rainfall” selected, and bottom-left 3 km scale. Match the screenshot’s viewport/feel and keep lower Manasota Key / Englewood station boxes visible.
+- Include a clear note that any custom 3 km grid is an interpolation/visualization from station totals, not an official gridded rainfall product. This disclaimer is not needed for a pure Water Atlas-style station screenshot recreation unless a custom grid is overlaid.
+- Visually QA that the land is not black, station labels do not overlap/crop badly, the radio panel does not hide the lower stations, and the title/header plus 3 km scale are readable before sending.
+
+## Sarasota Water Atlas rainfall maps
+
+When Ron asks for Manasota Key / Englewood rainfall maps from the Sarasota Water Atlas near-real-time rainfall page, use the API behind the page rather than screenshotting markers:
+
+- Page: `https://sarasota.wateratlas.usf.edu/rainfall/latest/`
+- API: `https://api.wateratlas.usf.edu/rainfall/latest/?s=8`
+- Fields: `total24h`, `total7d`, `total31d`, with station name/id/location/lastUpdated.
+- For a 3 km resolution map, build a 3 km IDW interpolation grid from all Sarasota ARMS stations, overlay station dots/values, and label lower coastal stations near Manasota Key / Englewood.
+- Always include a disclaimer that the 3 km grid is an interpolated visualization from station totals, not an official gridded rainfall product.
+- For Florida email use, produce a 3-panel tile in this order: **24-Hour**, **7-Day**, **31-Day**, and visually QA spelling, labels, footer/source, and lower station readability before sending.
+
+Detailed notes and station/extent defaults: `references/wateratlas-rainfall-map-rendering.md`.
+
+## Sargassum/KMZ map defaults
+
+Use these defaults for NOAA/USF-style sargassum risk/current files unless the user asks otherwise:
+
+- Low risk: bright light blue.
+- Risk 1: bright yellow.
+- Risk 2: vivid orange.
+- Risk 3: bright red.
+- Current raster layer: keep visible but subtle; original current rasters can look like thick smudges if opacity is too high.
+- Density raster layer: transparent enough to preserve basemap context.
+- Risk contours/features: bright and high contrast against the basemap.
+
+## Daily NOAA/AOML sargassum cron automation
+
+When the user wants a recurring Florida sargassum map:
+
+1. Store reusable scripts under `~/.hermes/scripts/` and reference them in cron by filename only, e.g. `daily-sargassum-map.py`.
+2. Build the KMZ URL from a `YYYYMMDD` product date:
+   - `https://cwcgom.aoml.noaa.gov/SIR/KMZ/Sargassum_risk_currents_FA_<YYYYMMDD>.kmz`
+3. For morning cron runs, try today's local date first, then walk backward several days because the newest NOAA/AOML KMZ may not be posted yet at 6am.
+4. Treat the downloaded `.kmz` as a ZIP archive in Python (`zipfile.ZipFile`) and validate that it contains KML before rendering.
+5. Read the KML `GroundOverlay` bounds and KML `SimpleData name="date"` instead of hardcoding dates/bounds.
+- For Ron's daily Florida packet, include:
+   - the rendered sargassum map,
+   - NHC 7-day Atlantic tropical outlook: `https://www.nhc.noaa.gov/xgtwo/resize/xgtwo_atl_7d0_w1920.png`,
+   - a public NOAA/NWS weather/radar image that includes Florida, currently `https://radar.weather.gov/ridge/standard/SOUTHEAST_0.gif` converted to PNG for Telegram delivery,
+   - Sarasota Water Atlas-style Manasota Key / Englewood rainfall maps for 24-hour, 7-day, and 31-day totals when Ron asks to include local rainfall; use `~/.hermes/scripts/sarasota-rainfall-wateratlas-maps.py --period all` and see `references/florida-email-rainfall-integration.md`.
+7. Test with a known historical date before scheduling, e.g. `python3 ~/.hermes/scripts/daily-sargassum-map.py --date 20260601 --force`.
+8. Schedule with Hermes cron at `0 6 * * *`, `script="daily-sargassum-map.py"`, and `no_agent=True` for a low-token daily watchdog-style image delivery.
+
+## Florida Email Task
+
+## Sarasota Water Atlas rainfall maps
+
+When Ron asks for rainfall maps from `https://sarasota.wateratlas.usf.edu/rainfall/latest/`, default to Water Atlas-style station amount maps rather than a polished interpolated thematic map unless he explicitly requests interpolation/contours.
+
+- Use the public page API directly: `https://api.wateratlas.usf.edu/rainfall/latest/?s=8`.
+- Render 24-hour, 7-day, and 31-day totals from `total24h`, `total7d`, and `total31d`.
+- Focus the view on Manasota Key / Englewood and preserve lower station coverage, including CST-3 Indian Mound Park / Englewood, Lemon Bay Park, Lemon Bay Canal, Jacaranda Bridge, Venice Ave E, Capri Isle, and Forked/Gottfried Creek area stations.
+- If the user asks for “3 km resolution” in the Water Atlas-style version, include a 3 km scale marker; do not imply the station-box map is an official gridded product.
+- Accepted local renderer: `~/.hermes/scripts/sarasota-rainfall-wateratlas-maps.py`.
+- Session-specific implementation details and GitHub preservation notes: `references/sarasota-wateratlas-rainfall-email-maps.md`.
+
+## Florida Email Task
+
+## Sarasota Water Atlas rainfall maps
+
+When Ron asks for Sarasota/Manasota/Englewood rainfall maps from the Water Atlas page, prefer a Water Atlas-style station-box map rather than a polished interpolated surface unless he explicitly asks for interpolation.
+
+- Source page: `https://sarasota.wateratlas.usf.edu/rainfall/latest/`
+- Public API used by the page: `https://api.wateratlas.usf.edu/rainfall/latest/?s=8`
+- Render 24-hour, 7-day, and 31-day variants from `total24h`, `total7d`, and `total31d`.
+- Include a 3 km scale marker and keep lower Manasota Key / Englewood stations visible.
+- Use the session reference for exact viewport, label nudges, and Florida Email Task integration: `references/sarasota-wateratlas-rainfall-maps.md`.
+
+## Florida Email Task
+
+For Ron's daily emailed Florida packet, use `~/.hermes/scripts/florida-email-task.py` plus the cron wrapper `~/.hermes/scripts/florida-email-task-send.sh`.
+
+- The email task is authorized to send only to `reisworth@gmail.com` by default.
+- It calls `daily-sargassum-map.py` to generate the 3 images: sargassum map, NHC 7-day Atlantic tropical outlook, and NOAA/NWS Southeast radar image including Florida.
+- It calls `sarasota-rainfall-wateratlas-maps.py --period all` to generate Water Atlas-style 24-hour, 7-day, and 31-day rainfall maps for the Manasota Key / Englewood lower stations, embedded with CIDs `rainfall_24h`, `rainfall_7d`, and `rainfall_31d`.
+- It calls `manasota-tide-graph.py` for a one-day Manasota Key tide graph with daylight shading.
+- It calls `fwc-red-tide-current-status-map.py` for the FWC ArcGIS current-status sampling map and embeds it inline with CID `red_tide_map`; see `references/fwc-red-tide-current-status-map.md`.
+- It fetches SandBar Tiki & Grille live music from `https://www.sandbartikigrille.com/events/` and includes events for the next 5 days from the Florida email date.
+- The SandBar page uses event archive `<article>` cards with date blocks, `post-title`, and `span.sr` labels for `Time` and `Genre`; parse those HTML fields directly rather than relying on loose visible-text regex.
+- Build a fun, lively HTML email with the images inline via CIDs and a 5-day music lineup section.
+- Send via Gmail SMTP using `EMAIL_ADDRESS`, `EMAIL_PASSWORD`, and `EMAIL_SMTP_HOST` from `~/.hermes/.env`.
+- The send wrapper stays silent on success so cron does not send Telegram status pings; it prints the captured log only on failure.
+- Cron job name: `Florida Email Task`; script: `florida-email-task-send.sh`; schedule: `20 6 * * *`.
+
+## Verification checklist
+
+Before final delivery:
+
+- Basemap has no duplicate built-in city callouts if custom city labels are present.
+- Custom city labels are readable and not badly overlapping.
+- User-requested places are present.
+- Current layer is visible but not dominant/smudgy.
+- Risk colors are bright enough to see.
+- Legend includes data date, density, currents, low risk, and higher risk classes.
+- Final image file exists and was visually inspected.
+
+## References
+
+- `references/sargassum-kmz-map-rendering.md` — session-derived details for NOAA/USF-style sargassum KMZ/ZIP map rendering.
+- `references/florida-red-tide-prediction-map.md` — USF/FWC HAB trajectory forecast composite map workflow.
+- `references/fwc-red-tide-current-status-map.md` — FWC ArcGIS FeatureServer current-status red tide sampling map workflow and Florida email integration notes.
+- `references/sarasota-water-atlas-rainfall-map.md` — Sarasota Water Atlas rainfall API, 31-day/3 km Manasota Key-Englewood map workflow, and lower-station callout notes.
+- `references/wateratlas-rainfall-map-rendering.md` — Water Atlas-style screenshot recreation details, viewport defaults, and 24h/7d/31d email tile guidance.
+- `references/florida-email-rainfall-integration.md` — Florida Email Task integration for Water Atlas-style 24h/7d/31d rainfall maps and reusable renderer details.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/manasota-key-fun-pack-email.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/manasota-key-fun-pack-email.md
@@ -1,0 +1,49 @@
+# Manasota Key Fun Pack daily email notes
+
+Use this reference when maintaining Ron's daily Manasota Key environmental/entertainment email generator.
+
+## Branding and recipient expectations
+- Brand the email as **Manasota Key Fun Pack** throughout: sender display name, subject prefix, header/title, and greeting.
+- Avoid broad/old branding such as "Ara1bot Florida Fun Pack".
+- Send samples only to `reisworth@gmail.com` unless Ron explicitly authorizes another recipient.
+
+## Gmail display and clipping/collapsing
+- Gmail clips HTML bodies around ~102 KB; verify generated HTML stays well below this threshold.
+- Keep repeated inline CSS and wrapper markup lean.
+- Add a generated `Message-ID` and `X-Entity-Ref-ID` so repeated test sends are less likely to thread/collapse together in Gmail.
+- If same-day test samples still collapse in conversation view, add a small test-only timestamp/token to the subject; avoid doing this for the normal scheduled daily email.
+
+## Forecast chart layout standards
+- For 7-day weather/wind/swell charts, use high-resolution canvases suitable for email/PDF screenshots (the current target is ~2200×1360).
+- Do not put legends in the plot area if they can collide with day/date labels or source/footer text.
+- Reserve separate vertical bands for:
+  1. title/subtitle/header,
+  2. condition/callout chips,
+  3. plotted data,
+  4. secondary rows such as rain probability/amount,
+  5. legend,
+  6. source/footer.
+- Specific weather pitfall: rain percentage/amount labels near the bottom must not overlap low-temperature labels. Put rain data in its own row below the temp plot.
+- Specific weather pitfall: high-temperature labels must not crowd conditions callouts at the top. Put condition callouts in their own row above the plot or leave enough top padding.
+- Use polished coastal styling: soft gradients, day panels/cards, readable typography, high-contrast series colors, and labeled axes/gridlines.
+
+## Entertainment source and format
+- Primary entertainment source is SWFLLive Englewood events, e.g. `https://swfllive.com/events?city=Englewood` with date parameters as needed.
+- Parse the structured data from the page rather than searching daily.
+- Filter to these venues unless Ron changes the list:
+  - Beachcomber Trading Post
+  - SandBar Tiki & Grille
+  - White Elephant Pub
+- Music horizon preference changed during the session: Ron requested 5 days after initially trying 3 days. Use 5 days for the Manasota Key Fun Pack unless he explicitly asks to compact it again.
+- Organize entertainment by day, then venue. Keep it compact: time, performer/event name, optional genre.
+- Brave Search is useful as a fallback/discovery tool if SWFLLive changes or venue URLs move, but do not use search as the daily source of truth when structured SWFLLive data is available.
+
+## Secret handling
+- Never hard-code Brave Search API keys or other credentials into the email script.
+- If Brave Search is used, rely on Hermes/environment configuration and do not echo the key value in responses, logs, or references.
+
+## Verification checklist
+- Run Python compile/syntax check on the email script.
+- Generate a dry-run `.eml`.
+- Parse the `.eml` to verify sender/subject/header branding, HTML byte size, entertainment date range, and no secret leakage.
+- Generate a contact sheet or preview for the 7-day weather/wind/swell images and visually check overlap/readability before sending a sample.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/noaa-tide-graph-pattern.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/noaa-tide-graph-pattern.md
@@ -1,0 +1,87 @@
+# NOAA Tide Graph Pattern
+
+Session-derived pattern for producing Telegram-ready tide charts.
+
+## NOAA CO-OPS API
+
+Smooth tide curve:
+
+```text
+https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?begin_date=YYYYMMDD&end_date=YYYYMMDD&station=STATION_ID&product=predictions&datum=MLLW&time_zone=lst_ldt&units=english&interval=6&format=json
+```
+
+High/low labels:
+
+```text
+https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?begin_date=YYYYMMDD&end_date=YYYYMMDD&station=STATION_ID&product=predictions&datum=MLLW&time_zone=lst_ldt&units=english&interval=hilo&format=json
+```
+
+Station metadata:
+
+```text
+https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations/STATION_ID.json
+```
+
+Manasota Key example:
+
+- Nearby station: `8725809`
+- Station name from metadata: `MANASOTA`
+- Coordinates: `27.0117, -82.41`
+- Timezone for rendering: `America/New_York`
+- Source label: `NOAA CO-OPS tide predictions API; station Manasota, FL`
+
+## One-day x-axis
+
+For a full-day chart, set:
+
+```python
+t0 = datetime.combine(date, time(0), tzinfo=tz)
+t1 = t0 + timedelta(days=1)
+```
+
+Map x positions against `t0..t1`, even when the final NOAA 6-minute point is 23:54. This prevents the chart from visually ending early.
+
+## Daylight shading
+
+Use NOAA-style solar calculation or an equivalent trustworthy library using the station/location latitude and longitude. The implementation used in-session exposed a date-boundary pitfall: sunset converted from UTC appeared as the previous local date. Guard with:
+
+```python
+if sunset < sunrise:
+    sunset += timedelta(days=1)
+```
+
+Shade only `sunrise..sunset` with light yellow. Label sunrise/sunset on the chart and in the footer.
+
+## Pillow rendering notes
+
+`matplotlib` may not be installed on the Raspberry Pi environment. Pillow is sufficient:
+
+- `Image.new('RGB', (1600, 1000), background)`
+- Draw grid lines and labels with `ImageDraw`.
+- Draw daylight rectangle before grid and tide curve.
+- Draw tide fill with `polygon([(x0, baseline)] + curve_points + [(xN, baseline)])`.
+- Draw tide line with `line(points, width=5 or 6)`.
+- Use DejaVu fonts from `/usr/share/fonts/truetype/dejavu/` when present.
+
+## Visual QA checklist
+
+Before sending to Telegram, inspect the rendered PNG and verify:
+
+- Requested time range is visible, e.g. 12 AM through evening and next midnight implied.
+- Daylight yellow starts at sunrise and ends at sunset.
+- Title and subtitle are not covered by the legend.
+- High/low callouts do not hide the main curve too badly.
+- Footer/source text is not cut off.
+- Legend is preferably in the footer if the top area is crowded.
+
+## Telegram delivery
+
+Final response can be short:
+
+```text
+Updated tide graph with one full day and daylight shading:
+
+MEDIA:/absolute/path/to/chart.png
+```
+
+Mention station/source only if useful; avoid long explanations unless the user asks.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/sarasota-water-atlas-rainfall-map.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/sarasota-water-atlas-rainfall-map.md
@@ -1,0 +1,49 @@
+# Sarasota Water Atlas rainfall map workflow
+
+Use this when Ron asks for rainfall maps from Sarasota County Water Atlas, especially Manasota Key / Englewood / lower Sarasota County.
+
+## Source page and API
+
+- User-facing page: `https://sarasota.wateratlas.usf.edu/rainfall/latest/`
+- The page uses Leaflet and fetches rainfall station totals from:
+  - `https://api.wateratlas.usf.edu/rainfall/latest/?s=8`
+- API records include:
+  - `name`, `id`, `lastUpdated`
+  - `location.latitude`, `location.longitude`
+  - `total24h`, `total7d`, `total31d`
+
+## User-requested map style
+
+For a 31-day Manasota Key / Englewood rainfall map:
+
+1. Query the API and use `total31d` values.
+2. Focus the extent around south Sarasota / Manasota / Englewood, roughly:
+   - longitude `-82.56` to `-82.16`
+   - latitude `26.90` to `27.25`
+3. Use a **3 km grid** when requested. Treat this as a visualization/interpolation from point stations, not an official gridded rainfall product.
+4. Use all available Sarasota ARMS stations for interpolation, but label the lower/coastal stations near Manasota Key / Englewood prominently.
+5. Include a footer note similar to:
+   - `Values are station-based 31-day totals from the Water Atlas API; grid is a 3 km visualization/interpolation, not an official gridded rainfall product.`
+
+## Lower/coastal station callouts to include when in extent
+
+These names were present in the API and are useful around Manasota Key / Englewood:
+
+- `CST-3 Indian Mound Park` — label as `Englewood / Indian Mound Park`
+- `Lemon Bay Park`
+- `Lemon Bay Canal`
+- `AL-1  Jacaranda Bridge` — label as `Jacaranda Bridge`
+- `FRK-1 Donavan Rd`
+- `FRK-2 Stoner Road`
+- `GOT-1 Tangerine Wds`
+- `GOT-2 Park Forest`
+- `HC-1  Venice Ave E` — label as `Venice Ave E`
+- `SO-1 Oscar Scherer Park` — label as `Oscar Scherer`
+- `CUR-2 Capri Isle` — label as `Capri Isle`
+
+## Rendering notes
+
+- A simple no-label county outline basemap works better than a label-heavy tile map because custom station callouts are dense.
+- Plot county polygons underneath the interpolated cells; do not accidentally redraw land polygons with transparent fill on an RGB image, which can make the land render black. Draw transparent overlays on an RGBA layer and alpha-composite, then redraw boundaries only.
+- Use a readable green precipitation color ramp, station dots, numeric station values, and a separate legend card.
+- Visually QA before delivery: title visible, land not black, 3 km grid visible, Manasota/Englewood station labels readable, source/footer not cropped.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/sarasota-wateratlas-rainfall-email-maps.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/sarasota-wateratlas-rainfall-email-maps.md
@@ -1,0 +1,141 @@
+# Sarasota Water Atlas rainfall maps for Florida Email Task
+
+Session-derived workflow for rendering Sarasota Water Atlas-style rainfall maps focused on Manasota Key / Englewood and preserving the workflow in GitHub.
+
+## Data source
+
+- Page: `https://sarasota.wateratlas.usf.edu/rainfall/latest/`
+- API used by the page: `https://api.wateratlas.usf.edu/rainfall/latest/?s=8`
+- Key fields:
+  - `total24h`
+  - `total7d`
+  - `total31d`
+  - `name`, `id`, `lastUpdated`, `location.latitude`, `location.longitude`
+
+## User preference / expected visual style
+
+Ron preferred the Water Atlas-style station map over a polished interpolated thematic map for the email. When he asks for rainfall maps from this source:
+
+1. Default to Water Atlas-style station amount boxes unless he explicitly asks for interpolation/contours.
+2. Keep the map zoomed into Manasota Key / Englewood, not all of Sarasota County.
+3. Include the lower stations around Manasota Key / Englewood, especially:
+   - CST-3 Indian Mound Park / Englewood area
+   - Lemon Bay Park
+   - Lemon Bay Canal
+   - Jacaranda Bridge
+   - Venice Ave E
+   - Capri Isle
+   - Forked Creek / Gottfried Creek area stations
+4. Include a 3 km scale marker when requested. In the Water Atlas-style version, this is a scale marker, not a 3 km gridded interpolation.
+5. For the daily Florida email, include all three period maps: 24-hour, 7-day, and 31-day totals.
+
+## Known-good renderer on Ara1bot
+
+Script:
+
+```text
+~/.hermes/scripts/sarasota-rainfall-wateratlas-maps.py
+```
+
+Typical commands:
+
+```bash
+/usr/bin/python3 ~/.hermes/scripts/sarasota-rainfall-wateratlas-maps.py --period all
+/usr/bin/python3 ~/.hermes/scripts/sarasota-rainfall-wateratlas-maps.py --period 24h
+/usr/bin/python3 ~/.hermes/scripts/sarasota-rainfall-wateratlas-maps.py --period 7d
+/usr/bin/python3 ~/.hermes/scripts/sarasota-rainfall-wateratlas-maps.py --period 31d
+```
+
+Output directory:
+
+```text
+~/.hermes/cache/sarasota_rainfall/
+```
+
+Important viewport settings from the accepted version:
+
+```python
+XMIN, XMAX = -82.555, -82.125
+YMIN, YMAX = 26.835, 27.245
+W, H = 760, 1230
+ZOOM = 12
+```
+
+Rendering approach:
+
+- Fetch public Water Atlas API JSON directly rather than scraping the rendered page.
+- Use OpenStreetMap tiles, then desaturate/brighten them to resemble the Water Atlas Leaflet/Esri style.
+- Draw the white Water Atlas-style header and gray angled corner.
+- Draw the radio selector panel and select the requested period.
+- Draw station totals as pale-blue boxes similar to the Water Atlas site.
+- Use hand-tuned nudges for congested lower-station labels so they do not crop at the image edge.
+
+## Florida Email Task integration
+
+Main script:
+
+```text
+~/.hermes/scripts/florida-email-task.py
+```
+
+Wrapper:
+
+```text
+~/.hermes/scripts/florida-email-task-send.sh
+```
+
+The full email workflow now includes:
+
+1. Sargassum packet.
+2. Sarasota Water Atlas rainfall maps for 24h, 7d, 31d.
+3. Manasota Key tide graph.
+4. FWC red tide current-status map.
+5. SWFLLive Englewood live music lineup filtered to Beachcomber Trading Post, SandBar Tiki & Grille, and White Elephant Pub.
+6. HTML email with CID inline images.
+
+Dry-run verification:
+
+```bash
+/usr/bin/python3 ~/.hermes/scripts/florida-email-task.py --to reisworth@gmail.com --dry-run
+```
+
+The dry run should produce an `.eml` preview under:
+
+```text
+~/.hermes/cache/florida_email_task/
+```
+
+## GitHub preservation
+
+Local repo created to preserve scripts and instructions:
+
+```text
+/home/ara1/florida-email-maps
+```
+
+It includes:
+
+- `scripts/florida-email-task.py`
+- `scripts/florida-email-task-send.sh`
+- `scripts/daily-sargassum-map.py`
+- `scripts/sarasota-rainfall-wateratlas-maps.py`
+- `scripts/manasota-tide-graph.py`
+- `scripts/fwc-red-tide-current-status-map.py`
+- `README.md`
+- `docs/map-workflows.md`
+
+Before pushing, scan for actual secrets, run Python syntax checks, and commit locally.
+
+GitHub repo created/pushed after token access was fixed:
+
+```text
+https://github.com/Araeisgit/FloridaEmail
+```
+
+Observed auth pitfall: a GitHub token can be valid for `gh repo list`/repo reads but still fail repository creation with:
+
+```text
+GraphQL: Resource not accessible by personal access token (createRepository)
+```
+
+When that happens, either create the empty private repo manually and grant the token access, or re-authenticate `gh` with a classic PAT that includes `repo` scope and repository-creation permission. After access is fixed, merge any GitHub-created initial README commit with `--allow-unrelated-histories` if needed, keep the fuller local README, then push `main`.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/sarasota-wateratlas-rainfall-maps.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/sarasota-wateratlas-rainfall-maps.md
@@ -1,0 +1,86 @@
+# Sarasota Water Atlas rainfall maps — Manasota Key / Englewood
+
+Session-derived workflow for rendering Water Atlas-style rainfall station maps for Ron's Florida packet.
+
+## Source
+
+- Page: `https://sarasota.wateratlas.usf.edu/rainfall/latest/`
+- Public API used by the page: `https://api.wateratlas.usf.edu/rainfall/latest/?s=8`
+
+The page exposes three station total fields:
+
+- `total24h` → 24 Hour Total Rainfall
+- `total7d` → 7 Day Total Rainfall
+- `total31d` → 31 Day Total Rainfall
+
+Station objects include `name`, `id`, `lastUpdated`, `stationUrl`, `location.latitude`, and `location.longitude`.
+
+## User-preferred output
+
+Ron preferred a screenshot-like Water Atlas/Leaflet presentation over a polished interpolated GIS surface for this use case:
+
+- White Water Atlas-style header.
+- Left control panel with the rainfall radio options and the active period selected.
+- Pale basemap with station total boxes, not city callout-heavy cartography.
+- A **3 km scale marker**.
+- Focus zoomed to the **Manasota Key / Englewood / lower Sarasota** area.
+- Lower stations must remain visible, including Englewood / Indian Mound Park, Lemon Bay Park, Lemon Bay Canal, Jacaranda Bridge, Venice Ave E, Capri Isle, Forked/Gottfried Creek-area stations.
+
+## Working implementation on Ara1bot
+
+Script now used by the Florida Email Task:
+
+```text
+~/.hermes/scripts/sarasota-rainfall-wateratlas-maps.py
+```
+
+Run all three periods:
+
+```bash
+/usr/bin/python3 ~/.hermes/scripts/sarasota-rainfall-wateratlas-maps.py --period all
+```
+
+Expected output directory:
+
+```text
+~/.hermes/cache/sarasota_rainfall/
+```
+
+## Viewport/settings that worked
+
+```python
+XMIN, XMAX = -82.555, -82.125
+YMIN, YMAX = 26.835, 27.245
+W, H = 760, 1230
+ZOOM = 12
+```
+
+Rendering approach:
+
+1. Fetch OSM tiles for the viewport.
+2. Desaturate, reduce contrast, and brighten the basemap to resemble the Water Atlas map style.
+3. Draw the Water Atlas-style header and selector panel.
+4. Draw blue rainfall boxes at station locations.
+5. Apply hand-tuned nudges for congested lower stations.
+6. Add a 3 km scale marker.
+7. QA visually for clipped labels, especially Lemon Bay Canal and lower Englewood-area stations.
+
+## Integration notes
+
+The Florida Email Task embeds the three rainfall maps inline with CIDs:
+
+- `rainfall_24h`
+- `rainfall_7d`
+- `rainfall_31d`
+
+The main email script calls the rainfall renderer before tide/red-tide generation and attaches all three PNGs.
+
+## GitHub backup
+
+The Florida email/maps automation was backed up to private GitHub repo:
+
+```text
+https://github.com/Araeisgit/FloridaEmail
+```
+
+Do not commit `.env` or credentials. A token may be configured in `gh`; verify access with `gh auth status` before pushing.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/sargassum-kmz-map-rendering.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/sargassum-kmz-map-rendering.md
@@ -1,0 +1,114 @@
+# Sargassum KMZ/ZIP map rendering notes
+
+These notes came from an iterative Florida Gulf Coast sargassum map task using an uploaded ZIP renamed from/standing in for KMZ:
+
+- Archive: `Sargassum_risk_currents_FA_20260611.zip`
+- Main KML: `risk_currents_FA.kml`
+- Raster overlays: `FA_density.png`, `currents.png`
+- KML date field: `20260611` / displayed as `2026-06-11`
+
+## Upload/ingestion workaround
+
+KMZ files are ZIP containers, but the document-ingestion layer may reject the `.kmz` extension before the agent can access the file. When that happens, do not imply a local rename will fix the already-rejected upload. Ask the user to upload one of these instead:
+
+- the same file renamed from `.kmz` to `.zip`
+- a `.zip` containing the original `.kmz`
+- extracted `.kml` plus referenced raster/image assets
+
+Once saved locally, inspect it as a normal ZIP/KMZ archive and extract KML/raster assets from the package.
+
+## File structure encountered
+
+Typical contents:
+
+- `risk_currents_FA.kml`
+- `currents.png`
+- `FA_density.png`
+- `images/*Logo*.png`
+- `images/risk_colors.png`
+
+The KML contained thousands of `Placemark` features with `LineString` geometries and `ExtendedData` like:
+
+- `SimpleData name="risk"`: classes `0`, `1`, `2`, `3`
+- `SimpleData name="date"`: `YYYYMMDD`
+
+The raster overlays were intended to be georeferenced with KML `GroundOverlay` bounds. In this session the overlay bounds were:
+
+- west: `-100`
+- east: `-50`
+- south: `2`
+- north: `35`
+
+Always read bounds from the actual KML rather than hardcoding them.
+
+## Rendering decisions that worked
+
+Layer order:
+
+1. No-label physical/topographic basemap.
+2. `FA_density.png`, with near-white/empty pixels transparent.
+3. `currents.png`, with opacity reduced heavily to avoid broad smudges.
+4. KML risk lines/contours, recolored brightly.
+5. Custom labels and legend.
+
+Risk colors that were easier to see:
+
+- risk `0`: bright light blue / low risk
+- risk `1`: yellow
+- risk `2`: orange
+- risk `3`: red
+
+Legend preferences:
+
+- Include the data date inside the legend.
+- Use same-size rectangles for density, currents, and all risk classes.
+- Show a small arrow cue for currents if possible.
+
+City/context preferences for Florida maps:
+
+- Include Gulf cities: Pensacola, Destin, Panama City, Apalachicola, Cedar Key, Crystal River, Tampa, Clearwater, St. Petersburg, Sarasota, Venice, Manasota Key, Punta Gorda, Fort Myers, Naples, Marco Island, Key West.
+- Include Atlantic/interior context cities: Fernandina Beach, Jacksonville, St. Augustine, Daytona Beach, Cape Canaveral, Melbourne, Orlando, Vero Beach, Port St. Lucie, West Palm Beach, Boca Raton, Fort Lauderdale, Miami.
+- If the basemap already has labels, do not add duplicate callouts. Switch basemap instead.
+
+## Basemap lesson
+
+OpenTopoMap looked better/colorful but included built-in city labels, causing duplicate city callouts. Esri World Terrain Base avoided duplicate labels but looked too gray/plain. Esri World Physical Map was the best compromise in this task: more color/topographic texture with no obvious duplicate city callouts at the Florida Gulf/Atlantic scale. Always visually verify because tile-provider styling can change.
+
+## Daily cron workflow
+
+Use `/home/ara1/.hermes/scripts/daily-sargassum-map.py` for the recurring NOAA/AOML Florida sargassum map job.
+
+- The source URL pattern is `https://cwcgom.aoml.noaa.gov/SIR/KMZ/Sargassum_risk_currents_FA_<YYYYMMDD>.kmz`.
+- The script accepts `--date YYYYMMDD` for tests and otherwise tries today's local date, then walks backward through recent dates so a 6am run still succeeds if the newest product has not posted yet.
+- It downloads the `.kmz`, validates it as a ZIP/KMZ with KML inside, reads KML `GroundOverlay` bounds and `SimpleData name="date"`, renders the final sargassum map, then also downloads supporting public weather images and prints multiple `MEDIA:/absolute/path.png` lines for direct Telegram delivery.
+- Supporting images currently included:
+  - NHC 7-day Atlantic tropical outlook: `https://www.nhc.noaa.gov/xgtwo/resize/xgtwo_atl_7d0_w1920.png`
+  - Public NOAA/NWS Southeast radar mosaic including Florida: `https://radar.weather.gov/ridge/standard/SOUTHEAST_0.gif` converted to PNG for delivery.
+- Historical sargassum test that succeeded: `python3 ~/.hermes/scripts/daily-sargassum-map.py --date 20260601 --force` rendered `/home/ara1/.hermes/cache/sargassum_maps/florida_sargassum_risk_density_currents_20260601.png` with 1673 risk features drawn.
+- Full packet trial that succeeded on 2026-06-12 produced the sargassum map, NHC tropical outlook image, and NOAA/NWS Southeast radar image.
+- Cron should be script-only/no-agent at `0 6 * * *`, delivered to the origin/home chat.
+- Hermes cron runs `.py` scripts with the scheduler's `sys.executable`, not the file shebang. On Ara1bot, the sargassum script needs system Pillow/NumPy, so schedule the bash wrapper `daily-sargassum-map.sh`, which execs `/usr/bin/python3 /home/ara1/.hermes/scripts/daily-sargassum-map.py`, rather than scheduling `daily-sargassum-map.py` directly.
+
+## Florida Email Task
+
+Daily email variant:
+
+- Script: `/home/ara1/.hermes/scripts/florida-email-task.py`
+- Cron wrapper: `/home/ara1/.hermes/scripts/florida-email-task-send.sh`
+- Cron job name: `Florida Email Task`
+- Schedule: `20 6 * * *`
+- Recipient safety default: only `reisworth@gmail.com`
+- Email contents:
+  - inline sargassum map from `daily-sargassum-map.py`
+  - inline NHC 7-day Atlantic tropical outlook
+  - inline NOAA/NWS Southeast radar map including Florida
+  - SandBar Tiki & Grille next-5-day live music lineup from `https://www.sandbartikigrille.com/events/`
+- SandBar parsing note: the page has event cards with `<div class="day/month/date">`, `<h2 class="post-title">`, and meta `<span class="sr">Time</span>` / `<span class="sr">Genre</span>`; parse those fields directly to avoid truncating genres such as `Rock, Pop, Country`.
+- Email send uses Python `smtplib` with `EMAIL_ADDRESS`, `EMAIL_PASSWORD`, and `EMAIL_SMTP_HOST` from `~/.hermes/.env`.
+
+## Common pitfalls
+
+- Current rasters can look like thick gray/yellow smudges when too opaque. Start with low opacity and inspect.
+- A plain no-label basemap can look boring; prefer no-label physical/topographic layers when available.
+- Offshore boxed callouts can be legible but may feel less polished; direct map labels with a white halo often look cleaner.
+- User may iterate on cartographic aesthetics several times; treat visual QA as part of the task, not an optional extra.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/tide-forecast-graphics-skill.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/tide-forecast-graphics-skill.md
@@ -1,0 +1,63 @@
+---
+name: tide-forecast-graphics
+description: Create NOAA tide forecast graphs with daylight shading, high/low labels, and Telegram-ready image delivery.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    tags: [tides, noaa, coops, forecast, chart, daylight, sunrise, sunset, telegram, visualization]
+    category: productivity
+    requires_toolsets: [terminal, vision]
+---
+
+# Tide Forecast Graphics
+
+Use this skill when the user asks for a tide chart/graph/forecast for a coastal location, especially if they want it pasted/sent to Telegram as an image.
+
+## Workflow
+
+1. **Resolve the tide station**
+   - Search NOAA CO-OPS / Tides & Currents for the nearest station.
+   - If the user names a beach/island rather than a station, use the nearest relevant NOAA station and state it in the footer.
+   - For Manasota Key, FL, a good station is `8725809` — Manasota, FL.
+
+2. **Fetch NOAA tide predictions**
+   - Use NOAA CO-OPS datagetter API with `product=predictions`, `datum=MLLW`, `time_zone=lst_ldt`, `units=english`, `format=json`.
+   - Use `interval=6` for a smooth curve.
+   - Use `interval=hilo` for high/low marker labels.
+   - For a one-day chart, make the x-axis exactly local `12:00 AM` to next-day `12:00 AM`, not just the API's last data point.
+
+3. **Compute daylight accurately**
+   - Use the station or location coordinates and local timezone.
+   - Shade daylight hours with a light yellow background from sunrise to sunset.
+   - Label sunrise and sunset times on the chart and repeat them in the footer.
+   - Watch for sunset calculations returning the previous local date when converting from UTC; if sunset is earlier than sunrise for the target date, add one day.
+
+4. **Render a polished graph**
+   - Prefer a high-resolution PNG, e.g. 1600px wide.
+   - Use a readable title, subtitle, y-axis in feet above MLLW, local-time x-axis, high/low callouts, and a source footer.
+   - Use light yellow for daylight, pale blue/gray for night, blue tide fill/line, and orange low-tide markers.
+   - Keep legends out of the title/subtitle area; footer legends are safer for Telegram image previews.
+
+5. **Verify visually before sending**
+   - Use vision QA before final delivery.
+   - Check that the chart is the requested span, daylight shading starts/ends at the labeled sunrise/sunset, labels are legible, and no legend/title/footer overlaps.
+   - If there is overlap, patch/regenerate the image before sending.
+
+6. **Deliver to Telegram**
+   - Include `MEDIA:/absolute/path/to/file.png` in the final response.
+   - Briefly mention the source station and sunrise/sunset basis.
+
+## Pitfalls
+
+- Do not use mental date/time math; use tools for current date and timezone-aware calculations.
+- Do not rely on `matplotlib` being installed. Pillow (`PIL`) can draw a complete chart with lines, filled polygons, labels, and legends.
+- NOAA `end_date` for a single date may return points through 23:54; set the x-axis to next midnight manually for a true full-day chart.
+- Visual overlap is common when placing legends at the top right; after QA, move legends to the footer if they cover the subtitle.
+- If the user asks for daylight shading, calculate sunrise/sunset for the actual location/date rather than approximating by fixed hours.
+
+## Reference
+
+See `references/noaa-tide-graph-pattern.md` for API endpoints, rendering details, and the Manasota Key example from the session that created this skill.

--- a/skills/productivity/environmental-map-and-forecast-graphics/references/wateratlas-rainfall-map-rendering.md
+++ b/skills/productivity/environmental-map-and-forecast-graphics/references/wateratlas-rainfall-map-rendering.md
@@ -1,0 +1,103 @@
+# Sarasota Water Atlas rainfall map rendering
+
+Session-derived workflow for creating Manasota Key / Englewood rainfall maps from the Sarasota Water Atlas near-real-time rainfall page.
+
+## Data source
+
+- Public page: `https://sarasota.wateratlas.usf.edu/rainfall/latest/`
+- The page fetches JSON from: `https://api.wateratlas.usf.edu/rainfall/latest/?s=8`
+- Useful fields per station:
+  - `name`, `id`, `lastUpdated`
+  - `location.latitude`, `location.longitude`
+  - `total24h`, `total7d`, `total31d`
+- Page radio options correspond to API fields:
+  - 24 Hour Total Rainfall → `total24h`
+  - 7 Day Total Rainfall → `total7d`
+  - 31 Day Total Rainfall → `total31d`
+
+## Map extent that captures lower Sarasota / Manasota Key / Englewood
+
+A good working extent for the requested lower stations is:
+
+- lon min/max: `-82.56, -82.16`
+- lat min/max: `26.90, 27.25`
+
+This captures the lower coastal / Englewood-area stations, including:
+
+- `CST-3 Indian Mound Park` — label as `Englewood / Indian Mound Park`
+- `Lemon Bay Park`
+- `Lemon Bay Canal`
+- `AL-1  Jacaranda Bridge`
+- `FRK-1 Donavan Rd`
+- `FRK-2 Stoner Road`
+- `GOT-1 Tangerine Wds`
+- `GOT-2 Park Forest`
+- `HC-1  Venice Ave E`
+- `SO-1 Oscar Scherer Park`
+- `CUR-2 Capri Isle`
+
+## 3 km rainfall grid technique
+
+For a 3 km resolution visualization:
+
+1. Fetch all Sarasota ARMS stations from the API.
+2. Convert lon/lat to approximate km coordinates using:
+   - `km_per_deg_lat = 110.574`
+   - `km_per_deg_lon = 111.320 * cos(mid_lat)`
+3. Create grid cell centers every 3 km over the map extent.
+4. Optionally clip grid cells to county polygons so cells do not cover the Gulf. A simple source for county outlines is Plotly's public county GeoJSON: `https://raw.githubusercontent.com/plotly/datasets/master/geojson-counties-fips.json`; use Florida FIPS for Sarasota (`12115`), Charlotte (`12015`), Manatee (`12081`), and DeSoto (`12027`) as needed.
+5. Interpolate each cell using inverse-distance weighting from all available stations:
+   - radius: about 45 km
+   - power: `2.0`
+6. Draw cells as semi-transparent rectangles with subtle white outlines so the 3 km resolution is visible.
+7. Overlay station dots and numeric labels using the selected field's station total.
+
+Important disclaimer: label the result as a 3 km visualization/interpolation from station totals, not an official gridded rainfall product.
+
+## Water Atlas-style screenshot recreation
+
+When Ron references the prior screenshot/map and asks to “go back to this map,” he likely wants the page-like Water Atlas visual, not the polished custom 3 km interpolation map.
+
+Use these visual targets:
+
+- Output aspect close to the screenshot: portrait image around `760 x 1230`.
+- Header: white band with `Sarasota County Water Atlas` in teal and `Near Real-time Rainfall Map` underneath, plus a dark teal separator line.
+- Basemap: pale road/topographic map resembling the Water Atlas Leaflet/Esri view. OSM tiles can be used if desaturated, brightened, and low-contrast.
+- Controls: left zoom +/- box and left white radio panel; select `31 Day Total Rainfall` with blue checked radio and bold label.
+- Station style: draw blue-gray rectangles with dark outline and large numeric rainfall totals, mimicking Leaflet marker labels.
+- Extent: keep the same south Sarasota / Venice / Manasota Key / Englewood area, with lower stations visible rather than hidden by the radio panel.
+- Include a bottom-left `3 km` scale marker.
+
+Useful approximate viewport:
+
+- lon min/max: about `-82.555, -82.125`
+- lat min/max: about `26.835, 27.245`
+- portrait canvas: `760 x 1230`
+- map area below header: header about `112 px`; map height about `1065 px`
+
+Implementation notes:
+
+1. Fetch current station values from `https://api.wateratlas.usf.edu/rainfall/latest/?s=8` and draw `total31d` labels.
+2. Use Web Mercator math to crop tiles to the viewport, typically at zoom 12.
+3. Cache public OSM tiles under `~/.hermes/cache/osm_tiles/` to avoid repeated downloads.
+4. Apply `Color ~0.58`, `Contrast ~0.78`, `Brightness ~1.18` to make OSM tiles look closer to the pale Water Atlas basemap.
+5. Add small manual nudges for congested labels so Englewood/Manasota-area values remain readable:
+   - `CST-3 Indian Mound Park`
+   - `Lemon Bay Park`
+   - `Lemon Bay Canal`
+   - `FRK-1 Donavan Rd`
+   - `FRK-2 Stoner Road`
+   - `GOT-1 Tangerine Wds`
+   - `GOT-2 Park Forest`
+6. QA with vision before delivery: header not cropped, radio panel readable, 31-day option selected, lower station labels visible, 3 km scale present.
+
+## Styling notes for Ron's Florida email
+
+- Use a clean no-label basemap or simple county/coastline geometry; avoid cluttered road/city labels since custom callouts are added.
+- Keep Manasota Key and Englewood explicitly labeled.
+- Add callouts for lower coastal stations so they remain readable when the map is tiled or emailed.
+- Include source URL and latest update timestamp from the station data.
+- For an email tile, create the three panels in this order: `24-Hour`, `7-Day`, `31-Day`.
+- Use a concise header such as: `Manasota Key / Englewood Rainfall Totals`.
+- In the tile subtitle, include: `24-hour, 7-day, and 31-day totals • 3 km grid • Sarasota Water Atlas ARMS • latest <timestamp>`.
+- Visually QA the tile before delivery: check spelling, all three panel labels, no severe cropping, source/footer readable, and lower station callouts still visible enough at the tile scale.


### PR DESCRIPTION
## Summary
- Add `environmental-map-and-forecast-graphics` skill under productivity
- Include references for KML/KMZ rendering, sargassum, red tide, rainfall, tide charts, and Manasota Key Fun Pack email automation
- Document current Manasota Key Fun Pack standards: branding, Gmail clipping/collapsing safeguards, high-resolution forecast chart spacing, SWFLLive 5-day entertainment parsing, and Brave Search secret handling

## Verification
- Validated SKILL.md frontmatter and size constraints with Python/YAML parser
- Confirmed 15 reference markdown files are included
- Scanned copied skill files for the provided Brave key pattern; not present