### PR TITLE
fix: guard _is_copilot_url() with getattr to prevent AttributeError (#59845)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1161,7 +1161,7 @@ def run_conversation(
                 # Copilot x-initiator: the first API call of a user turn is
                 # marked "user" so Copilot bills a premium request; tool-loop
                 # follow-ups keep the default "agent" header (#3040).
-                if getattr(agent, "_is_user_initiated_turn", False) and agent._is_copilot_url():
+                if getattr(agent, "_is_user_initiated_turn", False) and getattr(agent, "_is_copilot_url", lambda: False)():
                     _xh = dict(api_kwargs.get("extra_headers") or {})
                     _xh["x-initiator"] = "user"
                     api_kwargs["extra_headers"] = _xh


### PR DESCRIPTION
## Summary

Guard `_is_copilot_url()` call with `getattr` to prevent `AttributeError` on dynamically constructed agent instances.

## Problem

`_is_copilot_url()` is called directly at `conversation_loop.py:1164` without a guard. When the agent is constructed outside the normal `AIAgent.__init__` path (e.g. cron jobs, certain gateway contexts), the method may not exist, causing an intermittent `AttributeError: 'AIAgent' object has no attribute '_is_copilot_url'`.

## Fix

Replace `agent._is_copilot_url()` with `getattr(agent, "_is_copilot_url", lambda: False)()`. This follows the same defensive pattern already used for `_is_user_initiated_turn` on the same line.

## Testing

- 1 file, 1 line changed
- No behavior change when the method exists (returns the same boolean)
- Graceful fallback to `False` when the method is missing
