### PR TITLE
fix(cli): honor agent.save_trajectories config in interactive chat

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3882,6 +3882,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self.checkpoint_max_snapshots = cp_cfg.get("max_snapshots", 20)
         self.checkpoint_max_total_size_mb = cp_cfg.get("max_total_size_mb", 500)
         self.checkpoint_max_file_size_mb = cp_cfg.get("max_file_size_mb", 10)
+        # Trajectory sample capture (documented as agent.save_trajectories in
+        # config.yaml). The AIAgent already knows how to write JSONL samples,
+        # but the interactive CLI never read the config flag, so enabling it
+        # in config.yaml did nothing (issue #58200). Config is the sole
+        # user-facing control (no new non-secret HERMES_* env vars).
+        self.save_trajectories = bool(CLI_CONFIG["agent"].get("save_trajectories", False))
         self.pass_session_id = pass_session_id
         # --ignore-rules: honor either the constructor flag or the env var set
         # by `hermes chat --ignore-rules` in hermes_cli/main.py. When true we

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -353,6 +353,7 @@ class CLIAgentSetupMixin:
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,
                 disabled_toolsets=self.disabled_toolsets,
+                save_trajectories=getattr(self, "save_trajectories", False),
                 verbose_logging=self.verbose,
                 quiet_mode=not self.verbose,
                 tool_progress_mode=getattr(self, "tool_progress_mode", "all"),

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -91,6 +91,85 @@ class TestMaxTurnsResolution:
         assert isinstance(cli.max_turns, int) and cli.max_turns == 90
 
 
+class TestSaveTrajectories:
+    """agent.save_trajectories in config.yaml must reach the CLI (issue #58200)."""
+
+    def test_default_save_trajectories_is_false(self):
+        cli = _make_cli()
+        assert cli.save_trajectories is False
+
+    def test_config_enables_save_trajectories(self):
+        cli = _make_cli(config_overrides={"agent": {"save_trajectories": True}})
+        assert cli.save_trajectories is True
+
+    def test_config_forwards_save_trajectories_to_aiagent(self):
+        """Config must reach AIAgent(...), not just the HermesCLI attribute."""
+        import importlib
+        from unittest.mock import MagicMock, patch
+
+        _clean_config = {
+            "model": {
+                "default": "anthropic/claude-opus-4.6",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": "auto",
+            },
+            "display": {"compact": False, "tool_progress": "all"},
+            "agent": {"save_trajectories": True},
+            "terminal": {"env_type": "local"},
+        }
+        prompt_toolkit_stubs = {
+            "prompt_toolkit": MagicMock(),
+            "prompt_toolkit.history": MagicMock(),
+            "prompt_toolkit.styles": MagicMock(),
+            "prompt_toolkit.patch_stdout": MagicMock(),
+            "prompt_toolkit.application": MagicMock(),
+            "prompt_toolkit.layout": MagicMock(),
+            "prompt_toolkit.layout.processors": MagicMock(),
+            "prompt_toolkit.filters": MagicMock(),
+            "prompt_toolkit.layout.dimension": MagicMock(),
+            "prompt_toolkit.layout.menus": MagicMock(),
+            "prompt_toolkit.widgets": MagicMock(),
+            "prompt_toolkit.key_binding": MagicMock(),
+            "prompt_toolkit.completion": MagicMock(),
+            "prompt_toolkit.formatted_text": MagicMock(),
+            "prompt_toolkit.auto_suggest": MagicMock(),
+        }
+
+        class _DummyAgent:
+            def __init__(self, *args, **kwargs):
+                self.kwargs = kwargs
+
+        with patch.dict(sys.modules, prompt_toolkit_stubs), \
+             patch.dict("os.environ", {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}, clear=False):
+            import cli as _cli_mod
+            _cli_mod = importlib.reload(_cli_mod)
+            with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
+                 patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}), \
+                 patch.object(_cli_mod, "AIAgent", _DummyAgent), \
+                 patch(
+                     "hermes_cli.runtime_provider.resolve_runtime_provider",
+                     return_value={
+                         "provider": "openrouter",
+                         "api_mode": "chat_completions",
+                         "base_url": "https://openrouter.ai/api/v1",
+                         "api_key": "test-key",
+                         "source": "env/config",
+                     },
+                 ), \
+                 patch(
+                     "hermes_cli.runtime_provider.format_runtime_provider_error",
+                     side_effect=lambda exc: str(exc),
+                 ), \
+                 patch("hermes_cli.mcp_startup.wait_for_mcp_discovery"), \
+                 patch.object(_cli_mod, "_prepare_deferred_agent_startup"):
+                shell = _cli_mod.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+                # Skip session-db / credential side paths where practical.
+                shell._session_db = None
+                assert shell._init_agent() is True
+                assert shell.agent is not None
+                assert shell.agent.kwargs.get("save_trajectories") is True
+
+
 class TestVerboseAndToolProgress:
     def test_default_verbose_is_bool(self):
         cli = _make_cli()


### PR DESCRIPTION
## Summary

- The documented `agent.save_trajectories` config flag now actually enables trajectory JSONL capture in `hermes` / `hermes tui`.
- Config is the sole user-facing control (no new non-secret `HERMES_*` env vars).

## Motivation

Closes #58200.

The [trajectory-format docs](https://hermes-agent.nousresearch.com/docs/developer-guide/trajectory-format) say you can enable trajectory files with:

```yaml
agent:
  save_trajectories: true
```

But the interactive CLI never read this config value. `AIAgent` already knows how to write trajectory samples (`_save_trajectory` gates on `self.save_trajectories`), and `run_agent.py`'s `--save_trajectories` CLI path wires it up — but `HermesCLI` neither read the config flag nor forwarded `save_trajectories` into `AIAgent`, so the config setting was a no-op and no files were ever created.

## Fix

- `HermesCLI.__init__`: read `agent.save_trajectories` from config into `self.save_trajectories`.
- `CLIAgentSetupMixin`: forward `save_trajectories=self.save_trajectories` into the `AIAgent(...)` construction.

## Verification

- `python3 -m pytest tests/cli/test_cli_init.py -k SaveTrajectories` — 3 passed.
- New tests fail without the fix and pass with it: default False, config-enable, and AIAgent constructor forwarding when config enables it.
- Did NOT change: `AIAgent._save_trajectory` or the `run_agent.py` `--save_trajectories` path.

## Review feedback addressed (hermes-sweeper / teknium1)

- Removed the `HERMES_SAVE_TRAJECTORIES` env override (conflicts with AGENTS.md rule against new non-secret `HERMES_*` behavioral config).
- Added wiring test that captures `AIAgent(...)` and asserts `save_trajectories=True` when config enables it.