### PR TITLE
feat(tts): allow per-call provider override

### DIFF
--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -450,6 +450,37 @@ class TestTextToSpeechToolWithCommandProvider:
         assert data["voice_compatible"] is False
         assert Path(data["file_path"]).exists()
 
+    def test_provider_override_routes_internal_call_without_mutating_config(self, tmp_path):
+        cfg = {
+            "provider": "py-config",
+            "providers": {
+                "py-config": {
+                    "type": "command",
+                    "command": _python_copy_command(),
+                    "output_format": "mp3",
+                },
+                "py-override": {
+                    "type": "command",
+                    "command": _python_copy_command(),
+                    "output_format": "mp3",
+                },
+            },
+        }
+        out = tmp_path / "override.mp3"
+
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg):
+            result = text_to_speech_tool(
+                text="hi",
+                output_path=str(out),
+                provider_override="py-override",
+            )
+
+        data = json.loads(result)
+        assert data["success"] is True, data
+        assert data["provider"] == "py-override"
+        assert cfg["provider"] == "py-config"
+        assert Path(data["file_path"]).exists()
+
     def test_voice_compatible_opt_in_toggles_flag(self, tmp_path):
         """voice_compatible=true is reflected in the response when the
         file is already .ogg (no ffmpeg needed)."""

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2153,12 +2153,14 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 def text_to_speech_tool(
     text: str,
     output_path: Optional[str] = None,
+    provider_override: Optional[str] = None,
 ) -> str:
     """
     Convert text to speech audio.
 
-    Reads provider/voice config from ~/.hermes/config.yaml (tts: section).
-    The model sends text; the user configures voice and provider.
+    Reads provider/voice config from ~/.hermes/config.yaml (tts: section),
+    unless an internal caller passes provider_override. The model sends text;
+    the user configures voice and provider.
 
     On messaging platforms, the returned MEDIA:<path> tag is intercepted
     by the send pipeline and delivered as a native voice message.
@@ -2167,6 +2169,8 @@ def text_to_speech_tool(
     Args:
         text: The text to convert to speech.
         output_path: Optional custom save path. Defaults to ~/voice-memos/<timestamp>.mp3
+        provider_override: Optional internal provider override for system-owned
+            call sites that must not mutate global tts.provider.
 
     Returns:
         str: JSON result with success, file_path, and optionally MEDIA tag.
@@ -2175,7 +2179,8 @@ def text_to_speech_tool(
         return tool_error("Text is required", success=False)
 
     tts_config = _load_tts_config()
-    provider = _get_provider(tts_config)
+    override = str(provider_override).lower().strip() if provider_override else ""
+    provider = override or _get_provider(tts_config)
 
     # User-declared command provider (type: command under tts.providers.<name>)
     # resolves BEFORE the built-in dispatch. Built-in names short-circuit here


### PR DESCRIPTION
## Summary
- Allows text_to_speech callers to override the configured TTS provider for one request.

## Test Plan
- uv run --python 3.11 --with pytest --with pytest-asyncio --with pytest-xdist python -m pytest -q -o 'addopts=' tests/tools/test_tts_command_providers.py::TestTextToSpeechToolWithCommandProvider

## Notes
- Split from a local Hermes patch queue branch based on current upstream/main.
- Draft PR so maintainers can review the generic seam independently.
