### PR TITLE
fix(install): raise Python ceiling to <3.15 for Python 3.14 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,15 @@ name = "hermes-agent"
 version = "0.18.0"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
-# Upper bound is load-bearing, not cosmetic. uv resolves the project's
+# Upper bound is load-bearing, not cosmetic.  uv resolves the project's
 # Python from `requires-python`, and an inherited `UV_PYTHON` env var (or a
 # fresh distro whose newest interpreter uv auto-picks) will otherwise select
-# 3.14, where Rust-backed transitives (e.g. pydantic-core) have no cp314
-# wheel yet and fall back to a maturin source build that fails. Capping at
-# <3.14 makes uv refuse 3.14 with a clear error instead of attempting that
-# build. Raise the ceiling once our Rust transitives ship cp314 wheels.
-requires-python = ">=3.11,<3.14"
+# 3.14+, where Rust-backed transitives (e.g. pydantic-core) historically had
+# no cp314 wheel and fell back to a maturin source build that failed.  As of
+# 2026-07 pydantic-core 2.46.4, Pillow 12.2.0, and cryptography 46.0.7 all
+# ship cp314 wheels, so the ceiling is raised to <3.15.  Bump again once
+# cp315 wheels ship for the Rust transitives.
+requires-python = ">=3.11,<3.15"
 authors = [{ name = "Nous Research" }]
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary

Rust-backed transitives (pydantic-core 2.46.4, Pillow 12.2.0, cryptography 46.0.7) now ship `cp314` wheels on PyPI, so the `requires-python` ceiling can be safely raised from `<3.14` to `<3.15`.

This unblocks installation on systems that ship Python 3.14 by default (e.g. Termux 0.118.3 with Python 3.14.6), where the previous `<3.14` cap caused:

```
ERROR: Package 'hermes-agent' requires a different Python: 3.14.6 not in '<3.14,>=3.11'
```

## Verification

Confirmed cp314 wheel availability via `pip download`:

| Package | Version | cp314 wheel |
|---------|---------|-------------|
| pydantic-core | 2.46.4 | `cp314-cp314-manylinux_2_17_x86_64` ✓ |
| Pillow | 12.2.0 | `cp314-cp314-manylinux2014_x86_64` ✓ |
| cryptography | 46.0.7 | `cp311-abi3` (abi3-compatible) ✓ |

Closes #59877