### PR TITLE
fix(cli): wait for MCP before first-turn agent builds

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -234,9 +234,9 @@ class CLIAgentSetupMixin:
         if not self._ensure_runtime_credentials():
             return False
 
-        from hermes_cli.mcp_startup import wait_for_mcp_discovery
+        from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
 
-        wait_for_mcp_discovery()
+        ensure_mcp_discovery_before_agent_build(logger=logger)
 
         # Initialize SQLite session store for CLI sessions (if not already done in __init__)
         if self._session_db is None:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1343,19 +1343,12 @@ DEFAULT_CONFIG = {
     "file_read_max_chars": 100_000,
 
     # Seconds to wait at agent-build time for in-flight MCP server discovery
-    # to finish before the agent snapshots its tool list.  MCP discovery runs
-    # in a background thread so a slow/dead server can't freeze startup; this
-    # bounds how long the first agent build blocks on it.  The wait returns
-    # the INSTANT discovery completes, so users with no MCP servers (the common
-    # case) or fast servers pay ~0s regardless of this value — the bound is
-    # only reached when a server is genuinely still connecting.  The old 0.75s
-    # default was a touch short for HTTP/OAuth servers on a cold connect; a
-    # modest bump lets more of them land in the FIRST turn's snapshot.  This is
-    # only a turn-1 latency/UX knob: a server that misses this window is still
-    # picked up automatically on the next turn by the between-turns refresh
-    # (see agent/turn_context.py), so correctness never depends on it.  Keep it
-    # small so a slow/dead server adds little to first-response latency.
-    "mcp_discovery_timeout": 1.5,
+    # to finish before the agent snapshots its tool list. For one-shot and
+    # first-only turns this is a correctness bound: tools discovered after the
+    # snapshot cannot be used on that only turn. ``thread.join(timeout)`` returns
+    # as soon as discovery completes, so reachable servers only wait for their
+    # real handshake time while unavailable servers remain bounded.
+    "mcp_discovery_timeout": 15.0,
 
     # Tool-output truncation thresholds. When terminal output or a
     # single read_file page exceeds these limits, Hermes truncates the

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -56,19 +56,22 @@ def _resolve_discovery_timeout(explicit: "float | None") -> float:
     Reads ``mcp_discovery_timeout`` from config.yaml, defaulting to the value in
     ``DEFAULT_CONFIG`` (single source of truth) when the key is absent. Kept lazy
     and fail-safe — a missing/invalid value or a broken config falls back to a
-    short safe bound so startup can never hang or crash.
+    finite safe bound so startup can never hang or crash.
     """
     if explicit is not None:
         return explicit
     try:
         from hermes_cli.config import load_config, DEFAULT_CONFIG
 
-        default = float(DEFAULT_CONFIG.get("mcp_discovery_timeout", 1.5))
-        raw = (load_config() or {}).get("mcp_discovery_timeout", default)
-        val = float(raw)
-        return val if val > 0 else default
+        default = float(DEFAULT_CONFIG.get("mcp_discovery_timeout", 15.0))
+        try:
+            raw = (load_config() or {}).get("mcp_discovery_timeout", default)
+            val = float(raw)
+            return val if val > 0 else default
+        except Exception:
+            return default
     except Exception:
-        return 1.5
+        return 15.0
 
 
 def _discover_mcp_tools_without_interactive_oauth() -> None:
@@ -98,6 +101,26 @@ def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:
     if thread is None or not thread.is_alive():
         return
     thread.join(timeout=_resolve_discovery_timeout(timeout))
+
+
+def ensure_mcp_discovery_before_agent_build(
+    *,
+    logger,
+    timeout: "float | None" = None,
+    thread_name: str = "cli-mcp-discovery",
+) -> None:
+    """Give configured MCP tools a bounded chance to register before AIAgent.
+
+    Non-interactive first turns can build ``AIAgent`` before the normal banner
+    or tool-list paths touch ``get_tool_definitions()``.  This keeps startup
+    fail-open while preserving the existing background discovery path, including
+    OAuth prompt suppression and the configured timeout bound.
+    """
+    try:
+        start_background_mcp_discovery(logger=logger, thread_name=thread_name)
+        wait_for_mcp_discovery(timeout=timeout)
+    except Exception:
+        logger.debug("MCP discovery readiness check failed before agent build", exc_info=True)
 
 
 def mcp_discovery_in_flight() -> bool:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -384,6 +384,13 @@ def _run_agent(
     # honour the same merge semantics as interactive CLI and gateway sessions.
     _fb = get_fallback_chain(cfg)
 
+    from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
+
+    ensure_mcp_discovery_before_agent_build(
+        logger=logging.getLogger(__name__),
+        thread_name="oneshot-mcp-discovery",
+    )
+
     agent = AIAgent(
         api_key=runtime.get("api_key"),
         base_url=runtime.get("base_url"),

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -14,6 +14,7 @@ import pytest
 import cli as cli_mod
 from hermes_cli import main as main_mod
 from hermes_cli import mcp_startup
+from hermes_cli import oneshot as oneshot_mod
 
 
 @pytest.fixture(autouse=True)
@@ -198,8 +199,51 @@ def test_cli_get_tool_definitions_briefly_waits_for_fast_mcp_thread(monkeypatch)
     assert not thread.is_alive()
 
 
-def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):
-    waited = {"done": False}
+def test_ensure_mcp_discovery_starts_and_waits_for_configured_servers(monkeypatch):
+    events: list[str] = []
+
+    class SuppressInteractiveOAuth:
+        def __enter__(self):
+            events.append("oauth-enter")
+
+        def __exit__(self, *_exc):
+            events.append("oauth-exit")
+
+    def _discover():
+        events.append("discover")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"demo": {"transport": "stdio"}}},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(
+            suppress_interactive_oauth=lambda: SuppressInteractiveOAuth(),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=_discover),
+    )
+
+    mcp_startup.ensure_mcp_discovery_before_agent_build(
+        logger=types.SimpleNamespace(debug=lambda *_a, **_k: None),
+        timeout=1.0,
+    )
+
+    assert events == ["oauth-enter", "discover", "oauth-exit"]
+    assert mcp_startup._mcp_discovery_thread is not None
+    assert not mcp_startup._mcp_discovery_thread.is_alive()
+
+
+def test_init_agent_ensures_mcp_discovery_before_agent_build(monkeypatch):
+    calls: list[str] = []
 
     cli = cli_mod.HermesCLI(compact=True)
     cli._session_db = object()
@@ -211,14 +255,75 @@ def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):
 
     monkeypatch.setattr(
         mcp_startup,
-        "wait_for_mcp_discovery",
-        lambda timeout=0.75: waited.__setitem__("done", True),
+        "ensure_mcp_discovery_before_agent_build",
+        lambda *, logger, timeout=None, thread_name="cli-mcp-discovery": calls.append("mcp"),
+        raising=False,
     )
 
     def _fake_agent(*_a, **_k):
-        assert waited["done"] is True
+        calls.append("agent")
         return types.SimpleNamespace()
 
     monkeypatch.setattr(cli_mod, "AIAgent", _fake_agent)
 
     assert cli._init_agent() is True
+    assert calls == ["mcp", "agent"]
+
+
+def test_oneshot_run_agent_ensures_mcp_discovery_before_agent_build(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(load_config=lambda: {"model": {"default": "demo-model"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        types.SimpleNamespace(detect_provider_for_model=lambda *_a, **_k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        types.SimpleNamespace(
+            resolve_runtime_provider=lambda **_k: {
+                "api_key": "key",
+                "base_url": "https://example.test/v1",
+                "provider": "openai",
+                "api_mode": "chat_completions",
+            }
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        types.SimpleNamespace(_get_platform_tools=lambda *_a, **_k: {"terminal"}),
+    )
+    monkeypatch.setattr(oneshot_mod, "_create_session_db_for_oneshot", lambda: object())
+    monkeypatch.setattr(oneshot_mod, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr(
+        mcp_startup,
+        "ensure_mcp_discovery_before_agent_build",
+        lambda *, logger, timeout=None, thread_name="cli-mcp-discovery": calls.append("mcp"),
+        raising=False,
+    )
+
+    class FakeAgent:
+        def __init__(self, *_a, **_k):
+            calls.append("agent")
+
+        def run_conversation(self, prompt):
+            return {"final_response": f"ok: {prompt}"}
+
+    monkeypatch.setitem(
+        sys.modules,
+        "run_agent",
+        types.SimpleNamespace(AIAgent=FakeAgent),
+    )
+
+    response, result = oneshot_mod._run_agent("hello")
+
+    assert response == "ok: hello"
+    assert result["final_response"] == "ok: hello"
+    assert calls == ["mcp", "agent"]

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7495,13 +7495,13 @@ def test_make_agent_waits_for_shared_mcp_discovery(monkeypatch):
     monkeypatch.setattr(
         mcp_startup,
         "wait_for_mcp_discovery",
-        lambda timeout=0.75: waited.append(timeout),
+        lambda timeout=None: waited.append(timeout),
     )
 
     with patch("run_agent.AIAgent"):
         server._make_agent("sid1", "key1")
 
-    assert waited == [0.75]
+    assert waited == [None]
 
 
 def test_make_agent_nested_max_turns_takes_priority(monkeypatch):

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -249,17 +249,39 @@ def test_resolve_discovery_timeout_reads_config(monkeypatch):
     assert mcp_startup._resolve_discovery_timeout(None) == 8.0
 
 
+def test_resolve_discovery_timeout_default_is_remote_cold_start_sane(monkeypatch):
+    from hermes_cli import mcp_startup
+    import hermes_cli.config as cfg
+
+    monkeypatch.setattr(cfg, "load_config", lambda: {})
+
+    default = mcp_startup._resolve_discovery_timeout(None)
+
+    assert 10.0 <= default <= 30.0
+
+
 def test_resolve_discovery_timeout_falls_back_on_bad_value(monkeypatch):
     from hermes_cli import mcp_startup
     import hermes_cli.config as cfg
 
     # Non-positive / unparsable → DEFAULT_CONFIG value, never hang.
-    default = float(cfg.DEFAULT_CONFIG.get("mcp_discovery_timeout", 1.5))
+    default = float(cfg.DEFAULT_CONFIG.get("mcp_discovery_timeout", 15.0))
     monkeypatch.setattr(cfg, "load_config", lambda: {"mcp_discovery_timeout": 0})
     assert mcp_startup._resolve_discovery_timeout(None) == default
 
     monkeypatch.setattr(cfg, "load_config", lambda: {"mcp_discovery_timeout": "oops"})
     assert mcp_startup._resolve_discovery_timeout(None) == default
+
+
+def test_resolve_discovery_timeout_uses_default_when_config_load_fails(monkeypatch):
+    from hermes_cli import mcp_startup
+    import hermes_cli.config as cfg
+
+    monkeypatch.setattr(cfg, "load_config", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    default = mcp_startup._resolve_discovery_timeout(None)
+
+    assert 10.0 <= default <= 30.0
 
 
 def test_stale_generation_refresh_does_not_clobber_newer(monkeypatch):

--- a/tests/tui_gateway/test_wait_for_mcp_discovery.py
+++ b/tests/tui_gateway/test_wait_for_mcp_discovery.py
@@ -7,6 +7,7 @@ discovery thread before building — bounded, so a dead server can't re-introduc
 the startup hang, and a no-op once discovery has finished.
 """
 
+import builtins
 import threading
 import time
 
@@ -75,4 +76,34 @@ def test_hung_thread_is_bounded_by_timeout():
         assert t.is_alive()  # thread still running; we did not block on it
     finally:
         stop.set()
+        _restore_thread_slot(saved)
+
+
+def test_import_failure_fallback_bound_is_remote_cold_start_sane(monkeypatch):
+    """If the shared resolver cannot import, the emergency bound is still
+    long enough for ordinary cold remote startup and finite."""
+    saved = entry._mcp_discovery_thread
+    original_import = builtins.__import__
+    joined = {}
+
+    class FakeThread:
+        def is_alive(self):
+            return True
+
+        def join(self, timeout=None):
+            joined["timeout"] = timeout
+
+    def fake_import(name, *args, **kwargs):
+        if name == "hermes_cli.mcp_startup":
+            raise ImportError("blocked for test")
+        return original_import(name, *args, **kwargs)
+
+    try:
+        entry._mcp_discovery_thread = FakeThread()
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        entry.wait_for_mcp_discovery()
+
+        assert 10.0 <= joined["timeout"] <= 30.0
+    finally:
         _restore_thread_slot(saved)

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -228,7 +228,7 @@ def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:
 
         bound = _resolve_discovery_timeout(timeout)
     except Exception:
-        bound = timeout if timeout is not None else 0.75
+        bound = timeout if timeout is not None else 15.0
     thread.join(timeout=bound)
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4346,7 +4346,7 @@ def _schedule_mcp_late_refresh(sid: str, agent) -> None:
     The agent snapshots ``agent.tools`` once at build time and never re-reads
     the registry (run_agent/agent_init). ``_make_agent`` briefly joins the
     background MCP discovery thread (``wait_for_mcp_discovery``, bounded by the
-    ``mcp_discovery_timeout`` config value, default 1.5s) so
+    ``mcp_discovery_timeout`` config value, default 15s) so
     already-spawning servers land in that snapshot — but a server that takes
     longer than the bound to connect (common for an HTTP MCP server on first
     connect) lands *after* the agent is built. Its tools are then absent from


