### PR TITLE
fix(runtime): restore request_overrides after transport recovery

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2067,6 +2067,7 @@ def init_agent(
         "base_url": agent.base_url,
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
+        "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1007,6 +1007,7 @@ def try_recover_primary_transport(
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
+        agent.request_overrides = dict(rt.get("request_overrides") or {})
 
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -1170,6 +1171,7 @@ def restore_primary_runtime(agent) -> bool:
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
+        agent.request_overrides = dict(rt.get("request_overrides") or {})
         agent._client_kwargs = dict(rt["client_kwargs"])
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -30,12 +30,18 @@ def _make_tool_defs(*names: str) -> list:
     ]
 
 
-def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"):
+def _make_agent(
+    fallback_model=None,
+    provider="custom",
+    base_url="https://my-llm.example.com/v1",
+    request_overrides=None,
+):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
+        patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
     ):
         agent = AIAgent(
             api_key="test-key-12345678",
@@ -45,6 +51,7 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
             skip_context_files=True,
             skip_memory=True,
             fallback_model=fallback_model,
+            request_overrides=dict(request_overrides or {}),
         )
         agent.client = MagicMock()
         return agent
@@ -73,6 +80,13 @@ class TestPrimaryRuntimeSnapshot:
         assert rt["api_mode"] == agent.api_mode
         assert "client_kwargs" in rt
         assert "compressor_context_length" in rt
+
+    def test_snapshot_includes_request_overrides(self):
+        overrides = {"extra_body": {"reasoning": {"effort": "medium"}}}
+        agent = _make_agent(request_overrides=overrides)
+        rt = agent._primary_runtime
+        assert rt["request_overrides"] == overrides
+        assert rt["request_overrides"] is not agent.request_overrides
 
     def test_snapshot_includes_compressor_state(self):
         agent = _make_agent()
@@ -200,6 +214,19 @@ class TestRestorePrimaryRuntime:
             agent._restore_primary_runtime()
 
         assert agent._use_prompt_caching == original_caching
+
+    def test_restores_request_overrides(self):
+        original_overrides = {"extra_body": {"reasoning": {"effort": "medium"}}}
+        agent = _make_agent(request_overrides=original_overrides)
+        agent._fallback_activated = True
+        agent.request_overrides = {"extra_body": {"fallback_only": True}}
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent.request_overrides == original_overrides
+        assert agent.request_overrides is not agent._primary_runtime["request_overrides"]
 
     def test_restore_skips_cross_provider_pool_entry(self):
         """Restore must not swap in a fallback provider credential for the primary runtime."""
@@ -409,6 +436,22 @@ class TestTryRecoverPrimaryTransport:
 
         assert result is True
 
+    def test_recovery_restores_request_overrides(self):
+        original_overrides = {"extra_body": {"reasoning": {"effort": "medium"}}}
+        agent = _make_agent(provider="custom", request_overrides=original_overrides)
+        error = _make_transport_error("ReadTimeout")
+        agent.request_overrides = {"extra_body": {"fallback_only": True}}
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("time.sleep"):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+        assert agent.request_overrides == original_overrides
+        assert agent.request_overrides is not agent._primary_runtime["request_overrides"]
+
     def test_recovers_on_connect_timeout(self):
         agent = _make_agent(provider="custom")
         error = _make_transport_error("ConnectTimeout")
@@ -502,6 +545,7 @@ class TestTryRecoverPrimaryTransport:
         error = _make_transport_error("ConnectError")
 
         with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()), \
              patch("time.sleep"):
             result = agent._try_recover_primary_transport(
                 error, retry_count=3, max_retries=3,


### PR DESCRIPTION
## Summary
- Includes request_overrides in primary runtime snapshots so transport recovery restores request-level model parameters.

## Test Plan
- uv run --python 3.11 --with pytest --with pytest-asyncio --with pytest-xdist python -m pytest -q -o 'addopts=' tests/run_agent/test_primary_runtime_restore.py::TestPrimaryRuntimeSnapshot::test_snapshot_includes_request_overrides tests/run_agent/test_primary_runtime_restore.py::TestRestorePrimaryRuntime::test_restores_request_overrides tests/run_agent/test_primary_runtime_restore.py::TestTryRecoverPrimaryTransport::test_recovery_restores_request_overrides

## Notes
- Split from a local Hermes patch queue branch based on current upstream/main.
- Draft PR so maintainers can review the generic seam independently.
