### PR TITLE
fix(simplex): resolve received-file paths against SIMPLEX_FILES_FOLDER

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -32,14 +32,16 @@ Optional environment variables:
                                for any group. Omit to disable groups entirely.
     SIMPLEX_HOME_CHANNEL       Default contact/group ID for cron delivery
     SIMPLEX_HOME_CHANNEL_NAME  Human label for the home channel
-    SIMPLEX_FILES_FOLDER       Absolute path of the daemon's --files-folder;
-                               used to resolve the relative file paths the
-                               daemon reports for received attachments
     HERMES_SIMPLEX_TEXT_BATCH_DELAY
                                Quiet-period seconds (default: 0.8) used to
                                concatenate rapid-fire inbound text messages
                                into a single MessageEvent — same pattern as
                                Telegram's text batching.
+
+Optional ``config.yaml`` settings (``platforms.simplex.extra``):
+    files_folder               Absolute path of the daemon's --files-folder;
+                               used to resolve the relative file paths the
+                               daemon reports for received attachments
 
 The ``websockets`` Python package is imported lazily — the plugin is
 discoverable and ``hermes setup`` can describe it even when websockets is
@@ -165,9 +167,7 @@ class SimplexAdapter(BasePlatformAdapter):
         # Mirrors the daemon's ``--files-folder`` flag. The daemon reports
         # received-file paths relative to it and offers no WS API to query
         # it (``/_files_folder`` is a setter only).
-        self.files_folder = os.getenv("SIMPLEX_FILES_FOLDER", "") or extra.get(
-            "files_folder", ""
-        )
+        self.files_folder = extra.get("files_folder", "")
 
         # Group allowlist. Without ``SIMPLEX_GROUP_ALLOWED``, group messages
         # are ignored entirely (safer default — a bot in a group otherwise

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -32,6 +32,9 @@ Optional environment variables:
                                for any group. Omit to disable groups entirely.
     SIMPLEX_HOME_CHANNEL       Default contact/group ID for cron delivery
     SIMPLEX_HOME_CHANNEL_NAME  Human label for the home channel
+    SIMPLEX_FILES_FOLDER       Absolute path of the daemon's --files-folder;
+                               used to resolve the relative file paths the
+                               daemon reports for received attachments
     HERMES_SIMPLEX_TEXT_BATCH_DELAY
                                Quiet-period seconds (default: 0.8) used to
                                concatenate rapid-fire inbound text messages
@@ -158,6 +161,13 @@ class SimplexAdapter(BasePlatformAdapter):
             self.auto_accept = env_auto.strip().lower() not in {"0", "false", "no", ""}
         else:
             self.auto_accept = bool(extra.get("auto_accept", True))
+
+        # Mirrors the daemon's ``--files-folder`` flag. The daemon reports
+        # received-file paths relative to it and offers no WS API to query
+        # it (``/_files_folder`` is a setter only).
+        self.files_folder = os.getenv("SIMPLEX_FILES_FOLDER", "") or extra.get(
+            "files_folder", ""
+        )
 
         # Group allowlist. Without ``SIMPLEX_GROUP_ALLOWED``, group messages
         # are ignored entirely (safer default — a bot in a group otherwise
@@ -568,6 +578,11 @@ class SimplexAdapter(BasePlatformAdapter):
             )
             file_name = file_info.get("fileName", "")
             file_id = file_info.get("fileId")
+
+            # The daemon reports filePath relative to its --files-folder;
+            # downstream consumers need an absolute path they can open.
+            if file_path and not os.path.isabs(file_path) and self.files_folder:
+                file_path = os.path.join(self.files_folder, file_path)
 
             ext = ""
             if file_path:

--- a/plugins/platforms/simplex/plugin.yaml
+++ b/plugins/platforms/simplex/plugin.yaml
@@ -47,12 +47,6 @@ optional_env:
     description: "Human label for the home channel (defaults to the ID)"
     prompt: "Home channel display name (or empty)"
     password: false
-  - name: SIMPLEX_FILES_FOLDER
-    description: >-
-      Absolute path of the daemon's --files-folder. Used to resolve the
-      relative file paths the daemon reports for received attachments.
-    prompt: "Daemon files folder (matches --files-folder, or empty)"
-    password: false
   - name: HERMES_SIMPLEX_TEXT_BATCH_DELAY
     description: >-
       Quiet-period seconds (default: 0.8) used to concatenate rapid-fire

