### PR TITLE
fix(daemon): support Python 3.14 multiprocessing pools

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -49,15 +49,28 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            # CPython 3.14 changed ThreadPoolExecutor internals from
+            # (_initializer, _initargs, work_queue) to a WorkerContext object.
+            # Keep the daemon/no-_threads_queues behavior while matching the
+            # active stdlib worker signature.
+            create_worker_context = getattr(self, "_create_worker_context", None)
+            if create_worker_context is not None:
+                args = (
+                    weakref.ref(self, weakref_cb),
+                    create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
## Summary
- Updates daemon pool lifecycle handling for Python 3.14 compatibility.

## Test Plan
- python3 -m py_compile tools/daemon_pool.py

## Notes
- Split from a local Hermes patch queue branch based on current upstream/main.
- Draft PR so maintainers can review the generic seam independently.
