### PR TITLE
feat(display): show file_path in skill_view tool progress lines

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -515,6 +515,16 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
             msg = msg[:17] + "..."
         return f"to {target}: \"{msg}\""
 
+    if tool_name == "skill_view":
+        name = _oneline(str(args.get("name") or ""))
+        file_path = args.get("file_path")
+        if file_path:
+            file_path = _oneline(str(file_path))
+            preview = f"{name} → {file_path}" if name else file_path
+        else:
+            preview = name
+        return _truncate_preview(preview, max_len) if preview else None
+
     key = primary_args.get(tool_name)
     if not key:
         for fallback_key in ("query", "text", "command", "path", "name", "prompt", "code", "goal"):
@@ -1384,7 +1394,11 @@ def get_cute_tool_message(
     if tool_name == "skills_list":
         return _wrap(f"┊ 📚 skills    list {args.get('category', 'all')}  {dur}")
     if tool_name == "skill_view":
-        return _wrap(f"┊ 📚 skill     {_trunc(args.get('name', ''), 30)}  {dur}")
+        label = args.get("name", "")
+        file_path = args.get("file_path")
+        if file_path:
+            label = f"{label} → {file_path}" if label else str(file_path)
+        return _wrap(f"┊ 📚 skill     {_trunc(label, 44)}  {dur}")
     if tool_name == "image_generate":
         return _wrap(f"┊ 🎨 create    {_trunc(args.get('prompt', ''), 35)}  {dur}")
     if tool_name == "text_to_speech":


### PR DESCRIPTION
## Summary
`skill_view` tool progress lines now show which supporting file was loaded (`name → file_path`), not just the skill name — previously a reference/script load rendered identically to a full SKILL.md load.

## Changes
- `agent/display.py` `get_cute_tool_message()`: CLI quiet-mode line renders `┊ 📚 skill  <name> → <file_path>` when `file_path` is passed (wider 44-char truncation budget for the combined label)
- `agent/display.py` `build_tool_preview()`: dedicated `skill_view` branch appending `→ file_path`; flows to friendly labels ("Reading skill hermes-agent-dev → references/git-safety.md") in TUI, gateway api_server, and tool_executor spinner lines

## Validation
| Call | Before | After |
|---|---|---|
| `skill_view(name)` | `📚 skill  hermes-agent-dev` | unchanged |
| `skill_view(name, file_path)` | `📚 skill  hermes-agent-dev` | `📚 skill  hermes-agent-dev → references/pr-review-workflow.md` |
| `skill_view(file_path only)` | *(blank)* | `📚 skill  scripts/foo.py` |

Verified live via real imports (`get_cute_tool_message`, `build_tool_preview`, `build_tool_label`); `tests/agent/test_display_tool_failure.py` passes via `scripts/run_tests.sh`.

## Infographic

![skill-view-file-path-display](https://v3b.fal.media/files/b/0aa144da/pZ8gO5HAWEiE2twrvzA9m_l6TUYubc.png)
