### PR TITLE
fix(update): recognize official remotes with embedded credentials

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -63,6 +63,7 @@ except ModuleNotFoundError:
 
 import os
 import sys
+from urllib.parse import urlsplit, urlunsplit
 
 
 def _set_process_title() -> None:
@@ -6665,19 +6666,36 @@ def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
     return None
 
 
+def _normalize_remote_url(remote_url: str) -> str:
+    normalized = remote_url.strip().rstrip("/")
+    if not normalized:
+        return ""
+
+    try:
+        parsed = urlsplit(normalized)
+        if parsed.scheme in {"http", "https"} and parsed.netloc:
+            host = parsed.hostname or ""
+            if parsed.port:
+                host = f"{host}:{parsed.port}"
+            normalized = urlunsplit(
+                (parsed.scheme.lower(), host.lower(), parsed.path, "", "")
+            )
+    except ValueError:
+        pass
+
+    normalized = normalized.rstrip("/")
+    if normalized.endswith(".git"):
+        normalized = normalized[:-4]
+    return normalized
+
+
 def _is_fork(origin_url: Optional[str]) -> bool:
     """Check if the origin remote points to a fork (not the official repo)."""
     if not origin_url:
         return False
-    # Normalize URL for comparison (strip trailing .git if present)
-    normalized = origin_url.rstrip("/")
-    if normalized.endswith(".git"):
-        normalized = normalized[:-4]
+    normalized = _normalize_remote_url(origin_url)
     for official in OFFICIAL_REPO_URLS:
-        official_normalized = official.rstrip("/")
-        if official_normalized.endswith(".git"):
-            official_normalized = official_normalized[:-4]
-        if normalized == official_normalized:
+        if normalized == _normalize_remote_url(official):
             return False
     return True
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -35,6 +35,7 @@ import time as _time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
 
 from hermes_cli.config import get_hermes_home
 from hermes_constants import venv_python_path
@@ -2187,19 +2188,37 @@ def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
         pass
     return None
 
+
+def _normalize_remote_url(remote_url: str) -> str:
+    normalized = remote_url.strip().rstrip("/")
+    if not normalized:
+        return ""
+
+    try:
+        parsed = urlsplit(normalized)
+        if parsed.scheme in {"http", "https"} and parsed.netloc:
+            host = parsed.hostname or ""
+            if parsed.port:
+                host = f"{host}:{parsed.port}"
+            normalized = urlunsplit(
+                (parsed.scheme.lower(), host.lower(), parsed.path, "", "")
+            )
+    except ValueError:
+        pass
+
+    normalized = normalized.rstrip("/")
+    if normalized.endswith(".git"):
+        normalized = normalized[:-4]
+    return normalized
+
+
 def _is_fork(origin_url: Optional[str]) -> bool:
     """Check if the origin remote points to a fork (not the official repo)."""
     if not origin_url:
         return False
-    # Normalize URL for comparison (strip trailing .git if present)
-    normalized = origin_url.rstrip("/")
-    if normalized.endswith(".git"):
-        normalized = normalized[:-4]
+    normalized = _normalize_remote_url(origin_url)
     for official in OFFICIAL_REPO_URLS:
-        official_normalized = official.rstrip("/")
-        if official_normalized.endswith(".git"):
-            official_normalized = official_normalized[:-4]
-        if normalized == official_normalized:
+        if normalized == _normalize_remote_url(official):
             return False
     return True
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -250,6 +250,19 @@ class TestCmdUpdateBranchFallback:
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
 
+    def test_official_origin_with_embedded_credentials_is_not_fork(self):
+        from hermes_cli import main as hm
+
+        assert not hm._is_fork(
+            "https://ghp_example@github.com/NousResearch/hermes-agent.git"
+        )
+        assert not hm._is_fork(
+            "https://user:token@github.com/NousResearch/hermes-agent.git"
+        )
+        assert hm._is_fork(
+            "https://ghp_example@github.com/example/hermes-agent.git"
+        )
+
     @patch("shutil.which")
     @patch("subprocess.run")
     def test_update_refreshes_repo_and_tui_node_dependencies(

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -252,6 +252,19 @@ class TestCmdUpdateBranchFallback:
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
 
+    def test_official_origin_with_embedded_credentials_is_not_fork(self):
+        from hermes_cli import main as hm
+
+        assert not hm._is_fork(
+            "https://ghp_example@github.com/NousResearch/hermes-agent.git"
+        )
+        assert not hm._is_fork(
+            "https://user:token@github.com/NousResearch/hermes-agent.git"
+        )
+        assert hm._is_fork(
+            "https://ghp_example@github.com/example/hermes-agent.git"
+        )
+
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""
         with patch("shutil.which", return_value=None), patch(


### PR DESCRIPTION
Fixes #59584.

## Summary
- Normalize HTTPS remotes before fork detection by dropping embedded credentials.
- Preserve existing official URL handling for HTTPS and SSH remotes.
- Add a regression test for token and user:token official remotes.

## Validation
- `uv run --with pytest python -m pytest tests/hermes_cli/test_cmd_update.py -q -k embedded_credentials`
- `uv run python -m py_compile hermes_cli/main.py tests/hermes_cli/test_cmd_update.py`

## Notes
- I checked current open PRs/issues and did not find a duplicate for this credentialed official-remote case.
- Full `tests/hermes_cli/test_cmd_update.py` still has existing Windows-specific failures unrelated to this change: one assertion expects bare `git` while runtime adds `-c windows.appendAtomically=false`, and one npm-call assertion is affected by the active lazy backend refresh path.