### PR TITLE
fix(delegate): process-based subagent isolation to eliminate GIL contention

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2164,6 +2164,15 @@ DEFAULT_CONFIG = {
                                        # delegation units. New async dispatches beyond the cap
                                        # fall back to synchronous execution. Floor of 1, no ceiling.
                                        # (Replaces the deprecated max_async_children.)
+        # Run batch subagents in isolated OS processes instead of worker
+        # threads inside the parent process. Each child gets its own GIL, so
+        # heavy subagent work (SSE parsing, regex, JSON) can no longer starve
+        # the parent's TUI/desktop WebSocket event loop (the "event loop
+        # stalled / desktop drops with 3+ subagents" class of issues: #58576,
+        # #57903, #32079). Opt-in while the process path matures; the default
+        # (false) keeps the historical in-process thread pool. Single-task
+        # delegations always run in-process either way.
+        "process_isolation": False,
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
         # raise deliberately, each level multiplies API cost.

--- a/tests/tools/test_delegate_process.py
+++ b/tests/tools/test_delegate_process.py
@@ -245,12 +245,12 @@ class TestProcessSpawn(unittest.TestCase):
                 pid_str = summary.split("PID=")[1].strip()
                 child_pids.add(int(pid_str))
 
-        # At least 2 of the 3 children should have different PIDs from the parent
-        # (spawn guarantees separate processes; the PID is the proof)
+        # All 3 children should have PIDs different from the parent AND
+        # from each other (spawn guarantees separate processes).
         child_pids.discard(parent_pid)
-        self.assertGreaterEqual(
-            len(child_pids), 1,
-            f"Expected child processes with different PIDs from parent ({parent_pid}), "
+        self.assertEqual(
+            len(child_pids), 3,
+            f"Expected 3 distinct child PIDs (all different from parent {parent_pid}), "
             f"got child PIDs: {child_pids}"
         )
 

--- a/tests/tools/test_delegate_process.py
+++ b/tests/tools/test_delegate_process.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python3
+"""
+Tests for process-based subagent isolation (delegation.process_isolation).
+
+These tests exercise the process-isolation path in tools/delegate_process.py
+without requiring real API keys or LLM calls.  They use a stub agent factory
+that runs inside the spawned child process and verifies:
+
+  1. Children actually run in separate OS processes (not threads)
+  2. IPC bridge relays progress events correctly
+  3. Interrupt propagation works across process boundaries
+  4. Timeout / hard-termination works (the key advantage over threads)
+  5. The config gate correctly selects process vs thread path
+  6. Results are correctly collected and sorted by task_index
+  7. No zombie processes survive the batch
+
+Run with:  python -m pytest tests/tools/test_delegate_process.py -v --timeout=60
+"""
+
+import json
+import multiprocessing as mp
+import os
+import sys
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Ensure the repo root is importable when running from the project dir
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Stub agent that runs INSIDE the spawned child process.
+# Must be defined at module level so multiprocessing(spawn) can pickle it.
+# ──────────────────────────────────────────────────────────────────────
+
+class StubAgent:
+    """Minimal agent that satisfies the AIAgent interface _child_process_main needs.
+
+    Runs entirely in-process (no API calls).  Configurable behaviour via
+    class attributes so different test scenarios can use different stubs.
+    """
+
+    # Class-level config that tests set BEFORE the child is spawned.
+    # Because spawn re-imports the module, these are read at construction
+    # time inside the child and reflect whatever was set on the class
+    # object in the parent before fork... EXCEPT spawn doesn't inherit
+    # class mutations.  So we pass config via the params dict instead.
+    #
+    # The factory function below reads config from params.
+
+    def __init__(self, **kwargs):
+        self._kwargs = kwargs
+        self._delegate_depth = kwargs.get("_delegate_depth", 1)
+        self._delegate_role = kwargs.get("role", "leaf")
+        self._subagent_id = kwargs.get("subagent_id")
+        self._parent_subagent_id = kwargs.get("parent_subagent_id")
+        self._subagent_goal = kwargs.get("goal", "")
+        self._parent_turn_id = kwargs.get("parent_turn_id", "")
+        self._session_init_model_config = {}
+        self.session_id = kwargs.get("session_id", "test-session")
+        self.model = kwargs.get("model", "test-model")
+        self._interrupt_requested = False
+
+    def run_conversation(self, user_message="", task_id="", stream_callback=None, **kw):
+        """Simulate a conversation run. Returns the same shape as AIAgent."""
+        config = self._kwargs.get("_test_config") or {}
+        sleep_seconds = config.get("sleep", 0)
+        emit_events = config.get("emit_events", [])
+        do_cpu_work = config.get("cpu_work_seconds", 0)
+        fail = config.get("fail", False)
+        report_pid = config.get("report_pid", False)
+
+        # Emit any requested progress events
+        cb = self._kwargs.get("tool_progress_callback")
+        if cb:
+            for evt in emit_events:
+                cb(evt[0], evt[1] if len(evt) > 1 else None,
+                   evt[2] if len(evt) > 2 else None)
+
+        # Optional CPU-bound work (simulates GIL-holding load)
+        if do_cpu_work > 0:
+            end = time.monotonic() + do_cpu_work
+            while time.monotonic() < end:
+                # Busy-wait — holds the GIL in the thread path
+                _ = sum(range(10000))
+
+        # Optional sleep (simulates waiting on I/O / slow tool)
+        # Check interrupt flag periodically so interrupt propagation works
+        if sleep_seconds > 0:
+            end = time.monotonic() + sleep_seconds
+            while time.monotonic() < end:
+                if self._interrupt_requested:
+                    break
+                time.sleep(min(0.2, end - time.monotonic()))
+
+        if fail:
+            raise RuntimeError(config.get("fail_message", "Stub failure"))
+
+        # Build response — evaluate PID in the CHILD process
+        if report_pid:
+            response = f"PID={os.getpid()}"
+        else:
+            response = config.get("response", f"Stub completed: {user_message}")
+
+        return {
+            "final_response": response,
+            "completed": True,
+            "api_calls": config.get("api_calls", 1),
+            "interrupted": self._interrupt_requested,
+        }
+
+    def get_activity_summary(self):
+        return {
+            "current_tool": None,
+            "api_call_count": 1,
+            "max_iterations": 50,
+            "last_activity_desc": "stub working",
+        }
+
+    def interrupt(self, message=None):
+        config = self._kwargs.get("_test_config") or {}
+        if not config.get("ignore_interrupt", False):
+            self._interrupt_requested = True
+
+    def close(self):
+        pass
+
+
+def _stub_agent_factory(**kwargs):
+    """Factory that constructs a StubAgent from the params dict.
+
+    Registered via params['agent_factory'] = 'tests.tools.test_delegate_process:_stub_agent_factory'
+    """
+    return StubAgent(**kwargs)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────
+
+def _make_mock_parent(depth=0):
+    """Create a mock parent agent matching the fields _build_child_process_spec needs.
+
+    Every attribute that _resolve_child_settings reads must be set to a
+    picklable value (None, str, list, dict) — MagicMock auto-attributes are
+    NOT picklable and would fail the pickle validation in _build_child_process_spec.
+    """
+    parent = MagicMock(spec=[])
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "test-key"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent.openrouter_min_coding_score = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent.max_tokens = None
+    parent.prefill_messages = None
+    parent._fallback_chain = None
+    parent.reasoning_config = None
+    parent.acp_command = None
+    parent.acp_args = []
+    parent.session_id = "parent-test-session"
+    parent._current_turn_id = "test-turn"
+    parent._current_task_id = None
+    parent._touch_activity = MagicMock()
+    parent._interrupt_requested = False
+    parent.enabled_toolsets = ["web", "terminal", "file", "delegation"]
+    parent.valid_tool_names = ["web_search", "terminal", "read_file", "delegate_task"]
+    parent._client_kwargs = {}
+    return parent
+
+
+def _make_process_spec(task_index, goal, parent_agent, test_config=None,
+                       toolsets=None, max_iterations=10):
+    """Build a ChildProcessSpec with the stub agent factory."""
+    from tools.delegate_tool import _build_child_process_spec
+
+    spec = _build_child_process_spec(
+        task_index=task_index,
+        goal=goal,
+        context=None,
+        toolsets=toolsets,
+        model=None,
+        max_iterations=max_iterations,
+        task_count=2,
+        parent_agent=parent_agent,
+    )
+    # Inject the stub agent factory and test config
+    spec.params["agent_factory"] = "tests.tools.test_delegate_process:_stub_agent_factory"
+    spec.params["_test_config"] = test_config or {}
+    return spec
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 1: Children run in separate OS processes
+# ──────────────────────────────────────────────────────────────────────
+
+class TestProcessSpawn(unittest.TestCase):
+    """Verify that process-isolation actually spawns OS processes, not threads."""
+
+    @patch("tools.delegate_tool._get_process_isolation", return_value=True)
+    @patch("tools.delegate_tool._get_max_concurrent_children", return_value=6)
+    def test_children_get_separate_pids(self, _mock_cc, _mock_pi):
+        """Each child should report a different OS PID via os.getpid()."""
+        from tools.delegate_process import run_children_in_processes
+
+        parent = _make_mock_parent()
+
+        # The stub writes its PID into the response (evaluated in the child)
+        children = []
+        for i in range(3):
+            spec = _make_process_spec(
+                i, f"Get PID {i}", parent,
+                test_config={"report_pid": True},
+            )
+            children.append((i, {"goal": f"Get PID {i}"}, spec))
+
+        results = run_children_in_processes(
+            children=children,
+            parent_agent=parent,
+            child_timeout=30,
+        )
+
+        self.assertEqual(len(results), 3)
+        parent_pid = os.getpid()
+        child_pids = set()
+        for r in results:
+            self.assertEqual(r["status"], "completed")
+            summary = r.get("summary") or ""
+            # The stub response contains "PID=<child_pid>"
+            if "PID=" in summary:
+                pid_str = summary.split("PID=")[1].strip()
+                child_pids.add(int(pid_str))
+
+        # At least 2 of the 3 children should have different PIDs from the parent
+        # (spawn guarantees separate processes; the PID is the proof)
+        child_pids.discard(parent_pid)
+        self.assertGreaterEqual(
+            len(child_pids), 1,
+            f"Expected child processes with different PIDs from parent ({parent_pid}), "
+            f"got child PIDs: {child_pids}"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 2: IPC bridge relays progress events
+# ──────────────────────────────────────────────────────────────────────
+
+class TestIPCEventRelay(unittest.TestCase):
+    """Verify that progress events from child processes reach the parent."""
+
+    @patch("tools.delegate_tool._get_process_isolation", return_value=True)
+    @patch("tools.delegate_tool._get_max_concurrent_children", return_value=6)
+    def test_progress_events_relayed(self, _mock_cc, _mock_pi):
+        """Events emitted by the stub agent inside the child should appear
+        in the parent's progress callback."""
+        from tools.delegate_process import run_children_in_processes
+
+        parent = _make_mock_parent()
+        received_events = []
+
+        spec = _make_process_spec(
+            0, "Emit events", parent,
+            test_config={
+                "emit_events": [
+                    ("tool.start", "terminal", "running ls"),
+                    ("tool.complete", "terminal", "file1.txt"),
+                ],
+                "sleep": 0.5,  # Give parent time to drain events before result
+                "response": "Events emitted",
+            },
+        )
+
+        # Replace the progress callback with a capturing one
+        def capture_cb(event_type, tool_name=None, preview=None, args=None, **kw):
+            received_events.append({
+                "type": event_type,
+                "tool": tool_name,
+                "preview": preview,
+            })
+
+        spec.progress_cb = capture_cb
+
+        children = [(0, {"goal": "Emit events"}, spec)]
+        results = run_children_in_processes(
+            children=children, parent_agent=parent, child_timeout=30,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["status"], "completed")
+
+        # The child should have relayed at least the subagent.start and
+        # the two tool events we configured
+        event_types = [e["type"] for e in received_events]
+        self.assertIn("subagent.start", event_types)
+        # The stub emits tool.start and tool.complete via the progress callback
+        tool_starts = [e for e in received_events if e["type"] == "tool.start"]
+        self.assertGreaterEqual(len(tool_starts), 1)
+        self.assertEqual(tool_starts[0]["tool"], "terminal")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 3: Interrupt propagation across process boundaries
+# ──────────────────────────────────────────────────────────────────────
+
+class TestInterruptPropagation(unittest.TestCase):
+    """Verify that interrupt signals reach child processes."""
+
+    @patch("tools.delegate_tool._get_process_isolation", return_value=True)
+    @patch("tools.delegate_tool._get_max_concurrent_children", return_value=6)
+    def test_interrupt_stops_sleeping_child(self, _mock_cc, _mock_pi):
+        """A child sleeping for 30s should be interrupted within a few
+        seconds when the parent signals interrupt."""
+        from tools.delegate_process import run_children_in_processes
+
+        parent = _make_mock_parent()
+
+        spec = _make_process_spec(
+            0, "Sleep then get interrupted", parent,
+            test_config={"sleep": 30, "response": "should not reach here"},
+        )
+
+        children = [(0, {"goal": "Sleep"}, spec)]
+
+        # Start interrupt after 2 seconds in a background thread
+        def interrupt_after_delay():
+            time.sleep(2)
+            spec.interrupt("Test interrupt")
+
+        threading.Thread(target=interrupt_after_delay, daemon=True).start()
+
+        start = time.monotonic()
+        results = run_children_in_processes(
+            children=children, parent_agent=parent, child_timeout=60,
+        )
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(len(results), 1)
+        # The child should have been interrupted, not completed or timed out
+        self.assertIn(results[0]["status"], ("interrupted", "completed", "error"))
+        # Should NOT have taken the full 30s
+        self.assertLess(
+            elapsed, 20,
+            f"Interrupt should have stopped the 30s sleep quickly, "
+            f"but took {elapsed:.1f}s"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 4: Timeout hard-terminates stuck processes
+# ──────────────────────────────────────────────────────────────────────
+
+class TestTimeoutTermination(unittest.TestCase):
+    """Verify that child_timeout hard-terminates a stuck child process."""
+
+    @patch("tools.delegate_tool._get_process_isolation", return_value=True)
+    @patch("tools.delegate_tool._get_max_concurrent_children", return_value=6)
+    def test_timeout_kills_stuck_child(self, _mock_cc, _mock_pi):
+        """A child sleeping for 60s with a 3s timeout should be killed and
+        return a timeout entry — this is the key advantage over threads,
+        which CANNOT be hard-killed in Python."""
+        from tools.delegate_process import run_children_in_processes
+
+        parent = _make_mock_parent()
+
+        spec = _make_process_spec(
+            0, "Sleep forever", parent,
+            test_config={"sleep": 60, "response": "should not reach here"},
+        )
+
+        children = [(0, {"goal": "Sleep forever"}, spec)]
+
+        start = time.monotonic()
+        results = run_children_in_processes(
+            children=children, parent_agent=parent, child_timeout=3,
+        )
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(len(results), 1)
+        # The child should have been stopped by the timeout mechanism.
+        # The timeout sends an interrupt first; if the child responds to
+        # interrupt (our stub does), it exits with "interrupted". If it
+        # ignores the interrupt, it gets hard-killed with "timeout".
+        # Both are valid — the key assertion is it did NOT run for 60s.
+        self.assertIn(results[0]["status"], ("timeout", "interrupted"))
+        # For timeout status, the error message should mention timing out.
+        # For interrupted status, the child was stopped by the interrupt signal.
+        if results[0]["status"] == "timeout":
+            self.assertIn("timed out", (results[0].get("error") or "").lower())
+
+        # Should have terminated within a reasonable window of the timeout
+        # (3s timeout + 10s grace = 13s max, but should be much faster)
+        self.assertLess(
+            elapsed, 20,
+            f"Timeout should have fired at 3s + grace, but took {elapsed:.1f}s"
+        )
+
+        # Verify the process is actually dead (no zombie)
+        proc = spec.process
+        if proc is not None:
+            self.assertFalse(
+                proc.is_alive(),
+                "Child process should be terminated, not alive"
+            )
+
+
+class TestTimeoutHardKill(unittest.TestCase):
+    """Verify that a child that IGNORES interrupts gets hard-killed."""
+
+    @patch("tools.delegate_tool._get_process_isolation", return_value=True)
+    @patch("tools.delegate_tool._get_max_concurrent_children", return_value=6)
+    def test_unresponsive_child_hard_killed(self, _mock_cc, _mock_pi):
+        """A child that ignores interrupts should be hard-terminated by the
+        timeout mechanism — the key advantage of processes over threads."""
+        from tools.delegate_process import run_children_in_processes
+
+        parent = _make_mock_parent()
+        spec = _make_process_spec(
+            0, "Ignore interrupt and sleep", parent,
+            test_config={"sleep": 60, "ignore_interrupt": True},
+        )
+
+        children = [(0, {"goal": "Ignore interrupt"}, spec)]
+
+        start = time.monotonic()
+        results = run_children_in_processes(
+            children=children, parent_agent=parent, child_timeout=2,
+        )
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(len(results), 1)
+        # Should be "timeout" (hard-killed) since the child ignores interrupts
+        self.assertEqual(results[0]["status"], "timeout")
+
+        # Should have terminated within timeout + grace period
+        self.assertLess(
+            elapsed, 20,
+            f"Hard kill should have happened at ~2s + 10s grace, "
+            f"but took {elapsed:.1f}s"
+        )
+
+        # Process must be dead
+        proc = spec.process
+        if proc is not None:
+            self.assertFalse(proc.is_alive(), "Process should be hard-killed")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 5: Config gate selects process vs thread path
+# ──────────────────────────────────────────────────────────────────────
+
+class TestConfigGate(unittest.TestCase):
+    """Verify that delegation.process_isolation config controls which path runs."""
+
+    def test_default_is_thread_path(self):
+        """With process_isolation=false (default), batch should use ThreadPoolExecutor."""
+        from tools.delegate_tool import _get_process_isolation
+        # The default should be False
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            self.assertFalse(_get_process_isolation())
+
+    def test_true_enables_process_path(self):
+        """With process_isolation=true, the process path should be selected."""
+        from tools.delegate_tool import _get_process_isolation
+        with patch("tools.delegate_tool._load_config",
+                   return_value={"process_isolation": True}):
+            self.assertTrue(_get_process_isolation())
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 6: Results sorted by task_index
+# ──────────────────────────────────────────────────────────────────────
+
+class TestResultOrdering(unittest.TestCase):
+    """Verify that results come back sorted by task_index regardless of
+    completion order."""
+
+    @patch("tools.delegate_tool._get_process_isolation", return_value=True)
+    @patch("tools.delegate_tool._get_max_concurrent_children", return_value=6)
+    def test_results_sorted_by_index(self, _mock_cc, _mock_pi):
+        """Even if task 2 finishes before task 0, results should be [0, 1, 2]."""
+        from tools.delegate_process import run_children_in_processes
+
+        parent = _make_mock_parent()
+        children = []
+
+        # Task 0 sleeps longest, task 2 sleeps shortest — completion order is 2,1,0
+        for i in range(3):
+            sleep_map = {0: 2.0, 1: 1.0, 2: 0.2}
+            spec = _make_process_spec(
+                i, f"Task {i}", parent,
+                test_config={
+                    "sleep": sleep_map[i],
+                    "response": f"Task {i} done",
+                },
+            )
+            children.append((i, {"goal": f"Task {i}"}, spec))
+
+        results = run_children_in_processes(
+            children=children, parent_agent=parent, child_timeout=30,
+        )
+
+        self.assertEqual(len(results), 3)
+        # Results must be sorted by task_index
+        indices = [r["task_index"] for r in results]
+        self.assertEqual(indices, [0, 1, 2])
+        # All should be completed
+        for r in results:
+            self.assertEqual(r["status"], "completed")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 7: No zombie processes survive the batch
+# ──────────────────────────────────────────────────────────────────────
+
+class TestNoZombies(unittest.TestCase):
+    """Verify that all child processes are reaped — no zombies left behind."""
+
+    @patch("tools.delegate_tool._get_process_isolation", return_value=True)
+    @patch("tools.delegate_tool._get_max_concurrent_children", return_value=6)
+    def test_all_processes_reaped(self, _mock_cc, _mock_pi):
+        """After run_children_in_processes returns, no child process should
+        still be alive."""
+        from tools.delegate_process import run_children_in_processes
+
+        parent = _make_mock_parent()
+        children = []
+        procs = []
+
+        for i in range(3):
+            spec = _make_process_spec(
+                i, f"Quick task {i}", parent,
+                test_config={"response": f"Done {i}"},
+            )
+            children.append((i, {"goal": f"Quick {i}"}, spec))
+
+        results = run_children_in_processes(
+            children=children, parent_agent=parent, child_timeout=30,
+        )
+
+        self.assertEqual(len(results), 3)
+
+        # Check all processes are dead
+        for i, _, spec in children:
+            proc = spec.process
+            if proc is not None:
+                self.assertFalse(
+                    proc.is_alive(),
+                    f"Child process {i} is still alive — zombie!"
+                )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 8: GIL freedom — child CPU work doesn't block parent
+# ──────────────────────────────────────────────────────────────────────
+
+class TestGILFreedom(unittest.TestCase):
+    """Verify that CPU-bound work in child processes does not block the
+    parent's main thread — the whole point of process isolation."""
+
+    @patch("tools.delegate_tool._get_process_isolation", return_value=True)
+    @patch("tools.delegate_tool._get_max_concurrent_children", return_value=6)
+    def test_parent_responsive_during_child_cpu_work(self, _mock_cc, _mock_pi):
+        """While 3 children do CPU-heavy work, the parent should be able to
+        do its own work without being blocked by the GIL."""
+        from tools.delegate_process import run_children_in_processes
+
+        parent = _make_mock_parent()
+        children = []
+
+        for i in range(3):
+            spec = _make_process_spec(
+                i, f"CPU burn {i}", parent,
+                test_config={
+                    "cpu_work_seconds": 3,  # 3s of GIL-holding busy-wait
+                    "response": f"Burned {i}",
+                },
+            )
+            children.append((i, {"goal": f"CPU {i}"}, spec))
+
+        # Run in a background thread so we can check parent responsiveness
+        result_holder = {}
+
+        def run_batch():
+            result_holder["results"] = run_children_in_processes(
+                children=children, parent_agent=parent, child_timeout=30,
+            )
+
+        batch_thread = threading.Thread(target=run_batch, daemon=True)
+        batch_thread.start()
+
+        # Give children time to start
+        time.sleep(1)
+
+        # While children burn CPU, the parent should be able to do work
+        # In the thread path, this would be blocked by the GIL.
+        # In the process path, the parent's thread is free.
+        parent_counter = 0
+        parent_start = time.monotonic()
+        while batch_thread.is_alive() and (time.monotonic() - parent_start) < 5:
+            parent_counter += 1
+            # Small amount of work to measure responsiveness
+            _ = sum(range(1000))
+
+        parent_elapsed = time.monotonic() - parent_start
+
+        # The parent should have been able to run its loop many times
+        # (if the GIL were blocking us, parent_counter would be very low)
+        self.assertGreater(
+            parent_counter, 50,
+            f"Parent was starved — only ran {parent_counter} iterations "
+            f"in {parent_elapsed:.1f}s. GIL contention detected."
+        )
+
+        # Wait for batch to finish
+        batch_thread.join(timeout=30)
+        self.assertIn("results", result_holder)
+        self.assertEqual(len(result_holder["results"]), 3)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 9: Child process exception is caught and reported
+# ──────────────────────────────────────────────────────────────────────
+
+class TestChildException(unittest.TestCase):
+    """Verify that an exception inside a child process is caught and
+    returned as an error entry, not crashing the parent."""
+
+    @patch("tools.delegate_tool._get_process_isolation", return_value=True)
+    @patch("tools.delegate_tool._get_max_concurrent_children", return_value=6)
+    def test_child_exception_becomes_error_entry(self, _mock_cc, _mock_pi):
+        from tools.delegate_process import run_children_in_processes
+
+        parent = _make_mock_parent()
+        spec = _make_process_spec(
+            0, "Crash", parent,
+            test_config={"fail": True, "fail_message": "Intentional crash"},
+        )
+
+        children = [(0, {"goal": "Crash"}, spec)]
+        results = run_children_in_processes(
+            children=children, parent_agent=parent, child_timeout=30,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["status"], "error")
+        self.assertIn("Intentional crash", results[0].get("error", ""))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Test 10: Params are picklable (spawn requirement)
+# ──────────────────────────────────────────────────────────────────────
+
+class TestPicklability(unittest.TestCase):
+    """Verify that _build_child_process_spec produces picklable params."""
+
+    def test_params_survive_pickle(self):
+        """If params can't be pickled, spawn will fail silently. Test early."""
+        import pickle
+        from tools.delegate_tool import _build_child_process_spec
+
+        parent = _make_mock_parent()
+        spec = _build_child_process_spec(
+            task_index=0,
+            goal="Picklability test",
+            context="Some context",
+            toolsets=None,
+            model=None,
+            max_iterations=10,
+            task_count=1,
+            parent_agent=parent,
+        )
+
+        # The params dict must be picklable
+        try:
+            data = pickle.dumps(spec.params)
+            restored = pickle.loads(data)
+            self.assertEqual(restored["goal"], "Picklability test")
+            self.assertEqual(restored["task_index"], 0)
+        except Exception as exc:
+            self.fail(f"Params are not picklable: {exc}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_process.py
+++ b/tools/delegate_process.py
@@ -19,7 +19,7 @@ Architecture
   (progress callback, credential lease).  Presents the same duck-typed
   surface the aggregator expects from a child agent (``session_id``,
   ``_delegate_role``, ``interrupt()``).
-* ``_child_process_main`` — the ``spawn`` entry point.  Reconstructs the
+* ``_child_process_main`` — the ``forkserver`` entry point.  Reconstructs the
   AIAgent inside the child process (fresh SQLite connection, fresh httpx
   clients), runs the conversation, and streams progress events back over
   an IPC queue as plain dicts.
@@ -106,7 +106,7 @@ class ChildProcessSpec:
         self._delegate_depth = params.get("child_depth", 1)
         self._subagent_goal = goal
 
-        self.process = None
+        self.process: Any = None
         self.interrupt_event = None  # created once the mp context exists
         self._lock = threading.Lock()
         self._interrupt_requested = False
@@ -184,6 +184,13 @@ def _child_process_main(params, event_queue, result_queue, interrupt_event) -> N
     goal = params.get("goal") or ""
     child_start = time.monotonic()
     wall_start = time.time()
+
+    # With forkserver, the child is forked from a clean helper process
+    # (started before the parent opened httpx clients / SQLite connections),
+    # so there are no parent fds to leak.  The multiprocessing Queue and
+    # Event objects the child needs for IPC are managed by the forkserver
+    # context itself.  Do NOT blindly close fds here — that would break
+    # the IPC queues and interrupt event.
 
     def emit(event_type, tool_name=None, preview=None, args=None, **kwargs) -> None:
         try:
@@ -473,10 +480,19 @@ def run_children_in_processes(
     from tools import file_state
     from tools import delegate_tool as dt
 
-    # "spawn" (not fork): the parent holds live httpx/SSL clients, SQLite
-    # connections, and running threads — fork would inherit them in a
-    # corrupt state. Spawn gives each child a clean interpreter.
-    ctx = mp.get_context("spawn")
+    # "forkserver" (not "spawn" or "fork"):
+    # - fork is unsafe: the parent holds live httpx/SSL clients, SQLite
+    #   connections, and running threads — fork would inherit them in a
+    #   corrupt state.
+    # - spawn is safe but slow: each child re-imports the entire module
+    #   tree (~1-2s, ~150 MB/child).
+    # - forkserver starts a clean helper process early (before the parent
+    #   has opened clients/threads), then forks children from it.  The
+    #   forkserver process is clean (no clients, no threads, no SSL), so
+    #   forking from it is always safe.  Children inherit the already-
+    #   imported modules via copy-on-write, dropping startup to ~10 ms and
+    #   memory to ~20-30 MB/child (vs ~150 MB for spawn).
+    ctx = mp.get_context("forkserver")
     event_queue = ctx.Queue()
     result_queue = ctx.Queue()
 

--- a/tools/delegate_process.py
+++ b/tools/delegate_process.py
@@ -584,7 +584,6 @@ def run_children_in_processes(
         proc = ctx.Process(
             target=_child_process_main,
             args=(spec.params, event_queue, result_queue, spec.interrupt_event),
-            daemon=True,
             name=f"hermes-subagent-{i}",
         )
         spec.process = proc

--- a/tools/delegate_process.py
+++ b/tools/delegate_process.py
@@ -19,7 +19,7 @@ Architecture
   (progress callback, credential lease).  Presents the same duck-typed
   surface the aggregator expects from a child agent (``session_id``,
   ``_delegate_role``, ``interrupt()``).
-* ``_child_process_main`` — the ``forkserver`` entry point.  Reconstructs the
+* ``_child_process_main`` — the ``spawn`` entry point.  Reconstructs the
   AIAgent inside the child process (fresh SQLite connection, fresh httpx
   clients), runs the conversation, and streams progress events back over
   an IPC queue as plain dicts.
@@ -106,7 +106,7 @@ class ChildProcessSpec:
         self._delegate_depth = params.get("child_depth", 1)
         self._subagent_goal = goal
 
-        self.process: Any = None
+        self.process = None
         self.interrupt_event = None  # created once the mp context exists
         self._lock = threading.Lock()
         self._interrupt_requested = False
@@ -184,13 +184,6 @@ def _child_process_main(params, event_queue, result_queue, interrupt_event) -> N
     goal = params.get("goal") or ""
     child_start = time.monotonic()
     wall_start = time.time()
-
-    # With forkserver, the child is forked from a clean helper process
-    # (started before the parent opened httpx clients / SQLite connections),
-    # so there are no parent fds to leak.  The multiprocessing Queue and
-    # Event objects the child needs for IPC are managed by the forkserver
-    # context itself.  Do NOT blindly close fds here — that would break
-    # the IPC queues and interrupt event.
 
     def emit(event_type, tool_name=None, preview=None, args=None, **kwargs) -> None:
         try:
@@ -480,19 +473,10 @@ def run_children_in_processes(
     from tools import file_state
     from tools import delegate_tool as dt
 
-    # "forkserver" (not "spawn" or "fork"):
-    # - fork is unsafe: the parent holds live httpx/SSL clients, SQLite
-    #   connections, and running threads — fork would inherit them in a
-    #   corrupt state.
-    # - spawn is safe but slow: each child re-imports the entire module
-    #   tree (~1-2s, ~150 MB/child).
-    # - forkserver starts a clean helper process early (before the parent
-    #   has opened clients/threads), then forks children from it.  The
-    #   forkserver process is clean (no clients, no threads, no SSL), so
-    #   forking from it is always safe.  Children inherit the already-
-    #   imported modules via copy-on-write, dropping startup to ~10 ms and
-    #   memory to ~20-30 MB/child (vs ~150 MB for spawn).
-    ctx = mp.get_context("forkserver")
+    # "spawn" (not fork): the parent holds live httpx/SSL clients, SQLite
+    # connections, and running threads — fork would inherit them in a
+    # corrupt state. Spawn gives each child a clean interpreter.
+    ctx = mp.get_context("spawn")
     event_queue = ctx.Queue()
     result_queue = ctx.Queue()
 

--- a/tools/delegate_process.py
+++ b/tools/delegate_process.py
@@ -255,6 +255,9 @@ def _child_process_main(params, event_queue, result_queue, interrupt_event) -> N
         factory = _resolve_agent_factory(params.get("agent_factory"))
         # Collect extra params (non-constructor keys) so test stub factories
         # can receive test configuration across the spawn boundary.
+        # ONLY pass keys that the real AIAgent constructor doesn't know about
+        # — the stub factory accepts **kwargs and reads what it needs, but the
+        # real AIAgent will TypeError on unknown kwargs.
         _constructor_keys = {
             "base_url", "api_key", "model", "provider", "api_mode",
             "acp_command", "acp_args", "max_iterations", "max_tokens",
@@ -262,18 +265,26 @@ def _child_process_main(params, event_queue, result_queue, interrupt_event) -> N
             "enabled_toolsets", "ephemeral_system_prompt", "session_id",
             "parent_session_id", "providers_allowed", "providers_ignored",
             "providers_order", "provider_sort", "openrouter_min_coding_score",
+            "task_index", "task_count", "subagent_id", "parent_subagent_id",
+            "child_depth", "parent_turn_id", "session_db_path",
+            "parent_reads_snapshot", "parent_session_id", "auto_approve",
+            "heartbeat_interval", "agent_factory", "role", "goal",
         }
         _extra = {
             k: v for k, v in params.items()
-            if k not in _constructor_keys and not k.startswith("_")
+            if k not in _constructor_keys
         }
-        # _test_config starts with _ but is needed by stub factories
-        _extra["_test_config"] = params.get("_test_config")
-        _extra["goal"] = goal
-        _extra["role"] = params.get("role", "leaf")
-        _extra["subagent_id"] = params.get("subagent_id")
-        _extra["parent_subagent_id"] = params.get("parent_subagent_id")
-        _extra["parent_turn_id"] = params.get("parent_turn_id")
+        # Always provide these for stub factories that need them.
+        # The real AIAgent ignores **_extra kwargs it doesn't accept IF
+        # they're not in its signature — but it DOES TypeError on unknown
+        # kwargs, so we must only add them when using a stub factory.
+        _is_stub = params.get("agent_factory") is not None
+        if _is_stub:
+            _extra["goal"] = goal
+            _extra["role"] = params.get("role", "leaf")
+            _extra["subagent_id"] = params.get("subagent_id")
+            _extra["parent_subagent_id"] = params.get("parent_subagent_id")
+            _extra["_test_config"] = params.get("_test_config")
         agent = factory(
             base_url=params.get("base_url"),
             api_key=params.get("api_key"),

--- a/tools/delegate_process.py
+++ b/tools/delegate_process.py
@@ -488,6 +488,7 @@ def run_children_in_processes(
     entries: Dict[int, Dict[str, Any]] = {}
     dead_since: Dict[int, float] = {}
     timeout_signaled: Dict[int, float] = {}
+    child_start_mono: Dict[int, float] = {}  # per-child proc.start() timestamp
     # Per-child heartbeat staleness state (port of _run_single_child's
     # heartbeat loop): [last_iter, last_tool, stale_count, stopped]
     hb_state: Dict[int, list] = {}
@@ -593,6 +594,7 @@ def run_children_in_processes(
             logger.warning("Failed to start subagent process %d: %s", i, exc)
             _finalize(i, _fabricated(i, "error", f"Failed to start subagent process: {exc}"))
             continue
+        child_start_mono[i] = time.monotonic()
         procs[i] = proc
         _fire_start_hook(spec)
 
@@ -709,9 +711,11 @@ def run_children_in_processes(
         now = time.monotonic()
 
         # Per-child wall-clock timeout (delegation.child_timeout_seconds).
+        # Measure from each child's own proc.start(), not the batch start,
+        # so staggered startup doesn't eat into a child's timeout budget.
         if child_timeout:
             for i in list(pending):
-                elapsed = now - started_mono
+                elapsed = now - child_start_mono.get(i, started_mono)
                 if i not in timeout_signaled and elapsed > child_timeout:
                     timeout_signaled[i] = now
                     specs[i].interrupt(f"Timed out after {child_timeout}s")

--- a/tools/delegate_process.py
+++ b/tools/delegate_process.py
@@ -1,0 +1,761 @@
+"""Process-based subagent isolation for delegate_task.
+
+The default delegation path runs child AIAgents on ``ThreadPoolExecutor``
+workers inside the parent process.  Every child then shares the parent's
+GIL, so a batch of subagents doing CPU-heavy work (SSE parsing, regex,
+JSON) starves the parent's event loop — the TUI/desktop WebSocket stalls
+for tens of seconds and the desktop app drops the connection (issues
+#58576, #57903, #32079).
+
+This module is the opt-in fix (``delegation.process_isolation: true`` in
+config.yaml): each batch child runs in its own OS process with its own
+GIL, mirroring how OpenClaw spawns subagents as separate Node processes.
+
+Architecture
+------------
+* ``ChildProcessSpec`` — parent-side handle built by
+  ``delegate_tool._build_child_process_spec``.  Carries only *picklable*
+  constructor params for the child AIAgent plus parent-side plumbing
+  (progress callback, credential lease).  Presents the same duck-typed
+  surface the aggregator expects from a child agent (``session_id``,
+  ``_delegate_role``, ``interrupt()``).
+* ``_child_process_main`` — the ``spawn`` entry point.  Reconstructs the
+  AIAgent inside the child process (fresh SQLite connection, fresh httpx
+  clients), runs the conversation, and streams progress events back over
+  an IPC queue as plain dicts.
+* ``run_children_in_processes`` — parent-side poll loop.  Relays queued
+  child events into the exact same progress callbacks the thread path
+  uses (the TUI/gateway cannot tell the difference), heartbeats parent
+  activity from child activity snapshots, propagates interrupts via a
+  shared ``multiprocessing.Event``, enforces the optional child timeout
+  (processes CAN be hard-killed, unlike threads), and reaps every child
+  so no zombies survive the batch.
+
+Known semantic difference vs. the thread path: the cross-agent
+file-state registry (``tools.file_state``) is per-process.  The child
+checks its own writes against the parent's read snapshot (passed in via
+params) and the parent folds the child's writes back into its registry on
+completion, so the "subagent modified files you read" reminder and the
+parent's stale-write guard both keep working — but two *sibling* children
+cannot see each other's in-flight writes while both are still running.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue as _queue_mod
+import threading
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Seconds a child gets to unwind after an interrupt / timeout signal
+# before the parent hard-terminates its process.
+_TERMINATE_GRACE_SECONDS = 10.0
+# Seconds to keep waiting for a dead child's result to surface from the
+# IPC queue (the feeder thread may still be flushing) before fabricating
+# a crash entry.
+_DEAD_RESULT_GRACE_SECONDS = 5.0
+
+
+def _sanitize(obj: Any, _depth: int = 0) -> Any:
+    """Return a picklable, plain-data copy of *obj* for IPC transport."""
+    if _depth > 8:
+        return str(obj)
+    if obj is None or isinstance(obj, (str, int, float, bool)):
+        return obj
+    if isinstance(obj, dict):
+        return {str(k): _sanitize(v, _depth + 1) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple, set)):
+        return [_sanitize(v, _depth + 1) for v in obj]
+    return str(obj)
+
+
+class ChildProcessSpec:
+    """Parent-side handle for one process-isolated subagent.
+
+    Duck-types the slice of the child-agent surface that
+    ``delegate_task``'s aggregation code touches (``session_id``,
+    ``_delegate_role``, ``_subagent_id``, ``interrupt()``) so the generic
+    hook/memory/cost plumbing works unchanged in process mode.
+    """
+
+    def __init__(
+        self,
+        *,
+        task_index: int,
+        goal: str,
+        params: Dict[str, Any],
+        progress_cb: Optional[Callable] = None,
+        pool=None,
+        leased_cred_id: Optional[str] = None,
+    ) -> None:
+        self.task_index = task_index
+        self.goal = goal
+        self.params = params
+        self.progress_cb = progress_cb
+        self.pool = pool
+        self.leased_cred_id = leased_cred_id
+
+        self.session_id = params.get("session_id") or ""
+        self.model = params.get("model")
+        self._subagent_id = params.get("subagent_id")
+        self._parent_subagent_id = params.get("parent_subagent_id")
+        self._delegate_role = params.get("role", "leaf")
+        self._delegate_depth = params.get("child_depth", 1)
+        self._subagent_goal = goal
+
+        self.process = None
+        self.interrupt_event = None  # created once the mp context exists
+        self._lock = threading.Lock()
+        self._interrupt_requested = False
+        self._interrupt_message: Optional[str] = None
+
+    def attach_context(self, ctx) -> None:
+        """Create the shared interrupt Event on the spawn context.
+
+        Called by the runner just before ``Process(...)`` is built.  An
+        interrupt requested earlier (e.g. background-batch cancellation
+        racing process startup) is replayed onto the fresh Event.
+        """
+        with self._lock:
+            self.interrupt_event = ctx.Event()
+            if self._interrupt_requested:
+                self.interrupt_event.set()
+
+    def interrupt(self, message: Optional[str] = None) -> None:
+        """Request the child process stop at its next iteration boundary."""
+        with self._lock:
+            self._interrupt_requested = True
+            self._interrupt_message = message
+            if self.interrupt_event is not None:
+                try:
+                    self.interrupt_event.set()
+                except Exception:
+                    pass
+
+    def flush_progress(self) -> None:
+        cb = self.progress_cb
+        if cb is not None and hasattr(cb, "_flush"):
+            try:
+                cb._flush()
+            except Exception as exc:
+                logger.debug("Progress callback flush failed: %s", exc)
+
+    def release(self) -> None:
+        """Release the credential leased for this child (idempotent)."""
+        pool, cred = self.pool, self.leased_cred_id
+        self.pool = None
+        self.leased_cred_id = None
+        if pool is not None and cred is not None:
+            try:
+                pool.release_lease(cred)
+            except Exception as exc:
+                logger.debug("Failed to release credential lease: %s", exc)
+
+
+def _resolve_agent_factory(dotted: Optional[str]):
+    """Resolve the AIAgent constructor inside the child process.
+
+    ``dotted`` ("module:attr") exists so tests can substitute a stub agent
+    across the spawn boundary, where monkeypatching cannot reach.  Real
+    delegations always leave it unset and get run_agent.AIAgent.
+    """
+    if dotted:
+        import importlib
+
+        mod_name, _, attr = dotted.partition(":")
+        return getattr(importlib.import_module(mod_name), attr)
+    from run_agent import AIAgent
+
+    return AIAgent
+
+
+def _child_process_main(params, event_queue, result_queue, interrupt_event) -> None:
+    """Entry point executed inside the spawned child process.
+
+    Builds the child AIAgent from picklable *params*, runs the delegated
+    conversation, relays progress/activity over *event_queue*, and puts
+    exactly one result entry (the same shape ``_run_single_child``
+    returns) on *result_queue* before exiting.
+    """
+    task_index = int(params.get("task_index", 0))
+    goal = params.get("goal") or ""
+    child_start = time.monotonic()
+    wall_start = time.time()
+
+    def emit(event_type, tool_name=None, preview=None, args=None, **kwargs) -> None:
+        try:
+            event_queue.put(
+                {
+                    "kind": "progress",
+                    "task_index": task_index,
+                    "event": (
+                        event_type,
+                        tool_name,
+                        _sanitize(preview),
+                        _sanitize(args),
+                        _sanitize(kwargs),
+                    ),
+                }
+            )
+        except Exception:
+            pass
+
+    entry: Dict[str, Any] = {
+        "task_index": task_index,
+        "status": "error",
+        "summary": None,
+        "error": "Subagent process exited before producing a result.",
+        "api_calls": 0,
+        "duration_seconds": 0,
+        "_child_role": params.get("role"),
+    }
+    agent = None
+    stop = threading.Event()
+    try:
+        # Non-interactive approval callback: same policy as the thread path
+        # (delegation.subagent_auto_approve), installed on this process's
+        # main thread since the child owns no TUI/stdin.
+        from tools.delegate_tool import (
+            _subagent_auto_approve,
+            _subagent_auto_deny,
+            _summarize_child_run,
+        )
+        from tools.terminal_tool import set_approval_callback
+
+        set_approval_callback(
+            _subagent_auto_approve
+            if params.get("auto_approve")
+            else _subagent_auto_deny
+        )
+
+        session_db = None
+        db_path = params.get("session_db_path")
+        if db_path:
+            try:
+                from pathlib import Path
+
+                from hermes_state import SessionDB
+
+                session_db = SessionDB(Path(db_path))
+            except Exception as exc:
+                logger.warning(
+                    "[subagent-%d] could not open session DB %s: %s",
+                    task_index,
+                    db_path,
+                    exc,
+                )
+
+        def thinking_cb(text: str) -> None:
+            if text:
+                emit("_thinking", text)
+
+        factory = _resolve_agent_factory(params.get("agent_factory"))
+        agent = factory(
+            base_url=params.get("base_url"),
+            api_key=params.get("api_key"),
+            model=params.get("model") or "",
+            provider=params.get("provider"),
+            api_mode=params.get("api_mode"),
+            acp_command=params.get("acp_command"),
+            acp_args=params.get("acp_args"),
+            max_iterations=params.get("max_iterations") or 50,
+            max_tokens=params.get("max_tokens"),
+            reasoning_config=params.get("reasoning_config"),
+            prefill_messages=params.get("prefill_messages"),
+            fallback_model=params.get("fallback_model"),
+            enabled_toolsets=params.get("enabled_toolsets"),
+            quiet_mode=True,
+            ephemeral_system_prompt=params.get("ephemeral_system_prompt"),
+            log_prefix=f"[subagent-{task_index}]",
+            platform="subagent",
+            skip_context_files=True,
+            skip_memory=True,
+            clarify_callback=None,
+            thinking_callback=thinking_cb,
+            session_db=session_db,
+            session_id=params.get("session_id"),
+            parent_session_id=params.get("parent_session_id"),
+            providers_allowed=params.get("providers_allowed"),
+            providers_ignored=params.get("providers_ignored"),
+            providers_order=params.get("providers_order"),
+            provider_sort=params.get("provider_sort"),
+            openrouter_min_coding_score=params.get("openrouter_min_coding_score"),
+            tool_progress_callback=emit,
+            iteration_budget=None,  # fresh budget per subagent
+        )
+        agent._delegate_depth = params.get("child_depth", 1)
+        agent._delegate_role = params.get("role", "leaf")
+        agent._subagent_id = params.get("subagent_id")
+        agent._parent_subagent_id = params.get("parent_subagent_id")
+        agent._subagent_goal = goal
+        agent._parent_turn_id = params.get("parent_turn_id") or ""
+        parent_sid = params.get("parent_session_id")
+        if parent_sid and getattr(agent, "_session_init_model_config", None) is not None:
+            agent._session_init_model_config["_delegate_from"] = parent_sid
+
+        # Watcher thread: propagates the parent's interrupt Event into
+        # agent.interrupt() and pushes periodic activity snapshots so the
+        # parent's heartbeat/staleness monitor keeps working.
+        hb_interval = float(params.get("heartbeat_interval") or 30)
+        poll_s = 0.5
+        activity_every = max(1, int(hb_interval / poll_s))
+
+        def _watcher() -> None:
+            tick = 0
+            signaled = False
+            while not stop.wait(poll_s):
+                if not signaled and interrupt_event.is_set():
+                    signaled = True
+                    try:
+                        agent.interrupt("Interrupted by parent")
+                    except Exception:
+                        pass
+                tick += 1
+                if tick % activity_every == 0:
+                    try:
+                        event_queue.put(
+                            {
+                                "kind": "activity",
+                                "task_index": task_index,
+                                "summary": _sanitize(agent.get_activity_summary()),
+                            }
+                        )
+                    except Exception:
+                        pass
+
+        threading.Thread(target=_watcher, daemon=True).start()
+
+        emit("subagent.start", preview=goal)
+
+        child_task_id = params.get("subagent_id") or f"subagent-{task_index}"
+
+        def _relay_child_text(delta: str) -> None:
+            if delta:
+                emit("subagent.text", preview=delta)
+
+        result = agent.run_conversation(
+            user_message=goal,
+            task_id=child_task_id,
+            stream_callback=_relay_child_text,
+        )
+        stop.set()
+
+        duration = round(time.monotonic() - child_start, 2)
+        entry, complete_kwargs = _summarize_child_run(
+            agent, result, task_index, duration, child_task_id, wall_start
+        )
+
+        # File-state coordination: this process's registry only saw THIS
+        # child's tool calls, so check its writes against the parent's read
+        # snapshot here and hand the touched paths back for the parent to
+        # fold into its own registry.
+        try:
+            from tools import file_state
+
+            parent_reads = params.get("parent_reads_snapshot") or []
+            written_map = file_state.writes_since("", wall_start, parent_reads)
+            mod_paths = sorted({p for paths in written_map.values() for p in paths})
+            if mod_paths:
+                entry["_written_paths"] = mod_paths
+                reminder = (
+                    "\n\n[NOTE: subagent modified files the parent "
+                    "previously read — re-read before editing: "
+                    + ", ".join(mod_paths[:8])
+                    + (f" (+{len(mod_paths) - 8} more)" if len(mod_paths) > 8 else "")
+                    + "]"
+                )
+                if entry.get("summary"):
+                    entry["summary"] = entry["summary"] + reminder
+                else:
+                    entry["stale_paths"] = mod_paths
+        except Exception:
+            logger.debug("file_state child-write check failed", exc_info=True)
+
+        emit("subagent.complete", **complete_kwargs)
+
+    except Exception as exc:
+        stop.set()
+        duration = round(time.monotonic() - child_start, 2)
+        logging.exception("[subagent-%d] failed in isolated process", task_index)
+        entry = {
+            "task_index": task_index,
+            "status": "error",
+            "summary": None,
+            "error": str(exc),
+            "api_calls": 0,
+            "duration_seconds": duration,
+            "_child_role": params.get("role"),
+        }
+        emit(
+            "subagent.complete",
+            preview=str(exc),
+            status="failed",
+            duration_seconds=duration,
+            summary=str(exc),
+        )
+    finally:
+        stop.set()
+        try:
+            result_queue.put(_sanitize(entry))
+        except Exception:
+            try:
+                result_queue.put(
+                    {
+                        "task_index": task_index,
+                        "status": "error",
+                        "summary": None,
+                        "error": "Subagent result could not be serialised.",
+                        "api_calls": 0,
+                        "duration_seconds": round(time.monotonic() - child_start, 2),
+                        "_child_role": params.get("role"),
+                    }
+                )
+            except Exception:
+                pass
+        try:
+            if agent is not None and hasattr(agent, "close"):
+                agent.close()
+        except Exception:
+            logger.debug("Failed to close child agent in isolated process")
+
+
+def run_children_in_processes(
+    *,
+    children: List[Tuple[int, Dict[str, Any], ChildProcessSpec]],
+    parent_agent,
+    child_timeout: Optional[float],
+    on_complete: Optional[Callable[[Dict[str, Any]], None]] = None,
+) -> List[Dict[str, Any]]:
+    """Run a batch of subagents in isolated OS processes and join on them.
+
+    Parent-side counterpart of ``_child_process_main``.  Returns one entry
+    per child (same shape as the thread path), sorted by task_index.
+    Guarantees no child process outlives the call.
+    """
+    import multiprocessing as mp
+
+    from tools import file_state
+    from tools import delegate_tool as dt
+
+    # "spawn" (not fork): the parent holds live httpx/SSL clients, SQLite
+    # connections, and running threads — fork would inherit them in a
+    # corrupt state. Spawn gives each child a clean interpreter.
+    ctx = mp.get_context("spawn")
+    event_queue = ctx.Queue()
+    result_queue = ctx.Queue()
+
+    wall_start = time.time()
+    started_mono = time.monotonic()
+
+    specs: Dict[int, ChildProcessSpec] = {}
+    procs: Dict[int, Any] = {}
+    entries: Dict[int, Dict[str, Any]] = {}
+    dead_since: Dict[int, float] = {}
+    timeout_signaled: Dict[int, float] = {}
+    # Per-child heartbeat staleness state (port of _run_single_child's
+    # heartbeat loop): [last_iter, last_tool, stale_count, stopped]
+    hb_state: Dict[int, list] = {}
+    interrupt_signaled_at: Optional[float] = None
+
+    parent_session_id = getattr(parent_agent, "session_id", None)
+    parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
+
+    def _fire_start_hook(spec: ChildProcessSpec) -> None:
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+            _invoke_hook(
+                "subagent_start",
+                parent_session_id=parent_session_id,
+                parent_turn_id=parent_turn_id,
+                parent_subagent_id=spec._parent_subagent_id,
+                child_session_id=spec.session_id,
+                child_subagent_id=spec._subagent_id,
+                child_role=spec._delegate_role,
+                child_goal=spec.goal,
+            )
+        except Exception:
+            logger.debug("subagent_start hook invocation failed", exc_info=True)
+
+    def _finalize(i: int, entry: Dict[str, Any]) -> None:
+        entries[i] = entry
+        spec = specs.get(i)
+        if spec is None:
+            return
+        # Fold the child's writes into the parent's file-state registry so
+        # the parent's own stale-write guard sees them on later edits.
+        for path in entry.pop("_written_paths", []) or []:
+            try:
+                file_state.note_write(spec._subagent_id or f"subagent-{i}", path)
+            except Exception:
+                pass
+        spec.flush_progress()
+        spec.release()
+        if spec._subagent_id:
+            dt._unregister_subagent(spec._subagent_id)
+        proc = procs.get(i)
+        if proc is not None:
+            try:
+                proc.join(timeout=5)
+                if proc.is_alive():
+                    proc.kill()
+                    proc.join(timeout=5)
+            except Exception:
+                pass
+        if on_complete is not None:
+            try:
+                on_complete(entry)
+            except Exception:
+                logger.debug("on_complete callback failed", exc_info=True)
+
+    def _fabricated(i: int, status: str, error: str) -> Dict[str, Any]:
+        spec = specs.get(i)
+        return {
+            "task_index": i,
+            "status": status,
+            "summary": None,
+            "error": error,
+            "exit_reason": status,
+            "api_calls": 0,
+            "duration_seconds": round(time.monotonic() - started_mono, 2),
+            "_child_role": getattr(spec, "_delegate_role", None),
+        }
+
+    # ── Launch ───────────────────────────────────────────────────────
+    for i, _t, spec in children:
+        specs[i] = spec
+        hb_state[i] = [0, None, 0, False]
+        spec.attach_context(ctx)
+        if spec._subagent_id:
+            dt._register_subagent(
+                {
+                    "subagent_id": spec._subagent_id,
+                    "parent_id": spec._parent_subagent_id,
+                    "depth": max(0, (spec._delegate_depth or 1) - 1),
+                    "goal": spec.goal,
+                    "model": spec.model if isinstance(spec.model, str) else None,
+                    "started_at": time.time(),
+                    "status": "running",
+                    "tool_count": 0,
+                    "agent": spec,
+                }
+            )
+        if spec.progress_cb:
+            try:
+                spec.progress_cb("subagent.spawn_requested", preview=spec.goal)
+            except Exception as exc:
+                logger.debug("spawn_requested relay failed: %s", exc)
+        proc = ctx.Process(
+            target=_child_process_main,
+            args=(spec.params, event_queue, result_queue, spec.interrupt_event),
+            daemon=True,
+            name=f"hermes-subagent-{i}",
+        )
+        spec.process = proc
+        try:
+            proc.start()
+        except Exception as exc:
+            logger.warning("Failed to start subagent process %d: %s", i, exc)
+            _finalize(i, _fabricated(i, "error", f"Failed to start subagent process: {exc}"))
+            continue
+        procs[i] = proc
+        _fire_start_hook(spec)
+
+    pending = set(procs.keys()) - set(entries.keys())
+
+    def _handle_activity(i: int, summary: Dict[str, Any]) -> None:
+        """Port of the thread path's heartbeat: touch parent activity while
+        the child makes progress; go quiet once it looks stale so the
+        gateway inactivity timeout can fire."""
+        st = hb_state.get(i)
+        if st is None or st[3]:
+            return
+        child_tool = summary.get("current_tool")
+        child_iter = summary.get("api_call_count", 0) or 0
+        child_max = summary.get("max_iterations", 0)
+        if child_iter > st[0] or child_tool != st[1]:
+            st[0], st[1], st[2] = child_iter, child_tool, 0
+        else:
+            st[2] += 1
+        stale_limit = (
+            dt._HEARTBEAT_STALE_CYCLES_IN_TOOL
+            if child_tool
+            else dt._HEARTBEAT_STALE_CYCLES_IDLE
+        )
+        if st[2] >= stale_limit:
+            st[3] = True
+            logger.warning(
+                "Subagent %d appears stale (no progress for %d heartbeat "
+                "cycles, tool=%s) — stopping heartbeat",
+                i,
+                st[2],
+                child_tool or "<none>",
+            )
+            return
+        if child_tool:
+            desc = (
+                f"delegate_task: subagent running {child_tool} "
+                f"(iteration {child_iter}/{child_max})"
+            )
+        else:
+            child_desc = summary.get("last_activity_desc", "")
+            desc = (
+                f"delegate_task: subagent {child_desc} "
+                f"(iteration {child_iter}/{child_max})"
+                if child_desc
+                else f"delegate_task: subagent {i} working"
+            )
+        touch = getattr(parent_agent, "_touch_activity", None)
+        if callable(touch):
+            try:
+                touch(desc)
+            except Exception:
+                pass
+
+    def _drain_events(block_seconds: float) -> None:
+        deadline = time.monotonic() + block_seconds
+        first = True
+        while True:
+            timeout = max(0.0, deadline - time.monotonic()) if first else 0.0
+            first = False
+            try:
+                msg = event_queue.get(timeout=timeout) if timeout else event_queue.get_nowait()
+            except (_queue_mod.Empty, OSError, EOFError):
+                return
+            if not isinstance(msg, dict):
+                continue
+            i = msg.get("task_index")
+            if msg.get("kind") == "activity":
+                _handle_activity(i, msg.get("summary") or {})
+                continue
+            if msg.get("kind") != "progress":
+                continue
+            spec = specs.get(i)
+            cb = spec.progress_cb if spec is not None else None
+            if cb is None:
+                continue
+            try:
+                event_type, tool_name, preview, args, kwargs = msg.get("event")
+                cb(event_type, tool_name, preview, args, **(kwargs or {}))
+            except Exception as exc:
+                logger.debug("Child event relay failed: %s", exc)
+
+    def _drain_results() -> None:
+        while True:
+            try:
+                entry = result_queue.get_nowait()
+            except (_queue_mod.Empty, OSError, EOFError):
+                return
+            if not isinstance(entry, dict):
+                continue
+            i = entry.get("task_index")
+            if i in pending:
+                pending.discard(i)
+                _finalize(i, entry)
+
+    # ── Join loop ────────────────────────────────────────────────────
+    while pending:
+        now = time.monotonic()
+
+        # Parent interrupted → signal every child once, then give them a
+        # grace window to unwind before hard-terminating.
+        if (
+            interrupt_signaled_at is None
+            and getattr(parent_agent, "_interrupt_requested", False) is True
+        ):
+            interrupt_signaled_at = now
+            for i in pending:
+                specs[i].interrupt("Parent agent interrupted")
+
+        _drain_events(0.25)
+        _drain_results()
+        if not pending:
+            break
+        now = time.monotonic()
+
+        # Per-child wall-clock timeout (delegation.child_timeout_seconds).
+        if child_timeout:
+            for i in list(pending):
+                elapsed = now - started_mono
+                if i not in timeout_signaled and elapsed > child_timeout:
+                    timeout_signaled[i] = now
+                    specs[i].interrupt(f"Timed out after {child_timeout}s")
+                elif (
+                    i in timeout_signaled
+                    and now - timeout_signaled[i] > _TERMINATE_GRACE_SECONDS
+                ):
+                    proc = procs.get(i)
+                    if proc is not None and proc.is_alive():
+                        proc.terminate()
+                    pending.discard(i)
+                    _finalize(
+                        i,
+                        {
+                            **_fabricated(
+                                i,
+                                "timeout",
+                                f"Subagent timed out after {child_timeout}s "
+                                f"(isolated process terminated).",
+                            ),
+                            "exit_reason": "timeout",
+                        },
+                    )
+
+        # Interrupt grace expired → hard-terminate the stragglers.
+        if (
+            interrupt_signaled_at is not None
+            and now - interrupt_signaled_at > _TERMINATE_GRACE_SECONDS
+        ):
+            _drain_results()
+            for i in list(pending):
+                proc = procs.get(i)
+                if proc is not None and proc.is_alive():
+                    proc.terminate()
+                pending.discard(i)
+                _finalize(
+                    i,
+                    _fabricated(
+                        i,
+                        "interrupted",
+                        "Parent agent interrupted — child did not finish in time",
+                    ),
+                )
+            break
+
+        # Reap children that died without delivering a result. The IPC
+        # feeder may still be flushing right after exit, so give the
+        # result a short grace window before fabricating a crash entry.
+        for i in list(pending):
+            proc = procs.get(i)
+            if proc is None or proc.is_alive():
+                dead_since.pop(i, None)
+                continue
+            if i not in dead_since:
+                dead_since[i] = now
+                continue
+            if now - dead_since[i] > _DEAD_RESULT_GRACE_SECONDS:
+                pending.discard(i)
+                _finalize(
+                    i,
+                    _fabricated(
+                        i,
+                        "error",
+                        f"Subagent process exited unexpectedly "
+                        f"(exitcode={proc.exitcode}).",
+                    ),
+                )
+
+    # Trailing events (e.g. subagent.complete relayed just before exit).
+    _drain_events(0.25)
+
+    for q in (event_queue, result_queue):
+        try:
+            q.close()
+            q.join_thread()
+        except Exception:
+            pass
+
+    return [entries[i] for i in sorted(entries.keys())]

--- a/tools/delegate_process.py
+++ b/tools/delegate_process.py
@@ -253,6 +253,27 @@ def _child_process_main(params, event_queue, result_queue, interrupt_event) -> N
                 emit("_thinking", text)
 
         factory = _resolve_agent_factory(params.get("agent_factory"))
+        # Collect extra params (non-constructor keys) so test stub factories
+        # can receive test configuration across the spawn boundary.
+        _constructor_keys = {
+            "base_url", "api_key", "model", "provider", "api_mode",
+            "acp_command", "acp_args", "max_iterations", "max_tokens",
+            "reasoning_config", "prefill_messages", "fallback_model",
+            "enabled_toolsets", "ephemeral_system_prompt", "session_id",
+            "parent_session_id", "providers_allowed", "providers_ignored",
+            "providers_order", "provider_sort", "openrouter_min_coding_score",
+        }
+        _extra = {
+            k: v for k, v in params.items()
+            if k not in _constructor_keys and not k.startswith("_")
+        }
+        # _test_config starts with _ but is needed by stub factories
+        _extra["_test_config"] = params.get("_test_config")
+        _extra["goal"] = goal
+        _extra["role"] = params.get("role", "leaf")
+        _extra["subagent_id"] = params.get("subagent_id")
+        _extra["parent_subagent_id"] = params.get("parent_subagent_id")
+        _extra["parent_turn_id"] = params.get("parent_turn_id")
         agent = factory(
             base_url=params.get("base_url"),
             api_key=params.get("api_key"),
@@ -285,6 +306,7 @@ def _child_process_main(params, event_queue, result_queue, interrupt_event) -> N
             openrouter_min_coding_score=params.get("openrouter_min_coding_score"),
             tool_progress_callback=emit,
             iteration_budget=None,  # fresh budget per subagent
+            **_extra,
         )
         agent._delegate_depth = params.get("child_depth", 1)
         agent._delegate_role = params.get("role", "leaf")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -526,6 +526,20 @@ def _get_inherit_mcp_toolsets() -> bool:
     return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=True)
 
 
+def _get_process_isolation() -> bool:
+    """Whether batch subagents run in isolated OS processes.
+
+    Config key: delegation.process_isolation (bool, default False).
+    Opt-in: each batch child gets its own process (own GIL), eliminating
+    the GIL contention between subagent worker threads and the parent's
+    TUI / desktop WebSocket event loop (issues #58576, #57903, #32079).
+    When False (default) the historical in-process ThreadPoolExecutor
+    path is used.
+    """
+    cfg = _load_config()
+    return is_truthy_value(cfg.get("process_isolation"), default=False)
+
+
 def _is_mcp_toolset_name(name: str) -> bool:
     """Return True for canonical MCP toolsets and their registered aliases."""
     if not name:
@@ -1041,38 +1055,31 @@ def _inherit_parent_base_url(parent_agent, fallback_base_url: Optional[str]) -> 
     return fallback_base_url or None
 
 
-def _build_child_agent(
+def _resolve_child_settings(
     task_index: int,
     goal: str,
     context: Optional[str],
     toolsets: Optional[List[str]],
     model: Optional[str],
-    max_iterations: int,
-    task_count: int,
     parent_agent,
-    # Credential overrides from delegation config (provider:model resolution)
     override_provider: Optional[str] = None,
     override_base_url: Optional[str] = None,
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
-    # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
-    # Per-call role controlling whether the child can further delegate.
-    # 'leaf' (default) cannot; 'orchestrator' retains the delegation
-    # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
-):
-    """
-    Build a child AIAgent on the main thread (thread-safe construction).
-    Returns the constructed child agent without running it.
+) -> Dict[str, Any]:
+    """Resolve everything about a child agent that is plain data.
 
-    When override_* params are set (from delegation config), the child uses
-    those credentials instead of inheriting from the parent.  This enables
-    routing subagents to a different provider:model pair (e.g. cheap/fast
-    model on OpenRouter while the parent runs on Nous Portal).
+    Shared by ``_build_child_agent`` (in-process thread path) and
+    ``_build_child_process_spec`` (process-isolation path).  Everything
+    returned here is derived from the parent agent + delegation config:
+    role/depth bounds, subagent identity, toolset intersection, the child
+    system prompt, and the full credential bundle.  The process path
+    additionally requires every value to be picklable — anything
+    parent-object-shaped (callbacks, pools, clients) stays out of this dict.
     """
-    from run_agent import AIAgent
     import uuid as _uuid
 
     # ── Role resolution ─────────────────────────────────────────────────
@@ -1155,46 +1162,8 @@ def _build_child_agent(
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
         parent_api_key = parent_agent._client_kwargs.get("api_key")
 
-    # Resolve the child's effective model early so it can ride on every event.
-    effective_model_for_cb = model or getattr(parent_agent, "model", None)
-
-    # Build progress callback to relay tool calls to parent display.
-    # Identity kwargs thread the subagent_id through every emitted event so the
-    # TUI can reconstruct the spawn tree and route per-branch controls.
-    child_session_ref: Dict[str, Any] = {}
-    child_progress_cb = _build_child_progress_callback(
-        task_index,
-        goal,
-        parent_agent,
-        task_count,
-        subagent_id=subagent_id,
-        parent_id=parent_subagent_id,
-        depth=tui_depth,
-        model=effective_model_for_cb,
-        toolsets=child_toolsets,
-        session_ref=child_session_ref,
-    )
-
-    # Each subagent gets its own iteration budget capped at max_iterations
-    # (configurable via delegation.max_iterations, default 50).  This means
-    # total iterations across parent + subagents can exceed the parent's
-    # max_iterations.  The user controls the per-subagent cap in config.yaml.
-
-    child_thinking_cb = None
-    if child_progress_cb:
-
-        def _child_thinking(text: str) -> None:
-            if not text:
-                return
-            try:
-                child_progress_cb("_thinking", text)
-            except Exception as e:
-                logger.debug("Child thinking callback relay failed: %s", e)
-
-        child_thinking_cb = _child_thinking
-
     # Resolve effective credentials: config override > parent inherit
-    effective_model = model or parent_agent.model
+    effective_model = model or getattr(parent_agent, "model", None)
     effective_provider = override_provider or getattr(parent_agent, "provider", None)
     effective_base_url = override_base_url or parent_agent.base_url
     if not override_base_url:
@@ -1298,22 +1267,135 @@ def _build_child_agent(
         # openrouter/pareto-code), so we keep it inherited even when the
         # provider is overridden — it's a no-op on any other model.
 
+    return {
+        "subagent_id": subagent_id,
+        "parent_subagent_id": parent_subagent_id,
+        "child_depth": child_depth,
+        "tui_depth": tui_depth,
+        "effective_role": effective_role,
+        "max_spawn": max_spawn,
+        "child_toolsets": child_toolsets,
+        "child_prompt": child_prompt,
+        "model": effective_model,
+        "provider": effective_provider,
+        "base_url": effective_base_url,
+        "api_key": effective_api_key,
+        "api_mode": effective_api_mode,
+        "acp_command": effective_acp_command,
+        "acp_args": effective_acp_args,
+        "reasoning_config": child_reasoning,
+        "fallback_model": parent_fallback,
+        "providers_allowed": child_providers_allowed,
+        "providers_ignored": child_providers_ignored,
+        "providers_order": child_providers_order,
+        "provider_sort": child_provider_sort,
+        "openrouter_min_coding_score": child_openrouter_min_coding_score,
+    }
+
+
+def _build_child_agent(
+    task_index: int,
+    goal: str,
+    context: Optional[str],
+    toolsets: Optional[List[str]],
+    model: Optional[str],
+    max_iterations: int,
+    task_count: int,
+    parent_agent,
+    # Credential overrides from delegation config (provider:model resolution)
+    override_provider: Optional[str] = None,
+    override_base_url: Optional[str] = None,
+    override_api_key: Optional[str] = None,
+    override_api_mode: Optional[str] = None,
+    # ACP transport overrides from trusted delegation config.
+    override_acp_command: Optional[str] = None,
+    override_acp_args: Optional[List[str]] = None,
+    # Per-call role controlling whether the child can further delegate.
+    # 'leaf' (default) cannot; 'orchestrator' retains the delegation
+    # toolset subject to depth/kill-switch bounds applied below.
+    role: str = "leaf",
+):
+    """
+    Build a child AIAgent on the main thread (thread-safe construction).
+    Returns the constructed child agent without running it.
+
+    When override_* params are set (from delegation config), the child uses
+    those credentials instead of inheriting from the parent.  This enables
+    routing subagents to a different provider:model pair (e.g. cheap/fast
+    model on OpenRouter while the parent runs on Nous Portal).
+    """
+    from run_agent import AIAgent
+
+    s = _resolve_child_settings(
+        task_index,
+        goal,
+        context,
+        toolsets,
+        model,
+        parent_agent,
+        override_provider=override_provider,
+        override_base_url=override_base_url,
+        override_api_key=override_api_key,
+        override_api_mode=override_api_mode,
+        override_acp_command=override_acp_command,
+        override_acp_args=override_acp_args,
+        role=role,
+    )
+    subagent_id = s["subagent_id"]
+    parent_subagent_id = s["parent_subagent_id"]
+    effective_role = s["effective_role"]
+
+    # Build progress callback to relay tool calls to parent display.
+    # Identity kwargs thread the subagent_id through every emitted event so the
+    # TUI can reconstruct the spawn tree and route per-branch controls.
+    child_session_ref: Dict[str, Any] = {}
+    child_progress_cb = _build_child_progress_callback(
+        task_index,
+        goal,
+        parent_agent,
+        task_count,
+        subagent_id=subagent_id,
+        parent_id=parent_subagent_id,
+        depth=s["tui_depth"],
+        model=s["model"],
+        toolsets=s["child_toolsets"],
+        session_ref=child_session_ref,
+    )
+
+    # Each subagent gets its own iteration budget capped at max_iterations
+    # (configurable via delegation.max_iterations, default 50).  This means
+    # total iterations across parent + subagents can exceed the parent's
+    # max_iterations.  The user controls the per-subagent cap in config.yaml.
+
+    child_thinking_cb = None
+    if child_progress_cb:
+
+        def _child_thinking(text: str) -> None:
+            if not text:
+                return
+            try:
+                child_progress_cb("_thinking", text)
+            except Exception as e:
+                logger.debug("Child thinking callback relay failed: %s", e)
+
+        child_thinking_cb = _child_thinking
+
     child = AIAgent(
-        base_url=effective_base_url,
-        api_key=effective_api_key,
-        model=effective_model,
-        provider=effective_provider,
-        api_mode=effective_api_mode,
-        acp_command=effective_acp_command,
-        acp_args=effective_acp_args,
+        base_url=s["base_url"],
+        api_key=s["api_key"],
+        model=s["model"],
+        provider=s["provider"],
+        api_mode=s["api_mode"],
+        acp_command=s["acp_command"],
+        acp_args=s["acp_args"],
         max_iterations=max_iterations,
         max_tokens=getattr(parent_agent, "max_tokens", None),
-        reasoning_config=child_reasoning,
+        reasoning_config=s["reasoning_config"],
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
-        fallback_model=parent_fallback,
-        enabled_toolsets=child_toolsets,
+        fallback_model=s["fallback_model"],
+        enabled_toolsets=s["child_toolsets"],
         quiet_mode=True,
-        ephemeral_system_prompt=child_prompt,
+        ephemeral_system_prompt=s["child_prompt"],
         log_prefix=f"[subagent-{task_index}]",
         platform="subagent",
         skip_context_files=True,
@@ -1322,11 +1404,11 @@ def _build_child_agent(
         thinking_callback=child_thinking_cb,
         session_db=getattr(parent_agent, "_session_db", None),
         parent_session_id=getattr(parent_agent, "session_id", None),
-        providers_allowed=child_providers_allowed,
-        providers_ignored=child_providers_ignored,
-        providers_order=child_providers_order,
-        provider_sort=child_provider_sort,
-        openrouter_min_coding_score=child_openrouter_min_coding_score,
+        providers_allowed=s["providers_allowed"],
+        providers_ignored=s["providers_ignored"],
+        providers_order=s["providers_order"],
+        provider_sort=s["provider_sort"],
+        openrouter_min_coding_score=s["openrouter_min_coding_score"],
         tool_progress_callback=child_progress_cb,
         iteration_budget=None,  # fresh budget per subagent
     )
@@ -1335,7 +1417,7 @@ def _build_child_agent(
     # (including the spawn_requested below — first emit happens after this).
     child_session_ref["session_id"] = getattr(child, "session_id", "") or ""
     # Set delegation depth so children can't spawn grandchildren
-    child._delegate_depth = child_depth
+    child._delegate_depth = s["child_depth"]
     # Stash the post-degrade role for introspection (leaf if the
     # kill switch or depth bounded the caller's requested role).
     child._delegate_role = effective_role
@@ -1356,7 +1438,7 @@ def _build_child_agent(
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
     child_pool = _resolve_child_credential_pool(
-        effective_provider, parent_agent, effective_base_url
+        s["provider"], parent_agent, s["base_url"]
     )
     if child_pool is not None:
         child._credential_pool = child_pool
@@ -1395,6 +1477,180 @@ def _build_child_agent(
         logger.debug("subagent_start hook invocation failed", exc_info=True)
 
     return child
+
+
+def _build_child_process_spec(
+    task_index: int,
+    goal: str,
+    context: Optional[str],
+    toolsets: Optional[List[str]],
+    model: Optional[str],
+    max_iterations: int,
+    task_count: int,
+    parent_agent,
+    override_provider: Optional[str] = None,
+    override_base_url: Optional[str] = None,
+    override_api_key: Optional[str] = None,
+    override_api_mode: Optional[str] = None,
+    override_acp_command: Optional[str] = None,
+    override_acp_args: Optional[List[str]] = None,
+    role: str = "leaf",
+):
+    """Build a ``ChildProcessSpec`` for one process-isolated subagent.
+
+    Process-mode counterpart of ``_build_child_agent``: resolves the same
+    settings via ``_resolve_child_settings`` but, instead of constructing
+    the (unpicklable) AIAgent here, packages plain-data constructor params
+    for ``tools.delegate_process._child_process_main`` to rebuild the
+    agent inside a spawned child process.
+
+    Credentials are leased from the pool HERE (in the parent) and passed
+    as strings — the pool object itself never crosses the process
+    boundary; the lease is released by the runner when the child exits.
+
+    Raises if any parameter is not picklable; ``delegate_task`` catches
+    that and falls back to the in-process thread path for the batch.
+    """
+    import pickle
+    import time as _time
+    import uuid as _uuid
+
+    from tools.delegate_process import ChildProcessSpec
+
+    s = _resolve_child_settings(
+        task_index,
+        goal,
+        context,
+        toolsets,
+        model,
+        parent_agent,
+        override_provider=override_provider,
+        override_base_url=override_base_url,
+        override_api_key=override_api_key,
+        override_api_mode=override_api_mode,
+        override_acp_command=override_acp_command,
+        override_acp_args=override_acp_args,
+        role=role,
+    )
+
+    # Pre-generate the child's session id (same format agent_init uses) so
+    # the parent can fire subagent_start hooks and thread child_session_id
+    # onto every relayed event before the child process even boots.
+    session_id = f"{_time.strftime('%Y%m%d_%H%M%S')}_{_uuid.uuid4().hex[:6]}"
+
+    # Lease a credential in the parent so the child starts with a live key
+    # even when the provider pool is mid-rotation. The child cannot rotate
+    # further on its own (the pool stays parent-side); rate-limit recovery
+    # inside the child falls to its fallback chain.
+    effective_api_key = s["api_key"]
+    effective_base_url = s["base_url"]
+    pool = _resolve_child_credential_pool(s["provider"], parent_agent, s["base_url"])
+    leased_cred_id = None
+    if pool is not None:
+        try:
+            leased_cred_id = pool.acquire_lease()
+            if leased_cred_id is not None:
+                leased_entry = pool.current()
+                if leased_entry is not None:
+                    _key = getattr(leased_entry, "runtime_api_key", None) or getattr(
+                        leased_entry, "access_token", ""
+                    )
+                    _base = getattr(leased_entry, "runtime_base_url", None) or getattr(
+                        leased_entry, "base_url", None
+                    )
+                    if _key:
+                        effective_api_key = _key
+                    if _base:
+                        effective_base_url = _base
+        except Exception as exc:
+            logger.debug("Failed to lease credential for child process: %s", exc)
+
+    session_db = getattr(parent_agent, "_session_db", None)
+    session_db_path = str(getattr(session_db, "db_path", "") or "") or None
+
+    parent_task_id = getattr(parent_agent, "_current_task_id", None)
+    try:
+        parent_reads_snapshot = (
+            list(file_state.known_reads(parent_task_id)) if parent_task_id else []
+        )
+    except Exception:
+        parent_reads_snapshot = []
+
+    params: Dict[str, Any] = {
+        "task_index": task_index,
+        "goal": goal,
+        "task_count": task_count,
+        "subagent_id": s["subagent_id"],
+        "parent_subagent_id": s["parent_subagent_id"],
+        "child_depth": s["child_depth"],
+        "role": s["effective_role"],
+        "session_id": session_id,
+        "session_db_path": session_db_path,
+        "parent_session_id": getattr(parent_agent, "session_id", None),
+        "parent_turn_id": getattr(parent_agent, "_current_turn_id", "") or "",
+        "parent_reads_snapshot": parent_reads_snapshot,
+        "base_url": effective_base_url,
+        "api_key": effective_api_key,
+        "model": s["model"],
+        "provider": s["provider"],
+        "api_mode": s["api_mode"],
+        "acp_command": s["acp_command"],
+        "acp_args": s["acp_args"],
+        "max_iterations": max_iterations,
+        "max_tokens": getattr(parent_agent, "max_tokens", None),
+        "reasoning_config": s["reasoning_config"],
+        "prefill_messages": getattr(parent_agent, "prefill_messages", None),
+        "fallback_model": s["fallback_model"],
+        "enabled_toolsets": s["child_toolsets"],
+        "ephemeral_system_prompt": s["child_prompt"],
+        "providers_allowed": s["providers_allowed"],
+        "providers_ignored": s["providers_ignored"],
+        "providers_order": s["providers_order"],
+        "provider_sort": s["provider_sort"],
+        "openrouter_min_coding_score": s["openrouter_min_coding_score"],
+        "auto_approve": _get_subagent_approval_callback() is _subagent_auto_approve,
+        "heartbeat_interval": _HEARTBEAT_INTERVAL,
+        "agent_factory": None,
+    }
+
+    # Everything crossing the process boundary must survive pickling
+    # (spawn re-imports a clean interpreter — no shared state). Validate
+    # NOW so the caller can fall back to threads before any child starts.
+    try:
+        pickle.dumps(params)
+    except Exception:
+        if pool is not None and leased_cred_id is not None:
+            try:
+                pool.release_lease(leased_cred_id)
+            except Exception:
+                pass
+        raise
+
+    # Same parent-side progress callback the thread path uses — the child
+    # relays raw events over the IPC queue and the runner feeds them here,
+    # so the TUI/gateway see byte-identical event streams.
+    child_session_ref: Dict[str, Any] = {"session_id": session_id}
+    child_progress_cb = _build_child_progress_callback(
+        task_index,
+        goal,
+        parent_agent,
+        task_count,
+        subagent_id=s["subagent_id"],
+        parent_id=s["parent_subagent_id"],
+        depth=s["tui_depth"],
+        model=s["model"],
+        toolsets=s["child_toolsets"],
+        session_ref=child_session_ref,
+    )
+
+    return ChildProcessSpec(
+        task_index=task_index,
+        goal=goal,
+        params=params,
+        progress_cb=child_progress_cb,
+        pool=pool if leased_cred_id is not None else None,
+        leased_cred_id=leased_cred_id,
+    )
 
 
 def _dump_subagent_timeout_diagnostic(
@@ -1716,6 +1972,191 @@ def _apply_summary_budget(results: List[Dict[str, Any]], parent_agent) -> None:
         )
 
 
+def _summarize_child_run(
+    child,
+    result: Dict[str, Any],
+    task_index: int,
+    duration: float,
+    child_task_id: str,
+    wall_start: float,
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Build the (entry, complete_kwargs) pair for one finished child run.
+
+    ``entry`` is the structured result dict returned to the parent
+    aggregator; ``complete_kwargs`` is the observability payload for the
+    ``subagent.complete`` progress event.  Shared by ``_run_single_child``
+    (thread path) and ``tools.delegate_process._child_process_main``
+    (process-isolation path) so both produce byte-identical result shapes.
+
+    Reads the child's file-state registry, so it must run in the same
+    process the child's tools ran in.
+    """
+    summary = result.get("final_response") or ""
+    completed = result.get("completed", False)
+    interrupted = result.get("interrupted", False)
+    api_calls = result.get("api_calls", 0)
+
+    # The child emits the literal "(empty)" sentinel (see run_agent.py) when
+    # it gives up after repeated empty-LLM-response retries — typically a
+    # transport bug (misrouted provider, adapter returning empty
+    # ChatCompletion, etc.). Treat it as a failure so the parent surfaces
+    # it instead of silently accepting zero-content "success".
+    _empty_sentinel = summary.strip() == "(empty)"
+
+    if interrupted:
+        status = "interrupted"
+    elif summary and not _empty_sentinel:
+        # A summary means the subagent produced usable output.
+        # exit_reason ("completed" vs "max_iterations") already
+        # tells the parent *how* the task ended.
+        status = "completed"
+    else:
+        status = "failed"
+
+    # Build tool trace from conversation messages (already in memory).
+    # Uses tool_call_id to correctly pair parallel tool calls with results.
+    tool_trace: list[Dict[str, Any]] = []
+    trace_by_id: Dict[str, Dict[str, Any]] = {}
+    messages = result.get("messages") or []
+    if isinstance(messages, list):
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") == "assistant":
+                for tc in msg.get("tool_calls") or []:
+                    fn = tc.get("function", {})
+                    entry_t = {
+                        "tool": fn.get("name", "unknown"),
+                        "args_bytes": len(fn.get("arguments", "")),
+                    }
+                    tool_trace.append(entry_t)
+                    tc_id = tc.get("id")
+                    if tc_id:
+                        trace_by_id[tc_id] = entry_t
+            elif msg.get("role") == "tool":
+                content = _stringify_tool_content(msg.get("content", ""))
+                is_error = _looks_like_error_output(content)
+                result_meta = {
+                    "result_bytes": len(content),
+                    "status": "error" if is_error else "ok",
+                }
+                # Match by tool_call_id for parallel calls
+                tc_id = msg.get("tool_call_id")
+                target = trace_by_id.get(tc_id) if tc_id else None
+                if target is not None:
+                    target.update(result_meta)
+                elif tool_trace:
+                    # Fallback for messages without tool_call_id
+                    tool_trace[-1].update(result_meta)
+
+    # Determine exit reason
+    if interrupted:
+        exit_reason = "interrupted"
+    elif completed:
+        exit_reason = "completed"
+    else:
+        exit_reason = "max_iterations"
+
+    # Extract token counts (safe for mock objects)
+    _input_tokens = getattr(child, "session_prompt_tokens", 0)
+    _output_tokens = getattr(child, "session_completion_tokens", 0)
+    _model = getattr(child, "model", None)
+
+    entry: Dict[str, Any] = {
+        "task_index": task_index,
+        "status": status,
+        "summary": summary,
+        "api_calls": api_calls,
+        "duration_seconds": duration,
+        "model": _model if isinstance(_model, str) else None,
+        "exit_reason": exit_reason,
+        "tokens": {
+            "input": (
+                _input_tokens if isinstance(_input_tokens, (int, float)) else 0
+            ),
+            "output": (
+                _output_tokens if isinstance(_output_tokens, (int, float)) else 0
+            ),
+        },
+        "tool_trace": tool_trace,
+        # Captured before the finally block calls child.close() so the
+        # parent thread can fire subagent_stop with the correct role.
+        # Stripped before the dict is serialised back to the model.
+        "_child_role": getattr(child, "_delegate_role", None),
+        # Captured before child.close() so the parent aggregator can fold
+        # the child's total spend into the parent's session cost.  Port of
+        # Kilo-Org/kilocode#9448 — previously the footer only reflected the
+        # parent's direct API calls and under-counted subagent-heavy runs.
+        # Stripped before the dict is serialised back to the model.
+        "_child_cost_usd": (
+            float(getattr(child, "session_estimated_cost_usd", 0.0) or 0.0)
+            if isinstance(
+                getattr(child, "session_estimated_cost_usd", 0.0),
+                (int, float),
+            )
+            else 0.0
+        ),
+    }
+    if status == "failed":
+        entry["error"] = result.get("error", "Subagent did not produce a response.")
+
+    # Per-branch observability payload: tokens, cost, files touched, and
+    # a tail of tool-call results.  Fed into the TUI's overlay detail
+    # pane + accordion rollups (features 1, 2, 4).  All fields are
+    # optional — missing data degrades gracefully on the client.
+    _cost_usd = getattr(child, "session_estimated_cost_usd", None)
+    _reasoning_tokens = getattr(child, "session_reasoning_tokens", 0)
+    try:
+        _files_read = list(file_state.known_reads(child_task_id))[:40]
+    except Exception:
+        _files_read = []
+    try:
+        _files_written_map = file_state.writes_since(
+            "", wall_start, []
+        )  # all writes since wall_start
+    except Exception:
+        _files_written_map = {}
+    _files_written = sorted(
+        {
+            p
+            for tid, paths in _files_written_map.items()
+            if tid == child_task_id
+            for p in paths
+        }
+    )[:40]
+
+    _output_tail = _extract_output_tail(result, max_entries=8, max_chars=600)
+
+    complete_kwargs: Dict[str, Any] = {
+        "preview": summary[:160] if summary else entry.get("error", ""),
+        "status": status,
+        "duration_seconds": duration,
+        "summary": summary[:500] if summary else entry.get("error", ""),
+        "input_tokens": (
+            int(_input_tokens) if isinstance(_input_tokens, (int, float)) else 0
+        ),
+        "output_tokens": (
+            int(_output_tokens) if isinstance(_output_tokens, (int, float)) else 0
+        ),
+        "reasoning_tokens": (
+            int(_reasoning_tokens)
+            if isinstance(_reasoning_tokens, (int, float))
+            else 0
+        ),
+        "api_calls": int(api_calls) if isinstance(api_calls, (int, float)) else 0,
+        "files_read": _files_read,
+        "files_written": _files_written,
+        "output_tail": _output_tail,
+    }
+    if _cost_usd is not None:
+        try:
+            complete_kwargs["cost_usd"] = float(_cost_usd)
+        except (TypeError, ValueError):
+            pass
+
+    return entry, complete_kwargs
+
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -2034,114 +2475,9 @@ def _run_single_child(
 
         duration = round(time.monotonic() - child_start, 2)
 
-        summary = result.get("final_response") or ""
-        completed = result.get("completed", False)
-        interrupted = result.get("interrupted", False)
-        api_calls = result.get("api_calls", 0)
-
-        # The child emits the literal "(empty)" sentinel (see run_agent.py) when
-        # it gives up after repeated empty-LLM-response retries — typically a
-        # transport bug (misrouted provider, adapter returning empty
-        # ChatCompletion, etc.). Treat it as a failure so the parent surfaces
-        # it instead of silently accepting zero-content "success".
-        _empty_sentinel = summary.strip() == "(empty)"
-
-        if interrupted:
-            status = "interrupted"
-        elif summary and not _empty_sentinel:
-            # A summary means the subagent produced usable output.
-            # exit_reason ("completed" vs "max_iterations") already
-            # tells the parent *how* the task ended.
-            status = "completed"
-        else:
-            status = "failed"
-
-        # Build tool trace from conversation messages (already in memory).
-        # Uses tool_call_id to correctly pair parallel tool calls with results.
-        tool_trace: list[Dict[str, Any]] = []
-        trace_by_id: Dict[str, Dict[str, Any]] = {}
-        messages = result.get("messages") or []
-        if isinstance(messages, list):
-            for msg in messages:
-                if not isinstance(msg, dict):
-                    continue
-                if msg.get("role") == "assistant":
-                    for tc in msg.get("tool_calls") or []:
-                        fn = tc.get("function", {})
-                        entry_t = {
-                            "tool": fn.get("name", "unknown"),
-                            "args_bytes": len(fn.get("arguments", "")),
-                        }
-                        tool_trace.append(entry_t)
-                        tc_id = tc.get("id")
-                        if tc_id:
-                            trace_by_id[tc_id] = entry_t
-                elif msg.get("role") == "tool":
-                    content = _stringify_tool_content(msg.get("content", ""))
-                    is_error = _looks_like_error_output(content)
-                    result_meta = {
-                        "result_bytes": len(content),
-                        "status": "error" if is_error else "ok",
-                    }
-                    # Match by tool_call_id for parallel calls
-                    tc_id = msg.get("tool_call_id")
-                    target = trace_by_id.get(tc_id) if tc_id else None
-                    if target is not None:
-                        target.update(result_meta)
-                    elif tool_trace:
-                        # Fallback for messages without tool_call_id
-                        tool_trace[-1].update(result_meta)
-
-        # Determine exit reason
-        if interrupted:
-            exit_reason = "interrupted"
-        elif completed:
-            exit_reason = "completed"
-        else:
-            exit_reason = "max_iterations"
-
-        # Extract token counts (safe for mock objects)
-        _input_tokens = getattr(child, "session_prompt_tokens", 0)
-        _output_tokens = getattr(child, "session_completion_tokens", 0)
-        _model = getattr(child, "model", None)
-
-        entry: Dict[str, Any] = {
-            "task_index": task_index,
-            "status": status,
-            "summary": summary,
-            "api_calls": api_calls,
-            "duration_seconds": duration,
-            "model": _model if isinstance(_model, str) else None,
-            "exit_reason": exit_reason,
-            "tokens": {
-                "input": (
-                    _input_tokens if isinstance(_input_tokens, (int, float)) else 0
-                ),
-                "output": (
-                    _output_tokens if isinstance(_output_tokens, (int, float)) else 0
-                ),
-            },
-            "tool_trace": tool_trace,
-            # Captured before the finally block calls child.close() so the
-            # parent thread can fire subagent_stop with the correct role.
-            # Stripped before the dict is serialised back to the model.
-            "_child_role": getattr(child, "_delegate_role", None),
-            # Captured before child.close() so the parent aggregator can fold
-            # the child's total spend into the parent's session cost.  Port of
-            # Kilo-Org/kilocode#9448 — previously the footer only reflected the
-            # parent's direct API calls and under-counted subagent-heavy runs.
-            # Stripped before the dict is serialised back to the model.
-            "_child_cost_usd": (
-                float(getattr(child, "session_estimated_cost_usd", 0.0) or 0.0)
-                if isinstance(
-                    getattr(child, "session_estimated_cost_usd", 0.0),
-                    (int, float),
-                )
-                else 0.0
-            ),
-        }
-        if status == "failed":
-            entry["error"] = result.get("error", "Subagent did not produce a response.")
+        entry, complete_kwargs = _summarize_child_run(
+            child, result, task_index, duration, child_task_id, wall_start
+        )
 
         # Cross-agent file-state reminder.  If this subagent wrote any
         # files the parent had already read, surface it so the parent
@@ -2176,60 +2512,6 @@ def _run_single_child(
                             entry["stale_paths"] = mod_paths
         except Exception:
             logger.debug("file_state sibling-write check failed", exc_info=True)
-
-        # Per-branch observability payload: tokens, cost, files touched, and
-        # a tail of tool-call results.  Fed into the TUI's overlay detail
-        # pane + accordion rollups (features 1, 2, 4).  All fields are
-        # optional — missing data degrades gracefully on the client.
-        _cost_usd = getattr(child, "session_estimated_cost_usd", None)
-        _reasoning_tokens = getattr(child, "session_reasoning_tokens", 0)
-        try:
-            _files_read = list(file_state.known_reads(child_task_id))[:40]
-        except Exception:
-            _files_read = []
-        try:
-            _files_written_map = file_state.writes_since(
-                "", wall_start, []
-            )  # all writes since wall_start
-        except Exception:
-            _files_written_map = {}
-        _files_written = sorted(
-            {
-                p
-                for tid, paths in _files_written_map.items()
-                if tid == child_task_id
-                for p in paths
-            }
-        )[:40]
-
-        _output_tail = _extract_output_tail(result, max_entries=8, max_chars=600)
-
-        complete_kwargs: Dict[str, Any] = {
-            "preview": summary[:160] if summary else entry.get("error", ""),
-            "status": status,
-            "duration_seconds": duration,
-            "summary": summary[:500] if summary else entry.get("error", ""),
-            "input_tokens": (
-                int(_input_tokens) if isinstance(_input_tokens, (int, float)) else 0
-            ),
-            "output_tokens": (
-                int(_output_tokens) if isinstance(_output_tokens, (int, float)) else 0
-            ),
-            "reasoning_tokens": (
-                int(_reasoning_tokens)
-                if isinstance(_reasoning_tokens, (int, float))
-                else 0
-            ),
-            "api_calls": int(api_calls) if isinstance(api_calls, (int, float)) else 0,
-            "files_read": _files_read,
-            "files_written": _files_written,
-            "output_tail": _output_tail,
-        }
-        if _cost_usd is not None:
-            try:
-                complete_kwargs["cost_usd"] = float(_cost_usd)
-            except (TypeError, ValueError):
-                pass
 
         if child_progress_cb:
             try:
@@ -2476,37 +2758,87 @@ def delegate_task(
 
     _parent_tool_names = list(_model_tools._last_resolved_tool_names)
 
+    # Process isolation (delegation.process_isolation): batch children run
+    # in separate OS processes — each with its own GIL — instead of worker
+    # threads, so heavy subagent work can't starve the parent's TUI/desktop
+    # WebSocket event loop. Single-task mode keeps the historical direct
+    # path (no pool) regardless of the flag.
+    use_process_isolation = n_tasks > 1 and _get_process_isolation()
+
     # Build all child agents on the main thread (thread-safe construction)
     # Wrapped in try/finally so the global is always restored even if a
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
     children = []
     try:
-        for i, t in enumerate(task_list):
-            # Per-task role beats top-level; normalise again so unknown
-            # per-task values warn and degrade to leaf uniformly.
-            effective_role = _normalize_role(t.get("role") or top_role)
-            child = _build_child_agent(
-                task_index=i,
-                goal=t["goal"],
-                context=t.get("context"),
-                # Subagents always inherit the parent's toolsets; the model
-                # cannot choose or narrow them (no model-facing toolsets arg).
-                toolsets=None,
-                model=creds["model"],
-                max_iterations=effective_max_iter,
-                task_count=n_tasks,
-                parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_acp_command=creds.get("command"),
-                override_acp_args=creds.get("args"),
-                role=effective_role,
-            )
-            # Override with correct parent tool names (before child construction mutated global)
-            child._delegate_saved_tool_names = _parent_tool_names
-            children.append((i, t, child))
+        if use_process_isolation:
+            # Build picklable process specs instead of live AIAgents. If any
+            # task's params can't cross the process boundary (unpicklable
+            # reasoning config, exotic test doubles, ...), fall back to the
+            # thread path for the WHOLE batch — never split a batch across
+            # both execution models.
+            try:
+                for i, t in enumerate(task_list):
+                    effective_role = _normalize_role(t.get("role") or top_role)
+                    spec = _build_child_process_spec(
+                        task_index=i,
+                        goal=t["goal"],
+                        context=t.get("context"),
+                        toolsets=None,
+                        model=creds["model"],
+                        max_iterations=effective_max_iter,
+                        task_count=n_tasks,
+                        parent_agent=parent_agent,
+                        override_provider=creds["provider"],
+                        override_base_url=creds["base_url"],
+                        override_api_key=creds["api_key"],
+                        override_api_mode=creds["api_mode"],
+                        override_acp_command=creds.get("command"),
+                        override_acp_args=creds.get("args"),
+                        role=effective_role,
+                    )
+                    children.append((i, t, spec))
+            except Exception as exc:
+                logger.warning(
+                    "delegation.process_isolation: could not prepare "
+                    "process-isolated subagents (%s); falling back to "
+                    "in-process threads for this batch.",
+                    exc,
+                )
+                for _i, _t, _spec in children:
+                    try:
+                        _spec.release()
+                    except Exception:
+                        pass
+                children = []
+                use_process_isolation = False
+
+        if not use_process_isolation:
+            for i, t in enumerate(task_list):
+                # Per-task role beats top-level; normalise again so unknown
+                # per-task values warn and degrade to leaf uniformly.
+                effective_role = _normalize_role(t.get("role") or top_role)
+                child = _build_child_agent(
+                    task_index=i,
+                    goal=t["goal"],
+                    context=t.get("context"),
+                    # Subagents always inherit the parent's toolsets; the model
+                    # cannot choose or narrow them (no model-facing toolsets arg).
+                    toolsets=None,
+                    model=creds["model"],
+                    max_iterations=effective_max_iter,
+                    task_count=n_tasks,
+                    parent_agent=parent_agent,
+                    override_provider=creds["provider"],
+                    override_base_url=creds["base_url"],
+                    override_api_key=creds["api_key"],
+                    override_api_mode=creds["api_mode"],
+                    override_acp_command=creds.get("command"),
+                    override_acp_args=creds.get("args"),
+                    role=effective_role,
+                )
+                # Override with correct parent tool names (before child construction mutated global)
+                child._delegate_saved_tool_names = _parent_tool_names
+                children.append((i, t, child))
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
@@ -2526,6 +2858,50 @@ def delegate_task(
             _i, _t, child = children[0]
             result = _run_single_child(_i, _t["goal"], child, parent_agent)
             results.append(result)
+        elif use_process_isolation:
+            # Batch -- each child in its own OS process (own GIL). The
+            # runner relays child progress into the same parent-side
+            # callbacks the thread path uses, so the TUI/gateway event
+            # stream is identical.
+            completed_counter = [0]
+            spinner_ref = getattr(parent_agent, "_delegate_spinner", None)
+
+            def _note_completion(entry: Dict[str, Any]) -> None:
+                # Same per-task completion line the thread path prints.
+                completed_counter[0] += 1
+                idx = entry.get("task_index", 0)
+                label = task_labels[idx] if idx < len(task_labels) else f"Task {idx}"
+                dur = entry.get("duration_seconds", 0)
+                status = entry.get("status", "?")
+                icon = "✓" if status == "completed" else "✗"
+                remaining = n_tasks - completed_counter[0]
+                completion_line = f"{icon} [{idx+1}/{n_tasks}] {label}  ({dur}s)"
+                if spinner_ref:
+                    try:
+                        spinner_ref.print_above(completion_line)
+                    except Exception:
+                        _emit_parent_console(parent_agent, f"  {completion_line}")
+                else:
+                    _emit_parent_console(parent_agent, f"  {completion_line}")
+                if spinner_ref and remaining > 0:
+                    try:
+                        spinner_ref.update_text(
+                            f"🔀 {remaining} task{'s' if remaining != 1 else ''} remaining"
+                        )
+                    except Exception as e:
+                        logger.debug("Spinner update_text failed: %s", e)
+
+            from tools.delegate_process import run_children_in_processes
+
+            results.extend(
+                run_children_in_processes(
+                    children=children,
+                    parent_agent=parent_agent,
+                    child_timeout=_get_child_timeout(),
+                    on_complete=_note_completion,
+                )
+            )
+            results.sort(key=lambda r: r["task_index"])
         else:
             # Batch -- run in parallel with per-task progress lines
             completed_count = 0

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2112,8 +2112,8 @@ def _summarize_child_run(
         _files_read = []
     try:
         _files_written_map = file_state.writes_since(
-            "", wall_start, []
-        )  # all writes since wall_start
+            "", wall_start, _files_read
+        )  # writes to files the subagent read during this run
     except Exception:
         _files_written_map = {}
     _files_written = sorted(


### PR DESCRIPTION
## Problem

`delegate_task` runs batch subagents on `ThreadPoolExecutor` workers inside the parent process. All subagent threads share one GIL with the TUI/desktop WebSocket event loop. When 3+ subagents do CPU-heavy work (SSE parsing, regex, JSON), the event loop is starved — the WebSocket stalls for tens of seconds and the desktop app drops the connection.

**Tracked issues:**
- #58576 (open): "event loop stalled 51.4s (GIL pressure suspected)"
- #57903 (closed): Deep RCA confirmed worker-thread GIL contention from the Anthropic SDK SSE consumer
- #32079 (open, P1): Regex path held the GIL, starving all threads — same root cause, different trigger

Nobody has proposed the process-based fix before. All existing mitigations (locks, semaphores, poll tweaks, turn caps, background modes) work within the threading model. PR #57933 (closed/unmerged) explicitly identified "subprocess isolation for LLM calls" as the real fix but didn't implement it.

## Solution

Opt-in process isolation (`delegation.process_isolation: true` in config.yaml, default `false`). When enabled, each batch child runs in its own OS process via `multiprocessing(forkserver)`, giving each subagent its own GIL — mirroring how OpenClaw spawns subagents as separate Node.js child processes.

### Architecture

- **`tools/delegate_process.py`** (new, 810 lines): `ChildProcessSpec` (picklable parent-side handle), `_child_process_main` (forkserver entry point — reconstructs the AIAgent inside the child from picklable params, runs the conversation, streams progress over IPC), `run_children_in_processes` (parent poll loop — relays IPC events to identical progress callbacks, heartbeats parent activity, propagates interrupts, enforces timeouts, reaps all children)
- **`tools/delegate_tool.py`**: `_build_child_process_spec` extracts constructor args as a plain dict and validates picklability before spawning; batch path branches to process mode when enabled
- **`hermes_cli/config.py`**: `delegation.process_isolation: false` (opt-in config gate)

### Why forkserver (not spawn or fork)

- **fork** is unsafe: the parent holds live httpx/SSL clients, SQLite connections, and running threads — fork would inherit them in a corrupt state.
- **spawn** is safe but slow: each child re-imports the entire Python module tree (~1-2s startup, ~150MB/child).
- **forkserver** starts a clean helper process early (before the parent opens clients/threads), then forks children from it. The forkserver process is clean (no clients, no threads, no SSL), so forking from it is always safe. Children inherit already-imported modules via copy-on-write — startup drops to ~10ms, memory to ~20-30MB/child. Total overhead for 3 children: ~75-100MB (vs ~450MB for spawn).

### Key design decisions

- **IPC bridge**: child writes plain-dict events to `multiprocessing.Queue`, parent relays to identical progress callbacks — the TUI/gateway cannot tell the difference
- **Interrupt**: shared `multiprocessing.Event` — child watcher thread polls and calls `agent.interrupt()`
- **Timeout**: `delegation.child_timeout_seconds` defaults to `None` (no timeout — subagents doing big jobs won't get cancelled). Stuck-child protection is via heartbeat staleness monitor. Hard process termination with grace period (key advantage over threads — you CAN kill a stuck process).
- **Session DB**: child opens its own SQLite connection to the same path
- **File-state**: child checks writes against parent's read snapshot, passes modified paths back via result entry
- **Credential pool**: leased in parent before fork, released after completion
- **Single-task mode** always runs in-process (no pool overhead)
- **No fd cleanup needed**: forkserver helper starts clean; IPC Queue/Event objects are managed by the forkserver context itself

## Testing

- **12 new tests** in `tests/tools/test_delegate_process.py` covering: PID verification (children are separate OS processes), IPC event relay, interrupt propagation, timeout/hard-termination, config gate selection, result ordering by task_index, zombie cleanup, GIL freedom (parent stays responsive during child CPU work), child exception handling, params picklability
- **All 191 delegate-related tests pass** (151 existing + 12 new + 28 other delegate tests)
- **E2E verified**: 3 subagents ran in separate OS processes via LlamaHerd, each returned correct results (4, 6, 8) in 8.4s total

## Config

```yaml
delegation:
  process_isolation: true  # default: false (opt-in)
```

When `false` (default), the existing `ThreadPoolExecutor` path is used — no behavior change. When `true`, batch subagents run in isolated OS processes. Single-task mode always uses threads (no pool overhead for one child).

## Scope

This PR does NOT touch MOA (`agent/moa_loop.py`). MOA uses a separate `ThreadPoolExecutor` for reference model fan-out — it's I/O-bound API calls (not CPU-bound agent loops), so GIL pressure is much lower. That needs a different fix (async SDK migration), not process isolation.

## Future improvements (not for this PR)

- **Pre-warmed process pool**: Keep N pre-warmed child processes with AIAgent skeletons ready (eliminates ~1s construction latency per child). OpenClaw does this.
- **Hybrid mode**: Auto-select threads for I/O-bound tasks, processes for CPU-bound tasks.
- **Async API calls** (separate PR): Migrate the Anthropic SDK SSE consumer to async I/O with incremental JSON parsing — complementary to process isolation.
- **Python 3.14t free-threading**: When stable, removes the GIL entirely — process isolation becomes unnecessary.