### PR TITLE
fix(dashboard): preserve MoA save_traces/trace_dir on Desktop save

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4487,6 +4487,16 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                     "enabled": body.enabled,
                 }
             normalized = normalize_moa_config(raw)
+            # Preserve persistence-only fields the Desktop/dashboard payload
+            # never round-trips. normalize_moa_config drops keys it doesn't
+            # know about, and this endpoint does a wholesale overwrite of
+            # cfg["moa"], so a hand-edited save_traces / trace_dir would be
+            # silently discarded on every GUI save (issue #58819).
+            prev_moa = cfg.get("moa")
+            if isinstance(prev_moa, dict):
+                for key in ("save_traces", "trace_dir"):
+                    if key in prev_moa and key not in normalized:
+                        normalized[key] = prev_moa[key]
             cfg["moa"] = normalized
             save_config(cfg)
             return {"ok": True, **normalized}

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -510,6 +510,41 @@ class TestWebServerEndpoints:
         assert cfg["moa"]["reference_models"] == payload["reference_models"]
         assert cfg["moa"]["aggregator"] == payload["aggregator"]
 
+    def test_put_moa_models_preserves_save_traces_and_trace_dir(self):
+        """save_traces / trace_dir survive a Desktop MOA save (issue #58819).
+
+        The Desktop payload never carries these persistence-only fields, and
+        set_moa_models does a wholesale overwrite of cfg["moa"], so without the
+        preserve step a hand-edited save_traces/trace_dir is silently dropped.
+        """
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        moa = dict(cfg.get("moa") or {})
+        moa["save_traces"] = True
+        moa["trace_dir"] = "/tmp/moa-traces"
+        cfg["moa"] = moa
+        save_config(cfg)
+
+        payload = {
+            "reference_models": [
+                {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
+            ],
+            "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+            "max_tokens": 4096,
+            "enabled": True,
+        }
+
+        resp = self.client.put("/api/model/moa", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+        cfg = load_config()
+        assert cfg["moa"]["save_traces"] is True
+        assert cfg["moa"]["trace_dir"] == "/tmp/moa-traces"
+        # And the newly submitted slots still applied.
+        assert cfg["moa"]["reference_models"] == payload["reference_models"]
+
     # ── GET /api/media (remote image display) ───────────────────────────
 
     def test_get_media_serves_image_in_root(self):


### PR DESCRIPTION
## Summary

- Desktop MOA settings saves no longer silently drop `save_traces` / `trace_dir`.
- Users can keep MoA trace persistence enabled while editing MoA presets through the GUI.

## Motivation

Closes #58819.

The Desktop MOA settings panel calls `PUT /api/model/moa`. The endpoint runs the payload through `normalize_moa_config` (which only emits the keys it knows about) and then does a **wholesale overwrite** of `cfg["moa"]`. The Desktop payload (`MoaConfigPayload`) never carries the persistence-only `save_traces` / `trace_dir` fields, so any hand-edited value in `~/.hermes/config.yaml` is discarded on every GUI save — without warning or log entry. This makes it impossible to keep MoA trace persistence on while using the Desktop UI.

## Fix

In `set_moa_models`, before writing `cfg["moa"]`, carry `save_traces` and `trace_dir` forward from the previous `cfg["moa"]` when the normalized result omits them. Minimal, targeted, and does not change the normalize path.

## Verification

- `python3 -m pytest tests/hermes_cli/test_web_server.py -k moa` — 3 passed
- New regression test `test_put_moa_models_preserves_save_traces_and_trace_dir` **fails without the fix** (confirmed by reverting the preserve block) and passes with it.
- Did NOT change: `normalize_moa_config` behavior or the flattened compatibility view.