### PR TITLE
feat(gateway): pre-agent log_entry routing fast-path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -40,6 +40,7 @@ import tempfile
 import threading
 import time
 import sqlite3
+import subprocess
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
@@ -155,6 +156,47 @@ _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bglpat-[A-Za-z0-9_\-]{20,}\b"),
     re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._\-]{20,}\b"),
 )
+
+
+def _run_agentless_log_entry_router(*, message_text: str) -> Optional[Dict[str, Any]]:
+    """Best-effort gateway fast-path for short logging messages.
+
+    Executes ``~/.hermes/scripts/log_entry.py`` and returns parsed JSON payload
+    when available. Returns ``None`` when the router script is unavailable,
+    execution fails, or output is not valid JSON.
+    """
+    msg = (message_text or "").strip()
+    if not msg:
+        return None
+
+    router_path = _hermes_home / "scripts" / "log_entry.py"
+    if not router_path.exists():
+        return None
+
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(router_path),
+                "--silent",
+                msg,
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(router_path.parent),
+            timeout=12,
+        )
+    except Exception:
+        return None
+
+    raw = (proc.stdout or "").strip() or (proc.stderr or "").strip()
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
 def _ensure_windows_gateway_venv_imports() -> None:
@@ -10054,6 +10096,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents_ts[_quick_key] = time.time()
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
+
+        # Agent-less logging fast-path: run short log-like messages through
+        # ~/.hermes/scripts/log_entry.py after the session slot is claimed but
+        # before full agent dispatch. This preserves active-session race
+        # semantics (sentinel/queue/stop), while still avoiding agent fallback
+        # when router handling succeeds. If router reports needs_agent=true
+        # (or emits invalid output), we fall through to normal handling.
+        if not is_internal:
+            _router_payload = await asyncio.to_thread(
+                _run_agentless_log_entry_router,
+                message_text=(event.text or ""),
+            )
+            if isinstance(_router_payload, dict):
+                if _router_payload.get("needs_agent") is True:
+                    logger.debug(
+                        "log_entry router escalated to agent: reason=%s",
+                        _router_payload.get("reason"),
+                    )
+                elif _router_payload.get("ok") is True:
+                    logger.info(
+                        "log_entry router handled message: domain=%s confidence=%s",
+                        _router_payload.get("domain"),
+                        _router_payload.get("confidence"),
+                    )
+                    self._release_running_agent_state(_quick_key)
+                    return ""
 
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -177,3 +177,61 @@ async def test_internal_events_bypass_hook(monkeypatch):
     # Even though the hook would say skip, internal events bypass it.
     await runner._handle_message(event)
     assert called["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_log_entry_fastpath_handles_and_skips_agent(monkeypatch):
+    """Successful router payload short-circuits before agent dispatch."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+
+    seen = {"called": False}
+
+    def _fake_hook(name, **kwargs):
+        return []
+
+    async def _capture(event, source, _quick_key, _run_generation):
+        seen["called"] = True
+        return "ok"
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    monkeypatch.setattr(
+        "gateway.run._run_agentless_log_entry_router",
+        lambda *, message_text: {"ok": True, "domain": "expense", "confidence": 0.95},
+    )
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    runner._handle_message_with_agent = _capture  # noqa: SLF001
+
+    result = await runner._handle_message(_make_event("Rs 120 dinner"))
+    assert result == ""
+    assert seen["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_log_entry_fastpath_needs_agent_falls_through(monkeypatch):
+    """Router escalation (needs_agent=true) continues to normal agent path."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+
+    seen = {"called": False}
+
+    def _fake_hook(name, **kwargs):
+        return []
+
+    async def _capture(event, source, _quick_key, _run_generation):
+        seen["called"] = True
+        return "ok"
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    monkeypatch.setattr(
+        "gateway.run._run_agentless_log_entry_router",
+        lambda *, message_text: {"ok": False, "needs_agent": True, "reason": "low_confidence"},
+    )
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    runner._handle_message_with_agent = _capture  # noqa: SLF001
+
+    result = await runner._handle_message(_make_event("stuff happened"))
+    assert result == "ok"
+    assert seen["called"] is True


### PR DESCRIPTION
## Summary
- add a gateway pre-agent fast-path that calls `~/.hermes/scripts/log_entry.py` for short logging messages
- run the fast-path after session slot claim (sentinel semantics preserved) and before `_handle_message_with_agent`
- short-circuit on router success (`ok=true` and not `needs_agent`); fall through to normal agent path on escalation/failure
- add focused gateway tests for handled short-circuit and needs-agent fallback behavior

## Why this placement
- keeps existing race-guard behavior (`_running_agents` sentinel, queued second-message behavior, `/stop` during sentinel)
- avoids regressing active-session tests while still skipping expensive agent fallback for deterministic log messages

## Files
- `gateway/run.py`
- `tests/gateway/test_pre_gateway_dispatch.py`

## Verification
- `python3 -m py_compile gateway/run.py tests/gateway/test_pre_gateway_dispatch.py`
- `pytest -q tests/gateway/test_pre_gateway_dispatch.py --tb=short`
- `pytest -q tests/gateway/test_pre_gateway_dispatch.py tests/gateway/test_session_race_guard.py --tb=short`
- `pytest -q tests/gateway/test_pre_gateway_dispatch.py tests/gateway/test_max_concurrent_sessions.py tests/gateway/test_internal_event_bypass_pairing.py --tb=short`

All above passed locally.
