### PR TITLE
fix(tui): persist default sessions to launch state db

### DIFF
--- a/tests/gateway/test_session_list_allowed_sources.py
+++ b/tests/gateway/test_session_list_allowed_sources.py
@@ -51,7 +51,7 @@ def test_session_list_surfaces_all_user_facing_sources(monkeypatch):
         {"id": "custom-1", "source": "my-custom-source", "started_at": 3},
     ]
     db = _StubDB(rows)
-    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: db)
 
     resp = _call(limit=10)
     ids = [s["id"] for s in resp["result"]["sessions"]]
@@ -72,7 +72,7 @@ def test_session_list_surfaces_all_user_facing_sources(monkeypatch):
 def test_session_list_default_limit_is_200(monkeypatch):
     """Default limit should be wide enough for long-running users."""
     db = _StubDB([{"id": "x", "source": "cli", "started_at": 1}])
-    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: db)
 
     _call()  # no explicit limit
     # fetch_limit = max(limit * 2, 200); limit defaults to 200, so 400.
@@ -81,7 +81,7 @@ def test_session_list_default_limit_is_200(monkeypatch):
 
 def test_session_list_respects_explicit_limit(monkeypatch):
     db = _StubDB([{"id": "x", "source": "cli", "started_at": 1}])
-    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: db)
 
     _call(limit=10)
     # fetch_limit = max(limit * 2, 200) = 200 when limit is small.
@@ -96,7 +96,7 @@ def test_session_list_preserves_ordering_after_filter(monkeypatch):
         {"id": "also-visible", "source": "webhook", "started_at": 2},
         {"id": "oldest", "source": "discord", "started_at": 1},
     ]
-    monkeypatch.setattr(server, "_get_db", lambda: _StubDB(rows))
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _StubDB(rows))
 
     resp = _call()
     ids = [s["id"] for s in resp["result"]["sessions"]]

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2759,7 +2759,7 @@ def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
         {"role": "assistant", "content": "done"},
     ]
     server._sessions["trunc-sid"] = _session(history=list(history))
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: _FakeDB())
     # If the guard ever lets a negative ordinal through, these would run and the
     # session would be marked busy; failing here makes that regression loud.
     monkeypatch.setattr(
@@ -3420,7 +3420,7 @@ def test_run_prompt_submit_prefers_origin_ui_session_id(monkeypatch, tmp_path):
         def create_session(self, *args, **kwargs):
             created.append((args, kwargs))
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: _FakeDB())
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
     monkeypatch.setattr(
         server.threading,
@@ -3449,7 +3449,7 @@ def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path), "explicit_cwd": True})
@@ -3468,7 +3468,7 @@ def test_ensure_session_db_row_persists_session_source(monkeypatch):
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
     server._ensure_session_db_row({"session_key": "k1", "source": "tool"})
@@ -3489,7 +3489,7 @@ def test_ensure_session_db_row_defaults_to_no_workspace(monkeypatch, tmp_path):
                 {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path)})
@@ -3516,7 +3516,7 @@ def test_ensure_session_db_row_persists_session_model_override(monkeypatch):
                 {"key": key, "model": model, "model_config": model_config, "cwd": cwd}
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "global/default")
 
     server._ensure_session_db_row(
@@ -3546,12 +3546,37 @@ def test_ensure_session_db_row_no_override_uses_global(monkeypatch):
         def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None):
             created.append({"model": model, "model_config": model_config})
 
-    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr("hermes_state.SessionDB", lambda db_path=None: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "global/default")
 
     server._ensure_session_db_row({"session_key": "k1", "model_override": None})
 
     assert created == [{"model": "global/default", "model_config": None}]
+
+
+def test_ensure_session_db_row_default_session_uses_launch_home(monkeypatch, tmp_path):
+    from hermes_state import SessionDB
+
+    launch_home = tmp_path / "launch-home"
+    stale_home = tmp_path / "stale-home"
+    launch_home.mkdir()
+    stale_home.mkdir()
+    stale_db = SessionDB(db_path=stale_home / "state.db")
+    launch_db = None
+
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    monkeypatch.setattr(server, "_get_db", lambda: stale_db)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "global/default")
+
+    try:
+        server._ensure_session_db_row({"session_key": "k-default"})
+        launch_db = SessionDB(db_path=launch_home / "state.db")
+        assert launch_db.get_session("k-default") is not None
+        assert stale_db.get_session("k-default") is None
+    finally:
+        if launch_db is not None:
+            launch_db.close()
+        stale_db.close()
 
 
 def test_session_title_clears_pending_after_persist(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1429,7 +1429,7 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
                 else [{"role": "user", "content": "tip prompt"}]
             )
 
