### PR TITLE
test(kanban): cover durable completion evidence regressions

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -649,26 +649,29 @@ class GatewayKanbanWatchersMixin:
         chat.
 
         Sources scanned, in priority order:
-          1. ``event_payload['artifacts']`` (explicit list — preferred)
-          2. ``event_payload['summary']`` (truncated first line)
-          3. ``task.result`` (legacy fallback)
+          1. ``event_payload['artifacts']`` (durable completion copies)
+          2. ``event_payload['completion_artifact_evidence']`` preserved records
+          3. ``event_payload['summary']`` (truncated first line)
+          4. ``task.result`` (legacy fallback)
 
-        Files are deduplicated, missing files are silently skipped (the
-        path may have been mentioned for reference only), and delivery
-        errors are logged but do not break the notifier loop.
+        Files are deduplicated. Missing/unavailable completion evidence is
+        logged with its machine-checkable reason instead of silently skipped;
+        delivery errors are logged but do not break the notifier loop.
         """
         from pathlib import Path as _Path
 
         candidates: list[str] = []
+        missing_candidates: list[tuple[str, str]] = []
         seen: set[str] = set()
 
-        def _add(path: str) -> None:
+        def _add(path: str, source: str) -> None:
             if not path:
                 return
             expanded = os.path.expanduser(path)
             if expanded in seen:
                 return
             if not os.path.isfile(expanded):
+                missing_candidates.append((expanded, source))
                 return
             seen.add(expanded)
             candidates.append(expanded)
@@ -679,21 +682,46 @@ class GatewayKanbanWatchersMixin:
             if isinstance(raw, (list, tuple)):
                 for item in raw:
                     if isinstance(item, str):
-                        _add(item)
+                        _add(item, "event_payload.artifacts")
 
-            # 2. Paths embedded in the payload summary.
+            evidence = event_payload.get("completion_artifact_evidence")
+            if isinstance(evidence, (list, tuple)):
+                for item in evidence:
+                    if not isinstance(item, dict):
+                        continue
+                    status = item.get("status")
+                    if status == "preserved":
+                        stored_path = item.get("stored_path")
+                        if isinstance(stored_path, str):
+                            _add(stored_path, "completion_artifact_evidence")
+                    elif status in {"missing", "unavailable"}:
+                        logger.warning(
+                            "kanban notifier: completion artifact unavailable "
+                            "(%s): %s",
+                            item.get("original_path") or item.get("resolved_path"),
+                            item.get("reason") or status,
+                        )
+
+            # 3. Paths embedded in the payload summary.
             summary = event_payload.get("summary")
             if isinstance(summary, str) and summary:
                 paths, _ = adapter.extract_local_files(summary)
                 for p in paths:
-                    _add(p)
+                    _add(p, "event_payload.summary")
 
-        # 3. Legacy: paths embedded in task.result.
+        # 4. Legacy: paths embedded in task.result.
         if task is not None and getattr(task, "result", None):
             result_text = str(task.result)
             paths, _ = adapter.extract_local_files(result_text)
             for p in paths:
-                _add(p)
+                _add(p, "task.result")
+
+        for path, source in missing_candidates:
+            logger.warning(
+                "kanban notifier: artifact path from %s is missing: %s",
+                source,
+                path,
+            )
 
         if not candidates:
             return

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -83,6 +83,7 @@ import subprocess
 import sys
 import threading
 import logging
+import mimetypes
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
@@ -101,6 +102,7 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+COMPLETION_ARTIFACT_EVIDENCE_KEY = "completion_artifact_evidence"
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -2962,6 +2964,63 @@ def list_comments(conn: sqlite3.Connection, task_id: str) -> list[Comment]:
 # Attachments
 # ---------------------------------------------------------------------------
 
+def _safe_attachment_filename(raw: str, *, fallback: str = "artifact") -> str:
+    """Return a safe basename for a board-owned attachment blob."""
+    name = (raw or "").replace("\\", "/").split("/")[-1].strip()
+    name = "".join(ch for ch in name if ch.isprintable() and ch != "\x00").strip()
+    name = name.lstrip(".").strip()
+    if not name:
+        name = fallback
+    return name[:200]
+
+
+def _unique_attachment_path(dest_dir: Path, filename: str) -> Path:
+    """Resolve ``filename`` under ``dest_dir`` without clobbering a blob."""
+    stem, dot, ext = filename.partition(".")
+    candidate = filename
+    n = 1
+    while (dest_dir / candidate).exists():
+        candidate = f"{stem} ({n}){dot}{ext}"
+        n += 1
+    return dest_dir / candidate
+
+
+def _insert_attachment_row(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    filename: str,
+    stored_path: str,
+    content_type: Optional[str] = None,
+    size: int = 0,
+    uploaded_by: Optional[str] = None,
+    created_at: Optional[int] = None,
+) -> int:
+    """Insert an attachment row inside an already-open write transaction."""
+    now = int(created_at if created_at is not None else time.time())
+    cur = conn.execute(
+        "INSERT INTO task_attachments "
+        "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            task_id,
+            filename.strip(),
+            stored_path,
+            content_type,
+            int(size),
+            uploaded_by,
+            now,
+        ),
+    )
+    _append_event(
+        conn,
+        task_id,
+        "attached",
+        {"filename": filename.strip(), "size": int(size), "by": uploaded_by},
+    )
+    return int(cur.lastrowid or 0)
+
+
 def add_attachment(
     conn: sqlite3.Connection,
     task_id: str,
@@ -2982,33 +3041,20 @@ def add_attachment(
         raise ValueError("attachment filename is required")
     if not stored_path or not stored_path.strip():
         raise ValueError("attachment stored_path is required")
-    now = int(time.time())
     with write_txn(conn):
         if not conn.execute(
             "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
         ).fetchone():
             raise ValueError(f"unknown task {task_id}")
-        cur = conn.execute(
-            "INSERT INTO task_attachments "
-            "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                task_id,
-                filename.strip(),
-                stored_path,
-                content_type,
-                int(size),
-                uploaded_by,
-                now,
-            ),
-        )
-        _append_event(
+        return _insert_attachment_row(
             conn,
             task_id,
-            "attached",
-            {"filename": filename.strip(), "size": int(size), "by": uploaded_by},
+            filename=filename.strip(),
+            stored_path=stored_path,
+            content_type=content_type,
+            size=size,
+            uploaded_by=uploaded_by,
         )
-        return int(cur.lastrowid or 0)
 
 
 def list_attachments(conn: sqlite3.Connection, task_id: str) -> list[Attachment]:
@@ -3975,6 +4021,178 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+def _completion_artifact_claims(metadata: Optional[dict]) -> list[str]:
+    """Return unique artifact path claims from completion metadata.
+
+    ``kanban_complete(artifacts=[...])`` stores claims under
+    ``metadata['artifacts']``. Older callers sometimes used a singular
+    ``metadata['artifact']`` field; preserve it too so those claims get the
+    same durability treatment instead of being left as dead scratch paths.
+    """
+    if not isinstance(metadata, dict):
+        return []
+    claims: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if not isinstance(value, str):
+            return
+        s = value.strip()
+        if s and s not in seen:
+            seen.add(s)
+            claims.append(s)
+
+    raw_artifacts = metadata.get("artifacts")
+    if isinstance(raw_artifacts, str):
+        add(raw_artifacts)
+    elif isinstance(raw_artifacts, (list, tuple)):
+        for item in raw_artifacts:
+            add(item)
+    add(metadata.get("artifact"))
+    return claims
+
+
+def _path_metadata_string(path: Path) -> str:
+    try:
+        return str(path.resolve(strict=False))
+    except OSError:
+        return str(path)
+
+
+def _windows_msys_path(raw: str) -> str:
+    """Translate /c/Users/... paths when a Windows worker used git-bash."""
+    if os.name == "nt" and re.match(r"^/[A-Za-z]/", raw):
+        return f"{raw[1]}:{raw[2:]}"
+    return raw
+
+
+def _resolve_completion_artifact_source(raw: str, workspace_path: Optional[str]) -> Path:
+    expanded = _windows_msys_path(os.path.expanduser(raw.strip()))
+    source = Path(expanded)
+    if not source.is_absolute() and workspace_path:
+        source = Path(workspace_path).expanduser() / source
+    return source
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _prepare_completion_artifacts(
+    conn: sqlite3.Connection,
+    task_id: str,
+    metadata: Optional[dict],
+    *,
+    expected_run_id: Optional[int] = None,
+    allowed_statuses: Optional[set[str]] = None,
+) -> tuple[Optional[dict], list[dict]]:
+    """Copy claimed completion artifacts to durable task attachments.
+
+    Returns a metadata copy plus machine-checkable evidence records. Missing
+    or uncopyable sources are recorded as unavailable evidence and are not
+    carried forward in ``metadata['artifacts']`` as successful artifact paths.
+    """
+    claims = _completion_artifact_claims(metadata)
+    if not claims or not isinstance(metadata, dict):
+        return metadata, []
+
+    row = conn.execute(
+        "SELECT status, workspace_path, current_run_id FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if allowed_statuses is None:
+        allowed_statuses = {"running", "ready", "blocked"}
+    if not row or row["status"] not in allowed_statuses:
+        return metadata, []
+    if expected_run_id is not None and row["current_run_id"] != int(expected_run_id):
+        return metadata, []
+
+    evidence: list[dict] = []
+    durable_paths: list[str] = []
+    dest_dir = task_attachments_dir(task_id)
+
+    for idx, raw in enumerate(claims, start=1):
+        source = _resolve_completion_artifact_source(raw, row["workspace_path"])
+        resolved_source = _path_metadata_string(source)
+        base = {"original_path": raw, "resolved_path": resolved_source}
+        try:
+            if not source.exists():
+                evidence.append({
+                    **base,
+                    "status": "missing",
+                    "reason": "source_missing_at_completion",
+                })
+                continue
+            if not source.is_file():
+                evidence.append({
+                    **base,
+                    "status": "unavailable",
+                    "reason": "source_not_file_at_completion",
+                })
+                continue
+
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            safe_name = _safe_attachment_filename(source.name or raw, fallback=f"artifact-{idx}")
+            dest = _unique_attachment_path(dest_dir, safe_name)
+            shutil.copy2(source, dest)
+            stored_path = _path_metadata_string(dest)
+            durable_paths.append(stored_path)
+            content_type, _ = mimetypes.guess_type(dest.name)
+            if content_type is None and dest.suffix.lower() in {".md", ".markdown"}:
+                content_type = "text/markdown"
+            evidence.append({
+                **base,
+                "status": "preserved",
+                "stored_path": stored_path,
+                "filename": dest.name,
+                "size": dest.stat().st_size,
+                "sha256": _sha256_file(dest),
+                "content_type": content_type,
+            })
+        except OSError as exc:
+            evidence.append({
+                **base,
+                "status": "unavailable",
+                "reason": "preservation_failed",
+                "error": str(exc),
+            })
+
+    prepared = dict(metadata)
+    prepared[COMPLETION_ARTIFACT_EVIDENCE_KEY] = evidence
+    prepared["artifacts"] = durable_paths
+    if "artifact" in prepared:
+        prepared["artifact"] = durable_paths[0] if durable_paths else None
+    return prepared, evidence
+
+
+def _record_preserved_completion_artifacts(
+    conn: sqlite3.Connection,
+    task_id: str,
+    evidence: list[dict],
+    *,
+    created_at: Optional[int] = None,
+) -> None:
+    """Persist task_attachments rows for already-copied completion artifacts."""
+    for item in evidence:
+        if item.get("status") != "preserved" or item.get("attachment_id"):
+            continue
+        att_id = _insert_attachment_row(
+            conn,
+            task_id,
+            filename=str(item.get("filename") or "artifact"),
+            stored_path=str(item.get("stored_path") or ""),
+            content_type=item.get("content_type"),
+            size=int(item.get("size") or 0),
+            uploaded_by="completion-evidence",
+            created_at=created_at,
+        )
+        item["attachment_id"] = att_id
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4042,6 +4260,15 @@ def complete_task(
     else:
         verified_cards = []
 
+    artifact_evidence: list[dict] = []
+    if isinstance(metadata, dict):
+        metadata, artifact_evidence = _prepare_completion_artifacts(
+            conn,
+            task_id,
+            metadata,
+            expected_run_id=expected_run_id,
+        )
+
     with write_txn(conn):
         if expected_run_id is None:
             cur = conn.execute(
@@ -4080,6 +4307,12 @@ def complete_task(
             )
         if cur.rowcount != 1:
             return False
+        _record_preserved_completion_artifacts(
+            conn,
+            task_id,
+            artifact_evidence,
+            created_at=now,
+        )
         run_id = _end_run(
             conn, task_id,
             outcome="completed", status="done",
@@ -4123,6 +4356,9 @@ def complete_task(
                 ]
                 if cleaned_artifacts:
                     completed_payload["artifacts"] = cleaned_artifacts
+            evidence = metadata.get(COMPLETION_ARTIFACT_EVIDENCE_KEY)
+            if isinstance(evidence, list) and evidence:
+                completed_payload[COMPLETION_ARTIFACT_EVIDENCE_KEY] = evidence
         _append_event(
             conn, task_id, "completed",
             completed_payload,
@@ -4481,12 +4717,21 @@ def edit_completed_task_result(
 ) -> bool:
     """Backfill the user-visible result for an already completed task."""
     handoff_summary = summary if summary is not None else result
+    artifact_evidence: list[dict] = []
+    if isinstance(metadata, dict):
+        metadata, artifact_evidence = _prepare_completion_artifacts(
+            conn,
+            task_id,
+            metadata,
+            allowed_statuses={"done"},
+        )
     with write_txn(conn):
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if not row or row["status"] != "done":
             return False
+        _record_preserved_completion_artifacts(conn, task_id, artifact_evidence)
         conn.execute(
             "UPDATE tasks SET result = ? WHERE id = ?",
             (result, task_id),

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -7,6 +7,7 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
@@ -67,3 +68,53 @@ def test_singleton_dispatcher_lock_is_exclusive(tmp_path):
     h3, st3 = _acquire_singleton_lock(lock)
     assert st3 == "held" and h3 is not None
     _release_singleton_lock(h3)
+
+
+class RecordingArtifactAdapter:
+    def __init__(self):
+        self.documents = []
+        self.images = []
+        self.videos = []
+
+    def extract_local_files(self, text):
+        return [], text
+
+    async def send_multiple_images(self, chat_id, images, metadata=None):
+        self.images.append((chat_id, images, metadata or {}))
+
+    async def send_document(self, chat_id, file_path, metadata=None):
+        self.documents.append((chat_id, file_path, metadata or {}))
+
+    async def send_video(self, chat_id, video_path, metadata=None):
+        self.videos.append((chat_id, video_path, metadata or {}))
+
+
+def test_artifact_delivery_uses_preserved_completion_evidence(tmp_path):
+    """Notifier should upload durable evidence paths, not only legacy payload paths."""
+    durable = tmp_path / "report.pdf"
+    durable.write_bytes(b"durable report")
+    missing = tmp_path / "missing.pdf"
+    adapter = RecordingArtifactAdapter()
+
+    asyncio.run(
+        GatewayKanbanWatchersMixin()._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={"source": "test"},
+            event_payload={
+                "completion_artifact_evidence": [
+                    {"status": "preserved", "stored_path": str(durable)},
+                    {
+                        "status": "missing",
+                        "original_path": str(missing),
+                        "reason": "source_missing_at_completion",
+                    },
+                ]
+            },
+            task=None,
+        )
+    )
+
+    assert adapter.documents == [("chat-1", str(durable), {"source": "test"})]
+    assert adapter.images == []
+    assert adapter.videos == []

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1218,6 +1218,76 @@ def test_complete_preserves_claimed_artifact_before_scratch_cleanup(kanban_home)
     assert payload["completion_artifact_evidence"] == evidence
 
 
+def test_completion_artifact_claims_unit_dedupes_supported_metadata_keys():
+    """The artifact verifier only treats explicit artifact fields as claims.
+
+    Legacy report tasks sometimes stored a report path under the singular
+    ``artifact`` key, while newer tool calls use ``artifacts``.  Arbitrary
+    descriptive metadata such as ``report_path`` is intentionally not promoted
+    unless the worker also lists it under one of those explicit artifact keys.
+    """
+    metadata = {
+        "artifacts": [" report.md ", "report.md", "chart.png", None],
+        "artifact": "report.md",
+        "report_path": "unsupported-unless-explicit.md",
+    }
+
+    assert kb._completion_artifact_claims(metadata) == ["report.md", "chart.png"]
+
+
+def test_complete_preserves_legacy_singular_artifact_regression_t_12fe5625(kanban_home):
+    """Regression for t_12fe5625-style report metadata.
+
+    That run recorded its report path in ``task_runs.metadata['artifact']`` and
+    the completed event's artifact payload.  Completion must rewrite the legacy
+    singular field to a durable attachment path before scratch cleanup, not
+    leave a dead workspace path as the durable evidence.
+    """
+    workspace = kb.workspaces_root() / "t_12fe5625-style-workspace"
+    workspace.mkdir(parents=True)
+    report = workspace / "territory_state_sos_backtest_report.md"
+    report.write_text("# NO-BUILD\n", encoding="utf-8")
+
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="Backtest: territory-state incorporation registries as discovery source",
+            workspace_kind="scratch",
+            workspace_path=str(workspace),
+            tenant="prospecting",
+        )
+        assert kb.complete_task(
+            conn,
+            t,
+            summary="Completed the read-only backtest report",
+            metadata={
+                "artifact": str(report),
+                "recommendation": "NO-BUILD",
+                "registry_snapshot": "C:/external/snapshot.sqlite",
+            },
+        )
+        run = kb.latest_run(conn, t)
+        payload = [e for e in kb.list_events(conn, t) if e.kind == "completed"][-1].payload or {}
+        attachments = kb.list_attachments(conn, t)
+
+    assert not workspace.exists(), "scratch workspace should still be cleaned up"
+    assert len(attachments) == 1
+    stored = Path(attachments[0].stored_path)
+    assert stored.is_file()
+    assert stored.read_text(encoding="utf-8") == "# NO-BUILD\n"
+
+    evidence = run.metadata["completion_artifact_evidence"]
+    assert len(evidence) == 1
+    assert evidence[0]["status"] == "preserved"
+    assert evidence[0]["original_path"] == str(report)
+    assert evidence[0]["stored_path"] == str(stored.resolve())
+    assert run.metadata["artifact"] == str(stored.resolve())
+    assert run.metadata["artifacts"] == [str(stored.resolve())]
+    assert run.metadata["recommendation"] == "NO-BUILD"
+    assert payload["artifacts"] == [str(stored.resolve())]
+    assert payload["completion_artifact_evidence"] == evidence
+
+
 def test_complete_marks_missing_artifact_with_machine_checkable_reason(kanban_home):
     workspace = kb.workspaces_root() / "missing-artifact-source"
     workspace.mkdir(parents=True)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1170,6 +1170,91 @@ def test_complete_records_result(kanban_home):
     assert task.completed_at is not None
 
 
+def test_complete_preserves_claimed_artifact_before_scratch_cleanup(kanban_home):
+    workspace = kb.workspaces_root() / "artifact-source"
+    workspace.mkdir(parents=True)
+    report = workspace / "report.md"
+    report.write_bytes(b"durable evidence\n")
+
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="x",
+            workspace_kind="scratch",
+            workspace_path=str(workspace),
+        )
+        assert kb.complete_task(
+            conn,
+            t,
+            summary="done",
+            metadata={"artifacts": [str(report)]},
+        )
+        run = kb.latest_run(conn, t)
+        events = [e for e in kb.list_events(conn, t) if e.kind == "completed"]
+        attachments = kb.list_attachments(conn, t)
+
+    assert not workspace.exists(), "scratch workspace should still be cleaned up"
+    assert len(attachments) == 1
+    stored = Path(attachments[0].stored_path)
+    assert stored.is_file()
+    assert stored.read_bytes() == b"durable evidence\n"
+    assert stored.is_relative_to(kb.task_attachments_dir(t).resolve())
+
+    evidence = run.metadata["completion_artifact_evidence"]
+    assert len(evidence) == 1
+    ev = evidence[0]
+    assert ev["original_path"] == str(report)
+    assert ev["resolved_path"] == str(report.resolve(strict=False))
+    assert ev["status"] == "preserved"
+    assert ev["stored_path"] == str(stored.resolve())
+    assert ev["attachment_id"] == attachments[0].id
+    assert ev["filename"] == attachments[0].filename
+    assert ev["size"] == len("durable evidence\n".encode("utf-8"))
+    assert ev["sha256"] == "382edde31df119f6a9b8298cecd1d0d3a482ca4becd35b5a80827af11d2b92ac"
+    assert ev["content_type"] == "text/markdown"
+    assert run.metadata["artifacts"] == [str(stored.resolve())]
+    payload = events[-1].payload or {}
+    assert payload["artifacts"] == [str(stored.resolve())]
+    assert payload["completion_artifact_evidence"] == evidence
+
+
+def test_complete_marks_missing_artifact_with_machine_checkable_reason(kanban_home):
+    workspace = kb.workspaces_root() / "missing-artifact-source"
+    workspace.mkdir(parents=True)
+    missing = workspace / "missing-report.md"
+
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="x",
+            workspace_kind="scratch",
+            workspace_path=str(workspace),
+        )
+        assert kb.complete_task(
+            conn,
+            t,
+            summary="done",
+            metadata={"artifacts": [str(missing)]},
+        )
+        run = kb.latest_run(conn, t)
+        payload = [e for e in kb.list_events(conn, t) if e.kind == "completed"][-1].payload or {}
+        attachments = kb.list_attachments(conn, t)
+
+    assert attachments == []
+    assert run.metadata["artifacts"] == []
+    evidence = run.metadata["completion_artifact_evidence"]
+    assert evidence == [
+        {
+            "original_path": str(missing),
+            "resolved_path": str(missing.resolve(strict=False)),
+            "status": "missing",
+            "reason": "source_missing_at_completion",
+        }
+    ]
+    assert "artifacts" not in payload
+    assert payload["completion_artifact_evidence"] == evidence
+
+
 def test_block_then_unblock(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -397,16 +397,23 @@ def test_complete_with_result_only(worker_env):
     assert d["ok"] is True
 
 
-def test_complete_with_artifacts_lands_in_event_payload(worker_env):
-    """``artifacts=[...]`` rides into the completed event payload so the
-    gateway notifier can upload them as native attachments. See the
-    kanban notifier in gateway/run.py for the consumer side."""
+def test_complete_with_artifacts_lands_in_event_payload(worker_env, tmp_path):
+    """``artifacts=[...]`` are verified and promoted to durable attachment paths
+    in the completed event payload so the gateway notifier can upload them even
+    after scratch workspaces are cleaned up."""
+    from pathlib import Path
+
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
+    chart = tmp_path / "q3-revenue.png"
+    report = tmp_path / "q3-report.pdf"
+    chart.write_bytes(b"png-ish")
+    report.write_bytes(b"pdf-ish")
+
     out = kt._handle_complete({
         "summary": "rendered the chart",
-        "artifacts": ["/tmp/q3-revenue.png", "/tmp/q3-report.pdf"],
+        "artifacts": [str(chart), str(report)],
     })
     assert json.loads(out)["ok"] is True
 
@@ -417,57 +424,102 @@ def test_complete_with_artifacts_lands_in_event_payload(worker_env):
         completed = [e for e in events if e.kind == "completed"]
         assert len(completed) == 1
         payload = completed[0].payload or {}
-        assert payload.get("artifacts") == [
-            "/tmp/q3-revenue.png",
-            "/tmp/q3-report.pdf",
-        ]
-        # And the artifacts also live on metadata for downstream workers
+        durable_paths = payload.get("artifacts")
+        assert len(durable_paths) == 2
+        assert all(Path(p).is_file() for p in durable_paths)
+        assert durable_paths != [str(chart), str(report)]
+        evidence = payload.get("completion_artifact_evidence")
+        assert [e["status"] for e in evidence] == ["preserved", "preserved"]
+        assert [e["original_path"] for e in evidence] == [str(chart), str(report)]
+        assert [e["stored_path"] for e in evidence] == durable_paths
+        # And the durable artifacts also live on metadata for downstream workers
         run = kb.latest_run(conn, worker_env)
-        assert run.metadata.get("artifacts") == [
-            "/tmp/q3-revenue.png",
-            "/tmp/q3-report.pdf",
-        ]
+        assert run.metadata.get("artifacts") == durable_paths
+        assert run.metadata.get("completion_artifact_evidence") == evidence
     finally:
         conn.close()
 
 
-def test_complete_artifacts_accepts_single_string(worker_env):
+def test_complete_artifacts_accepts_single_string(worker_env, tmp_path):
     """A bare string is auto-promoted to a single-element list for convenience."""
+    from pathlib import Path
+
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
+
+    chart = tmp_path / "chart.png"
+    chart.write_bytes(b"chart")
 
     out = kt._handle_complete({
         "summary": "one chart",
-        "artifacts": "/tmp/chart.png",
+        "artifacts": str(chart),
     })
     assert json.loads(out)["ok"] is True
 
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)
-        assert run.metadata.get("artifacts") == ["/tmp/chart.png"]
+        durable_paths = run.metadata.get("artifacts")
+        assert len(durable_paths) == 1
+        assert Path(durable_paths[0]).is_file()
+        assert durable_paths[0] != str(chart)
     finally:
         conn.close()
 
 
-def test_complete_artifacts_merges_with_explicit_metadata_field(worker_env):
+def test_complete_surfaces_missing_artifact_evidence(worker_env, tmp_path):
+    """Missing explicit artifacts should be visible in the tool response."""
+    from tools import kanban_tools as kt
+
+    missing = tmp_path / "missing.png"
+    out = kt._handle_complete({
+        "summary": "missing chart",
+        "artifacts": str(missing),
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["artifact_evidence"] == [
+        {
+            "original_path": str(missing),
+            "resolved_path": str(missing.resolve(strict=False)),
+            "status": "missing",
+            "reason": "source_missing_at_completion",
+        }
+    ]
+
+
+def test_complete_artifacts_merges_with_existing_metadata(worker_env, tmp_path):
     """If the worker passes metadata.artifacts AND the top-level artifacts
