### PR TITLE
fix(memory): make user profile capture opt-in by default

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2260,6 +2260,48 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             )
 
 
+def execute_builtin_memory_tool(
+    agent,
+    function_args: dict,
+    *,
+    effective_task_id: str,
+    tool_call_id: Optional[str] = None,
+) -> str:
+    """Execute built-in memory with the agent's runtime profile policy."""
+    target = function_args.get("target", "memory")
+    if target == "user" and not getattr(agent, "_user_profile_enabled", False):
+        from tools.registry import tool_error
+
+        return tool_error(
+            "User profile memory is disabled. Set "
+            "memory.user_profile_enabled: true to allow target='user'.",
+            success=False,
+        )
+
+    from tools.memory_tool import memory_tool
+
+    result = memory_tool(
+        action=function_args.get("action"),
+        target=target,
+        content=function_args.get("content"),
+        old_text=function_args.get("old_text"),
+        operations=function_args.get("operations"),
+        store=agent._memory_store,
+    )
+    # Mirror successful built-in memory writes to external providers. All
+    # gating/op-expansion lives behind the manager interface.
+    if getattr(agent, "_memory_manager", None):
+        agent._memory_manager.notify_memory_tool_write(
+            result,
+            function_args,
+            build_metadata=lambda: agent._build_memory_write_metadata(
+                task_id=effective_task_id,
+                tool_call_id=tool_call_id,
+            ),
+        )
+    return result
+
+
 def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,
                  tool_call_id: Optional[str] = None, messages: list = None,
                  pre_tool_block_checked: bool = False,
@@ -2388,30 +2430,15 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
     elif function_name == "memory":
         def _execute(next_args: dict) -> Any:
-            target = next_args.get("target", "memory")
-            operations = next_args.get("operations")
-            from tools.memory_tool import memory_tool as _memory_tool
-            result = _memory_tool(
-                action=next_args.get("action"),
-                target=target,
-                content=next_args.get("content"),
-                old_text=next_args.get("old_text"),
-                operations=operations,
-                store=agent._memory_store,
-            )
-            # Mirror successful built-in memory writes to external providers.
-            # All gating/op-expansion lives behind the manager interface
-            # (MemoryManager.notify_memory_tool_write).
-            if agent._memory_manager:
-                agent._memory_manager.notify_memory_tool_write(
-                    result,
+            return _finish_agent_tool(
+                execute_builtin_memory_tool(
+                    agent,
                     next_args,
-                    build_metadata=lambda: agent._build_memory_write_metadata(
-                        task_id=effective_task_id,
-                        tool_call_id=tool_call_id,
-                    ),
-                )
-            return _finish_agent_tool(result, next_args)
+                    effective_task_id=effective_task_id,
+                    tool_call_id=tool_call_id,
+                ),
+                next_args,
+            )
     elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
         def _execute(next_args: dict) -> Any:
             return _finish_agent_tool(agent._memory_manager.handle_tool_call(function_name, next_args), next_args)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1294,30 +1294,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
         elif function_name == "memory":
             def _execute(next_args: dict) -> Any:
