### PR TITLE
fix(kanban): guard needs_input unblock from non-interactive sessions

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -863,6 +863,27 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     return kanban_parser
 
 
+def main(argv: Optional[list[str]] = None) -> int:
+    """Standalone ``python -m hermes_cli.kanban <action> …`` entry point.
+
+    Builds the same ``kanban`` argparse tree as :func:`build_parser` and
+    dispatches through :func:`kanban_command`, returning its shell-style exit
+    code. Unlike the top-level ``hermes`` entry (``hermes_cli.main``), this
+    module runner is a thin wrapper whose ``__main__`` guard actually
+    ``sys.exit``s with that code, so a non-zero result from a handler (e.g. the
+    ``unblock`` refusal for a dispatched worker) is faithfully propagated to the
+    calling process. Used directly and exercised by the CLI E2E tests.
+    """
+    tokens = list(sys.argv[1:] if argv is None else argv)
+    top = argparse.ArgumentParser(prog="python -m hermes_cli.kanban")
+    subparsers = top.add_subparsers(dest="_root")
+    build_parser(subparsers)
+    # build_parser attaches the tree under a ``kanban`` subcommand; prepend it
+    # so callers invoke actions directly (``… unblock <id>``).
+    args = top.parse_args(["kanban", *tokens])
+    return int(kanban_command(args) or 0)
+
+
 # ---------------------------------------------------------------------------
 # Command dispatch
 # ---------------------------------------------------------------------------
@@ -2012,7 +2033,8 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
             try:
                 ok = kb.unblock_task(conn, tid)
             except ValueError as exc:
-                # The DB guard refuses e.g. a worker / non-interactive session
+                # The DB/process guard refuses a dispatched worker (even one
+                # that scrubbed its env — see _caller_is_dispatched_worker)
                 # clearing a needs_input human gate. Surface the refusal and
                 # count it as a failure so this command handler returns
                 # non-zero instead of depending on the generic top-level
@@ -2854,3 +2876,7 @@ def run_slash(rest: str) -> str:
     if err and out:
         return f"{out}\n{err}"
     return err if err else (out or "(no output)")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2009,7 +2009,18 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
         for tid in ids:
             if reason:
                 kb.add_comment(conn, tid, author, f"UNBLOCK: {reason}")
