### PR TITLE
fix(kanban): preserve completion artifact evidence

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -649,26 +649,29 @@ class GatewayKanbanWatchersMixin:
         chat.
 
         Sources scanned, in priority order:
-          1. ``event_payload['artifacts']`` (explicit list — preferred)
-          2. ``event_payload['summary']`` (truncated first line)
-          3. ``task.result`` (legacy fallback)
+          1. ``event_payload['artifacts']`` (durable completion copies)
+          2. ``event_payload['completion_artifact_evidence']`` preserved records
+          3. ``event_payload['summary']`` (truncated first line)
+          4. ``task.result`` (legacy fallback)
 
-        Files are deduplicated, missing files are silently skipped (the
-        path may have been mentioned for reference only), and delivery
-        errors are logged but do not break the notifier loop.
+        Files are deduplicated. Missing/unavailable completion evidence is
+        logged with its machine-checkable reason instead of silently skipped;
+        delivery errors are logged but do not break the notifier loop.
         """
         from pathlib import Path as _Path
 
         candidates: list[str] = []
+        missing_candidates: list[tuple[str, str]] = []
         seen: set[str] = set()
 
-        def _add(path: str) -> None:
+        def _add(path: str, source: str) -> None:
             if not path:
                 return
             expanded = os.path.expanduser(path)
             if expanded in seen:
                 return
             if not os.path.isfile(expanded):
+                missing_candidates.append((expanded, source))
                 return
             seen.add(expanded)
             candidates.append(expanded)
@@ -679,21 +682,46 @@ class GatewayKanbanWatchersMixin:
             if isinstance(raw, (list, tuple)):
                 for item in raw:
                     if isinstance(item, str):
-                        _add(item)
+                        _add(item, "event_payload.artifacts")
 
-            # 2. Paths embedded in the payload summary.
+            evidence = event_payload.get("completion_artifact_evidence")
+            if isinstance(evidence, (list, tuple)):
+                for item in evidence:
+                    if not isinstance(item, dict):
+                        continue
+                    status = item.get("status")
+                    if status == "preserved":
+                        stored_path = item.get("stored_path")
+                        if isinstance(stored_path, str):
+                            _add(stored_path, "completion_artifact_evidence")
+                    elif status in {"missing", "unavailable"}:
+                        logger.warning(
+                            "kanban notifier: completion artifact unavailable "
+                            "(%s): %s",
+                            item.get("original_path") or item.get("resolved_path"),
+                            item.get("reason") or status,
+                        )
+
+            # 3. Paths embedded in the payload summary.
             summary = event_payload.get("summary")
             if isinstance(summary, str) and summary:
                 paths, _ = adapter.extract_local_files(summary)
                 for p in paths:
-                    _add(p)
+                    _add(p, "event_payload.summary")
 
-        # 3. Legacy: paths embedded in task.result.
+        # 4. Legacy: paths embedded in task.result.
         if task is not None and getattr(task, "result", None):
             result_text = str(task.result)
             paths, _ = adapter.extract_local_files(result_text)
             for p in paths:
-                _add(p)
+                _add(p, "task.result")
+
+        for path, source in missing_candidates:
+            logger.warning(
+                "kanban notifier: artifact path from %s is missing: %s",
+                source,
+                path,
+            )
 
         if not candidates:
             return

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -103,6 +103,11 @@ _log = logging.getLogger(__name__)
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 COMPLETION_ARTIFACT_EVIDENCE_KEY = "completion_artifact_evidence"
+# Shared cap for every durable Kanban attachment write path. Dashboard uploads
+# and completion-artifact preservation both land under task attachments; keeping
+# one limit prevents workers from bypassing the UI's disk-growth guard by
+# claiming arbitrarily large completion artifacts.
+KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -4082,6 +4087,30 @@ def _sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
+def _copy_file_bounded(source: Path, dest: Path, *, max_bytes: int) -> int:
+    """Copy ``source`` to ``dest`` without writing more than ``max_bytes``.
+
+    Callers should still preflight ``stat()`` when possible so known-oversized
+    files fail before opening a destination. This streaming guard is the second
+    line of defense for files that grow between stat and copy or for platforms
+    where size metadata is unreliable. Partial destinations are removed before
+    raising.
+    """
+    total = 0
+    try:
+        with source.open("rb") as src, dest.open("wb") as out:
+            for chunk in iter(lambda: src.read(1024 * 1024), b""):
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ValueError("source_exceeds_size_limit")
+                out.write(chunk)
+        shutil.copystat(source, dest)
+    except Exception:
+        dest.unlink(missing_ok=True)
+        raise
+    return total
+
+
 def _prepare_completion_artifacts(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4135,10 +4164,25 @@ def _prepare_completion_artifacts(
                 })
                 continue
 
+            source_size = source.stat().st_size
+            if source_size > KANBAN_ATTACHMENT_MAX_BYTES:
+                evidence.append({
+                    **base,
+                    "status": "unavailable",
+                    "reason": "source_exceeds_size_limit",
+                    "size": source_size,
+                    "limit": KANBAN_ATTACHMENT_MAX_BYTES,
+                })
+                continue
+
             dest_dir.mkdir(parents=True, exist_ok=True)
             safe_name = _safe_attachment_filename(source.name or raw, fallback=f"artifact-{idx}")
             dest = _unique_attachment_path(dest_dir, safe_name)
-            shutil.copy2(source, dest)
+            copied_size = _copy_file_bounded(
+                source,
+                dest,
+                max_bytes=KANBAN_ATTACHMENT_MAX_BYTES,
+            )
             stored_path = _path_metadata_string(dest)
             durable_paths.append(stored_path)
             content_type, _ = mimetypes.guess_type(dest.name)
@@ -4149,10 +4193,27 @@ def _prepare_completion_artifacts(
                 "status": "preserved",
                 "stored_path": stored_path,
                 "filename": dest.name,
-                "size": dest.stat().st_size,
+                "size": copied_size,
                 "sha256": _sha256_file(dest),
                 "content_type": content_type,
             })
+        except ValueError as exc:
+            if str(exc) == "source_exceeds_size_limit":
+                try:
+                    size = source.stat().st_size
+                except OSError:
+                    size = None
+                item = {
+                    **base,
+                    "status": "unavailable",
+                    "reason": "source_exceeds_size_limit",
+                    "limit": KANBAN_ATTACHMENT_MAX_BYTES,
+                }
+                if size is not None:
+                    item["size"] = size
+                evidence.append(item)
+            else:
+                raise
         except OSError as exc:
             evidence.append({
                 **base,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -83,6 +83,7 @@ import subprocess
 import sys
 import threading
 import logging
+import mimetypes
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
@@ -101,6 +102,7 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+COMPLETION_ARTIFACT_EVIDENCE_KEY = "completion_artifact_evidence"
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -2962,6 +2964,63 @@ def list_comments(conn: sqlite3.Connection, task_id: str) -> list[Comment]:
 # Attachments
 # ---------------------------------------------------------------------------
 
+def _safe_attachment_filename(raw: str, *, fallback: str = "artifact") -> str:
+    """Return a safe basename for a board-owned attachment blob."""
+    name = (raw or "").replace("\\", "/").split("/")[-1].strip()
+    name = "".join(ch for ch in name if ch.isprintable() and ch != "\x00").strip()
+    name = name.lstrip(".").strip()
+    if not name:
+        name = fallback
+    return name[:200]
+
+
+def _unique_attachment_path(dest_dir: Path, filename: str) -> Path:
+    """Resolve ``filename`` under ``dest_dir`` without clobbering a blob."""
+    stem, dot, ext = filename.partition(".")
+    candidate = filename
+    n = 1
+    while (dest_dir / candidate).exists():
+        candidate = f"{stem} ({n}){dot}{ext}"
+        n += 1
+    return dest_dir / candidate
+
+
+def _insert_attachment_row(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    filename: str,
+    stored_path: str,
+    content_type: Optional[str] = None,
+    size: int = 0,
+    uploaded_by: Optional[str] = None,
+    created_at: Optional[int] = None,
+) -> int:
+    """Insert an attachment row inside an already-open write transaction."""
+    now = int(created_at if created_at is not None else time.time())
+    cur = conn.execute(
+        "INSERT INTO task_attachments "
+        "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            task_id,
+            filename.strip(),
+            stored_path,
+            content_type,
+            int(size),
+            uploaded_by,
+            now,
+        ),
+    )
+    _append_event(
+        conn,
+        task_id,
+        "attached",
+        {"filename": filename.strip(), "size": int(size), "by": uploaded_by},
+    )
+    return int(cur.lastrowid or 0)
+
+
 def add_attachment(
     conn: sqlite3.Connection,
     task_id: str,
@@ -2982,33 +3041,20 @@ def add_attachment(
         raise ValueError("attachment filename is required")
     if not stored_path or not stored_path.strip():
         raise ValueError("attachment stored_path is required")
-    now = int(time.time())
     with write_txn(conn):
         if not conn.execute(
             "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
         ).fetchone():
             raise ValueError(f"unknown task {task_id}")
-        cur = conn.execute(
-            "INSERT INTO task_attachments "
-            "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                task_id,
-                filename.strip(),
-                stored_path,
-                content_type,
-                int(size),
-                uploaded_by,
-                now,
-            ),
-        )
-        _append_event(
+        return _insert_attachment_row(
             conn,
             task_id,
-            "attached",
-            {"filename": filename.strip(), "size": int(size), "by": uploaded_by},
+            filename=filename.strip(),
+            stored_path=stored_path,
+            content_type=content_type,
+            size=size,
+            uploaded_by=uploaded_by,
         )
-        return int(cur.lastrowid or 0)
 
 
 def list_attachments(conn: sqlite3.Connection, task_id: str) -> list[Attachment]:
@@ -3975,6 +4021,178 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+def _completion_artifact_claims(metadata: Optional[dict]) -> list[str]:
+    """Return unique artifact path claims from completion metadata.
+
+    ``kanban_complete(artifacts=[...])`` stores claims under
+    ``metadata['artifacts']``. Older callers sometimes used a singular
+    ``metadata['artifact']`` field; preserve it too so those claims get the
+    same durability treatment instead of being left as dead scratch paths.
+    """
+    if not isinstance(metadata, dict):
+        return []
+    claims: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if not isinstance(value, str):
+            return
+        s = value.strip()
+        if s and s not in seen:
+            seen.add(s)
+            claims.append(s)
+
+    raw_artifacts = metadata.get("artifacts")
+    if isinstance(raw_artifacts, str):
+        add(raw_artifacts)
+    elif isinstance(raw_artifacts, (list, tuple)):
+        for item in raw_artifacts:
+            add(item)
+    add(metadata.get("artifact"))
+    return claims
+
+
+def _path_metadata_string(path: Path) -> str:
+    try:
+        return str(path.resolve(strict=False))
+    except OSError:
+        return str(path)
+
+
+def _windows_msys_path(raw: str) -> str:
+    """Translate /c/Users/... paths when a Windows worker used git-bash."""
+    if os.name == "nt" and re.match(r"^/[A-Za-z]/", raw):
+        return f"{raw[1]}:{raw[2:]}"
+    return raw
+
+
+def _resolve_completion_artifact_source(raw: str, workspace_path: Optional[str]) -> Path:
+    expanded = _windows_msys_path(os.path.expanduser(raw.strip()))
+    source = Path(expanded)
+    if not source.is_absolute() and workspace_path:
+        source = Path(workspace_path).expanduser() / source
+    return source
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _prepare_completion_artifacts(
+    conn: sqlite3.Connection,
+    task_id: str,
+    metadata: Optional[dict],
+    *,
+    expected_run_id: Optional[int] = None,
+    allowed_statuses: Optional[set[str]] = None,
+) -> tuple[Optional[dict], list[dict]]:
+    """Copy claimed completion artifacts to durable task attachments.
+
+    Returns a metadata copy plus machine-checkable evidence records. Missing
+    or uncopyable sources are recorded as unavailable evidence and are not
+    carried forward in ``metadata['artifacts']`` as successful artifact paths.
+    """
+    claims = _completion_artifact_claims(metadata)
+    if not claims or not isinstance(metadata, dict):
+        return metadata, []
+
+    row = conn.execute(
+        "SELECT status, workspace_path, current_run_id FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if allowed_statuses is None:
+        allowed_statuses = {"running", "ready", "blocked"}
+    if not row or row["status"] not in allowed_statuses:
+        return metadata, []
+    if expected_run_id is not None and row["current_run_id"] != int(expected_run_id):
+        return metadata, []
+
+    evidence: list[dict] = []
+    durable_paths: list[str] = []
+    dest_dir = task_attachments_dir(task_id)
+
+    for idx, raw in enumerate(claims, start=1):
+        source = _resolve_completion_artifact_source(raw, row["workspace_path"])
+        resolved_source = _path_metadata_string(source)
+        base = {"original_path": raw, "resolved_path": resolved_source}
+        try:
+            if not source.exists():
+                evidence.append({
+                    **base,
+                    "status": "missing",
+                    "reason": "source_missing_at_completion",
+                })
+                continue
+            if not source.is_file():
+                evidence.append({
+                    **base,
+                    "status": "unavailable",
+                    "reason": "source_not_file_at_completion",
+                })
+                continue
+
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            safe_name = _safe_attachment_filename(source.name or raw, fallback=f"artifact-{idx}")
+            dest = _unique_attachment_path(dest_dir, safe_name)
+            shutil.copy2(source, dest)
+            stored_path = _path_metadata_string(dest)
+            durable_paths.append(stored_path)
+            content_type, _ = mimetypes.guess_type(dest.name)
+            if content_type is None and dest.suffix.lower() in {".md", ".markdown"}:
+                content_type = "text/markdown"
+            evidence.append({
+                **base,
+                "status": "preserved",
+                "stored_path": stored_path,
+                "filename": dest.name,
+                "size": dest.stat().st_size,
+                "sha256": _sha256_file(dest),
+                "content_type": content_type,
+            })
+        except OSError as exc:
+            evidence.append({
+                **base,
+                "status": "unavailable",
+                "reason": "preservation_failed",
+                "error": str(exc),
+            })
+
+    prepared = dict(metadata)
+    prepared[COMPLETION_ARTIFACT_EVIDENCE_KEY] = evidence
+    prepared["artifacts"] = durable_paths
+    if "artifact" in prepared:
+        prepared["artifact"] = durable_paths[0] if durable_paths else None
+    return prepared, evidence
+
+
+def _record_preserved_completion_artifacts(
+    conn: sqlite3.Connection,
+    task_id: str,
+    evidence: list[dict],
+    *,
+    created_at: Optional[int] = None,
+) -> None:
+    """Persist task_attachments rows for already-copied completion artifacts."""
+    for item in evidence:
+        if item.get("status") != "preserved" or item.get("attachment_id"):
+            continue
+        att_id = _insert_attachment_row(
+            conn,
+            task_id,
+            filename=str(item.get("filename") or "artifact"),
+            stored_path=str(item.get("stored_path") or ""),
+            content_type=item.get("content_type"),
+            size=int(item.get("size") or 0),
+            uploaded_by="completion-evidence",
+            created_at=created_at,
+        )
+        item["attachment_id"] = att_id
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4042,6 +4260,15 @@ def complete_task(
     else:
         verified_cards = []
 
+    artifact_evidence: list[dict] = []
+    if isinstance(metadata, dict):
+        metadata, artifact_evidence = _prepare_completion_artifacts(
+            conn,
+            task_id,
+            metadata,
+            expected_run_id=expected_run_id,
+        )
+
     with write_txn(conn):
         if expected_run_id is None:
             cur = conn.execute(
@@ -4080,6 +4307,12 @@ def complete_task(
             )
         if cur.rowcount != 1:
             return False
+        _record_preserved_completion_artifacts(
+            conn,
+            task_id,
+            artifact_evidence,
+            created_at=now,
+        )
         run_id = _end_run(
             conn, task_id,
             outcome="completed", status="done",
@@ -4123,6 +4356,9 @@ def complete_task(
                 ]
                 if cleaned_artifacts:
                     completed_payload["artifacts"] = cleaned_artifacts
+            evidence = metadata.get(COMPLETION_ARTIFACT_EVIDENCE_KEY)
+            if isinstance(evidence, list) and evidence:
+                completed_payload[COMPLETION_ARTIFACT_EVIDENCE_KEY] = evidence
         _append_event(
             conn, task_id, "completed",
             completed_payload,
@@ -4481,12 +4717,21 @@ def edit_completed_task_result(
 ) -> bool:
     """Backfill the user-visible result for an already completed task."""
     handoff_summary = summary if summary is not None else result
+    artifact_evidence: list[dict] = []
+    if isinstance(metadata, dict):
+        metadata, artifact_evidence = _prepare_completion_artifacts(
+            conn,
+            task_id,
+            metadata,
+            allowed_statuses={"done"},
+        )
     with write_txn(conn):
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if not row or row["status"] != "done":
             return False
+        _record_preserved_completion_artifacts(conn, task_id, artifact_evidence)
         conn.execute(
             "UPDATE tasks SET result = ? WHERE id = ?",
             (result, task_id),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -644,9 +644,10 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
 # Attachments — upload / list / download / delete (#35338)
 # ---------------------------------------------------------------------------
 
-# Cap a single upload so a runaway request can't fill the disk. 25 MB
-# comfortably covers PDFs, images, and source docs — the kanban use case.
-_MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
+# Cap a single upload so a runaway request can't fill the disk. Completion
+# artifact preservation reuses the same central cap in ``kanban_db`` so workers
+# cannot bypass the dashboard upload guard by claiming oversized files.
+_MAX_ATTACHMENT_BYTES = kanban_db.KANBAN_ATTACHMENT_MAX_BYTES
 
 
 def _safe_attachment_name(raw: str) -> str:

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -7,6 +7,7 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
@@ -67,3 +68,53 @@ def test_singleton_dispatcher_lock_is_exclusive(tmp_path):
     h3, st3 = _acquire_singleton_lock(lock)
     assert st3 == "held" and h3 is not None
     _release_singleton_lock(h3)
+
+
+class RecordingArtifactAdapter:
+    def __init__(self):
+        self.documents = []
+        self.images = []
+        self.videos = []
+
+    def extract_local_files(self, text):
+        return [], text
+
+    async def send_multiple_images(self, chat_id, images, metadata=None):
+        self.images.append((chat_id, images, metadata or {}))
+
+    async def send_document(self, chat_id, file_path, metadata=None):
+        self.documents.append((chat_id, file_path, metadata or {}))
+
+    async def send_video(self, chat_id, video_path, metadata=None):
+        self.videos.append((chat_id, video_path, metadata or {}))
+
+
+def test_artifact_delivery_uses_preserved_completion_evidence(tmp_path):
+    """Notifier should upload durable evidence paths, not only legacy payload paths."""
+    durable = tmp_path / "report.pdf"
+    durable.write_bytes(b"durable report")
+    missing = tmp_path / "missing.pdf"
+    adapter = RecordingArtifactAdapter()
+
+    asyncio.run(
+        GatewayKanbanWatchersMixin()._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={"source": "test"},
+            event_payload={
+                "completion_artifact_evidence": [
+                    {"status": "preserved", "stored_path": str(durable)},
+                    {
+                        "status": "missing",
+                        "original_path": str(missing),
+                        "reason": "source_missing_at_completion",
+                    },
+                ]
+            },
+            task=None,
+        )
+    )
+
+    assert adapter.documents == [("chat-1", str(durable), {"source": "test"})]
+    assert adapter.images == []
+    assert adapter.videos == []

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1170,6 +1170,91 @@ def test_complete_records_result(kanban_home):
     assert task.completed_at is not None
 
 
+def test_complete_preserves_claimed_artifact_before_scratch_cleanup(kanban_home):
+    workspace = kb.workspaces_root() / "artifact-source"
+    workspace.mkdir(parents=True)
+    report = workspace / "report.md"
+    report.write_bytes(b"durable evidence\n")
+
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="x",
+            workspace_kind="scratch",
+            workspace_path=str(workspace),
+        )
+        assert kb.complete_task(
+            conn,
+            t,
+            summary="done",
+            metadata={"artifacts": [str(report)]},
+        )
+        run = kb.latest_run(conn, t)
+        events = [e for e in kb.list_events(conn, t) if e.kind == "completed"]
+        attachments = kb.list_attachments(conn, t)
+
+    assert not workspace.exists(), "scratch workspace should still be cleaned up"
+    assert len(attachments) == 1
+    stored = Path(attachments[0].stored_path)
+    assert stored.is_file()
+    assert stored.read_bytes() == b"durable evidence\n"
+    assert stored.is_relative_to(kb.task_attachments_dir(t).resolve())
+
+    evidence = run.metadata["completion_artifact_evidence"]
+    assert len(evidence) == 1
+    ev = evidence[0]
+    assert ev["original_path"] == str(report)
+    assert ev["resolved_path"] == str(report.resolve(strict=False))
+    assert ev["status"] == "preserved"
+    assert ev["stored_path"] == str(stored.resolve())
+    assert ev["attachment_id"] == attachments[0].id
+    assert ev["filename"] == attachments[0].filename
+    assert ev["size"] == len("durable evidence\n".encode("utf-8"))
+    assert ev["sha256"] == "382edde31df119f6a9b8298cecd1d0d3a482ca4becd35b5a80827af11d2b92ac"
+    assert ev["content_type"] == "text/markdown"
+    assert run.metadata["artifacts"] == [str(stored.resolve())]
+    payload = events[-1].payload or {}
+    assert payload["artifacts"] == [str(stored.resolve())]
+    assert payload["completion_artifact_evidence"] == evidence
+
+
+def test_complete_marks_missing_artifact_with_machine_checkable_reason(kanban_home):
+    workspace = kb.workspaces_root() / "missing-artifact-source"
+    workspace.mkdir(parents=True)
+    missing = workspace / "missing-report.md"
+
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="x",
+            workspace_kind="scratch",
+            workspace_path=str(workspace),
+        )
+        assert kb.complete_task(
+            conn,
+            t,
+            summary="done",
+            metadata={"artifacts": [str(missing)]},
+        )
+        run = kb.latest_run(conn, t)
+        payload = [e for e in kb.list_events(conn, t) if e.kind == "completed"][-1].payload or {}
+        attachments = kb.list_attachments(conn, t)
+
+    assert attachments == []
+    assert run.metadata["artifacts"] == []
+    evidence = run.metadata["completion_artifact_evidence"]
+    assert evidence == [
+        {
+            "original_path": str(missing),
+            "resolved_path": str(missing.resolve(strict=False)),
+            "status": "missing",
+            "reason": "source_missing_at_completion",
+        }
+    ]
+    assert "artifacts" not in payload
+    assert payload["completion_artifact_evidence"] == evidence
+
+
 def test_block_then_unblock(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1218,6 +1218,49 @@ def test_complete_preserves_claimed_artifact_before_scratch_cleanup(kanban_home)
     assert payload["completion_artifact_evidence"] == evidence
 
 
+def test_complete_rejects_over_limit_artifact_without_copying(kanban_home, monkeypatch):
+    monkeypatch.setattr(kb, "KANBAN_ATTACHMENT_MAX_BYTES", 8)
+    workspace = kb.workspaces_root() / "oversized-artifact-source"
+    workspace.mkdir(parents=True)
+    report = workspace / "huge-report.bin"
+    report.write_bytes(b"0123456789")
+
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="x",
+            workspace_kind="scratch",
+            workspace_path=str(workspace),
+        )
+        assert kb.complete_task(
+            conn,
+            t,
+            summary="done",
+            metadata={"artifacts": [str(report)]},
+        )
+        run = kb.latest_run(conn, t)
+        payload = [e for e in kb.list_events(conn, t) if e.kind == "completed"][-1].payload or {}
+        attachments = kb.list_attachments(conn, t)
+
+    assert not workspace.exists(), "scratch workspace should still be cleaned up"
+    assert attachments == []
+    assert run.metadata["artifacts"] == []
+    evidence = run.metadata["completion_artifact_evidence"]
+    assert evidence == [
+        {
+            "original_path": str(report),
+            "resolved_path": str(report.resolve(strict=False)),
+            "status": "unavailable",
+            "reason": "source_exceeds_size_limit",
+            "size": 10,
+            "limit": 8,
+        }
+    ]
+    assert "artifacts" not in payload
+    assert payload["completion_artifact_evidence"] == evidence
+    assert not kb.task_attachments_dir(t).exists()
+
+
 def test_complete_marks_missing_artifact_with_machine_checkable_reason(kanban_home):
     workspace = kb.workspaces_root() / "missing-artifact-source"
     workspace.mkdir(parents=True)

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -397,16 +397,23 @@ def test_complete_with_result_only(worker_env):
     assert d["ok"] is True
 
 
-def test_complete_with_artifacts_lands_in_event_payload(worker_env):
-    """``artifacts=[...]`` rides into the completed event payload so the
-    gateway notifier can upload them as native attachments. See the
-    kanban notifier in gateway/run.py for the consumer side."""
+def test_complete_with_artifacts_lands_in_event_payload(worker_env, tmp_path):
+    """``artifacts=[...]`` are verified and promoted to durable attachment paths
+    in the completed event payload so the gateway notifier can upload them even
+    after scratch workspaces are cleaned up."""
+    from pathlib import Path
+
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
+    chart = tmp_path / "q3-revenue.png"
+    report = tmp_path / "q3-report.pdf"
+    chart.write_bytes(b"png-ish")
+    report.write_bytes(b"pdf-ish")
+
     out = kt._handle_complete({
         "summary": "rendered the chart",
-        "artifacts": ["/tmp/q3-revenue.png", "/tmp/q3-report.pdf"],
+        "artifacts": [str(chart), str(report)],
     })
     assert json.loads(out)["ok"] is True
 
@@ -417,57 +424,102 @@ def test_complete_with_artifacts_lands_in_event_payload(worker_env):
         completed = [e for e in events if e.kind == "completed"]
         assert len(completed) == 1
         payload = completed[0].payload or {}
-        assert payload.get("artifacts") == [
-            "/tmp/q3-revenue.png",
-            "/tmp/q3-report.pdf",
-        ]
-        # And the artifacts also live on metadata for downstream workers
+        durable_paths = payload.get("artifacts")
+        assert len(durable_paths) == 2
+        assert all(Path(p).is_file() for p in durable_paths)
+        assert durable_paths != [str(chart), str(report)]
+        evidence = payload.get("completion_artifact_evidence")
+        assert [e["status"] for e in evidence] == ["preserved", "preserved"]
+        assert [e["original_path"] for e in evidence] == [str(chart), str(report)]
+        assert [e["stored_path"] for e in evidence] == durable_paths
+        # And the durable artifacts also live on metadata for downstream workers
         run = kb.latest_run(conn, worker_env)
-        assert run.metadata.get("artifacts") == [
-            "/tmp/q3-revenue.png",
-            "/tmp/q3-report.pdf",
-        ]
+        assert run.metadata.get("artifacts") == durable_paths
+        assert run.metadata.get("completion_artifact_evidence") == evidence
     finally:
         conn.close()
 
 
-def test_complete_artifacts_accepts_single_string(worker_env):
+def test_complete_artifacts_accepts_single_string(worker_env, tmp_path):
     """A bare string is auto-promoted to a single-element list for convenience."""
+    from pathlib import Path
+
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
+
+    chart = tmp_path / "chart.png"
+    chart.write_bytes(b"chart")
 
     out = kt._handle_complete({
         "summary": "one chart",
-        "artifacts": "/tmp/chart.png",
+        "artifacts": str(chart),
     })
     assert json.loads(out)["ok"] is True
 
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)
-        assert run.metadata.get("artifacts") == ["/tmp/chart.png"]
+        durable_paths = run.metadata.get("artifacts")
+        assert len(durable_paths) == 1
+        assert Path(durable_paths[0]).is_file()
+        assert durable_paths[0] != str(chart)
     finally:
         conn.close()
 
 
-def test_complete_artifacts_merges_with_explicit_metadata_field(worker_env):
+def test_complete_surfaces_missing_artifact_evidence(worker_env, tmp_path):
+    """Missing explicit artifacts should be visible in the tool response."""
+    from tools import kanban_tools as kt
+
+    missing = tmp_path / "missing.png"
+    out = kt._handle_complete({
+        "summary": "missing chart",
+        "artifacts": str(missing),
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["artifact_evidence"] == [
+        {
+            "original_path": str(missing),
+            "resolved_path": str(missing.resolve(strict=False)),
+            "status": "missing",
+            "reason": "source_missing_at_completion",
+        }
+    ]
+
+
+def test_complete_artifacts_merges_with_existing_metadata(worker_env, tmp_path):
     """If the worker passes metadata.artifacts AND the top-level artifacts
