### PR TITLE
fix(auth): recover missing Nous runtime token from shared store

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5555,6 +5555,7 @@ def resolve_nous_runtime_credentials(
 
         verify = _resolve_verify(insecure=insecure, ca_bundle=ca_bundle, auth_state=state)
         timeout = httpx.Timeout(timeout_seconds if timeout_seconds else 15.0)
+        shared_store_lock_timeout = max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)
         _oauth_trace(
             "nous_runtime_credentials_start",
             sequence_id=sequence_id,
@@ -5566,6 +5567,13 @@ def resolve_nous_runtime_credentials(
             refresh_token = state.get("refresh_token")
 
             if not isinstance(access_token, str) or not access_token:
+                with _nous_shared_store_lock(timeout_seconds=shared_store_lock_timeout):
+                    if _merge_shared_nous_oauth_state(state):
+                        access_token = state.get("access_token")
+                        refresh_token = state.get("refresh_token")
+                        _persist_state("runtime_shared_merge_missing_access")
+
+            if not isinstance(access_token, str) or not access_token:
                 raise AuthError("No access token found for Nous Portal login.",
                                 provider="nous", relogin_required=True)
 
@@ -5575,7 +5583,7 @@ def resolve_nous_runtime_credentials(
                 expires_at=state.get("expires_at"),
             )
             if force_refresh or invoke_jwt_status is not None:
-                with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
+                with _nous_shared_store_lock(timeout_seconds=shared_store_lock_timeout):
                     if _merge_shared_nous_oauth_state(state):
                         access_token = state.get("access_token")
                         refresh_token = state.get("refresh_token")

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -1954,6 +1954,48 @@ def test_runtime_refresh_uses_newer_shared_token_before_local_stale_token(
     assert profile_state["access_token"] == shared_token
 
 
+def test_runtime_credentials_merge_shared_token_when_local_access_missing(
+    tmp_path, monkeypatch, shared_store_env,
+):
+    """Runtime resolution must not dead-end before consulting shared auth."""
+    from hermes_cli import auth as auth_mod
+
+    profile_b = tmp_path / "profile_b"
+    _setup_nous_auth(
+        profile_b,
+        access_token="local-access-to-remove",
+        refresh_token="local-stale-refresh",
+    )
+    payload = json.loads((profile_b / "auth.json").read_text())
+    payload["providers"]["nous"]["access_token"] = None
+    payload["providers"]["nous"]["agent_key"] = None
+    (profile_b / "auth.json").write_text(json.dumps(payload))
+    monkeypatch.setenv("HERMES_HOME", str(profile_b))
+
+    shared_state = _full_state_fixture()
+    shared_token = _invoke_jwt(seconds=3600)
+    shared_state["access_token"] = shared_token
+    shared_state["refresh_token"] = "shared-fresh-refresh"
+    shared_state["expires_at"] = "2099-01-01T00:00:00+00:00"
+    shared_state["scope"] = "inference:invoke"
+    auth_mod._write_shared_nous_state(shared_state)
+
+    def _refresh_should_not_happen(**_kwargs):
+        raise AssertionError("shared access token was ignored")
+
+    monkeypatch.setattr(auth_mod, "_refresh_access_token", _refresh_should_not_happen)
+
+    creds = auth_mod.resolve_nous_runtime_credentials()
+
+    assert creds["api_key"] == shared_token
+
+    profile_state = auth_mod.get_provider_auth_state("nous")
+    assert profile_state is not None
+    assert profile_state["refresh_token"] == "shared-fresh-refresh"
+    assert profile_state["access_token"] == shared_token
+    assert profile_state["agent_key"] == shared_token
+
+
 def test_managed_gateway_access_token_uses_newer_shared_token(
     tmp_path, monkeypatch, shared_store_env,
 ):


### PR DESCRIPTION
## What does this PR do?

Fixes the Nous runtime credential path so a profile-local `auth.json` with `providers.nous.access_token = null` can recover from the shared Nous OAuth store before raising `No access token found for Nous Portal login.`

The managed-token resolver already merges the shared store before checking for an access token. Runtime resolution had the same shared-store merge only after the empty-token guard, so multi-profile deployments could dead-end on live requests even when a sibling profile had populated `~/.hermes/shared/nous_auth.json` with a usable token.

## Related Issue

Fixes #60035

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/auth.py`: reuse a named shared-store lock timeout and attempt `_merge_shared_nous_oauth_state(state)` before the runtime empty-access-token error.
- `tests/hermes_cli/test_auth_nous_provider.py`: add a regression test for a profile with `access_token = None` recovering from a fresher shared Nous token without refreshing.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_auth_nous_provider.py -q`.
2. Optionally reproduce manually with a temp `HERMES_HOME` whose profile-local `auth.json` has `access_token = null` and whose shared store has a valid token; `resolve_nous_runtime_credentials()` should now return that shared token instead of raising `AuthError`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; pure auth-state ordering change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted validation:

```text
$ .venv/bin/python -m pytest tests/hermes_cli/test_auth_nous_provider.py -q
....................................................................     [100%]
68 passed in 5.47s
```
