### PR TITLE
fix(usage): fetch Codex account limits from credential pool (pool-only setups)

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -436,20 +436,53 @@ def _resolve_codex_usage_url(base_url: str) -> str:
     return normalized + "/api/codex/usage"
 
 
-def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
-    creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-    token_data = _read_codex_tokens()
-    tokens = token_data.get("tokens") or {}
-    account_id = str(tokens.get("account_id", "") or "").strip() or None
+def _resolve_codex_usage_credentials(
+    base_url: Optional[str],
+    api_key: Optional[str],
+) -> tuple[str, str, Optional[str]]:
+    """Resolve Codex quota credentials from the native runtime path.
+
+    Prefer explicit live-agent credentials, then the legacy singleton OAuth
+    state, then the credential pool.  Hermes's native OAuth setup now stores
+    device-code logins in the pool, so quota diagnostics must not depend only
+    on the older singleton store.
+    """
+    explicit_key = str(api_key or "").strip()
+    if explicit_key:
+        return explicit_key, str(base_url or "").strip(), None
+
+    try:
+        creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+        token_data = _read_codex_tokens()
+        tokens = token_data.get("tokens") or {}
+        account_id = str(tokens.get("account_id", "") or "").strip() or None
+        return creds["api_key"], str(creds.get("base_url", "") or "").strip(), account_id
+    except Exception:
+        pass
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    if entry is None:
+        raise RuntimeError("No available openai-codex credential in credential pool")
+    return entry.runtime_api_key, str(entry.runtime_base_url or base_url or "").strip(), None
+
+
+def _fetch_codex_account_usage(
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Optional[AccountUsageSnapshot]:
+    token, resolved_base_url, account_id = _resolve_codex_usage_credentials(base_url, api_key)
     headers = {
-        "Authorization": f"Bearer {creds['api_key']}",
+        "Authorization": f"Bearer {token}",
         "Accept": "application/json",
         "User-Agent": "codex-cli",
     }
     if account_id:
         headers["ChatGPT-Account-Id"] = account_id
     with httpx.Client(timeout=15.0) as client:
-        response = client.get(_resolve_codex_usage_url(creds.get("base_url", "")), headers=headers)
+        response = client.get(_resolve_codex_usage_url(resolved_base_url), headers=headers)
         response.raise_for_status()
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
@@ -628,7 +661,7 @@ def fetch_account_usage(
         return None
     try:
         if normalized == "openai-codex":
-            return _fetch_codex_account_usage()
+            return _fetch_codex_account_usage(base_url=base_url, api_key=api_key)
         if normalized == "anthropic":
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
-from hermes_cli.auth import _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.auth import AuthError, _read_codex_tokens, resolve_codex_runtime_credentials
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 if TYPE_CHECKING:
@@ -451,15 +451,40 @@ def _resolve_codex_usage_credentials(
     if explicit_key:
         return explicit_key, str(base_url or "").strip(), None
 
+    # Tier 2: the native runtime resolver. It ALREADY falls back to the
+    # credential pool when the singleton is empty (see
+    # ``resolve_codex_runtime_credentials`` — issue #32992), so in a pool-only
+    # setup this returns a usable ``source="credential_pool"`` token.
+    #
+    # Only ``AuthError`` ("no creds" / rate-limited) is caught so tier 3 can
+    # run: a broad ``except Exception`` would (a) mask a transient refresh /
+    # network failure and silently hand back a DIFFERENT pool account's usage,
+    # and (b) hide genuine programming errors. A refresh/network error must
+    # propagate — the outer ``fetch_account_usage`` guard fails open (shows
+    # nothing this turn) rather than reporting the wrong account.
+    #
+    # The ``account_id`` (for the ``ChatGPT-Account-Id`` header) is read
+    # best-effort: a partial/missing singleton token store must not sink an
+    # otherwise-usable resolver credential and force a header-less pool fallback.
     try:
         creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-        token_data = _read_codex_tokens()
-        tokens = token_data.get("tokens") or {}
-        account_id = str(tokens.get("account_id", "") or "").strip() or None
+        account_id: Optional[str] = None
+        try:
+            token_data = _read_codex_tokens()
+            tokens = token_data.get("tokens") or {}
+            account_id = str(tokens.get("account_id", "") or "").strip() or None
+        except AuthError:
+            # Pool-only creds carry no singleton account_id; header is optional.
+            logger.debug("codex ▸ /usage account_id read failed (best-effort)", exc_info=True)
         return creds["api_key"], str(creds.get("base_url", "") or "").strip(), account_id
-    except Exception:
-        pass
+    except AuthError:
+        logger.debug("codex ▸ /usage runtime resolver returned no creds; trying pool", exc_info=True)
 
+    # Tier 3: direct pool select. Reached only when the resolver itself raises
+    # AuthError (e.g. singleton missing AND its own pool read found nothing at
+    # resolve time, but a pool entry is usable now). Pool credentials have no
+    # account_id concept, so the ChatGPT-Account-Id header is intentionally
+    # omitted here.
     from agent.credential_pool import load_pool
 
     pool = load_pool("openai-codex")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "spiky02plateau@users.noreply.github.com": "spiky02plateau",  # PR #32824 salvage (usage: fetch Codex account limits from the credential pool in pool-only setups; superseded by #60028)
     "taylorhp@gmail.com": "hwrdprkns",  # PR #36896 salvage (secrets: 1Password op:// secret source + shared _cache substrate, adapted onto the SecretSource interface)
     "ishengeqi@163.com": "isheng-eqi",  # PR #59428 salvage (cron: reject past one-shot timestamps in update_job fallback + resume_job; #59395). Also PR #59446 salvage (cron: advance one-shot next_run_at before dispatch so concurrent gateway+desktop schedulers can't double-execute; #59229).
     "derek2000139@qq.com": "derek2000139",  # PR #57838 salvage (desktop/windows: pre-write update marker before quit dwell so the renderer's waitForUpdateToFinish gate parks instead of respawning a backend that re-locks venv .pyd files mid-update)

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -108,3 +108,46 @@ def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usa
     assert snapshot.windows[1].label == "Weekly"
     assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
     assert calls[0]["headers"]["Authorization"] == "Bearer pooled-token"
+
+
+def test_codex_usage_treats_wham_used_percent_as_used_not_remaining(monkeypatch):
+    """ChatGPT UI says "left"; /wham/usage.used_percent is already used."""
+    payload = {
+        "plan_type": "plus",
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 85,
+                "reset_at": 1779846359,
+            },
+            "secondary_window": {
+                "used_percent": 14,
+                "reset_at": 1780230796,
+            },
+        },
+        "credits": {"has_credits": False},
+    }
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, payload),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_codex_runtime_credentials",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("explicit auth should be used")),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert [window.used_percent for window in snapshot.windows] == [85, 14]
+    rendered = "\n".join(account_usage.render_account_usage_lines(snapshot, markdown=True))
+    assert "85% used" in rendered
+    assert "14% used" in rendered
+    assert "15% used" not in rendered
+    assert "86% used" not in rendered

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -85,10 +85,15 @@ def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usa
         "Client",
         lambda timeout: _FakeClient(calls, codex_usage_payload),
     )