-    param, merge the two without duplicates."""
+    param, merge the two without duplicates before durability preservation."""
+    from pathlib import Path
+
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
+    a = tmp_path / "a.png"
+    b = tmp_path / "b.pdf"
+    a.write_bytes(b"a")
+    b.write_bytes(b"b")
+
     out = kt._handle_complete({
         "summary": "merged",
-        "metadata": {"artifacts": ["/tmp/a.png"], "other": "fact"},
-        "artifacts": ["/tmp/b.pdf", "/tmp/a.png"],
+        "metadata": {"artifacts": [str(a)], "other": "fact"},
+        "artifacts": [str(b), str(a)],
     })
     assert json.loads(out)["ok"] is True
 
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)
-        # Order: existing entries first, then new ones, deduplicated.
-        assert run.metadata.get("artifacts") == ["/tmp/a.png", "/tmp/b.pdf"]
+        # Order: existing entries first, then new ones, deduplicated, then
+        # rewritten as durable stored paths.
+        durable_paths = run.metadata.get("artifacts")
+        assert len(durable_paths) == 2
+        assert all(Path(p).is_file() for p in durable_paths)
+        assert durable_paths != [str(a), str(b)]
+        evidence = run.metadata.get("completion_artifact_evidence")
+        assert [e["original_path"] for e in evidence] == [str(a), str(b)]
+        assert [e["stored_path"] for e in evidence] == durable_paths
         assert run.metadata.get("other") == "fact"
     finally:
         conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -552,11 +552,11 @@ def _handle_complete(args: dict, **kw) -> str:
         artifacts = [
             str(p).strip() for p in artifacts if str(p).strip()
         ]