--- a/plugins/platforms/simplex/plugin.yaml
+++ b/plugins/platforms/simplex/plugin.yaml
@@ -47,6 +47,12 @@ optional_env:
     description: "Human label for the home channel (defaults to the ID)"
     prompt: "Home channel display name (or empty)"
     password: false
+  - name: SIMPLEX_FILES_FOLDER
+    description: >-
+      Absolute path of the daemon's --files-folder. Used to resolve the
+      relative file paths the daemon reports for received attachments.
+    prompt: "Daemon files folder (matches --files-folder, or empty)"
+    password: false
   - name: HERMES_SIMPLEX_TEXT_BATCH_DELAY
     description: >-
       Quiet-period seconds (default: 0.8) used to concatenate rapid-fire

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -470,18 +470,20 @@ async def test_image_file_still_sets_photo_type():
 
 
 # ---------------------------------------------------------------------------
-# Received-file path resolution (SIMPLEX_FILES_FOLDER)
+# Received-file path resolution (extra.files_folder)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_relative_file_path_resolved_against_files_folder(monkeypatch, tmp_path):
+async def test_relative_file_path_resolved_against_files_folder(tmp_path):
     """The daemon reports paths relative to its --files-folder; the adapter
     must hand the gateway an absolute path it can actually open."""
     from gateway.config import PlatformConfig
 
-    monkeypatch.setenv("SIMPLEX_FILES_FOLDER", str(tmp_path))
-    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"ws_url": "ws://localhost:5225", "files_folder": str(tmp_path)},
+    )
     adapter = SimplexAdapter(cfg)
     dispatched = []
 
@@ -496,11 +498,13 @@ async def test_relative_file_path_resolved_against_files_folder(monkeypatch, tmp
 
 
 @pytest.mark.asyncio
-async def test_absolute_file_path_not_rewritten(monkeypatch, tmp_path):
+async def test_absolute_file_path_not_rewritten(tmp_path):
     from gateway.config import PlatformConfig
 
-    monkeypatch.setenv("SIMPLEX_FILES_FOLDER", str(tmp_path))
-    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"ws_url": "ws://localhost:5225", "files_folder": str(tmp_path)},
+    )
     adapter = SimplexAdapter(cfg)
     dispatched = []
 