-    param, merge the two without duplicates."""
+    param, merge the two without duplicates before durability preservation."""
+    from pathlib import Path
+
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
+    a = tmp_path / "a.png"
+    b = tmp_path / "b.pdf"
+    a.write_bytes(b"a")
+    b.write_bytes(b"b")
+
     out = kt._handle_complete({
         "summary": "merged",
-        "metadata": {"artifacts": ["/tmp/a.png"], "other": "fact"},
-        "artifacts": ["/tmp/b.pdf", "/tmp/a.png"],
+        "metadata": {"artifacts": [str(a)], "other": "fact"},
+        "artifacts": [str(b), str(a)],
     })
     assert json.loads(out)["ok"] is True
 
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)
-        # Order: existing entries first, then new ones, deduplicated.
-        assert run.metadata.get("artifacts") == ["/tmp/a.png", "/tmp/b.pdf"]
+        # Order: existing entries first, then new ones, deduplicated, then
+        # rewritten as durable stored paths.
+        durable_paths = run.metadata.get("artifacts")
+        assert len(durable_paths) == 2
+        assert all(Path(p).is_file() for p in durable_paths)
+        assert durable_paths != [str(a), str(b)]
+        evidence = run.metadata.get("completion_artifact_evidence")
+        assert [e["original_path"] for e in evidence] == [str(a), str(b)]
+        assert [e["stored_path"] for e in evidence] == durable_paths
         assert run.metadata.get("other") == "fact"
     finally:
         conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -552,11 +552,11 @@ def _handle_complete(args: dict, **kw) -> str:
         artifacts = [
             str(p).strip() for p in artifacts if str(p).strip()
         ]