-    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: FakeDB())
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
     monkeypatch.setattr(server, "_set_session_context", lambda target: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
@@ -1504,7 +1504,7 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
         captured.setdefault("agent_session_id", session_id)
         return types.SimpleNamespace(model="test", provider="test")
 
-    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: db)
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
     monkeypatch.setattr(server, "_set_session_context", lambda target: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
@@ -1562,7 +1562,7 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
         captured.update(kwargs)
         return types.SimpleNamespace(model="gpt-5.4", provider="openai-codex")
 
-    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: FakeDB())
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
     monkeypatch.setattr(server, "_set_session_context", lambda target: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
@@ -3576,6 +3576,62 @@ def test_ensure_session_db_row_default_session_uses_launch_home(monkeypatch, tmp
     finally:
         if launch_db is not None:
             launch_db.close()
+        stale_db.close()
+
+
+def test_session_list_default_session_uses_launch_home(monkeypatch, tmp_path):
+    from hermes_state import SessionDB
+
+    launch_home = tmp_path / "launch-home"
+    stale_home = tmp_path / "stale-home"
+    launch_home.mkdir()
+    stale_home.mkdir()
+    launch_db = SessionDB(db_path=launch_home / "state.db")
+    stale_db = SessionDB(db_path=stale_home / "state.db")
+    launch_db.create_session("launch-session", source="tui")
+    try:
+        monkeypatch.setattr(server, "_hermes_home", launch_home)
+        monkeypatch.setattr(server, "_get_db", lambda: stale_db)
+
+        resp = server.handle_request({"id": "1", "method": "session.list", "params": {}})
+
+        assert [row["id"] for row in resp["result"]["sessions"]] == ["launch-session"]
+    finally:
+        launch_db.close()
+        stale_db.close()
+
+
+def test_session_resume_default_session_uses_launch_home(monkeypatch, tmp_path):
+    from hermes_state import SessionDB
+
+    launch_home = tmp_path / "launch-home"
+    stale_home = tmp_path / "stale-home"
+    launch_home.mkdir()
+    stale_home.mkdir()
+    launch_db = SessionDB(db_path=launch_home / "state.db")
+    stale_db = SessionDB(db_path=stale_home / "state.db")
+    launch_db.create_session("launch-session", source="tui")
+    launch_db.append_message("launch-session", role="user", content="hello")
+    launch_db.append_message("launch-session", role="assistant", content="world")
+
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    monkeypatch.setattr(server, "_get_db", lambda: stale_db)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
+    monkeypatch.setattr(server, "_make_agent", lambda *args, **kwargs: types.SimpleNamespace(model="test"))
+    monkeypatch.setattr(server, "_session_info", lambda agent, *args: {"model": "test", "tools": {}, "skills": {}})
+    monkeypatch.setattr(server, "_init_session", lambda *args, **kwargs: None)
+
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.resume", "params": {"session_id": "launch-session", "eager_build": True}}
+        )
+
+        assert "error" not in resp
+        assert resp["result"]["session_key"] == "launch-session"
+    finally:
+        launch_db.close()
         stale_db.close()
 
 
@@ -7469,7 +7525,7 @@ def test_session_create_lazy_info_reports_desktop_contract(monkeypatch):
 
 
 def test_session_list_returns_clean_error_when_state_db_is_unavailable(monkeypatch):
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: None)
     monkeypatch.setattr(server, "_db_error", "locking protocol")
 
     resp = server.handle_request({"id": "1", "method": "session.list", "params": {}})
