### PR TITLE
fix(logging): suppress transient fd errors (EIO/ESTALE) from surfacing in chat output

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -29,6 +29,7 @@ Session context:
 
 import atexit
 import copy
+import errno
 import io
 import logging
 import os
@@ -137,6 +138,28 @@ def _is_windows_concurrent_log_lock_timeout(exc: BaseException | None) -> bool:
         and isinstance(exc, RuntimeError)
         and _CONCURRENT_LOG_LOCK_TIMEOUT in str(exc)
     )
+
+
+def _is_transient_fd_error(exc: BaseException | None) -> bool:
+    """Return True for transient file descriptor errors.
+
+    These errors indicate a stale or temporarily unavailable fd (e.g., after
+    external rotation, filesystem transient failure).  They should not surface
+    as tracebacks in interactive output; the handler can recover by reopening
+    the stream.
+
+    We deliberately DO NOT suppress errors that indicate real problems:
+    - ENOSPC (disk full)
+    - EACCES/EPERM (permission problems)
+    - ENOENT (path problems)
+    - EINVAL/EBADF (configuration bugs)
+    """
+    if not isinstance(exc, OSError):
+        return False
+    err_num = getattr(exc, "errno", None)
+    # EIO: I/O error (stale fd, filesystem transient)
+    # ESTALE: stale file handle (NFS, external rotation)
+    return err_num in (errno.EIO, errno.ESTALE)
 
 
 # Third-party loggers that are noisy at DEBUG/INFO level.
@@ -519,18 +542,40 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         super().emit(record)
 
     def handleError(self, record: logging.LogRecord) -> None:
-        """Suppress the known Windows ``concurrent-log-handler`` lock timeout
-        instead of printing a traceback.
+        """Suppress known logging errors that should not appear in chat output.
 
-        CLH's own ``emit()`` wraps its body in ``try/except Exception:
-        self.handleError(record)``, so the ``"Cannot acquire lock after N
-        attempts"`` RuntimeError raised in ``_do_lock()`` is caught inside CLH
-        and routed here — it never propagates out of ``super().emit()``.  This
-        override is the single point where that timeout can be silenced before
-        the stdlib handler prints it to stderr (which, under the Desktop
-        slash-worker, is captured and surfaced into chat output)."""
+        Two error classes are suppressed:
+
+        1. Windows ``concurrent-log-handler`` lock timeout.  CLH's own ``emit()``
+           wraps its body in ``try/except Exception: self.handleError(record)``,
+           so the ``"Cannot acquire lock after N attempts"`` RuntimeError raised
+           in ``_do_lock()`` is caught inside CLH and routed here — it never
+           propagates out of ``super().emit()``.  This override is the single
+           point where that timeout can be silenced before the stdlib handler
+           prints it to stderr (which, under the Desktop slash-worker, is
+           captured and surfaced into chat output).
+
+        2. Transient file descriptor errors (EIO, ESTALE).  These occur when
+           a rotating file handler's stream becomes stale due to external
+           rotation, filesystem transient failures, or QueueListener lifecycle
+           races.  The handler can recover by reopening the stream on the next
+           emit, so these errors should not surface as user-visible tracebacks.
+           We deliberately do NOT suppress errors that indicate real problems
+           (disk full, permission denied, missing path, configuration bugs).
+        """
         exc = sys.exc_info()[1]
         if _is_windows_concurrent_log_lock_timeout(exc):
+            return
+        if _is_transient_fd_error(exc):
+            # Attempt recovery: close and reopen the stream.  If this fails,
+            # the next emit will bail via the existing stream=None check.
+            try:
+                if self.stream is not None:
+                    self.stream.close()
+            except Exception:
+                pass
+            self.stream = None  # type: ignore[assignment]
+            # Suppress the traceback to stderr (avoid cluttering chat output).
             return
         super().handleError(record)
 

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -1,4 +1,5 @@
 """Tests for hermes_logging — centralized logging setup."""
+import errno
 import io
 import logging
 import os
@@ -875,6 +876,69 @@ class TestWindowsConcurrentLogLockTimeout:
 
             captured = capsys.readouterr()
             assert "unexpected logging failure" in captured.err