-        # Carry the artifact list inside metadata so it rides the
-        # existing completed-event payload without a schema change at
-        # the DB layer.  The gateway notifier reads payload['artifacts']
-        # off the completion event and uploads each path as a native
-        # attachment.
+        # Carry the artifact claims inside metadata; ``complete_task``
+        # verifies them, rewrites successful claims to durable
+        # board-owned attachment paths, and records machine-checkable
+        # evidence for preserved or unavailable sources.  The gateway
+        # notifier then uploads the durable payload['artifacts'] paths.
         if artifacts:
             if metadata is None:
                 metadata = {}
@@ -655,7 +655,12 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"could not complete {tid} (unknown id or already terminal)"
                 )
             run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
+            fields = {"task_id": tid, "run_id": run.id if run else None}
+            if run and isinstance(run.metadata, dict):
+                evidence = run.metadata.get("completion_artifact_evidence")
+                if evidence:
+                    fields["artifact_evidence"] = evidence
+            return _ok(**fields)
         finally:
             conn.close()
     except ValueError as e:


### PR DESCRIPTION
## What does this PR do?

Draft status: Opened as draft for the Kanban reviewer/test-analyst lane.

Fixes the Kanban completion-evidence lifecycle so a done card no longer records claimed artifact paths that disappear when scratch workspaces are cleaned up. Completion now verifies explicit artifact claims, copies existing files into the board-owned task attachments directory, rewrites successful `metadata.artifacts` / completed-event `artifacts` to the durable paths, and records `completion_artifact_evidence` with preserved/missing/unavailable status, reason, size, content type, sha256, and attachment id where available.

