### PR TITLE
fix(gateway): allow .py/.markdown/.stl/.3mf media & document attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1333,6 +1333,7 @@ def _log_safe_path(path: str) -> str:
 SUPPORTED_DOCUMENT_TYPES = {
     ".pdf": "application/pdf",
     ".md": "text/markdown",
+    ".markdown": "text/markdown",
     ".txt": "text/plain",
     ".csv": "text/csv",
     ".log": "text/plain",
@@ -1353,6 +1354,8 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".ts": "text/plain",
     ".py": "text/plain",
     ".sh": "text/plain",
+    ".stl": "model/stl",
+    ".3mf": "model/3mf",
 }
 
 
@@ -1437,11 +1440,13 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Audio (delivered as voice/audio where supported)
     ".mp3", ".wav", ".ogg", ".opus", ".m4a", ".flac",
     # Documents (uploaded as file attachments)
-    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".epub",
+    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".markdown", ".py", ".epub",
     # Spreadsheets / data
     ".xlsx", ".xls", ".ods", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml",
     # Presentations
     ".pptx", ".ppt", ".odp", ".key",
+    # 3D models
+    ".stl", ".3mf",
     # Archives
     ".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz", ".7z", ".rar", ".apk", ".ipa",
     # Web / rendered output

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3622,8 +3622,10 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs. The extension
-        # set is the shared MEDIA_DELIVERY_EXTS source of truth (built once into
-        # MEDIA_TAG_CLEANUP_RE) so it can never drift from extract_local_files.
+        # set is MEDIA_DELIVERY_EXTS (built once into MEDIA_TAG_CLEANUP_RE) — the
+        # *outbound* delivery allowlist. Inbound bare-path extraction
+        # (extract_local_files) reuses the same allowlist minus source-code
+        # extensions like ``.py``, which must not be auto-shipped from a message.
         media_pattern = MEDIA_TAG_CLEANUP_RE
         # Mask example/stored MEDIA: paths before scanning so they are never
         # delivered as real attachments:
