### PR TITLE
fix(model): resolve aliases in auxiliary and delegation paths

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3804,6 +3804,10 @@ def _try_configured_fallback_chain(
 
     task_config = _get_auxiliary_task_config(task)
     chain = task_config.get("fallback_chain")
+    if not chain:
+        alias = _task_model_alias(task_config)
+        if alias is not None:
+            chain = alias.get("fallback_chain")
     if not chain or not isinstance(chain, list):
         return None, None, ""
 
@@ -3995,6 +3999,7 @@ def _resolve_single_provider(
     model: Optional[str] = None,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ) -> Optional[Any]:
     """Resolve a single provider entry from fallback_chain to an OpenAI client.
 
@@ -4006,6 +4011,7 @@ def _resolve_single_provider(
         model=model,
         explicit_base_url=base_url,
         explicit_api_key=api_key,
+        api_mode=api_mode,
     )
     return client
 
@@ -5738,6 +5744,55 @@ _AUX_DIRECT_API_BASE_URLS: Dict[str, str] = {
 }
 
 
+def _model_alias_entry(alias_name: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Return config.yaml model_aliases.<alias_name> when it is usable.
+
+    Auxiliary task configs historically accepted only concrete provider/model
+    pairs. Adam's cheap-worker aliases carry the same pair plus a fallback_chain;
+    resolving them here lets auxiliary.<task>.model: smart-cheap inherit that
+    routing without copying fallback blocks into every task/profile.
+    """
+    key = str(alias_name or "").strip().lower()
+    if not key:
+        return None
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+    except Exception:
+        return None
+    aliases = config.get("model_aliases") if isinstance(config, dict) else None
+    if not isinstance(aliases, dict):
+        return None
+    for name, entry in aliases.items():
+        if str(name or "").strip().lower() != key or not isinstance(entry, dict):
+            continue
+        provider = str(entry.get("provider") or "").strip()
+        model = str(entry.get("model") or "").strip()
+        if not provider or not model:
+            return None
+        return dict(entry)
+    return None
+
+
+def _alias_api_mode(alias: Dict[str, Any]) -> Optional[str]:
+    raw = str(alias.get("api_mode") or alias.get("transport") or "").strip()
+    if raw:
+        return raw
+    api_format = str(alias.get("api_format") or "").strip().lower()
+    if api_format in {"anthropic", "anthropic_messages"}:
+        return "anthropic_messages"
+    if api_format in {"openai", "chat_completions", "openai_chat"}:
+        return "chat_completions"
+    if api_format == "codex_responses":
+        return "codex_responses"
+    return None
+
+
+def _task_model_alias(task_config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    alias_name = task_config.get("model_alias") or task_config.get("model")
+    return _model_alias_entry(str(alias_name or "").strip())
+
+
 def _resolve_task_provider_model(
     task: str = None,
     provider: str = None,
@@ -5771,6 +5826,19 @@ def _resolve_task_provider_model(
         cfg_base_url = str(task_config.get("base_url", "")).strip() or None
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
+        # If auxiliary.<task>.model names a configured model_alias, treat the
+        # alias as the task's concrete provider/model and inherit its fallback
+        # chain. Explicit call-time provider/model args still win below. A
+        # base_url/api_mode is inherited only when the alias uses base_url.
+        if not model:
+            alias = _task_model_alias(task_config)
+            if alias is not None:
+                cfg_provider = str(alias.get("provider") or cfg_provider or "").strip() or cfg_provider
+                cfg_model = str(alias.get("model") or cfg_model or "").strip() or cfg_model
+                alias_base_url = str(alias.get("base_url") or "").strip() or None
+                if alias_base_url:
+                    cfg_base_url = cfg_base_url or alias_base_url
+                    cfg_api_mode = cfg_api_mode or _alias_api_mode(alias)
 
     # 'auto' is a sentinel meaning "inherit from main runtime / auto-detect", not
     # a literal model id. Without this, a config of `auxiliary.<task>.model: auto`

--- a/cli.py
+++ b/cli.py
@@ -3789,6 +3789,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _DEFAULT_CONFIG_MODEL = ""
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
+        self._model_alias_name = None
+        self._model_alias_base_url = None
+        self._model_alias_api_mode = None
+        _resolved_model_alias = None
+        try:
+            from hermes_cli.model_aliases import resolve_model_alias
+
+            _resolved_model_alias = resolve_model_alias(CLI_CONFIG, self.model)
+            if _resolved_model_alias is not None:
+                self._model_alias_name = _resolved_model_alias.get("name")
+                self._model_alias_base_url = _resolved_model_alias.get("base_url") or None
+                self._model_alias_api_mode = _resolved_model_alias.get("api_mode") or None
+                self.model = _resolved_model_alias["model"]
+        except Exception:
+            _resolved_model_alias = None
         # Read max_tokens from config (env var override: HERMES_MAX_TOKENS)
         _env_mt = os.environ.get("HERMES_MAX_TOKENS")
         if _env_mt:
@@ -3825,17 +3840,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (
             provider
+            or (_resolved_model_alias.get("provider") if _resolved_model_alias is not None else None)
             or CLI_CONFIG["model"].get("provider")
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"
         )
         self._provider_source: Optional[str] = None
         self.provider = self.requested_provider
-        self.api_mode = "chat_completions"
+        self.api_mode = self._model_alias_api_mode or "chat_completions"
         self.acp_command: Optional[str] = None
         self.acp_args: list[str] = []
         self.base_url = (
             base_url
+            or self._model_alias_base_url
             or CLI_CONFIG["model"].get("base_url", "")
             or os.getenv("OPENROUTER_BASE_URL", "")
         ) or None

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -41,7 +41,11 @@ class CLIAgentSetupMixin:
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
-                explicit_base_url=self._explicit_base_url,
+                explicit_base_url=(
+                    self._explicit_base_url
+                    or getattr(self, "_model_alias_base_url", None)
+                ),
+                target_model=self.model,
             )
         except Exception as exc:
             _primary_exc = exc

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -52,17 +52,39 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     """Return the effective fallback chain merged across old and new config keys.
 
     ``fallback_providers`` remains the primary source of truth and keeps its
-    order. Legacy ``fallback_model`` entries are appended afterwards unless
-    they target the same provider/model/base_url route as an earlier entry.
-    The returned list always contains fresh dict copies.
+    order. If the primary ``model.default`` names a configured ``model_aliases``
+    entry, that alias' ``fallback_chain`` is appended next. Legacy
+    ``fallback_model`` entries are appended afterwards unless they target the
+    same provider/model/base_url route as an earlier entry. The returned list
+    always contains fresh dict copies.
     """
 
     config = config or {}
     chain: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
 
-    for key in ("fallback_providers", "fallback_model"):
-        for entry in _iter_fallback_entries(config.get(key)):
+    alias_fallback_chain: Any = None
+    try:
+        from hermes_cli.model_aliases import get_model_alias_entry
+
+        model_cfg = config.get("model")
+        if isinstance(model_cfg, dict):
+            alias_name = model_cfg.get("default") or model_cfg.get("model")
+        else:
+            alias_name = model_cfg
+        alias = get_model_alias_entry(config, alias_name)
+        if alias is not None:
+            alias_fallback_chain = alias.get("fallback_chain")
+    except Exception:
+        alias_fallback_chain = None
+
+    sources = (
+        config.get("fallback_providers"),
+        alias_fallback_chain,
+        config.get("fallback_model"),
+    )
+    for raw_entries in sources:
+        for entry in _iter_fallback_entries(raw_entries):
             identity = _entry_identity(entry)
             if identity in seen:
                 continue

--- a/hermes_cli/model_aliases.py
+++ b/hermes_cli/model_aliases.py
@@ -1,0 +1,161 @@
+"""Model alias resolution helpers.
+
+Model aliases are local Hermes config templates under ``model_aliases``.
+They are not provider-side model IDs, so callers must resolve them before
+building an LLM request. Keep this module dependency-light so it can be used
+by CLI startup, runtime provider resolution, and fallback-chain config.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+
+_VALID_API_MODES = {
+    "chat_completions",
+    "codex_responses",
+    "anthropic_messages",
+    "bedrock_converse",
+    "codex_app_server",
+}
+
+
+def _clean_str(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def alias_api_mode(alias: dict[str, Any]) -> Optional[str]:
+    """Return the normalized api_mode implied by a model alias."""
+    raw = _clean_str(alias.get("api_mode") or alias.get("transport")).lower()
+    if raw in _VALID_API_MODES:
+        return raw
+
+    api_format = _clean_str(alias.get("api_format")).lower()
+    if api_format in {"anthropic", "anthropic_messages"}:
+        return "anthropic_messages"
+    if api_format in {"openai", "chat_completions", "openai_chat"}:
+        return "chat_completions"
+    if api_format in {"codex", "codex_responses", "responses"}:
+        return "codex_responses"
+    if api_format == "bedrock_converse":
+        return "bedrock_converse"
+    return None
+
+
+def _endpoint_from_alias(alias: dict[str, Any]) -> str:
+    endpoint_env = _clean_str(alias.get("endpoint_env"))
+    if endpoint_env:
+        env_value = os.getenv(endpoint_env, "").strip()
+        if env_value:
+            return env_value
+    return _clean_str(alias.get("endpoint"))
+
+
+def _endpoint_to_base_url(endpoint: str, api_mode: Optional[str]) -> str:
+    """Convert a request endpoint to the base URL expected by transports.
+
+    Alias configs historically stored full endpoints such as
+    ``https://api.z.ai/api/anthropic/v1/messages``. The Anthropic transport
+    expects the API root (``.../anthropic``), while OpenAI-compatible clients
+    expect the root before ``/chat/completions``.
+    """
+    endpoint = (endpoint or "").strip().rstrip("/")
+    if not endpoint:
+        return ""
+
+    parsed = urlparse(endpoint)
+    path = parsed.path.rstrip("/")
+    lowered = path.lower()
+
+    suffixes: tuple[str, ...]
+    if api_mode == "anthropic_messages":
+        suffixes = ("/v1/messages", "/messages")
+    elif api_mode in {"chat_completions", "codex_responses", None}:
+        suffixes = ("/v1/chat/completions", "/chat/completions", "/responses")
+    else:
+        suffixes = ()
+
+    for suffix in suffixes:
+        if lowered.endswith(suffix):
+            new_path = path[: -len(suffix)] or ""
+            return parsed._replace(path=new_path, params="", query="", fragment="").geturl().rstrip("/")
+
+    return endpoint
+
+
+def get_model_alias_entry(config: dict[str, Any] | None, alias_name: Any) -> Optional[dict[str, Any]]:
+    """Return a validated copy of ``model_aliases.<alias_name>`` if present."""
+    key = _clean_str(alias_name).lower()
+    if not key or not isinstance(config, dict):
+        return None
+    aliases = config.get("model_aliases")
+    if not isinstance(aliases, dict):
+        return None
+
+    for name, entry in aliases.items():
+        if _clean_str(name).lower() != key or not isinstance(entry, dict):
+            continue
+        provider = _clean_str(entry.get("provider"))
+        model = _clean_str(entry.get("model"))
+        if not provider or not model:
+            return None
+        result = dict(entry)
+        result["name"] = _clean_str(name)
+        result["provider"] = provider
+        result["model"] = model
+        api_mode = alias_api_mode(result)
+        if api_mode:
+            result["api_mode"] = api_mode
+        base_url = _clean_str(result.get("base_url"))
+        if not base_url:
+            base_url = _endpoint_to_base_url(_endpoint_from_alias(result), api_mode)
+        if base_url:
+            result["base_url"] = base_url.rstrip("/")
+        return result
+    return None
+
+
+def _normalize_model_config(model_cfg: Any) -> dict[str, Any]:
+    if isinstance(model_cfg, dict):
+        cfg = dict(model_cfg)
+        if not cfg.get("default") and cfg.get("model"):
+            cfg["default"] = cfg.get("model")
+        return cfg
+    if isinstance(model_cfg, str) and model_cfg.strip():
+        return {"default": model_cfg.strip()}
+    return {}
+
+
+def resolve_model_alias(config: dict[str, Any] | None, model_name: Any) -> Optional[dict[str, Any]]:
+    """Resolve ``model_name`` when it names a configured model alias."""
+    return get_model_alias_entry(config, model_name)
+
+
+def apply_model_alias_to_model_config(config: dict[str, Any] | None) -> dict[str, Any]:
+    """Return ``model`` config with ``model.default`` aliases expanded.
+
+    If ``model.default`` (or legacy ``model.model``) names an entry under
+    ``model_aliases``, the returned config contains the concrete provider/model
+    route plus inherited base_url/api_mode/api_key when present. The original
+    alias name is preserved as ``configured_alias_intent`` for diagnostics.
+    """
+    config = config or {}
+    cfg = _normalize_model_config(config.get("model"))
+    alias_name = cfg.get("default") or cfg.get("model")
+    alias = get_model_alias_entry(config, alias_name)
+    if alias is None:
+        return cfg
+
+    resolved = dict(cfg)
+    resolved["configured_alias_intent"] = alias.get("name") or _clean_str(alias_name)
+    resolved["default"] = alias["model"]
+    resolved["provider"] = alias["provider"]
+
+    for key in ("base_url", "api_mode", "api_key"):
+        value = alias.get(key)
+        if value and not resolved.get(key):
+            resolved[key] = value
+
+    return resolved

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -274,12 +274,23 @@ def _auto_detect_local_model(base_url: str) -> str:
 
 def _get_model_config() -> Dict[str, Any]:
     config = load_config()
-    model_cfg = config.get("model")
-    if isinstance(model_cfg, dict):
-        cfg = dict(model_cfg)
-        # Accept "model" as alias for "default" (users intuitively write model.model)
-        if not cfg.get("default") and cfg.get("model"):
-            cfg["default"] = cfg["model"]
+    try:
+        from hermes_cli.model_aliases import apply_model_alias_to_model_config
+
+        cfg = apply_model_alias_to_model_config(config)
+    except Exception:
+        model_cfg = config.get("model")
+        if isinstance(model_cfg, dict):
+            cfg = dict(model_cfg)
+            # Accept "model" as alias for "default" (users intuitively write model.model)
+            if not cfg.get("default") and cfg.get("model"):
+                cfg["default"] = cfg["model"]
+        elif isinstance(model_cfg, str) and model_cfg.strip():
+            cfg = {"default": model_cfg.strip()}
+        else:
+            cfg = {}
+
+    if cfg:
         default = (cfg.get("default") or "").strip()
         base_url = (cfg.get("base_url") or "").strip()
         is_local = "localhost" in base_url or "127.0.0.1" in base_url
@@ -289,8 +300,6 @@ def _get_model_config() -> Dict[str, Any]:
             if detected:
                 cfg["default"] = detected
         return cfg
-    if isinstance(model_cfg, str) and model_cfg.strip():
-        return {"default": model_cfg.strip()}
     return {}
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -5161,6 +5161,47 @@ class TestCompressionFallbackContextFilter:
 
     # ── L2: configured fallback chain ─────────────────────────────────
 
+    def test_alias_model_inherits_fallback_chain(self, monkeypatch):
+        """auxiliary.<task>.model may name model_aliases.<alias>.
+
+        Adam's config uses auxiliary.*.model: smart-cheap and stores the
+        fallback_chain under model_aliases.smart-cheap. This must not be
+        treated as the literal provider model name "smart-cheap".
+        """
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fallback_client = MagicMock(name="alias_fallback_client")
+        chain = [
+            {"provider": "openai-codex", "model": "gpt-5.4", "api_mode": "codex_responses"}
+        ]
+        cfg = {
+            "model_aliases": {
+                "smart-cheap": {
+                    "provider": "zai",
+                    "model": "glm-5.2",
+                    "fallback_chain": chain,
+                }
+            }
+        }
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"model": "smart-cheap"} if task == "compression" else {},
+        )
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+
+        with patch(
+            "agent.auxiliary_client._resolve_fallback_entry",
+            return_value=(fallback_client, "gpt-5.4"),
+        ):
+            client, model, label = _try_configured_fallback_chain(
+                task="compression", failed_provider="zai", reason="error"
+            )
+
+        assert client is fallback_client
+        assert model == "gpt-5.4"
+        assert "openai-codex" in label
+
     def test_configured_chain_skips_too_small_candidate_for_compression(self, monkeypatch):
         """When entry[0] is reachable but too small and entry[1] is large enough,
         _try_configured_fallback_chain must return entry[1], not entry[0]."""

--- a/tests/hermes_cli/test_model_aliases.py
+++ b/tests/hermes_cli/test_model_aliases.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.model_aliases import apply_model_alias_to_model_config, get_model_alias_entry
+
+
+def _config() -> dict:
+    return {
+        "model": {"default": "smart-cheap", "provider": "stale-provider"},
+        "model_aliases": {
+            "smart-cheap": {
+                "provider": "zai",
+                "model": "glm-5.2",
+                "api_format": "anthropic",
+                "endpoint": "https://api.z.ai/api/anthropic/v1/messages",
+                "fallback_chain": [
+                    {
+                        "provider": "openai-codex",
+                        "model": "gpt-5.4",
+                        "api_mode": "codex_responses",
+                    }
+                ],
+            }
+        },
+    }
+
+
+def test_model_alias_entry_resolves_endpoint_to_transport_base_url():
+    alias = get_model_alias_entry(_config(), "smart-cheap")
+
+    assert alias is not None
+    assert alias["provider"] == "zai"
+    assert alias["model"] == "glm-5.2"
+    assert alias["api_mode"] == "anthropic_messages"
+    assert alias["base_url"] == "https://api.z.ai/api/anthropic"
+
+
+def test_apply_model_alias_to_model_config_expands_main_model():
+    model_cfg = apply_model_alias_to_model_config(_config())
+
+    assert model_cfg["default"] == "glm-5.2"
+    assert model_cfg["provider"] == "zai"
+    assert model_cfg["api_mode"] == "anthropic_messages"
+    assert model_cfg["base_url"] == "https://api.z.ai/api/anthropic"
+    assert model_cfg["configured_alias_intent"] == "smart-cheap"
+
+
+def test_fallback_chain_inherits_active_model_alias_fallback_chain():
+    chain = get_fallback_chain(_config())
+
+    assert chain == [
+        {
+            "provider": "openai-codex",
+            "model": "gpt-5.4",
+            "api_mode": "codex_responses",
+        }
+    ]
+
+
+def test_explicit_fallback_providers_precede_alias_fallback_and_dedupe():
+    cfg = _config()
+    cfg["fallback_providers"] = [
+        {"provider": "nous", "model": "Hermes-4"},
+        {"provider": "openai-codex", "model": "gpt-5.4"},
+    ]
+
+    chain = get_fallback_chain(cfg)
+
+    assert chain == [
+        {"provider": "nous", "model": "Hermes-4"},
+        {"provider": "openai-codex", "model": "gpt-5.4"},
+    ]

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1095,7 +1095,32 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["base_url"])
         self.assertIsNone(creds["api_key"])
 
+    def test_resolve_delegation_credentials_expands_model_alias_and_carries_fallback(self):
+        fallback = {
+            "provider": "openai-codex",
+            "model": "gpt-5.4",
+            "api_mode": "codex_responses",
+        }
+        cfg = {"model": "smart-cheap", "provider": "", "base_url": "", "api_mode": ""}
+        alias = {"provider": "zai", "model": "glm-5.2", "fallback_chain": [fallback]}
 
+        with patch("tools.delegate_tool._delegation_model_alias_entry", return_value=alias), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_resolve:
+            mock_resolve.return_value = {
+                "provider": "zai",
+                "model": "glm-5.2",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+                "api_key": "sk-test",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": [],
+            }
+            creds = _resolve_delegation_credentials(cfg, parent_agent=None)
+
+        self.assertEqual(creds["model"], "glm-5.2")
+        self.assertEqual(creds["provider"], "zai")
+        self.assertEqual(creds["fallback_chain"], [fallback])
+        mock_resolve.assert_called_once_with(requested="zai", target_model="glm-5.2")
 
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
         parent = _make_mock_parent(depth=0)
@@ -3028,6 +3053,34 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+    def test_child_uses_override_fallback_chain_from_alias(self):
+        """Alias-resolved delegation fallback_chain overrides parent fallback."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [{"provider": "parent", "model": "parent-model"}]
+        alias_fallback = {
+            "provider": "openai-codex",
+            "model": "gpt-5.4",
+            "api_mode": "codex_responses",
+        }
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test alias fallback override",
+                context=None,
+                toolsets=None,
+                model="glm-5.2",
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_provider="zai",
+                override_fallback_model=[alias_fallback],
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["fallback_model"], [alias_fallback])
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1058,6 +1058,7 @@ def _build_child_agent(
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    override_fallback_model: Optional[List[Dict[str, Any]]] = None,
     # Per-call role controlling whether the child can further delegate.
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
@@ -1275,7 +1276,11 @@ def _build_child_agent(
     # from rate-limits and credential exhaustion exactly like the top-level
     # agent does.  _fallback_chain is a list accepted by AIAgent's
     # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    parent_fallback = (
+        override_fallback_model
+        if override_fallback_model is not None
+        else (getattr(parent_agent, "_fallback_chain", None) or None)
+    )
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -2502,6 +2507,7 @@ def delegate_task(
                 override_api_mode=creds["api_mode"],
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
+                override_fallback_model=creds.get("fallback_chain"),
                 role=effective_role,
             )
             # Override with correct parent tool names (before child construction mutated global)
@@ -2888,6 +2894,38 @@ def delegate_task(
     return json.dumps(_execute_and_aggregate(), ensure_ascii=False)
 
 
+def _delegation_model_alias_entry(alias_name: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Return config.yaml model_aliases.<alias_name> when usable for delegation.
+
+    Delegation historically accepted only concrete provider/model values.
+    model_aliases entries carry a provider/model pair plus optional routing
+    metadata such as fallback_chain; resolving them here lets
+    delegation.model: smart-cheap use the same symbolic worker lane as
+    auxiliary tasks without passing the literal alias string to a provider.
+    """
+    key = str(alias_name or "").strip().lower()
+    if not key:
+        return None
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    except Exception:
+        return None
+    aliases = config.get("model_aliases") if isinstance(config, dict) else None
+    if not isinstance(aliases, dict):
+        return None
+    for name, entry in aliases.items():
+        if str(name or "").strip().lower() != key or not isinstance(entry, dict):
+            continue
+        provider = str(entry.get("provider") or "").strip()
+        model = str(entry.get("model") or "").strip()
+        if not provider or not model:
+            return None
+        return dict(entry)
+    return None
+
+
 def _resolve_child_credential_pool(
     effective_provider: Optional[str],
     parent_agent,
@@ -2997,6 +3035,19 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_model = str(cfg.get("model") or "").strip() or None
     configured_provider = str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
+
+    # Resolve model_aliases: if delegation.model names a configured alias
+    # (e.g. smart-cheap), expand to the alias's concrete provider/model pair.
+    alias = _delegation_model_alias_entry(cfg.get("model_alias") or configured_model)
+    if alias is not None:
+        configured_model = str(alias.get("model") or configured_model or "").strip() or None
+        configured_provider = (
+            str(alias.get("provider") or configured_provider or "").strip()
+            or configured_provider
+        )
+        alias_base_url = str(alias.get("base_url") or "").strip() or None
+        if alias_base_url:
+            configured_base_url = configured_base_url or alias_base_url
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
     configured_api_mode = str(cfg.get("api_mode") or "").strip().lower() or None
 
@@ -3054,6 +3105,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
+            "fallback_chain": alias.get("fallback_chain") if alias is not None else None,
         }
 
     if not configured_provider:
@@ -3064,6 +3116,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": None,
             "api_key": None,
             "api_mode": None,
+            "fallback_chain": alias.get("fallback_chain") if alias is not None else None,
         }
 
     # Provider is configured — resolve full credentials
@@ -3094,6 +3147,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "api_mode": runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
+        "fallback_chain": alias.get("fallback_chain") if alias is not None else None,
     }
 
 


### PR DESCRIPTION
## Summary
- Resolves configured model aliases consistently in auxiliary clients and delegation credential/fallback paths.

## Test Plan
- uv run --python 3.11 --with pytest --with pytest-asyncio --with pytest-xdist python -m pytest -q -o 'addopts=' tests/agent/test_auxiliary_client.py::TestCompressionFallbackContextFilter::test_alias_model_inherits_fallback_chain tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_resolve_delegation_credentials_expands_model_alias_and_carries_fallback tests/tools/test_delegate.py::TestFallbackModelInheritance::test_child_uses_override_fallback_chain_from_alias

## Notes
- Split from a local Hermes patch queue branch based on current upstream/main.
- Draft PR so maintainers can review the generic seam independently.
