### PR TITLE
Fix auto-SSO redirect for password-only auth providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -188,9 +188,14 @@ def _auto_sso_response(request: Request) -> Response | None:
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote
-    auth_login = f"{prefix}/auth/login?provider={quote(provider.name, safe='')}"
+    # Password providers don't support the OAuth redirect entrypoint.
+    if getattr(provider, "supports_password", False):
+        auth_login = f"{prefix}/login"
+    else:
+        auth_login = f"{prefix}/auth/login?provider={quote(provider.name, safe='')}"
     if next_param:
-        auth_login = f"{auth_login}&next={next_param}"
+        sep = "&" if "?" in auth_login else "?"
+        auth_login = f"{auth_login}{sep}next={next_param}"
 
     resp = RedirectResponse(url=auth_login, status_code=302)
     # Drop the one-shot marker so a return trip that's STILL unauthenticated

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -221,6 +221,16 @@ class TestProviderListFlag:
 
 
 class TestPasswordLoginRoute:
+    def test_password_provider_html_redirects_to_login_with_next(self, gated_app):
+        resp = gated_app.get("/sessions", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login?next=%2Fsessions"
+
+    def test_password_provider_root_redirects_to_login(self, gated_app):
+        resp = gated_app.get("/", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"] in ("/login", "/login?next=%2F")
+
     def test_valid_credentials_set_session_cookies_and_return_next(
         self, gated_app
     ):


### PR DESCRIPTION
Summary:
- send password-capable auth providers to /login instead of /auth/login
- preserve next= correctly for both /login and /auth/login URLs
- add password-provider regression tests for the auto-redirect path

Problem:
When only a password provider (for example basic auth) is configured, the dashboard auto-SSO gate redirects unauthenticated HTML requests to /auth/login?provider=<name>. Password providers do not implement the OAuth redirect flow, so that path raises NotImplementedError and returns a 500.

Fix:
Detect supports_password providers in the gate and redirect them to /login instead. Also build the next query parameter with the correct separator so /login gets ?next=... while OAuth providers keep &next=....

Test plan:
- ./venv/bin/python -m pytest tests/hermes_cli/test_dashboard_auth_password_login.py tests/hermes_cli/test_dashboard_auth_401_reauth.py -q
- manually verified the dashboard login works again with basic auth on 0.0.0.0:9119