### PR TITLE
fix(cli): resolve deferred platform plugin so its CLI subcommand registers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13123,6 +13123,35 @@ def main():
                 seen_plugin_commands.add(cmd_info["name"])
 
             discover_plugins()
+
+            # Bundled platform plugins load lazily (deferred): their module —
+            # and thus any ``ctx.register_cli_command()`` call inside the
+            # plugin's ``register()`` — is only imported when the
+            # platform_registry is first asked for that platform (gateway
+            # start / setup / send). A standalone ``hermes <platform> ...``
+            # invocation parses args before the registry is ever touched, so
+            # the plugin's subcommand would never be wired up and argparse
+            # rejects it as an invalid choice. If the first positional token
+            # names a deferred platform, force-resolve just that one so its
+            # ``register()`` runs and registers its CLI command. Only the
+            # matched platform is imported, so the lazy-load fast path for
+            # chat and every built-in subcommand is preserved.
+            _first_plugin_token = _first_positional_argv()
+            if (
+                _first_plugin_token is not None
+                and _first_plugin_token not in _BUILTIN_SUBCOMMANDS
+            ):
+                try:
+                    from gateway.platform_registry import platform_registry
+
+                    if _first_plugin_token in platform_registry._deferred:
+                        platform_registry.get(_first_plugin_token)
+                except Exception as _exc:
+                    logging.getLogger(__name__).debug(
+                        "Deferred platform CLI resolve failed for '%s': %s",
+                        _first_plugin_token, _exc,
+                    )
+
             for cmd_info in get_plugin_manager()._cli_commands.values():
                 if cmd_info["name"] in seen_plugin_commands:
                     continue

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -183,3 +183,96 @@ class TestProviderCollectorCliNoop:
         )
         # Should not store anything — CLI is discovered via file convention
         assert not hasattr(collector, "_cli_commands")
+
+
+# ── Deferred platform plugin CLI resolution ───────────────────────────────
+
+
+class TestDeferredPlatformCliResolution:
+    """A bundled platform plugin registers its ``hermes <platform>`` CLI
+    command inside ``register()``, but platform plugins load lazily (deferred):
+    the module — and thus the ``register_cli_command()`` call — is only imported
+    when the platform_registry is first asked for that platform.
+
+    Regression: a standalone ``hermes <platform> ...`` invocation parses argv
+    before the registry is touched, so the subcommand was never wired up and
+    argparse rejected it as an invalid choice. The fix force-resolves the one
+    deferred platform whose name matches the first positional token. These
+    tests assert the underlying contract that fix relies on: resolving a
+    deferred platform runs its loader, which populates ``_cli_commands``.
+    """
+
+    def _make_deferred_platform(self, platform_name):
+        """Wire a deferred loader whose module registers a CLI command.
+
+        Returns ``(registry, manager, loader_calls)`` where ``loader_calls`` is
+        a single-element list used as a call counter so tests can assert the
+        loader ran at most once.
+        """
+        from gateway.platform_registry import PlatformRegistry
+
+        registry = PlatformRegistry()
+        manager = PluginManager()
+        loader_calls = []
+
+        def _loader():
+            # Mirrors what a real platform plugin's register() does: register
+            # the platform entry AND its `hermes <platform>` CLI command.
+            loader_calls.append(1)
+            ctx = PluginContext(PluginManifest(name=f"{platform_name}-platform"), manager)
+            ctx.register_cli_command(
+                name=platform_name,
+                help=f"Manage the {platform_name} integration",
+                setup_fn=MagicMock(),
+                handler_fn=MagicMock(),
+            )
+
+        registry.register_deferred(platform_name, _loader)
+        return registry, manager, loader_calls
+
+    def test_cli_command_absent_until_resolved(self):
+        """Before the platform is resolved, its CLI command is not registered."""
+        registry, manager, loader_calls = self._make_deferred_platform("acmechat")
+        # Deferred loader is pending but has NOT run yet.
+        assert "acmechat" in registry._deferred
+        assert loader_calls == []
+        assert "acmechat" not in manager._cli_commands
+
+    def test_resolving_platform_registers_cli_command(self):
+        """Resolving the deferred platform runs its loader and wires the CLI."""
+        registry, manager, loader_calls = self._make_deferred_platform("acmechat")
+
+        entry = registry.get("acmechat")
+
+        assert entry is None or entry.name == "acmechat"  # loader may skip register()
+        assert loader_calls == [1]
+        # The CLI command is now available on the manager.
+        assert "acmechat" in manager._cli_commands
+        assert manager._cli_commands["acmechat"]["help"] == (
+            "Manage the acmechat integration"
+        )
+
+    def test_loader_runs_at_most_once(self):
+        """A second lookup does not re-run the loader (deferred entry popped)."""
+        registry, manager, loader_calls = self._make_deferred_platform("acmechat")
+        registry.get("acmechat")
+        registry.get("acmechat")
+        assert loader_calls == [1]
+
+    def test_unrelated_token_does_not_resolve_platform(self):
+        """A non-platform token (e.g. a chat prompt) leaves loaders untouched.
+
+        This is the fast-path guarantee: ``hermes <chat prompt>`` must not
+        import any platform SDK just because discovery ran.
+        """
+        registry, manager, loader_calls = self._make_deferred_platform("acmechat")
+
+        # Simulate the guard in main(): only resolve when the token names a
+        # deferred platform. "hello" is not a platform, so nothing resolves.
+        token = "hello"
+        if token in registry._deferred:
+            registry.get(token)
+
+        assert loader_calls == []
+        assert "acmechat" not in manager._cli_commands
+


