### PR TITLE
fix(cron): add whatsapp_cloud to _KNOWN_DELIVERY_PLATFORMS

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -202,7 +202,7 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
-    "telegram", "discord", "slack", "whatsapp", "signal",
+    "telegram", "discord", "slack", "whatsapp", "whatsapp_cloud", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
     "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
     "qqbot", "yuanbao",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -4066,10 +4066,11 @@ class TestHomeTargetEnvVarRegistry:
         """``deliver=whatsapp_cloud`` routes through
         WHATSAPP_CLOUD_HOME_CHANNEL — added alongside the existing
         ``whatsapp`` Baileys entry."""
-        from cron.scheduler import _HOME_TARGET_ENV_VARS
+        from cron.scheduler import _HOME_TARGET_ENV_VARS, _KNOWN_DELIVERY_PLATFORMS
 
         assert "whatsapp_cloud" in _HOME_TARGET_ENV_VARS
         assert _HOME_TARGET_ENV_VARS["whatsapp_cloud"] == "WHATSAPP_CLOUD_HOME_CHANNEL"
+        assert "whatsapp_cloud" in _KNOWN_DELIVERY_PLATFORMS
 
     def test_baileys_whatsapp_still_registered(self):
         """Sanity guard: the Cloud addition didn't disturb Baileys


### PR DESCRIPTION
## What does this PR do?

`whatsapp_cloud` was added to `_HOME_TARGET_ENV_VARS` and the `Platform` enum, but `_KNOWN_DELIVERY_PLATFORMS` was not updated during the initial implementation. This omission caused cron delivery validation to fail for `whatsapp_cloud` jobs with a cryptic "unknown platform" error, even though the platform is fully supported in the gateway.

This PR adds `"whatsapp_cloud"` to `_KNOWN_DELIVERY_PLATFORMS` and updates the existing `test_whatsapp_cloud_registered()` test to assert this invariant, preventing future regressions.

## Related Issue

Fixes #59988

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Add `"whatsapp_cloud"` to `_KNOWN_DELIVERY_PLATFORMS` frozenset
- `tests/cron/test_scheduler.py`: Import `_KNOWN_DELIVERY_PLATFORMS` and add assertion `assert "whatsapp_cloud" in _KNOWN_DELIVERY_PLATFORMS`

## How to Test

1. Run the updated test: `pytest tests/cron/test_scheduler.py -k test_whatsapp_cloud_registered -xvs`
   - Observed result: Test passes, confirming `whatsapp_cloud` is now in both `_HOME_TARGET_ENV_VARS` and `_KNOWN_DELIVERY_PLATFORMS`
2. Verify the validation function accepts `whatsapp_cloud`:
   ```python
   from cron.scheduler import _is_known_delivery_platform
   assert _is_known_delivery_platform("whatsapp_cloud") is True
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
