### PR TITLE
fix(agent): honor NO_PROXY CIDR ranges

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -23,6 +23,7 @@ unchanged.
 
 from __future__ import annotations
 
+import ipaddress
 import os
 import sys
 import urllib.request
@@ -123,6 +124,27 @@ def _get_proxy_from_env() -> Optional[str]:
     return None
 
 
+def _no_proxy_cidr_bypasses(host: str) -> bool:
+    try:
+        address = ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        return False
+
+    for key in ("NO_PROXY", "no_proxy"):
+        for entry in os.environ.get(key, "").split(","):
+            entry = entry.strip()
+            if "/" not in entry:
+                continue
+            if entry.startswith("[") and "]" in entry:
+                entry = entry.replace("[", "", 1).replace("]", "", 1)
+            try:
+                if address in ipaddress.ip_network(entry, strict=False):
+                    return True
+            except ValueError:
+                continue
+    return False
+
+
 def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
     """Return an env-configured proxy unless NO_PROXY excludes this base URL."""
     proxy = _get_proxy_from_env()
@@ -134,7 +156,7 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
         return proxy
 
     try:
-        if urllib.request.proxy_bypass_environment(host):
+        if _no_proxy_cidr_bypasses(host) or urllib.request.proxy_bypass_environment(host):
             return None
     except Exception:
         pass

--- a/tests/agent/test_auxiliary_client_proxy_env.py
+++ b/tests/agent/test_auxiliary_client_proxy_env.py
@@ -84,9 +84,10 @@ def test_get_proxy_for_base_url_respects_no_proxy(monkeypatch):
                 "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
-    monkeypatch.setenv("NO_PROXY", "internal.example.com")
+    monkeypatch.setenv("NO_PROXY", "internal.example.com,192.168.0.0/16")
 
     assert _get_proxy_for_base_url("https://litellm.internal.example.com/v1") is None
+    assert _get_proxy_for_base_url("http://192.168.12.34:11434/v1") is None
     assert _get_proxy_for_base_url("https://api.openai.com/v1") == "http://127.0.0.1:7897"
 
 

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -178,6 +178,7 @@ def test_get_proxy_for_base_url_returns_none_when_host_bypassed(monkeypatch):
     # Local endpoint — must bypass the proxy.
     assert _get_proxy_for_base_url("http://127.0.0.1:11434/v1") is None
     assert _get_proxy_for_base_url("http://localhost:1234/v1") is None
+    assert _get_proxy_for_base_url("http://192.168.12.34:11434/v1") is None
 
     # Non-local endpoint — proxy still applies.
     assert _get_proxy_for_base_url("https://api.openai.com/v1") == "http://127.0.0.1:7897"


### PR DESCRIPTION
Fixes #59465.

## Summary
- Teach agent proxy resolution to evaluate CIDR entries in `NO_PROXY` / `no_proxy`.
- Keep the existing stdlib domain/host bypass behavior for non-CIDR entries.
- Add coverage for a LAN address inside `192.168.0.0/16`.

## Validation
- `uv run --with pytest python -m pytest tests/agent/test_auxiliary_client_proxy_env.py tests/run_agent/test_create_openai_client_proxy_env.py -q`
- `uv run python -m py_compile agent/process_bootstrap.py tests/agent/test_auxiliary_client_proxy_env.py tests/run_agent/test_create_openai_client_proxy_env.py`

## Notes
- I checked current open PRs/issues and did not find a duplicate agent/httpx CIDR bypass fix.
- The targeted pytest run passed with pre-existing Windows cp932 reader-thread warnings from subprocess capture.