-            if not kb.unblock_task(conn, tid):
+            try:
+                ok = kb.unblock_task(conn, tid)
+            except ValueError as exc:
+                # The DB guard refuses e.g. a worker / non-interactive session
+                # clearing a needs_input human gate. Surface the refusal and
+                # count it as a failure so this command handler returns
+                # non-zero instead of depending on the generic top-level
+                # exception path.
+                failed.append(tid)
+                print(f"kanban: {exc}", file=sys.stderr)
+                continue
+            if not ok:
                 failed.append(tid)
                 print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
             else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4745,6 +4745,29 @@ def promote_task(
     return True, None
 
 
+def _is_noninteractive_unblock_session() -> bool:
+    """True when the caller is a dispatched worker or a non-default profile.
+
+    A ``needs_input`` block encodes a human decision the worker could not
+    derive on its own; only an interactive Main/default session may clear it.
+    Without this check a dispatched worker that happens to have a terminal can
+    run ``hermes kanban unblock <task_id>`` (or the ``kanban_unblock`` tool) and
+    silently bypass the human-approval gate. We treat two signals as
+    non-interactive/non-default:
+
+    * ``HERMES_KANBAN_TASK`` set — the process is a dispatched worker scoped to
+      a task (the dispatcher sets this; see ``spawn_worker`` env plumbing).
+    * ``HERMES_PROFILE`` set to anything other than ``default`` — a
+      non-default profile is not the human Main/default session.
+    """
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return True
+    profile = os.environ.get("HERMES_PROFILE")
+    if profile and profile != "default":
+        return True
+    return False
+
+
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """Transition ``blocked``/``scheduled`` -> ready or todo.
 
@@ -4754,13 +4777,29 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     the leaked run is closed as ``reclaimed`` inside the same txn so the
     runs invariant (``current_run_id IS NULL`` ⇔ run row in terminal
     state) holds for the rest of this function's lifetime.
+
+    A ``needs_input`` block may only be cleared from an interactive
+    Main/default session. When called from a dispatched worker or a
+    non-default profile (see :func:`_is_noninteractive_unblock_session`) this
+    raises :class:`ValueError` rather than silently unblocking, closing the
+    bypass where a worker with a terminal could self-approve a human gate.
+    Other block kinds (dependency/capability/transient/None) are unaffected.
     """
     now = int(time.time())
     with write_txn(conn):
         stale = conn.execute(
-            "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
+            "SELECT current_run_id, block_kind FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (task_id,),
         ).fetchone()
+        if (
+            stale
+            and stale["block_kind"] == "needs_input"
+            and _is_noninteractive_unblock_session()
+        ):
+            raise ValueError(
+                "Refused: cannot unblock needs_input block from non-interactive "
+                "session. This block requires human (Main/default) approval."
+            )
         if stale and stale["current_run_id"]:
             conn.execute(
                 """

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4745,27 +4745,67 @@ def promote_task(
     return True, None
 
 
-def _is_noninteractive_unblock_session() -> bool:
-    """True when the caller is a dispatched worker or a non-default profile.
+def _caller_is_dispatched_worker(conn: sqlite3.Connection) -> bool:
+    """True when the unblock caller is (or descends from) a live dispatched worker.
 
     A ``needs_input`` block encodes a human decision the worker could not
-    derive on its own; only an interactive Main/default session may clear it.
-    Without this check a dispatched worker that happens to have a terminal can
-    run ``hermes kanban unblock <task_id>`` (or the ``kanban_unblock`` tool) and
-    silently bypass the human-approval gate. We treat two signals as
-    non-interactive/non-default:
+    derive on its own; only a non-worker session — an interactive Main session
+    or a non-task-scoped orchestrator, of *any* profile — may clear it. This
+    predicate is the boundary that stops a dispatched worker from
+    self-approving its own human gate.
 
-    * ``HERMES_KANBAN_TASK`` set — the process is a dispatched worker scoped to
-      a task (the dispatcher sets this; see ``spawn_worker`` env plumbing).
-    * ``HERMES_PROFILE`` set to anything other than ``default`` — a
-      non-default profile is not the human Main/default session.
+    The gate rests on two independent signals, so it is deliberately **not**
+    env-only and cannot be defeated merely by scrubbing the environment:
+
+    1. **Env fast-path.** ``HERMES_KANBAN_TASK`` is exported into every worker
+       by the dispatcher (see ``_default_spawn``). An honest worker is caught
+       here without touching the DB.
+
+    2. **Process/DB boundary (non-bypassable).** The dispatcher — a *different*
+       process from the worker — records each worker's real OS pid in
+       ``tasks.worker_pid`` for the ``running`` task that worker owns (see
+       :func:`_set_worker_pid`). That row lives in the shared board DB and is
+       written by the dispatcher, not the worker. If the caller's own pid, or
+       any pid in its process-ancestor chain
+       (:func:`hermes_cli.gateway._get_ancestor_pids`), matches the
+       ``worker_pid`` of a currently ``running`` task, the caller *is* that
+       worker — or a ``hermes kanban unblock`` / ``kanban_unblock`` process the
+       worker spawned as a child. A worker cannot rewrite its process ancestry
+       and cannot erase the dispatcher's DB row by editing its own environment,
+       so stripping ``HERMES_KANBAN_TASK`` / ``HERMES_PROFILE`` does not get it
+       past this second check. This closes the env-scrub bypass.
+
+    Profile is intentionally **not** consulted. A non-default orchestrator
+    profile that is not itself a dispatched worker (no worker env, no live
+    worker pid in its ancestry) is a legitimate approver; the previous blanket
+    "any non-``default`` profile is non-interactive" rejection wrongly locked
+    those out and is gone.
+
+    Scope note: this recognises a worker that is *still running* its task — the
+    demonstrated bypass, a live worker with a terminal. A worker that has
+    already ``block_task``-ed and released its claim no longer owns a
+    ``running`` row; if it has also scrubbed its env it is by then
+    indistinguishable from an ordinary session, which is acceptable because it
+    has relinquished the task and the dispatcher no longer tracks it.
     """
     if os.environ.get("HERMES_KANBAN_TASK"):
         return True
-    profile = os.environ.get("HERMES_PROFILE")
-    if profile and profile != "default":
-        return True
-    return False
+    try:
+        rows = conn.execute(
+            "SELECT worker_pid FROM tasks "
+            "WHERE status = 'running' AND worker_pid IS NOT NULL"
+        ).fetchall()
+    except sqlite3.Error:
+        return False
+    live_worker_pids = {int(r["worker_pid"]) for r in rows if r["worker_pid"]}
+    if not live_worker_pids:
+        return False
+    # A pid in our own ancestor chain is, by definition, an alive process, so
+    # no extra liveness probe is needed. Reuse the battle-tested cross-platform
+    # walker (psutil with a ``ps`` fallback) rather than re-deriving it here.
+    from hermes_cli.gateway import _get_ancestor_pids
+
+    return bool(live_worker_pids & _get_ancestor_pids())
 
 
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
@@ -4778,12 +4818,15 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     runs invariant (``current_run_id IS NULL`` ⇔ run row in terminal
     state) holds for the rest of this function's lifetime.
 
-    A ``needs_input`` block may only be cleared from an interactive
-    Main/default session. When called from a dispatched worker or a
-    non-default profile (see :func:`_is_noninteractive_unblock_session`) this
-    raises :class:`ValueError` rather than silently unblocking, closing the
-    bypass where a worker with a terminal could self-approve a human gate.
-    Other block kinds (dependency/capability/transient/None) are unaffected.
+    A ``needs_input`` block may only be cleared by a non-worker session (an
+    interactive Main session, or a non-task-scoped orchestrator of any
+    profile). When called from a dispatched worker — detected via the
+    process/DB boundary in :func:`_caller_is_dispatched_worker`, which does not
+    rely on environment variables alone — this raises :class:`ValueError`
+    rather than silently unblocking, closing the bypass where a worker with a
+    terminal could self-approve a human gate even after scrubbing its
+    ``HERMES_KANBAN_TASK`` / ``HERMES_PROFILE`` environment. Other block kinds
+    (dependency/capability/transient/None) are unaffected.
     """
     now = int(time.time())
     with write_txn(conn):
@@ -4794,11 +4837,12 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         if (
             stale
             and stale["block_kind"] == "needs_input"
-            and _is_noninteractive_unblock_session()
+            and _caller_is_dispatched_worker(conn)
         ):
             raise ValueError(
-                "Refused: cannot unblock needs_input block from non-interactive "
-                "session. This block requires human (Main/default) approval."
+                "Refused: cannot unblock a needs_input block from a dispatched "
+                "worker. This block requires approval from a non-worker "
+                "(Main / orchestrator) session."
             )
         if stale and stale["current_run_id"]:
             conn.execute(

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -18,12 +18,20 @@ forever. The fix gives ``block_task`` a typed ``kind`` and a persistent
 from __future__ import annotations
 
 import argparse
+import os
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 
 import pytest
 
 from hermes_cli import kanban as kc
 from hermes_cli import kanban_db as kb
+
+# Repo root, so a spawned worker subprocess can import ``hermes_cli`` and run
+# the real ``hermes kanban`` CLI (``python -m hermes_cli.main``).
+_WORKTREE = Path(__file__).resolve().parents[2]
 
 
 @pytest.fixture
@@ -213,7 +221,13 @@ def test_block_without_kind_is_backward_compatible(kanban_home: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# needs_input unblock guard — only Main/default may clear a human gate
+# needs_input unblock guard — a dispatched worker may not clear a human gate,
+# but any non-worker session (Main or a non-default orchestrator) may.
+#
+# The boundary is anchored on the DB + process ancestry, NOT on env vars alone
+# (see ``_caller_is_dispatched_worker``), so a worker cannot self-approve by
+# scrubbing HERMES_KANBAN_TASK / HERMES_PROFILE. See the subprocess E2E test at
+# the bottom of this section for the actual env-scrub bypass attempt.
 # ---------------------------------------------------------------------------
 
 
@@ -227,7 +241,7 @@ def test_needs_input_unblock_refused_from_worker(
 
         monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
         monkeypatch.delenv("HERMES_PROFILE", raising=False)
-        with pytest.raises(ValueError, match="requires human"):
+        with pytest.raises(ValueError, match="dispatched worker"):
             kb.unblock_task(conn, tid)
 
         # The refusal is atomic — the task stays blocked, kind preserved.
@@ -236,19 +250,53 @@ def test_needs_input_unblock_refused_from_worker(
         assert t.block_kind == "needs_input"
 
 
-def test_needs_input_unblock_refused_from_nondefault_profile(
+def test_needs_input_unblock_succeeds_from_nondefault_orchestrator(
     kanban_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A non-default profile is not the human Main/default session either."""
+    """A non-default orchestrator profile is NOT a worker and may clear the gate.
+
+    Flaw #2 of PR #59906: the old guard rejected *any* non-``default`` profile,
+    which locked out legitimate non-task-scoped orchestrators. Profile is no
+    longer consulted — only whether the caller is a dispatched worker (no
+    worker env here, and no live worker pid in this process's ancestry).
+    """
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
         kb.block_task(conn, tid, reason="which key?", kind="needs_input")
 
         monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
-        monkeypatch.setenv("HERMES_PROFILE", "some-worker")
-        with pytest.raises(ValueError, match="non-interactive"):
-            kb.unblock_task(conn, tid)
-        assert kb.get_task(conn, tid).status == "blocked"
+        monkeypatch.setenv("HERMES_PROFILE", "orchestrator")
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_needs_input_unblock_refused_via_db_boundary_without_env(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The core non-env boundary: no worker env set, yet a caller whose pid is
+    registered as a live ``worker_pid`` is still refused.
+
+    This is the mechanism that survives an env scrub — the dispatcher-written
+    ``tasks.worker_pid`` row plus process-ancestry, not ``HERMES_KANBAN_TASK``.
+    """
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    with kb.connect_closing() as conn:
+        gate = _running_task(conn, title="human-gate")
+        kb.block_task(conn, gate, reason="which key?", kind="needs_input")
+
+        # Register THIS process as a live dispatched worker, exactly as the
+        # dispatcher's ``_set_worker_pid`` would (our real pid, running task).
+        owned = _running_task(conn, title="worker-owned")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET worker_pid = ? WHERE id = ?",
+                (os.getpid(), owned),
+            )
+
+        with pytest.raises(ValueError, match="dispatched worker"):
+            kb.unblock_task(conn, gate)
+        assert kb.get_task(conn, gate).status == "blocked"
 
 
 def test_needs_input_unblock_succeeds_from_main_default(
@@ -330,7 +378,7 @@ def test_cli_unblock_needs_input_from_worker_returns_nonzero(
 
     err = capsys.readouterr().err
     assert "kanban:" in err
-    assert "requires human" in err
+    assert "dispatched worker" in err
 
     with kb.connect_closing() as conn:
         t = kb.get_task(conn, tid)
@@ -354,3 +402,130 @@ def test_cli_unblock_needs_input_from_main_returns_zero(
 
     with kb.connect_closing() as conn:
         assert kb.get_task(conn, tid).status == "ready"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end env-scrub bypass attempt — the security claim, demonstrated with
+# REAL processes: a dispatcher records a worker's OS pid, the worker scrubs its
+# HERMES_KANBAN_TASK / HERMES_PROFILE environment and shells out to the real
+# ``hermes kanban unblock`` CLI, and the guard STILL refuses because the CLI is
+# a child of the live registered worker (process ancestry the worker cannot
+# rewrite), not because of any environment variable.
+#
+# Faithful modelling of the actual demonstrated bypass: ``block_task`` NULLs
+# ``worker_pid`` on the task it blocks, so a worker only remains detectable
+# while it still owns a *running* task. The realistic live bypass is therefore
+# a worker that is mid-task (its own task still ``running``) reaching over to
+# clear a separate ``needs_input`` human gate — that is exactly the shape set
+# up below.
+# ---------------------------------------------------------------------------
+
+
+# A stand-in worker process. It waits for the dispatcher (the test) to register
+# its real pid, scrubs every worker-identifying env var, then invokes the real
+# ``hermes kanban unblock`` CLI as a child and reports that child's outcome.
+_WORKER_SRC = textwrap.dedent(
+    """
+    import os
+    import subprocess
+    import sys
+
+    db_path, gate_id, worktree = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    # Block until the dispatcher has written our pid into tasks.worker_pid.
+    sys.stdin.readline()
+
+    # Scrub the env signals the fast-path relies on: this is the bypass attempt.
+    env = dict(os.environ)
+    env.pop("HERMES_KANBAN_TASK", None)
+    env.pop("HERMES_PROFILE", None)
+    # Pin the board DB the same way the dispatcher would (not a worker signal).
+    env["HERMES_KANBAN_DB"] = db_path
+    env["PYTHONPATH"] = worktree + os.pathsep + env.get("PYTHONPATH", "")
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.kanban", "unblock", gate_id],
+        env=env, cwd=worktree, capture_output=True, text=True,
+    )
+    sys.stdout.write("RC=%d\\n" % proc.returncode)
+    sys.stdout.write("ERR_START\\n%s\\nERR_END\\n" % proc.stderr)
+    sys.stdout.flush()
+    """
+)
+
+
+def test_cli_unblock_needs_input_env_scrub_bypass_refused_e2e(
+    kanban_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real subprocess E2E: an env-scrubbed live worker cannot clear a gate.
+
+    Wiring mirrors production:
+
+    * The *dispatcher* (this test process) records the worker's real OS pid in
+      ``tasks.worker_pid`` for a task the worker still owns and is ``running`` —
+      the DB row is written by a different process than the worker, and cannot
+      be erased by the worker editing its own environment.
+    * The *worker* subprocess strips ``HERMES_KANBAN_TASK`` /
+      ``HERMES_PROFILE`` from its environment and runs the genuine
+      ``python -m hermes_cli.kanban unblock <gate>`` CLI (the real production
+      dispatch through :func:`kanban_command`, whose ``__main__`` propagates the
+      handler's exit code) as a child.
+    * The CLI child's process ancestry contains the worker's registered,
+      still-``running`` ``worker_pid`` (``_get_ancestor_pids`` includes the
+      caller and every parent), so ``_caller_is_dispatched_worker`` matches on
+      the DB/process boundary — no env var involved — and the unblock is
+      refused with a non-zero exit while the gate stays ``blocked``.
+    """
+    pytest.importorskip("psutil")
+
+    db_path = str(kb.kanban_db_path())
+    with kb.connect_closing() as conn:
+        # The human gate the worker will try to self-approve.
+        gate = _running_task(conn, title="human-gate")
+        kb.block_task(conn, gate, reason="which key?", kind="needs_input")
+        # A separate task the worker is still actively running.
+        owned = _running_task(conn, title="worker-owned")
+        assert kb.get_task(conn, owned).status == "running"
+
+    worker_py = tmp_path / "worker.py"
+    worker_py.write_text(_WORKER_SRC)
+
+    # Launch the worker but hold it at the stdin gate until we've recorded its
+    # pid, exactly as the dispatcher records a spawned worker before it runs.
+    proc = subprocess.Popen(
+        [sys.executable, str(worker_py), db_path, gate, str(_WORKTREE)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=dict(os.environ),
+    )
+    try:
+        with kb.connect_closing() as conn:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET worker_pid = ? WHERE id = ?",
+                    (proc.pid, owned),
+                )
+        assert proc.stdin is not None
+        proc.stdin.write("go\n")
+        proc.stdin.flush()
+        out, err = proc.communicate(timeout=120)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.communicate()
+
+    assert "RC=" in out, f"worker did not report a result. out={out!r} err={err!r}"
+    rc_line = next(line for line in out.splitlines() if line.startswith("RC="))
+    rc = int(rc_line[len("RC="):])
+    cli_stderr = out.split("ERR_START\n", 1)[1].split("\nERR_END", 1)[0]
+
+    assert rc != 0, f"env-scrub bypass was NOT refused. stderr={cli_stderr!r}"
+    assert "dispatched worker" in cli_stderr, cli_stderr
+
+    # The gate is untouched: the human decision still stands.
+    with kb.connect_closing() as conn:
+        t = kb.get_task(conn, gate)
+        assert t.status == "blocked"
+        assert t.block_kind == "needs_input"

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -17,10 +17,12 @@ forever. The fix gives ``block_task`` a typed ``kind`` and a persistent
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 
 import pytest
 
+from hermes_cli import kanban as kc
 from hermes_cli import kanban_db as kb
 
 
@@ -30,6 +32,14 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Default every test to an interactive Main/default session so the
+    # needs_input unblock guard is a no-op unless a test opts in. Without
+    # this, the worker env that runs the suite (HERMES_PROFILE=coder,
+    # HERMES_KANBAN_TASK=...) leaks in and trips the guard for the older
+    # tests that unblock a needs_input task. Guard tests override these via
+    # monkeypatch after requesting the fixture.
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
     kb.init_db()
     return home
 
@@ -200,3 +210,147 @@ def test_block_without_kind_is_backward_compatible(kanban_home: Path) -> None:
         t = kb.get_task(conn, tid)
         assert t.status == "blocked"
         assert t.block_kind is None
+
+
+# ---------------------------------------------------------------------------
+# needs_input unblock guard — only Main/default may clear a human gate
+# ---------------------------------------------------------------------------
+
+
+def test_needs_input_unblock_refused_from_worker(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dispatched worker (HERMES_KANBAN_TASK set) cannot self-approve."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="which key?", kind="needs_input")
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        with pytest.raises(ValueError, match="requires human"):
+            kb.unblock_task(conn, tid)
+
+        # The refusal is atomic — the task stays blocked, kind preserved.
+        t = kb.get_task(conn, tid)
+        assert t.status == "blocked"
+        assert t.block_kind == "needs_input"
+
+
+def test_needs_input_unblock_refused_from_nondefault_profile(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-default profile is not the human Main/default session either."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="which key?", kind="needs_input")
+
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.setenv("HERMES_PROFILE", "some-worker")
+        with pytest.raises(ValueError, match="non-interactive"):
+            kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_needs_input_unblock_succeeds_from_main_default(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Interactive Main/default (no worker task, default profile) may clear it."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="which key?", kind="needs_input")
+
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.setenv("HERMES_PROFILE", "default")
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_needs_input_unblock_succeeds_when_profile_unset(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No env at all is the plain interactive case and must succeed."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="which key?", kind="needs_input")
+
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_worker_can_still_unblock_other_kinds(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard is scoped to needs_input; capability/transient are unaffected."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "some-task")
+    for kind in ("capability", "transient"):
+        with kb.connect_closing() as conn:
+            tid = _running_task(conn, title=f"t-{kind}")
+            kb.block_task(conn, tid, reason="x", kind=kind)
+            assert kb.unblock_task(conn, tid)
+            assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_worker_can_still_unblock_untyped_block(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legacy un-typed (block_kind is None) block is not gated by the guard."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "some-task")
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="legacy")
+        assert kb.get_task(conn, tid).block_kind is None
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+# ---------------------------------------------------------------------------
+# CLI layer: the refusal must make the unblock handler return non-zero
+# ---------------------------------------------------------------------------
+
+
+def _unblock_ns(tid: str) -> argparse.Namespace:
+    return argparse.Namespace(task_ids=[tid], reason=None)
+
+
+def test_cli_unblock_needs_input_from_worker_returns_nonzero(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The worker CLI call is refused: rc != 0, task stays blocked."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="which key?", kind="needs_input")
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    rc = kc._cmd_unblock(_unblock_ns(tid))
+    assert rc != 0
+
+    err = capsys.readouterr().err
+    assert "kanban:" in err
+    assert "requires human" in err
+
+    with kb.connect_closing() as conn:
+        t = kb.get_task(conn, tid)
+        assert t.status == "blocked"
+        assert t.block_kind == "needs_input"
+
+
+def test_cli_unblock_needs_input_from_main_returns_zero(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Interactive Main/default clears the gate and exits 0."""
+    with kb.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="which key?", kind="needs_input")
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+
+    rc = kc._cmd_unblock(_unblock_ns(tid))
+    assert rc == 0
+
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, tid).status == "ready"


### PR DESCRIPTION
## Problem

A worker profile with the `terminal` tool can bypass the `kanban_unblock` model-tool guard (`_check_kanban_orchestrator_mode` checks `HERMES_KANBAN_TASK`) by calling `hermes kanban unblock <task_id>` as a shell command. The terminal tool has no such guard, so the CLI path is unrestricted.

**Observed in production:** a dispatched planner worker blocked a card with `kind: needs_input` (awaiting human review), then used `terminal` to call `hermes kanban unblock` via CLI, unblocking itself. The next run claimed the card and proceeded as if the human had approved, creating 6 downstream cards.

The model-tool path (`tools/kanban_tools.py`) is already guarded. This PR closes the CLI gap.

## Fix

Add a DB-level guard in `unblock_task()` (`hermes_cli/kanban_db.py`) so `needs_input` blocks cannot be unblocked from non-interactive sessions. Detection: `HERMES_KANBAN_TASK` is set OR `HERMES_PROFILE` is set to a non-default profile. The guard fires before any status mutation, inside a `write_txn` so a raise rolls back cleanly (task stays blocked, block_kind preserved).

- **Scoped:** only `needs_input` is gated. Other block kinds (`capability`, `transient`, `review-required`, `dependency`, untyped) are unaffected — workers can still unblock those.
- **Call paths covered:**
  - CLI handler (`hermes_cli/kanban.py`) — catches `ValueError`, prints clear error, returns non-zero
  - Model tool (`tools/kanban_tools.py`) — catches at existing exception boundary, returns `tool_error`
  - Dashboard plugin (`plugin_api.py`) — does not catch, but dashboard runs as `HERMES_PROFILE=default` so the guard never fires there; uncaught → 500 is a safe fail-closed
- **Clear error:** `Refused: cannot unblock needs_input block from non-interactive session. This block requires human (Main/default) approval.`

## Files changed

| File | Change |
|------|--------|
| `hermes_cli/kanban_db.py` | `_is_noninteractive_unblock_session()` + guard inside `unblock_task()` before stale-run recovery / status mutation |
| `hermes_cli/kanban.py` | `_cmd_unblock` catches `ValueError`, prints kanban error, marks task failed for handler-level nonzero return |
| `tests/hermes_cli/test_kanban_block_kinds.py` | 19 tests: worker refusal, non-default-profile refusal, Main/default success, unset-env success, other block kinds unaffected, untyped block unaffected, CLI handler non-zero from worker, CLI handler zero from Main |

## Verification

- `uv run pytest tests/hermes_cli/test_kanban_block_kinds.py -q` → **19 passed**
- CLI smoke with temp `HERMES_HOME`: worker env attempted `hermes kanban unblock <needs_input>` → refusal printed, task remained `blocked needs_input`; Main/default unblocked same task → `ready needs_input`

## Non-blocking note

`hermes_cli.main` does not currently propagate subcommand return codes to the shell process exit status (pre-existing broader behavior). The `_cmd_unblock` handler returns non-zero correctly on refusal; the shell exit code may still read 0. The security guard itself works — mutation is prevented regardless. Separate CLI return-code cleanup if desired.