### PR TITLE
[codex] Guard required Kanban create subscriptions

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1408,6 +1408,19 @@ DEFAULT_CONFIG = {
         # behaviour — e.g. for a profile that prefers explicit
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
+        # Optional guard for orchestrator profiles that must not create
+        # human-close-loop cards silently. When a create targets one of
+        # these assignees (or the global flag is true), kanban_create
+        # preflights that a gateway/TUI delivery target exists and
+        # returns an error instead of creating an unobservable task.
+        #
+        # Example:
+        #   require_auto_subscribe_on_create: true
+        #   # or:
+        #   require_auto_subscribe_for_assignees:
+        #     - reviewer-profile
+        "require_auto_subscribe_on_create": False,
+        "require_auto_subscribe_for_assignees": [],
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -2179,6 +2179,192 @@ def test_create_respects_auto_subscribe_on_create_false(monkeypatch, worker_env,
     assert _list_subs_for_task(d["task_id"]) == []
 
 
+def test_create_required_subscription_global_config_fails_without_delivery_target(
+    monkeypatch, worker_env
+):
+    """Profiles can require auto-subscribe for every kanban_create call.
+
+    This is useful for orchestrators that must observe all downstream work,
+    regardless of whether the new task is assigned to a coder, reviewer, or
+    QA profile.
+    """
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    monkeypatch.setattr(
+        kt,
+        "load_config",
+        lambda: {"kanban": {"require_auto_subscribe_on_create": True}},
+    )
+
+    out = kt._handle_create({
+        "title": "Coder: silent card",
+        "assignee": "coder-profile",
+    })
+    d = json.loads(out)
+    assert "error" in d
+    assert "requires a notification subscription" in d["error"]
+
+    conn = kb.connect()
+    try:
+        tasks = kb.list_tasks(
+            conn, assignee="coder-profile", include_archived=True
+        )
+    finally:
+        conn.close()
+    assert tasks == []
+
+
+def test_create_required_subscription_global_config_succeeds_with_gateway_target(
+    monkeypatch, worker_env
+):
+    """Global required-subscription mode still allows any assignee when
+    auto-subscribe can register the calling gateway session."""
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
+    monkeypatch.setattr(
+        kt,
+        "load_config",
+        lambda: {"kanban": {"require_auto_subscribe_on_create": True}},
+    )
+
+    out = kt._handle_create({
+        "title": "QA: observable card",
+        "assignee": "qa-profile",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["subscribed"] is True
+
+    subs = _sub_index(_list_subs_for_task(d["task_id"]))
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "chat-42"
+
+
+def test_create_required_subscription_assignee_config_fails_without_delivery_target(
+    monkeypatch, worker_env
+):
+    """Profiles can require auto-subscribe for selected human-close-loop
+    assignees without forcing every create."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    monkeypatch.setattr(
+        kt,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "require_auto_subscribe_for_assignees": ["reviewer-profile"],
+            },
+        },
+    )
+
+    out = kt._handle_create({
+        "title": "Review: silent card",
+        "assignee": "reviewer-profile",
+    })
+    d = json.loads(out)
+    assert "error" in d
+    assert "requires a notification subscription" in d["error"]
+
+    conn = kb.connect()
+    try:
+        tasks = kb.list_tasks(
+            conn, assignee="reviewer-profile", include_archived=True
+        )
+    finally:
+        conn.close()
+    assert tasks == []
+
+
+def test_create_required_subscription_assignee_config_succeeds_with_gateway_target(
+    monkeypatch, worker_env
+):
+    """Required-subscription assignees still work when auto-subscribe can
+    actually register the calling gateway session."""
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
+    monkeypatch.setattr(
+        kt,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "require_auto_subscribe_for_assignees": ["reviewer-profile"],
+            },
+        },
+    )
+
+    out = kt._handle_create({
+        "title": "Review: observable card",
+        "assignee": "reviewer-profile",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["subscribed"] is True
+
+    subs = _sub_index(_list_subs_for_task(d["task_id"]))
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "chat-42"
+
+
+
+def test_create_required_subscription_blocks_task_when_subscribe_write_fails(
+    monkeypatch, worker_env
+):
+    """If required subscription passes preflight but the subscription write
+    itself fails, do not let the task keep running toward silent completion."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
+    monkeypatch.setattr(
+        kt,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "require_auto_subscribe_for_assignees": ["reviewer-profile"],
+            },
+        },
+    )
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated DB failure")
+
+    monkeypatch.setattr(kb, "add_notify_sub", _boom)
+
+    out = kt._handle_create({
+        "title": "Review: write failure",
+        "assignee": "reviewer-profile",
+    })
+    d = json.loads(out)
+    assert "error" in d
+    assert "could not register a required notification subscription" in d["error"]
+
+    conn = kb.connect()
+    try:
+        tasks = kb.list_tasks(
+            conn, assignee="reviewer-profile", include_archived=True
+        )
+        assert len(tasks) == 1
+        assert tasks[0].status == "blocked"
+        events = [e.kind for e in kb.list_events(conn, tasks[0].id)]
+        assert "blocked" in events
+    finally:
+        conn.close()
+
 def test_create_partial_session_context_no_subscribe(monkeypatch, worker_env):
     """Only one of (platform, chat_id) set -> no implicit subscribe.
     Either both are set (gateway) or neither (TUI / CLI); partial is

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -315,6 +315,88 @@ def _parse_bool_arg(args: dict, name: str, *, default: bool = False):
     return default, f"{name} must be a boolean or 'true'/'false'"
 
 
+def _as_config_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def _subscription_required_for_create(
+    args: dict, assignee: str
+) -> tuple[bool, Optional[str]]:
+    explicit, bool_error = _parse_bool_arg(args, "require_subscription")
+    if bool_error:
+        return False, bool_error
+    required = bool(explicit)
+    try:
+        cfg = load_config()
+        required = required or bool(
+            cfg_get(
+                cfg,
+                "kanban",
+                "require_auto_subscribe_on_create",
+                default=False,
+            )
+        )
+        required_assignees = _as_config_list(
+            cfg_get(
+                cfg,
+                "kanban",
+                "require_auto_subscribe_for_assignees",
+                default=[],
+            )
+        )
+        target = str(assignee or "").strip()
+        required = required or "*" in required_assignees or target in required_assignees
+    except Exception:
+        # Config read failures should not unexpectedly force every create.
+        # An explicit require_subscription=True argument is still honored.
+        pass
+    return required, None
+
+
+def _auto_subscribe_preflight_error() -> Optional[str]:
+    try:
+        cfg = load_config()
+        if not cfg_get(cfg, "kanban", "auto_subscribe_on_create", default=True):
+            return "kanban.auto_subscribe_on_create is false"
+    except Exception:
+        # Match _maybe_auto_subscribe: config load failures fail open.
+        pass
+
+    try:
+        from gateway.session_context import get_session_env
+
+        platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+        chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+        if platform and chat_id:
+            return None
+
+        session_key = (
+            get_session_env("HERMES_SESSION_KEY", "")
+            or os.environ.get("HERMES_SESSION_KEY", "")
+        )
+        if session_key:
+            return None
+    except Exception as exc:
+        return f"could not inspect session delivery target: {exc}"
+
+    return "no gateway or TUI session delivery target is available"
+
+
+def _required_subscription_error(assignee: str, reason: str) -> str:
+    return (
+        "kanban_create requires a notification subscription for "
+        f"assignee {assignee!r}, but {reason}. Create the task from a "
+        "gateway/TUI session or relax kanban.require_auto_subscribe_* "
+        "for this profile."
+    )
+
+
 def _require_orchestrator_tool(tool_name: str) -> Optional[str]:
     """Belt-and-suspenders runtime guard for orchestrator-only handlers.
 
@@ -847,6 +929,14 @@ def _handle_create(args: dict, **kw) -> str:
             "task (the dispatcher will only spawn tasks with an assignee)"
         )
     body = args.get("body")
+    require_subscription, subscription_error = _subscription_required_for_create(
+        args, str(assignee)
+    )
+    if subscription_error:
+        return tool_error(subscription_error)
+    if require_subscription:
+        if preflight_error := _auto_subscribe_preflight_error():
+            return tool_error(_required_subscription_error(str(assignee), preflight_error))
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
     # Stamp the originating session id when the agent loop runs under
@@ -936,6 +1026,25 @@ def _handle_create(args: dict, **kw) -> str:
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
+            if require_subscription and not subscribed:
+                reason = (
+                    "notification subscription was required for this task, "
+                    "but kanban_create could not register one"
+                )
+                try:
+                    kb.block_task(conn, new_tid, reason=reason, kind="capability")
+                except Exception:
+                    logger.warning(
+                        "failed to block task after required subscribe failure: %s",
+                        new_tid,
+                        exc_info=True,
+                    )
+                return tool_error(
+                    f"kanban_create created {new_tid} but could not register "
+                    "a required notification subscription; the task was "
+                    "blocked to avoid silent completion. Fix the notification "
+                    "session context, subscribe explicitly, then unblock it."
+                )
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
@@ -1539,6 +1648,16 @@ KANBAN_CREATE_SCHEMA = {
                     "continuation turns the worker may take before the task "
                     "is blocked for review. Ignored unless goal_mode is "
                     "true. Defaults to the goal-engine default (20)."
+                ),
+            },
+            "require_subscription": {
+                "type": "boolean",
+                "description": (
+                    "Require this create to register a notification "
+                    "subscription for the originating gateway/TUI session. "
+                    "If no delivery target is available, the create fails "
+                    "before writing a task. Profiles can also require this "
+                    "by config via kanban.require_auto_subscribe_*."
                 ),
             },
             "board": _board_schema_prop(),


### PR DESCRIPTION
## Summary

- add a required-subscription guard for `kanban_create`, controlled by an explicit tool argument, a global `kanban.require_auto_subscribe_on_create` config flag, or a per-assignee config list
- preflight gateway/TUI delivery context before creating required cards, so unobservable tasks fail before they hit the board
- block a just-created task if a required subscription write unexpectedly fails after creation, preventing silent completion
- cover global, per-assignee, gateway success, and write-failure paths in `tests/tools/test_kanban_tools.py`

## Why

Orchestrator profiles can fan out work to other agents and then rely on task notifications to continue the workflow. If a card is created without a notification subscription, the downstream work can complete or block without the orchestrator being prompted to resume, leaving workflows stalled until someone manually checks the board.

This keeps the existing best-effort default intact, while giving orchestrators a programmatic way to require observable child tasks.

## Validation

- `cd /tmp/hermes-agent-required-subscribe-pr-20260707 && /home/ubuntu/.hermes/hermes-agent/.venv/bin/python -m pytest tests/tools/test_kanban_tools.py`
