### PR TITLE
fix(agent): strip non-API message properties in sanitize_api_messages — strict endpoints (Groq) reject them

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2388,6 +2388,18 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
         filtered.append(msg)
     messages = filtered
 
+    # --- Strip non-API properties: strict OpenAI-compatible endpoints ---
+    # (e.g. Groq) reject unknown message keys like the session-store's
+    # "timestamp" with HTTP 400 ("property 'timestamp' is unsupported").
+    # Rebuild dicts (non-mutating) rather than popping, so stored session
+    # messages keep their metadata.
+    _NON_API_KEYS = {"timestamp"}
+    if any(k in m for m in messages for k in _NON_API_KEYS):
+        messages = [
+            {k: v for k, v in m.items() if k not in _NON_API_KEYS}
+            for m in messages
+        ]
+
     # --- Drop empty / malformed tool_calls arrays on assistant messages ---
     # An assistant message carrying ``tool_calls: []`` (an empty array) — or a
     # non-list value under the key — is semantically identical to an assistant

--- a/tests/run_agent/test_session_meta_filtering.py
+++ b/tests/run_agent/test_session_meta_filtering.py
@@ -86,3 +86,35 @@ class TestCLISessionRestoreFiltering:
         assert all(m["role"] != "session_meta" for m in filtered)
         assert filtered[0]["role"] == "user"
         assert filtered[1]["role"] == "assistant"
+
+
+# ---------------------------------------------------------------------------
+# Non-API property stripping — strict endpoints (e.g. Groq) reject unknown
+# message keys like "timestamp" with HTTP 400.
+# ---------------------------------------------------------------------------
+
+class TestSanitizeApiMessagesPropertyStrip:
+
+    def test_strips_timestamp_property(self):
+        msgs = [
+            {"role": "user", "content": "hello", "timestamp": "2026-07-06T21:43:12"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert all("timestamp" not in m for m in out)
+
+    def test_preserves_standard_keys(self):
+        msgs = [
+            {"role": "assistant", "content": "hi", "timestamp": "x",
+             "tool_calls": [{"id": "c1", "function": {"name": "t", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok", "timestamp": "y"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["tool_calls"][0]["id"] == "c1"
+        assert out[1]["tool_call_id"] == "c1"
+        assert all("timestamp" not in m for m in out)
+
+    def test_non_mutating(self):
+        original = {"role": "user", "content": "hello", "timestamp": "keep-me"}
+        AIAgent._sanitize_api_messages([original])
+        assert original["timestamp"] == "keep-me"


### PR DESCRIPTION
## Problem

Session-store messages carry a `timestamp` property that leaks into the chat-completions payload. Tolerant providers (OpenAI, OpenRouter, Gemini-compat) silently ignore unknown keys, but strict OpenAI-compatible endpoints validate the message schema and refuse the request:

```
HTTP 400: 'messages.1' : for 'role:user' the following must be
satisfied[('messages.1' : property 'timestamp' is unsupported)]
```

This makes the custom-provider path unusable with Groq (and any other strict validator). Worse, because the error text mentions the context window, the 400 gets misclassified downstream as a context-overflow, triggering futile compression attempts and a session auto-reset — happy to file that error-classification report as a separate issue.

## Fix

Strip non-API keys in `sanitize_api_messages()`, which already runs before every LLM call (both call sites: `conversation_loop` and `chat_completion_helpers`). Dicts are rebuilt rather than mutated, so stored session messages keep their metadata. The strip is gated on key presence, so the common case pays ~nothing.

## Tests

Added `TestSanitizeApiMessagesPropertyStrip` to `tests/run_agent/test_session_meta_filtering.py` (the sanitizer's existing test home):
- strips `timestamp` from user/assistant messages
- preserves standard keys (`tool_calls`, `tool_call_id`) while stripping
- verifies non-mutation of the original stored message dicts

**8/8 pass** (5 existing + 3 new — no regressions).

## Context

Hit in production use — Hermes gateway → Slack → Groq `llama-3.3-70b-versatile` via the custom provider (v0.16.0, reproduced against today's HEAD). Related report from the same setup: #59539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)