### PR TITLE
fix(codex): support pool usage and strict aux timeouts

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -438,9 +438,19 @@ def _resolve_codex_usage_url(base_url: str) -> str:
 
 def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
     creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-    token_data = _read_codex_tokens()
-    tokens = token_data.get("tokens") or {}
-    account_id = str(tokens.get("account_id", "") or "").strip() or None
+    account_id = str(creds.get("account_id", "") or "").strip() or None
+    if not account_id:
+        try:
+            token_data = _read_codex_tokens()
+            tokens = token_data.get("tokens") or {}
+            account_id = str(tokens.get("account_id", "") or "").strip() or None
+        except Exception:
+            # Credential-pool OAuth entries do not necessarily have a legacy
+            # single-account Codex token blob. The usage endpoint still works
+            # without ChatGPT-Account-Id for the active credential, so do not
+            # drop the whole /usage block just because that optional header is
+            # unavailable.
+            account_id = None
     headers = {
         "Authorization": f"Bearer {creds['api_key']}",
         "Accept": "application/json",
@@ -454,7 +464,7 @@ def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
-    for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
+    for key, label in (("primary_window", "5h"), ("secondary_window", "7d")):
         window = rate_limit.get(key) or {}
         used = window.get("used_percent")
         if used is None:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1025,9 +1025,18 @@ class _CodexCompletionsAdapter:
                 logger.debug("Codex auxiliary: cache eviction on timeout failed", exc_info=True)
 
         def _check_cancelled() -> None:
+            if timed_out.is_set():
+                raise TimeoutError(_timeout_message())
             if deadline is not None and time.monotonic() >= deadline:
                 if not timed_out.is_set():
                     _close_client_on_timeout()
+                raise TimeoutError(_timeout_message())
+            # Avoid spending the last few milliseconds of a strict total-timeout
+            # budget importing/checking the best-effort interrupt hook. Timeout
+            # enforcement is the hard contract here; interrupt handling can wait
+            # for the next event on very small budgets.
+            near_deadline_slack = min(0.05, float(total_timeout) * 0.5) if total_timeout else 0.0
+            if deadline is not None and deadline - time.monotonic() < near_deadline_slack:
                 raise TimeoutError(_timeout_message())
             try:
                 from tools.interrupt import is_interrupted
@@ -1043,6 +1052,10 @@ class _CodexCompletionsAdapter:
                 # Interrupt state is a best-effort UX hook; never make it a
                 # new failure mode for auxiliary calls.
                 pass
+            if timed_out.is_set() or (deadline is not None and time.monotonic() >= deadline):
+                if not timed_out.is_set():
+                    _close_client_on_timeout()
+                raise TimeoutError(_timeout_message())
 
         try:
             if total_timeout:

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -89,10 +89,58 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot is not None
     assert snapshot.plan == "Pro"
     assert len(snapshot.windows) == 2
-    assert snapshot.windows[0].label == "Session"
+    assert snapshot.windows[0].label == "5h"
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+
+
+def test_fetch_account_usage_codex_works_without_legacy_token_blob(monkeypatch):
+    seen_headers = {}
+
+    class _HeaderCaptureClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, headers=None):
+            seen_headers.update(headers or {})
+            return _Response(
+                {
+                    "plan_type": "team",
+                    "rate_limit": {
+                        "primary_window": {"used_percent": 99, "reset_at": 1_900_000_000},
+                        "secondary_window": {"used_percent": 10, "reset_at": 1_900_500_000},
+                    },
+                }
+            )
+
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "pool-access-token",
+            "source": "credential_pool",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage._read_codex_tokens",
+        lambda: (_ for _ in ()).throw(RuntimeError("no legacy codex token blob")),
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _HeaderCaptureClient(),
+    )
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert snapshot.plan == "Team"
+    assert [w.label for w in snapshot.windows] == ["5h", "7d"]
+    assert "ChatGPT-Account-Id" not in seen_headers
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():


### PR DESCRIPTION
## Summary

Fixes two Codex-account edge cases:

- allow `/usage` for OpenAI Codex credential-pool entries that do not have a legacy single-account token blob
- label Codex rate-limit windows using the provider's actual windows (`5h` / `7d`) instead of the ambiguous `Session` / `Weekly`
- make Codex auxiliary streaming honor strict total timeouts even when the stream keeps emitting non-terminal events near the deadline

## Why

Credential-pool OAuth entries can be valid for Codex usage calls while lacking the legacy token JSON that previously supplied `account_id`. The usage endpoint still works without `ChatGPT-Account-Id` for the active credential, so `/usage` should not disappear just because that optional header is unavailable.

The auxiliary timeout fix keeps compression/side-task calls from continuing past their requested wall-clock budget when a Responses stream remains alive but never completes.

## Tests

- `python -m pytest tests/test_account_usage.py tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events tests/agent/test_auxiliary_compression_timeout_floor.py -q`
- `python -m pytest tests/test_account_usage.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_compression_timeout_floor.py tests/gateway/test_tool_response_drop_recovery.py tests/cron/test_jobs.py -q` → 443 passed
- `python -m ruff check agent/auxiliary_client.py tests/test_account_usage.py`
- `python -m compileall agent hermes_cli gateway cron tools`