### PR DESCRIPTION
## What does this PR do?

Fixes a first-turn MCP readiness race for non-interactive CLI runs. `hermes chat -q` and top-level `hermes -z` / `--oneshot` can construct `AIAgent` before configured MCP servers finish registering their dynamic tools. Because the agent snapshots its tool registry at construction time, the first and only model turn can miss native `mcp__...` tools even when the MCP server itself is healthy and the profile/toolset is configured correctly.

## Why this matters

This is not just a missing-tool edge case. `chat -q` is the natural command for scripted agent runs, evals, batch tests, kanban/worker-style invocations, and other automation where there is no second turn to recover from late MCP discovery. The failure is especially confusing because out-of-band checks can pass: a configured MCP server can test successfully, but the agent still snapshots its tools too early and never sees that server's tools for the run. When MCP tools are absent from that first snapshot, the model may silently degrade into slower or less reliable workarounds such as shell/Python calls, or conclude that required native tools are unavailable. In a real evaluation workflow this caused multiple runs to be invalid, wasted hours of debugging, and burned substantial model tokens before the root cause was visible: `chat -q` looked like configured `chat`, but its first-turn tool schema did not reliably include configured MCP tools.

The expected contract is simple: if `hermes chat` would expose a configured MCP toolset, then `hermes chat -q "..."` should expose the same tools for its first and only prompt.

