### PR TITLE
feat(cron): add executions prune/clear CLI commands (#59909)

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -451,6 +451,70 @@ def cron_command(args):
     if subcmd in {"remove", "rm", "delete"}:
         return _job_action("remove", args.job_id, "Removed")
 
+    if subcmd == "executions":
+        return _cron_executions(args)
+
     print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick]")
+    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick|executions]")
     sys.exit(1)
+
+
+def _cron_executions(args):
+    """Handle cron executions subcommands (prune/clear)."""
+    import shutil
+    import time
+    import re
+
+    cron_output_dir = Path.home() / ".hermes" / "cron" / "output"
+    if not cron_output_dir.exists():
+        print("No cron execution history found.")
+        return 0
+
+    subcmd = getattr(args, "cron_exec_command", None)
+
+    if subcmd == "prune":
+        # Parse --older-than (e.g. "7d", "30d")
+        match = re.match(r"^(\d+)([dhms])$", args.older_than)
+        if not match:
+            print(f"Invalid format: {args.older_than}. Use e.g. '7d', '30d'.")
+            return 1
+        value, unit = int(match.group(1)), match.group(2)
+        multipliers = {"d": 86400, "h": 3600, "m": 60, "s": 1}
+        cutoff = time.time() - (value * multipliers[unit])
+
+        deleted = 0
+        for job_dir in sorted(cron_output_dir.iterdir()):
+            if job_dir.is_dir():
+                for f in sorted(job_dir.iterdir()):
+                    if f.is_file() and f.stat().st_mtime < cutoff:
+                        f.unlink()
+                        deleted += 1
+                # Remove empty job directories
+                if not any(job_dir.iterdir()):
+                    job_dir.rmdir()
+
+        print(f"Deleted {deleted} execution file(s) older than {args.older_than}.")
+        return 0
+
+    if subcmd == "clear":
+        if args.all:
+            for job_dir in sorted(cron_output_dir.iterdir()):
+                if job_dir.is_dir():
+                    shutil.rmtree(job_dir)
+            print("Cleared all cron execution history.")
+            return 0
+
+        if args.job_id:
+            job_dir = cron_output_dir / args.job_id
+            if not job_dir.exists():
+                print(f"No execution history found for job '{args.job_id}'.")
+                return 1
+            shutil.rmtree(job_dir)
+            print(f"Cleared execution history for job '{args.job_id}'.")
+            return 0
+
+        print("Specify --job-id <id> or --all.")
+        return 1
+
+    print("Usage: hermes cron executions [prune --older-than 7d | clear --job-id <id> | clear --all]")
+    return 1

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -159,5 +159,27 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     # cron tick (mostly for debugging)
     cron_tick = cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
     add_accept_hooks_flag(cron_tick)
+    # cron executions
+    cron_exec = cron_subparsers.add_parser(
+        "executions", help="Manage cron job execution history"
+    )
+    exec_subparsers = cron_exec.add_subparsers(dest="cron_exec_command")
+
+    # executions prune
+    exec_prune = exec_subparsers.add_parser(
+        "prune", help="Delete execution output older than N days"
+    )
+    exec_prune.add_argument(
+        "--older-than", required=True,
+        help="Age threshold (e.g. '7d', '30d', '90d')"
+    )
+
+    # executions clear
+    exec_clear = exec_subparsers.add_parser(
+        "clear", help="Clear execution history for a job or all jobs"
+    )
+    exec_clear.add_argument("--job-id", help="Clear history for a specific job ID")
+    exec_clear.add_argument("--all", action="store_true", help="Clear all execution history")
+
     add_accept_hooks_flag(cron_parser)
     cron_parser.set_defaults(func=cmd_cron)


### PR DESCRIPTION
## Summary

Cron job execution history accumulates indefinitely under `~/.hermes/cron/output/<job_id>/`, with no way to clean it. This adds CLI commands to manage it.

## Changes

### `hermes cron executions prune --older-than 7d`

Deletes execution output files older than N days/hours/minutes/seconds. Useful for automated cleanup (can be run as a cron job itself).

### `hermes cron executions clear --job-id <id>` / `hermes cron executions clear --all`

Clears execution history for a specific job or all jobs.

### Implementation

- **Parser:** `hermes_cli/subcommands/cron.py` — new `executions` subcommand with `prune` and `clear` sub-parsers
- **Handler:** `hermes_cli/cron.py` — `_cron_executions()` function reading from `~/.hermes/cron/output/`
- Gracefully handles missing output directory, invalid `--older-than` format, and non-existent job IDs

## Files Changed

| File | Δ |
|------|---|
| `hermes_cli/subcommands/cron.py` | +22 lines |
| `hermes_cli/cron.py` | +66 lines |

Closes #59909