### PR DESCRIPTION
## Summary

Bundled platform plugins load **lazily** (deferred): the plugin module — and therefore any `ctx.register_cli_command()` call inside its `register()` — is only imported when the `platform_registry` is first asked for that platform (gateway start / `hermes setup` / `hermes gateway status` / `send`). This is a deliberate optimization so a plain `hermes chat` doesn't eagerly import ~20 platform SDKs (`discord.py`, `slack_bolt`, `lark_oapi`, `microsoft_teams`, spectrum-ts, …).

The side effect: a standalone `hermes <platform> …` invocation parses argv **before** the registry is ever touched, so a platform plugin's own subcommand is never wired into argparse and the CLI rejects it as an invalid choice.

## Reproduction

The Photon iMessage plugin registers a `hermes photon` CLI (`setup` / `status` / `install-sidecar` / `telemetry`) inside its `register()`. With the plugin enabled:

```
$ hermes photon setup --phone +1...
hermes: error: argument command: invalid choice: 'photon' (choose from 'chat', 'model', ...)
```

This is the exact command the plugin's own `plugin.yaml` `install_hint` and the user docs tell people to run, so first-time Photon setup is a dead end from the CLI. The `hermes gateway setup` wizard happens to work only because it iterates the registry (`all_entries()` → `_resolve_all()`), which force-loads every deferred platform as a side effect.

Slack and WhatsApp don't hit this because their subcommands are hardcoded built-ins (`build_slack_parser` / `build_whatsapp_parser`); Photon is currently the only platform plugin that ships its CLI via `register_cli_command`, and it's the canonical example — any future platform plugin that does the same is affected.

## Fix

During plugin CLI discovery in `main()`, if the first positional token names a **deferred** platform, force-resolve just that one via `platform_registry.get(token)` before reading `_cli_commands`. That runs the plugin's `register()`, which registers its CLI command, so argparse sees the subcommand.

Scope is deliberately minimal:
- Only fires when the token isn't a built-in subcommand **and** matches a pending deferred platform, so **only the matched platform** is imported. A chat prompt like `hermes what is 2+2` calls `get("what")`, finds no deferred entry, and imports nothing — the lazy-load fast path is preserved (verified: `hermes --version` still ~0.3s, no platform SDK import).
- Wrapped in try/except at debug level — a resolve failure can never break argparse setup.
- Reuses the existing `_first_positional_argv()` helper and `_BUILTIN_SUBCOMMANDS` set already used to decide whether discovery runs at all.

## Tests

Adds `TestDeferredPlatformCliResolution` to `tests/hermes_cli/test_plugin_cli_registration.py`, asserting the behavior contract the fix depends on:

- CLI command is absent until the platform is resolved.
- Resolving the deferred platform runs its loader and populates `_cli_commands`.
- The loader runs at most once across repeated lookups.
- An unrelated (non-platform) token never triggers a platform import — the fast-path guarantee.

All 12 tests in the file pass; broader plugin/gateway/send suites (153 tests) green. Verified end-to-end that `hermes photon --help` / `hermes photon status` resolve and that unknown tokens still route to chat.
