### PR TITLE
fix(computer_use): bypass Windows enumeration for explicit screen capture

### DIFF
--- a/apps/desktop/src/store/layout.test.ts
+++ b/apps/desktop/src/store/layout.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const GROUPED_KEY = 'hermes.desktop.agentsGroupedByWorkspace'
+
+async function freshLayoutStore() {
+  vi.resetModules()
+
+  return await import('./layout')
+}
+
+afterEach(() => {
+  window.localStorage.clear()
+  vi.resetModules()
+})
+
+describe('desktop sidebar session visibility', () => {
+  it('does not restore persisted Projects mode over the human Sessions inbox', async () => {
+    window.localStorage.setItem(GROUPED_KEY, 'true')
+
+    const { $sidebarAgentsGrouped } = await freshLayoutStore()
+
+    expect($sidebarAgentsGrouped.get()).toBe(false)
+  })
+
+  it('keeps Projects mode as per-window state instead of persisting it across reloads', async () => {
+    const first = await freshLayoutStore()
+
+    first.setSidebarAgentsGrouped(true)
+
+    expect(first.$sidebarAgentsGrouped.get()).toBe(true)
+    expect(window.localStorage.getItem(GROUPED_KEY)).toBeNull()
+
+    const second = await freshLayoutStore()
+
+    expect(second.$sidebarAgentsGrouped.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -17,7 +17,6 @@ export const FILE_BROWSER_MAX_WIDTH = '20rem'
 export const SIDEBAR_SESSIONS_PAGE_SIZE = 50
 
 const SIDEBAR_PINNED_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
-const SIDEBAR_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.agentsGroupedByWorkspace'
 const SIDEBAR_CRON_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarCronOpen'
 const SIDEBAR_MESSAGING_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarMessagingOpen'
 const SIDEBAR_SESSION_ORDER_STORAGE_KEY = 'hermes.desktop.sessionOrder'
@@ -136,7 +135,12 @@ export const $sidebarMessagingOpenIds = persistentAtom(
   [] as string[],
   Codecs.stringArray
 )
-export const $sidebarAgentsGrouped = persistentAtom(SIDEBAR_AGENTS_GROUPED_STORAGE_KEY, false, Codecs.bool)
+// Keep the default sidebar as a human-chat inbox. Project grouping is a useful
+// drill-down view, but persisting it across restarts can make the user's actual
+// session history and messaging-platform threads look like they disappeared.
+// Treat the Projects view as per-window state: the user can still toggle into it,
+// but every fresh Desktop boot comes back to flat Sessions.
+export const $sidebarAgentsGrouped = atom(false)
 // When true, the sessions sidebar moves to the right and the file browser +
 // preview rail move to the left — a mirror of the default layout.
 export const $panesFlipped = persistentAtom(PANES_FLIPPED_STORAGE_KEY, false, Codecs.bool)

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2867,3 +2867,67 @@ class TestCuaToolCoverageExpansion:
         backend.call_tool("get_cursor_position")
         name, args = backend._session.call_tool.call_args.args
         assert args == {"session": backend._session_id}
+
+
+class TestStartupTimeoutPhaseDetail:
+    """Issue #57025: ready-timeout errors should identify the startup phase."""
+
+    def test_timeout_error_includes_startup_phase(self):
+        import asyncio
+        import threading
+        from typing import Any, cast
+        from unittest.mock import MagicMock, patch as _patch
+
+        from tools.computer_use.cua_backend import _CuaDriverSession
+
+        session = cast(Any, _CuaDriverSession.__new__(_CuaDriverSession))
+        session._lock = threading.Lock()
+        session._ready_event = threading.Event()
+        session._setup_error = None
+        session._shutdown_event = None
+        session._startup_phase = "mcp-initialize"
+        session._signal_shutdown_locked = lambda: None
+
+        fake_bridge = MagicMock()
+        fake_bridge._loop = MagicMock()
+        session._bridge = fake_bridge
+
+        with _patch.object(session._ready_event, "wait", return_value=False), \
+             _patch.object(asyncio, "run_coroutine_threadsafe", return_value=MagicMock()), \
+             _patch.object(_CuaDriverSession, "_lifecycle_coro", lambda self: None):
+            try:
+                session._start_lifecycle_locked()
+                assert False, "expected RuntimeError"
+            except RuntimeError as e:
+                msg = str(e)
+                assert "timeout 30s" in msg
+                assert "stuck in phase: mcp-initialize" in msg
+                assert "computer-use doctor" in msg
+
+    def test_timeout_error_defaults_to_unknown_phase(self):
+        import asyncio
+        import threading
+        from typing import Any, cast
+        from unittest.mock import MagicMock, patch as _patch
+
+        from tools.computer_use.cua_backend import _CuaDriverSession
+
+        session = cast(Any, _CuaDriverSession.__new__(_CuaDriverSession))
+        session._lock = threading.Lock()
+        session._ready_event = threading.Event()
+        session._setup_error = None
+        session._shutdown_event = None
+        session._signal_shutdown_locked = lambda: None
+
+        fake_bridge = MagicMock()
+        fake_bridge._loop = MagicMock()
+        session._bridge = fake_bridge
+
+        with _patch.object(session._ready_event, "wait", return_value=False), \
+             _patch.object(asyncio, "run_coroutine_threadsafe", return_value=MagicMock()), \
+             _patch.object(_CuaDriverSession, "_lifecycle_coro", lambda self: None):
+            try:
+                session._start_lifecycle_locked()
+                assert False, "expected RuntimeError"
+            except RuntimeError as e:
+                assert "stuck in phase: unknown" in str(e)

--- a/tests/tools/test_computer_use_desktop_fallback.py
+++ b/tests/tools/test_computer_use_desktop_fallback.py
@@ -1,0 +1,81 @@
+"""Regression tests for Windows desktop/screen capture fallback.
+
+When cua-driver's Windows enumeration tools hang (`list_windows`,
+`list_apps`, UIA tree walks), the driver can still take a full desktop
+screenshot via `get_desktop_state`. Explicit `app="screen"` captures must use
+that path directly instead of getting stuck on window enumeration first.
+"""
+
+from __future__ import annotations
+
+
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+    "NgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+)
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    def call_tool(self, name, args, timeout=30.0):
+        self.calls.append((name, args, timeout))
+        if name == "list_windows":
+            raise AssertionError("screen capture must not enumerate windows")
+        if name == "get_config":
+            return {
+                "structuredContent": {"capture_scope": "window"},
+                "data": {},
+                "images": [],
+                "image_mime_types": [],
+                "isError": False,
+            }
+        if name == "set_config":
+            return {
+                "structuredContent": {"capture_scope": args.get("value")},
+                "data": {},
+                "images": [],
+                "image_mime_types": [],
+                "isError": False,
+            }
+        if name == "get_desktop_state":
+            return {
+                "structuredContent": {
+                    "screen_width": 1920,
+                    "screen_height": 1080,
+                    "screenshot_width": 8,
+                    "screenshot_height": 8,
+                    "screenshot_mime_type": "image/png",
+                },
+                "data": "desktop screenshot 8x8 px",
+                "images": [_PNG_B64],
+                "image_mime_types": ["image/png"],
+                "isError": False,
+            }
+        raise AssertionError(f"unexpected tool {name}")
+
+
+def test_screen_capture_bypasses_list_windows_and_uses_desktop_state():
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    fake = FakeSession()
+    backend._session = fake
+
+    cap = backend.capture(mode="vision", app="screen")
+
+    assert cap.app == "screen"
+    assert cap.width == 8
+    assert cap.height == 8
+    assert cap.png_b64 == _PNG_B64
+    assert cap.image_mime_type == "image/png"
+    assert cap.elements == []
+    assert [c[0] for c in fake.calls] == [
+        "get_config",
+        "set_config",
+        "get_desktop_state",
+        "set_config",
+    ]
+    assert fake.calls[1][1] == {"key": "capture_scope", "value": "desktop"}
+    assert fake.calls[-1][1] == {"key": "capture_scope", "value": "window"}

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -567,6 +567,7 @@ class _CuaDriverSession:
         different task than it was entered in" warning emitted by the
         previous _aenter/_aexit split.
         """
+        import time as _time
         from mcp import ClientSession, StdioServerParameters
         from mcp.client.stdio import stdio_client
         from tools.environments.local import _sanitize_subprocess_env
@@ -574,6 +575,11 @@ class _CuaDriverSession:
         # Build the shutdown event on the loop's thread so the asyncio
         # primitive belongs to the correct loop.
         self._shutdown_event = asyncio.Event()
+        _t0 = _time.monotonic()
+        # Phase marker surfaced by the ready-timeout error (issue #57025):
+        # when startup wedges, the caller reports HOW FAR it got instead of
+        # an opaque "never reached ready".
+        self._startup_phase = "binary-check"
 
         try:
             if not cua_driver_binary_available():
@@ -582,7 +588,9 @@ class _CuaDriverSession:
             # Surface 8: ask cua-driver itself which subcommand spawns
             # the MCP server, instead of hardcoding ["mcp"]. Falls back
             # transparently for older drivers / any discovery failure.
+            self._startup_phase = "manifest-discovery"
             command, args = _resolve_mcp_invocation(_CUA_DRIVER_CMD)
+            _t_manifest = _time.monotonic()
             params = StdioServerParameters(
                 command=command,
                 args=args,
@@ -592,14 +600,25 @@ class _CuaDriverSession:
             )
 
             async with stdio_client(params) as (read, write):
+                self._startup_phase = "mcp-initialize"
                 async with ClientSession(read, write) as session:
                     await session.initialize()
+                    _t_init = _time.monotonic()
                     # Populate capabilities + capability_version BEFORE
                     # exposing the session to callers, so the first
                     # tool call already sees them.
+                    self._startup_phase = "capability-discovery"
                     await self._populate_capabilities(session)
                     self._session = session
+                    self._startup_phase = "ready"
                     self._ready_event.set()
+                    logger.info(
+                        "cua-driver session ready in %.1fs "
+                        "(manifest=%.1fs, mcp_init=%.1fs)",
+                        _time.monotonic() - _t0,
+                        _t_manifest - _t0,
+                        _t_init - _t_manifest,
+                    )
                     # Hold the contexts open until stop() / restart asks
                     # us to wind down. Tool calls run as their own tasks
                     # on the same loop and touch self._session directly.
@@ -677,10 +696,20 @@ class _CuaDriverSession:
         self._lifecycle_future = asyncio.run_coroutine_threadsafe(
             self._lifecycle_coro(), loop
         )
-        if not self._ready_event.wait(timeout=15.0):
+        if not self._ready_event.wait(timeout=30.0):
             # Best-effort: signal shutdown if the future is still alive.
             self._signal_shutdown_locked()
-            raise RuntimeError("cua-driver session never reached ready (timeout 15s)")
+            # Surface which startup phase wedged (issue #57025) — "doctor
+            # passes but the wrapper times out" reports are undiagnosable
+            # from a bare "never reached ready".
+            phase = getattr(self, "_startup_phase", "unknown")
+            from hermes_constants import display_hermes_home
+            raise RuntimeError(
+                "cua-driver session never reached ready (timeout 30s; "
+                f"stuck in phase: {phase}). "
+                "Run `hermes computer-use doctor` and check "
+                f"{display_hermes_home()}/logs/agent.log for the phase timings."
+            )
         # If setup failed, the lifecycle coroutine set _setup_error
         # before setting _ready_event. Re-raise it on the caller's thread.
         if self._setup_error is not None:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1038,12 +1038,84 @@ class CuaDriverBackend(ComputerUseBackend):
         return cua_driver_binary_available()
 
     # ── Capture ────────────────────────────────────────────────────
+    def _capture_desktop_state(self, mode: str = "vision") -> CaptureResult:
+        """Capture the full desktop directly via cua-driver's desktop path.
+
+        Windows CUA can have a healthy MCP/session/screenshot lane while
+        `list_windows` / UIA enumeration hangs (trycua/cua#2110/#2113).
+        For explicit `app="screen"` / `app="desktop"` requests, do not route
+        through window enumeration first. Use `get_desktop_state` directly so
+        users still get a real screenshot when the enumeration layer is sick.
+        """
+        previous_scope: Optional[str] = None
+        try:
+            cfg = self._session.call_tool("get_config", {}, timeout=10.0)
+            sc = cfg.get("structuredContent") or {}
+            if isinstance(sc, dict):
+                val = sc.get("capture_scope")
+                if isinstance(val, str):
+                    previous_scope = val
+        except Exception as e:
+            logger.debug("cua-driver get_config before desktop capture failed: %s", e)
+
+        try:
+            if previous_scope != "desktop":
+                self._session.call_tool(
+                    "set_config",
+                    {"key": "capture_scope", "value": "desktop"},
+                    timeout=10.0,
+                )
+            out = self._session.call_tool("get_desktop_state", {}, timeout=15.0)
+        finally:
+            if previous_scope and previous_scope != "desktop":
+                try:
+                    self._session.call_tool(
+                        "set_config",
+                        {"key": "capture_scope", "value": previous_scope},
+                        timeout=10.0,
+                    )
+                except Exception as e:
+                    logger.debug("cua-driver restore capture_scope failed: %s", e)
+
+        png_b64, image_mime_type = _image_from_tool_result(out)
+        structured = out.get("structuredContent") or {}
+        width = int(structured.get("screenshot_width") or structured.get("screen_width") or 0)
+        height = int(structured.get("screenshot_height") or structured.get("screen_height") or 0)
+        png_bytes_len = 0
+        if png_b64:
+            try:
+                raw = base64.b64decode(png_b64, validate=False)
+                png_bytes_len = len(raw)
+                detected_width, detected_height = _image_dimensions_from_bytes(raw)
+                if detected_width and detected_height:
+                    width = detected_width
+                    height = detected_height
+            except Exception:
+                png_bytes_len = len(png_b64) * 3 // 4
+        return CaptureResult(
+            mode=mode,
+            width=width,
+            height=height,
+            png_b64=png_b64,
+            elements=[],
+            app="screen",
+            window_title="Desktop screenshot via cua-driver get_desktop_state",
+            png_bytes_len=png_bytes_len,
+            image_mime_type=image_mime_type,
+        )
+
     def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
         """Capture the frontmost on-screen window (optionally filtered by app name).
 
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
-        `get_window_state` (ax/som) or `screenshot` (vision).
+        `get_window_state` (ax/som) or `screenshot` (vision). Explicit
+        whole-screen requests bypass `list_windows` and use `get_desktop_state`
+        directly so Windows screenshot capture still works when enumeration
+        hangs.
         """
+        if app and app.strip().lower() in _SCREEN_CAPTURE_SENTINELS:
+            return self._capture_desktop_state(mode=mode)
+
         # Step 1: enumerate on-screen windows to find target pid/window_id.
         # Surface 3 of NousResearch/hermes-agent#47072: read the canonical
         # `structuredContent.windows` array directly. Pre-fix the wrapper


### PR DESCRIPTION
## Summary

Adds a Windows-resilient path for explicit `computer_use(... app="screen"|"desktop")` capture requests.

When CUA's Windows enumeration tools hang (`list_windows`, `list_apps`, UIA tree walk), the driver can still successfully capture the full desktop via `get_desktop_state`. The current Hermes wrapper routes every capture through `list_windows` first, so even explicit screen captures hang before reaching the healthy screenshot lane.

This patch makes explicit screen/desktop captures bypass `list_windows` and call `get_desktop_state` directly.

## Why

Fresh local evidence on Windows 11 Pro:

- `hermes computer-use doctor` passes after local signing/trust repair.
- `hermes mcp test cua-driver` passes.
- `cua-driver call get_screen_size '{}'` passes.
- `cua-driver call get_desktop_state ...` passes in ~0.13s and writes a real screenshot.
- `list_apps`, `list_windows`, and `get_accessibility_tree` still hang or time out.

Related CUA-side issues:

- trycua/cua#2110
- trycua/cua#2113
- trycua/cua#2118

This is not a full replacement for the CUA enumeration fix. It is a Hermes-side salvage path so explicit screen captures remain useful when enumeration is the broken layer.

## Implementation

- Adds `CuaDriverBackend._capture_desktop_state()`.
- For explicit screen sentinels (`screen`, `desktop`, `fullscreen`, etc.), `capture()` now calls `get_desktop_state` directly.
- Temporarily switches `capture_scope` to `desktop`, then restores the prior scope.
- Returns a normal `CaptureResult` with PNG bytes and no elements.
- Leaves app/window-specific capture behavior unchanged.

## Tests

```text
PYTHONPATH=. uv run --with pytest --with pytest-xdist --with pyyaml python -m pytest tests/tools/test_computer_use_desktop_fallback.py tests/tools/test_computer_use_capture_routing.py tests/tools/test_computer_use_vision_routing.py -q -n 0
45 passed in 2.89s
```

## Local smoke

Standalone backend smoke after patch:

```text
START 0.94
CAPTURE vision dt 0.09 size 1920 1080 png_len 1933076 bytes 1449805 elements 0 app screen
CAPTURE som dt 0.09 size 1920 1080 png_len 1933076 bytes 1449805 elements 0 app screen
```