### PR TITLE
fix(setup): enable Windows VT processing for ANSI escape codes

### DIFF
--- a/hermes_cli/colors.py
+++ b/hermes_cli/colors.py
@@ -4,17 +4,71 @@ import os
 import sys
 
 
+def _enable_windows_vt_processing() -> bool:
+    """Enable Virtual Terminal Processing on Windows console handles.
+
+    Modern Windows 10+ terminals support ANSI escape sequences, but they
+    must be explicitly opted-in via ``SetConsoleMode`` with the
+    ``ENABLE_VIRTUAL_TERMINAL_PROCESSING`` flag (0x0004).  Without this
+    the kernel passes raw escape codes through as literal text — exactly
+    the symptom reported in #59397.
+
+    Returns True when VT processing was successfully enabled or when the
+    call is not applicable (non-Windows).
+    """
+    if sys.platform != "win32":
+        return True
+
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+
+        STD_OUTPUT_HANDLE = -11
+        STD_ERROR_HANDLE = -12
+        ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+
+        def _try_enable(handle_id: int) -> bool:
+            handle = kernel32.GetStdHandle(handle_id)
+            if handle is None or handle == -1:
+                return False
+            mode = wintypes.DWORD()
+            if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+                return False
+            if mode.value & ENABLE_VIRTUAL_TERMINAL_PROCESSING:
+                return True  # already enabled
+            new_mode = mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING
+            if kernel32.SetConsoleMode(handle, new_mode):
+                return True
+            return False
+
+        # Enable on both stdout and stderr; at least one must succeed.
+        return _try_enable(STD_OUTPUT_HANDLE) or _try_enable(STD_ERROR_HANDLE)
+    except Exception:
+        # ctypes or Windows API unavailable — fall through to disable colors.
+        return False
+
+
+# Cache the result so we only call into the Windows API once.
+_vt_enabled: bool = _enable_windows_vt_processing()
+
+
 def should_use_color() -> bool:
     """Return True when colored output is appropriate.
 
-    Respects the NO_COLOR environment variable (https://no-color.org/)
-    and TERM=dumb, in addition to the existing TTY check.
+    Respects the NO_COLOR environment variable (https://no-color.org/),
+    TERM=dumb, and the existing TTY check.  On Windows, also verifies
+    that Virtual Terminal Processing is active so ANSI escape codes are
+    rendered as colors instead of printed literally (see #59397).
     """
     if os.environ.get("NO_COLOR") is not None:
         return False
     if os.environ.get("TERM") == "dumb":
         return False
     if not sys.stdout.isatty():
+        return False
+    if sys.platform == "win32" and not _vt_enabled:
         return False
     return True
 


### PR DESCRIPTION
Fixes #59397

## Problem
On Windows (CMD and PowerShell), the 
⚕ Hermes Setup — Non-interactive mode

  Running in a non-interactive environment (no TTY detected).
  The interactive wizard cannot be used here.

  Configure Hermes using environment variables or config commands:
    hermes config set model.provider custom
    hermes config set model.base_url http://localhost:8080/v1
    hermes config set model.default your-model-name

  Or set OPENROUTER_API_KEY / OPENAI_API_KEY in your environment.
  Run 'hermes setup' in an interactive terminal to use the full wizard. wizard and other CLI interfaces print ANSI escape codes as literal text (e.g. , ) instead of rendering colors and box-drawing elements. This happens because Windows does not enable Virtual Terminal Processing by default, even though  returns True.

## Root Cause
 checks  to decide whether to emit ANSI codes, but does not verify that the Windows console actually supports VT processing. Without the  flag (0x0004) set via , the raw escape codes pass through uninterpreted.

## Fix
Added  which:
1. Calls  /  /  via  to enable  on stdout and stderr
2. Caches the result at module import time
3.  now returns False on Windows if VT enablement failed

This is a no-op on non-Windows platforms. Falls back gracefully if ctypes or the Windows API is unavailable.

## Testing
- Import succeeds on Linux/macOS (no-op path)
- On Windows 10+ terminals (Windows Terminal, modern CMD, PowerShell), ANSI colors now render correctly
- If VT enablement fails (older Windows, non-conhost hosts), colors are gracefully disabled