### PR TITLE
fix(contributor-attribution): add fix@bot.dev to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1901,6 +1901,7 @@ AUTHOR_MAP = {
     "yosapol@jitrak.dev": "Eji4h",  # direct email match
     "kiljadn@gmail.com": "designnotdrum",  # PR #56480 salvage (toolset static-inference fix)
     "lavya@loom.local": "LavyaTandel",  # PR #57893 salvage local git identity (envelope-layout cache markers on tool/empty-assistant messages; #57845)
+    "fix@bot.dev": "indigokarasu",  # Fix Bot - Indigo Karasu auto-fix tool
 }
 
 


### PR DESCRIPTION
Fixes Contributor Attribution Check failure for Fix Bot commits.

The Fix Bot email (fix@bot.dev) was not mapped in AUTHOR_MAP,
causing the check-attribution workflow to fail on PRs with Fix Bot commits.
This maps it to indigokarasu (Indigo Karasu) who owns the auto-fix tool.