### PR TITLE
fix(telegram): skip fallback discovery when disabled

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3029,7 +3029,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in {"1", "true", "yes", "on"})
             fallback_ips = self._fallback_ips()
-            if not fallback_ips:
+            if disable_fallback:
+                fallback_ips = []
+                logger.info("[%s] Telegram fallback-IP discovery/transport disabled via env", self.name)
+            elif not fallback_ips:
                 logger.warning("[%s] Discovering Telegram API fallback IPs via DNS-over-HTTPS…", self.name)
                 fallback_ips = await discover_fallback_ips()
                 logger.info(

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -497,6 +497,68 @@ class TestAdapterFallbackIps:
         adapter = self._make_adapter(extra={"fallback_ips": ["149.154.167.220", "not-valid"]})
         assert adapter._fallback_ips() == ["149.154.167.220"]
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("extra", [None, {"fallback_ips": ["149.154.167.220"]}])
+    async def test_disable_env_skips_fallback_resolution_during_connect(self, monkeypatch, extra):
+        """Disabling fallback IPs should skip both config fallback IPs and DoH discovery."""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        from plugins.platforms.telegram import adapter as telegram_mod
+
+        adapter = self._make_adapter(extra=extra)
+        monkeypatch.setattr(adapter, "_acquire_platform_lock", lambda *args: True)
+        monkeypatch.setattr(adapter, "_release_platform_lock", lambda: None)
+        monkeypatch.setattr(adapter, "_delete_webhook_best_effort", AsyncMock())
+        monkeypatch.setattr(adapter, "_start_polling_resilient", AsyncMock(return_value=True))
+        monkeypatch.setattr(adapter, "_start_post_connect_housekeeping", MagicMock())
+        monkeypatch.setenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "1")
+
+        discover = AsyncMock(return_value=["149.154.167.221"])
+        monkeypatch.setattr(telegram_mod, "discover_fallback_ips", discover)
+
+        resolved_targets = []
+
+        def fake_resolve_proxy_url(platform_env_var, *, target_hosts=None):
+            resolved_targets.append((platform_env_var, list(target_hosts or [])))
+            return None
+
+        monkeypatch.setattr(telegram_mod, "resolve_proxy_url", fake_resolve_proxy_url)
+
+        request_kwargs = []
+
+        def fake_httpx_request(**kwargs):
+            request_kwargs.append(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(telegram_mod, "HTTPXRequest", fake_httpx_request)
+
+        app = SimpleNamespace(
+            bot=SimpleNamespace(),
+            updater=SimpleNamespace(),
+            add_handler=MagicMock(),
+            initialize=AsyncMock(),
+            start=AsyncMock(),
+        )
+        builder = MagicMock()
+        builder.token.return_value = builder
+        builder.request.return_value = builder
+        builder.get_updates_request.return_value = builder
+        builder.build.return_value = app
+        monkeypatch.setattr(
+            telegram_mod,
+            "Application",
+            SimpleNamespace(builder=MagicMock(return_value=builder)),
+        )
+
+        ok = await adapter.connect()
+
+        assert ok is True
+        discover.assert_not_awaited()
+        assert resolved_targets == [("TELEGRAM_PROXY", ["api.telegram.org"])]
+        assert request_kwargs
+        assert all("transport" not in kwargs.get("httpx_kwargs", {}) for kwargs in request_kwargs)
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # DoH auto-discovery


### PR DESCRIPTION
## Summary

Fix Telegram startup when `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS` is enabled.

Before this change, the adapter read the disable flag but still ran fallback-IP discovery when no explicit fallback IPs were configured. That meant a user asking Hermes to disable fallback IP behavior could still get DNS-over-HTTPS discovery and fallback targets in the startup path before the transport branch later skipped using them.

This makes the flag truthful: when disabled, fallback IPs are cleared before discovery and proxy-target resolution, so Telegram connects through the normal `api.telegram.org` path only.

## Context

This is the same bug class as the closed, unmerged PR #18702 (`fix(telegram): honor disabled fallback IPs`), updated for the current plugin path and current adapter implementation.

## Changes

- Skip fallback-IP discovery when `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS` is truthy.
- Keep proxy target resolution to `api.telegram.org` only in that mode.
- Add regression coverage proving disabled fallback mode ignores both configured fallback IPs and DoH discovery.

## Verification

Local Pi verification was intentionally minimal per operator constraint; GitHub Actions should do the real CI run.

- `python3 -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_network.py`
- `git diff --check`

