### PR TITLE
fix(curator): reject symlinks in tarball pre-check for Python < 3.12

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -627,6 +627,12 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
                     raise tarfile.TarError(
                         f"refusing to extract unsafe path: {name!r}"
                     )
+                # Symlinks can bypass the path check on Python < 3.12
+                # where filter='data' is unavailable (zip-slip via symlink).
+                if member.issym() or member.islnk():
+                    raise tarfile.TarError(
+                        f"refusing to extract symlink: {name!r}"
+                    )
             try:
                 tf.extractall(str(skills), filter="data")  # type: ignore[call-arg]
             except TypeError:


### PR DESCRIPTION
## Summary

Reject symlinks and hard links in the tarball pre-extraction check for Python < 3.12.

## Problem

`agent/curator_backup.py:624` — the pre-extraction loop rejects absolute paths and `..` components but does not reject symlinks. On Python < 3.12 where `filter='data'` is unavailable, a malicious tarball can exploit symlinks for zip-slip:

1. Include a symlink `foo` -> `../../etc`
2. Include a regular file `foo/passwd` with attacker content
3. The pre-check sees `foo/passwd` (safe path), but extraction follows the symlink and writes to `/etc/passwd`

The `filter='data'` path on Python 3.12+ already handles this, but the fallback path is vulnerable.

## Fix

Add `member.issym()` and `member.islnk()` checks to the pre-extraction validation loop, raising `TarError` if any symlink or hard link is found.

## Testing

1-file change. The existing curator backup tests exercise the extraction path.
