### PR TITLE
fix(desktop): call discover_plugins() in _make_agent so plugin hooks fire in the desktop GUI

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4239,6 +4239,17 @@ def _make_agent(
 ):
     from run_agent import AIAgent
 
+    # discover_plugins() is not triggered by lazy imports in the dashboard/
+    # desktop WebSocket path the way it is for the CLI and slash_worker paths.
+    # Call it explicitly here so plugin hooks (e.g. clawd-on-desk) fire for
+    # every agent created by the desktop GUI.  discover_plugins() is idempotent
+    # (no-ops after the first call per process), so this is safe.
+    try:
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins()
+    except Exception:
+        pass
+
     # MCP tool discovery runs in a background daemon thread at startup so a
     # dead server can't freeze the shell.  The agent snapshots its tool list
     # once here and never re-reads it, so briefly wait for in-flight discovery


### PR DESCRIPTION
## Summary

Plugin hooks (`on_session_start`, `pre_llm_call`, `post_llm_call`, etc.) never fire for users running the desktop GUI app.

## Root Cause

The desktop app's conversation path goes through `tui_gateway/server.py` → `_make_agent()`, which is called for every new WebSocket session from the Electron frontend. Unlike the TUI `slash_worker` path (which already has an explicit `discover_plugins()` call for the same reason — see the comment added in that file) and the `oneshot`/`gateway` paths, `_make_agent()` never called `discover_plugins()`.

As a result, any installed plugin's hooks are silently never registered for desktop users.

## Fix

Call `discover_plugins()` at the top of `_make_agent()`, immediately after `from run_agent import AIAgent`. `discover_plugins()` is idempotent — it no-ops after the first call per process — so this adds no overhead for subsequent agent creations in the same session.

```python
# discover_plugins() is not triggered by lazy imports in the dashboard/
# desktop WebSocket path the way it is for the CLI and slash_worker paths.
try:
    from hermes_cli.plugins import discover_plugins
    discover_plugins()
except Exception:
    pass
```

## Verification

After applying the fix, the plugin's `plugin_registered` and `on_session_start` log entries appear in the debug log (`CLAWD_HERMES_DEBUG=1`) when starting a desktop conversation — confirming hooks are now registered and firing.

Tested with the [Clawd on Desk](https://github.com/clawd-on-desk) plugin on Windows.
