### PR TITLE
fix(stage2-hook): add missing state files to chown allowlist

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -324,7 +324,7 @@ for f in \
     state.db state.db-shm state.db-wal \
     hermes_state.db \
     response_store.db response_store.db-shm response_store.db-wal \
-    gateway.pid gateway.lock gateway_state.json processes.json \
+    gateway.pid gateway.lock gateway_state.json processes.json discord-approved.json exec-approvals.json channel_directory.json \
     active_profile; do
     if [ -e "$HERMES_HOME/$f" ]; then
         if refuse_symlinked_path "chown" "$HERMES_HOME/$f"; then


### PR DESCRIPTION
## Problem

When Hermes plugins create state files via `docker exec` (which runs as root), those files remain owned by root. On subsequent container restarts, stage2-hook.sh chowns only known directories and an explicit allowlist of top-level files — but the following file patterns are missing:

| File | Created By |
|------|-----------|
| `discord-approved.json` | Discord platform plugin (pairing approval) |
| `exec-approvals.json` | Command execution approval system |
| `channel_directory.json` | Channel discovery subsystem |

This causes `PermissionError [Errno 13]` when the Hermes runtime (running as `hermes` user) tries to read/write these files.

## Fix

Add the three missing file patterns to the explicit top-level file allowlist in `docker/stage2-hook.sh`.

## Context

The allowlist approach is intentional — see issue #19788 and PR #19795. A blanket `find -user root` sweep was rejected to avoid silently chowning unrelated host-owned files in bind-mounted `$HERMES_HOME` directories. This fix simply extends the existing allowlist with the known missing entries.

## Testing

Verified that the added patterns mirror the canonical state files created by Hermes platform plugins at runtime.