### PR TITLE
fix(tools): add timeout to post-kill proc.wait() in voice playback

### DIFF
--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1106,7 +1106,7 @@ def play_audio_file(file_path: str) -> bool:
             except subprocess.TimeoutExpired:
                 logger.warning("System player %s timed out, killing process", cmd[0])
                 proc.kill()
-                proc.wait()
+                proc.wait(timeout=10)
                 with _playback_lock:
                     _active_playback = None
             except Exception as e:


### PR DESCRIPTION
## Summary

Add a 10-second timeout to `proc.wait()` after `proc.kill()` in `_playback_system()` (tools/voice_mode.py).

## Problem

At `tools/voice_mode.py:1109`, after the audio player times out (300s) and is killed via `proc.kill()`, the subsequent `proc.wait()` call has no timeout. On macOS/FreeBSD a killed process can become a zombie that isn't reaped promptly, causing `proc.wait()` to block indefinitely and hang the entire agent turn.

## Fix

Change `proc.wait()` to `proc.wait(timeout=10)`. If the process still hasn't exited 10 seconds after SIGKILL, the exception propagates but at least the agent turn isn't permanently blocked.

## Testing
- Syntax check passed (py_compile)
- Behavior verified: `proc.wait(timeout=10)` is valid on Python 3.3+ and will raise `subprocess.TimeoutExpired` if the zombie isn't reaped within 10s.