-        # Carry the artifact list inside metadata so it rides the
-        # existing completed-event payload without a schema change at
-        # the DB layer.  The gateway notifier reads payload['artifacts']
-        # off the completion event and uploads each path as a native
-        # attachment.
+        # Carry the artifact claims inside metadata; ``complete_task``
+        # verifies them, rewrites successful claims to durable
+        # board-owned attachment paths, and records machine-checkable
+        # evidence for preserved or unavailable sources.  The gateway
+        # notifier then uploads the durable payload['artifacts'] paths.
         if artifacts:
             if metadata is None:
                 metadata = {}
@@ -655,7 +655,12 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"could not complete {tid} (unknown id or already terminal)"
                 )
             run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
+            fields = {"task_id": tid, "run_id": run.id if run else None}
+            if run and isinstance(run.metadata, dict):
+                evidence = run.metadata.get("completion_artifact_evidence")
+                if evidence:
+                    fields["artifact_evidence"] = evidence
+            return _ok(**fields)
         finally:
             conn.close()
     except ValueError as e:


### PR DESCRIPTION
## Draft Status
Opened as draft; test-only companion/stack on top of PR #59937 (`kanban-durable-evidence-t_63eaf2c5`).

## Summary
- Adds a unit test for completion artifact claim extraction/deduping across supported `artifact` and `artifacts` metadata keys.
- Adds a t_12fe5625-style regression asserting legacy singular report artifact metadata is rewritten to durable task attachments before scratch workspace cleanup.
- Documents the intentionally unsupported behavior for arbitrary `report_path` metadata unless it is also listed as an explicit artifact claim.

