### PR TITLE
feat(browser): inherit global proxy config as --proxy-server (#59773)

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2415,6 +2415,29 @@ def _run_browser_command(
                     "--no-sandbox,--disable-dev-shm-usage"
                 )
 
+        # Inherit global proxy config for the browser engine (#59773).
+        if "--proxy-server=" not in browser_env.get("AGENT_BROWSER_ARGS", ""):
+            try:
+                from hermes_cli.config import read_raw_config
+
+                proxy_url = read_raw_config().get("proxy")
+                if proxy_url:
+                    existing = browser_env.get("AGENT_BROWSER_ARGS", "")
+                    if existing:
+                        browser_env["AGENT_BROWSER_ARGS"] = (
+                            f"{existing},--proxy-server={proxy_url}"
+                        )
+                    else:
+                        browser_env["AGENT_BROWSER_ARGS"] = (
+                            f"--proxy-server={proxy_url}"
+                        )
+                    logger.debug(
+                        "browser: inherited proxy config as --proxy-server=%s",
+                        proxy_url,
+                    )
+            except Exception:
+                pass  # No config available — skip proxy injection
+
         # Use temp files for stdout/stderr instead of pipes.
         # agent-browser starts a background daemon that inherits file
         # descriptors.  With capture_output=True (pipes), the daemon keeps


### PR DESCRIPTION
## Summary

When `proxy: http://127.0.0.1:3067` is set in `config.yaml`, HTTP tools (web_search, web_extract) correctly use it — but the browser engine doesn't. This makes the browser unusable behind proxies.

## Change

In `_run_browser_command()`, after the `--no-sandbox` injection, read the global `proxy` config and pass it as `--proxy-server` to Chromium.

- Does **not** override user-specified `AGENT_BROWSER_ARGS` if `--proxy-server=` is already present
- Adds a `try/except` guard so missing/broken config doesn't crash the browser
- Logs at debug level when proxy inheritance activates

## Files Changed

| File | Δ | 
|------|---|
| `tools/browser_tool.py` | +23 lines |

Closes #59773