### PR TITLE
fix(delegate): add default=[] to tasks schema for strict OpenAI backends (#59386)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3340,6 +3340,7 @@ DELEGATE_TASK_SCHEMA = {
             },
             "tasks": {
                 "type": "array",
+                "default": [],
                 "items": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
## Summary

The `tasks` parameter in `delegate_task` schema has `type: array` but is optional (not in `required`). Strict OpenAI-compatible backends reject `null` for array-typed parameters, causing:

```
Invalid schema for function 'delegate_task': null is not of type "array"
```

This is a `BadRequestError` (non-retryable), killing the session immediately on any provider using a strict API proxy.

## Fix

Added `"default": []` to the `tasks` property definition. This tells schema validators to use an empty array when the parameter is omitted — matching the runtime behavior (no tasks = single-goal mode).

## Files Changed

| File | Δ |
|------|---|
| `tools/delegate_tool.py` | +1 line |

Closes #59386