### PR TITLE
fix(security): validate custom provider model probes

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3527,6 +3527,33 @@ def github_model_reasoning_efforts(
     return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
 
 
+def _provider_models_probe_url(base_url: str) -> tuple[str | None, str | None]:
+    raw = (base_url or "").strip()
+    if not raw:
+        return None, None
+    try:
+        parsed = urllib.parse.urlsplit(raw)
+        _ = parsed.port
+    except ValueError:
+        return None, "invalid provider endpoint URL"
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        return None, "provider endpoint must use http or https"
+    if not parsed.netloc or not parsed.hostname:
+        return None, "provider endpoint must include a host"
+    if parsed.username or parsed.password:
+        return None, "provider endpoint URL must not include credentials"
+    url = raw.rstrip("/") + "/models"
+    try:
+        from tools.url_safety import is_always_blocked_url
+
+        if is_always_blocked_url(url):
+            return None, "provider endpoint targets a blocked metadata or link-local address"
+    except Exception:
+        return None, "provider endpoint safety check failed"
+    return url, None
+
+
 def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
@@ -3586,13 +3613,25 @@ def probe_api_models(
 
         headers.update(normalize_extra_headers(request_headers))
 
+    blocked_all_candidates = True
     for candidate_base, is_fallback in candidates:
-        url = candidate_base.rstrip("/") + "/models"
+        url, blocked_reason = _provider_models_probe_url(candidate_base)
+        if blocked_reason:
+            continue
+        if url is None:
+            continue
+        blocked_all_candidates = False
         tried.append(url)
-        req = urllib.request.Request(url, headers=headers)
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
-                data = json.loads(resp.read().decode())
+            import httpx
+
+            with httpx.Client(
+                timeout=httpx.Timeout(timeout),
+                follow_redirects=True,
+            ) as client:
+                resp = client.get(url, headers=headers)
+                resp.raise_for_status()
+                data = resp.json()
                 return {
                     "models": [m.get("id", "") for m in data.get("data", [])],
                     "probed_url": url,
@@ -3605,7 +3644,9 @@ def probe_api_models(
 
     return {
         "models": None,
-        "probed_url": tried[0] if tried else normalized.rstrip("/") + "/models",
+        "probed_url": tried[0] if tried else (
+            None if blocked_all_candidates else normalized.rstrip("/") + "/models"
+        ),
         "resolved_base_url": normalized,
         "suggested_base_url": alternate_base if alternate_base != normalized else None,
         "used_fallback": False,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5614,6 +5614,33 @@ def github_model_reasoning_efforts(
     return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
 
 
+def _provider_models_probe_url(base_url: str) -> tuple[str | None, str | None]:
+    raw = (base_url or "").strip()
+    if not raw:
+        return None, None
+    try:
+        parsed = urllib.parse.urlsplit(raw)
+        _ = parsed.port
+    except ValueError:
+        return None, "invalid provider endpoint URL"
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        return None, "provider endpoint must use http or https"
+    if not parsed.netloc or not parsed.hostname:
+        return None, "provider endpoint must include a host"
+    if parsed.username or parsed.password:
+        return None, "provider endpoint URL must not include credentials"
+    url = raw.rstrip("/") + "/models"
+    try:
+        from tools.url_safety import is_always_blocked_url
+
+        if is_always_blocked_url(url):
+            return None, "provider endpoint targets a blocked metadata or link-local address"
+    except Exception:
+        return None, "provider endpoint safety check failed"
+    return url, None
+
+
 def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
@@ -5676,8 +5703,14 @@ def probe_api_models(
         headers.update(normalize_extra_headers(request_headers))
 
     _ssl_context = _custom_provider_ssl_context(normalized)
+    blocked_all_candidates = True
     for candidate_base, is_fallback in candidates:
-        url = candidate_base.rstrip("/") + "/models"
+        url, blocked_reason = _provider_models_probe_url(candidate_base)
+        if blocked_reason:
+            continue
+        if url is None:
+            continue
+        blocked_all_candidates = False
         tried.append(url)
         req = urllib.request.Request(url, headers=headers)
         # Only thread ssl_context when a per-provider TLS override actually
@@ -5701,7 +5734,9 @@ def probe_api_models(
 
     return {
         "models": None,
-        "probed_url": tried[0] if tried else normalized.rstrip("/") + "/models",
+        "probed_url": tried[0] if tried else (
+            None if blocked_all_candidates else normalized.rstrip("/") + "/models"
+        ),
         "resolved_base_url": normalized,
         "suggested_base_url": alternate_base if alternate_base != normalized else None,
         "used_fallback": False,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1094,11 +1094,14 @@ def _apply_main_model_assignment(
     if not isinstance(model_cfg, dict):
         model_cfg = {}
     prev_provider = str(model_cfg.get("provider") or "").strip().lower()
+    prev_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
     new_provider = provider.strip().lower()
+    incoming_base_url = base_url.strip()
+    base_url_changed = bool(incoming_base_url) and incoming_base_url.rstrip("/") != prev_base_url
     model_cfg["provider"] = provider
     model_cfg["default"] = model
-    if base_url.strip():
-        model_cfg["base_url"] = base_url.strip()
+    if incoming_base_url:
+        model_cfg["base_url"] = incoming_base_url
     elif model_cfg.get("base_url") and new_provider != prev_provider:
         # Switching providers: the old URL belonged to the old provider, drop
         # it so the new provider's default endpoint is used. Same-provider
@@ -1111,7 +1114,7 @@ def _apply_main_model_assignment(
     if api_key.strip():
         model_cfg["api_key"] = api_key.strip()
         model_cfg.pop("api", None)
-    elif model_cfg.get("api_key") and new_provider != prev_provider:
+    elif model_cfg.get("api_key") and (new_provider != prev_provider or base_url_changed):
         clear_model_endpoint_credentials(model_cfg, clear_api_mode=False)
     if new_provider != prev_provider:
         clear_model_endpoint_credentials(model_cfg, clear_api_key=False)
@@ -6145,6 +6148,43 @@ def _parse_model_ids(resp: "Any") -> List[str]:
     return ids
 
 
+def _provider_models_probe_url(base_url: str) -> tuple[str | None, str | None]:
+    raw = (base_url or "").strip()
+    if not raw:
+        return None, "Enter a value first."
+    try:
+        parsed = urllib.parse.urlsplit(raw)
+        _ = parsed.port
+    except ValueError:
+        return None, "Enter a valid provider endpoint URL."
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        return None, "Provider endpoints must use http or https."
+    if not parsed.netloc or not parsed.hostname:
+        return None, "Provider endpoints must include a host."
+    if parsed.username or parsed.password:
+        return None, "Provider endpoint URLs must not include credentials."
+    return raw.rstrip("/") + "/models", None
+
+
+def _provider_probe_block_reason(url: str, *, strict_private: bool = False) -> str | None:
+    try:
+        from tools.url_safety import is_always_blocked_url, is_safe_url
+    except Exception:
+        _log.warning("Provider endpoint safety checks unavailable", exc_info=True)
+        return "Could not verify that provider endpoint safely."
+
+    if is_always_blocked_url(url):
+        return "Provider endpoints cannot target cloud metadata or link-local addresses."
+    if strict_private and not is_safe_url(url):
+        return (
+            "Private or local provider endpoints can only be validated from a "
+            "loopback dashboard session. Configure them locally or enable the "
+            "private URL opt-in first."
+        )
+    return None
+
+
 @app.post("/api/providers/validate")
 async def validate_provider_credential(body: EnvVarUpdate, request: Request):
     """Live-probe a provider credential before it's saved.
@@ -6167,7 +6207,16 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
     # ids the endpoint advertises (OpenAI ``/v1/models`` shape) so the GUI can
     # auto-pick a default without asking the user to type a model name.
     if key == "OPENAI_BASE_URL":
-        url = value.rstrip("/") + "/models"
+        url, error = _provider_models_probe_url(value)
+        if error:
+            return {"ok": False, "reachable": True, "message": error}
+        assert url is not None
+        block_reason = _provider_probe_block_reason(
+            url,
+            strict_private=bool(getattr(request.app.state, "auth_required", False)),
+        )
+        if block_reason:
+            return {"ok": False, "reachable": False, "message": block_reason}
         # Send the optional API key so endpoints that require auth on
         # ``/v1/models`` (many hosted OpenAI-compatible servers) still enumerate
         # their models instead of returning an empty list behind a 401.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1746,11 +1746,14 @@ def _apply_main_model_assignment(
     if not isinstance(model_cfg, dict):
         model_cfg = {}
     prev_provider = str(model_cfg.get("provider") or "").strip().lower()
+    prev_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
     new_provider = provider.strip().lower()
+    incoming_base_url = base_url.strip()
+    base_url_changed = bool(incoming_base_url) and incoming_base_url.rstrip("/") != prev_base_url
     model_cfg["provider"] = provider
     model_cfg["default"] = model
-    if base_url.strip():
-        model_cfg["base_url"] = base_url.strip()
+    if incoming_base_url:
+        model_cfg["base_url"] = incoming_base_url
     elif model_cfg.get("base_url") and new_provider != prev_provider:
         # Switching providers: the old URL belonged to the old provider, drop
         # it so the new provider's default endpoint is used. Same-provider
@@ -1763,12 +1766,15 @@ def _apply_main_model_assignment(
     if api_key.strip():
         model_cfg["api_key"] = api_key.strip()
         model_cfg.pop("api", None)
-    elif (model_cfg.get("api_key") or model_cfg.get("api")) and new_provider != prev_provider:
+    elif (model_cfg.get("api_key") or model_cfg.get("api")) and (
+        new_provider != prev_provider or base_url_changed
+    ):
         # A stale endpoint secret can live under the legacy ``api`` alias with
         # no ``api_key`` (the resolver still reads ``model.api`` as a key), so
         # the switch-clears-the-key path must trigger on either field — else the
         # old endpoint's secret survives in config.yaml and contaminates a later
         # custom resolution. clear_model_endpoint_credentials scrubs both.
+        clear_model_endpoint_credentials(model_cfg, clear_api_mode=False)
         clear_model_endpoint_credentials(model_cfg, clear_api_mode=False)
     if new_provider != prev_provider:
         clear_model_endpoint_credentials(model_cfg, clear_api_key=False)
@@ -8305,13 +8311,21 @@ async def validate_custom_endpoint(body: CustomEndpointUpdate):
     if not base_url:
         return {"ok": False, "reachable": True, "message": "Enter an endpoint URL first.", "models": []}
 
-    url = base_url + "/models"
+    url, error = _provider_models_probe_url(base_url)
+    if error:
+        return {"ok": False, "reachable": True, "message": error, "models": []}
+    assert url is not None
+    block_reason = _provider_probe_block_reason(url)
+    if block_reason:
+        return {"ok": False, "reachable": False, "message": block_reason, "models": []}
     headers = {"Accept": "application/json"}
     if body.api_key and body.api_key.strip():
         headers["Authorization"] = f"Bearer {body.api_key.strip()}"
 
     try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(8.0)) as client:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(8.0), follow_redirects=False
+        ) as client:
             resp = await client.get(url, headers=headers)
     except Exception:
         return {"ok": False, "reachable": False, "message": f"Could not reach {url}.", "models": []}
@@ -8322,6 +8336,43 @@ async def validate_custom_endpoint(body: CustomEndpointUpdate):
         return {"ok": False, "reachable": True, "message": f"Endpoint returned HTTP {resp.status_code}.", "models": []}
 
     return {"ok": True, "reachable": True, "message": "", "models": _parse_model_ids(resp)}
+
+
+def _provider_models_probe_url(base_url: str) -> tuple[str | None, str | None]:
+    raw = (base_url or "").strip()
+    if not raw:
+        return None, "Enter a value first."
+    try:
+        parsed = urllib.parse.urlsplit(raw)
+        _ = parsed.port
+    except ValueError:
+        return None, "Enter a valid provider endpoint URL."
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        return None, "Provider endpoints must use http or https."
+    if not parsed.netloc or not parsed.hostname:
+        return None, "Provider endpoints must include a host."
+    if parsed.username or parsed.password:
+        return None, "Provider endpoint URLs must not include credentials."
+    return raw.rstrip("/") + "/models", None
+
+
+def _provider_probe_block_reason(url: str, *, strict_private: bool = False) -> str | None:
+    try:
+        from tools.url_safety import is_always_blocked_url, is_safe_url
+    except Exception:
+        _log.warning("Provider endpoint safety checks unavailable", exc_info=True)
+        return "Could not verify that provider endpoint safely."
+
+    if is_always_blocked_url(url):
+        return "Provider endpoints cannot target cloud metadata or link-local addresses."
+    if strict_private and not is_safe_url(url):
+        return (
+            "Private or local provider endpoints can only be validated from a "
+            "loopback dashboard session. Configure them locally or enable the "
+            "private URL opt-in first."
+        )
+    return None
 
 
 @app.post("/api/providers/validate")
@@ -8346,7 +8397,16 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
     # ids the endpoint advertises (OpenAI ``/v1/models`` shape) so the GUI can
     # auto-pick a default without asking the user to type a model name.
     if key == "OPENAI_BASE_URL":
-        url = value.rstrip("/") + "/models"
+        url, error = _provider_models_probe_url(value)
+        if error:
+            return {"ok": False, "reachable": True, "message": error}
+        assert url is not None
+        block_reason = _provider_probe_block_reason(
+            url,
+            strict_private=bool(getattr(request.app.state, "auth_required", False)),
+        )
+        if block_reason:
+            return {"ok": False, "reachable": False, "message": block_reason}
         # Send the optional API key so endpoints that require auth on
         # ``/v1/models`` (many hosted OpenAI-compatible servers) still enumerate
         # their models instead of returning an empty list behind a 401.

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -4,8 +4,6 @@ PR #3526 salvage — user-configurable extra HTTP headers on LLM API calls
 (reverse proxies, gateways, custom auth such as Cloudflare Access tokens).
 """
 
-import json
-
 from hermes_cli.config import (
     _normalize_custom_provider_entry,
     apply_custom_provider_extra_headers_to_client_kwargs,
@@ -147,25 +145,30 @@ def test_fetch_api_models_sends_extra_headers_to_models_probe(monkeypatch):
     captured = {}
 
     class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": [{"id": "proxy-model"}]}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            captured["client_kwargs"] = kwargs
+
         def __enter__(self):
             return self
 
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def read(self):
-            return json.dumps({"data": [{"id": "proxy-model"}]}).encode()
+        def get(self, url, headers=None):
+            captured["url"] = url
+            captured["headers"] = {
+                key.lower(): value for key, value in (headers or {}).items()
+            }
+            return FakeResponse()
 
-    def fake_urlopen(request, timeout=0):
-        captured["url"] = request.full_url
-        captured["timeout"] = timeout
-        captured["headers"] = {
-            key.lower(): value
-            for key, value in request.header_items()
-        }
-        return FakeResponse()
-
-    monkeypatch.setattr(models_mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr("httpx.Client", FakeClient)
 
     models = models_mod.fetch_api_models(
         "proxy-key",

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -4,8 +4,6 @@ PR #3526 salvage — user-configurable extra HTTP headers on LLM API calls
 (reverse proxies, gateways, custom auth such as Cloudflare Access tokens).
 """
 
-import json
-
 from hermes_cli.config import (
     _normalize_custom_provider_entry,
     apply_custom_provider_extra_headers_to_client_kwargs,
@@ -210,14 +208,28 @@ def test_fetch_api_models_sends_extra_headers_to_models_probe(monkeypatch):
     captured = {}
 
     class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": [{"id": "proxy-model"}]}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            captured["client_kwargs"] = kwargs
+
         def __enter__(self):
             return self
 
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def read(self):
-            return json.dumps({"data": [{"id": "proxy-model"}]}).encode()
+        def get(self, url, headers=None):
+            captured["url"] = url
+            captured["headers"] = {
+                key.lower(): value for key, value in (headers or {}).items()
+            }
+            return FakeResponse()
 
     def fake_urlopen(request, timeout=0):
         captured["url"] = request.full_url

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -278,26 +278,46 @@ class TestFetchApiModels:
         with patch("hermes_cli.models.urllib.request.urlopen", side_effect=Exception("timeout")):
             assert fetch_api_models("key", "https://example.com/v1") is None
 
+    def test_rejects_metadata_url_without_network_call(self):
+        with patch(
+            "httpx.Client",
+            side_effect=AssertionError("metadata endpoints must not be probed"),
+        ):
+            probe = probe_api_models("key", "http://169.254.169.254/latest")
+
+        assert probe["models"] is None
+        assert probe["probed_url"] is None
+
+    def test_rejects_non_http_scheme_without_network_call(self):
+        with patch(
+            "httpx.Client",
+            side_effect=AssertionError("non-http endpoints must not be probed"),
+        ):
+            probe = probe_api_models("key", "file:///etc/passwd")
+
+        assert probe["models"] is None
+        assert probe["probed_url"] is None
+
     def test_probe_api_models_tries_v1_fallback(self):
-        class _Resp:
+        class _Client:
             def __enter__(self):
                 return self
 
             def __exit__(self, exc_type, exc, tb):
                 return False
 
-            def read(self):
-                return b'{"data": [{"id": "local-model"}]}'
+            def get(self, url, headers=None):
+                calls.append(url)
+                if url.endswith("/v1/models"):
+                    response = MagicMock()
+                    response.raise_for_status.return_value = None
+                    response.json.return_value = {"data": [{"id": "local-model"}]}
+                    return response
+                raise Exception("404")
 
         calls = []
 
-        def _fake_urlopen(req, timeout=5.0):
-            calls.append(req.full_url)
-            if req.full_url.endswith("/v1/models"):
-                return _Resp()
-            raise Exception("404")
-
-        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=_fake_urlopen):
+        with patch("httpx.Client", return_value=_Client()):
             probe = probe_api_models("key", "http://localhost:8000")
 
         assert calls == ["http://localhost:8000/models", "http://localhost:8000/v1/models"]
@@ -897,48 +917,43 @@ class TestProbeApiModelsUserAgent:
     endpoint is reachable and the listing exists.
     """
 
-    def _make_mock_response(self, body: bytes):
-        from unittest.mock import MagicMock
-        mock_resp = MagicMock()
-        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_resp.read = MagicMock(return_value=body)
-        return mock_resp
-
     def test_probe_sends_hermes_user_agent(self):
         from unittest.mock import patch
 
-        body = b'{"data":[{"id":"claude-opus-4.7"}]}'
-        with patch(
-            "hermes_cli.models.urllib.request.urlopen",
-            return_value=self._make_mock_response(body),
-        ) as mock_urlopen:
+        captured = {}
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": [{"id": "claude-opus-4.7"}]}
+        mock_client.get.return_value = mock_response
+        mock_client.get.side_effect = lambda url, headers=None: (
+            captured.update({"url": url, "headers": headers}) or mock_response
+        )
+        with patch("httpx.Client", return_value=mock_client):
             result = probe_api_models("sk-test", "https://example.com/v1")
 
         assert result["models"] == ["claude-opus-4.7"]
-        # The urlopen call receives a Request object as its first positional arg
-        req = mock_urlopen.call_args[0][0]
-        ua = req.get_header("User-agent")  # urllib title-cases header names
+        ua = captured["headers"].get("User-Agent")
         assert ua, "probe_api_models must send a User-Agent header"
         assert ua.startswith("hermes-cli/"), (
             f"User-Agent must advertise hermes-cli, got {ua!r}"
         )
-        # Must not fall back to urllib's default — that's what Cloudflare 1010 blocks.
-        assert not ua.startswith("Python-urllib")
 
     def test_probe_user_agent_sent_without_api_key(self):
         """UA must be present even for endpoints that don't need auth."""
         from unittest.mock import patch
 
-        body = b'{"data":[]}'
-        with patch(
-            "hermes_cli.models.urllib.request.urlopen",
-            return_value=self._make_mock_response(body),
-        ) as mock_urlopen:
+        captured = {}
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": []}
+        mock_client.get.side_effect = lambda url, headers=None: (
+            captured.update({"url": url, "headers": headers}) or mock_response
+        )
+        with patch("httpx.Client", return_value=mock_client):
             probe_api_models(None, "https://example.com/v1")
 
-        req = mock_urlopen.call_args[0][0]
-        ua = req.get_header("User-agent")
+        ua = captured["headers"].get("User-Agent")
         assert ua and ua.startswith("hermes-cli/")
-        # No Authorization was set, but UA must still be present.
-        assert req.get_header("Authorization") is None
+        assert captured["headers"].get("Authorization") is None

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -173,7 +173,45 @@ class TestFetchApiModels:
         assert fetch_api_models("key", None) is None
 
 
+    def test_rejects_metadata_url_without_network_call(self):
+        with patch(
+            "httpx.Client",
+            side_effect=AssertionError("metadata endpoints must not be probed"),
+        ):
+            probe = probe_api_models("key", "http://169.254.169.254/latest")
+
+        assert probe["models"] is None
+        assert probe["probed_url"] is None
+
+    def test_rejects_non_http_scheme_without_network_call(self):
+        with patch(
+            "httpx.Client",
+            side_effect=AssertionError("non-http endpoints must not be probed"),
+        ):
+            probe = probe_api_models("key", "file:///etc/passwd")
+
+        assert probe["models"] is None
+        assert probe["probed_url"] is None
+
     def test_probe_api_models_tries_v1_fallback(self):
+        class _Client:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def get(self, url, headers=None):
+                calls.append(url)
+                if url.endswith("/v1/models"):
+                    response = MagicMock()
+                    response.raise_for_status.return_value = None
+                    response.json.return_value = {"data": [{"id": "local-model"}]}
+                    return response
+                raise Exception("404")
+
+        calls = []
+
         class _Resp:
             def __enter__(self):
                 return self
@@ -184,15 +222,16 @@ class TestFetchApiModels:
             def read(self):
                 return b'{"data": [{"id": "local-model"}]}'
 
-        calls = []
-
-        def _fake_urlopen(req, timeout=5.0):
+        def _fake_urlopen(req, timeout=5.0, **kwargs):
             calls.append(req.full_url)
             if req.full_url.endswith("/v1/models"):
                 return _Resp()
             raise Exception("404")
 
-        with patch("hermes_cli.models._urlopen_model_catalog_request", side_effect=_fake_urlopen):
+        with patch(
+            "hermes_cli.models._urlopen_model_catalog_request",
+            side_effect=_fake_urlopen,
+        ):
             probe = probe_api_models("key", "http://localhost:8000")
 
         assert calls == ["http://localhost:8000/models", "http://localhost:8000/v1/models"]
@@ -517,50 +556,57 @@ class TestProbeApiModelsUserAgent:
     endpoint is reachable and the listing exists.
     """
 
-    def _make_mock_response(self, body: bytes):
-        from unittest.mock import MagicMock
-        mock_resp = MagicMock()
-        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_resp.read = MagicMock(return_value=body)
-        return mock_resp
-
     def test_probe_sends_hermes_user_agent(self):
         from unittest.mock import patch
 
         body = b'{"data":[{"id":"claude-opus-4.7"}]}'
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return body
+
         with patch(
             "hermes_cli.models._urlopen_model_catalog_request",
-            return_value=self._make_mock_response(body),
+            return_value=_Resp(),
         ) as mock_urlopen:
             result = probe_api_models("sk-test", "https://example.com/v1")
 
         assert result["models"] == ["claude-opus-4.7"]
-        # The urlopen call receives a Request object as its first positional arg
-        req = mock_urlopen.call_args[0][0]
-        ua = req.get_header("User-agent")  # urllib title-cases header names
+        req = mock_urlopen.call_args.args[0]
+        ua = req.get_header("User-agent")
         assert ua, "probe_api_models must send a User-Agent header"
         assert ua.startswith("hermes-cli/"), (
             f"User-Agent must advertise hermes-cli, got {ua!r}"
         )
-        # Must not fall back to urllib's default — that's what Cloudflare 1010 blocks.
-        assert not ua.startswith("Python-urllib")
 
     def test_probe_user_agent_sent_without_api_key(self):
         """UA must be present even for endpoints that don't need auth."""
         from unittest.mock import patch
 
         body = b'{"data":[]}'
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return body
+
         with patch(
             "hermes_cli.models._urlopen_model_catalog_request",
-            return_value=self._make_mock_response(body),
+            return_value=_Resp(),
         ) as mock_urlopen:
             probe_api_models(None, "https://example.com/v1")
 
-        req = mock_urlopen.call_args[0][0]
+        req = mock_urlopen.call_args.args[0]
         ua = req.get_header("User-agent")
         assert ua and ua.startswith("hermes-cli/")
         # No Authorization was set, but UA must still be present.
         assert req.get_header("Authorization") is None
-
-

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -7167,6 +7167,73 @@ class TestValidateProviderCredential:
         )
         assert captured["headers"] is None
 
+    def test_local_endpoint_rejects_metadata_url_without_network_call(self, monkeypatch):
+        class _Client:
+            def __init__(self, *a, **k):
+                raise AssertionError("metadata endpoints must not be probed")
+
+        monkeypatch.setattr("httpx.Client", _Client)
+
+        data = self.client.post(
+            "/api/providers/validate",
+            json={
+                "key": "OPENAI_BASE_URL",
+                "value": "http://169.254.169.254/latest/meta-data",
+            },
+        ).json()
+
+        assert data["ok"] is False
+        assert data["reachable"] is False
+        assert "metadata" in data["message"].lower()
+
+    def test_remote_endpoint_rejects_private_provider_url(self):
+        from hermes_cli.web_server import _provider_probe_block_reason
+
+        reason = _provider_probe_block_reason(
+            "http://127.0.0.1:8000/v1/models",
+            strict_private=True,
+        )
+
+        assert reason is not None
+        assert "private" in reason.lower()
+
+    def test_local_endpoint_rejects_non_http_scheme_without_network_call(self, monkeypatch):
+        class _Client:
+            def __init__(self, *a, **k):
+                raise AssertionError("non-http endpoints must not be probed")
+
+        monkeypatch.setattr("httpx.Client", _Client)
+
+        data = self.client.post(
+            "/api/providers/validate",
+            json={"key": "OPENAI_BASE_URL", "value": "file:///etc/passwd"},
+        ).json()
+
+        assert data["ok"] is False
+        assert data["reachable"] is True
+        assert "http" in data["message"].lower()
+
+    def test_custom_base_url_change_without_key_clears_endpoint_key(self):
+        from hermes_cli.web_server import _apply_main_model_assignment
+
+        model_cfg = {
+            "provider": "custom",
+            "default": "old-model",
+            "base_url": "https://old.example.com/v1",
+            "api_key": "sk-old-endpoint",
+        }
+
+        updated = _apply_main_model_assignment(
+            model_cfg,
+            "custom",
+            "new-model",
+            "https://new.example.com/v1",
+            "",
+        )
+
+        assert updated["base_url"] == "https://new.example.com/v1"
+        assert "api_key" not in updated
+
 
 class TestDesktopCronTicker:
     """The dashboard backend fires cron jobs itself only when desktop-spawned."""

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4651,6 +4651,73 @@ class TestValidateProviderCredential:
             },
         }
 
+    def test_local_endpoint_rejects_metadata_url_without_network_call(self, monkeypatch):
+        class _Client:
+            def __init__(self, *a, **k):
+                raise AssertionError("metadata endpoints must not be probed")
+
+        monkeypatch.setattr("httpx.Client", _Client)
+
+        data = self.client.post(
+            "/api/providers/validate",
+            json={
+                "key": "OPENAI_BASE_URL",
+                "value": "http://169.254.169.254/latest/meta-data",
+            },
+        ).json()
+
+        assert data["ok"] is False
+        assert data["reachable"] is False
+        assert "metadata" in data["message"].lower()
+
+    def test_remote_endpoint_rejects_private_provider_url(self):
+        from hermes_cli.web_server import _provider_probe_block_reason
+
+        reason = _provider_probe_block_reason(
+            "http://127.0.0.1:8000/v1/models",
+            strict_private=True,
+        )
+
+        assert reason is not None
+        assert "private" in reason.lower()
+
+    def test_local_endpoint_rejects_non_http_scheme_without_network_call(self, monkeypatch):
+        class _Client:
+            def __init__(self, *a, **k):
+                raise AssertionError("non-http endpoints must not be probed")
+
+        monkeypatch.setattr("httpx.Client", _Client)
+
+        data = self.client.post(
+            "/api/providers/validate",
+            json={"key": "OPENAI_BASE_URL", "value": "file:///etc/passwd"},
+        ).json()
+
+        assert data["ok"] is False
+        assert data["reachable"] is True
+        assert "http" in data["message"].lower()
+
+    def test_custom_base_url_change_without_key_clears_endpoint_key(self):
+        from hermes_cli.web_server import _apply_main_model_assignment
+
+        model_cfg = {
+            "provider": "custom",
+            "default": "old-model",
+            "base_url": "https://old.example.com/v1",
+            "api_key": "sk-old-endpoint",
+        }
+
+        updated = _apply_main_model_assignment(
+            model_cfg,
+            "custom",
+            "new-model",
+            "https://new.example.com/v1",
+            "",
+        )
+
+        assert updated["base_url"] == "https://new.example.com/v1"
+        assert "api_key" not in updated
+
 
 class TestDesktopCronTicker:
     """The dashboard backend fires cron jobs itself only when desktop-spawned."""


### PR DESCRIPTION
## Summary

- Validate custom provider `/models` probe URLs before any request.
- Reject malformed, non-HTTP(S), credential-bearing, metadata, and link-local endpoints.
- Reject private/local endpoints for authenticated remote dashboard sessions while preserving loopback/local-provider workflows.
- Clear a stale endpoint API key when the custom base URL changes, and forward an explicitly supplied key to authenticated model catalogs.

## Overlap review

Open PR #57860 already owns connection-level DNS pinning and media fetch transport hardening. This PR deliberately leaves `tools/url_safety.py`, `tools/vision_tools.py`, and their tests unchanged, so review is limited to the uncovered custom-provider probe surface.

The fork-only `plugins/scrapling-feeds` code is also excluded from this upstream PR.

## Validation

- Focused provider/WebUI suite: `141 passed, 325 deselected`
- Ruff on all four changed files: passed
- `git diff --check upstream/main...HEAD`: passed
- Rebased onto upstream `caf557be5b4c9ae75b3a7566d65d3df2c701c5df`

## Agent disclosure

Prepared with Codex and independently reviewed before narrowing the scope against the active upstream PR queue.