### PR TITLE
fix(test): clear ambient HERMES_REAL_HOME in copilot_acp_client test

### DIFF
--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -285,6 +285,7 @@ def test_run_prompt_preserves_real_home_when_profile_home_available(monkeypatch,
     real_home = tmp_path / "real-home"
     real_home.mkdir()
 
+    monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
     monkeypatch.setenv("HOME", str(real_home))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -378,6 +378,10 @@ class TestExtractCacheBustingConfig:
         assert parse_calls == [config_path]
 
         config_path.write_text("{\n  \"changed\": true\n}")
+        # Nudge mtime forward so the cache-busting check detects the edit
+        # even on filesystems with coarse (1 s) timestamp resolution.
+        import os as _os, time as _time
+        _os.utime(config_path, (_time.time() + 2, _time.time() + 2))
         third = GatewayRunner._extract_honcho_cache_busting_config()
 
         assert third == first


### PR DESCRIPTION
## Summary

Fixes two test flakes caused by ambient environment / filesystem timing issues.

### Fix 1: HERMES_REAL_HOME env leak (`test_copilot_acp_client.py`)

`test_run_prompt_preserves_real_home_when_profile_home_available` sets `HOME` and `HERMES_HOME` via `monkeypatch.setenv` but does **not** clear the ambient `HERMES_REAL_HOME`. The production code in `_iter_real_home_candidates()` reads `HERMES_REAL_HOME` via `os.getenv()` as a fallback, so when the host shell has this variable set (common during normal hermes usage), the test compares against the host path instead of the test fixture path.

**Fix:** Add `monkeypatch.delenv("HERMES_REAL_HOME", raising=False)` — the same pattern used by `test_run_prompt_passes_home_when_parent_env_is_clean` in the same file.

### Fix 2: Coarse mtime resolution (`test_agent_cache.py`)

`test_honcho_cache_busting_config_memoized_by_mtime` writes to a config file and expects the mtime-based cache-busting check to detect the edit. On filesystems with coarse (1 s) timestamp resolution, `write_text()` may not advance the mtime, causing the second parse to be skipped.

**Fix:** Add `os.utime()` with a +2 s offset after the write — the pattern documented in `hermes-agent-test-pitfalls.md`.

## Test Results

```
tests/agent/test_copilot_acp_client.py::test_run_prompt_preserves_real_home_when_profile_home_available PASSED
tests/gateway/test_agent_cache.py::TestExtractCacheBustingConfig::test_honcho_cache_busting_config_memoized_by_mtime PASSED
```

## Before / After

```
# Fix 1 - Before (HERMES_REAL_HOME=/home/tony in shell):
AssertionError: assert '/home/tony' == '/tmp/pytest-.../real-home'

# Fix 2 - Before (coarse mtime):
AssertionError: assert [PosixPath('...')] == [PosixPath('...'), PosixPath('...')]

# After: 2 passed
```
