### PR TITLE
fix(desktop): add NSContactsUsageDescription and NSAppleEventsUsageDescription

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -204,7 +204,9 @@
         "CFBundleExecutable": "Hermes",
         "CFBundleName": "Hermes",
         "NSAudioCaptureUsageDescription": "Hermes uses audio capture for voice conversations.",
-        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations."
+        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations.",
+        "NSContactsUsageDescription": "Hermes accesses your contacts to look up and manage contact information on your behalf.",
+        "NSAppleEventsUsageDescription": "Hermes uses Apple Events to write notes and other fields to your contacts."
       },
       "gatekeeperAssess": false,
       "hardenedRuntime": true,


### PR DESCRIPTION
Fixes #59482

## Problem
The Hermes desktop app silently fails when agent tries to read or write macOS Contacts. No macOS permission prompt appears; the tool returns a "denied" error instead. This works fine in CLI because permission is granted to the terminal, but the .app bundle needs its own Info.plist privacy keys.

## Root Cause
The macOS `Info.plist` (generated by electron-builder from `extendInfo` in package.json) is missing two required privacy usage description keys:

- `NSContactsUsageDescription` — required for any `Contacts.framework` access
- `NSAppleEventsUsageDescription` — required for Apple Events used to write the notes field on contacts

The existing `extendInfo` section already declares `NSAudioCaptureUsageDescription` and `NSMicrophoneUsageDescription` for audio features; contacts was simply overlooked.

## Fix
Added both keys to the `mac.extendInfo` section in `apps/desktop/package.json`:

- `NSContactsUsageDescription`: "Hermes accesses your contacts to look up and manage contact information on your behalf."
- `NSAppleEventsUsageDescription`: "Hermes uses Apple Events to write notes and other fields to your contacts."

After this change, on first contacts access macOS will show the standard permission prompt. After granting, Hermes appears under Privacy & Security > Contacts, matching the existing Microphone and Calendar behavior.

## Verification
- `python3 -c "import json; json.load(open('apps/desktop/package.json'))"` passes (valid JSON)
- The `extendInfo` merge works the same way as the existing microphone/audio entries
- No entitlements changes needed — contacts access is not sandbox-gated