+            assert "--- Logging error ---" in captured.err
+        finally:
+            logger.removeHandler(handler)
+            handler.close()
+
+    def test_transient_fd_error_eio_suppresses_traceback(self, tmp_path, capsys):
+        """OSError EIO must be suppressed and the stream must be marked for recovery."""
+        logger, handler = self._make_logger_and_handler(tmp_path / "agent.log")
+        record = logger.makeRecord(
+            logger.name, logging.INFO, __file__, 0, "test message", (), None,
+        )
+        try:
+            # Simulate EIO from flush() or tell() as reported in #59997.
+            try:
+                raise OSError(errno.EIO, "Input/output error")
+            except OSError:
+                handler.handleError(record)
+
+            captured = capsys.readouterr()
+            # EIO should be suppressed — no "Logging error" or traceback.
+            assert "Input/output error" not in captured.err
+            assert "--- Logging error ---" not in captured.err
+            # Stream should be marked for recovery (closed on next emit).
+            assert handler.stream is None
+        finally:
+            logger.removeHandler(handler)
+            handler.close()
+
+    def test_transient_fd_error_estale_suppresses_traceback(self, tmp_path, capsys):
+        """OSError ESTALE (stale NFS handle) must be suppressed and stream marked for recovery."""
+        logger, handler = self._make_logger_and_handler(tmp_path / "agent.log")
+        record = logger.makeRecord(
+            logger.name, logging.INFO, __file__, 0, "test message", (), None,
+        )
+        try:
+            try:
+                raise OSError(errno.ESTALE, "Stale file handle")
+            except OSError:
+                handler.handleError(record)
+
+            captured = capsys.readouterr()
+            assert "Stale file handle" not in captured.err
+            assert "--- Logging error ---" not in captured.err
+            assert handler.stream is None
+        finally:
+            logger.removeHandler(handler)
+            handler.close()
+
+    def test_other_oserrors_still_print_to_stderr(self, tmp_path, capsys):
+        """OSError that indicates real problems must still emit the normal stdlib output."""
+        logger, handler = self._make_logger_and_handler(tmp_path / "agent.log")
+        record = logger.makeRecord(
+            logger.name, logging.INFO, __file__, 0, "test message", (), None,
+        )
+        try:
+            # ENOSPC (disk full) is a real problem — must surface.
+            try:
+                raise OSError(errno.ENOSPC, "No space left on device")
+            except OSError:
+                handler.handleError(record)
+
+            captured = capsys.readouterr()
+            assert "No space left on device" in captured.err
             assert "--- Logging error ---" in captured.err
         finally:
             logger.removeHandler(handler)


### PR DESCRIPTION
## What does this PR do?

When a RotatingFileHandler encounters `OSError: [Errno 5] Input/output error` or `ESTALE` during `flush()` or `tell()`, these indicate stale or temporarily unavailable file descriptors — e.g., after external rotation, filesystem transient failures, or QueueListener lifecycle races. The handler can recover by reopening the stream on the next emit, so these errors should not surface as user-visible tracebacks in interactive output (Desktop chat, CLI transcript).

Before this fix, stdlib logging's `handleError()` printed these tracebacks to stderr, which under the Desktop slash-worker is captured and surfaced into chat output. This produced noisy `--- Logging error ---` blocks interleaved with assistant responses, confusing users.

This fix adds a second error suppression class to `_ManagedRotatingFileHandler.handleError()`, complementing the existing Windows CLH lock timeout suppression:

1. Windows `concurrent-log-handler` lock timeout (already suppressed)
2. **New:** Transient fd errors (EIO, ESTALE) — suppressed and stream marked for recovery

We deliberately do NOT suppress errors that indicate real problems (disk full, permission denied, missing path, configuration bugs) — these still surface via the normal stdlib path.

## Related Issue

Fixes #59997

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Add `import errno` to `hermes_logging.py` for errno constants
- Add `_is_transient_fd_error()` helper to identify EIO/ESTALE (but not real problems like ENOSPC, EACCES, ENOENT)
- Extend `_ManagedRotatingFileHandler.handleError()` to suppress transient fd errors and mark the stream for recovery (set `stream=None`)
- Add three regression tests to `tests/test_hermes_logging.py`:
  - `test_transient_fd_error_eio_suppresses_traceback`: EIO is suppressed and stream marked for recovery
  - `test_transient_fd_error_estale_suppresses_traceback`: ESTALE is suppressed and stream marked for recovery
  - `test_other_oserrors_still_print_to_stderr`: ENOSPC (disk full) still surfaces via normal stdlib path

## How to Test

1. All existing logging tests pass: `pytest tests/test_hermes_logging.py -q` (71 tests)
2. New regression tests verify:
   - EIO/ESTALE are suppressed (no stderr output, no `--- Logging error ---`)
   - Handler stream is marked for recovery (`stream=None` after transient error)
   - Non-transient OSError (ENOSPC) still surfaces for real problems
3. Cross-platform impact: The fix is platform-agnostic; EIO/ESTALE suppression applies on all platforms, Windows CLH timeout suppression only on Windows

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_hermes_logging.py -q` and all tests pass (71 tests)
- [x] I've added tests for my changes (3 new regression tests for transient fd error suppression)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (updated docstring in `handleError()`)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — errno constants are portable on all platforms
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A