### PR TITLE
fix(api-server): expose redacted approval command in run status snapshot

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4116,6 +4116,11 @@ class APIServerAdapter(BasePlatformAdapter):
         })
         current.setdefault("created_at", fields.pop("created_at", now))
         current.update(fields)
+        # The approval payload is only meaningful while the run is blocked
+        # waiting; drop it on any transition away so pollers never render a
+        # stale command as still pending.
+        if status != "waiting_for_approval":
+            current.pop("approval", None)
         self._run_statuses[run_id] = current
         return current
 
@@ -4318,6 +4323,15 @@ class APIServerAdapter(BasePlatformAdapter):
                         run_id,
                         "waiting_for_approval",
                         last_event="approval.request",
+                        # Expose the (already redacted) command in the pollable
+                        # snapshot so clients that missed the SSE event — offline,
+                        # killed, or polling GET /v1/runs/{id} for recovery — are
+                        # not asked to approve blind.
+                        approval={
+                            "command": event.get("command"),
+                            "choices": event.get("choices"),
+                            "requested_at": event["timestamp"],
+                        },
                     )
                     try:
                         loop.call_soon_threadsafe(q.put_nowait, event)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -4073,3 +4073,48 @@ class TestModelRoutesAgentCreation:
         assert adapter._session_model_override_for("chan-1") == {"model": "user/model"}
         assert adapter._session_model_override_for("chan-2") is None
         assert adapter._session_model_override_for(None) is None
+
+
+class TestApprovalCommandInRunSnapshot:
+    """`GET /v1/runs/{id}` snapshot exposes the (redacted) approval command
+    while waiting, and clears it on any transition away, so pollers that
+    missed the SSE event are not asked to approve blind."""
+
+    def _adapter(self):
+        # _set_run_status only touches self._run_statuses; bypass the heavy
+        # __init__ so this stays a focused unit test.
+        adapter = APIServerAdapter.__new__(APIServerAdapter)
+        adapter._run_statuses = {}
+        return adapter
+
+    def test_approval_payload_retained_while_waiting(self):
+        adapter = self._adapter()
+        snap = adapter._set_run_status(
+            "run_1",
+            "waiting_for_approval",
+            last_event="approval.request",
+            approval={
+                "command": "rm -r /tmp/x",
+                "choices": ["once", "session", "always", "deny"],
+                "requested_at": 1.0,
+            },
+        )
+        assert snap["status"] == "waiting_for_approval"
+        assert snap["approval"]["command"] == "rm -r /tmp/x"
+        assert snap["approval"]["choices"] == ["once", "session", "always", "deny"]
+
+    def test_approval_payload_cleared_on_transition_away(self):
+        adapter = self._adapter()
+        adapter._set_run_status(
+            "run_1",
+            "waiting_for_approval",
+            approval={"command": "rm -r /tmp/x", "choices": ["once"], "requested_at": 1.0},
+        )
+        snap = adapter._set_run_status("run_1", "running", last_event="approval.responded")
+        assert snap["status"] == "running"
+        assert "approval" not in snap
+
+    def test_absent_when_never_waiting(self):
+        adapter = self._adapter()
+        snap = adapter._set_run_status("run_1", "running")
+        assert "approval" not in snap


### PR DESCRIPTION
## What does this PR do?

`GET /v1/runs/{run_id}` omits the pending approval command while a run is `waiting_for_approval`. A client that missed the `approval.request` SSE event — offline, killed, or polling the status snapshot to recover state — can see that *an* approval is pending but not *what command* it is, forcing a blind approve/deny of a potentially destructive action.

The SSE `approval.request` event already carries the (redacted) command. This mirrors it into the pollable snapshot as `approval.{command, choices, requested_at}`, and clears it on any transition away from `waiting_for_approval` so a stale command is never shown as still pending.

## Related Issue

No existing issue/PR found (searched open + merged PRs and issues for `approval` / `waiting_for_approval` / `run status approval`).

Fixes # (n/a — filing fix directly per Contributing Guide, small bug fix)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`
  - `_approval_notify`: when setting `waiting_for_approval`, attach `approval={command, choices, requested_at}` to the pollable status. `command` reuses the existing `_redact_approval_command` seam already applied to the SSE event — no new egress surface.
  - `_set_run_status`: drop the `approval` payload on any transition to a non-`waiting_for_approval` status, so pollers never render a resolved/stale command as still pending.
- `tests/gateway/test_api_server.py`
  - `TestApprovalCommandInRunSnapshot`: retain-while-waiting, clear-on-transition, absent-when-never-waiting.

## How to Test

Automated:

```
pytest tests/gateway/test_api_server.py::TestApprovalCommandInRunSnapshot -q   # 3 passed
```

Manual (live gateway, `approvals.mode: manual`):

1. `POST /v1/runs {"input":"Run this exact terminal command: rm -r /tmp/x","session_id":"S"}`
2. Poll `GET /v1/runs/{run_id}` → snapshot now includes
   `"approval": {"command": "rm -r /tmp/x", "choices": ["once","session","always","deny"], "requested_at": ...}`
3. `POST /v1/runs/{run_id}/approval {"choice":"deny"}` → poll again → `approval` field is gone, run reaches terminal state.

Context: found while building an iOS client that recovers run state by polling `GET /v1/runs/{id}` after reconnecting; without the command in the snapshot the approval UI could only ask the user to approve blind.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(api-server): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (2 files, no unrelated commits)
- [x] I've run the added tests and they pass (`pytest tests/gateway/test_api_server.py::TestApprovalCommandInRunSnapshot -q` → 3 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.5.0), Python via project venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (additive field on an existing response; no config keys)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure Python dict handling, no platform-specific code)
