### PR TITLE
fix(gateway): don't capture full process argv in shutdown forensics

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20137,7 +20137,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
         # Always log who/what triggered the signal — most useful single
         # line when diagnosing "the gateway keeps dying" tickets.  Format
-        # is one line, key=value, parent_cmdline last (often long).
+        # is one line, key=value, parent_comm last.
         if _shutdown_ctx is not None:
             try:
                 logger.warning(
@@ -20146,7 +20146,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             except Exception as _e:
                 logger.debug("format_context_for_log failed: %s", _e)
 
-            # Spawn the heavyweight diagnostic (ps auxf, pstree, dmesg) in
+            # Spawn the heavyweight diagnostic (ps, pstree, dmesg) in
             # a detached subprocess so it can finish writing to disk even
             # if our cgroup is being torn down.  Bounded by an internal
             # timeout; never blocks the event loop here.

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -58,7 +58,12 @@ def _read_proc_field(pid: int, key: str) -> Optional[str]:
 
 
 def _read_proc_cmdline(pid: int) -> Optional[str]:
-    """Read /proc/<pid>/cmdline as a printable string.  Linux only; None elsewhere."""
+    """Read /proc/<pid>/cmdline as a printable string.  Linux only; None elsewhere.
+
+    NOTE: raw argv can contain secrets (tokens, DB URIs, ``--mcp-config`` blobs).
+    Never write its result into a persisted diagnostic; use :func:`_read_proc_comm`
+    for anything that lands in a log.  Retained for in-memory callers only.
+    """
     try:
         with open(f"/proc/{pid}/cmdline", "rb") as fh:
             data = fh.read()
@@ -70,8 +75,21 @@ def _read_proc_cmdline(pid: int) -> Optional[str]:
     return data.replace(b"\x00", b" ").decode("utf-8", errors="replace").strip()
 
 
+def _read_proc_comm(pid: int) -> Optional[str]:
+    """Read /proc/<pid>/comm — the executable name only, never arguments.
+
+    Safe for persisted diagnostics: identifies *what program* a pid is without
+    exposing the argv (which can carry secrets).  Linux only; None elsewhere.
+    """
+    try:
+        with open(f"/proc/{pid}/comm", encoding="utf-8") as fh:
+            return fh.read().strip()
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
+
+
 def _proc_summary(pid: int) -> Dict[str, Any]:
-    """Compact /proc/<pid> snapshot: pid, ppid, state, uid, cmdline.
+    """Compact /proc/<pid> snapshot: pid, ppid, state, uid, comm.
 
     Best-effort.  Missing fields are simply omitted rather than raising.
     """
@@ -94,10 +112,11 @@ def _proc_summary(pid: int) -> Dict[str, Any]:
     if uid is not None:
         # "real effective saved fs"
         summary["uid"] = uid.split()[0] if uid else uid
-    cmdline = _read_proc_cmdline(pid)
-    if cmdline:
-        # Truncate aggressively — these can be 4KB
-        summary["cmdline"] = cmdline[:300]
+    # Executable name only — never argv, which can carry secrets that would
+    # then be persisted to the (possibly shared) diagnostic log.
+    comm = _read_proc_comm(pid)
+    if comm:
+        summary["comm"] = comm
     return summary
 
 
@@ -229,10 +248,10 @@ def spawn_async_diagnostic(
     script = (
         f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
         "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
-        "echo '--- ps auxf (top 60 by cpu) ---'; "
-        "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
-        "echo '--- pstree of self ---'; "
-        f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
+        "echo '--- ps (top 60 by cpu, comm only — no argv) ---'; "
+        "ps -eo pid,ppid,user,pcpu,pmem,stat,comm --sort=-pcpu 2>/dev/null | head -60; "
+        "echo '--- pstree of self (no args) ---'; "
+        f"pstree -pl {os.getpid()} 2>/dev/null | head -40 || true; "
         "echo '--- /proc/loadavg ---'; "
         "cat /proc/loadavg 2>/dev/null || true; "
         "echo '--- recent dmesg (oom/killed) ---'; "
@@ -244,7 +263,9 @@ def spawn_async_diagnostic(
         # Open the log file in append mode and let the subprocess inherit.
         # We use os.O_APPEND so concurrent diagnostics from rapid signals
         # don't trample each other.
-        fd = os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        # 0o600: the diagnostic must not be world-readable — it still names
+        # processes/users and sits in a shared logs dir.
+        fd = os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
     except OSError:
         return None
 
@@ -282,7 +303,8 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     """Render a shutdown context dict as a single, scannable log line."""
     sig = ctx.get("signal", "?")
     parent = ctx.get("parent") or {}
-    parent_cmd = parent.get("cmdline", "(unknown)")
+    # comm (executable name), not cmdline — argv can carry secrets.
+    parent_comm = parent.get("comm") or "(unknown)"
     parent_name = parent.get("name") or "?"
     parent_pid = parent.get("pid") or "?"
     under_systemd = "yes" if ctx.get("under_systemd") else "no"
@@ -299,7 +321,7 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     if ctx.get("tracer_pid"):
         extras.append(f"tracer_pid={ctx['tracer_pid']}")
     extras_str = (" " + " ".join(extras)) if extras else ""
-    # Parent cmdline is the most useful single signal — log it prominently.
+    # Parent executable name is the most useful non-sensitive single signal.
     return (
         f"signal={sig} "
         f"under_systemd={under_systemd} "
@@ -307,7 +329,7 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
         f"parent_name={parent_name} "
         f"loadavg_1m={load_str}"
         f"{extras_str} "
-        f"parent_cmdline={parent_cmd!r}"
+        f"parent_comm={parent_comm!r}"
     )
 
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -31,6 +31,7 @@ import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { createInboundWebhook, resolveSenderPhone } from './inbound_webhook.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
@@ -107,6 +108,14 @@ const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   ? DEFAULT_REPLY_PREFIX
   : process.env.WHATSAPP_REPLY_PREFIX.replace(/\\n/g, '\n');
 const MAX_MESSAGE_LENGTH = parseInt(process.env.WHATSAPP_MAX_MESSAGE_LENGTH || '4096', 10);
+// Deterministic routing for campaign replies: senders on the server-provided
+// numbers list are forwarded to an operator webhook instead of being dropped,
+// and are NEVER enqueued for the agent. See inbound_webhook.js.
+const inboundWebhook = createInboundWebhook({
+  url: process.env.WHATSAPP_INBOUND_WEBHOOK_URL,
+  numbersUrl: process.env.WHATSAPP_INBOUND_WEBHOOK_NUMBERS_URL,
+  secret: process.env.WHATSAPP_INBOUND_WEBHOOK_SECRET,
+});
 const CHUNK_DELAY_MS = parseInt(process.env.WHATSAPP_CHUNK_DELAY_MS || '300', 10);
 // Per-call timeout for sock.sendMessage(). Baileys occasionally hangs forever
 // when uploading media to WhatsApp servers (and, less often, on text sends),
@@ -360,6 +369,58 @@ function rememberSentId(id) {
 let sock = null;
 let connectionState = 'disconnected';
 
+function extractEventFrom(msg, { chatId, senderId, senderNumber, botIds, isGroup }) {
+  return extractBridgeEvent({
+    msg,
+    chatId,
+    senderId,
+    senderNumber,
+    botIds,
+    isGroup,
+    downloadMedia: async (mediaMsg) => downloadMediaMessage(mediaMsg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage }),
+    cacheDirs: {
+      image: IMAGE_CACHE_DIR,
+      document: DOCUMENT_CACHE_DIR,
+      audio: AUDIO_CACHE_DIR,
+    },
+  });
+}
+
+/**
+ * Forwards a non-agent sender's message to the inbound webhook when the sender
+ * is on the server's numbers list. Returns true when the message was consumed
+ * (forwarded, empty, or failed-and-logged) — a matched sender must never fall
+ * through to any other handling, so every outcome past the match is terminal.
+ */
+async function routeToInboundWebhook(msg, { chatId, senderId, senderNumber, botIds, isGroup }) {
+  if (!inboundWebhook.enabled || isGroup || chatId.includes('@broadcast') || chatId.includes('status')) {
+    return false;
+  }
+  const phone = resolveSenderPhone(msg, senderId, lidToPhone);
+  if (!(await inboundWebhook.shouldForward(phone))) {
+    return false;
+  }
+  try {
+    const event = await extractEventFrom(msg, { chatId, senderId, senderNumber, botIds, isGroup });
+    if (!event.body && !event.hasMedia) {
+      return true;
+    }
+    await inboundWebhook.forward({
+      from: phone,
+      text: event.body,
+      mediaUrls: event.mediaUrls,
+      mime: event.mime,
+      fileName: event.fileName,
+    });
+    try {
+      console.log(JSON.stringify({ event: 'forwarded', reason: 'inbound_webhook', chatId }));
+    } catch {}
+  } catch (err) {
+    console.warn('[bridge] inbound webhook forward failed:', err?.message || err);
+  }
+  return true;
+}
+
 async function startSocket() {
   const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
   const { version } = await fetchLatestBaileysVersion();
@@ -557,6 +618,7 @@ async function startSocket() {
       // to arbitrary incoming messages (#8389).
       if (!msg.key.fromMe) {
         if (WHATSAPP_MODE === 'self-chat') {
+          if (await routeToInboundWebhook(msg, { chatId, senderId, senderNumber, botIds, isGroup })) continue;
           try {
             console.log(JSON.stringify({
               event: 'ignored',
@@ -568,6 +630,7 @@ async function startSocket() {
           continue;
         }
         if (!matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+          if (await routeToInboundWebhook(msg, { chatId, senderId, senderNumber, botIds, isGroup })) continue;
           try {
             console.log(JSON.stringify({
               event: 'ignored',
@@ -640,20 +703,7 @@ async function startSocket() {
         continue;
       }
 
-      const event = await extractBridgeEvent({
-        msg,
-        chatId,
-        senderId,
-        senderNumber,
-        botIds,
-        isGroup,
-        downloadMedia: async (mediaMsg) => downloadMediaMessage(mediaMsg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage }),
-        cacheDirs: {
-          image: IMAGE_CACHE_DIR,
-          document: DOCUMENT_CACHE_DIR,
-          audio: AUDIO_CACHE_DIR,
-        },
-      });
+      const event = await extractEventFrom(msg, { chatId, senderId, senderNumber, botIds, isGroup });
       event.fromOwner = fromOwner;
 
       // Ignore Hermes' own reply messages in self-chat mode to avoid loops.
@@ -993,6 +1043,7 @@ app.get('/health', (req, res) => {
     queueLength: messageQueue.length,
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
+    inboundWebhook: inboundWebhook.enabled,
   });
 });
 
@@ -1018,6 +1069,10 @@ if (PAIR_ONLY) {
     }
     if (WHATSAPP_MODE === 'bot' && FORWARD_OWNER_MESSAGES) {
       console.log(`👤 WHATSAPP_FORWARD_OWNER_MESSAGES=true — owner-typed messages will be forwarded with fromOwner:true`);
+    }
+    if (inboundWebhook.enabled) {
+      inboundWebhook.start();
+      console.log(`📮 Inbound webhook routing enabled — listed campaign senders are forwarded, never agent-processed.`);
     }
     console.log();
     startSocket();

--- a/scripts/whatsapp-bridge/inbound_webhook.js
+++ b/scripts/whatsapp-bridge/inbound_webhook.js
@@ -1,0 +1,193 @@
+/**
+ * Inbound webhook routing for the WhatsApp bridge.
+ *
+ * Some deployments send outbound campaigns (through POST /send) to people who
+ * must be able to reply in the same chat without ever reaching the agent. The
+ * allowlist is the gate on who may instruct the agent, so those senders can
+ * never be added to it. This module gives their messages somewhere safe to go
+ * instead: a deterministic HTTP forward to an operator controlled webhook,
+ * decided purely by sender number, with no model anywhere in the path.
+ *
+ * The server behind `numbersUrl` decides who is routable. It returns
+ * `{ tails: ["<digits>", ...] }` and a sender matches when its phone number
+ * ends with one of the tails, so the server controls match length and the
+ * bridge never holds full foreign numbers longer than a refresh interval.
+ * The list refreshes on an interval and once per cooldown on a miss, so a
+ * number that just entered a campaign is picked up within a message or two.
+ *
+ * Off unless `url` is configured. Wire from env in bridge.js:
+ *   WHATSAPP_INBOUND_WEBHOOK_URL          POST target for matched messages
+ *   WHATSAPP_INBOUND_WEBHOOK_NUMBERS_URL  GET, returns { tails: [] }
+ *   WHATSAPP_INBOUND_WEBHOOK_SECRET       sent as x-hermes-key on both calls
+ *
+ * POST body: { from, text, attachments: [{ name, contentType, contentB64 }] }.
+ * A 404 from the webhook means "no open conversation for this number" and is
+ * not an error; the message is simply not stored server side.
+ */
+
+import { readFileSync, unlinkSync } from 'fs';
+import path from 'path';
+
+const REFRESH_MS = 30000;
+const MISS_COOLDOWN_MS = 10000;
+const REQUEST_TIMEOUT_MS = 20000;
+const MAX_ATTACHMENT_BYTES = 12 * 1024 * 1024;
+
+/**
+ * The sender's real phone number as bare digits.
+ *
+ * WhatsApp increasingly addresses chats by an opaque @lid instead of the phone
+ * number. Baileys exposes the underlying number as senderPn / participantPn
+ * when that happens, and the bridge keeps a LID to phone map from the session
+ * files as a fallback. An unmapped LID resolves to '' rather than leaking LID
+ * digits that would never match a phone tail.
+ */
+export function resolveSenderPhone(msg, senderId, lidToPhone = {}) {
+  for (const candidate of [msg?.key?.senderPn, msg?.key?.participantPn]) {
+    if (typeof candidate === 'string' && candidate.endsWith('@s.whatsapp.net')) {
+      return candidate.replace(/\D/g, '');
+    }
+  }
+  const bare = String(senderId || '').replace(/:.*@/, '@');
+  const digits = bare.replace(/@.*/, '').replace(/\D/g, '');
+  if (bare.endsWith('@lid')) {
+    return lidToPhone[digits] || '';
+  }
+  return digits;
+}
+
+export function createInboundWebhook({
+  url = '',
+  numbersUrl = '',
+  secret = '',
+  refreshMs = REFRESH_MS,
+  missCooldownMs = MISS_COOLDOWN_MS,
+  requestTimeoutMs = REQUEST_TIMEOUT_MS,
+  maxAttachmentBytes = MAX_ATTACHMENT_BYTES,
+  fetchImpl = fetch,
+  now = Date.now,
+  readFile = readFileSync,
+  unlink = unlinkSync,
+  log = console,
+} = {}) {
+  const enabled = Boolean(url && numbersUrl && secret);
+
+  let tails = [];
+  let lastRefreshAttempt = -Infinity;
+  let timer = null;
+
+  const headers = { 'x-hermes-key': secret };
+
+  async function refresh() {
+    // Stamped before the request so a failing server is retried at the
+    // cooldown pace, not once per incoming message.
+    lastRefreshAttempt = now();
+    try {
+      const response = await fetchImpl(numbersUrl, {
+        headers,
+        signal: AbortSignal.timeout(requestTimeoutMs),
+      });
+      if (!response.ok) {
+        return;
+      }
+      const body = await response.json();
+      if (Array.isArray(body?.tails)) {
+        tails = body.tails.map((tail) => String(tail).replace(/\D/g, '')).filter(Boolean);
+      }
+    } catch (err) {
+      // Keep the previous set rather than opening up or going silent on a blip.
+      try {
+        log.warn(`[bridge] inbound webhook numbers refresh failed: ${err?.message || err}`);
+      } catch {}
+    }
+  }
+
+  function matches(phone) {
+    return tails.some((tail) => phone.endsWith(tail));
+  }
+
+  /**
+   * Whether a sender's messages should be forwarded instead of dropped.
+   * On a miss, refreshes the list once per cooldown window and rechecks, so
+   * a number contacted moments ago is not lost to a stale list.
+   */
+  async function shouldForward(phone) {
+    if (!enabled || !phone) {
+      return false;
+    }
+    if (matches(phone)) {
+      return true;
+    }
+    if (now() - lastRefreshAttempt < missCooldownMs) {
+      return false;
+    }
+    await refresh();
+    return matches(phone);
+  }
+
+  function collectAttachments(mediaUrls, mime, fileName) {
+    const attachments = [];
+    for (const filePath of mediaUrls || []) {
+      try {
+        const buffer = readFile(filePath);
+        if (buffer.length > maxAttachmentBytes) {
+          log.warn(`[bridge] inbound webhook attachment skipped, ${buffer.length} bytes exceeds the limit`);
+          continue;
+        }
+        attachments.push({
+          name: fileName || path.basename(filePath),
+          contentType: mime || 'application/octet-stream',
+          contentB64: buffer.toString('base64'),
+        });
+      } catch (err) {
+        log.warn(`[bridge] inbound webhook could not read ${filePath}: ${err?.message || err}`);
+      }
+    }
+    return attachments;
+  }
+
+  /**
+   * Forwards one message. Throws when the webhook is unreachable or errors, so
+   * the caller can log the loss; a 404 (no open conversation) is a normal
+   * outcome. Media files are deleted after the webhook has answered — they
+   * belong to the campaign owner, not to this machine's caches.
+   */
+  async function forward({ from, text = '', mediaUrls = [], mime = '', fileName = '' }) {
+    const attachments = collectAttachments(mediaUrls, mime, fileName);
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from, text, attachments }),
+      signal: AbortSignal.timeout(requestTimeoutMs),
+    });
+    if (!response.ok && response.status !== 404) {
+      throw new Error(`inbound webhook returned ${response.status}`);
+    }
+    for (const filePath of mediaUrls || []) {
+      try {
+        unlink(filePath);
+      } catch {}
+    }
+    return { stored: response.ok };
+  }
+
+  function start() {
+    if (!enabled || timer) {
+      return;
+    }
+    refresh();
+    timer = setInterval(refresh, refreshMs);
+    if (typeof timer.unref === 'function') {
+      timer.unref();
+    }
+  }
+
+  function stop() {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  return { enabled, shouldForward, forward, refresh, start, stop };
+}

--- a/scripts/whatsapp-bridge/inbound_webhook.test.mjs
+++ b/scripts/whatsapp-bridge/inbound_webhook.test.mjs
@@ -1,0 +1,171 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInboundWebhook, resolveSenderPhone } from './inbound_webhook.js';
+
+function jsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
+function makeWebhook(overrides = {}) {
+  const calls = { fetches: [], unlinked: [] };
+  let clock = 0;
+  const webhook = createInboundWebhook({
+    url: 'https://backend.example/inbound',
+    numbersUrl: 'https://backend.example/numbers',
+    secret: 's3cret',
+    fetchImpl: async (target, options = {}) => {
+      calls.fetches.push({ target, options });
+      return overrides.respond
+        ? overrides.respond(target, options)
+        : jsonResponse({ tails: ['501111111'] });
+    },
+    now: () => clock,
+    readFile: overrides.readFile || (() => Buffer.from('media-bytes')),
+    unlink: (filePath) => calls.unlinked.push(filePath),
+    log: { warn: () => {} },
+    ...overrides.config,
+  });
+  return { webhook, calls, tick: (ms) => { clock += ms; } };
+}
+
+test('resolveSenderPhone prefers senderPn over the chat id', () => {
+  const msg = { key: { senderPn: '972501111111@s.whatsapp.net' } };
+  assert.equal(resolveSenderPhone(msg, '123456@lid', {}), '972501111111');
+});
+
+test('resolveSenderPhone maps a LID through the session map', () => {
+  assert.equal(resolveSenderPhone({}, '123456@lid', { 123456: '972502222222' }), '972502222222');
+});
+
+test('resolveSenderPhone refuses to guess for an unmapped LID', () => {
+  assert.equal(resolveSenderPhone({}, '123456@lid', {}), '');
+});
+
+test('resolveSenderPhone strips a device suffix from a phone JID', () => {
+  assert.equal(resolveSenderPhone({}, '972503333333:12@s.whatsapp.net', {}), '972503333333');
+});
+
+test('disabled without full configuration', async () => {
+  const webhook = createInboundWebhook({ url: 'https://x', numbersUrl: '', secret: 'k' });
+  assert.equal(webhook.enabled, false);
+  assert.equal(await webhook.shouldForward('972501111111'), false);
+});
+
+test('a sender matching a tail is forwarded', async () => {
+  const { webhook } = makeWebhook();
+  await webhook.refresh();
+  assert.equal(await webhook.shouldForward('972501111111'), true);
+  assert.equal(await webhook.shouldForward('972509999999'), false);
+});
+
+test('a miss refreshes at most once per cooldown window', async () => {
+  const { webhook, calls, tick } = makeWebhook();
+  assert.equal(await webhook.shouldForward('972501111111'), true);
+  assert.equal(calls.fetches.length, 1);
+
+  assert.equal(await webhook.shouldForward('972509999999'), false);
+  assert.equal(calls.fetches.length, 1, 'second miss inside the cooldown must not refetch');
+
+  tick(10001);
+  assert.equal(await webhook.shouldForward('972509999999'), false);
+  assert.equal(calls.fetches.length, 2, 'a miss after the cooldown refreshes again');
+});
+
+test('a failed numbers fetch keeps the previous list', async () => {
+  let failNext = false;
+  const { webhook, tick } = makeWebhook({
+    respond: () => {
+      if (failNext) {
+        throw new Error('down');
+      }
+      return jsonResponse({ tails: ['501111111'] });
+    },
+  });
+  await webhook.refresh();
+  failNext = true;
+  tick(60000);
+  await webhook.refresh();
+  assert.equal(await webhook.shouldForward('972501111111'), true);
+});
+
+test('forward posts the message with the shared secret and stores media as base64', async () => {
+  const { webhook, calls } = makeWebhook({
+    respond: (target) => (target.endsWith('/inbound')
+      ? jsonResponse({ ok: true })
+      : jsonResponse({ tails: [] })),
+  });
+  const result = await webhook.forward({
+    from: '972501111111',
+    text: 'הכל נכון',
+    mediaUrls: ['/cache/img_1.jpg'],
+    mime: 'image/jpeg',
+  });
+  assert.equal(result.stored, true);
+
+  const post = calls.fetches.find((call) => call.target.endsWith('/inbound'));
+  assert.equal(post.options.method, 'POST');
+  assert.equal(post.options.headers['x-hermes-key'], 's3cret');
+  const body = JSON.parse(post.options.body);
+  assert.equal(body.from, '972501111111');
+  assert.equal(body.text, 'הכל נכון');
+  assert.deepEqual(body.attachments, [{
+    name: 'img_1.jpg',
+    contentType: 'image/jpeg',
+    contentB64: Buffer.from('media-bytes').toString('base64'),
+  }]);
+  assert.deepEqual(calls.unlinked, ['/cache/img_1.jpg'], 'media leaves the cache after forwarding');
+});
+
+test('a 404 means no open conversation, not an error, and media is still cleaned up', async () => {
+  const { webhook, calls } = makeWebhook({
+    respond: (target) => (target.endsWith('/inbound')
+      ? jsonResponse({ error: 'no open outreach' }, 404)
+      : jsonResponse({ tails: [] })),
+  });
+  const result = await webhook.forward({ from: '972501111111', text: 'hi', mediaUrls: ['/cache/a.jpg'] });
+  assert.equal(result.stored, false);
+  assert.deepEqual(calls.unlinked, ['/cache/a.jpg']);
+});
+
+test('a server error throws and leaves media on disk for the logs', async () => {
+  const { webhook, calls } = makeWebhook({
+    respond: (target) => (target.endsWith('/inbound')
+      ? jsonResponse({}, 500)
+      : jsonResponse({ tails: [] })),
+  });
+  await assert.rejects(
+    () => webhook.forward({ from: '972501111111', text: 'hi', mediaUrls: ['/cache/a.jpg'] }),
+    /inbound webhook returned 500/,
+  );
+  assert.deepEqual(calls.unlinked, []);
+});
+
+test('an oversized attachment is skipped, the text still goes through', async () => {
+  const { webhook, calls } = makeWebhook({
+    config: { maxAttachmentBytes: 4 },
+    respond: (target) => (target.endsWith('/inbound')
+      ? jsonResponse({ ok: true })
+      : jsonResponse({ tails: [] })),
+  });
+  await webhook.forward({ from: '972501111111', text: 'hi', mediaUrls: ['/cache/big.jpg'] });
+  const post = calls.fetches.find((call) => call.target.endsWith('/inbound'));
+  assert.deepEqual(JSON.parse(post.options.body).attachments, []);
+});
+
+test('an unreadable media file degrades to a text-only forward', async () => {
+  const { webhook, calls } = makeWebhook({
+    readFile: () => { throw new Error('gone'); },
+    respond: (target) => (target.endsWith('/inbound')
+      ? jsonResponse({ ok: true })
+      : jsonResponse({ tails: [] })),
+  });
+  const result = await webhook.forward({ from: '972501111111', text: 'hi', mediaUrls: ['/cache/x.jpg'] });
+  assert.equal(result.stored, true);
+  const post = calls.fetches.find((call) => call.target.endsWith('/inbound'));
+  assert.deepEqual(JSON.parse(post.options.body).attachments, []);
+});

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -63,6 +63,13 @@ class TestSnapshotShutdownContext:
         assert "parent" in ctx
         assert ctx["parent"]["pid"] == os.getppid()
 
+    def test_proc_summary_never_captures_argv(self):
+        """/proc summaries carry comm (executable name), never the argv."""
+        summary = sf._proc_summary(os.getpid())
+        assert summary["pid"] == os.getpid()
+        # cmdline can carry secrets — it must never be persisted in a summary.
+        assert "cmdline" not in summary
+
     def test_under_systemd_flag_uses_invocation_id(self, monkeypatch):
         monkeypatch.setenv("INVOCATION_ID", "abc123")
         ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
@@ -128,7 +135,27 @@ class TestFormatters:
         line = sf.format_context_for_log(ctx)
         assert "signal=SIGTERM" in line
         assert "parent_pid=" in line
-        assert "parent_cmdline=" in line
+        # comm (executable name), never the argv-bearing cmdline
+        assert "parent_comm=" in line
+        assert "parent_cmdline=" not in line
+
+    def test_format_context_for_log_never_emits_argv(self):
+        """A parent carrying a secret on its argv must not reach the log line."""
+        ctx = {
+            "signal": "SIGTERM",
+            "parent": {
+                "pid": 42,
+                "name": "python",
+                "comm": "python",
+                # Simulate a stale/hostile field: even if a cmdline with a
+                # secret is present in the dict, the formatter must ignore it.
+                "cmdline": "python run.py mongodb+srv://u:hunter2@cluster/db",
+            },
+        }
+        line = sf.format_context_for_log(ctx)
+        assert "parent_comm='python'" in line
+        assert "hunter2" not in line
+        assert "mongodb+srv" not in line
 
     def test_context_as_json_round_trips(self):
         ctx = sf.snapshot_shutdown_context(signal.SIGTERM)
@@ -173,9 +200,15 @@ class TestSpawnAsyncDiagnostic:
             pass
 
         assert log_path.exists()
+        # The diagnostic can name processes/users and lands in a shared logs
+        # dir, so it must never be group/other-readable.
+        mode = log_path.stat().st_mode & 0o777
+        assert mode == 0o600, f"diag log mode {oct(mode)} — must be 0o600"
         contents = log_path.read_text(encoding="utf-8", errors="replace")
         assert "shutdown diagnostic" in contents
         assert "SIGTERM" in contents
+        # No argv-bearing ps/pstree flags should be in the script's output.
+        assert "ps auxf" not in contents
 
     def test_returns_none_on_windows(self, tmp_path, monkeypatch):
         monkeypatch.setattr(sf, "sys", type("M", (), {"platform": "win32"})())


### PR DESCRIPTION
## The bug

On SIGTERM/SIGINT, `gateway/shutdown_forensics.py` captures a diagnostic to `~/.hermes/logs/gateway-shutdown-diag.log`. It captured **full command lines** three ways:

- `spawn_async_diagnostic()` runs `ps auxf --sort=-pcpu | head -60` (full argv) and `pstree -plau` (the `a` = show args), writing to a log opened **`0644` (world-readable)**.
- `_proc_summary()` stores `/proc/<pid>/cmdline[:300]` per process into the JSON snapshot — same argv exposure, just truncated (still enough to leak a `--mcp-config {...}` prefix or a URI).

Any process that carries a secret on its argv (a MongoDB/Atlas connection string with password, an API token, a Redis password passed as a CLI arg, an `--mcp-config {...}` blob) had that secret persisted in plaintext to a world-readable file.

## The fix (keep the diagnostic value, drop the argv)

The useful forensic signal is *which* process, owned by whom, using how much CPU/mem, and the process-tree shape — not the argv. This PR switches every **persisted** capture to the executable name only:

- `_read_proc_cmdline()` is documented as unsafe for persisted logs; a new `_read_proc_comm()` (reads `/proc/<pid>/comm`, executable name only) is added for anything that lands on disk.
- `_proc_summary()` stores `comm` instead of `cmdline[:300]`.
- `spawn_async_diagnostic()` uses `ps -eo pid,ppid,user,pcpu,pmem,stat,comm --sort=-pcpu` (no argv) and `pstree -pl` (drops the `a`), and opens the log fd **`0600`** as defense in depth.
- `format_context_for_log()` emits `parent_comm` instead of `parent_cmdline`.

The CPU-hog, ownership, process-tree, load-average, and dmesg/OOM diagnostics are all preserved; only the argv exfiltration vector is removed.

This is defense in depth: the primary responsibility for keeping secrets off argv belongs upstream of the diagnostic, but the shutdown diagnostic itself should never be the channel that persists them.

## Tests

`tests/gateway/test_shutdown_forensics.py`:
- `format_context_for_log` and `_proc_summary` are asserted to never emit argv — a `mongodb+srv://user:hunter2@...` secret injected into a `cmdline` field is confirmed absent from the output.
- `spawn_async_diagnostic` is asserted to create the diag log with mode `0600` and to contain no `ps auxf`.

All 32 tests in the file pass; `ruff` and `ty` are clean on the changed files.