### PR TITLE
fix: skip no-op writes in patch _apply_update (#59600)

### DIFF
--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -402,8 +402,9 @@ def apply_v4a_operations(operations: List[PatchOperation],
             elif op.operation == OperationType.UPDATE:
                 result = _apply_update(op, file_ops)
                 if result[0]:
-                    files_modified.append(op.file_path)
-                    all_diffs.append(result[1])
+                    if result[1]:  # non-empty diff = actual change
+                        files_modified.append(op.file_path)
+                        all_diffs.append(result[1])
                     if result[2]:
                         lsp_blocks.append(result[2])
                 else:
@@ -605,7 +606,11 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, Optiona
             else:
                 new_content = new_content.rstrip('\n') + '\n' + insert_text + '\n'
     
-    # Write new content
+    # Write new content — skip if unchanged to avoid spurious lint runs
+    # and false "file modified" reports.
+    if new_content == current_content:
+        return True, "", None
+
     write_result = file_ops.write_file(op.file_path, new_content)
     if write_result.error:
         return False, write_result.error, None


### PR DESCRIPTION
## Summary

Skip no-op writes in patch `_apply_update` and filter empty diffs from `files_modified` reports.

## Problem

When a V4A patch hunk matches but produces identical content (e.g., the replacement is the same as the original), the file was still written to disk and reported as modified. This caused:
- Spurious lint runs on unchanged files
- False "success" with empty diff confusing the agent into thinking a change was made
- Unnecessary filesystem I/O

## Fix

Two changes in `tools/patch_parser.py`:

1. **`_apply_update`**: Added early return when `new_content == current_content` — returns `True` with empty diff instead of writing the file.

2. **`apply_v4a_operations`**: Only add files to `files_modified` when the diff is non-empty (actual change occurred).

## Testing

- 1 file, 8 insertions, 3 deletions
- No behavior change when patches produce actual changes
- No-op patches now correctly report zero files modified
