### PR TITLE
fix: narrow over-broad except Exception to sqlite3.Error in hermes_state.py

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1219,7 +1219,7 @@ class SessionDB:
                         "WAL checkpoint: %d/%d pages checkpointed",
                         result[2], result[1],
                     )
-        except Exception:
+        except sqlite3.Error:
             pass  # Best effort — never fatal.
 
     def _try_optimize_fts(self) -> None:
@@ -1235,7 +1235,7 @@ class SessionDB:
         """
         try:
             self.optimize_fts()
-        except Exception:
+        except sqlite3.Error:
             pass  # Best effort — never fatal.
 
     def close(self):
@@ -1248,7 +1248,7 @@ class SessionDB:
             if self._conn:
                 try:
                     self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-                except Exception:
+                except sqlite3.Error:
                     pass
                 self._conn.close()
                 self._conn = None


### PR DESCRIPTION
## Summary

Narrow `except Exception: pass` to `except sqlite3.Error` in three best-effort methods in `hermes_state.py`.

## Problem

Three methods use `except Exception: pass` to suppress errors in best-effort database maintenance operations:

1. **`_try_wal_checkpoint()`** (line 1222) — WAL checkpoint pragma
2. **`_try_optimize_fts()`** (line 1238) — FTS5 segment merge
3. **`close()`** (line 1251) — WAL checkpoint before closing

This catches everything including:
- `MemoryError` — system out of memory, silently ignored
- `KeyboardInterrupt` / `SystemExit` — prevents clean shutdown
- Programming bugs (e.g. `AttributeError` from `self._conn` being `None` after a concurrent `close()`) — hidden instead of surfaced

When `close()` sets `self._conn = None` concurrently with `_try_wal_checkpoint()`, the resulting `AttributeError` is silently swallowed, hiding the race condition rather than making it visible.

## Fix

Replace `except Exception` with `except sqlite3.Error` in all three locations. This ensures only expected database errors are suppressed while letting genuine bugs and system-level exceptions propagate.

## Testing

Existing tests pass (`tests/test_hermes_state_compression_locks.py` — 12/12). The change is purely additive — no behavior changes for the happy path.
