### PR TITLE
fix(simplex): drive daemon address-level auto-accept on connect

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -309,6 +309,17 @@ class SimplexAdapter(BasePlatformAdapter):
                     self._last_ws_activity = time.time()
                     logger.info("SimpleX WS: connected")
 
+                    # simplex-chat >= 6.5 emits no WS event for incoming
+                    # address requests (prepared-contacts flow), so the
+                    # event-driven ``contactRequest`` handler never fires
+                    # there. Sync the daemon's own address-level
+                    # auto-accept to our config instead — it works on old
+                    # and new daemons and also covers requests that
+                    # arrived while the gateway was down.
+                    await self._send_fire_and_forget(
+                        f"/auto_accept {'on' if self.auto_accept else 'off'}"
+                    )
+
                     async for raw in ws:
                         if not self._running:
                             break

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -467,3 +467,94 @@ async def test_image_file_still_sets_photo_type():
 
     assert dispatched, "_handle_chat_item did not dispatch any event"
     assert dispatched[0].message_type == MessageType.PHOTO
+
+
+# ---------------------------------------------------------------------------
+# Auto-accept: address-level sync on WS connect
+# ---------------------------------------------------------------------------
+
+
+class _FakeWsConnect:
+    """Async context manager standing in for ``websockets.connect``."""
+
+    def __init__(self, ws):
+        self._ws = ws
+
+    async def __aenter__(self):
+        return self._ws
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _one_shot_ws(adapter):
+    """A fake WS that ends iteration immediately and stops the listener."""
+    ws = MagicMock()
+
+    async def _anext(_self=None):
+        adapter._running = False
+        raise StopAsyncIteration
+
+    ws.__aiter__ = lambda self: self
+    ws.__anext__ = _anext
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_syncs_auto_accept_on(monkeypatch):
+    """On WS connect the adapter enables daemon-side address auto-accept.
+
+    simplex-chat >= 6.5 emits no WS event for incoming address requests
+    (prepared-contacts flow), so auto-accept must be enforced on the
+    daemon's address, not by reacting to ``contactRequest`` events.
+    """
+    import websockets as _wsclient
+
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    assert adapter.auto_accept is True  # default
+
+    sent = []
+
+    async def _record(command):
+        sent.append(command)
+
+    adapter._send_fire_and_forget = _record
+    adapter._running = True
+    ws = _one_shot_ws(adapter)
+    monkeypatch.setattr(_wsclient, "connect", lambda *a, **k: _FakeWsConnect(ws))
+
+    await asyncio.wait_for(adapter._ws_listener(), timeout=5)
+
+    assert "/auto_accept on" in sent
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_syncs_auto_accept_off(monkeypatch):
+    """SIMPLEX_AUTO_ACCEPT=false must disable daemon-side auto-accept too,
+    so operators who lock down pairing get the same behavior on every
+    daemon version."""
+    import websockets as _wsclient
+
+    from gateway.config import PlatformConfig
+
+    monkeypatch.setenv("SIMPLEX_AUTO_ACCEPT", "false")
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    assert adapter.auto_accept is False
+
+    sent = []
+
+    async def _record(command):
+        sent.append(command)
+
+    adapter._send_fire_and_forget = _record
+    adapter._running = True
+    ws = _one_shot_ws(adapter)
+    monkeypatch.setattr(_wsclient, "connect", lambda *a, **k: _FakeWsConnect(ws))
+
+    await asyncio.wait_for(adapter._ws_listener(), timeout=5)
+
+    assert "/auto_accept off" in sent


### PR DESCRIPTION
## What does this PR do?

Makes `SIMPLEX_AUTO_ACCEPT` actually work against simplex-chat ≥ 6.5.

The adapter's auto-accept is event-driven: it waits for a `contactRequest` WS event and replies `/accept <id>`. simplex-chat 6.5 reworked incoming address requests into **prepared contacts** and, as far as we can observe, emits **no WS event of any kind** when a request arrives — so the handler never fires, and with default settings first-time pairing hangs on "connection request sent!" forever. On the bot side the contact exists with `contactStatus: "active"` but `activeConn: null`, indefinitely.

The fix stops relying on events entirely: on every WS (re)connect the adapter syncs the daemon's own **address-level** auto-accept (`/auto_accept on|off`) to its configured `auto_accept` value. Address-level auto-accept long predates 6.5, so this is version-robust; it also covers requests that arrive while the gateway is down, and sidesteps a second latent problem (`/accept <numeric id>` is parsed as a name lookup on 6.5.x — the same command-parsing class of bug as #46265). The legacy `contactRequest` handler is left in place for older daemons.

Verification behind the diagnosis (Fedora, Hermes v0.18.0/2026.7.1, simplex-chat v6.5.5):
- Two 45 s raw-WS capture windows around two real incoming requests recorded **zero events**; the contacts stayed connectionless indefinitely.
- Manually running `/ac <displayName>` completed those handshakes within seconds — everything after acceptance works.
- With `/auto_accept on` set on the daemon, an identical fresh request connected fully automatically with no adapter involvement.

## Related Issue

No existing issue covers this (searched open/closed issues and PRs for `simplex auto-accept`, `receivedContactRequest`, `contactRequest`; nearest neighbours #46265 and #55180 are different bugs in the same adapter). Root-cause analysis is included above in lieu of a pre-filed issue — happy to split it into one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/simplex/adapter.py`: in `_ws_listener()`, after the WS connection is established, send `/auto_accept on` when `self.auto_accept` is true, `/auto_accept off` otherwise (fire-and-forget, matching how `/freceive` is sent).
- `tests/gateway/test_simplex_plugin.py`: two tests asserting the sync command is sent on connect for both the enabled (default) and `SIMPLEX_AUTO_ACCEPT=false` cases.

## How to Test

1. Run simplex-chat v6.5.x as the daemon (`simplex-chat -p 5225`), bot profile with a long-term address, Hermes gateway with the SimpleX plugin and auto-accept left at default.
2. Without this patch: send a connection request to the bot's address from any SimpleX client — it hangs on "request sent" forever; gateway log stays silent.
3. With this patch: the same request connects within seconds, no operator action.
4. With `SIMPLEX_AUTO_ACCEPT=false`: requests stay pending until manually accepted (`/ac <name>`), i.e. the lockdown behavior is preserved and now enforced daemon-side too.
5. `pytest tests/gateway/test_simplex_plugin.py -q` — 32 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(simplex): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (open + closed, `simplex`, `auto-accept`, `receivedContactRequest`)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_simplex_plugin.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Fedora Linux (kernel 7.0.11), Python 3.11, simplex-chat v6.5.5

### Documentation & Housekeeping

- [x] Documentation — N/A (behavior now matches what the docs already promise for `SIMPLEX_AUTO_ACCEPT`)
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — the change is a string command over an existing WS send path; no OS-specific code
- [x] Tool descriptions/schemas — N/A
