### PR TITLE
fix(dashboard): exclude lifecycle commands from --status PID scan (#59626)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5873,6 +5873,8 @@ def _find_stale_dashboard_pids(
                     if (
                         any(p in current_cmd for p in patterns)
                         and int(pid_str) != self_pid
+                        and "--status" not in current_cmd
+                        and "--stop" not in current_cmd
                     ):
                         try:
                             dashboard_pids.append(int(pid_str))
@@ -5904,7 +5906,12 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if (
+                        any(p in command for p in patterns)
+                        and pid != self_pid
+                        and "--status" not in command
+                        and "--stop" not in command
+                    ):
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []


### PR DESCRIPTION
## Summary

`hermes dashboard --status` can falsely report a running dashboard when the only matching process is the `--status` command itself (or a wrapper/sandbox that invoked it).

## Fix

Added `--status` and `--stop` exclusion to both the Windows (wmic) and POSIX (ps) process matching branches in `_find_stale_dashboard_pids()`. Lifecycle commands now correctly excluded; real dashboard servers still detected.

## Files Changed

| File | Δ |
|------|---|
| `hermes_cli/main.py` | +4 lines |

Closes #59626