+    # Pool fallback fires only on AuthError (the documented "no creds" mode of
+    # the resolver), NOT on arbitrary exceptions — see the transient-error guard
+    # test below.
     monkeypatch.setattr(
         account_usage,
         "resolve_codex_runtime_credentials",
-        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("no singleton auth")),
+        lambda **kwargs: (_ for _ in ()).throw(
+            account_usage.AuthError("no singleton auth", provider="openai-codex", code="codex_auth_missing")
+        ),
     )
 
     pool_entry = SimpleNamespace(
@@ -108,6 +113,85 @@ def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usa
     assert snapshot.windows[1].label == "Weekly"
     assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
     assert calls[0]["headers"]["Authorization"] == "Bearer pooled-token"
+    # Pool creds have no account_id concept — the ChatGPT-Account-Id header must
+    # be omitted rather than sent stale/wrong.
+    assert "ChatGPT-Account-Id" not in calls[0]["headers"]
+
+
+def test_codex_usage_does_not_swap_to_pool_on_transient_resolver_error(monkeypatch, codex_usage_payload):
+    """A transient refresh/network failure (non-AuthError) must NOT silently
+    downgrade to a possibly-different pool account. It fails open (no snapshot)
+    instead of reporting the wrong account's usage."""
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_codex_runtime_credentials",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("refresh endpoint 503")),
+    )
+
+    pool_entry = SimpleNamespace(
+        runtime_api_key="pooled-token-WRONG-ACCOUNT",
+        runtime_base_url="https://chatgpt.com/backend-api/codex",
+    )
+    pool = SimpleNamespace(select=lambda: pool_entry)
+
+    import agent.credential_pool as credential_pool
+
+    # If the guard regressed, this pool would be consulted and return a snapshot
+    # for the wrong account. It must NOT be.
+    monkeypatch.setattr(credential_pool, "load_pool", lambda provider: pool)
+
+    snapshot = account_usage.fetch_account_usage("openai-codex")
+
+    assert snapshot is None
+    assert calls == []  # HTTP usage endpoint never hit with a wrong-account token
+
+
+def test_codex_usage_account_id_read_failure_keeps_singleton_token(monkeypatch, codex_usage_payload):
+    """When the resolver succeeds but the separate account_id read raises, the
+    working singleton token must still be used (best-effort account_id), NOT
+    abandoned in favor of a header-less pool credential."""
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_codex_runtime_credentials",
+        lambda **kwargs: {
+            "api_key": "singleton-token",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "_read_codex_tokens",
+        lambda *a, **k: (_ for _ in ()).throw(
+            account_usage.AuthError("partial store", provider="openai-codex", code="codex_auth_invalid_shape")
+        ),
+    )
+
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "load_pool",
+        lambda provider: (_ for _ in ()).throw(AssertionError("pool must not be consulted")),
+    )
+
+    snapshot = account_usage.fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert calls[0]["headers"]["Authorization"] == "Bearer singleton-token"
+    # account_id read failed → header omitted, but the singleton token is kept.
+    assert "ChatGPT-Account-Id" not in calls[0]["headers"]
 
 
 def test_codex_usage_treats_wham_used_percent_as_used_not_remaining(monkeypatch):

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -1,0 +1,110 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent import account_usage
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, calls, payload):
+        self.calls = calls
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get(self, url, headers):
+        self.calls.append({"url": url, "headers": headers})
+        return _FakeResponse(self.payload)
+
+
+@pytest.fixture
+def codex_usage_payload():
+    return {
+        "plan_type": "plus",
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 21,
+                "reset_at": 1779846359,
+            },
+            "secondary_window": {
+                "used_percent": 4,
+                "reset_at": 1780230796,
+            },
+        },
+        "credits": {"has_credits": False},
+    }
+
+
+def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_usage_payload):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_codex_runtime_credentials",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("legacy auth should not be used")),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.provider == "openai-codex"
+    assert snapshot.plan == "Plus"
+    assert [w.label for w in snapshot.windows] == ["Session", "Weekly"]
+    assert snapshot.windows[0].used_percent == 21
+    assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
+    assert calls[0]["headers"]["Authorization"] == "Bearer live-agent-token"
+
+
+def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usage_payload):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_codex_runtime_credentials",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("no singleton auth")),
+    )
+
+    pool_entry = SimpleNamespace(
+        runtime_api_key="pooled-token",
+        runtime_base_url="https://chatgpt.com/backend-api/codex",
+    )
+    pool = SimpleNamespace(select=lambda: pool_entry)
+
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(credential_pool, "load_pool", lambda provider: pool)
+
+    snapshot = account_usage.fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert snapshot.windows[0].label == "Session"
+    assert snapshot.windows[1].label == "Weekly"
+    assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
+    assert calls[0]["headers"]["Authorization"] == "Bearer pooled-token"


