### PR TITLE
fix(dashboard): guard config writes from fs editor

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -59,6 +59,7 @@ from hermes_cli.config import (
     get_config_path,
     get_env_path,
     get_hermes_home,
+    require_readable_config_before_write,
     load_config,
     load_env,
     read_raw_config,
@@ -2001,6 +2002,23 @@ async def fs_read_text(path: str):
     }
 
 
+def _fs_config_write_guard_target(target: Path) -> Path | None:
+    try:
+        resolved = target.resolve(strict=False)
+        config_path = get_config_path().resolve(strict=False)
+    except (OSError, RuntimeError):
+        return None
+    if resolved == config_path:
+        return config_path
+    try:
+        rel = resolved.relative_to(get_hermes_home().resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if len(rel.parts) == 3 and rel.parts[0] == "profiles" and rel.parts[2] == "config.yaml":
+        return resolved
+    return None
+
+
 class FsWriteText(BaseModel):
     path: str
     content: str
@@ -2022,6 +2040,13 @@ async def fs_write_text(payload: FsWriteText):
     text = payload.content or ""
     if len(text.encode("utf-8")) > _FS_TEXT_WRITE_MAX_BYTES:
         raise HTTPException(status_code=413, detail="Content too large")
+
+    guard_target = _fs_config_write_guard_target(target)
+    if guard_target is not None:
+        try:
+            require_readable_config_before_write(guard_target)
+        except RuntimeError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
 
     try:
         st: Optional[os.stat_result] = target.stat()

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -174,6 +174,57 @@ def test_fs_default_cwd_falls_back_when_terminal_cwd_is_invalid(client, tmp_path
     assert response.json() == {"cwd": str(fallback), "branch": ""}
 
 
+def test_fs_write_text_checks_existing_root_config_readability(client, tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model:\n  provider: openrouter\n")
+
+    calls = []
+
+    def fail_if_called(path=None):
+        calls.append(path)
+        raise RuntimeError("existing config.yaml cannot be read")
+
+    monkeypatch.setattr(web_server, "get_config_path", lambda: config_path)
+    monkeypatch.setattr(
+        web_server, "require_readable_config_before_write", fail_if_called, raising=False
+    )
+
+    response = client.post(
+        "/api/fs/write-text",
+        json={"path": str(config_path), "content": "model:\n  provider: x\n"},
+    )
+
+    assert response.status_code == 403
+    assert calls == [config_path]
+    assert config_path.read_text() == "model:\n  provider: openrouter\n"
+
+
+def test_fs_write_text_checks_existing_profile_config_readability(client, tmp_path, monkeypatch):
+    profile_config = tmp_path / "profiles" / "work" / "config.yaml"
+    profile_config.parent.mkdir(parents=True)
+    profile_config.write_text("model:\n  provider: openrouter\n")
+
+    calls = []
+
+    def fail_if_called(path=None):
+        calls.append(path)
+        raise RuntimeError("existing config.yaml cannot be read")
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        web_server, "require_readable_config_before_write", fail_if_called, raising=False
+    )
+
+    response = client.post(
+        "/api/fs/write-text",
+        json={"path": str(profile_config), "content": "model:\n  provider: x\n"},
+    )
+
+    assert response.status_code == 403
+    assert calls == [profile_config]
+    assert profile_config.read_text() == "model:\n  provider: openrouter\n"
+
+
 def test_fs_endpoints_require_auth(tmp_path):
     client = TestClient(web_server.app)
     target = tmp_path / "secret.txt"


### PR DESCRIPTION
## What does this PR do?

Guards dashboard spot-editor writes to Hermes config files with the same unreadable-config fail-closed check used by normal config writers.

The dashboard `/api/fs/write-text` endpoint writes arbitrary text files by staging a sibling temp file and `os.replace()`-ing it into place. That is correct for ordinary files, but it bypassed the #58986 config-write invariant for `config.yaml`: if an existing root or profile config becomes unreadable while the parent directory remains writable, the dashboard editor could still replace it without first proving the old config was readable.

This keeps ordinary spot-editor saves unchanged, but routes root `config.yaml` and profile `profiles/<name>/config.yaml` writes through `require_readable_config_before_write()` before replacement.

## Related Issue

Follow-up to the #58986 bug class: config write paths must fail closed instead of replacing an existing `config.yaml` that cannot be read.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`
  - Detect dashboard fs-editor targets that are the root config or a profile `config.yaml`.
  - Call `require_readable_config_before_write()` before the existing temp-file replacement.
  - Return `403` when the existing config cannot be read.
- `tests/hermes_cli/test_web_server_fs.py`
  - Add root config and profile config regression coverage.

## How to Test

1. Reproduced the current-main gap with the new root-config test: `/api/fs/write-text` returned `200` and replaced the config without calling the guard.

2. Ran the focused regression tests after the fix:

```bash
uv run pytest tests/hermes_cli/test_web_server_fs.py::test_fs_write_text_checks_existing_root_config_readability tests/hermes_cli/test_web_server_fs.py::test_fs_write_text_checks_existing_profile_config_readability -q
```

Result:

```text
2 passed
```

3. Ran the full fs endpoint test file:

```bash
uv run pytest tests/hermes_cli/test_web_server_fs.py -q
```

Result:

```text
15 passed
```

4. Ran targeted lint:

```bash
uv run ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server_fs.py
```

Result:

```text
All checks passed!
```

5. Ran targeted type check:

```bash
uv run ty check hermes_cli/web_server.py tests/hermes_cli/test_web_server_fs.py
```

This still reports pre-existing `web_server.py` typing diagnostics (Starlette middleware typing, nullable defaults, old dashboard typing issues). The PR's changed path is covered by the focused pytest and ruff checks above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