-                target = next_args.get("target", "memory")
-                operations = next_args.get("operations")
-                from tools.memory_tool import memory_tool as _memory_tool
-                result = _memory_tool(
-                    action=next_args.get("action"),
-                    target=target,
-                    content=next_args.get("content"),
-                    old_text=next_args.get("old_text"),
-                    operations=operations,
-                    store=agent._memory_store,
+                from agent.agent_runtime_helpers import execute_builtin_memory_tool
+
+                return execute_builtin_memory_tool(
+                    agent,
+                    next_args,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", None),
                 )
-                # Mirror successful built-in memory writes to external
-                # providers. All gating/op-expansion lives behind the manager
-                # interface (MemoryManager.notify_memory_tool_write).
-                if agent._memory_manager:
-                    agent._memory_manager.notify_memory_tool_write(
-                        result,
-                        next_args,
-                        build_metadata=lambda: agent._build_memory_write_metadata(
-                            task_id=effective_task_id,
-                            tool_call_id=getattr(tool_call, "id", None),
-                        ),
-                    )
-                return result
             function_result, function_args = _run_agent_tool_execution_middleware(
                 agent,
                 function_name=function_name,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -563,8 +563,9 @@ memory:
   # Agent's personal notes: environment facts, conventions, things learned
   memory_enabled: true
   
-  # User profile: preferences, communication style, expectations
-  user_profile_enabled: true
+  # User profile: preferences, communication style, expectations.
+  # Disabled by default because it captures personal traits/preferences.
+  user_profile_enabled: false
   
   # Character limits (~2.75 chars per token, model-independent)
   memory_char_limit: 2200   # ~800 tokens

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2275,7 +2275,9 @@ DEFAULT_CONFIG = {
     # Persistent memory -- bounded curated memory injected into system prompt
     "memory": {
         "memory_enabled": True,
-        "user_profile_enabled": True,
+        # User-profile capture can store personally identifying preferences and
+        # traits. Keep it opt-in unless a user explicitly enables it.
+        "user_profile_enabled": False,
         # Approval gate for memory writes (add/replace/remove), applied to BOTH
         # foreground agent turns and the background self-improvement review fork
         # (the source of unprompted "wrong assumption" saves users reported).
@@ -2287,7 +2289,7 @@ DEFAULT_CONFIG = {
         #                     on a prompt). Review staged entries with
         #                     /memory pending, /memory approve <id>,
         #                     /memory reject <id>.
-        # To disable memory entirely, use memory_enabled: false instead.
+        # To disable agent memory entirely, use memory_enabled: false instead.
         "write_approval": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -117,6 +117,31 @@ class TestLoadConfigDefaults:
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
+            assert config["memory"]["memory_enabled"] is True
+            assert config["memory"]["user_profile_enabled"] is False
+
+    def test_missing_memory_section_keeps_user_profile_opt_in(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("_config_version: 33\n")
+
+            config = load_config()
+
+            assert config["memory"]["memory_enabled"] is True
+            assert config["memory"]["user_profile_enabled"] is False
+
+    def test_explicit_user_profile_enabled_still_wins(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                "_config_version: 33\n"
+                "memory:\n"
+                "  user_profile_enabled: true\n"
+            )
+
+            config = load_config()
+
+            assert config["memory"]["user_profile_enabled"] is True
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/tests/run_agent/test_user_profile_runtime_gate.py
+++ b/tests/run_agent/test_user_profile_runtime_gate.py
@@ -1,0 +1,165 @@
+"""Runtime enforcement for opt-in USER.md access."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+from tools.memory_tool import MemoryStore
+
+
+def _tool_defs() -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "memory",
+                "description": "memory tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def _make_agent(tmp_path, monkeypatch, *, user_profile_enabled: bool) -> AIAgent:
+    home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent.tool_delay = 0
+    agent._flush_messages_to_session_db = MagicMock()
+    agent._memory_store = MemoryStore()
+    agent._memory_store.load_from_disk()
+    agent._memory_manager = None
+    agent._memory_enabled = True
+    agent._user_profile_enabled = user_profile_enabled
+    return agent
+
+
+def _memory_call(content: str, call_id: str = "memory-1") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(
+            name="memory",
+            arguments=json.dumps(
+                {"action": "add", "target": "user", "content": content}
+            ),
+        ),
+    )
+
+
+def _execute(agent: AIAgent, dispatch_mode: str, content: str) -> dict:
+    messages: list[dict] = []
+    assistant_message = SimpleNamespace(
+        content="",
+        tool_calls=[_memory_call(content)],
+    )
+    execute = getattr(agent, f"_execute_tool_calls_{dispatch_mode}")
+    execute(assistant_message, messages, "test-task")
+    assert len(messages) == 1
+    return json.loads(messages[0]["content"])
+
+
+@pytest.mark.parametrize("dispatch_mode", ["sequential", "concurrent"])
+def test_user_profile_target_is_blocked_without_opt_in(
+    tmp_path,
+    monkeypatch,
+    dispatch_mode: str,
+):
+    agent = _make_agent(tmp_path, monkeypatch, user_profile_enabled=False)
+
+    result = _execute(agent, dispatch_mode, "must not be captured")
+
+    assert result["success"] is False
+    assert "memory.user_profile_enabled" in result["error"]
+    assert not (tmp_path / "hermes-home" / "memories" / "USER.md").exists()
+
+
+@pytest.mark.parametrize("dispatch_mode", ["sequential", "concurrent"])
+def test_user_profile_target_is_allowed_with_explicit_opt_in(
+    tmp_path,
+    monkeypatch,
+    dispatch_mode: str,
+):
+    agent = _make_agent(tmp_path, monkeypatch, user_profile_enabled=True)
+
+    result = _execute(agent, dispatch_mode, "explicitly allowed")
+
+    assert result["success"] is True
+    user_file = tmp_path / "hermes-home" / "memories" / "USER.md"
+    assert "explicitly allowed" in user_file.read_text(encoding="utf-8")
+
+
+class _ImmediateThread:
+    def __init__(self, *, target, daemon=None, name=None):
+        self._target = target
+
+    def start(self):
+        self._target()
+
+
+def test_background_review_cannot_capture_user_profile_without_opt_in(
+    tmp_path,
+    monkeypatch,
+):
+    import run_agent as run_agent_module
+    from agent.agent_runtime_helpers import invoke_tool
+
+    parent = _make_agent(tmp_path, monkeypatch, user_profile_enabled=False)
+    captured: dict[str, object] = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self.session_id = "review-session"
+            self._memory_manager = None
+            self._session_messages: list[dict] = []
+
+        def run_conversation(self, **kwargs):
+            result = invoke_tool(
+                self,
+                "memory",
+                {
+                    "action": "add",
+                    "target": "user",
+                    "content": "background capture",
+                },
+                "background-review",
+                pre_tool_block_checked=True,
+                skip_tool_request_middleware=True,
+            )
+            captured["result"] = json.loads(result)
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", _ImmediateThread)
+
+    AIAgent._spawn_background_review(
+        parent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert captured["result"]["success"] is False
+    assert not (tmp_path / "hermes-home" / "memories" / "USER.md").exists()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -614,7 +614,7 @@ When on, skill writes are staged under `~/.hermes/pending/skills/` and reviewed 
 ```yaml
 memory:
   memory_enabled: true
-  user_profile_enabled: true
+  user_profile_enabled: false  # opt in to automatic USER.md profile capture
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
   write_approval: false     # true = require approval before any memory write

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -212,7 +212,7 @@ See [Session Search Tool](/user-guide/sessions#session-search-tool) for the thre
 # In ~/.hermes/config.yaml
 memory:
   memory_enabled: true
-  user_profile_enabled: true
+  user_profile_enabled: false  # opt in to automatic USER.md profile capture
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
   write_approval: false     # false = write freely (default) | true = require approval

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -452,7 +452,7 @@ skills:
 ```yaml
 memory:
   memory_enabled: true
-  user_profile_enabled: true
+  user_profile_enabled: false  # 需要显式开启自动 USER.md 用户画像捕获
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory.md
@@ -206,7 +206,7 @@ hermes sessions list    # 浏览过去的会话
 # In ~/.hermes/config.yaml
 memory:
   memory_enabled: true
-  user_profile_enabled: true
+  user_profile_enabled: false  # 需要显式开启自动 USER.md 用户画像捕获
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
 ```


### PR DESCRIPTION
## What does this PR do?

Makes automatic user-profile capture opt-in by default.

On current `main`, a profile with no `memory` section is deep-merged with `DEFAULT_CONFIG`, which currently enables both `memory.memory_enabled` and `memory.user_profile_enabled`. That means the background self-improvement review can write `USER.md` profile entries even when the user never explicitly opted into profile capture.

This keeps agent memory (`MEMORY.md`) enabled by default, but changes `user_profile_enabled` to `false` unless the user explicitly sets it to `true`. Existing profiles that already opted into `user_profile_enabled: true` keep that behavior.

This PR deliberately does not change RetainDB or external memory-provider activation. Source review did not show a path where Nous auth alone auto-selects RetainDB; external providers are still controlled by `memory.provider` plus provider credentials.

## Related Issue

Fixes #59953

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/config.py`: set `DEFAULT_CONFIG["memory"]["user_profile_enabled"]` to `False` and document why profile capture is opt-in.
- `tests/hermes_cli/test_config.py`: add regression coverage for missing `memory` section and explicit `user_profile_enabled: true`.
- `cli-config.yaml.example` and memory docs: update documented default to `user_profile_enabled: false`.

## How to Test

1. Reproduce the old behavior on `upstream/main`:
   - Create a config with only `_config_version: 33`.
   - `load_config()["memory"]["user_profile_enabled"]` returns `True`.
2. Verify the fixed behavior on this branch:
   - Same config now returns `False`.
   - Adding `memory.user_profile_enabled: true` still returns `True`.
3. Run the targeted tests listed below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / local Hermes worktree lane

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation run:

```text
baseline probe on upstream/main: missing memory section -> user_profile_enabled=True
fixed probe on this branch: missing memory section -> user_profile_enabled=False

.venv/bin/python -m pytest tests/hermes_cli/test_config.py -q
145 passed in 1.75s

.venv/bin/python -m pytest tests/run_agent/test_background_review_toolset_restriction.py tests/run_agent/test_background_review_summary.py -q
13 passed in 0.97s

.venv/bin/python -m pytest tests/tools/test_memory_tool.py tests/tools/test_memory_tool_schema.py -q
86 passed in 0.90s

.venv/bin/python -m compileall hermes_cli/config.py
# passed
```
