### PR TITLE
fix(cli): enable Windows Virtual Terminal Processing for ANSI colors

### DIFF
--- a/hermes_cli/colors.py
+++ b/hermes_cli/colors.py
@@ -4,6 +4,50 @@ import os
 import sys
 
 
+def _enable_windows_ansi() -> None:
+    """Enable Windows Virtual Terminal Processing for ANSI escape sequences.
+
+    On Windows, the console does not interpret ANSI escape sequences by
+    default.  This function enables the ``ENABLE_VIRTUAL_TERMINAL_PROCESSING``
+    flag on the stdout (and stderr) handles so that ``\\033[...`` codes
+    render as colors instead of being printed as raw text.
+
+    Safe to call on non-Windows platforms (no-op).  Never raises — if the
+    API call fails, we silently fall back to no-color output.
+    """
+    if sys.platform != "win32":
+        return
+
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+
+        # STD_OUTPUT_HANDLE = -11, STD_ERROR_HANDLE = -12
+        for handle_id in (-11, -12):
+            handle = kernel32.GetStdHandle(handle_id)
+            if handle is None or handle == wintypes.HANDLE(-1).value:
+                continue
+
+            # Read current mode
+            mode = wintypes.DWORD()
+            if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+                continue
+
+            # ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+            ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+            new_mode = mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING
+            kernel32.SetConsoleMode(handle, new_mode)
+    except Exception:
+        # Silently ignore — worst case, no colors on Windows.
+        pass
+
+
+# Enable Windows VT processing once at import time.
+_enable_windows_ansi()
+
+
 def should_use_color() -> bool:
     """Return True when colored output is appropriate.
 


### PR DESCRIPTION
## Summary
On Windows, the console does not interpret ANSI escape sequences by default. This causes the setup wizard and other CLI commands to print raw escape codes instead of colored text, making the output unreadable in both CMD and PowerShell.

This adds  to  which sets the  flag on stdout and stderr handles at import time. This is the standard Windows API approach for enabling VT100-compatible terminal output.

The function is a no-op on non-Windows platforms and silently falls back if the API call fails.

Closes #59397