### PR TITLE
fix(moa): add timeout to Future.result() in reference gathering

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
 from typing import Any
 
 from agent.auxiliary_client import call_llm
@@ -380,7 +380,16 @@ def _run_references_parallel(
         # Collect every reference before returning — the aggregator needs the
         # complete set, so there is no early-exit / first-completed path here.
         for future, idx in futures.items():
-            results[idx] = future.result()
+            try:
+                results[idx] = future.result(timeout=300)
+            except FutureTimeout:
+                label = _slot_label(reference_models[idx])
+                logger.warning("MoA reference %s timed out after 300s", label)
+                results[idx] = (
+                    label,
+                    "[timed out: reference model did not respond within 300s]",
+                    _RefAccounting(CanonicalUsage()),
+                )
 
     return [r for r in results if r is not None]
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1106,7 +1106,7 @@ def play_audio_file(file_path: str) -> bool:
             except subprocess.TimeoutExpired:
                 logger.warning("System player %s timed out, killing process", cmd[0])
                 proc.kill()
-                proc.wait()
+                proc.wait(timeout=10)
                 with _playback_lock:
                     _active_playback = None
             except Exception as e:


### PR DESCRIPTION
## Summary

Add a 300s timeout to  in  to prevent indefinite blocking when a reference model hangs.

## Problem

 calls  without a timeout. If a reference model's API call hangs (network issues, provider downtime, or a slow LLM), the entire MoA reference gathering phase blocks indefinitely, freezing the agent turn.

## Fix

- Import  from 
- Add  to 
- Catch  and return a graceful timeout message instead of hanging forever

## Testing
- Syntax check passed (py_compile)
- AST verification: all future.result() calls now have timeout parameter
- Import verified correct via AST parse