### PR TITLE
fix(desktop): add NSContactsUsageDescription + contacts entitlement for macOS

### DIFF
--- a/apps/desktop/electron/entitlements.mac.inherit.plist
+++ b/apps/desktop/electron/entitlements.mac.inherit.plist
@@ -10,5 +10,7 @@
   <true/>
   <key>com.apple.security.device.audio-input</key>
   <true/>
+  <key>com.apple.security.contacts</key>
+  <true/>
 </dict>
 </plist>

--- a/apps/desktop/electron/entitlements.mac.plist
+++ b/apps/desktop/electron/entitlements.mac.plist
@@ -10,5 +10,7 @@
   <true/>
   <key>com.apple.security.device.audio-input</key>
   <true/>
+  <key>com.apple.security.contacts</key>
+  <true/>
 </dict>
 </plist>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -204,6 +204,8 @@
         "CFBundleExecutable": "Hermes",
         "CFBundleName": "Hermes",
         "NSAudioCaptureUsageDescription": "Hermes uses audio capture for voice conversations.",
+        "NSContactsUsageDescription": "Hermes accesses your contacts to manage address book entries and contact-related notes.",
+        "NSAppleEventsUsageDescription": "Hermes writes notes to contact records in your address book.",
         "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations."
       },
       "gatekeeperAssess": false,


### PR DESCRIPTION
## Summary

The Hermes desktop app silently fails when trying to read/write macOS Contacts because it lacks the required privacy entitlements and usage descriptions. Without `NSContactsUsageDescription` in Info.plist, macOS never shows the permission prompt — tools just report 'denied'.

This adds:
- `com.apple.security.contacts` entitlement to both `entitlements.mac.plist` and `entitlements.mac.inherit.plist`
- `NSContactsUsageDescription` to the Info.plist `extendInfo`
- `NSAppleEventsUsageDescription` for the contacts notes field

## Changes

| File | Change |
|------|--------|
| `electron/entitlements.mac.plist` | Added `com.apple.security.contacts` entitlement |
| `electron/entitlements.mac.inherit.plist` | Added `com.apple.security.contacts` entitlement |
| `package.json` | Added `NSContactsUsageDescription` and `NSAppleEventsUsageDescription` |

## Testing

- Verified plist XML is well-formed
- Verified package.json is valid JSON
- Matches the pattern of existing entitlements (NSMicrophoneUsageDescription + com.apple.security.device.audio-input)

Closes #59482