### PR TITLE
feat(agent): add observe-only smart model router

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -597,6 +597,22 @@ def run_conversation(
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
+    try:
+        from agent.smart_model_router import evaluate_turn_route
+
+        _smart_route_decision = evaluate_turn_route(
+            agent,
+            original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+        )
+        if _smart_route_decision is not None:
+            agent._last_smart_route_decision = _smart_route_decision.as_dict()
+        else:
+            agent._last_smart_route_decision = None
+    except Exception as exc:
+        logger.debug("smart model routing observe step skipped: %s", exc, exc_info=True)
+
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None

--- a/agent/smart_model_router.py
+++ b/agent/smart_model_router.py
@@ -1,0 +1,334 @@
+"""Observe-mode smart model routing for Hermes turns.
+
+The first implementation is intentionally non-invasive: it evaluates a route
+before a turn starts, records the decision, and never mutates the active model.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from agent.smart_router_prompts import build_router_messages, parse_router_json
+from agent.task_features import TaskFeatures, extract_task_features
+
+logger = logging.getLogger(__name__)
+
+ROUTES = frozenset({"cheap", "default", "strong", "moa", "no_change"})
+MODES = frozenset({"off", "observe", "suggest", "auto"})
+
+
+@dataclass(frozen=True)
+class HistoricalTaskExample:
+    summary: str
+    route: str = ""
+    model: str = ""
+    provider: str = ""
+    tool_call_count: int | None = None
+    api_call_count: int | None = None
+    elapsed_seconds: float | None = None
+    success: bool | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SmartRouteDecision:
+    enabled: bool
+    mode: str
+    route: str
+    confidence: float
+    risk: str
+    reason: str
+    expected_tool_calls: int | None
+    should_use_moa: bool
+    source: str
+    features: TaskFeatures
+    historical_examples: list[HistoricalTaskExample] = field(default_factory=list)
+    provider: str | None = None
+    model: str | None = None
+    preset: str | None = None
+    decision_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    created_at: float = field(default_factory=time.time)
+
+    def as_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["features"] = self.features.as_dict()
+        data["historical_examples"] = [ex.as_dict() for ex in self.historical_examples]
+        return data
+
+
+def evaluate_turn_route(
+    agent: Any,
+    user_message: Any,
+    *,
+    messages: list[dict[str, Any]] | None = None,
+    effective_task_id: str = "",
+    config: dict[str, Any] | None = None,
+) -> SmartRouteDecision | None:
+    """Return an observe-mode route decision for this turn, if enabled."""
+
+    cfg = _normalize_config(config if config is not None else _read_router_config())
+    mode = cfg["mode"]
+    if mode == "off":
+        return None
+
+    features = extract_task_features(user_message, message_count=len(messages or []))
+    historical_examples = _retrieve_historical_examples(user_message, cfg)
+    heuristic = _heuristic_decision(features)
+    payload = _build_payload(
+        agent,
+        user_message,
+        features,
+        historical_examples,
+        cfg,
+        heuristic,
+        effective_task_id=effective_task_id,
+    )
+
+    parsed: dict[str, Any] | None = None
+    source = "heuristic"
+    if _llm_judge_enabled(cfg):
+        try:
+            parsed = _call_router_llm(agent, cfg, payload)
+            source = "llm" if parsed else "heuristic_after_llm_failure"
+        except Exception as exc:
+            logger.debug("smart_model_router LLM judge failed: %s", exc, exc_info=True)
+            source = "heuristic_after_llm_failure"
+
+    selected = _decision_from_parsed(parsed, heuristic)
+    route_cfg = _route_config(cfg, selected["route"])
+    decision = SmartRouteDecision(
+        enabled=True,
+        mode=mode,
+        route=selected["route"],
+        confidence=selected["confidence"],
+        risk=selected["risk"],
+        reason=selected["reason"],
+        expected_tool_calls=selected["expected_tool_calls"],
+        should_use_moa=selected["should_use_moa"],
+        source=source,
+        features=features,
+        historical_examples=historical_examples,
+        provider=route_cfg.get("provider"),
+        model=route_cfg.get("model"),
+        preset=route_cfg.get("preset"),
+    )
+    logger.info(
+        "smart_model_router decision mode=%s source=%s route=%s confidence=%.2f "
+        "risk=%s provider=%s model=%s task_id=%s reason=%s",
+        decision.mode,
+        decision.source,
+        decision.route,
+        decision.confidence,
+        decision.risk,
+        decision.provider or "-",
+        decision.model or decision.preset or "-",
+        effective_task_id or "-",
+        decision.reason,
+    )
+    return decision
+
+
+def _normalize_config(raw: dict[str, Any] | None) -> dict[str, Any]:
+    cfg = raw if isinstance(raw, dict) else {}
+    mode = str(cfg.get("mode") or "off").strip().lower()
+    if mode not in MODES:
+        mode = "off"
+    routes = cfg.get("routes") if isinstance(cfg.get("routes"), dict) else {}
+    router = cfg.get("router") if isinstance(cfg.get("router"), dict) else {}
+    return {
+        "mode": mode,
+        "judge": str(cfg.get("judge") or cfg.get("strategy") or "heuristic").strip().lower(),
+        "router": router,
+        "routes": routes,
+        "top_k": _coerce_int(cfg.get("top_k"), 0),
+        "confidence_threshold": _coerce_float(cfg.get("confidence_threshold"), 0.75),
+    }
+
+
+def _read_router_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import read_raw_config
+
+        raw = read_raw_config() or {}
+    except Exception:
+        return {}
+    cfg = raw.get("smart_model_routing")
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _retrieve_historical_examples(
+    user_message: Any,
+    cfg: dict[str, Any],
+) -> list[HistoricalTaskExample]:
+    """Placeholder for the embedding-backed history lookup.
+
+    Keeping this as a function makes the next step small: replace this body with
+    a task embedding index lookup and keep the router prompt contract stable.
+    """
+
+    _ = (user_message, cfg)
+    return []
+
+
+def _heuristic_decision(features: TaskFeatures) -> dict[str, Any]:
+    score = features.complexity_score
+    if features.high_risk_domain or features.destructive_intent:
+        route = "strong"
+        risk = "high"
+        confidence = 0.72
+    elif features.architecture_or_analysis and (features.review_or_debug or score >= 6):
+        route = "moa"
+        risk = "medium"
+        confidence = 0.62
+    elif score >= 6:
+        route = "strong"
+        risk = "medium"
+        confidence = 0.68
+    elif score <= 1:
+        route = "cheap"
+        risk = "low"
+        confidence = 0.65
+    else:
+        route = "default"
+        risk = "medium" if score >= 4 else "low"
+        confidence = 0.64
+
+    expected_tool_calls = 0
+    if features.likely_needs_file_access:
+        expected_tool_calls += 4
+    if features.requires_code_edit:
+        expected_tool_calls += 4
+    if features.likely_needs_tests:
+        expected_tool_calls += 2
+    if features.likely_needs_web:
+        expected_tool_calls += 2
+
+    return {
+        "route": route,
+        "confidence": confidence,
+        "risk": risk,
+        "expected_tool_calls": expected_tool_calls,
+        "reason": "heuristic score=%s signals=%s" % (score, ",".join(features.signals) or "none"),
+        "should_use_moa": route == "moa",
+    }
+
+
+def _build_payload(
+    agent: Any,
+    user_message: Any,
+    features: TaskFeatures,
+    historical_examples: list[HistoricalTaskExample],
+    cfg: dict[str, Any],
+    heuristic: dict[str, Any],
+    *,
+    effective_task_id: str,
+) -> dict[str, Any]:
+    return {
+        "user_message": _preview(user_message, 3000),
+        "platform": getattr(agent, "platform", "") or "",
+        "current_provider": getattr(agent, "provider", "") or "",
+        "current_model": getattr(agent, "model", "") or "",
+        "api_mode": getattr(agent, "api_mode", "") or "",
+        "task_id": effective_task_id,
+        "features": features.as_dict(),
+        "heuristic_decision": heuristic,
+        "retrieved_examples": [ex.as_dict() for ex in historical_examples],
+        "available_routes": cfg.get("routes") or {},
+    }
+
+
+def _llm_judge_enabled(cfg: dict[str, Any]) -> bool:
+    if cfg.get("judge") != "llm":
+        return False
+    router = cfg.get("router") if isinstance(cfg.get("router"), dict) else {}
+    return bool(router.get("provider") and router.get("model"))
+
+
+def _call_router_llm(
+    agent: Any,
+    cfg: dict[str, Any],
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    from agent.auxiliary_client import call_llm, extract_content_or_reasoning
+
+    router = cfg.get("router") if isinstance(cfg.get("router"), dict) else {}
+    response = call_llm(
+        task="smart_routing",
+        provider=router.get("provider"),
+        model=router.get("model"),
+        main_runtime={
+            "provider": getattr(agent, "provider", "") or "",
+            "model": getattr(agent, "model", "") or "",
+            "base_url": getattr(agent, "base_url", "") or "",
+            "api_key": getattr(agent, "api_key", "") or "",
+            "api_mode": getattr(agent, "api_mode", "") or "",
+        },
+        messages=build_router_messages(payload),
+        temperature=None,
+        max_tokens=_coerce_int(router.get("max_tokens"), 400),
+        timeout=_coerce_float(router.get("timeout"), 30.0),
+    )
+    return parse_router_json(extract_content_or_reasoning(response))
+
+
+def _decision_from_parsed(
+    parsed: dict[str, Any] | None,
+    fallback: dict[str, Any],
+) -> dict[str, Any]:
+    if not parsed:
+        return fallback
+    route = str(parsed.get("route") or "").strip().lower()
+    if route not in ROUTES:
+        route = fallback["route"]
+    return {
+        "route": route,
+        "confidence": max(0.0, min(1.0, _coerce_float(parsed.get("confidence"), fallback["confidence"]))),
+        "risk": _risk(parsed.get("risk"), fallback["risk"]),
+        "expected_tool_calls": max(
+            0,
+            _coerce_int(
+                parsed.get("expected_tool_calls"),
+                fallback["expected_tool_calls"] or 0,
+            ),
+        ),
+        "reason": _preview(parsed.get("reason") or fallback["reason"], 500),
+        "should_use_moa": bool(parsed.get("should_use_moa", route == "moa")),
+    }
+
+
+def _route_config(cfg: dict[str, Any], route: str) -> dict[str, Any]:
+    routes = cfg.get("routes") if isinstance(cfg.get("routes"), dict) else {}
+    entry = routes.get(route)
+    return entry if isinstance(entry, dict) else {}
+
+
+def _risk(value: Any, default: str) -> str:
+    risk = str(value or default or "medium").strip().lower()
+    return risk if risk in {"low", "medium", "high"} else "medium"
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _preview(value: Any, limit: int) -> str:
+    text = value if isinstance(value, str) else str(value or "")
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "..."

--- a/agent/smart_router_prompts.py
+++ b/agent/smart_router_prompts.py
@@ -1,0 +1,57 @@
+"""Prompt and JSON parsing helpers for the smart model router."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+ROUTER_SYSTEM_PROMPT = """You are Hermes's pre-turn smart model router.
+
+Choose the least expensive route that is likely to complete the user's next
+turn well. This is an advisory decision only: do not solve the task.
+
+Return strict JSON with these keys:
+- route: one of cheap, default, strong, moa, no_change
+- confidence: number from 0 to 1
+- risk: one of low, medium, high
+- expected_tool_calls: non-negative integer
+- reason: short explanation
+- should_use_moa: boolean
+
+Prefer no_change when evidence is weak. Prefer strong for high-risk or
+multi-file debugging tasks. Prefer moa only for complex architecture, review,
+or multi-perspective reasoning tasks where extra latency is justified.
+"""
+
+
+def build_router_messages(payload: dict[str, Any]) -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": ROUTER_SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": json.dumps(payload, ensure_ascii=False, sort_keys=True),
+        },
+    ]
+
+
+def parse_router_json(text: str) -> dict[str, Any] | None:
+    """Parse a router JSON object, tolerating fenced output."""
+
+    raw = (text or "").strip()
+    if not raw:
+        return None
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", raw, flags=re.DOTALL)
+    if fenced:
+        raw = fenced.group(1)
+    else:
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start >= 0 and end > start:
+            raw = raw[start : end + 1]
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, dict) else None

--- a/agent/task_features.py
+++ b/agent/task_features.py
@@ -1,0 +1,239 @@
+"""Lightweight task feature extraction for smart model routing.
+
+This module is intentionally heuristic-only.  It gives the router a cheap,
+explainable first pass before any auxiliary LLM judge is considered.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+_CODE_FILE_RE = re.compile(
+    r"(?i)\b[\w./-]+\.(?:py|ts|tsx|js|jsx|go|rs|java|kt|swift|c|cc|cpp|h|hpp|"
+    r"cs|rb|php|md|yaml|yml|json|toml|sql|sh|zsh|fish|css|scss|html)\b"
+)
+_PATH_RE = re.compile(r"(?:^|\s)(?:/[\w./-]+|\.{1,2}/[\w./-]+)")
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(term in lowered for term in terms)
+
+
+@dataclass(frozen=True)
+class TaskFeatures:
+    """Router-facing summary of the current user turn."""
+
+    requires_code_edit: bool = False
+    likely_needs_file_access: bool = False
+    likely_needs_tests: bool = False
+    likely_needs_web: bool = False
+    architecture_or_analysis: bool = False
+    review_or_debug: bool = False
+    high_risk_domain: bool = False
+    destructive_intent: bool = False
+    has_explicit_file_reference: bool = False
+    has_multimodal_hint: bool = False
+    asks_for_latest: bool = False
+    asks_for_plan: bool = False
+    complexity_score: int = 0
+    signals: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def extract_task_features(user_message: Any, *, message_count: int = 0) -> TaskFeatures:
+    """Extract cheap, deterministic routing features from a user request."""
+
+    text = _stringify_user_message(user_message)
+    lowered = text.lower()
+    signals: list[str] = []
+
+    requires_code_edit = _contains_any(
+        lowered,
+        (
+            "fix",
+            "implement",
+            "add",
+            "modify",
+            "patch",
+            "refactor",
+            "delete",
+            "remove",
+            "update the code",
+            "\u4fee\u590d",
+            "\u5b9e\u73b0",
+            "\u4fee\u6539",
+            "\u91cd\u6784",
+        ),
+    )
+    if requires_code_edit:
+        signals.append("code_edit_terms")
+
+    has_explicit_file_reference = bool(_CODE_FILE_RE.search(text) or _PATH_RE.search(text))
+    if has_explicit_file_reference:
+        signals.append("file_or_path_reference")
+
+    likely_needs_file_access = has_explicit_file_reference or _contains_any(
+        lowered,
+        (
+            "repo",
+            "codebase",
+            "project",
+            "branch",
+            "module",
+            "\u9879\u76ee",
+            "\u4ee3\u7801\u5e93",
+            "\u6587\u4ef6",
+            "\u6a21\u5757",
+        ),
+    )
+    if likely_needs_file_access:
+        signals.append("file_access_likely")
+
+    likely_needs_tests = _contains_any(
+        lowered,
+        ("test", "pytest", "vitest", "unit test", "e2e", "\u6d4b\u8bd5"),
+    )
+    if likely_needs_tests:
+        signals.append("tests_likely")
+
+    asks_for_latest = _contains_any(
+        lowered,
+        (
+            "latest",
+            "today",
+            "current",
+            "recent",
+            "newest",
+            "\u6700\u65b0",
+            "\u4eca\u5929",
+            "\u5f53\u524d",
+            "\u8fd1\u671f",
+        ),
+    )
+    likely_needs_web = asks_for_latest or _contains_any(
+        lowered,
+        ("search", "browse", "look up", "verify online", "\u641c", "\u67e5\u4e00\u4e0b"),
+    )
+    if likely_needs_web:
+        signals.append("web_or_freshness_likely")
+
+    architecture_or_analysis = _contains_any(
+        lowered,
+        (
+            "architecture",
+            "design",
+            "analyze",
+            "analysis",
+            "tradeoff",
+            "proposal",
+            "\u67b6\u6784",
+            "\u8bbe\u8ba1",
+            "\u5206\u6790",
+            "\u65b9\u6848",
+        ),
+    )
+    if architecture_or_analysis:
+        signals.append("architecture_or_analysis")
+
+    review_or_debug = _contains_any(
+        lowered,
+        ("review", "bug", "debug", "regression", "stack trace", "\u4ee3\u7801\u5ba1\u67e5", "\u62a5\u9519"),
+    )
+    if review_or_debug:
+        signals.append("review_or_debug")
+
+    high_risk_domain = _contains_any(
+        lowered,
+        (
+            "credential",
+            "secret",
+            "token",
+            "security",
+            "auth",
+            "payment",
+            "legal",
+            "finance",
+            "\u51ed\u8bc1",
+            "\u5bc6\u94a5",
+            "\u5b89\u5168",
+            "\u652f\u4ed8",
+            "\u6cd5\u5f8b",
+            "\u91d1\u878d",
+        ),
+    )
+    if high_risk_domain:
+        signals.append("high_risk_domain")
+
+    destructive_intent = _contains_any(
+        lowered,
+        ("delete", "remove", "drop table", "reset", "wipe", "\u5220\u9664", "\u6e05\u7a7a", "\u91cd\u7f6e"),
+    )
+    if destructive_intent:
+        signals.append("destructive_terms")
+
+    has_multimodal_hint = _contains_any(
+        lowered,
+        ("image", "screenshot", "photo", "pdf", "\u56fe\u7247", "\u622a\u56fe", "\u7167\u7247"),
+    )
+    if has_multimodal_hint:
+        signals.append("multimodal_hint")
+
+    asks_for_plan = _contains_any(
+        lowered,
+        ("plan", "todo", "roadmap", "steps", "\u8ba1\u5212", "\u6b65\u9aa4", "\u8def\u7ebf\u56fe"),
+    )
+    if asks_for_plan:
+        signals.append("planning_request")
+
+    score = 0
+    score += 2 if requires_code_edit else 0
+    score += 2 if likely_needs_file_access else 0
+    score += 1 if likely_needs_tests else 0
+    score += 1 if likely_needs_web else 0
+    score += 2 if architecture_or_analysis else 0
+    score += 2 if review_or_debug else 0
+    score += 3 if high_risk_domain else 0
+    score += 2 if destructive_intent else 0
+    score += 1 if has_multimodal_hint else 0
+    score += 1 if asks_for_plan else 0
+    score += 1 if message_count > 20 else 0
+    score = min(score, 10)
+
+    return TaskFeatures(
+        requires_code_edit=requires_code_edit,
+        likely_needs_file_access=likely_needs_file_access,
+        likely_needs_tests=likely_needs_tests,
+        likely_needs_web=likely_needs_web,
+        architecture_or_analysis=architecture_or_analysis,
+        review_or_debug=review_or_debug,
+        high_risk_domain=high_risk_domain,
+        destructive_intent=destructive_intent,
+        has_explicit_file_reference=has_explicit_file_reference,
+        has_multimodal_hint=has_multimodal_hint,
+        asks_for_latest=asks_for_latest,
+        asks_for_plan=asks_for_plan,
+        complexity_score=score,
+        signals=signals,
+    )
+
+
+def _stringify_user_message(user_message: Any) -> str:
+    if isinstance(user_message, str):
+        return user_message
+    if isinstance(user_message, list):
+        parts: list[str] = []
+        for item in user_message:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return str(user_message or "")

--- a/tests/agent/test_smart_model_router.py
+++ b/tests/agent/test_smart_model_router.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+from agent.smart_model_router import evaluate_turn_route
+from agent.smart_router_prompts import parse_router_json
+from agent.task_features import extract_task_features
+
+
+def test_task_features_detect_code_analysis_request():
+    features = extract_task_features(
+        "\u5206\u6790\u8fd9\u4e2a\u9879\u76ee\u7684 "
+        "agent/conversation_loop.py "
+        "\u5e76\u8bbe\u8ba1\u4fee\u6539\u65b9\u6848"
+    )
+
+    assert features.architecture_or_analysis is True
+    assert features.likely_needs_file_access is True
+    assert features.has_explicit_file_reference is True
+    assert features.complexity_score >= 4
+
+
+def test_router_off_returns_none():
+    agent = SimpleNamespace(provider="openai", model="gpt-test", api_mode="chat_completions")
+
+    decision = evaluate_turn_route(
+        agent,
+        "hello",
+        config={"mode": "off"},
+    )
+
+    assert decision is None
+
+
+def test_router_observe_heuristic_does_not_mutate_agent_model():
+    agent = SimpleNamespace(provider="openai", model="gpt-test", api_mode="chat_completions")
+
+    decision = evaluate_turn_route(
+        agent,
+        "fix the failing pytest in agent/router.py",
+        messages=[],
+        effective_task_id="task-1",
+        config={
+            "mode": "observe",
+            "routes": {
+                "strong": {"provider": "openrouter", "model": "strong-model"},
+            },
+        },
+    )
+
+    assert decision is not None
+    assert decision.mode == "observe"
+    assert decision.route in {"default", "strong", "moa"}
+    assert agent.provider == "openai"
+    assert agent.model == "gpt-test"
+
+
+def test_parse_router_json_tolerates_fenced_json():
+    parsed = parse_router_json(
+        "```json\n"
+        '{"route":"strong","confidence":0.8,"risk":"medium",'
+        '"expected_tool_calls":4,"reason":"x","should_use_moa":false}'
+        "\n```"
+    )
+
+    assert parsed["route"] == "strong"
+    assert parsed["confidence"] == 0.8


### PR DESCRIPTION
## What does this PR do?

Adds an observe-only smart model routing skeleton for Hermes turns. This does not switch the active provider/model, mutate the system prompt, change tool schemas, or affect prompt-cache stability. It only records a pre-turn route decision for later evaluation.

This is intentionally different from per-turn cheap-model swapping: the goal is to gather routing signals first, so future smart routing can become cache-aware instead of causing frequent model churn inside long sessions.

## Related Issue

N/A

Related prior art / possible overlap: #59390

## Type of Change

- [x] ✨ New feature
- [x] ✅ Tests

## Changes Made

- Added `agent/task_features.py` for cheap heuristic task feature extraction.
- Added `agent/smart_router_prompts.py` for router prompt and JSON parsing.
- Added `agent/smart_model_router.py` for observe-only route decisions.
- Hooked the observer into `agent/conversation_loop.py` after turn context setup.
- Added focused tests in `tests/agent/test_smart_model_router.py`.

## How to Test

1. Configure `smart_model_routing.mode: observe`.
2. Run a normal Hermes turn.
3. Confirm the active model does not change and `smart_model_router decision ...` appears in logs.

Verification run locally:

- `python3 -m py_compile agent/conversation_loop.py agent/task_features.py agent/smart_router_prompts.py agent/smart_model_router.py tests/agent/test_smart_model_router.py`
- Manual invocation of the focused test functions passed.

Full pytest/ruff were not run because this checkout has no `.venv`/`venv`, and system Python does not have `pytest` or `ruff` installed.