### PR TITLE
fix: guard response.text against httpx.ResponseNotRead in _summarize_api_error (#59769)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2143,7 +2143,12 @@ class AIAgent:
         # widens exposure vs the old empty-body "HTTP 400" string).
         response = getattr(error, "response", None)
         if response is not None:
-            snippet = (getattr(response, "text", None) or "").strip()
+            try:
+                snippet = (getattr(response, "text", None) or "").strip()
+            except Exception:
+                # httpx.ResponseNotRead when the body was never consumed
+                # (e.g. streaming error before first chunk arrived).
+                snippet = ""
             if snippet:
                 status_code = getattr(error, "status_code", None)
                 prefix = f"HTTP {status_code}: " if status_code else ""


### PR DESCRIPTION
## Summary

Guard `response.text` access in `_summarize_api_error` against `httpx.ResponseNotRead` exceptions.

## Problem

When a streaming error occurs before the first chunk arrives (e.g., Gemini free-tier 429 quota errors), the httpx response body was never consumed. Accessing `response.text` raises `httpx.ResponseNotRead`, which crashes `_summarize_api_error` and hides the real error message from the user.

## Fix

Wrap `response.text` access in a try/except that catches any exception (since httpx may not be imported at module level). When the body is unreadable, fall through to the generic error string fallback instead of crashing.

## Testing

- Verified the diff is minimal (1 file, 6 insertions, 1 deletion)
- The fix is purely defensive — no behavior change when response body is available