Missing or uncopyable artifacts are no longer carried forward as successful artifact paths: they are removed from `metadata.artifacts` and represented with a machine-checkable absence reason. The gateway notifier now reads preserved completion evidence and logs missing/unavailable evidence instead of silently skipping it.

## Related Issue

Kanban task: `t_63eaf2c5` (root `t_7d8a1203`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`
  - Added completion artifact claim extraction, path resolution, safe destination naming, sha256 hashing, durable copy into `task_attachments_dir()`, and evidence metadata.
  - Records preserved artifacts as `task_attachments` rows within completion/edit flows.
  - Rewrites completed run metadata and completed event payload artifact lists to durable stored paths only.
  - Marks missing/non-file/copy-failed claims as `missing`/`unavailable` with stable `reason` values.
- `tools/kanban_tools.py`
  - Keeps top-level `kanban_complete(artifacts=...)` merged into metadata, then surfaces `artifact_evidence` in the tool response when present.
- `gateway/kanban_watchers.py`
  - Delivers durable evidence paths and logs missing/unavailable artifact evidence instead of silently dropping it.
- Tests updated/added in:
  - `tests/hermes_cli/test_kanban_db.py`
  - `tests/tools/test_kanban_tools.py`
  - `tests/gateway/test_kanban_watchers_mixin.py`

## How to Test

1. Focused durable-evidence regression tests:

   ```bash
   export PYTHONPATH="$(pwd)"
   ./.venv/Scripts/python.exe -m pytest \
     tests/hermes_cli/test_kanban_db.py::test_complete_preserves_claimed_artifact_before_scratch_cleanup \
     tests/hermes_cli/test_kanban_db.py::test_complete_marks_missing_artifact_with_machine_checkable_reason \
     tests/tools/test_kanban_tools.py::test_complete_with_artifacts_lands_in_event_payload \
     tests/tools/test_kanban_tools.py::test_complete_artifacts_accepts_single_string \
     tests/tools/test_kanban_tools.py::test_complete_surfaces_missing_artifact_evidence \
     tests/tools/test_kanban_tools.py::test_complete_artifacts_merges_with_existing_metadata \
     tests/gateway/test_kanban_watchers_mixin.py::test_artifact_delivery_uses_preserved_completion_evidence \
     -q --tb=short
   ```

   Result: `7 passed in 1.52s`.

2. Static/syntax checks:

   ```bash
   git diff --check
   ./.venv/Scripts/python.exe -m compileall -q hermes_cli/kanban_db.py tools/kanban_tools.py gateway/kanban_watchers.py
   ```

   Result: both commands exited 0 with no output.

3. Broader changed-file run attempted:

   ```bash
   export PYTHONPATH="$(pwd)"
   ./.venv/Scripts/python.exe -m pytest tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py tests/gateway/test_kanban_watchers_mixin.py -q --tb=short
   ```

   Result: `314 passed, 14 failed` on this Windows desktop. The failures are existing environment/path-sensitive tests outside this change area (rate-limit sentinel classification, git worktree path slash normalization, `_resolve_hermes_argv`, zombie reaper mocks). The new durable-evidence tests passed in the same run.

## Checklist

### Code

- [x] I've read the Contributing Guide / AGENTS.md guidance loaded in this workspace
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate (no open PR for this branch)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 desktop / git-bash-backed Hermes terminal

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — implementation docstrings/comments updated; no user docs changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; response adds optional evidence field without schema change

## Screenshots / Logs

Focused validation log excerpt:

```text
.......                                                                  [100%]
7 passed in 1.52s
```
