### PR TITLE
feat: add optional code graph toolset

### DIFF
--- a/tests/tools/test_code_graph_indexer.py
+++ b/tests/tools/test_code_graph_indexer.py
@@ -1,0 +1,135 @@
+import json
+
+from tools.code_graph.indexer import index_repo
+from tools.code_graph.query import graph_status
+from tools.code_graph.storage import CodeGraphStore
+
+
+def test_index_repo_extracts_python_symbols(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "sample.py"
+    source.write_text(
+        '''"""Module doc."""
+
+class Greeter:
+    """Greeter docs."""
+    def hello(self, name: str) -> str:
+        """Say hello."""
+        return f"hello {name}"
+
+
+def helper(value: int) -> int:
+    return value + 1
+''',
+        encoding="utf-8",
+    )
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+
+    summary = index_repo(repo, store=store)
+
+    assert summary["files_indexed"] == 1
+    with store.connect() as conn:
+        symbols = conn.execute("SELECT name, kind FROM symbols ORDER BY name").fetchall()
+    assert [(row["name"], row["kind"]) for row in symbols] == [
+        ("Greeter", "class"),
+        ("hello", "function"),
+        ("helper", "function"),
+    ]
+
+
+def test_index_repo_records_python_import_edges(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("import json\nfrom pathlib import Path\n", encoding="utf-8")
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+
+    index_repo(repo, store=store)
+
+    with store.connect() as conn:
+        edges = conn.execute("SELECT edge_type, metadata_json FROM edges").fetchall()
+    imports = [
+        json.loads(row["metadata_json"])["module"]
+        for row in edges
+        if row["edge_type"] == "imports"
+    ]
+    assert imports == ["json", "pathlib"]
+
+
+def test_index_repo_records_textual_reference_edges(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("def helper():\n    return helper()\n", encoding="utf-8")
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+
+    index_repo(repo, store=store)
+
+    with store.connect() as conn:
+        edges = conn.execute("SELECT edge_type, metadata_json FROM edges").fetchall()
+    names = {
+        json.loads(row["metadata_json"])["name"]
+        for row in edges
+        if row["edge_type"] in {"references", "calls"}
+    }
+    assert "helper" in names
+
+
+def test_graph_status_reports_missing_before_index(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+
+    status = graph_status(repo, store=store)
+
+    assert status["graph_status"] == "missing"
+
+
+def test_graph_status_reports_stale_after_file_change(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    path = repo / "sample.py"
+    path.write_text("def one():\n    return 1\n", encoding="utf-8")
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+    index_repo(repo, store=store)
+
+    path.write_text("def two():\n    return 2\n", encoding="utf-8")
+    status = graph_status(repo, store=store)
+
+    assert status["graph_status"] == "stale"
+    assert status["stale_files"] == 1
+
+
+def test_index_repo_skips_large_files(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    big = repo / "big.py"
+    big.write_text("x = '" + ("a" * 600_000) + "'\n", encoding="utf-8")
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+
+    summary = index_repo(repo, store=store, max_file_size_bytes=512_000)
+
+    assert summary["files_seen"] == 0
+    assert summary["skipped_files"] == 1
+
+
+def test_force_reindex_rebuilds_unchanged_files(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+
+    first = index_repo(repo, store=store)
+    second = index_repo(repo, store=store)
+    forced = index_repo(repo, store=store, force=True)
+
+    assert first["files_indexed"] == 1
+    assert second["files_indexed"] == 0
+    assert forced["files_indexed"] == 1
+

--- a/tests/tools/test_code_graph_query.py
+++ b/tests/tools/test_code_graph_query.py
@@ -1,0 +1,107 @@
+from tools.code_graph.indexer import index_repo
+from tools.code_graph.query import (
+    context_for_goal,
+    impact_for_paths,
+    neighbors_for_symbol,
+    search_symbols,
+    symbol_detail,
+)
+from tools.code_graph.storage import CodeGraphStore
+
+
+def test_search_symbols_returns_compact_matches(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+    index_repo(repo, store=store)
+
+    result = search_symbols(repo, "help", store=store, limit=5)
+
+    assert result["success"] is True
+    assert result["matches"][0]["name"] == "helper"
+    assert result["matches"][0]["path"] == "sample.py"
+
+
+def test_symbol_detail_returns_definition_location(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+    index_repo(repo, store=store)
+
+    result = symbol_detail(repo, "helper", store=store)
+
+    assert result["success"] is True
+    assert result["symbol"]["name"] == "helper"
+    assert result["symbol"]["path"] == "sample.py"
+    assert result["symbol"]["start_line"] == 1
+
+
+def test_neighbors_for_symbol_returns_imports_and_references(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("import json\n\ndef helper():\n    return 1\n", encoding="utf-8")
+    (repo / "consumer.py").write_text("from sample import helper\n\nvalue = helper()\n", encoding="utf-8")
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+    index_repo(repo, store=store)
+
+    result = neighbors_for_symbol(repo, "helper", store=store)
+
+    assert result["success"] is True
+    assert {"module": "json"} in result["imports"]
+    assert any(item["path"] == "consumer.py" for item in result["calls"])
+
+
+def test_impact_for_paths_returns_symbols_imports_and_likely_tests(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    (repo / "tests").mkdir()
+    (repo / "src" / "thing.py").write_text(
+        "import json\n\ndef helper():\n    return 1\n",
+        encoding="utf-8",
+    )
+    (repo / "src" / "consumer.py").write_text(
+        "from src.thing import helper\n\nvalue = helper()\n",
+        encoding="utf-8",
+    )
+    (repo / "tests" / "test_thing.py").write_text(
+        "def test_helper():\n    assert True\n",
+        encoding="utf-8",
+    )
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+    index_repo(repo, store=store)
+
+    result = impact_for_paths(repo, ["src/thing.py"], store=store)
+
+    assert result["success"] is True
+    assert result["symbols"][0]["name"] == "helper"
+    assert {"path": "src/thing.py", "module": "json"} in result["imports"]
+    assert "src/consumer.py" in result["referencing_files"]
+    assert "tests/test_thing.py" in result["likely_tests"]
+
+
+def test_context_for_goal_returns_budgeted_bundle(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("def handle_function_call():\n    return 'ok'\n", encoding="utf-8")
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+    index_repo(repo, store=store)
+
+    result = context_for_goal(
+        repo,
+        "change handle function call behavior",
+        store=store,
+        budget_chars=2000,
+    )
+
+    assert result["success"] is True
+    assert result["symbols"]
+    assert len(str(result)) < 3000
+

--- a/tests/tools/test_code_graph_storage.py
+++ b/tests/tools/test_code_graph_storage.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+from tools.code_graph.models import Edge, FileRecord, Symbol
+from tools.code_graph.storage import CodeGraphStore, cache_path_for_root
+
+
+def test_code_graph_models_are_plain_data_containers():
+    file_record = FileRecord(
+        id=1,
+        repo_id=1,
+        path="tools/example.py",
+        language="python",
+        size=120,
+        mtime_ns=123,
+        sha256="abc",
+        indexed_at=456.0,
+    )
+    symbol = Symbol(
+        id=1,
+        repo_id=1,
+        file_id=1,
+        name="example",
+        qualname="tools.example.example",
+        kind="function",
+        start_line=10,
+        end_line=12,
+        signature="example()",
+        docstring="Example function.",
+    )
+    edge = Edge(
+        id=1,
+        repo_id=1,
+        source_kind="symbol",
+        source_id=1,
+        target_kind="symbol",
+        target_id=2,
+        edge_type="calls",
+        metadata_json="{}",
+    )
+
+    assert file_record.path == "tools/example.py"
+    assert symbol.kind == "function"
+    assert edge.edge_type == "calls"
+
+
+def test_cache_path_for_root_uses_repo_hash(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    cache_path = cache_path_for_root(root)
+
+    assert cache_path.parent.name == "code_graph"
+    assert cache_path.name.endswith(".sqlite")
+    assert str(cache_path).startswith(str(tmp_path / "hermes_home"))
+
+
+def test_store_initializes_schema(tmp_path):
+    db_path = tmp_path / "graph.sqlite"
+    store = CodeGraphStore(db_path)
+    store.initialize()
+
+    tables = store.table_names()
+
+    assert {"repos", "files", "symbols", "edges", "chunks", "index_runs"}.issubset(tables)
+
+
+def test_store_ensure_repo_returns_stable_id(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    store = CodeGraphStore(tmp_path / "graph.sqlite")
+    store.initialize()
+
+    first = store.ensure_repo(root)
+    second = store.ensure_repo(Path(root))
+
+    assert first == second
+    assert store.get_repo_id(root) == first
+

--- a/tests/tools/test_code_graph_tool.py
+++ b/tests/tools/test_code_graph_tool.py
@@ -1,0 +1,95 @@
+import json
+
+from tools import code_graph_tool
+from tools.registry import discover_builtin_tools, registry
+from toolsets import TOOLSETS, resolve_toolset
+
+
+def test_code_graph_status_tool_returns_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    payload = json.loads(code_graph_tool.code_graph_status(str(repo)))
+
+    assert payload["success"] is True
+    assert payload["graph_status"] in {"missing", "fresh", "stale"}
+
+
+def test_code_graph_index_tool_indexes_repo(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+
+    payload = json.loads(code_graph_tool.code_graph_index(str(repo)))
+
+    assert payload["success"] is True
+    assert payload["files_seen"] == 1
+    assert str(tmp_path / "hermes_home") in payload["cache_path"]
+
+
+def test_code_graph_search_symbol_neighbors_impact_and_context_tools(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text("import json\n\ndef helper():\n    return 1\n", encoding="utf-8")
+    (repo / "consumer.py").write_text("from sample import helper\n\nvalue = helper()\n", encoding="utf-8")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_sample.py").write_text("def test_helper():\n    assert True\n", encoding="utf-8")
+    json.loads(code_graph_tool.code_graph_index(str(repo)))
+
+    search_payload = json.loads(code_graph_tool.code_graph_search("help", str(repo)))
+    symbol_payload = json.loads(code_graph_tool.code_graph_symbol("helper", str(repo)))
+    neighbors_payload = json.loads(code_graph_tool.code_graph_neighbors("helper", str(repo)))
+    impact_payload = json.loads(code_graph_tool.code_graph_impact(["sample.py"], str(repo)))
+    context_payload = json.loads(
+        code_graph_tool.code_graph_context("change helper behavior", str(repo), budget_chars=2000)
+    )
+
+    assert search_payload["matches"][0]["name"] == "helper"
+    assert symbol_payload["symbol"]["path"] == "sample.py"
+    assert any(item["path"] == "consumer.py" for item in neighbors_payload["calls"])
+    assert "tests/test_sample.py" in impact_payload["likely_tests"]
+    assert context_payload["recommended_files"]
+
+
+def test_code_graph_index_rejects_missing_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+
+    payload = json.loads(code_graph_tool.code_graph_index(str(tmp_path / "missing")))
+
+    assert payload["success"] is False
+    assert "root does not exist" in payload["error"]
+
+
+def test_code_graph_toolset_is_opt_in():
+    assert "code_graph" in TOOLSETS
+    tools = set(resolve_toolset("code_graph"))
+    assert {
+        "code_graph_index",
+        "code_graph_status",
+        "code_graph_search",
+        "code_graph_symbol",
+        "code_graph_neighbors",
+        "code_graph_impact",
+        "code_graph_context",
+    }.issubset(tools)
+
+    assert "code_graph_index" not in TOOLSETS["hermes-cli"]["tools"]
+
+
+def test_code_graph_tool_module_registers_tools():
+    discover_builtin_tools()
+    names = set(registry.get_tool_names_for_toolset("code_graph"))
+
+    assert {
+        "code_graph_index",
+        "code_graph_status",
+        "code_graph_search",
+        "code_graph_symbol",
+        "code_graph_neighbors",
+        "code_graph_impact",
+        "code_graph_context",
+    }.issubset(names)
+

--- a/tools/code_graph/__init__.py
+++ b/tools/code_graph/__init__.py
@@ -1,0 +1,2 @@
+"""Local repository code graph support for Hermes tools."""
+

--- a/tools/code_graph/indexer.py
+++ b/tools/code_graph/indexer.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Iterable
+
+from tools.code_graph.storage import CodeGraphStore, cache_path_for_root
+
+
+IGNORED_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    "dist",
+    "build",
+    "coverage",
+}
+LANGUAGE_BY_SUFFIX = {
+    ".py": "python",
+    ".pyi": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".md": "markdown",
+}
+DEFAULT_MAX_FILE_SIZE_BYTES = 512_000
+CHUNK_LINES = 80
+MAX_REFERENCE_EDGES_PER_FILE = 500
+
+
+def _iter_source_files(root: Path) -> Iterable[Path]:
+    root = Path(root).resolve()
+    for current_dir, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if name not in IGNORED_DIRS]
+        for filename in filenames:
+            path = Path(current_dir) / filename
+            if path.suffix.lower() in LANGUAGE_BY_SUFFIX:
+                yield path
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _language_for_path(path: Path) -> str:
+    return LANGUAGE_BY_SUFFIX[path.suffix.lower()]
+
+
+def _module_name(rel_path: str) -> str:
+    if rel_path.endswith(".pyi"):
+        module = rel_path[:-4]
+    elif rel_path.endswith(".py"):
+        module = rel_path[:-3]
+    else:
+        module = rel_path
+    module = module.replace("/", ".")
+    if module == "__init__":
+        return ""
+    if module.endswith(".__init__"):
+        return module[: -len(".__init__")]
+    return module
+
+
+def _signature(node: ast.AST) -> str | None:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        args: list[str] = []
+        args.extend(arg.arg for arg in node.args.posonlyargs)
+        args.extend(arg.arg for arg in node.args.args)
+        if node.args.vararg:
+            args.append(f"*{node.args.vararg.arg}")
+        args.extend(arg.arg for arg in node.args.kwonlyargs)
+        if node.args.kwarg:
+            args.append(f"**{node.args.kwarg.arg}")
+        prefix = "async " if isinstance(node, ast.AsyncFunctionDef) else ""
+        return f"{prefix}{node.name}({', '.join(args)})"
+    if isinstance(node, ast.ClassDef):
+        return f"class {node.name}"
+    return None
+
+
+def _extract_python_symbols(tree: ast.AST, rel_path: str) -> list[dict]:
+    module = _module_name(rel_path)
+    symbols: list[dict] = []
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.scope: list[str] = []
+
+        def _qualname(self, name: str) -> str:
+            local = ".".join([*self.scope, name]) if self.scope else name
+            return f"{module}.{local}" if module else local
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            symbols.append(
+                {
+                    "name": node.name,
+                    "qualname": self._qualname(node.name),
+                    "kind": "class",
+                    "start_line": node.lineno,
+                    "end_line": getattr(node, "end_lineno", node.lineno),
+                    "signature": _signature(node),
+                    "docstring": ast.get_docstring(node),
+                }
+            )
+            self.scope.append(node.name)
+            self.generic_visit(node)
+            self.scope.pop()
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            symbols.append(
+                {
+                    "name": node.name,
+                    "qualname": self._qualname(node.name),
+                    "kind": "function",
+                    "start_line": node.lineno,
+                    "end_line": getattr(node, "end_lineno", node.lineno),
+                    "signature": _signature(node),
+                    "docstring": ast.get_docstring(node),
+                }
+            )
+            self.scope.append(node.name)
+            self.generic_visit(node)
+            self.scope.pop()
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+    Visitor().visit(tree)
+    return symbols
+
+
+def _extract_python_imports(tree: ast.AST) -> list[str]:
+    modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            prefix = "." * node.level
+            module = node.module or ""
+            modules.append(f"{prefix}{module}" or ".")
+    return sorted(dict.fromkeys(modules))
+
+
+def _reference_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _extract_python_references(tree: ast.AST) -> list[dict]:
+    refs: list[dict] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            name = _reference_name(node.func)
+            if name:
+                refs.append({"name": name, "line": node.lineno, "kind": "call"})
+    deduped: dict[tuple[str, int, str], dict] = {}
+    for ref in refs:
+        deduped[(ref["name"], ref["line"], ref["kind"])] = ref
+    return list(deduped.values())[:MAX_REFERENCE_EDGES_PER_FILE]
+
+
+def _line_chunks(source: str) -> Iterable[tuple[int, int, str]]:
+    lines = source.splitlines()
+    if not lines:
+        return
+    for start in range(0, len(lines), CHUNK_LINES):
+        chunk = lines[start : start + CHUNK_LINES]
+        yield start + 1, start + len(chunk), "\n".join(chunk)
+
+
+def _delete_file_owned_rows(conn, repo_id: int, file_id: int) -> None:
+    conn.execute("DELETE FROM symbols WHERE repo_id = ? AND file_id = ?", (repo_id, file_id))
+    conn.execute("DELETE FROM chunks WHERE repo_id = ? AND file_id = ?", (repo_id, file_id))
+    conn.execute(
+        """
+        DELETE FROM edges
+        WHERE repo_id = ?
+          AND (
+            (source_kind = 'file' AND source_id = ?)
+            OR (target_kind = 'file' AND target_id = ?)
+          )
+        """,
+        (repo_id, file_id, file_id),
+    )
+
+
+def _delete_files_by_path(conn, repo_id: int, paths: set[str]) -> int:
+    deleted = 0
+    for rel_path in sorted(paths):
+        row = conn.execute(
+            "SELECT id FROM files WHERE repo_id = ? AND path = ?",
+            (repo_id, rel_path),
+        ).fetchone()
+        if not row:
+            continue
+        file_id = int(row["id"])
+        _delete_file_owned_rows(conn, repo_id, file_id)
+        conn.execute("DELETE FROM files WHERE repo_id = ? AND id = ?", (repo_id, file_id))
+        deleted += 1
+    return deleted
+
+
+def index_repo(
+    root: Path,
+    *,
+    store: CodeGraphStore | None = None,
+    max_file_size_bytes: int = DEFAULT_MAX_FILE_SIZE_BYTES,
+    force: bool = False,
+) -> dict:
+    root = Path(root).resolve()
+    if not root.exists():
+        raise ValueError(f"root does not exist: {root}")
+    if not root.is_dir():
+        raise ValueError(f"root is not a directory: {root}")
+
+    store = store or CodeGraphStore(cache_path_for_root(root))
+    store.initialize()
+    repo_id = store.ensure_repo(root)
+    if force:
+        store.clear_repo_index(repo_id)
+
+    started_at = time.time()
+    files_seen = 0
+    files_indexed = 0
+    skipped_files = 0
+    deleted_files = 0
+    parse_errors: list[dict] = []
+
+    with store.connect() as conn:
+        run = conn.execute(
+            "INSERT INTO index_runs(repo_id, started_at, status) VALUES (?, ?, ?)",
+            (repo_id, started_at, "running"),
+        )
+        run_id = int(run.lastrowid)
+        try:
+            existing_rows = conn.execute(
+                "SELECT id, path, sha256 FROM files WHERE repo_id = ?",
+                (repo_id,),
+            ).fetchall()
+            existing_by_path = {
+                row["path"]: {"id": int(row["id"]), "sha256": row["sha256"]}
+                for row in existing_rows
+            }
+            current_paths: set[str] = set()
+
+            for path in _iter_source_files(root):
+                rel_path = path.relative_to(root).as_posix()
+                stat = path.stat()
+                if stat.st_size > max_file_size_bytes:
+                    skipped_files += 1
+                    continue
+
+                current_paths.add(rel_path)
+                files_seen += 1
+                digest = _sha256(path)
+                existing = existing_by_path.get(rel_path)
+                if existing and existing["sha256"] == digest and not force:
+                    continue
+
+                source_text = path.read_text(encoding="utf-8", errors="replace")
+                language = _language_for_path(path)
+                indexed_at = time.time()
+                conn.execute(
+                    """
+                    INSERT INTO files(repo_id, path, language, size, mtime_ns, sha256, indexed_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(repo_id, path) DO UPDATE SET
+                        language=excluded.language,
+                        size=excluded.size,
+                        mtime_ns=excluded.mtime_ns,
+                        sha256=excluded.sha256,
+                        indexed_at=excluded.indexed_at
+                    """,
+                    (
+                        repo_id,
+                        rel_path,
+                        language,
+                        stat.st_size,
+                        stat.st_mtime_ns,
+                        digest,
+                        indexed_at,
+                    ),
+                )
+                file_id = int(
+                    conn.execute(
+                        "SELECT id FROM files WHERE repo_id = ? AND path = ?",
+                        (repo_id, rel_path),
+                    ).fetchone()["id"]
+                )
+                _delete_file_owned_rows(conn, repo_id, file_id)
+
+                for start_line, end_line, text in _line_chunks(source_text):
+                    conn.execute(
+                        """
+                        INSERT INTO chunks(repo_id, file_id, start_line, end_line, text)
+                        VALUES (?, ?, ?, ?, ?)
+                        """,
+                        (repo_id, file_id, start_line, end_line, text),
+                    )
+
+                symbols: list[dict] = []
+                imports: list[str] = []
+                references: list[dict] = []
+                if language == "python":
+                    try:
+                        tree = ast.parse(source_text, filename=rel_path)
+                        symbols = _extract_python_symbols(tree, rel_path)
+                        imports = _extract_python_imports(tree)
+                        references = _extract_python_references(tree)
+                    except SyntaxError as exc:
+                        parse_errors.append(
+                            {"path": rel_path, "line": exc.lineno, "error": exc.msg}
+                        )
+
+                for symbol in symbols:
+                    conn.execute(
+                        """
+                        INSERT INTO symbols(
+                            repo_id, file_id, name, qualname, kind, start_line,
+                            end_line, signature, docstring
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            repo_id,
+                            file_id,
+                            symbol["name"],
+                            symbol["qualname"],
+                            symbol["kind"],
+                            symbol["start_line"],
+                            symbol["end_line"],
+                            symbol["signature"],
+                            symbol["docstring"],
+                        ),
+                    )
+
+                for module in imports:
+                    conn.execute(
+                        """
+                        INSERT INTO edges(
+                            repo_id, source_kind, source_id, target_kind,
+                            target_id, edge_type, metadata_json
+                        )
+                        VALUES (?, 'file', ?, 'module', 0, 'imports', ?)
+                        """,
+                        (
+                            repo_id,
+                            file_id,
+                            json.dumps({"module": module}, sort_keys=True),
+                        ),
+                    )
+
+                for ref in references:
+                    edge_type = "calls" if ref["kind"] == "call" else "references"
+                    conn.execute(
+                        """
+                        INSERT INTO edges(
+                            repo_id, source_kind, source_id, target_kind,
+                            target_id, edge_type, metadata_json
+                        )
+                        VALUES (?, 'file', ?, 'symbol_name', 0, ?, ?)
+                        """,
+                        (
+                            repo_id,
+                            file_id,
+                            edge_type,
+                            json.dumps(ref, sort_keys=True),
+                        ),
+                    )
+                files_indexed += 1
+
+            deleted_files = _delete_files_by_path(
+                conn,
+                repo_id,
+                set(existing_by_path) - current_paths,
+            )
+            conn.execute(
+                """
+                UPDATE index_runs
+                SET finished_at = ?, files_seen = ?, files_indexed = ?, status = ?, message = ?
+                WHERE id = ?
+                """,
+                (
+                    time.time(),
+                    files_seen,
+                    files_indexed,
+                    "ok",
+                    None,
+                    run_id,
+                ),
+            )
+        except Exception as exc:
+            conn.execute(
+                """
+                UPDATE index_runs
+                SET finished_at = ?, files_seen = ?, files_indexed = ?, status = ?, message = ?
+                WHERE id = ?
+                """,
+                (time.time(), files_seen, files_indexed, "error", str(exc), run_id),
+            )
+            raise
+
+    return {
+        "success": True,
+        "repo_root": str(root),
+        "cache_path": str(store.db_path),
+        "files_seen": files_seen,
+        "files_indexed": files_indexed,
+        "skipped_files": skipped_files,
+        "deleted_files": deleted_files,
+        "parse_errors": parse_errors[:20],
+        "force": bool(force),
+    }

--- a/tools/code_graph/models.py
+++ b/tools/code_graph/models.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RepoRecord:
+    id: int
+    root: str
+    root_hash: str
+    created_at: float
+    updated_at: float
+
+
+@dataclass(frozen=True)
+class FileRecord:
+    id: int
+    repo_id: int
+    path: str
+    language: str
+    size: int
+    mtime_ns: int
+    sha256: str
+    indexed_at: float
+
+
+@dataclass(frozen=True)
+class Symbol:
+    id: int
+    repo_id: int
+    file_id: int
+    name: str
+    qualname: str
+    kind: str
+    start_line: int
+    end_line: int
+    signature: str | None = None
+    docstring: str | None = None
+
+
+@dataclass(frozen=True)
+class Edge:
+    id: int
+    repo_id: int
+    source_kind: str
+    source_id: int
+    target_kind: str
+    target_id: int
+    edge_type: str
+    metadata_json: str = "{}"
+
+
+@dataclass(frozen=True)
+class ChunkRecord:
+    id: int
+    repo_id: int
+    file_id: int
+    start_line: int
+    end_line: int
+    text: str
+
+
+@dataclass(frozen=True)
+class IndexRun:
+    id: int
+    repo_id: int
+    started_at: float
+    finished_at: float | None
+    files_seen: int
+    files_indexed: int
+    status: str
+    message: str | None = None
+

--- a/tools/code_graph/query.py
+++ b/tools/code_graph/query.py
@@ -1,0 +1,582 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from tools.code_graph.indexer import (
+    DEFAULT_MAX_FILE_SIZE_BYTES,
+    _iter_source_files,
+    _sha256,
+)
+from tools.code_graph.storage import CodeGraphStore, cache_path_for_root
+
+
+_TERM_RE = re.compile(r"[A-Za-z0-9_]{3,}")
+
+
+def _limit(value: int, default: int = 20, maximum: int = 100) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(1, min(parsed, maximum))
+
+
+def _missing_status(store: CodeGraphStore) -> dict:
+    return {
+        "success": True,
+        "graph_status": "missing",
+        "stale_files": 0,
+        "indexed_files": 0,
+        "source_files_seen": 0,
+        "skipped_files": 0,
+        "cache_path": str(store.db_path),
+    }
+
+
+def _repo_id_for_query(root: Path, store: CodeGraphStore) -> int | None:
+    if not store.db_path.exists():
+        return None
+    store.initialize()
+    return store.get_repo_id(root)
+
+
+def graph_status(
+    root: Path,
+    *,
+    store: CodeGraphStore | None = None,
+    max_file_size_bytes: int = DEFAULT_MAX_FILE_SIZE_BYTES,
+) -> dict:
+    root = Path(root).resolve()
+    store = store or CodeGraphStore(cache_path_for_root(root))
+    repo_id = _repo_id_for_query(root, store)
+    if repo_id is None:
+        return _missing_status(store)
+
+    stale_files = 0
+    source_files_seen = 0
+    skipped_files = 0
+    stale_details: list[dict] = []
+    current_by_path: dict[str, str] = {}
+    with store.connect() as conn:
+        indexed = conn.execute(
+            "SELECT path, sha256 FROM files WHERE repo_id = ?",
+            (repo_id,),
+        ).fetchall()
+        indexed_by_path = {row["path"]: row["sha256"] for row in indexed}
+        if not indexed_by_path:
+            return _missing_status(store)
+
+        for path in _iter_source_files(root):
+            stat = path.stat()
+            if stat.st_size > max_file_size_bytes:
+                skipped_files += 1
+                continue
+            source_files_seen += 1
+            rel_path = path.relative_to(root).as_posix()
+            digest = _sha256(path)
+            current_by_path[rel_path] = digest
+            if indexed_by_path.get(rel_path) != digest:
+                stale_files += 1
+                if len(stale_details) < 20:
+                    stale_details.append({"path": rel_path, "reason": "changed_or_new"})
+
+    deleted_paths = set(indexed_by_path) - set(current_by_path)
+    stale_files += len(deleted_paths)
+    for rel_path in sorted(deleted_paths)[: max(0, 20 - len(stale_details))]:
+        stale_details.append({"path": rel_path, "reason": "deleted_or_skipped"})
+
+    return {
+        "success": True,
+        "graph_status": "stale" if stale_files else "fresh",
+        "stale_files": stale_files,
+        "indexed_files": len(indexed_by_path),
+        "source_files_seen": source_files_seen,
+        "skipped_files": skipped_files,
+        "stale_details": stale_details,
+        "cache_path": str(store.db_path),
+    }
+
+
+def _compact_symbol(row) -> dict:
+    data = dict(row)
+    docstring = data.get("docstring")
+    if docstring and len(docstring) > 300:
+        data["docstring"] = docstring[:297] + "..."
+    return {key: value for key, value in data.items() if value is not None}
+
+
+def search_symbols(
+    root: Path,
+    query: str,
+    *,
+    store: CodeGraphStore | None = None,
+    limit: int = 20,
+) -> dict:
+    root = Path(root).resolve()
+    store = store or CodeGraphStore(cache_path_for_root(root))
+    repo_id = _repo_id_for_query(root, store)
+    status = graph_status(root, store=store)
+    if repo_id is None:
+        return {"success": True, "graph_status": "missing", "matches": []}
+
+    limit = _limit(limit)
+    query = str(query or "").strip()
+    like = f"%{query}%"
+    prefix = f"{query}%"
+    with store.connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT s.id, s.name, s.qualname, s.kind, s.start_line, s.end_line,
+                   s.signature, s.docstring, f.path
+            FROM symbols s
+            JOIN files f ON f.id = s.file_id
+            WHERE s.repo_id = ? AND (? = '' OR s.name LIKE ? OR s.qualname LIKE ?)
+            ORDER BY
+                CASE
+                    WHEN s.name = ? THEN 0
+                    WHEN s.name LIKE ? THEN 1
+                    ELSE 2
+                END,
+                LENGTH(s.qualname),
+                s.name
+            LIMIT ?
+            """,
+            (repo_id, query, like, like, query, prefix, limit),
+        ).fetchall()
+    return {
+        "success": True,
+        "graph_status": status["graph_status"],
+        "matches": [_compact_symbol(row) for row in rows],
+    }
+
+
+def symbol_detail(
+    root: Path,
+    symbol: str,
+    *,
+    store: CodeGraphStore | None = None,
+) -> dict:
+    root = Path(root).resolve()
+    store = store or CodeGraphStore(cache_path_for_root(root))
+    repo_id = _repo_id_for_query(root, store)
+    status = graph_status(root, store=store)
+    if repo_id is None:
+        return {
+            "success": False,
+            "graph_status": "missing",
+            "error": f"symbol not found: {symbol}",
+        }
+
+    with store.connect() as conn:
+        row = conn.execute(
+            """
+            SELECT s.id, s.file_id, s.name, s.qualname, s.kind, s.start_line,
+                   s.end_line, s.signature, s.docstring, f.path
+            FROM symbols s
+            JOIN files f ON f.id = s.file_id
+            WHERE s.repo_id = ? AND (s.name = ? OR s.qualname = ?)
+            ORDER BY LENGTH(s.qualname), s.start_line
+            LIMIT 1
+            """,
+            (repo_id, symbol, symbol),
+        ).fetchone()
+    if row is None:
+        return {
+            "success": False,
+            "graph_status": status["graph_status"],
+            "error": f"symbol not found: {symbol}",
+        }
+    return {
+        "success": True,
+        "graph_status": status["graph_status"],
+        "symbol": _compact_symbol(row),
+    }
+
+
+def _parse_edge_metadata(raw: str) -> dict:
+    try:
+        data = json.loads(raw or "{}")
+        return data if isinstance(data, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _chunk_references(conn, repo_id: int, name: str, limit: int) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT f.path, c.start_line, c.text
+        FROM chunks c
+        JOIN files f ON f.id = c.file_id
+        WHERE c.repo_id = ? AND c.text LIKE ?
+        ORDER BY f.path, c.start_line
+        LIMIT ?
+        """,
+        (repo_id, f"%{name}%", limit * 4),
+    ).fetchall()
+    refs: list[dict] = []
+    seen: set[tuple[str, int]] = set()
+    needle = name.lower()
+    for row in rows:
+        for offset, line in enumerate(str(row["text"]).splitlines()):
+            if needle not in line.lower():
+                continue
+            item = {
+                "path": row["path"],
+                "line": int(row["start_line"]) + offset,
+                "kind": "text",
+            }
+            key = (item["path"], item["line"])
+            if key in seen:
+                continue
+            seen.add(key)
+            refs.append(item)
+            if len(refs) >= limit:
+                return refs
+    return refs
+
+
+def neighbors_for_symbol(
+    root: Path,
+    symbol: str,
+    *,
+    store: CodeGraphStore | None = None,
+    limit: int = 50,
+) -> dict:
+    detail = symbol_detail(root, symbol, store=store)
+    if not detail.get("success"):
+        detail.setdefault("imports", [])
+        detail.setdefault("references", [])
+        detail.setdefault("calls", [])
+        return detail
+
+    root = Path(root).resolve()
+    store = store or CodeGraphStore(cache_path_for_root(root))
+    repo_id = _repo_id_for_query(root, store)
+    if repo_id is None:
+        return detail
+    limit = _limit(limit, default=50, maximum=200)
+    target = detail["symbol"]
+    target_name = target["name"]
+
+    imports: list[dict] = []
+    references: list[dict] = []
+    calls: list[dict] = []
+    like = f'%"name": "{target_name}"%'
+    with store.connect() as conn:
+        import_rows = conn.execute(
+            """
+            SELECT e.metadata_json
+            FROM edges e
+            WHERE e.repo_id = ?
+              AND e.source_kind = 'file'
+              AND e.source_id = ?
+              AND e.edge_type = 'imports'
+            ORDER BY e.metadata_json
+            LIMIT ?
+            """,
+            (repo_id, int(target["file_id"]), limit),
+        ).fetchall()
+        ref_rows = conn.execute(
+            """
+            SELECT e.edge_type, e.metadata_json, f.path
+            FROM edges e
+            JOIN files f ON f.id = e.source_id
+            WHERE e.repo_id = ?
+              AND e.source_kind = 'file'
+              AND e.edge_type IN ('references', 'calls')
+              AND e.metadata_json LIKE ?
+            ORDER BY f.path, e.edge_type
+            LIMIT ?
+            """,
+            (repo_id, like, limit * 4),
+        ).fetchall()
+        chunk_refs = _chunk_references(conn, repo_id, target_name, limit)
+
+    for row in import_rows:
+        data = _parse_edge_metadata(row["metadata_json"])
+        if data.get("module"):
+            imports.append({"module": data["module"]})
+
+    seen_refs: set[tuple[str, int, str]] = set()
+    for row in ref_rows:
+        data = _parse_edge_metadata(row["metadata_json"])
+        if data.get("name") != target_name:
+            continue
+        item = {
+            "path": row["path"],
+            "line": data.get("line"),
+            "kind": data.get("kind") or row["edge_type"],
+        }
+        key = (item["path"], int(item["line"] or 0), row["edge_type"])
+        if key in seen_refs:
+            continue
+        seen_refs.add(key)
+        if row["edge_type"] == "calls":
+            calls.append(item)
+        else:
+            references.append(item)
+        if len(calls) + len(references) >= limit:
+            break
+    for item in chunk_refs:
+        key = (item["path"], int(item["line"] or 0), "text")
+        if key in seen_refs:
+            continue
+        seen_refs.add(key)
+        references.append(item)
+        if len(calls) + len(references) >= limit:
+            break
+
+    return {
+        "success": True,
+        "graph_status": detail["graph_status"],
+        "symbol": target,
+        "imports": imports,
+        "references": references,
+        "calls": calls,
+    }
+
+
+def _normalize_rel_path(root: Path, path_value: str) -> str:
+    path = Path(str(path_value))
+    if path.is_absolute():
+        resolved = path.resolve()
+    else:
+        resolved = (root / path).resolve()
+    try:
+        return resolved.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ValueError(f"path is outside repository root: {path_value}") from exc
+
+
+def impact_for_paths(
+    root: Path,
+    paths: list[str],
+    *,
+    store: CodeGraphStore | None = None,
+    limit: int = 50,
+) -> dict:
+    root = Path(root).resolve()
+    store = store or CodeGraphStore(cache_path_for_root(root))
+    repo_id = _repo_id_for_query(root, store)
+    status = graph_status(root, store=store)
+    if repo_id is None:
+        return {
+            "success": True,
+            "graph_status": "missing",
+            "input_paths": [],
+            "symbols": [],
+            "imports": [],
+            "referencing_files": [],
+            "likely_tests": [],
+        }
+
+    limit = _limit(limit, default=50, maximum=200)
+    norm_paths = [_normalize_rel_path(root, p) for p in paths]
+    symbols: list[dict] = []
+    imports: list[dict] = []
+    likely_tests: set[str] = set()
+    referencing_files: set[str] = set()
+    symbol_names: set[str] = set()
+
+    with store.connect() as conn:
+        for rel_path in norm_paths:
+            rows = conn.execute(
+                """
+                SELECT s.name, s.qualname, s.kind, s.start_line, s.end_line, f.path
+                FROM symbols s
+                JOIN files f ON f.id = s.file_id
+                WHERE s.repo_id = ? AND f.path = ?
+                ORDER BY s.start_line
+                LIMIT ?
+                """,
+                (repo_id, rel_path, limit),
+            ).fetchall()
+            for row in rows:
+                item = dict(row)
+                symbols.append(item)
+                symbol_names.add(item["name"])
+
+            import_rows = conn.execute(
+                """
+                SELECT e.metadata_json, f.path
+                FROM edges e
+                JOIN files f ON f.id = e.source_id
+                WHERE e.repo_id = ?
+                  AND e.source_kind = 'file'
+                  AND f.path = ?
+                  AND e.edge_type = 'imports'
+                ORDER BY e.metadata_json
+                LIMIT ?
+                """,
+                (repo_id, rel_path, limit),
+            ).fetchall()
+            for row in import_rows:
+                data = _parse_edge_metadata(row["metadata_json"])
+                if data.get("module"):
+                    imports.append({"path": row["path"], "module": data["module"]})
+
+            stem = Path(rel_path).stem
+            candidates = conn.execute(
+                """
+                SELECT path FROM files
+                WHERE repo_id = ?
+                  AND (
+                    path LIKE ?
+                    OR path LIKE ?
+                    OR path LIKE ?
+                  )
+                """,
+                (repo_id, f"tests/%test_{stem}.py", f"%/test_{stem}.py", f"%/{stem}_test.py"),
+            ).fetchall()
+            likely_tests.update(row["path"] for row in candidates)
+
+        for name in sorted(symbol_names):
+            ref_rows = conn.execute(
+                """
+                SELECT DISTINCT f.path, e.metadata_json
+                FROM edges e
+                JOIN files f ON f.id = e.source_id
+                WHERE e.repo_id = ?
+                  AND e.source_kind = 'file'
+                  AND e.edge_type IN ('references', 'calls')
+                  AND e.metadata_json LIKE ?
+                LIMIT ?
+                """,
+                (repo_id, f'%"name": "{name}"%', limit),
+            ).fetchall()
+            for row in ref_rows:
+                data = _parse_edge_metadata(row["metadata_json"])
+                if data.get("name") == name and row["path"] not in norm_paths:
+                    referencing_files.add(row["path"])
+            chunk_rows = conn.execute(
+                """
+                SELECT DISTINCT f.path
+                FROM chunks c
+                JOIN files f ON f.id = c.file_id
+                WHERE c.repo_id = ? AND c.text LIKE ?
+                LIMIT ?
+                """,
+                (repo_id, f"%{name}%", limit),
+            ).fetchall()
+            for row in chunk_rows:
+                if row["path"] not in norm_paths:
+                    referencing_files.add(row["path"])
+
+    return {
+        "success": True,
+        "graph_status": status["graph_status"],
+        "input_paths": norm_paths,
+        "symbols": symbols[:limit],
+        "imports": imports[:limit],
+        "referencing_files": sorted(referencing_files)[:limit],
+        "likely_tests": sorted(likely_tests)[:limit],
+    }
+
+
+def _terms(text: str) -> list[str]:
+    return [match.group(0).lower() for match in _TERM_RE.finditer(str(text).replace("_", " "))]
+
+
+def context_for_goal(
+    root: Path,
+    goal: str,
+    *,
+    store: CodeGraphStore | None = None,
+    budget_chars: int = 20_000,
+) -> dict:
+    root = Path(root).resolve()
+    store = store or CodeGraphStore(cache_path_for_root(root))
+    repo_id = _repo_id_for_query(root, store)
+    status = graph_status(root, store=store)
+    if repo_id is None:
+        return {
+            "success": True,
+            "graph_status": "missing",
+            "goal": goal,
+            "symbols": [],
+            "recommended_files": [],
+            "chunks": [],
+        }
+
+    terms = _terms(goal)
+    budget_chars = max(1000, min(int(budget_chars or 20_000), 80_000))
+    with store.connect() as conn:
+        symbol_rows = conn.execute(
+            """
+            SELECT s.name, s.qualname, s.kind, s.start_line, s.end_line,
+                   s.signature, s.docstring, f.path
+            FROM symbols s
+            JOIN files f ON f.id = s.file_id
+            WHERE s.repo_id = ?
+            LIMIT 1000
+            """,
+            (repo_id,),
+        ).fetchall()
+        chunk_rows = conn.execute(
+            """
+            SELECT f.path, c.start_line, c.end_line, c.text
+            FROM chunks c
+            JOIN files f ON f.id = c.file_id
+            WHERE c.repo_id = ?
+            LIMIT 1000
+            """,
+            (repo_id,),
+        ).fetchall()
+
+    ranked_symbols: list[dict] = []
+    for row in symbol_rows:
+        data = _compact_symbol(row)
+        haystack = " ".join(
+            str(data.get(key) or "") for key in ("name", "qualname", "docstring", "path")
+        ).lower()
+        score = sum(1 for term in terms if term in haystack)
+        if score:
+            data["score"] = score
+            ranked_symbols.append(data)
+    ranked_symbols.sort(key=lambda item: (-item["score"], item["path"], item["start_line"]))
+
+    ranked_chunks: list[dict] = []
+    for row in chunk_rows:
+        data = dict(row)
+        haystack = f"{data['path']}\n{data['text']}".lower()
+        score = sum(1 for term in terms if term in haystack)
+        if score:
+            text = data["text"]
+            if len(text) > 1000:
+                text = text[:997] + "..."
+            ranked_chunks.append(
+                {
+                    "path": data["path"],
+                    "start_line": data["start_line"],
+                    "end_line": data["end_line"],
+                    "score": score,
+                    "text": text,
+                }
+            )
+    ranked_chunks.sort(key=lambda item: (-item["score"], item["path"], item["start_line"]))
+
+    payload = {
+        "success": True,
+        "graph_status": status["graph_status"],
+        "goal": goal,
+        "symbols": ranked_symbols[:20],
+        "chunks": ranked_chunks[:10],
+        "recommended_files": sorted(
+            {item["path"] for item in ranked_symbols[:20]}
+            | {item["path"] for item in ranked_chunks[:10]}
+        ),
+    }
+    while len(json.dumps(payload, ensure_ascii=False)) > budget_chars:
+        if payload["chunks"]:
+            payload["chunks"].pop()
+        elif payload["symbols"]:
+            payload["symbols"].pop()
+        else:
+            break
+        payload["recommended_files"] = sorted(
+            {item["path"] for item in payload["symbols"]}
+            | {item["path"] for item in payload["chunks"]}
+        )
+    return payload

--- a/tools/code_graph/storage.py
+++ b/tools/code_graph/storage.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import time
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+
+SCHEMA = """
+PRAGMA journal_mode=WAL;
+CREATE TABLE IF NOT EXISTS repos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    root TEXT NOT NULL UNIQUE,
+    root_hash TEXT NOT NULL UNIQUE,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+CREATE TABLE IF NOT EXISTS files (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id INTEGER NOT NULL,
+    path TEXT NOT NULL,
+    language TEXT NOT NULL,
+    size INTEGER NOT NULL,
+    mtime_ns INTEGER NOT NULL,
+    sha256 TEXT NOT NULL,
+    indexed_at REAL NOT NULL,
+    UNIQUE(repo_id, path)
+);
+CREATE TABLE IF NOT EXISTS symbols (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id INTEGER NOT NULL,
+    file_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    qualname TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    signature TEXT,
+    docstring TEXT
+);
+CREATE TABLE IF NOT EXISTS edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id INTEGER NOT NULL,
+    source_kind TEXT NOT NULL,
+    source_id INTEGER NOT NULL,
+    target_kind TEXT NOT NULL,
+    target_id INTEGER NOT NULL,
+    edge_type TEXT NOT NULL,
+    metadata_json TEXT NOT NULL DEFAULT '{}'
+);
+CREATE TABLE IF NOT EXISTS chunks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id INTEGER NOT NULL,
+    file_id INTEGER NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    text TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS index_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id INTEGER NOT NULL,
+    started_at REAL NOT NULL,
+    finished_at REAL,
+    files_seen INTEGER NOT NULL DEFAULT 0,
+    files_indexed INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL,
+    message TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_files_repo_path ON files(repo_id, path);
+CREATE INDEX IF NOT EXISTS idx_symbols_repo_name ON symbols(repo_id, name);
+CREATE INDEX IF NOT EXISTS idx_symbols_repo_qualname ON symbols(repo_id, qualname);
+CREATE INDEX IF NOT EXISTS idx_symbols_file ON symbols(repo_id, file_id);
+CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(repo_id, source_kind, source_id, edge_type);
+CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(repo_id, target_kind, target_id, edge_type);
+CREATE INDEX IF NOT EXISTS idx_chunks_file ON chunks(repo_id, file_id);
+"""
+
+
+def root_hash(root: Path) -> str:
+    return hashlib.sha256(str(Path(root).resolve()).encode("utf-8")).hexdigest()[:24]
+
+
+def cache_path_for_root(root: Path) -> Path:
+    return get_hermes_home() / "cache" / "code_graph" / f"{root_hash(root)}.sqlite"
+
+
+class CodeGraphStore:
+    def __init__(self, db_path: Path):
+        self.db_path = Path(db_path)
+
+    def connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def initialize(self) -> None:
+        with self.connect() as conn:
+            conn.executescript(SCHEMA)
+
+    def table_names(self) -> set[str]:
+        with self.connect() as conn:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        return {row["name"] for row in rows}
+
+    def ensure_repo(self, root: Path) -> int:
+        root_text = str(Path(root).resolve())
+        repo_hash = root_hash(Path(root))
+        now = time.time()
+        with self.connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO repos(root, root_hash, created_at, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(root) DO UPDATE SET updated_at=excluded.updated_at
+                """,
+                (root_text, repo_hash, now, now),
+            )
+            row = conn.execute(
+                "SELECT id FROM repos WHERE root = ?",
+                (root_text,),
+            ).fetchone()
+        return int(row["id"])
+
+    def get_repo_id(self, root: Path) -> int | None:
+        if not self.db_path.exists():
+            return None
+        root_text = str(Path(root).resolve())
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT id FROM repos WHERE root = ?",
+                (root_text,),
+            ).fetchone()
+        return int(row["id"]) if row else None
+
+    def clear_repo_index(self, repo_id: int) -> None:
+        with self.connect() as conn:
+            conn.execute("DELETE FROM symbols WHERE repo_id = ?", (repo_id,))
+            conn.execute("DELETE FROM edges WHERE repo_id = ?", (repo_id,))
+            conn.execute("DELETE FROM chunks WHERE repo_id = ?", (repo_id,))
+            conn.execute("DELETE FROM files WHERE repo_id = ?", (repo_id,))
+

--- a/tools/code_graph_tool.py
+++ b/tools/code_graph_tool.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from tools.code_graph.indexer import index_repo
+from tools.code_graph.query import (
+    context_for_goal,
+    graph_status,
+    impact_for_paths,
+    neighbors_for_symbol,
+    search_symbols,
+    symbol_detail,
+)
+from tools.registry import registry
+
+
+def _json(data: dict) -> str:
+    return json.dumps(data, ensure_ascii=False)
+
+
+def _root(root: str | None) -> Path:
+    path = Path(root or ".").resolve()
+    if not path.exists():
+        raise ValueError(f"root does not exist: {path}")
+    if not path.is_dir():
+        raise ValueError(f"root is not a directory: {path}")
+    return path
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
+def code_graph_index(
+    root: str | None = None,
+    force: bool = False,
+    max_file_size_bytes: int = 512_000,
+    task_id: str | None = None,
+) -> str:
+    try:
+        return _json(
+            index_repo(
+                _root(root),
+                force=bool(force),
+                max_file_size_bytes=int(max_file_size_bytes or 512_000),
+            )
+        )
+    except Exception as exc:
+        return _json({"success": False, "error": str(exc)})
+
+
+def code_graph_status(root: str | None = None, task_id: str | None = None) -> str:
+    try:
+        return _json(graph_status(_root(root)))
+    except Exception as exc:
+        return _json({"success": False, "error": str(exc)})
+
+
+def code_graph_search(
+    query: str,
+    root: str | None = None,
+    kind: str = "symbol",
+    limit: int = 20,
+    task_id: str | None = None,
+) -> str:
+    try:
+        if kind not in {"symbol", "all"}:
+            return _json({"success": False, "error": f"unsupported search kind for MVP: {kind}"})
+        return _json(search_symbols(_root(root), query, limit=int(limit or 20)))
+    except Exception as exc:
+        return _json({"success": False, "error": str(exc)})
+
+
+def code_graph_symbol(
+    symbol: str,
+    root: str | None = None,
+    task_id: str | None = None,
+) -> str:
+    try:
+        return _json(symbol_detail(_root(root), symbol))
+    except Exception as exc:
+        return _json({"success": False, "error": str(exc)})
+
+
+def code_graph_neighbors(
+    symbol: str,
+    root: str | None = None,
+    limit: int = 50,
+    task_id: str | None = None,
+) -> str:
+    try:
+        return _json(neighbors_for_symbol(_root(root), symbol, limit=int(limit or 50)))
+    except Exception as exc:
+        return _json({"success": False, "error": str(exc)})
+
+
+def code_graph_impact(
+    paths: list[str] | str,
+    root: str | None = None,
+    limit: int = 50,
+    task_id: str | None = None,
+) -> str:
+    try:
+        return _json(impact_for_paths(_root(root), _as_list(paths), limit=int(limit or 50)))
+    except Exception as exc:
+        return _json({"success": False, "error": str(exc)})
+
+
+def code_graph_context(
+    goal: str,
+    root: str | None = None,
+    budget_chars: int = 20_000,
+    task_id: str | None = None,
+) -> str:
+    try:
+        return _json(context_for_goal(_root(root), goal, budget_chars=int(budget_chars or 20_000)))
+    except Exception as exc:
+        return _json({"success": False, "error": str(exc)})
+
+
+_ROOT_PARAM = {
+    "type": "string",
+    "description": "Repository root. Defaults to the current workspace.",
+}
+
+
+registry.register(
+    name="code_graph_index",
+    toolset="code_graph",
+    schema={
+        "name": "code_graph_index",
+        "description": (
+            "Index a repository into Hermes' local read-only code graph cache. "
+            "This reads repository files and writes only the profile cache, not the repository."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "root": _ROOT_PARAM,
+                "force": {
+                    "type": "boolean",
+                    "description": "Reindex files even when their hashes are unchanged.",
+                    "default": False,
+                },
+                "max_file_size_bytes": {
+                    "type": "integer",
+                    "description": "Skip source files larger than this many bytes.",
+                    "default": 512000,
+                },
+            },
+        },
+    },
+    handler=lambda args, **kw: code_graph_index(
+        args.get("root"),
+        bool(args.get("force", False)),
+        int(args.get("max_file_size_bytes", 512_000) or 512_000),
+        kw.get("task_id"),
+    ),
+    max_result_size_chars=50_000,
+)
+
+registry.register(
+    name="code_graph_status",
+    toolset="code_graph",
+    schema={
+        "name": "code_graph_status",
+        "description": "Report whether the local code graph is missing, fresh, or stale for a repository.",
+        "parameters": {
+            "type": "object",
+            "properties": {"root": _ROOT_PARAM},
+        },
+    },
+    handler=lambda args, **kw: code_graph_status(args.get("root"), kw.get("task_id")),
+    max_result_size_chars=20_000,
+)
+
+registry.register(
+    name="code_graph_search",
+    toolset="code_graph",
+    schema={
+        "name": "code_graph_search",
+        "description": "Search indexed code graph symbols by name or qualified name.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Symbol query."},
+                "root": _ROOT_PARAM,
+                "kind": {
+                    "type": "string",
+                    "enum": ["symbol", "all"],
+                    "description": "MVP supports symbol search; all is accepted as an alias.",
+                    "default": "symbol",
+                },
+                "limit": {"type": "integer", "description": "Maximum matches.", "default": 20},
+            },
+            "required": ["query"],
+        },
+    },
+    handler=lambda args, **kw: code_graph_search(
+        args.get("query", ""),
+        args.get("root"),
+        args.get("kind", "symbol"),
+        int(args.get("limit", 20) or 20),
+        kw.get("task_id"),
+    ),
+    max_result_size_chars=50_000,
+)
+
+registry.register(
+    name="code_graph_symbol",
+    toolset="code_graph",
+    schema={
+        "name": "code_graph_symbol",
+        "description": "Inspect one indexed symbol's definition location and metadata.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "symbol": {"type": "string", "description": "Symbol name or qualified name."},
+                "root": _ROOT_PARAM,
+            },
+            "required": ["symbol"],
+        },
+    },
+    handler=lambda args, **kw: code_graph_symbol(
+        args.get("symbol", ""),
+        args.get("root"),
+        kw.get("task_id"),
+    ),
+    max_result_size_chars=30_000,
+)
+
+registry.register(
+    name="code_graph_neighbors",
+    toolset="code_graph",
+    schema={
+        "name": "code_graph_neighbors",
+        "description": "Return imports and textual references near an indexed symbol.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "symbol": {"type": "string", "description": "Symbol name or qualified name."},
+                "root": _ROOT_PARAM,
+                "limit": {"type": "integer", "description": "Maximum neighbor entries.", "default": 50},
+            },
+            "required": ["symbol"],
+        },
+    },
+    handler=lambda args, **kw: code_graph_neighbors(
+        args.get("symbol", ""),
+        args.get("root"),
+        int(args.get("limit", 50) or 50),
+        kw.get("task_id"),
+    ),
+    max_result_size_chars=50_000,
+)
+
+registry.register(
+    name="code_graph_impact",
+    toolset="code_graph",
+    schema={
+        "name": "code_graph_impact",
+        "description": "Estimate directly impacted symbols, imports, references, and likely tests for paths.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "paths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Repository-relative paths to inspect.",
+                },
+                "root": _ROOT_PARAM,
+                "limit": {"type": "integer", "description": "Maximum entries per section.", "default": 50},
+            },
+            "required": ["paths"],
+        },
+    },
+    handler=lambda args, **kw: code_graph_impact(
+        args.get("paths", []),
+        args.get("root"),
+        int(args.get("limit", 50) or 50),
+        kw.get("task_id"),
+    ),
+    max_result_size_chars=50_000,
+)
+
+registry.register(
+    name="code_graph_context",
+    toolset="code_graph",
+    schema={
+        "name": "code_graph_context",
+        "description": "Build a compact, ranked code graph context bundle for an implementation goal.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "goal": {"type": "string", "description": "Task or implementation goal."},
+                "root": _ROOT_PARAM,
+                "budget_chars": {
+                    "type": "integer",
+                    "description": "Approximate maximum JSON payload size.",
+                    "default": 20000,
+                },
+            },
+            "required": ["goal"],
+        },
+    },
+    handler=lambda args, **kw: code_graph_context(
+        args.get("goal", ""),
+        args.get("root"),
+        int(args.get("budget_chars", 20_000) or 20_000),
+        kw.get("task_id"),
+    ),
+    max_result_size_chars=80_000,
+)
+

