### PR TITLE
fix(slack): warn when slack_tokens.json is group/world-readable

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -985,6 +985,19 @@ class SlackAdapter(BasePlatformAdapter):
         tokens_file = get_hermes_home() / "slack_tokens.json"
         if tokens_file.exists():
             try:
+                # Warn if the token file is world- or group-readable — it
+                # contains plaintext bot tokens for all saved workspaces.
+                import stat as _stat
+
+                mode = tokens_file.stat().st_mode
+                if mode & (_stat.S_IRGRP | _stat.S_IROTH):
+                    logger.warning(
+                        "[Slack] %s is group/world-readable (mode 0%o). "
+                        "Run: chmod 600 %s",
+                        tokens_file.name,
+                        _stat.S_IMODE(mode),
+                        tokens_file,
+                    )
                 saved = json.loads(tokens_file.read_text(encoding="utf-8"))
                 for team_id, entry in saved.items():
                     tok = entry.get("token", "") if isinstance(entry, dict) else ""


### PR DESCRIPTION
## Summary

Warn at startup when `slack_tokens.json` is group- or world-readable.

## Problem

`plugins/platforms/slack/adapter.py:985` — the OAuth multi-workspace token file contains plaintext bot tokens for all saved Slack workspaces. Unlike the Google Chat adapter (`google_chat/oauth.py:329`) which explicitly sets `0o600` permissions when writing credential files, the Slack token file has no permission enforcement. With a default umask of `022`, the file is world-readable, exposing all saved workspace tokens to any local user.

## Fix

Check file permissions when reading `slack_tokens.json`. If the file is group-readable (`S_IRGRP`) or world-readable (`S_IROTH`), emit a `logger.warning` with the current mode and remediation command (`chmod 600`).

This follows the defense-in-depth pattern: don't refuse to load (that would break existing setups), but make the misconfiguration visible so operators can fix it.

## Testing

1-file change. The warning is a log-only side effect that doesn't affect existing functionality.
