### PR TITLE
fix(sessions): scope title uniqueness per source (closes #60020)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1552,14 +1552,27 @@ class SessionDB:
                     (SCHEMA_VERSION,),
                 )
 
-        # Unique title index — always ensure it exists
+        # Unique title index — scoped per source so that TUI, desktop, CLI,
+        # and gateway sessions don't block each other's renames.
+        # Migration runs once: check sqlite_master for the old global index
+        # definition and only rebuild when it's present.
         try:
-            cursor.execute(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_title_unique "
-                "ON sessions(title) WHERE title IS NOT NULL"
-            )
+            row = cursor.execute(
+                "SELECT sql FROM sqlite_master "
+                "WHERE type='index' AND name='idx_sessions_title_unique'"
+            ).fetchone()
+            existing_sql = row["sql"] if row else ""
+            needs_rebuild = not existing_sql or "source" not in existing_sql
+            if needs_rebuild:
+                cursor.execute(
+                    "DROP INDEX IF EXISTS idx_sessions_title_unique"
+                )
+                cursor.execute(
+                    "CREATE UNIQUE INDEX idx_sessions_title_unique "
+                    "ON sessions(source, title) WHERE title IS NOT NULL"
+                )
         except sqlite3.OperationalError:
-            pass  # Index already exists
+            pass  # Concurrent access or index already correct
 
         if fts5_available:
             # FTS5 setup. Run the DDL even when the virtual table exists so
@@ -2707,10 +2720,15 @@ class SessionDB:
         title = self.sanitize_title(title)
         def _do(conn):
             if title:
-                # Check uniqueness (allow the same session to keep its own title)
+                # Check uniqueness (allow the same session to keep its own
+                # title).  Scoped per source so that TUI, desktop, CLI, and
+                # gateway sessions don't block each other's renames — only
+                # a collision within the same source is an error.
                 cursor = conn.execute(
-                    "SELECT id FROM sessions WHERE title = ? AND id != ?",
-                    (title, session_id),
+                    "SELECT id FROM sessions "
+                    "WHERE title = ? AND id != ? "
+                    "AND source = (SELECT source FROM sessions WHERE id = ?)",
+                    (title, session_id, session_id),
                 )
                 conflict = cursor.fetchone()
                 if conflict:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2568,6 +2568,22 @@ class TestSessionTitleLineage:
         with pytest.raises(ValueError, match="already in use"):
             db.set_session_title("child", "shared")
 
+    def test_cross_source_title_does_not_conflict(self, db):
+        """A desktop session can use a title already held by a TUI session."""
+        db.create_session("tui_sess", "tui")
+        db.create_session("desk_sess", "desktop")
+        db.set_session_title("tui_sess", "Shared Title")
+        # No ValueError — different source
+        assert db.set_session_title("desk_sess", "Shared Title") is True
+
+    def test_same_source_title_still_conflicts(self, db):
+        """Two desktop sessions cannot share the same title."""
+        db.create_session("a", "desktop")
+        db.create_session("b", "desktop")
+        db.set_session_title("a", "Shared Title")
+        with pytest.raises(ValueError, match="already in use"):
+            db.set_session_title("b", "Shared Title")
+
 
 class TestSanitizeTitle:
     """Tests for SessionDB.sanitize_title() validation and cleaning."""


### PR DESCRIPTION
## Summary

Session title uniqueness is now scoped per `source` (TUI, desktop, CLI, gateway). Invisible TUI/CLI sessions no longer block desktop renames.

## Root cause

Two enforcement points in `hermes_state.py` applied title uniqueness globally:

1. **Application-level check** (`set_session_title`, line ~2712): `SELECT id FROM sessions WHERE title = ? AND id != ?` — no `source` filter.
2. **Database unique index** (line ~1555): `CREATE UNIQUE INDEX idx_sessions_title_unique ON sessions(title) WHERE title IS NOT NULL` — not scoped by `source` or `archived`.

The desktop sidebar only shows `source='desktop'` sessions, so TUI sessions holding a title were invisible but still blocked renames.

## Changes

### `hermes_state.py`

1. **Index DDL** (line 1555–1570): Now checks `sqlite_master` for the old global index definition and rebuilds **once** to `ON sessions(source, title) WHERE title IS NOT NULL`. The `sqlite_master` guard avoids the per-init `DROP/CREATE` perf hazard flagged by antigravity.

2. **Application-level query** (line 2712–2717): Scoped by source via subquery:
   ```sql
   SELECT id FROM sessions
   WHERE title = ? AND id != ?
   AND source = (SELECT source FROM sessions WHERE id = ?)
   ```
   The `source` column is `NOT NULL` (schema line 702), so the subquery is safe for valid sessions.

The compression-ancestor title-transfer logic from PR #49000 (lines 2747–2761) is **untouched** — it operates on `id`/`parent_session_id` only, not titles.

### `tests/test_hermes_state.py`

Two new tests in `TestSessionTitleLineage`:
- `test_cross_source_title_does_not_conflict` — TUI + desktop sessions can share a title.
- `test_same_source_title_still_conflicts` — two desktop sessions still conflict.

Full suite: **324 passed** (322 existing + 2 new).

## Migration safety

The old global unique index guaranteed zero duplicates of any kind. The new composite index `(source, title)` is strictly weaker, so it can never be violated by existing data. The `sqlite_master` probe ensures the rebuild runs exactly once on first startup after upgrade.

## Known limitation (follow-up)

`resolve_session_by_title` (line 2834) and `get_next_title_in_lineage` (line 2863) still resolve titles **globally** without a `source` filter. This means `hermes -c "My Session"` and auto-suffixing can resolve to the wrong session when cross-source collisions exist. This is a separate concern from the rename bug and will be addressed in a follow-up issue.

## Closes

#60020