@@ -8279,7 +8335,7 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
                 {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
             ]
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
 
     resp = server.handle_request(
         {"id": "1", "method": "session.most_recent", "params": {}}
@@ -8295,7 +8351,7 @@ def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
         def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
             return [{"id": "tool-1", "source": "tool", "started_at": 1}]
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
 
     resp = server.handle_request(
         {"id": "1", "method": "session.most_recent", "params": {}}
@@ -8313,7 +8369,7 @@ def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
         def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
             raise RuntimeError("db locked")
 
-    monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _BrokenDB())
 
     resp = server.handle_request(
         {"id": "1", "method": "session.most_recent", "params": {}}
@@ -8324,7 +8380,7 @@ def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
 
 
 def test_session_most_recent_handles_db_unavailable(monkeypatch):
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: None)
 
     resp = server.handle_request(
         {"id": "1", "method": "session.most_recent", "params": {}}

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -338,7 +338,7 @@ class TestBareCustomNoBaseUrlHealsFromConfig:
 
         from tui_gateway import server as srv
 
-        monkeypatch.setattr(srv, "_get_db", lambda: _DB())
+        monkeypatch.setattr(srv, "_open_session_db", lambda _home=None: _DB())
         monkeypatch.setattr(srv, "_resolve_model", lambda: "mimo-v2.5-pro")
 
         session = {

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -362,7 +362,7 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
                 {"role": "narrator", "content": "skip"},
             ]
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
     monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_id=None, session_db=None, **_kwargs: object())
     monkeypatch.setattr(server, "_init_session", lambda sid, key, agent, history, cols=80, **_kwargs: None)
     monkeypatch.setattr(server, "_session_info", lambda _agent, _session=None: {"model": "test/model"})
@@ -426,7 +426,7 @@ def test_session_resume_defaults_to_deferred_build(server, monkeypatch):
 
     builds: list = []
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
     # The response path must never call _make_agent; route the deferred timer
     # through a recorder so a 50ms fire can't build (or crash) under the test.
     monkeypatch.setattr(
@@ -568,7 +568,7 @@ def test_session_resume_handles_multimodal_list_content(server, monkeypatch):
         def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [multimodal_user, text_only_assistant]
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
     monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_id=None, session_db=None, **_kwargs: object())
     monkeypatch.setattr(server, "_init_session", lambda sid, key, agent, history, cols=80, **_kwargs: None)
     monkeypatch.setattr(server, "_session_info", lambda _agent, _session=None: {"model": "test/model"})
@@ -629,7 +629,7 @@ def test_session_resume_lazy_registers_watch_session_without_agent(server, monke
     def _boom(*_args, **_kwargs):
         raise AssertionError("lazy resume must not build an agent")
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
     monkeypatch.setattr(server, "_make_agent", _boom)
 
     resp = server.handle_request(
@@ -703,7 +703,7 @@ def test_session_resume_lazy_reports_running_for_inflight_child(server, monkeypa
         def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [{"role": "user", "content": "delegated goal"}]
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
     monkeypatch.setattr(
         server, "_make_agent", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no build"))
     )
@@ -761,7 +761,7 @@ def test_session_resume_lazy_tolerates_missing_row_for_active_child(server, monk
             # No rows for an unwritten session.
             return []
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
     monkeypatch.setattr(
         server, "_make_agent", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no build"))
     )
@@ -809,7 +809,7 @@ def test_session_resume_missing_row_non_lazy_still_errors(server, monkeypatch):
         def get_session_by_title(self, _title):
             return None
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
 
     # Non-lazy resume, no active child → hard error.
     resp = server.handle_request(
@@ -885,7 +885,7 @@ def test_session_resume_reuses_existing_live_session(server, monkeypatch):
         assert agent_can_finish.wait(timeout=1)
         return _Agent(sid, session_id or key)
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
     monkeypatch.setattr(server, "_make_agent", make_agent)
     monkeypatch.setattr(server, "_SlashWorker", lambda _key, _model: _Worker())
     monkeypatch.setattr(
@@ -991,7 +991,7 @@ def test_session_resume_reuses_live_agent_after_compression_rotation(server, mon
         def resolve_resume_session_id(self, _target):
             return target
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
     monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         server,
@@ -1092,7 +1092,7 @@ def test_session_resume_live_payload_uses_current_history_with_ancestors(server,
         def close(self):
             pass
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
     monkeypatch.setattr(
         server,
         "_make_agent",
@@ -1183,7 +1183,7 @@ def test_session_activate_rebinds_orphaned_ws_session_to_current_transport(serve
         "transport": old_transport,
     }
     monkeypatch.setattr(server, "current_transport", lambda: new_transport)
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: None)
     monkeypatch.setattr(
         server,
         "_session_info",
@@ -1228,7 +1228,7 @@ def test_session_branch_persists_branched_from_marker(server, monkeypatch):
         def set_session_title(self, _key, _title):
             return None
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
     monkeypatch.setattr(server, "_new_session_key", lambda: "20260101_000001_child0")
     monkeypatch.setattr(
@@ -1288,7 +1288,7 @@ def test_make_agent_accepts_list_system_prompt(server, monkeypatch):
     )
     monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"system_prompt": ["one", "two"]}})
     monkeypatch.setattr(server, "_resolve_startup_runtime", lambda: ("test/model", "test"))
-    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: None)
 
     server._make_agent("sid", "session-key", session_id="session-key")
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1228,7 +1228,7 @@ def test_session_branch_persists_branched_from_marker(server, monkeypatch):
         def set_session_title(self, _key, _title):
             return None
 
-    monkeypatch.setattr(server, "_open_session_db", lambda _home=None: _DB())
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
     monkeypatch.setattr(server, "_new_session_key", lambda: "20260101_000001_child0")
     monkeypatch.setattr(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1573,14 +1573,15 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # HERMES_HOME so config/skills/model resolve to it, and hand the
             # agent that profile's db so turns persist to the right state.db.
             session_db = None
+            db_home = Path(profile_home) if profile_home else Path(_hermes_home)
             if profile_home:
                 home_token = set_hermes_home_override(profile_home)
-                try:
-                    from hermes_state import SessionDB
+            try:
+                from hermes_state import SessionDB
 
-                    session_db = SessionDB(db_path=Path(profile_home) / "state.db")
-                except Exception:
-                    session_db = None
+                session_db = SessionDB(db_path=db_home / "state.db")
+            except Exception:
+                session_db = None
             try:
                 # Lazy-resumed (watch) sessions carry the stored conversation
                 # id — pass it through so the upgrade continues that session
@@ -1921,22 +1922,18 @@ def _ensure_session_db_row(session: dict) -> None:
     key = session.get("session_key")
     if not key:
         return
-    # Persist into the session's own profile db (global remote mode), not the
-    # launch profile's — otherwise the row lands in the wrong state.db, the
-    # unified list mis-tags it, and resume 404s ("session not found").
-    profile_home = session.get("profile_home")
-    if profile_home:
-        from hermes_state import SessionDB
+    # Persist into the session's owning state.db. Profile sessions use their
+    # profile home; default sessions use the gateway launch home explicitly so
+    # they cannot inherit a stale global SessionDB handle.
+    db_home = Path(session.get("profile_home") or _hermes_home)
+    from hermes_state import SessionDB
 
-        try:
-            db = SessionDB(db_path=Path(profile_home) / "state.db")
-        except Exception:
-            logger.debug("failed to open profile db for session row", exc_info=True)
-            return
-        close_db = True
-    else:
-        db = _get_db()
-        close_db = False
+    try:
+        db = SessionDB(db_path=db_home / "state.db")
+    except Exception:
+        logger.debug("failed to open session db for session row", exc_info=True)
+        return
+    close_db = True
     if db is None:
         return
     # The session's own model/effort/fast pick — the composer override shipped on
@@ -2045,21 +2042,17 @@ def _session_db(session: dict):
     """Yield the SessionDB that owns this session's row (profile-aware).
 
     Mirrors :func:`_ensure_session_db_row`: a remote/profile session persists
-    into its own profile's ``state.db`` (a fresh handle we close on exit);
-    everything else borrows the shared ``_get_db()`` handle (left open). Yields
-    None when the db is unavailable.
+    into its own profile's ``state.db``; default sessions persist into the
+    gateway launch home's ``state.db``. Yields None when the db is unavailable.
     """
     db, close_db = None, False
-    profile_home = session.get("profile_home")
-    if profile_home:
-        from hermes_state import SessionDB
+    db_home = Path(session.get("profile_home") or _hermes_home)
+    from hermes_state import SessionDB
 
-        try:
-            db, close_db = SessionDB(db_path=Path(profile_home) / "state.db"), True
-        except Exception:
-            logger.debug("failed to open profile db for session", exc_info=True)
-    else:
-        db = _get_db()
+    try:
+        db, close_db = SessionDB(db_path=db_home / "state.db"), True
+    except Exception:
+        logger.debug("failed to open session db for session", exc_info=True)
     try:
         yield db
     finally:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1034,6 +1034,15 @@ def _get_db():
     return _db
 
 
+def _open_session_db(home: Path | None = None):
+    from hermes_state import SessionDB
+
+    try:
+        return SessionDB(db_path=Path(home or _hermes_home) / "state.db")
+    except Exception:
+        return None
+
+
 def _db_unavailable_error(rid, *, code: int):
     detail = _db_error or "state.db unavailable"
     return _err(rid, code, f"state.db unavailable: {detail}")
@@ -1577,9 +1586,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
             if profile_home:
                 home_token = set_hermes_home_override(profile_home)
             try:
-                from hermes_state import SessionDB
-
-                session_db = SessionDB(db_path=db_home / "state.db")
+                session_db = _open_session_db(db_home)
             except Exception:
                 session_db = None
             try:
@@ -1926,10 +1933,8 @@ def _ensure_session_db_row(session: dict) -> None:
     # profile home; default sessions use the gateway launch home explicitly so
     # they cannot inherit a stale global SessionDB handle.
     db_home = Path(session.get("profile_home") or _hermes_home)
-    from hermes_state import SessionDB
-
     try:
-        db = SessionDB(db_path=db_home / "state.db")
+        db = _open_session_db(db_home)
     except Exception:
         logger.debug("failed to open session db for session row", exc_info=True)
         return
@@ -2047,10 +2052,8 @@ def _session_db(session: dict):
     """
     db, close_db = None, False
     db_home = Path(session.get("profile_home") or _hermes_home)
-    from hermes_state import SessionDB
-
     try:
-        db, close_db = SessionDB(db_path=db_home / "state.db"), True
+        db, close_db = _open_session_db(db_home), True
     except Exception:
         logger.debug("failed to open session db for session", exc_info=True)
     try:
@@ -5851,7 +5854,7 @@ def _(rid, params: dict) -> dict:
 
 @method("session.list")
 def _(rid, params: dict) -> dict:
-    db = _get_db()
+    db = _open_session_db()
     if db is None:
         return _db_unavailable_error(rid, code=5006)
     try:
@@ -5893,7 +5896,8 @@ def _(rid, params: dict) -> dict:
         )
     except Exception as e:
         return _err(rid, 5006, str(e))
-
+    finally:
+        getattr(db, "close", lambda: None)()
 
 @method("session.most_recent")
 def _(rid, params: dict) -> dict:
@@ -5910,7 +5914,7 @@ def _(rid, params: dict) -> dict:
     null-result shape (and logged) so callers don't have to special-
     case JSON-RPC error envelopes for what is a normal "no answer".
     """
-    db = _get_db()
+    db = _open_session_db()
     if db is None:
         return _ok(rid, {"session_id": None})
     try:
@@ -5937,7 +5941,8 @@ def _(rid, params: dict) -> dict:
     except Exception:
         logger.exception("session.most_recent failed")
         return _ok(rid, {"session_id": None})
-
+    finally:
+        getattr(db, "close", lambda: None)()
 
 @method("project.facts")
 def _(rid, params: dict) -> dict:
@@ -6103,11 +6108,9 @@ def _(rid, params: dict) -> dict:
     # In a profile scope, the agent OWNS a long-lived db handle bound to that
     # profile (do NOT auto-close it here). Otherwise reuse the shared launch db.
     if profile_home is not None:
-        from hermes_state import SessionDB
-
-        db = SessionDB(db_path=profile_home / "state.db")
+        db = _open_session_db(profile_home)
     else:
-        db = _get_db()
+        db = _open_session_db()
     if db is None:
         return _db_unavailable_error(rid, code=5000)
 


### PR DESCRIPTION
Fixes #59566.

## Summary
- Open an explicit launch-home SessionDB for default desktop/TUI sessions instead of falling back to a potentially stale global handle.
- Keep profile sessions writing to their profile-specific state.db.
- Pass the explicit session DB into deferred agent builds for both profile and default sessions.
- Add a regression test proving default sessions write to launch home even when `_get_db()` points elsewhere.

## Validation
- `uv run --with pytest python -m pytest tests/test_tui_gateway_server.py -q -k "ensure_session_db_row or start_agent_build_passes_session_model_override or prompt_submit_rejects_negative_truncate_ordinal or session_create_does_not_persist_empty_row"`
- `uv run python -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py`

## Notes
- I checked current open PRs/issues. Existing session/profile PRs are adjacent, but I did not find one that fixes the stale default-profile SessionDB fallback addressed here.