### PR TITLE
fix(dashboard): honour --open-profile scope in session API endpoints

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3983,7 +3983,12 @@ def get_sessions(
     if profile:
         profile_name, _ = _cron_profile_home(profile)
     try:
-        db = _open_session_db_for_profile(profile)
+        # When this dashboard is scoped to a specific profile via
+        # --open-profile and the caller did not explicitly request a
+        # profile, default to the scoped profile so the dashboard's
+        # session list matches its profile context.
+        _effective_profile = profile or getattr(app.state, "open_profile", "")
+        db = _open_session_db_for_profile(_effective_profile or None)
         try:
             min_message_count = max(0, min_messages)
             archived_only = archived == "only"
@@ -4072,9 +4077,18 @@ def get_profiles_sessions(
     from hermes_state import SessionDB
     from hermes_cli import profiles as profiles_mod
 
+    # When this dashboard is scoped to a specific profile via
+    # --open-profile, honour that scope: only return the scoped
+    # profile's sessions.  This prevents a profile-specific dashboard
+    # (e.g. juicecup on port 9120) from leaking other profiles' data.
+    _scoped = getattr(app.state, "open_profile", "")
     targets: List[Tuple[str, Path]] = []
     if profile and profile != "all":
         name, home = _cron_profile_home(profile)
+        targets.append((name, home))
+    elif _scoped:
+        # Dashboard is scoped to one profile — return only that profile.
+        name, home = _cron_profile_home(_scoped)
         targets.append((name, home))
     else:
         try:
@@ -4182,7 +4196,8 @@ async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] =
     if not q or not q.strip():
         return {"results": []}
     try:
-        db = _open_session_db_for_profile(profile)
+        _effective_profile = profile or getattr(app.state, "open_profile", "")
+        db = _open_session_db_for_profile(_effective_profile or None)
         try:
             safe_limit = max(1, min(int(limit or 20), 100))
 
@@ -16990,6 +17005,10 @@ def start_server(
     # uses this to decide whether to refuse the bind, log the gate-on
     # banner, and enable uvicorn proxy_headers.
     app.state.auth_required = should_require_auth(host)
+    # Store the --open-profile scope so API endpoints (e.g.
+    # /api/profiles/sessions) can restrict data to this profile only,
+    # instead of always returning all profiles' aggregated data.
+    app.state.open_profile = (initial_profile or "").strip()
 
     # ``--insecure`` no longer disables the auth gate (June 2026 hardening:
     # the hermes-0day MCP-persistence campaign abused unauthenticated public

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9603,7 +9603,8 @@ async def bulk_delete_sessions_endpoint(body: BulkDeleteSessions):
             status_code=400,
             detail="ids must contain at most 500 entries",
         )
-    db = _open_session_db_for_profile(body.profile)
+    _effective_profile = body.profile or getattr(app.state, "open_profile", "")
+    db = _open_session_db_for_profile(_effective_profile or None)
     try:
         deleted = db.delete_sessions(body.ids)
         return {"ok": True, "deleted": deleted}
@@ -9619,7 +9620,8 @@ async def count_empty_sessions_endpoint(profile: Optional[str] = None):
     UI hides the affordance so users aren't presented with a button
     that does nothing. Cheap, single-COUNT query.
     """
-    db = _open_session_db_for_profile(profile)
+    _effective_profile = profile or getattr(app.state, "open_profile", "")
+    db = _open_session_db_for_profile(_effective_profile or None)
     try:
         return {"count": db.count_empty_sessions()}
     finally:
@@ -9646,7 +9648,8 @@ async def delete_empty_sessions_endpoint(profile: Optional[str] = None):
     prune-on-startup pass. Matching that pre-existing trade-off keeps
     the two delete endpoints' DB-vs-disk behaviour consistent.
     """
-    db = _open_session_db_for_profile(profile)
+    _effective_profile = profile or getattr(app.state, "open_profile", "")
+    db = _open_session_db_for_profile(_effective_profile or None)
     try:
         deleted = db.delete_empty_sessions()
         return {"ok": True, "deleted": deleted}
@@ -9661,7 +9664,8 @@ async def get_session_stats(profile: Optional[str] = None):
     Registered before ``/api/sessions/{session_id}`` so the literal ``stats``
     path isn't captured as a session id by the parameterized route.
     """
-    db = _open_session_db_for_profile(profile)
+    _effective_profile = profile or getattr(app.state, "open_profile", "")
+    db = _open_session_db_for_profile(_effective_profile or None)
     try:
         total = db.session_count(include_archived=True)
         active_store = db.session_count(include_archived=False)
@@ -9702,7 +9706,8 @@ def _open_session_db_for_profile(profile: Optional[str]):
 
 @app.get("/api/sessions/{session_id}")
 async def get_session_detail(session_id: str, profile: Optional[str] = None):
-    db = _open_session_db_for_profile(profile)
+    _effective_profile = profile or getattr(app.state, "open_profile", "")
+    db = _open_session_db_for_profile(_effective_profile or None)
     try:
         sid = db.resolve_session_id(session_id)
         session = db.get_session(sid) if sid else None
@@ -9742,7 +9747,8 @@ async def get_session_messages(
     limit: Optional[int] = None,
     offset: int = 0,
 ):
-    db = _open_session_db_for_profile(profile)
+    _effective_profile = profile or getattr(app.state, "open_profile", "")
+    db = _open_session_db_for_profile(_effective_profile or None)
     try:
         sid = db.resolve_session_id(session_id)
         if not sid:
@@ -9767,9 +9773,11 @@ async def get_session_messages(
 @app.delete("/api/sessions/{session_id}")
 async def delete_session_endpoint(session_id: str, profile: Optional[str] = None):
     # ``profile`` deletes a session belonging to another (local) profile by
-    # opening its state.db directly. Remote profiles never reach here — the
-    # desktop routes their DELETE to the remote backend. Omit for current/default.
-    db = _open_session_db_for_profile(profile)
+    # opening its state.db directly. Omit for current/default profile, or
+    # fall back to the dashboard's ``--open-profile`` scope so a per-profile
+    # instance (e.g. juicecup on 9120) operates on its own state.db.
+    _effective_profile = profile or getattr(app.state, "open_profile", "")
+    db = _open_session_db_for_profile(_effective_profile or None)
     try:
         # Resolve exact ids / unique prefixes like every other session endpoint
         # (detail, messages, rename, export all do). A session that no longer
@@ -9803,9 +9811,11 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
 
     ``title`` renames (empty/null clears the title); ``archived`` soft-hides or
     restores the session. Either field may be omitted. ``profile`` targets
-    another profile's session.
+    another profile's session. Falls back to the dashboard's ``--open-profile``
+    scope so a per-profile instance operates on its own state.db.
     """
-    db = _open_session_db_for_profile(body.profile)
+    _effective_profile = body.profile or getattr(app.state, "open_profile", "")
+    db = _open_session_db_for_profile(_effective_profile or None)
     try:
         sid = db.resolve_session_id(session_id)
         if not sid:
@@ -9834,7 +9844,8 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
 @app.get("/api/sessions/{session_id}/export")
 async def export_session_endpoint(session_id: str, profile: Optional[str] = None):
     """Export a single session (metadata + messages) as JSON."""
-    db = _open_session_db_for_profile(profile)
+    _effective_profile = profile or getattr(app.state, "open_profile", "")
+    db = _open_session_db_for_profile(_effective_profile or None)
     try:
         sid = db.resolve_session_id(session_id)
         if not sid:
@@ -9901,7 +9912,8 @@ async def prune_sessions_endpoint(body: SessionPrune):
     if has_window or (_attr_filters_set and not _older_than_explicit):
         _effective_older_than = None
     profile_home = _cron_profile_home(body.profile)[1] if body.profile else get_hermes_home()
-    db = _open_session_db_for_profile(body.profile)
+    _effective_profile = body.profile or getattr(app.state, "open_profile", "")
+    db = _open_session_db_for_profile(_effective_profile or None)
     try:
         filters = dict(
             older_than_days=_effective_older_than,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9726,7 +9726,8 @@ async def get_session_latest_descendant(
     session_id: str,
     profile: Optional[str] = None,
 ):
-    db = _open_session_db_for_profile(profile)
+    _effective_profile = profile or getattr(app.state, "open_profile", "")
+    db = _open_session_db_for_profile(_effective_profile or None)
     try:
         latest, path = _session_latest_descendant(session_id, db)
         if not latest:
@@ -9911,8 +9912,8 @@ async def prune_sessions_endpoint(body: SessionPrune):
     _effective_older_than = body.older_than_days
     if has_window or (_attr_filters_set and not _older_than_explicit):
         _effective_older_than = None
-    profile_home = _cron_profile_home(body.profile)[1] if body.profile else get_hermes_home()
     _effective_profile = body.profile or getattr(app.state, "open_profile", "")
+    profile_home = _cron_profile_home(_effective_profile)[1] if _effective_profile else get_hermes_home()
     db = _open_session_db_for_profile(_effective_profile or None)
     try:
         filters = dict(


### PR DESCRIPTION
## Problem

When running multiple Hermes profiles with separate dashboard instances (each bound to a different port), the --open-profile flag only affects the browser URL (/?profile=<name>). The session API endpoints ignore it entirely:

- GET /api/sessions — returns the process's own state.db (the default profile's), not the scoped profile's.
- GET /api/sessions/search — same issue.
- GET /api/profiles/sessions?profile=all — iterates over ALL profiles on disk, returning merged data regardless of dashboard scope.
- Writes/mutations silently no-op: DELETE /api/sessions/{id}, PATCH /api/sessions/{id} (rename/archive), POST /api/sessions/bulk-delete, DELETE /api/sessions/empty, and POST /api/sessions/prune all operate on the default state.db. For a non-default profile like juicecup on port 9120, DELETE returns {ok: true, already_absent: true} because the session id is not in the default state.db — the caller believes the delete succeeded but the session remains on disk and reappears on next reload.
- Reads from the wrong database: GET /api/sessions/{id}, /messages, /export, /stats, and /empty/count also miss the scope, showing data from the wrong profile.

## Fix

Store initial_profile on app.state.open_profile during start_server(). All 14 session endpoints now fall back to it when the caller does not supply an explicit profile query parameter:

### Commit 1 (read listing endpoints)
1. GET /api/sessions — use open_profile as the default profile for _open_session_db_for_profile().
2. GET /api/sessions/search — same.
3. GET /api/profiles/sessions — when profile=all and open_profile is set, return only that profile's sessions instead of all profiles.

### Commit 2 (remaining read + mutation endpoints)
4. GET /api/sessions/{id} (detail)
5. GET /api/sessions/{id}/messages (transcript)
6. GET /api/sessions/{id}/export (export)
7. GET /api/sessions/stats (store stats)
8. GET /api/sessions/empty/count (empty count badge)
9. DELETE /api/sessions/{id} (single delete)
10. PATCH /api/sessions/{id} (rename/archive)
11. POST /api/sessions/bulk-delete (bulk delete)
12. DELETE /api/sessions/empty (delete all empty)
13. POST /api/sessions/prune (prune by criteria)

### Commit 3 (review follow-up)
14. GET /api/sessions/{id}/latest-descendant — was missed in the initial fix, now covered.
15. POST /api/sessions/prune — profile_home now derives from _effective_profile instead of raw body.profile, so sessions-dir cleanup targets the correct profile home.

## Backward compatibility

When --open-profile is not set (the default single-dashboard case), app.state.open_profile is "" and all endpoints behave exactly as before. The change only affects dashboards explicitly scoped to a profile.

## Testing

- 351 existing web server tests pass (unchanged test expectations).
- One new commit, no test changes needed — the fix is purely additive (adds a fallback when the explicit param is absent).