### PR TITLE
fix(mcp): catch RuntimeError when cancelling tasks on a closed event loop

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1837,7 +1837,10 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
+                    try:
+                        t.cancel()
+                    except RuntimeError:
+                        pass  # Event loop already closed — nothing to clean up
                     try:
                         await t
                     except (asyncio.CancelledError, Exception):
@@ -1881,7 +1884,10 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
+                    try:
+                        t.cancel()
+                    except RuntimeError:
+                        pass  # Event loop already closed — nothing to clean up
                     try:
                         await t
                     except (asyncio.CancelledError, Exception):


### PR DESCRIPTION
## Problem

When Hermes exits and an MCP server is in the parked state (initial connection failed), the `_wait_for_reconnect_or_shutdown` and `_wait_for_lifecycle_event` methods' finally blocks call `t.cancel()` on pending asyncio tasks. A race in `shutdown_mcp_servers()` can cause the event loop to be closed by `_stop_mcp_loop()` before the finally block finishes executing:

1. `shutdown_mcp_servers()` schedules `_shutdown()` on the MCP loop, with a 15-second timeout
2. Inside `_shutdown()`, all servers are shut down in parallel via `asyncio.gather`
3. If shutdown takes longer than 15s (e.g. a parked server is mid-cycle), `future.result(timeout=15)` times out
4. `_stop_mcp_loop()` closes the event loop while the server's finally block is mid-execution
5. `t.cancel()` → `call_soon()` → `_check_closed()` raises `RuntimeError: Event loop is closed`

This surfaces as an `Exception ignored in` warning during Python GC at exit:

```
Exception ignored in: <coroutine object MCPServerTask.run at 0x...>
Traceback (most recent call last):
  File "mcp_tool.py", line 2590, in run
    parked = await self._wait_for_reconnect_or_shutdown(...)
  File "mcp_tool.py", line 1884, in _wait_for_reconnect_or_shutdown
    t.cancel()
  File "base_events.py", line 762, in call_soon
    self._check_closed()
RuntimeError: Event loop is closed
```

The program shuts down correctly; the traceback is just noisy.

## Fix

Wrap `t.cancel()` in `try/except RuntimeError` in both `_wait_for_lifecycle_event` and `_wait_for_reconnect_or_shutdown`. When the loop is already closed there is nothing to clean up, so silently passing is correct. The subsequent `await t` is already guarded by `except (CancelledError, Exception)` which catches RuntimeError as well.

## Testing

Verified on macOS 15.7 with Python 3.11.15 — the `RuntimeError` traceback no longer appears on exit.