### PR TITLE
fix(pricing): resolve custom:<name> providers against models.dev

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from utils import atomic_json_write, base_url_host_matches
+from utils import atomic_json_write, base_url_hostname
 
 import requests
 
@@ -696,30 +696,64 @@ def get_provider_info(provider_id: str) -> Optional[ProviderInfo]:
 # Custom-endpoint provider validation
 # ---------------------------------------------------------------------------
 
-# Known upstream providers mapped to the API host(s) they serve from.  A custom
-# endpoint is resolved to a vendor's catalog ONLY when its ``base_url`` host
-# matches one of these — display-name matching risks mis-assigning pricing,
-# limits and capabilities to an unrelated endpoint that merely shares a name
-# (e.g. a custom endpoint named "friendli" pointed at a different host).
-_UPSTREAM_PROVIDER_HOSTS: Dict[str, str] = {
-    "api.friendli.ai": "friendli",
-}
+# Host → models.dev provider id, derived from each provider's registered ``api``
+# base URL so a custom endpoint is resolved to a vendor's catalog ONLY when its
+# ``base_url`` host matches (display-name matching mis-assigns pricing, limits
+# and capabilities to an unrelated endpoint that merely shares a name). Built
+# lazily from the cached registry, so it tracks the catalog without code changes.
+_UPSTREAM_PROVIDER_HOSTS_CACHE: Optional[Dict[str, str]] = None
+
+
+def _upstream_provider_host_index() -> Dict[str, str]:
+    """Host → models.dev provider id, from each provider's registered ``api`` URL.
+
+    Only servers whose host uniquely identifies one provider are indexed:
+    when two providers share a host (an aggregator exposing many vendors) no
+    single upstream identity applies, so it is left unindexed and the call site
+    falls back to the per-endpoint pricing path.
+    """
+    global _UPSTREAM_PROVIDER_HOSTS_CACHE
+    if _UPSTREAM_PROVIDER_HOSTS_CACHE is not None:
+        return _UPSTREAM_PROVIDER_HOSTS_CACHE
+
+    data = fetch_models_dev()
+    raw_index: Dict[str, list] = {}
+    for pid, pdata in data.items():
+        if not isinstance(pdata, dict):
+            continue
+        host = base_url_hostname(pdata.get("api") or "")
+        if not host:
+            continue
+        raw_index.setdefault(host, []).append(pid)
+
+    index = {
+        host: pids[0]
+        for host, pids in raw_index.items()
+        if len(pids) == 1
+    }
+    _UPSTREAM_PROVIDER_HOSTS_CACHE = index
+    return index
+
+
+def _reset_upstream_provider_host_index_cache() -> None:
+    """Drop the lazily-built host index (test/refresh hook)."""
+    global _UPSTREAM_PROVIDER_HOSTS_CACHE
+    _UPSTREAM_PROVIDER_HOSTS_CACHE = None
 
 
 def upstream_provider_id_for_base_url(base_url: Optional[str]) -> Optional[str]:
     """Return the models.dev provider id for a custom endpoint's base URL.
 
-    Returns ``None`` when the host is not a recognized upstream provider, so an
-    unrelated endpoint never inherits a vendor's catalog pricing.  Callers that
-    want the catalog short-circuit must validate identity here rather than from
-    the ``custom:<name>`` slug.
+    Resolves identity from the registry's per-provider ``api`` host, never the
+    ``custom:<name>`` slug. Returns ``None`` when the host is unrecognized or
+    shared/aggregated, so an unrelated endpoint never inherits a vendor's catalog.
     """
     if not base_url:
         return None
