### PR TITLE
feat(tools): add Scrapling backend availability check

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -320,6 +320,19 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
+    if backend == "scrapling":
+        # Local, no-key, no-credentials. Extract-only. Available iff the
+        # ``scrapling`` Python package + its CLI are importable.
+        try:
+            import importlib.util
+            import shutil
+            if importlib.util.find_spec("scrapling") is None:
+                return False
+            if not shutil.which("scrapling"):
+                return False
+        except Exception:
+            return False
+        return True
     if backend == "xai":
         # Cheap probe — env var OR auth.json has OAuth tokens. Must not
         # call resolve_xai_http_credentials() here because the OAuth path


### PR DESCRIPTION
## Summary

Adds `_is_backend_available()` support for the `"scrapling"` backend in `tools/web_tools.py`. This backend is local-only, requires no API keys, and is used for web content extraction.

## Changes

- **`tools/web_tools.py`** — extended `_is_backend_available()` with a `"scrapling"` case that verifies:
  1. The `scrapling` Python package is importable (`importlib.util.find_spec`)
  2. The `scrapling` CLI binary is on PATH (`shutil.which`)

## Rationale

Follows the same zero-credential pattern used by other local backends (e.g. `ddgs`) — no env var or API key to check, only package + CLI availability. The dual check prevents a broken install from silently enabling the backend.