@@ -514,11 +518,10 @@ async def test_absolute_file_path_not_rewritten(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_relative_file_path_without_base_unchanged(monkeypatch):
-    """No SIMPLEX_FILES_FOLDER configured — pass the path through as before."""
+async def test_relative_file_path_without_base_unchanged():
+    """No files_folder configured — pass the path through as before."""
     from gateway.config import PlatformConfig
 
-    monkeypatch.delenv("SIMPLEX_FILES_FOLDER", raising=False)
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
     adapter = SimplexAdapter(cfg)
     dispatched = []

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -467,3 +467,66 @@ async def test_image_file_still_sets_photo_type():
 
     assert dispatched, "_handle_chat_item did not dispatch any event"
     assert dispatched[0].message_type == MessageType.PHOTO
+
+
+# ---------------------------------------------------------------------------
+# Received-file path resolution (SIMPLEX_FILES_FOLDER)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_relative_file_path_resolved_against_files_folder(monkeypatch, tmp_path):
+    """The daemon reports paths relative to its --files-folder; the adapter
+    must hand the gateway an absolute path it can actually open."""
+    from gateway.config import PlatformConfig
+
+    monkeypatch.setenv("SIMPLEX_FILES_FOLDER", str(tmp_path))
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+    await adapter._handle_chat_item(_make_file_chat_item("pic.jpg", "pic.jpg"))
+
+    assert dispatched, "_handle_chat_item did not dispatch any event"
+    assert dispatched[0].media_urls == [str(tmp_path / "pic.jpg")]
+
+
+@pytest.mark.asyncio
+async def test_absolute_file_path_not_rewritten(monkeypatch, tmp_path):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.setenv("SIMPLEX_FILES_FOLDER", str(tmp_path))
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+    await adapter._handle_chat_item(_make_file_chat_item("/srv/pic.jpg", "pic.jpg"))
+
+    assert dispatched[0].media_urls == ["/srv/pic.jpg"]
+
+
+@pytest.mark.asyncio
+async def test_relative_file_path_without_base_unchanged(monkeypatch):
+    """No SIMPLEX_FILES_FOLDER configured — pass the path through as before."""
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("SIMPLEX_FILES_FOLDER", raising=False)
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+    await adapter._handle_chat_item(_make_file_chat_item("pic.jpg", "pic.jpg"))
+
+    assert dispatched[0].media_urls == ["pic.jpg"]

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -24,10 +24,22 @@ The SimpleX Chat project does not publish a prebuilt Docker image for the chat c
 ## Start the daemon
 
 ```bash
-simplex-chat -p 5225
+mkdir -p ~/.hermes/simplex/{files,temp}
+simplex-chat -p 5225 \
+  --files-folder ~/.hermes/simplex/files \
+  --temp-folder  ~/.hermes/simplex/temp
 ```
 
 The daemon listens on WebSocket at `ws://127.0.0.1:5225` by default.
+
+:::warning
+Keep `--temp-folder` on the **same filesystem** as `--files-folder`. Without
+`--temp-folder`, the daemon stages downloads in the system temp dir; on
+distros where `/tmp` is tmpfs (Fedora and derivatives, among others) the
+final cross-filesystem move fails silently and every received file wedges at
+100% with a 0-byte destination — no error is logged anywhere. If you set
+`--files-folder`, also set `SIMPLEX_FILES_FOLDER` to the same path (see below).
+:::
 
 ## Configure Hermes
 
@@ -58,6 +70,7 @@ SIMPLEX_HOME_CHANNEL=<contact-id>
 | `SIMPLEX_GROUP_ALLOWED` | Optional | Comma-separated group IDs the bot participates in, or `*` for any group. Omit to ignore group messages entirely |
 | `SIMPLEX_HOME_CHANNEL` | Optional | Default contact/group ID for cron job delivery |
 | `SIMPLEX_HOME_CHANNEL_NAME` | Optional | Human label for the home channel |
+| `SIMPLEX_FILES_FOLDER` | Optional | Absolute path of the daemon's `--files-folder`. Required for received attachments (images, documents) to reach the agent when the daemon uses a files folder — the daemon reports those paths relative to it |
 | `HERMES_SIMPLEX_TEXT_BATCH_DELAY` | Optional | Quiet-period seconds (default: `0.8`) used to concatenate rapid-fire inbound text messages into one event |
 
 ## Find your contact ID or display name

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -38,7 +38,8 @@ Keep `--temp-folder` on the **same filesystem** as `--files-folder`. Without
 distros where `/tmp` is tmpfs (Fedora and derivatives, among others) the
 final cross-filesystem move fails silently and every received file wedges at
 100% with a 0-byte destination — no error is logged anywhere. If you set
-`--files-folder`, also set `SIMPLEX_FILES_FOLDER` to the same path (see below).
+`--files-folder`, also point `platforms.simplex.extra.files_folder` at the
+same path in `config.yaml` (see below).
 :::
 
 ## Configure Hermes
@@ -70,8 +71,23 @@ SIMPLEX_HOME_CHANNEL=<contact-id>
 | `SIMPLEX_GROUP_ALLOWED` | Optional | Comma-separated group IDs the bot participates in, or `*` for any group. Omit to ignore group messages entirely |
 | `SIMPLEX_HOME_CHANNEL` | Optional | Default contact/group ID for cron job delivery |
 | `SIMPLEX_HOME_CHANNEL_NAME` | Optional | Human label for the home channel |
-| `SIMPLEX_FILES_FOLDER` | Optional | Absolute path of the daemon's `--files-folder`. Required for received attachments (images, documents) to reach the agent when the daemon uses a files folder — the daemon reports those paths relative to it |
 | `HERMES_SIMPLEX_TEXT_BATCH_DELAY` | Optional | Quiet-period seconds (default: `0.8`) used to concatenate rapid-fire inbound text messages into one event |
+
+### Received attachments (`config.yaml`)
+
+If the daemon runs with `--files-folder`, tell Hermes where that folder is
+under `platforms.simplex.extra` in `~/.hermes/config.yaml`:
+
+```yaml
+platforms:
+  simplex:
+    extra:
+      files_folder: /home/you/.hermes/simplex/files
+```
+
+The daemon reports received-attachment paths relative to its `--files-folder`
+and offers no API to query it, so without this setting incoming images and
+documents never reach the agent.
 
 ## Find your contact ID or display name
 


### PR DESCRIPTION
## What does this PR do?

Makes received attachments reach the agent when the simplex-chat daemon runs with `--files-folder` (the sensible setup for a headless bot — without it, received files land in the daemon's cwd).

The daemon reports `fileSource.filePath` **relative to its files folder** (a bare `IMG_1234.jpg`). The adapter passed that string through as the attachment path, and the gateway — whose cwd has no relation to the daemon's files folder — could not open it. With a vision-capable model the pipeline fails at the last step:

```
Image routing: native (model supports vision). 1 image(s) will be attached inline.
Native image attachment: skipped 1 unreadable path(s): ['IMG_20260707_032159.jpg']
```

and the agent answers as if no image was sent.

Fix: a new optional `SIMPLEX_FILES_FOLDER` env var (mirroring the daemon's `--files-folder` value, consistent with the plugin's env-driven config surface) used to absolutize relative paths in `_handle_chat_item`. The daemon offers no WS API to query the folder — `/_files_folder` is a setter only — so a config mirror is the only reliable resolution. Absolute paths and the unset-var case are passed through unchanged.

Verified end-to-end on a live deployment (Fedora, Hermes v0.18.0/2026.7.1, simplex-chat v6.5.5): before — `skipped 1 unreadable path(s)`; after — the image is attached natively and the model describes the photo.

The docs update also fixes an adjacent silent failure we hit while verifying: with no `--temp-folder`, the daemon stages XFTP downloads in the system temp dir, and on distros where `/tmp` is tmpfs (Fedora and derivatives, among others) the final cross-filesystem move fails **silently** — every received file wedges at 100 % progress with a 0-byte destination and an un-retryable `fileAlreadyReceiving` state. The recommended daemon invocation now sets `--files-folder`/`--temp-folder` on the same filesystem, with a warning callout.

Note: on current `main`, inbound *images* only reach this code path once the audio-only `/freceive` guard is fixed — #55180 / PR #55185. The two fixes are independent (this one also affects documents and any file with a reported relative path), but both are needed for the full image → vision flow.

## Related Issue

No existing issue covers this (searched open/closed issues and PRs for `SIMPLEX_FILES_FOLDER`, `simplex relative filePath files-folder`, `xftp temp`; #55180/#55185 cover the adjacent deferral bug, not path resolution). Root-cause analysis included above in lieu of a pre-filed issue — happy to split it into one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/simplex/adapter.py`: read `SIMPLEX_FILES_FOLDER` (env, then `extra.files_folder`) in `__init__`; in `_handle_chat_item`, join relative `filePath`s against it; document the var in the module docstring's env-var list.
- `plugins/platforms/simplex/plugin.yaml`: add `SIMPLEX_FILES_FOLDER` to `optional_env` so it surfaces in `hermes config` / setup.
- `website/docs/user-guide/messaging/simplex.md`: add the env var to the table; update the daemon invocation to set `--files-folder`/`--temp-folder` with a warning about the tmpfs `/tmp` silent-wedge failure mode.
- `tests/gateway/test_simplex_plugin.py`: three tests — relative path joined against the base, absolute path untouched, relative path without a configured base unchanged (backward compatible).

## How to Test

1. Run the daemon with `--files-folder /some/dir`, set `SIMPLEX_FILES_FOLDER=/some/dir` in `~/.hermes/.env`.
2. Send the bot an image from a phone client (with the #55185 fix applied so the image is received at all).
3. Without this patch: gateway logs `skipped 1 unreadable path(s): ['<name>.jpg']` and the agent never sees the image. With it: the image is attached natively and a vision model describes it.
4. `pytest tests/gateway/test_simplex_plugin.py -q` — 33 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(simplex): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (open + closed; nearest is #55185, which addresses the separate deferral guard)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_simplex_plugin.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Fedora Linux (kernel 7.0.11), Python 3.11, simplex-chat v6.5.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/messaging/simplex.md`, module docstring)
- [x] `cli-config.yaml.example` — N/A (env-only var, consistent with the plugin's other settings)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — path logic uses `os.path.isabs`/`os.path.join` per the compatibility guide
- [x] Tool descriptions/schemas — N/A
