### PR TITLE
fix(agent): surface blocked AGENTS.md warning to user and remove mythic false positive

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -57,6 +57,11 @@ def _scan_context_content(content: str, filename: str) -> str:
     findings = _scan_for_threats(content, scope="context")
     if findings:
         logger.warning("Context file %s blocked: %s", filename, ", ".join(findings))
+        msg = (
+            f"WARNING: {filename} blocked by threat scanner ({', '.join(findings)}). "
+            f"Content not loaded into system prompt. Review the file or add an exception."
+        )
+        _record_truncation_warning(msg)
         return f"[BLOCKED: {filename} contained potential prompt injection ({', '.join(findings)}). Content not loaded.]"
 
     return content

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -112,7 +112,7 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     # blocked. "praxis" was removed for exactly this reason — it's a common
     # word and a legitimate agent name (Greek for practice/action), not a
     # C2-specific tell like the brands below.
-    (r'\b(?:cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
+    (r'\b(?:cobalt\s*strike|sliver|havoc|metasploit|brainworm)\b', "known_c2_framework", "context"),
     (r'\bc2\s+(?:server|channel|infrastructure|beacon)\b', "c2_explicit", "context"),
     (r'\bcommand\s+and\s+control\b', "c2_explicit_long", "context"),
 


### PR DESCRIPTION
## Summary

When the threat-scanner blocks a project context file (AGENTS.md, CLAUDE.md, .cursorrules), the user receives **no notification** — only a `logger.warning` to the log file. The content is silently replaced with `[BLOCKED: ...]` in the system prompt, invisible to the user.

Additionally, `\bmythic\b` in the C2 framework regex causes false positives on legitimate content mentioning "Mythic" (a well-known RPG product, Mythic Game Master Emulator).

## Changes

### 1. User notification for blocked files (`agent/prompt_builder.py`)

When `_scan_context_content()` blocks a file, it now calls `_record_truncation_warning()` so the warning is surfaced to the user via the existing `drain_truncation_warnings()` → `_emit_status()` pipeline — the same mechanism already used for truncation warnings.

**Before:** Only `logger.warning()` → goes to log file, user never sees it.
**After:** `logger.warning()` + `_record_truncation_warning()` → user sees the warning.

### 2. Remove `mythic` false positive (`tools/threat_patterns.py`)

Removed `mythic` from the `known_c2_framework` regex. The comment on lines 109-114 already warns against adding common English words — `praxis` was removed for exactly this reason. "Mythic" is a common English word and the name of a well-known RPG product (Mythic Game Master Emulator).

## Files Changed

| File | Δ | Description |
|------|---|-------------|
| `agent/prompt_builder.py` | +5 lines | Add `_record_truncation_warning()` call when blocking context files |
| `tools/threat_patterns.py` | -1 token | Remove `mythic` from C2 framework regex |

## Verification

- `_record_truncation_warning()` is defined and exported in the same module (`prompt_builder.py:1232`), no import needed
- `_emit_status()` already consumes `drain_truncation_warnings()` output — the pipeline is fully wired
- `mythic` removal matches the existing pattern for `praxis` removal documented in the comment

Closes #59612