### PR TITLE
fix(model-switch): merge configured models with live /models discovery instead of replacing

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2057,7 +2057,11 @@ def list_authenticated_providers(
                         headers=_extra_headers_from_config(ep_cfg) or None,
                     )
                     if live_models:
-                        models_list = live_models
+                        # Merge: keep configured models not in live
+                        # response, then append live-only models.
+                        _live_set = {m.lower() for m in live_models}
+                        _extras = [m for m in models_list if m.lower() not in _live_set]
+                        models_list = _extras + live_models
                 except Exception:
                     pass
 
@@ -2328,8 +2332,19 @@ def list_authenticated_providers(
                         headers=grp.get("extra_headers") or None,
                     )
                     if live_models:
-                        grp["models"] = live_models
-                        grp["total_models"] = len(live_models)
+                        # Merge configured models with live discovery:
+                        # keep explicitly configured models (from the
+                        # ``models:`` dict) that aren't in the live
+                        # response, then append live-only models.  This
+                        # prevents router/combo endpoints from losing
+                        # user-declared models that the /v1/models
+                        # endpoint omits (e.g. aliases, custom names).
+                        _configured = list(grp["models"])
+                        _live_set = {m.lower() for m in live_models}
+                        _extras = [m for m in _configured if m.lower() not in _live_set]
+                        merged = _extras + live_models
+                        grp["models"] = merged
+                        grp["total_models"] = len(merged)
                 except Exception:
                     pass
             results.append({

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -108,7 +108,7 @@ def test_list_authenticated_providers_can_probe_only_current_custom_provider(mon
     offline = next(p for p in providers if p["slug"] == "custom:offline-proxy")
     assert calls == ["http://active.local/v1"]
     assert active["is_current"] is True
-    assert active["models"] == ["active-a", "active-b"]
+    assert active["models"] == ["configured-active", "active-a", "active-b"]
     assert offline["models"] == ["configured-offline"]
 
 


### PR DESCRIPTION
## Summary

When a `custom_providers` entry declares models in its `models:` dict and live `/v1/models` discovery succeeds, the code previously **replaced** the entire list with the live response. Router/combo endpoints (e.g. 9router, LiteLLM, OpenRouter-style proxies) expose many models via `/v1/models`, but users also declare specific models for context-length overrides or aliases. The live endpoint may omit those declared models, silently dropping them from the picker.

This fix changes the behavior to **merge**: explicitly configured models that aren't in the live response are preserved, then live-only models are appended. This applies to both Section 3 (user `providers:` entries) and Section 4 (`custom_providers` entries) in `list_authenticated_providers()`.

## Test Plan

- [x] All 35 tests in `tests/hermes_cli/test_model_switch_custom_providers.py` pass
- [x] All 38 tests in `tests/hermes_cli/test_inventory.py` pass
- [x] All 12 tests in `tests/hermes_cli/test_custom_provider_context_length.py` pass

## Before / After

**Before:** Config declares `models: {my_combo: ..., nvidia/z-ai/glm-5.2: ..., 1/claude-sonnet-5: ...}`. Live `/v1/models` returns `[gpt-4, claude-3, ...]`. Result: `[gpt-4, claude-3, ...]` — configured models lost.

**After:** Result: `[my_combo, nvidia/z-ai/glm-5.2, 1/claude-sonnet-5, gpt-4, claude-3, ...]` — configured models preserved + live models added.

Closes #59560