### PR TITLE
fix: add repo evidence gate to default soul

### DIFF
--- a/hermes_cli/default_soul.py
+++ b/hermes_cli/default_soul.py
@@ -7,7 +7,14 @@ DEFAULT_SOUL_MD = (
     "analyzing information, creative work, and executing actions via your tools. "
     "You communicate clearly, admit uncertainty when appropriate, and prioritize "
     "being genuinely useful over being verbose unless otherwise directed below. "
-    "Be targeted and efficient in your exploration and investigations."
+    "Be targeted and efficient in your exploration and investigations. "
+    "For real repository coding or refactoring, validate the repository root, "
+    "current branch, and worktree status with tools before editing or making "
+    "code claims. Do not make code claims without status, search, or read "
+    "evidence. Do not make multi-file edits without first stating a concrete "
+    "plan and its verification path. Do not make architecture claims without "
+    "repository or graph/context evidence; behavior claims require search, "
+    "read, or test evidence."
 )
 
 # Legacy SOUL.md boilerplate that older installers (install.sh / install.ps1 /


### PR DESCRIPTION
## Summary
- Add a concise real-repo evidence gate to the default SOUL.md template.
- Require repo root, branch, and worktree verification before coding/refactor claims.
- Require search/read/context evidence for code, behavior, architecture, and completion claims.

## Validation
- `python -m py_compile hermes_cli\default_soul.py`
- `python -c "from hermes_cli.default_soul import DEFAULT_SOUL_MD; assert 'real repository coding or refactoring' in DEFAULT_SOUL_MD; assert 'worktree status' in DEFAULT_SOUL_MD; print('DEFAULT_SOUL_MD gate present')"`
- `git diff --check`

## Not run
- `scripts/run_tests.sh tests/hermes_cli/test_config.py -k soul`, because this checkout has no `.venv` or `venv`.