@@ -3724,7 +3726,11 @@ class BasePlatformAdapter(ABC):
             Tuple of (list of expanded file paths, cleaned text with the
             raw path strings removed).
         """
-        _LOCAL_MEDIA_EXTS = MEDIA_DELIVERY_EXTS
+        # Inbound local-file extraction excludes source-code extensions such as
+        # ``.py``: auto-attaching a script referenced in a message would be a
+        # surprise. Outbound MEDIA: delivery (MEDIA_DELIVERY_EXTS, used by the
+        # MEDIA: tag path above) still allows them — see #42206.
+        _LOCAL_MEDIA_EXTS = tuple(e for e in MEDIA_DELIVERY_EXTS if e != ".py")
         ext_part = '|'.join(e.lstrip('.') for e in _LOCAL_MEDIA_EXTS)
 
         # (?<![/:\w.]) prevents matching inside URLs (e.g. https://…/img.png)

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -331,6 +331,25 @@ class TestEdgeCases:
         paths, _ = _extract("See /tmp/script.py and /tmp/server.log here")
         assert paths == []
 
+    def test_py_excluded_from_inbound_extraction_but_deliverable_via_media_tag(self):
+        """Regression for PR #60069 — the inbound bare-path extractor and the
+        outbound MEDIA: tag deliverable must agree on ``.py`` without leaking.
+
+        A script referenced as a bare path in prose must NOT be auto-shipped
+        by ``extract_local_files`` (a surprise to the user), while an explicit
+        ``MEDIA:/abs/path/script.py`` tag MUST still be deliverable via
+        ``extract_media`` (the outbound allowlist deliberately includes ``.py``).
+        """
+        from gateway.platforms.base import BasePlatformAdapter
+
+        # Inbound: bare .py path is not extracted.
+        inbound_paths, _ = _extract("The helper lives at /tmp/script.py — review it")
+        assert inbound_paths == []
+
+        # Outbound: explicit MEDIA: tag for the same .py path IS extracted.
+        media, _ = BasePlatformAdapter.extract_media("Here: MEDIA:/tmp/script.py")
+        assert media == [("/tmp/script.py", False)]
+
     def test_path_with_spaces_not_matched(self):
         """Paths with spaces are intentionally not matched (avoids false positives)."""
         paths, _ = _extract("File at /tmp/my file.png here")

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -672,6 +672,39 @@ class TestMediaExtensionAllowlistParity:
             assert "MEDIA:" not in stripped, f".{ext} tag not stripped"
 
 
+class TestSupportedDocumentTypeMappings:
+    """Regression for PR #60069 — Telegram consumes SUPPORTED_DOCUMENT_TYPES
+    when assigning incoming document media types. The new allowlist entries
+    must map to their exact MIME types (and pre-existing entries must not
+    regress)."""
+
+    def test_new_mime_mappings_present(self):
+        from gateway.platforms.base import SUPPORTED_DOCUMENT_TYPES as T
+
+        assert T[".markdown"] == "text/markdown"
+        assert T[".stl"] == "model/stl"
+        assert T[".3mf"] == "model/3mf"
+
+    def test_preexisting_mime_mappings_intact(self):
+        from gateway.platforms.base import SUPPORTED_DOCUMENT_TYPES as T
+
+        # A sample of long-standing mappings must be untouched by the extension.
+        assert T[".pdf"] == "application/pdf"
+        assert T[".md"] == "text/markdown"
+        assert T[".txt"] == "text/plain"
+        assert T[".csv"] == "text/csv"
+
+    def test_extension_keys_are_normalized_lowercase(self):
+        from gateway.platforms.base import SUPPORTED_DOCUMENT_TYPES as T
+
+        # Telegram document lookups are case-insensitive on the suffix; the
+        # table must key on lowercase dotted extensions.
+        for key in (".markdown", ".stl", ".3mf", ".py", ".md"):
+            assert key in T
+            assert key == key.lower()
+            assert key.startswith(".")
+
+
 class TestExtensionlessMediaDelivery:
     """Regression: MEDIA: tags for extension-less files (Caddyfile, Makefile)."""
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -616,6 +616,8 @@ class TestMediaExtensionAllowlistParity:
     DROPPED_BEFORE = ["md", "json", "yaml", "yml", "xml", "html", "htm",
                       "tsv", "svg"]
 
+    NEVER_COVERED = ["py", "markdown", "stl", "3mf"]
+
     def test_previously_dropped_extensions_now_extract(self):
         for ext in self.DROPPED_BEFORE:
             path = f"/tmp/report.{ext}"
@@ -626,7 +628,8 @@ class TestMediaExtensionAllowlistParity:
         from gateway.platforms.base import MEDIA_DELIVERY_EXTS
         # Both functions reference MEDIA_DELIVERY_EXTS; assert the documents
         # that motivated the bug are present in the shared set.
-        for ext in (".md", ".json", ".yaml", ".yml", ".xml", ".html", ".htm"):
+        for ext in (".md", ".json", ".yaml", ".yml", ".xml", ".html", ".htm",
+                    ".py", ".markdown", ".stl", ".3mf"):
             assert ext in MEDIA_DELIVERY_EXTS
 
     def test_unknown_extension_not_black_holed_by_cleanup(self):
@@ -647,6 +650,26 @@ class TestMediaExtensionAllowlistParity:
         assert "MEDIA:" not in stripped
         assert "/tmp/report.md" not in stripped
         assert "Here is your report:" in stripped
+
+
+    def test_new_media_extensions_extract_via_media_tag(self):
+        """.py, .markdown, .stl, and .3mf are deliverable via MEDIA: tag (covers
+        issues #42206, #35474, #53249). MEDIA: tag for these should yield a
+        matched path — not silently dropped."""
+        for ext in self.NEVER_COVERED:
+            path = f"/tmp/artifact.{ext}"
+            media, _ = BasePlatformAdapter.extract_media(f"Here: MEDIA:{path}")
+            assert media == [(path, False)], f".{ext} should extract via MEDIA:"
+
+
+    def test_new_extensions_stripped_from_body(self):
+        """A MEDIA: tag with .py/.markdown/.stl/.3mf is cleaned from the body
+        (not left as orphan text)."""
+        from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
+        for ext in self.NEVER_COVERED:
+            text = f"See MEDIA:/tmp/artifact.{ext} attached"
+            stripped = MEDIA_TAG_CLEANUP_RE.sub("", text).strip()
+            assert "MEDIA:" not in stripped, f".{ext} tag not stripped"
 
 
 class TestExtensionlessMediaDelivery:


### PR DESCRIPTION
This adds four extensions to `MEDIA_DELIVERY_EXTS` and three to `SUPPORTED_DOCUMENT_TYPES`, so Hermes delivers and classifies files it was silently dropping.

- `.py` (Python scripts) Fixes #42206
- `.markdown` (Markdown) Fixes #35474
- `.stl` and `.3mf` (3D models) Fixes #53249

This consolidates the work in #42374, #35477, and #53354. Those PRs stay open.

Root cause: `MEDIA_DELIVERY_EXTS` (gateway/platforms/base.py) is the only list that governs outbound `MEDIA:` tag delivery. Any extension absent from it is dropped with no error. `SUPPORTED_DOCUMENT_TYPES` was also missing `.stl`, `.3mf`, and `.markdown`, so inbound files got the wrong MIME type.

Note on `.py`: it is allowed for outbound `MEDIA:` delivery but excluded from inbound bare-path extraction, so a script named in a message is not auto-attached as an attachment.