-    for host, mdev_id in _UPSTREAM_PROVIDER_HOSTS.items():
-        if base_url_host_matches(base_url, host):
-            return mdev_id
-    return None
+    host = base_url_hostname(base_url)
+    if not host:
+        return None
+    return _upstream_provider_host_index().get(host)
 
 
 def get_model_info(

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -704,6 +704,13 @@ def get_model_info(
 
     data = fetch_models_dev()
     pdata = data.get(mdev_id)
+    if not isinstance(pdata, dict) and provider_id.startswith("custom:"):
+        # Custom providers are slugged "custom:<name>"; retry with the bare
+        # name so a custom endpoint that mirrors a known models.dev provider
+        # (e.g. "custom:friendli" -> "friendli") resolves to real pricing.
+        bare = provider_id.split(":", 1)[1]
+        mdev_id = PROVIDER_TO_MODELS_DEV.get(bare, bare)
+        pdata = data.get(mdev_id)
     if not isinstance(pdata, dict):
         return None
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from utils import atomic_json_write
+from utils import atomic_json_write, base_url_host_matches
 
 import requests
 
@@ -692,6 +692,36 @@ def get_provider_info(provider_id: str) -> Optional[ProviderInfo]:
 # Model-level queries (rich ModelInfo)
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Custom-endpoint provider validation
+# ---------------------------------------------------------------------------
+
+# Known upstream providers mapped to the API host(s) they serve from.  A custom
+# endpoint is resolved to a vendor's catalog ONLY when its ``base_url`` host
+# matches one of these — display-name matching risks mis-assigning pricing,
+# limits and capabilities to an unrelated endpoint that merely shares a name
+# (e.g. a custom endpoint named "friendli" pointed at a different host).
+_UPSTREAM_PROVIDER_HOSTS: Dict[str, str] = {
+    "api.friendli.ai": "friendli",
+}
+
+
+def upstream_provider_id_for_base_url(base_url: Optional[str]) -> Optional[str]:
+    """Return the models.dev provider id for a custom endpoint's base URL.
+
+    Returns ``None`` when the host is not a recognized upstream provider, so an
+    unrelated endpoint never inherits a vendor's catalog pricing.  Callers that
+    want the catalog short-circuit must validate identity here rather than from
+    the ``custom:<name>`` slug.
+    """
+    if not base_url:
+        return None
+    for host, mdev_id in _UPSTREAM_PROVIDER_HOSTS.items():
+        if base_url_host_matches(base_url, host):
+            return mdev_id
+    return None
+
+
 def get_model_info(
     provider_id: str, model_id: str
 ) -> Optional[ModelInfo]:
@@ -699,18 +729,16 @@ def get_model_info(
 
     Accepts Hermes or models.dev provider ID.  Tries exact match then
     case-insensitive fallback.  Returns None if not found.
+
+    A ``custom:<name>`` provider slug is a user-chosen display name, not a
+    verified vendor identity, so it intentionally does *not* match the catalog
+    here — resolving a custom endpoint to a vendor's pricing must go through
+    ``upstream_provider_id_for_base_url`` (host-validated), never the bare name.
     """
     mdev_id = PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
 
     data = fetch_models_dev()
     pdata = data.get(mdev_id)
-    if not isinstance(pdata, dict) and provider_id.startswith("custom:"):
-        # Custom providers are slugged "custom:<name>"; retry with the bare
-        # name so a custom endpoint that mirrors a known models.dev provider
-        # (e.g. "custom:friendli" -> "friendli") resolves to real pricing.
-        bare = provider_id.split(":", 1)[1]
-        mdev_id = PROVIDER_TO_MODELS_DEV.get(bare, bare)
-        pdata = data.get(mdev_id)
     if not isinstance(pdata, dict):
         return None
 

--- a/hermes_cli/model_cost_guard.py
+++ b/hermes_cli/model_cost_guard.py
@@ -72,13 +72,24 @@ def expensive_model_warning(
         return None
 
     input_cost, output_cost, source = _pricing_from_model_info(model_info)
-    if input_cost is None and output_cost is None and provider:
+    if input_cost is None and output_cost is None:
         try:
-            from agent.models_dev import get_model_info
-
-            input_cost, output_cost, source = _pricing_from_model_info(
-                get_model_info(provider, model)
+            from agent.models_dev import (
+                get_model_info,
+                upstream_provider_id_for_base_url,
             )
+
+            # Resolve vendor identity from the endpoint's base_url, never the
+            # ``custom:<name>`` slug: an unrelated endpoint named "friendli"
+            # pointed elsewhere must not inherit Friendli pricing.  A genuine
+            # custom endpoint whose host matches a known upstream provider (e.g.
+            # api.friendli.ai) resolves to that vendor's catalog short-circuiting
+            # the per-endpoint pricing path, which is otherwise unit-blind.
+            resolved = upstream_provider_id_for_base_url(base_url) or provider
+            if resolved:
+                input_cost, output_cost, source = _pricing_from_model_info(
+                    get_model_info(resolved, model)
+                )
         except Exception:
             pass
     if input_cost is None and output_cost is None:

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -418,6 +418,7 @@ class TestCustomEndpointProviderValidation:
         "friendli": {
             "id": "friendli",
             "name": "Friendli",
+            "api": "https://api.friendli.ai/serverless/v1",
             "models": {
                 "zai-org/GLM-5.2": {
                     "id": "zai-org/GLM-5.2",
@@ -439,31 +440,62 @@ class TestCustomEndpointProviderValidation:
             assert get_model_info("custom:friendli", "zai-org/GLM-5.2") is None
 
     def test_upstream_provider_resolved_from_base_url_host(self):
-        from agent.models_dev import upstream_provider_id_for_base_url
-
-        assert (
-            upstream_provider_id_for_base_url("https://api.friendli.ai/serverless/v1")
-            == "friendli"
+        from agent.models_dev import (
+            upstream_provider_id_for_base_url,
+            _reset_upstream_provider_host_index_cache,
         )
-        assert upstream_provider_id_for_base_url("https://api.friendli.ai") == "friendli"
+
+        _reset_upstream_provider_host_index_cache()
+        with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
+            assert (
+                upstream_provider_id_for_base_url("https://api.friendli.ai/serverless/v1")
+                == "friendli"
+            )
+            assert upstream_provider_id_for_base_url("https://api.friendli.ai") == "friendli"
 
     def test_unrelated_host_is_not_validated_as_friendli(self):
-        from agent.models_dev import upstream_provider_id_for_base_url
+        from agent.models_dev import (
+            upstream_provider_id_for_base_url,
+            _reset_upstream_provider_host_index_cache,
+        )
 
-        # Substring tricks and a same-named-but-different host must not validate.
-        assert upstream_provider_id_for_base_url("https://api.friendli.ai.evil/v1") is None
-        assert upstream_provider_id_for_base_url("https://evil.com/api.friendli.ai/v1") is None
-        assert upstream_provider_id_for_base_url(None) is None
-        assert upstream_provider_id_for_base_url("") is None
+        _reset_upstream_provider_host_index_cache()
+        with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
+            # Substring tricks and a same-named-but-different host must not
+            # validate — exact-host match against the registered API host only.
+            assert upstream_provider_id_for_base_url("https://api.friendli.ai.evil/v1") is None
+            assert upstream_provider_id_for_base_url("https://evil.com/api.friendli.ai/v1") is None
+            assert upstream_provider_id_for_base_url(None) is None
+            assert upstream_provider_id_for_base_url("") is None
+
+    def test_shared_aggregator_host_is_not_indexed(self):
+        from agent.models_dev import (
+            upstream_provider_id_for_base_url,
+            _reset_upstream_provider_host_index_cache,
+        )
+
+        # Two providers sharing one API host (an aggregator exposing many
+        # vendors) carry no single upstream identity: unindexed, returns None.
+        shared = {
+            "vendora": {"api": "https://gateway.example/v1", "models": {}},
+            "vendorb": {"api": "https://gateway.example/v1", "models": {}},
+        }
+        _reset_upstream_provider_host_index_cache()
+        with patch("agent.models_dev.fetch_models_dev", return_value=shared):
+            assert upstream_provider_id_for_base_url("https://gateway.example/v1") is None
 
     def test_validated_base_url_resolves_custom_endpoint_to_catalog(self):
-        from agent.models_dev import get_model_info, upstream_provider_id_for_base_url
+        from agent.models_dev import (
+            get_model_info,
+            upstream_provider_id_for_base_url,
+            _reset_upstream_provider_host_index_cache,
+        )
 
         base_url = "https://api.friendli.ai/serverless/v1"
-        resolved = upstream_provider_id_for_base_url(base_url)
-        assert resolved == "friendli"
-
+        _reset_upstream_provider_host_index_cache()
         with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
+            resolved = upstream_provider_id_for_base_url(base_url)
+            assert resolved == "friendli"
             info = get_model_info(resolved, "zai-org/GLM-5.2")
 
         assert info is not None

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -403,11 +403,15 @@ class TestGetModelCapabilities:
         assert caps is None
 
 
-class TestGetModelInfoCustomSlug:
-    """A ``custom:<name>`` provider slug must resolve to the same models.dev
-    entry as the bare name when ``<name>`` is a known provider, so custom
-    endpoints that mirror a catalog provider (e.g. Friendli) get real pricing
-    instead of falling through to the per-endpoint pricing path.
+class TestCustomEndpointProviderValidation:
+    """A ``custom:<name>`` slug is a display name, not a verified vendor
+    identity, so it must NOT match the catalog by name — only a host-validated
+    ``base_url`` may resolve a custom endpoint to a vendor's models.dev entry.
+
+    This is the Friendli route: ``api.friendli.ai`` is Friendli's own Model
+    API host, so an endpoint pointed there resolves to the ``friendli`` catalog
+    (per-million pricing) and never reaches the unit-blind per-endpoint path.
+    An unrelated endpoint merely *named* ``friendli`` must not inherit it.
     """
 
     REGISTRY = {
@@ -424,22 +428,45 @@ class TestGetModelInfoCustomSlug:
         },
     }
 
-    def test_custom_slug_resolves_to_bare_provider(self):
+    def test_display_name_slug_does_not_match_catalog(self):
         from agent.models_dev import get_model_info
 
         with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
-            bare = get_model_info("friendli", "zai-org/GLM-5.2")
-            slugged = get_model_info("custom:friendli", "zai-org/GLM-5.2")
+            # The bare name resolves; the "custom:friendli" slug deliberately
+            # does not, so an unrelated endpoint named "friendli" cannot pull
+            # Friendli pricing out of its display name alone.
+            assert get_model_info("friendli", "zai-org/GLM-5.2") is not None
+            assert get_model_info("custom:friendli", "zai-org/GLM-5.2") is None
 
-        assert bare is not None
-        assert slugged is not None
-        # Invariant: the custom slug yields identical pricing to the bare name.
-        assert slugged.cost_input == bare.cost_input
-        assert slugged.cost_output == bare.cost_output
-        assert slugged.provider_id == bare.provider_id
+    def test_upstream_provider_resolved_from_base_url_host(self):
+        from agent.models_dev import upstream_provider_id_for_base_url
 
-    def test_custom_slug_unknown_provider_returns_none(self):
-        from agent.models_dev import get_model_info
+        assert (
+            upstream_provider_id_for_base_url("https://api.friendli.ai/serverless/v1")
+            == "friendli"
+        )
+        assert upstream_provider_id_for_base_url("https://api.friendli.ai") == "friendli"
+
+    def test_unrelated_host_is_not_validated_as_friendli(self):
+        from agent.models_dev import upstream_provider_id_for_base_url
+
+        # Substring tricks and a same-named-but-different host must not validate.
+        assert upstream_provider_id_for_base_url("https://api.friendli.ai.evil/v1") is None
+        assert upstream_provider_id_for_base_url("https://evil.com/api.friendli.ai/v1") is None
+        assert upstream_provider_id_for_base_url(None) is None
+        assert upstream_provider_id_for_base_url("") is None
+
+    def test_validated_base_url_resolves_custom_endpoint_to_catalog(self):
+        from agent.models_dev import get_model_info, upstream_provider_id_for_base_url
+
+        base_url = "https://api.friendli.ai/serverless/v1"
+        resolved = upstream_provider_id_for_base_url(base_url)
+        assert resolved == "friendli"
 
         with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
-            assert get_model_info("custom:not-a-provider", "zai-org/GLM-5.2") is None
+            info = get_model_info(resolved, "zai-org/GLM-5.2")
+
+        assert info is not None
+        # Per-million models.dev pricing, *not* re-scaled by the endpoint path.
+        assert info.cost_input == 1.4
+        assert info.cost_output == 4.4

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -401,3 +401,45 @@ class TestGetModelCapabilities:
         with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
             caps = get_model_capabilities("anthropic", "nonexistent-model")
         assert caps is None
+
+
+class TestGetModelInfoCustomSlug:
+    """A ``custom:<name>`` provider slug must resolve to the same models.dev
+    entry as the bare name when ``<name>`` is a known provider, so custom
+    endpoints that mirror a catalog provider (e.g. Friendli) get real pricing
+    instead of falling through to the per-endpoint pricing path.
+    """
+
+    REGISTRY = {
+        "friendli": {
+            "id": "friendli",
+            "name": "Friendli",
+            "models": {
+                "zai-org/GLM-5.2": {
+                    "id": "zai-org/GLM-5.2",
+                    "cost": {"input": 1.4, "output": 4.4},
+                    "limit": {"context": 1048576, "output": 1048576},
+                },
+            },
+        },
+    }
+
+    def test_custom_slug_resolves_to_bare_provider(self):
+        from agent.models_dev import get_model_info
+
+        with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
+            bare = get_model_info("friendli", "zai-org/GLM-5.2")
+            slugged = get_model_info("custom:friendli", "zai-org/GLM-5.2")
+
+        assert bare is not None
+        assert slugged is not None
+        # Invariant: the custom slug yields identical pricing to the bare name.
+        assert slugged.cost_input == bare.cost_input
+        assert slugged.cost_output == bare.cost_output
+        assert slugged.provider_id == bare.provider_id
+
+    def test_custom_slug_unknown_provider_returns_none(self):
+        from agent.models_dev import get_model_info
+
+        with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
+            assert get_model_info("custom:not-a-provider", "zai-org/GLM-5.2") is None

--- a/tests/hermes_cli/test_model_cost_guard.py
+++ b/tests/hermes_cli/test_model_cost_guard.py
@@ -110,6 +110,7 @@ _FRIENDLI_REGISTRY = {
     "friendli": {
         "id": "friendli",
         "name": "Friendli",
+        "api": "https://api.friendli.ai/serverless/v1",
         "models": {
             "zai-org/GLM-5.2": {
                 "id": "zai-org/GLM-5.2",
@@ -133,6 +134,9 @@ def test_mapped_custom_friendli_endpoint_does_not_spuriously_trip(monkeypatch):
     host (``api.friendli.ai``) resolves it to the ``friendli`` catalog instead,
     so a $1.4/M model does NOT trip the $20/M threshold.
     """
+    from agent.models_dev import _reset_upstream_provider_host_index_cache
+
+    _reset_upstream_provider_host_index_cache()
     monkeypatch.setattr(
         "agent.models_dev.fetch_models_dev",
         lambda: _FRIENDLI_REGISTRY,
@@ -152,6 +156,9 @@ def test_mapped_custom_friendli_endpoint_uses_catalog_per_million_pricing(monkey
     warning carries the real per-million value ($50/M), not the $50,000,000/M
     the unit-blind endpoint path would have produced.
     """
+    from agent.models_dev import _reset_upstream_provider_host_index_cache
+
+    _reset_upstream_provider_host_index_cache()
     monkeypatch.setattr(
         "agent.models_dev.fetch_models_dev",
         lambda: _FRIENDLI_REGISTRY,
@@ -175,7 +182,11 @@ def test_imposter_friendli_endpoint_does_not_inherit_friendli_pricing(monkeypatc
     is the base_url, not the display name.  It falls through to the per-token
     endpoint pricing path instead.
     """
-    # No friendli catalog entry is consulted (host does not match).
+    from agent.models_dev import _reset_upstream_provider_host_index_cache
+
+    # The friendli registry is loaded, but the imposter host does not match the
+    # registered ``api.friendli.ai`` host, so no vendor identity is assigned.
+    _reset_upstream_provider_host_index_cache()
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: _FRIENDLI_REGISTRY)
     endpoint_meta = {
         # resolve_billing_route strips the "zai-org/" prefix for the slug

--- a/tests/hermes_cli/test_model_cost_guard.py
+++ b/tests/hermes_cli/test_model_cost_guard.py
@@ -95,3 +95,106 @@ def test_openai_gpt55_pro_warns_for_nous_portal_pricing(monkeypatch):
     assert warning.input_cost_per_million == Decimal("25.000000")
     assert warning.output_cost_per_million == Decimal("125.000000")
     assert "did you mean to select openai/gpt-5.5?" in warning.message
+
+
+# ---------------------------------------------------------------------------
+# Custom-endpoint provider identity must be validated against the endpoint's
+# base_url, never its display-name slug.  Regression coverage requested in the
+# Friendli PR review: (1) the host-validated custom route resolves to the
+# vendor's models.dev catalog (per-million pricing), and (2) a catalog miss —
+# an endpoint the host map does not recognize — falls through to the per-token
+# endpoint pricing path rather than mis-assigning a vendor's pricing.
+# ---------------------------------------------------------------------------
+
+_FRIENDLI_REGISTRY = {
+    "friendli": {
+        "id": "friendli",
+        "name": "Friendli",
+        "models": {
+            "zai-org/GLM-5.2": {
+                "id": "zai-org/GLM-5.2",
+                "cost": {"input": 1.4, "output": 4.4},
+                "limit": {"context": 1048576, "output": 1048576},
+            },
+            "zai-org/GLM-5.2-premium": {
+                "id": "zai-org/GLM-5.2-premium",
+                "cost": {"input": 50.0, "output": 1.0},
+                "limit": {"context": 1048576, "output": 1048576},
+            },
+        },
+    },
+}
+
+
+def test_mapped_custom_friendli_endpoint_does_not_spuriously_trip(monkeypatch):
+    """The initial issue: a genuine Friendli custom endpoint resolved its
+    per-million ``/models`` pricing through the unit-blind endpoint path,
+    turning $1.4/M into $1,400,000/M and tripping the guard.  Validating the
+    host (``api.friendli.ai``) resolves it to the ``friendli`` catalog instead,
+    so a $1.4/M model does NOT trip the $20/M threshold.
+    """
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: _FRIENDLI_REGISTRY,
+    )
+
+    warning = expensive_model_warning(
+        "zai-org/GLM-5.2",
+        provider="custom:friendli",
+        base_url="https://api.friendli.ai/serverless/v1",
+    )
+
+    assert warning is None
+
+
+def test_mapped_custom_friendli_endpoint_uses_catalog_per_million_pricing(monkeypatch):
+    """When the mapped route's catalog price does exceed the threshold, the
+    warning carries the real per-million value ($50/M), not the $50,000,000/M
+    the unit-blind endpoint path would have produced.
+    """
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: _FRIENDLI_REGISTRY,
+    )
+
+    warning = expensive_model_warning(
+        "zai-org/GLM-5.2-premium",
+        provider="custom:friendli",
+        base_url="https://api.friendli.ai/serverless/v1",
+    )
+
+    assert warning is not None
+    assert warning.input_cost_per_million == Decimal("50.0")
+    # Per-million catalog value, NOT the $50,000,000/M a second ×1M would yield.
+    assert "Input tokens: $50.00/M" in warning.message
+
+
+def test_imposter_friendli_endpoint_does_not_inherit_friendli_pricing(monkeypatch):
+    """A catalog miss: an endpoint slugged ``custom:friendli`` but pointed at an
+    unrelated host must NOT pick up Friendli catalog pricing — vendor identity
+    is the base_url, not the display name.  It falls through to the per-token
+    endpoint pricing path instead.
+    """
+    # No friendli catalog entry is consulted (host does not match).
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: _FRIENDLI_REGISTRY)
+    endpoint_meta = {
+        # resolve_billing_route strips the "zai-org/" prefix for the slug
+        # fallback route, so alias under both keys (as the real fetcher does).
+        "zai-org/GLM-5.2": {"pricing": {"prompt": "0.000025", "completion": "0.00005"}},
+        "GLM-5.2": {"pricing": {"prompt": "0.000025", "completion": "0.00005"}},
+    }
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda base_url, api_key="": endpoint_meta,
+    )
+
+    warning = expensive_model_warning(
+        "zai-org/GLM-5.2",
+        provider="custom:friendli",
+        base_url="https://example-friendli-imposter.dev/v1",
+    )
+
+    assert warning is not None
+    # Endpoint path scales per-token by 1M: $0.000025/token -> $25/M, NOT $1.4/M
+    # (Friendli catalog) and NOT $25,000,000 (a second spurious ×1M).
+    assert warning.input_cost_per_million == Decimal("25.000000")


### PR DESCRIPTION
## Problem

Selecting a `custom_providers` model backed by Friendli (e.g. `zai-org/GLM-5.2`) trips the expensive-model guard with absurd pricing:

```
zai-org/GLM-5.2 has known pricing above Hermes' safety threshold.
Input tokens:  $1400000.00/M
Output tokens: $4400000.00/M
```

## Root cause

A `custom_providers` entry is slugged `custom:<name>` (via `custom_provider_slug`), so `target_provider` becomes e.g. `custom:friendli`. `get_model_info("custom:friendli", ...)` never matches the models.dev catalog key `friendli`, so the guard's preferred (correct) models.dev lookup misses and falls through to the per-endpoint pricing path.

That path (`_pricing_entry_from_metadata`) assumes OpenRouter's *per-token* convention and multiplies by 1e6. Friendli's `/v1/models` reports pricing **per million tokens** (`prompt: 1.4`), so `1.4 x 1_000_000 = $1,400,000/M` — affecting every Friendli model.

## Fix

In `get_model_info`, when a `custom:<name>` slug misses, retry the lookup with the bare `<name>`. Custom endpoints that mirror a known models.dev provider (Friendli, etc.) now resolve to real pricing and short-circuit before the unreliable endpoint path is ever reached. Minimal, additive, no behavior change for non-`custom:` providers.

## Verification

Reproduced end-to-end against a real config + live Friendli endpoint:

| Switching to `zai-org/GLM-5.2` via `custom:friendli` | Result |
|---|---|
| Before | WARNING FIRED — `$1400000.00/M` in, `$4400000.00/M` out |
| After  | no warning; pricing resolves to `1.4 / 4.4` from models.dev |

Tests: `scripts/run_tests.sh tests/agent/test_models_dev.py tests/hermes_cli/test_model_cost_guard.py tests/agent/test_usage_pricing.py` → **52 passed, 0 failed**. Adds 2 invariant tests asserting `custom:friendli` yields identical pricing to `friendli`, and that an unknown `custom:` slug still returns None.

## Note / follow-up

The underlying units bug in `_pricing_entry_from_metadata` (per-million treated as per-token) is still latent for custom endpoints models.dev does **not** know about. This PR fixes the reported symptom by the smallest change; a magnitude-guard on that function would be a sensible defense-in-depth follow-up.