## Validation
- `export PYTHONPATH="$(pwd)"; /c/Users/edson/AppData/Local/hermes-desktop/kanban/workspaces/t_63eaf2c5/hermes-agent/.venv/Scripts/python.exe -m pytest tests/hermes_cli/test_kanban_db.py::test_completion_artifact_claims_unit_dedupes_supported_metadata_keys tests/hermes_cli/test_kanban_db.py::test_complete_preserves_legacy_singular_artifact_regression_t_12fe5625 tests/hermes_cli/test_kanban_db.py::test_complete_preserves_claimed_artifact_before_scratch_cleanup tests/hermes_cli/test_kanban_db.py::test_complete_marks_missing_artifact_with_machine_checkable_reason -q --tb=short` → 4 passed in 1.37s
- `export PYTHONPATH="$(pwd)"; /c/Users/edson/AppData/Local/hermes-desktop/kanban/workspaces/t_63eaf2c5/hermes-agent/.venv/Scripts/python.exe -m pytest tests/hermes_cli/test_kanban_db.py::test_complete_preserves_claimed_artifact_before_scratch_cleanup tests/hermes_cli/test_kanban_db.py::test_completion_artifact_claims_unit_dedupes_supported_metadata_keys tests/hermes_cli/test_kanban_db.py::test_complete_preserves_legacy_singular_artifact_regression_t_12fe5625 tests/hermes_cli/test_kanban_db.py::test_complete_marks_missing_artifact_with_machine_checkable_reason tests/tools/test_kanban_tools.py::test_complete_with_artifacts_lands_in_event_payload tests/tools/test_kanban_tools.py::test_complete_artifacts_accepts_single_string tests/tools/test_kanban_tools.py::test_complete_surfaces_missing_artifact_evidence tests/tools/test_kanban_tools.py::test_complete_artifacts_merges_with_existing_metadata tests/gateway/test_kanban_watchers_mixin.py::test_artifact_delivery_uses_preserved_completion_evidence -q --tb=short && git diff --check` → 9 passed in 0.95s; diff check clean

## Deployment Impact
Test-only change; no runtime behavior changes.

## Rollback
Revert commit `8b6f916` / remove the two added tests from `tests/hermes_cli/test_kanban_db.py`.

## Agent Notes
PR body complete. Validation reported or skipped checks justified. Runtime impact understood. Focused change. Correct target repo. No unrelated files included. No operator-only action required. Conflicts and companion PRs reviewed: companion to PR #59937.

## Merge Readiness
Draft pending maintainer/reviewer decision on whether to fold this commit into PR #59937 or review as a separate companion PR.
