### PR TITLE
fix(qqbot): add return_exceptions=True to asyncio.gather in chunked upload

### DIFF
--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -599,4 +599,7 @@ async def _run_with_concurrency(
         async with sem:
             await thunk()
 
-    await asyncio.gather(*(_wrap(t) for t in tasks))
+    results = await asyncio.gather(*(_wrap(t) for t in tasks), return_exceptions=True)
+    for r in results:
+        if isinstance(r, BaseException):
+            raise r


### PR DESCRIPTION
## Summary

Add  to  in  for QQ bot chunked upload.

## Problem

 without  means that if one part upload fails, all other in-flight parts are cancelled and the entire upload crashes. This is especially problematic for large multi-part uploads where transient network errors on a single part should not abort the entire operation.

## Fix

Added  to the gather call and re-raise the first exception after all tasks complete, preserving the original failure semantics while allowing in-flight tasks to finish cleanly.

## Testing
- Syntax check passed (py_compile)