### PR TITLE
fix: explicitly set active=1 in message INSERT statements (#51646)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3465,8 +3465,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -3484,6 +3484,7 @@ class SessionDB:
                     codex_message_items_json,
                     platform_message_id,
                     1 if observed else 0,
+                    1,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -3556,8 +3557,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -3575,6 +3576,7 @@ class SessionDB:
                     codex_message_items_json,
                     platform_msg_id,
                     1 if msg.get("observed") else 0,
+                    1,
                 ),
             )
             inserted += 1


### PR DESCRIPTION
## Summary

Explicitly include `active=1` in both `INSERT INTO messages` statements in `hermes_state.py`.

## Problem

The `active` column is omitted from the INSERT column list at two locations:
- `append_message()` (line 3465)
- `_insert_message_rows()` (line 3556)

When the `messages` table was created on an older database version and the `active` column was added later via `ALTER TABLE ADD COLUMN` (through `_reconcile_columns()`), SQLite's `NOT NULL DEFAULT 1` constraint may not reliably apply the default value to new INSERTs. This results in `active = NULL` instead of `active = 1`.

Since the gateway's transcript loader filters `WHERE active = 1`, every gateway-connected platform (Discord, dashboard, etc.) loads zero conversation history on each turn — the agent has no context from prior messages and appears to "forget" within a few exchanges.

## Fix

Add `active` to the column list and explicitly pass `1` as the value in both INSERT statements. This makes the code robust regardless of whether the column was part of the original CREATE TABLE or added via ALTER TABLE ADD COLUMN.

## Testing

- Verified the diff is minimal (1 file, 6 insertions, 4 deletions)
- The fix is purely additive — no existing behavior changes for databases where DEFAULT was already working