## Fix layer

The fix adds a small shared helper that idempotently starts the existing background MCP discovery path and bounded-waits at the point of agent construction, then calls it from both CLI agent setup and oneshot. This is slightly stronger than the old `wait_for_mcp_discovery()` call: `wait_for_mcp_discovery()` only joins an already-created discovery thread, so it no-ops if a direct/single-query path reaches agent construction before MCP startup created that thread. The new helper makes the construction site self-sufficient: start discovery if needed, then wait up to the existing bound.

Putting the guarantee at the construction site keeps the fix narrow: it composes existing MCP startup primitives, is a no-op if discovery already ran, remains bounded by `mcp_discovery_timeout`, skips work when no MCP servers are configured, and stays fail-open on errors.

Real-world validation showed that the previous 1.5-second default was too short for an otherwise healthy remote HTTP MCP cold handshake taking roughly 2–5 seconds. The agent still snapshotted its tools before registration completed. This PR therefore raises the default bound to 15 seconds. This is a ceiling, not a fixed sleep: `thread.join(timeout)` returns immediately when discovery completes, so healthy servers incur only their actual handshake time, while unavailable servers remain capped at 15 seconds.

## Related Issue

Fixes #38448

Also covers the `hermes chat -q` affected path described in the issue discussion.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests

## Changes Made

- `hermes_cli/mcp_startup.py`: adds `ensure_mcp_discovery_before_agent_build()`, composing the existing background MCP discovery and bounded wait while preserving OAuth-prompt suppression and fail-open semantics.
- `hermes_cli/cli_agent_setup_mixin.py`: calls the helper before CLI `AIAgent(...)` construction, covering `hermes chat -q` and the interactive first turn.
- `hermes_cli/oneshot.py`: calls the same helper before oneshot `AIAgent(...)` construction, covering `hermes -z` / `--oneshot`.
- `hermes_cli/config.py`: raises the bounded discovery default from 1.5 to 15 seconds so ordinary remote MCP cold starts can complete before the first-only tool snapshot.
- `tui_gateway/entry.py` and `tui_gateway/server.py`: keep fallback behavior and inline documentation aligned with the shared default.
- `tests/hermes_cli/test_mcp_startup.py`: adds regression coverage for the helper's real bounded discovery path, including OAuth-suppression ordering, plus ordering checks that discovery precedes agent build in both CLI and oneshot paths.
- MCP refresh/TUI tests cover the new finite default and emergency fallback as behavior contracts rather than pinning an exact literal.

## Sibling commands sharing this contract

`hermes chat -q`, top-level `hermes -z` / `--oneshot`, and the interactive first turn all need configured MCP tools available before the first model call. All three now route through the shared helper before `AIAgent` snapshots tools.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_mcp_startup.py tests/hermes_cli/test_tui_resume_flow.py -q
scripts/run_tests.sh tests/hermes_cli/test_oneshot_usage_file.py tests/agent/test_oneshot.py -q
scripts/run_tests.sh tests/tools/test_refresh_agent_mcp_tools.py tests/test_tui_mcp_late_refresh.py tests/tui_gateway/test_wait_for_mcp_discovery.py tests/tui_gateway/test_mcp_late_refresh_thread_owner.py -q
python -m pytest tests/test_tui_gateway_server.py::test_make_agent_waits_for_shared_mcp_discovery -q -o 'addopts='
git diff --check
python -m compileall hermes_cli/config.py hermes_cli/mcp_startup.py hermes_cli/cli_agent_setup_mixin.py hermes_cli/oneshot.py tui_gateway/entry.py tui_gateway/server.py
```

Manual end-to-end smoke against a profile with a healthy remote HTTP MCP toolset:

```text
Previous 1.5s bound: first-only run completed with the expected native MCP tool absent and zero MCP tool calls.
15s bound: discovery returned after the server's actual handshake time (roughly 2–5s), and a fresh `hermes chat -q` first turn natively executed `mcp__example__lookup`.
The executor recorded the native tool completion before the final answer.
```

## Verification Output

```text
=== Summary: 8 files, 105 tests passed, 0 failed (100% complete) in 1.5s ===
1 passed in 0.42s
```

`compileall` and `git diff --check` passed. The branch was rebased onto current upstream `main` before final verification.
