### PR TITLE
fix(dingtalk): track background message task via _spawn_bg instead of bare create_task

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -1491,7 +1491,7 @@ class _IncomingHandler(
             # eventually causing a disconnect.  _on_message is wrapped so
             # exceptions inside the task surface in logs instead of
             # disappearing into the event loop.
-            asyncio.create_task(self._safe_on_message(chatbot_msg))
+            self._adapter._spawn_bg(self._safe_on_message(chatbot_msg))
         except Exception:
             logger.exception(
                 "[%s] Error preparing incoming message", self._adapter.name


### PR DESCRIPTION
## Summary

Track background message processing task in DingTalk adapter via `_spawn_bg()` instead of bare `asyncio.create_task()`.

## Problem

`plugins/platforms/dingtalk/adapter.py:1494` — the callback handler uses bare `asyncio.create_task()` for the main message processing coroutine. If the resulting task is garbage-collected before completing (no strong reference kept), the exception callback may never fire, silently losing errors.

The adapter already has `_spawn_bg()` (line 527) which tracks tasks in `_bg_tasks` and discards them on completion. The emotion-send task on line 1483 already uses `_spawn_bg()` correctly — only the message processing task was missed.

## Fix

Replace `asyncio.create_task(self._safe_on_message(chatbot_msg))` with `self._adapter._spawn_bg(self._safe_on_message(chatbot_msg))` for consistency with the rest of the adapter.

## Testing

1-line change. Existing DingTalk adapter tests verify message processing behavior.
