### PR TITLE
fix(desktop): add NSContactsUsageDescription and NSAppleEventsUsageDescription

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -204,7 +204,9 @@
         "CFBundleExecutable": "Hermes",
         "CFBundleName": "Hermes",
         "NSAudioCaptureUsageDescription": "Hermes uses audio capture for voice conversations.",
-        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations."
+        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations.",
+        "NSContactsUsageDescription": "Hermes needs access to your contacts to read and update contact information via Apple Contacts.",
+        "NSAppleEventsUsageDescription": "Hermes uses Apple Events to write notes to your contacts."
       },
       "gatekeeperAssess": false,
       "hardenedRuntime": true,


### PR DESCRIPTION
## Summary
The Hermes desktop app silently denied Contacts access on macOS because the Info.plist lacked the required privacy usage descriptions. Without these keys, macOS never prompts the user for permission — tools that read or write Apple Contacts report a denied error instead.

This adds both  (general contacts access) and  (writing notes to contacts) to the electron-builder  configuration, matching the pattern already used for  and .

## Test Plan
- [ ] Build the desktop app on macOS
- [ ] Verify  shows the new keys
- [ ] Confirm Hermes appears under Privacy & Security → Contacts after first access

Closes #59482