### PR DESCRIPTION
## Summary

Fixes `/usage` omitting Codex account limits when the OAuth credential lives only in the native credential pool (created by `hermes auth add openai-codex --type oauth`) rather than the legacy singleton auth store.

Salvages and hardens #32824 by @spiky02plateau (rebased onto current `main`; the original base was ~5,000 commits behind). Original authorship preserved via cherry-pick.

## The bug (verified on current `main`)

`resolve_codex_runtime_credentials()` already pool-falls-back when the singleton store is empty (landed via #32992). But `_fetch_codex_account_usage()` made a **second, unguarded** direct call to `_read_codex_tokens()` — only to read `account_id` — which raises `AuthError` in pool-only setups. That threw before the HTTP call, so `/usage` silently dropped the Codex limits section even though runtime inference worked fine.

## Fix

`_fetch_codex_account_usage()` now resolves credentials through `_resolve_codex_usage_credentials()` in three tiers:

1. explicit live-agent credentials passed to `fetch_account_usage()`;
2. the native runtime resolver (singleton, with its own pool fallback) — with `account_id` read **best-effort** so a partial/missing token store can't sink an otherwise-usable credential;
3. direct `load_pool("openai-codex").select()` as a last resort.

The outer catch is scoped to **`AuthError`** (the documented "no creds" mode of both functions), not a broad `except Exception`. This is deliberate hardening over the original salvage:

- A transient refresh/network failure now **propagates** (fails open via the outer `fetch_account_usage` guard) instead of silently downgrading to a *different* pool account's usage.
- `PooledCredential` has no `account_id` concept, so the pool tier intentionally omits the `ChatGPT-Account-Id` header; the singleton tier is no longer abandoned just because the `account_id` read failed.
- Programming errors (`TypeError`/`KeyError`) are no longer masked.

## Tests

`tests/agent/test_account_usage.py` (behavior contracts, not snapshots):
- explicit live-agent credentials preferred;
- fallback to the native credential pool on `AuthError` (asserts no `ChatGPT-Account-Id` header on pool tier);
- **new guard:** a non-`AuthError` (transient) resolver failure must NOT swap to the pool — fails open, HTTP endpoint never hit with a wrong-account token;
- **new guard:** an `account_id` read failure keeps the working singleton token;
- `/wham/usage.used_percent` is treated as *used*, not remaining/left.

Existing pool-fallback test updated to raise `AuthError` (the real failure mode) instead of a generic `RuntimeError`, reflecting the corrected contract.

Ran (all green on current `main`):

```
pytest tests/agent/ -k "usage or codex or credential_pool" tests/test_account_usage.py tests/gateway/test_usage_command.py
540 passed, 4862 deselected
```

Supersedes #32824.

Co-authored-by: spiky02plateau <spiky02plateau@users.noreply.github.com>