--- a/toolsets.py
+++ b/toolsets.py
@@ -241,6 +241,24 @@ TOOLSETS = {
         "tools": ["execute_code"],
         "includes": []
     },
+
+    "code_graph": {
+        "description": (
+            "Optional read-only repository code graph tools: index into the "
+            "Hermes profile cache, search symbols, inspect neighbors, and "
+            "estimate impact. Off by default; enable via `hermes tools`."
+        ),
+        "tools": [
+            "code_graph_index",
+            "code_graph_status",
+            "code_graph_search",
+            "code_graph_symbol",
+            "code_graph_neighbors",
+            "code_graph_impact",
+            "code_graph_context",
+        ],
+        "includes": [],
+    },
     
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",

--- a/website/docs/user-guide/features/code-graph.md
+++ b/website/docs/user-guide/features/code-graph.md
@@ -1,0 +1,26 @@
+# Code Graph
+
+Hermes can optionally index a repository into a local read-only code graph and expose compact graph queries to the agent.
+
+## Enable
+
+Run `hermes tools` and enable the `code_graph` toolset for the surfaces where you want it available. Start a new session after changing toolsets.
+
+## Tools
+
+- `code_graph_index` - index or refresh the current repository into the Hermes profile cache.
+- `code_graph_status` - check whether the index is missing, fresh, or stale.
+- `code_graph_search` - search indexed symbols.
+- `code_graph_symbol` - inspect one symbol's definition.
+- `code_graph_neighbors` - inspect imports and textual references around a symbol.
+- `code_graph_impact` - estimate affected symbols, imports, references, and likely tests for changed paths.
+- `code_graph_context` - build a compact implementation context for a goal.
+
+## Storage
+
+Indexes are stored in the Hermes profile cache under `$HERMES_HOME/cache/code_graph/` and are safe to delete. Hermes will rebuild them when `code_graph_index` runs again.
+
+## Limitations
+
+The MVP focuses on Python symbols/imports plus language-agnostic file chunks and textual references. It does not perform type-aware resolution, semantic embeddings, LSP resolution, or automatic refactoring.
+

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -65,6 +65,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/tool-search',
             'user-guide/features/skills',
             'user-guide/features/lsp',
+            'user-guide/features/code-graph',
             'user-guide/features/curator',
             'user-guide/features/memory',
             'user-guide/features/memory-providers',


### PR DESCRIPTION
## Summary
- Add an opt-in read-only code_graph toolset backed by a SQLite cache under HERMES_HOME
- Index Python symbols/imports/references/chunks and expose graph status/search/symbol/neighbors/impact/context tools
- Add focused storage/index/query/tool tests plus user docs

## Test Plan
- python -m pytest tests/tools/test_code_graph_storage.py tests/tools/test_code_graph_indexer.py tests/tools/test_code_graph_query.py tests/tools/test_code_graph_tool.py tests/test_toolsets.py tests/test_model_tools.py -q
