### PR TITLE
fix: handle list content in _serialize_for_summary for multimodal messages

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1413,7 +1413,21 @@ class ContextCompressor(ContextEngine):
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
-            content = redact_sensitive_text(msg.get("content") or "")
+            content = msg.get("content")
+            if isinstance(content, list):
+                text_parts: list[str] = []
+                for part in content:
+                    if isinstance(part, dict):
+                        if part.get("type") == "text":
+                            text_parts.append(part.get("text", ""))
+                        elif part.get("type") in {
+                            "image", "image_url", "input_image",
+                        }:
+                            text_parts.append("[image]")
+                    elif isinstance(part, str):
+                        text_parts.append(part)
+                content = "\n".join(text_parts)
+            content = redact_sensitive_text(content or "")
             content = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", content)
 
             # Tool results: keep enough content for the summarizer

--- a/tests/agent/test_compressor_media_stripping.py
+++ b/tests/agent/test_compressor_media_stripping.py
@@ -54,3 +54,49 @@ class TestMediaDirectiveStripping:
         result = compressor._serialize_for_summary(turns)
         assert "MEDIA:" not in result
         assert result.count("[media attachment]") == 2
+
+    def test_multimodal_list_content_does_not_crash(self, compressor):
+        """content as a list (multimodal) must not crash redact_sensitive_text.
+
+        Regression: msg.get('content') can return a list of parts for
+        multimodal messages (images + text).  The old code passed this
+        list directly to redact_sensitive_text(str), which raised
+        AttributeError on list.replace().
+        """
+        turns = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is in this image?"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+                ],
+            },
+        ]
+        # Must not raise
+        result = compressor._serialize_for_summary(turns)
+        assert "What is in this image?" in result
+        assert "[image]" in result
+
+    def test_multimodal_list_text_parts_extracted(self, compressor):
+        """Text parts from multimodal list content are preserved in output."""
+        turns = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "first part"},
+                    {"type": "text", "text": "second part"},
+                ],
+            },
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "first part" in result
+        assert "second part" in result
+
+    def test_multimodal_list_bare_strings_handled(self, compressor):
+        """Bare strings inside a content list are joined."""
+        turns = [
+            {"role": "user", "content": ["hello", "world"]},
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "hello" in result
+        assert "world" in result


### PR DESCRIPTION
## Summary

Fix `AttributeError` crash in `_serialize_for_summary` when a message has multimodal (list) content — e.g. user sends an image + text.

## Problem

`agent/context_compressor.py:1416` — `msg.get("content")` can return a `list` of content parts for multimodal messages (images, text, etc.). The code passed this list directly to `redact_sensitive_text(text: str)`, which calls `.replace()` on its argument. A list has no `.replace()` method, so this raises `AttributeError`, causing context compression to fail entirely.

When compression fails, the session context grows unchecked until the provider rejects the request or the session becomes unusable.

**Reproduction:** Send a message with an attached image (e.g. via Telegram, Discord, or the dashboard) in a session with context compression enabled. When the compressor runs, it crashes on the multimodal message.

## Fix

Detect `isinstance(content, list)` before calling `redact_sensitive_text` and extract text/image placeholders from the parts list:
- `{"type": "text", "text": "..."}` → extracted as-is
- `{"type": "image_url"|"image"|"input_image"}` → replaced with `[image]`
- bare strings → joined as-is

This follows the same pattern used in `tool_dispatch_helpers.py` and `conversation_compression.py` for handling multimodal content.

## Testing

3 new tests in `tests/agent/test_compressor_media_stripping.py`:
- Multimodal list with text + image_url parts (does not crash)
- Multimodal list with multiple text parts (preserved in output)
- Bare string list (joined correctly)
