### PR TITLE
fix(computer_use): bypass Windows enumeration for explicit screen capture

### DIFF
--- a/agent/block_logic_threshold.py
+++ b/agent/block_logic_threshold.py
@@ -1,0 +1,214 @@
+"""Deterministic Block Logic continuity-pressure evaluation.
+
+The evaluator is pure and side-effect free. Host integrations decide whether to
+log, display a notice, or create a temporary noncanonical rescue artifact.
+Canonical Continuity Block writes are never authorized here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, fields
+from enum import Enum
+from typing import Any, Mapping
+
+
+class ThresholdLevel(str, Enum):
+    NORMAL = "normal"
+    QUIET = "quiet_indicator"
+    RECOMMEND = "block_logic_recommended"
+    PROMINENT = "prominent_warning"
+    RESCUE = "temporary_rescue_snapshot"
+
+
+@dataclass(frozen=True)
+class ThresholdConfig:
+    quiet_threshold: float = 0.70
+    recommend_threshold: float = 0.82
+    prominent_threshold: float = 0.90
+    rescue_threshold: float = 0.95
+
+    elapsed_hours_full: float = 24.0
+    message_count_full: int = 180
+    decision_count_full: int = 25
+    changed_files_full: int = 20
+    compression_events_full: int = 3
+    model_handoffs_full: int = 4
+
+    context_weight: float = 0.72
+    elapsed_weight: float = 0.08
+    messages_weight: float = 0.07
+    decisions_weight: float = 0.05
+    files_weight: float = 0.03
+    compression_weight: float = 0.03
+    handoffs_weight: float = 0.02
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "ThresholdConfig":
+        raw = raw if isinstance(raw, Mapping) else {}
+        allowed = {field.name for field in fields(cls)}
+        values = {key: raw[key] for key in allowed if key in raw}
+        config = cls(**values)
+        thresholds = (
+            config.quiet_threshold,
+            config.recommend_threshold,
+            config.prominent_threshold,
+            config.rescue_threshold,
+        )
+        if any(not 0.0 < value <= 1.0 for value in thresholds):
+            raise ValueError("Block Logic thresholds must be in the range (0, 1]")
+        if tuple(sorted(thresholds)) != thresholds:
+            raise ValueError("Block Logic thresholds must be monotonically increasing")
+        return config
+
+
+@dataclass(frozen=True)
+class SessionMetrics:
+    context_used: int
+    context_limit: int
+    elapsed_hours: float = 0.0
+    message_count: int = 0
+    decision_count: int = 0
+    changed_files: int = 0
+    compression_events: int = 0
+    model_handoffs: int = 0
+
+    @property
+    def context_ratio(self) -> float:
+        if self.context_limit <= 0:
+            raise ValueError("context_limit must be greater than zero")
+        if self.context_used < 0:
+            raise ValueError("context_used cannot be negative")
+        return min(self.context_used / self.context_limit, 1.0)
+
+
+@dataclass(frozen=True)
+class ThresholdDecision:
+    level: ThresholdLevel
+    context_ratio: float
+    operational_pressure: float
+    effective_pressure: float
+    should_notify: bool
+    should_offer_run_now: bool
+    should_offer_checkpoint: bool
+    should_create_temporary_rescue: bool
+    canonical_write_allowed: bool
+    headline: str
+    message: str
+    reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["level"] = self.level.value
+        payload["reasons"] = list(self.reasons)
+        return payload
+
+
+def _norm(value: float, full_value: float) -> float:
+    if full_value <= 0:
+        raise ValueError("normalization full value must be greater than zero")
+    return max(0.0, min(value / full_value, 1.0))
+
+
+def operational_pressure(metrics: SessionMetrics, config: ThresholdConfig) -> float:
+    pressure = (
+        metrics.context_ratio * config.context_weight
+        + _norm(metrics.elapsed_hours, config.elapsed_hours_full) * config.elapsed_weight
+        + _norm(metrics.message_count, config.message_count_full) * config.messages_weight
+        + _norm(metrics.decision_count, config.decision_count_full) * config.decisions_weight
+        + _norm(metrics.changed_files, config.changed_files_full) * config.files_weight
+        + _norm(metrics.compression_events, config.compression_events_full) * config.compression_weight
+        + _norm(metrics.model_handoffs, config.model_handoffs_full) * config.handoffs_weight
+    )
+    return min(max(pressure, 0.0), 1.0)
+
+
+def evaluate(
+    metrics: SessionMetrics,
+    config: ThresholdConfig | None = None,
+) -> ThresholdDecision:
+    config = config or ThresholdConfig()
+    context_ratio = metrics.context_ratio
+    pressure = operational_pressure(metrics, config)
+    effective = max(context_ratio, pressure)
+
+    reasons: list[str] = []
+    if context_ratio >= config.quiet_threshold:
+        reasons.append(f"context usage is {context_ratio:.1%}")
+    if metrics.elapsed_hours >= 12:
+        reasons.append(f"session has run for {metrics.elapsed_hours:.1f} hours")
+    if metrics.message_count >= 100:
+        reasons.append(f"message count is {metrics.message_count}")
+    if metrics.decision_count >= 12:
+        reasons.append(f"tracked decisions total {metrics.decision_count}")
+    if metrics.changed_files >= 10:
+        reasons.append(f"changed files total {metrics.changed_files}")
+    if metrics.compression_events:
+        reasons.append(f"compression events total {metrics.compression_events}")
+    if metrics.model_handoffs >= 2:
+        reasons.append(f"model handoffs total {metrics.model_handoffs}")
+
+    power_sprint_recommend = (
+        context_ratio >= 0.75
+        and metrics.elapsed_hours >= 24
+        and metrics.changed_files >= 10
+        and (metrics.message_count >= 150 or metrics.decision_count >= 18)
+    )
+    if power_sprint_recommend:
+        reasons.append("power-sprint continuity override triggered")
+
+    rescue = (
+        context_ratio >= config.rescue_threshold
+        or (
+            context_ratio >= config.prominent_threshold
+            and metrics.compression_events >= 1
+        )
+        or (pressure >= 0.97 and metrics.compression_events >= 1)
+    )
+
+    if rescue:
+        level = ThresholdLevel.RESCUE
+        headline = "Block Logic rescue threshold reached"
+        message = (
+            "Create a temporary noncanonical rescue snapshot before further "
+            "compression, then offer Block Logic or Continue."
+        )
+    elif effective >= config.prominent_threshold:
+        level = ThresholdLevel.PROMINENT
+        headline = "Block Logic strongly recommended"
+        message = "This session is at high continuity risk."
+    elif effective >= config.recommend_threshold or power_sprint_recommend:
+        level = ThresholdLevel.RECOMMEND
+        headline = "Block Logic recommended"
+        message = "This session is approaching its continuity threshold."
+    elif effective >= config.quiet_threshold:
+        level = ThresholdLevel.QUIET
+        headline = "Block Logic threshold approaching"
+        message = "Continue monitoring without interrupting the user."
+    else:
+        level = ThresholdLevel.NORMAL
+        headline = "Block Logic not needed"
+        message = "Continue monitoring."
+        reasons = []
+
+    return ThresholdDecision(
+        level=level,
+        context_ratio=round(context_ratio, 6),
+        operational_pressure=round(pressure, 6),
+        effective_pressure=round(effective, 6),
+        should_notify=level not in {ThresholdLevel.NORMAL, ThresholdLevel.QUIET},
+        should_offer_run_now=level in {
+            ThresholdLevel.RECOMMEND,
+            ThresholdLevel.PROMINENT,
+            ThresholdLevel.RESCUE,
+        },
+        should_offer_checkpoint=level in {
+            ThresholdLevel.RECOMMEND,
+            ThresholdLevel.PROMINENT,
+            ThresholdLevel.RESCUE,
+        },
+        should_create_temporary_rescue=level is ThresholdLevel.RESCUE,
+        canonical_write_allowed=False,
+        headline=headline,
+        message=message,
+        reasons=tuple(reasons),
+    )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -311,13 +311,21 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(
+    model_cfg: Dict[str, Any],
+    api_key: str,
+    target_model: Optional[str] = None,
+) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-    if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
+    if (
+        not target_model
+        and configured_mode
+        and _provider_supports_explicit_api_mode("copilot", configured_provider)
+    ):
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
+    model_name = str(target_model or model_cfg.get("default") or "").strip()
     if not model_name:
         return "chat_completions"
 
@@ -443,7 +451,11 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
         base_url = _nous_inference_base_url_override() or base_url
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_mode = _copilot_runtime_api_mode(
+            model_cfg,
+            getattr(entry, "runtime_api_key", ""),
+            target_model=target_model,
+        )
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config

--- a/tests/agent/test_block_logic_threshold.py
+++ b/tests/agent/test_block_logic_threshold.py
@@ -1,0 +1,69 @@
+import unittest
+
+from agent.block_logic_threshold import (
+    SessionMetrics,
+    ThresholdConfig,
+    ThresholdLevel,
+    evaluate,
+)
+
+
+class BlockLogicThresholdTests(unittest.TestCase):
+    def test_recommends_block_logic_at_default_82_percent_boundary(self):
+        decision = evaluate(SessionMetrics(context_used=82_000, context_limit=100_000))
+
+        self.assertIs(decision.level, ThresholdLevel.RECOMMEND)
+        self.assertTrue(decision.should_offer_run_now)
+        self.assertFalse(decision.should_create_temporary_rescue)
+        self.assertFalse(decision.canonical_write_allowed)
+
+    def test_power_sprint_recommends_without_authorizing_rescue(self):
+        decision = evaluate(
+            SessionMetrics(
+                context_used=78_000,
+                context_limit=100_000,
+                elapsed_hours=36,
+                message_count=190,
+                decision_count=24,
+                changed_files=18,
+                model_handoffs=3,
+            )
+        )
+
+        self.assertIs(decision.level, ThresholdLevel.RECOMMEND)
+        self.assertIn("power-sprint continuity override triggered", decision.reasons)
+        self.assertFalse(decision.should_create_temporary_rescue)
+
+    def test_prior_compression_can_trigger_rescue_at_prominent_pressure(self):
+        decision = evaluate(
+            SessionMetrics(
+                context_used=91_000,
+                context_limit=100_000,
+                compression_events=1,
+            )
+        )
+
+        self.assertIs(decision.level, ThresholdLevel.RESCUE)
+        self.assertTrue(decision.should_create_temporary_rescue)
+        self.assertFalse(decision.canonical_write_allowed)
+
+    def test_config_mapping_overrides_thresholds_without_enabling_writes(self):
+        config = ThresholdConfig.from_mapping(
+            {
+                "quiet_threshold": 0.60,
+                "recommend_threshold": 0.70,
+                "prominent_threshold": 0.78,
+                "rescue_threshold": 0.82,
+            }
+        )
+        decision = evaluate(
+            SessionMetrics(context_used=70_000, context_limit=100_000),
+            config,
+        )
+
+        self.assertIs(decision.level, ThresholdLevel.RECOMMEND)
+        self.assertFalse(decision.canonical_write_allowed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -45,6 +45,39 @@ def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
     assert resolved["source"] == "manual"
 
 
+def test_copilot_pool_runtime_uses_target_model_for_api_mode(monkeypatch):
+    """MoA/delegation targets must not inherit the acting model's API mode."""
+    entry = SimpleNamespace(
+        runtime_api_key="copilot-token",
+        runtime_base_url="https://api.githubcopilot.com",
+        source="copilot-oauth",
+    )
+    model_cfg = {
+        "provider": "copilot",
+        "default": "gpt-5.6-sol",
+        "api_mode": "codex_responses",
+    }
+
+    def fake_copilot_model_api_mode(model_id, *, api_key):
+        assert api_key == "copilot-token"
+        return "chat_completions" if model_id == "gpt-4.1" else "codex_responses"
+
+    monkeypatch.setattr(
+        "hermes_cli.models.copilot_model_api_mode",
+        fake_copilot_model_api_mode,
+    )
+
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="copilot",
+        entry=entry,
+        requested_provider="copilot",
+        model_cfg=model_cfg,
+        target_model="gpt-4.1",
+    )
+
+    assert resolved["api_mode"] == "chat_completions"
+
+
 def test_resolve_runtime_provider_nous_pool_uses_env_base_url_override(monkeypatch):
     entry = SimpleNamespace(
         provider="nous",

--- a/tests/test_block_logic_gateway_integration.py
+++ b/tests/test_block_logic_gateway_integration.py
@@ -1,0 +1,156 @@
+import json
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tui_gateway import server
+
+
+class BlockLogicGatewayIntegrationTests(unittest.TestCase):
+    def _agent(self, *, mode="observe_only", callback=None, log_path=None):
+        return types.SimpleNamespace(
+            model="gpt-5.6-sol",
+            session_total_tokens=82_000,
+            context_compressor=types.SimpleNamespace(
+                last_prompt_tokens=82_000,
+                context_length=100_000,
+                compression_count=0,
+            ),
+            _block_logic_threshold_config={
+                "enabled": True,
+                "mode": mode,
+                "log_path": str(log_path) if log_path else "",
+            },
+            notice_callback=callback,
+        )
+
+    @staticmethod
+    def _session():
+        return {
+            "created_at": time.time() - 18 * 3600,
+            "history": [{"role": "user", "content": "x"}] * 130,
+            "block_logic_metrics": {
+                "decision_count": 16,
+                "changed_files": 11,
+                "model_handoffs": 2,
+            },
+        }
+
+    def test_observe_only_adds_decision_logs_transition_and_emits_no_notice(self):
+        notices = []
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "decisions.jsonl"
+            agent = self._agent(callback=notices.append, log_path=log_path)
+            session = self._session()
+
+            first = server._get_usage(agent, session)
+            second = server._get_usage(agent, session)
+
+            self.assertEqual(first["block_logic"]["level"], "block_logic_recommended")
+            self.assertEqual(first["block_logic"]["mode"], "observe_only")
+            self.assertFalse(first["block_logic"]["canonical_write_allowed"])
+            self.assertEqual(notices, [])
+            lines = log_path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            self.assertEqual(json.loads(lines[0])["level"], "block_logic_recommended")
+            self.assertEqual(second["block_logic"], first["block_logic"])
+
+    def test_prompt_mode_emits_one_notice_per_level_transition(self):
+        notices = []
+        agent = self._agent(mode="prompt", callback=notices.append)
+        session = self._session()
+
+        server._get_usage(agent, session)
+        server._get_usage(agent, session)
+
+        self.assertEqual(len(notices), 1)
+        self.assertEqual(notices[0].key, "block_logic.threshold")
+        self.assertEqual(notices[0].level, "warn")
+
+    def test_live_config_is_loaded_once_when_agent_has_no_cached_config(self):
+        agent = self._agent()
+        del agent._block_logic_threshold_config
+        session = self._session()
+        config = {
+            "block_logic_threshold": {
+                "enabled": True,
+                "mode": "observe_only",
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config) as load:
+            usage = server._get_usage(agent, session)
+            server._get_usage(agent, session)
+
+        self.assertEqual(usage["block_logic"]["level"], "block_logic_recommended")
+        self.assertEqual(load.call_count, 1)
+        self.assertEqual(agent._block_logic_threshold_config["mode"], "observe_only")
+
+    def test_live_git_and_history_metrics_enable_power_sprint_override(self):
+        agent = self._agent()
+        agent.context_compressor.last_prompt_tokens = 78_000
+        session = {
+            "created_at": time.time() - 36 * 3600,
+            "cwd": "C:/repo",
+            "history": [
+                {"role": "user", "content": "ordinary work"}
+                for _ in range(148)
+            ]
+            + [
+                {
+                    "role": "user",
+                    "content": "[System: The active model for this chat has changed to model-a.]",
+                },
+                {
+                    "role": "user",
+                    "content": "[System: The active model for this chat has changed to model-b.]",
+                },
+            ],
+        }
+        changed = "\n".join(f" M file-{index}.py" for index in range(10))
+
+        with patch.object(server, "_git", return_value=changed) as git:
+            usage = server._get_usage(agent, session)
+            server._get_usage(agent, session)
+
+        self.assertEqual(usage["block_logic"]["level"], "block_logic_recommended")
+        self.assertIn(
+            "power-sprint continuity override triggered",
+            usage["block_logic"]["reasons"],
+        )
+        self.assertIn("model handoffs total 2", usage["block_logic"]["reasons"])
+        self.assertEqual(git.call_count, 1)
+
+    def test_unknown_post_compression_context_emits_no_decision_or_receipt(self):
+        notices = []
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "decisions.jsonl"
+            agent = self._agent(callback=notices.append, log_path=log_path)
+            agent.context_compressor.last_prompt_tokens = -1
+            session = self._session()
+
+            usage = server._get_usage(agent, session)
+
+            self.assertNotIn("context_used", usage)
+            self.assertNotIn("block_logic", usage)
+            self.assertFalse(log_path.exists())
+            self.assertEqual(notices, [])
+
+    def test_existing_usage_fields_are_preserved_when_decision_is_attached(self):
+        agent = self._agent()
+        session = self._session()
+
+        usage = server._get_usage(agent, session)
+
+        self.assertEqual(usage["context_used"], 82_000)
+        self.assertEqual(usage["context_max"], 100_000)
+        self.assertEqual(usage["context_percent"], 82)
+        self.assertEqual(usage["compressions"], 0)
+        self.assertIn("block_logic", usage)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1243,13 +1243,108 @@ class CuaDriverBackend(ComputerUseBackend):
             return False
         return cua_driver_binary_available()
 
+    def _capture_desktop_state(self, mode: str = "vision") -> CaptureResult:
+        """Capture the full desktop directly via cua-driver's desktop path.
+
+        Windows CUA can have a healthy MCP/session/screenshot lane while
+        `list_windows` / UIA enumeration hangs (trycua/cua#2110/#2113).
+        For explicit `app="screen"` / `app="desktop"` requests, do not route
+        through window enumeration first. Use `get_desktop_state` directly so
+        users still get a real screenshot when the enumeration layer is sick.
+
+        Constrained to ``vision`` mode only — desktop-state captures return PNG
+        data with no element tree, so ``ax`` and ``som`` modes are not supported
+        on this path. Callers requesting ``ax``/``som`` fall through to the
+        standard window-enumeration path.
+        """
+        if mode != "vision":
+            # ax/som require element data that get_desktop_state doesn't provide.
+            # Fall through to the normal window-enumeration path instead.
+            return self._failed_capture(
+                mode,
+                f"<desktop bypass only supports vision mode; requested {mode!r}>",
+            )
+
+        self._clear_active_target()
+        previous_scope: Optional[str] = None
+        try:
+            cfg = self._session.call_tool(
+                "get_config", {"session": self._session_id}, timeout=10.0,
+            )
+            sc = cfg.get("structuredContent") or {}
+            if isinstance(sc, dict):
+                val = sc.get("capture_scope")
+                if isinstance(val, str):
+                    previous_scope = val
+        except Exception as e:
+            logger.debug("cua-driver get_config before desktop capture failed: %s", e)
+
+        try:
+            if previous_scope != "desktop":
+                self._session.call_tool(
+                    "set_config",
+                    {"key": "capture_scope", "value": "desktop",
+                     "session": self._session_id},
+                    timeout=10.0,
+                )
+            out = self._session.call_tool(
+                "get_desktop_state",
+                {"session": self._session_id},
+                timeout=15.0,
+            )
+        finally:
+            if previous_scope and previous_scope != "desktop":
+                try:
+                    self._session.call_tool(
+                        "set_config",
+                        {"key": "capture_scope", "value": previous_scope,
+                         "session": self._session_id},
+                        timeout=10.0,
+                    )
+                except Exception as e:
+                    logger.debug("cua-driver restore capture_scope failed: %s", e)
+
+        png_b64, image_mime_type = _image_from_tool_result(out)
+        structured = out.get("structuredContent") or {}
+        width = int(structured.get("screenshot_width") or structured.get("screen_width") or 0)
+        height = int(structured.get("screenshot_height") or structured.get("screen_height") or 0)
+        png_bytes_len = 0
+        if png_b64:
+            try:
+                raw = base64.b64decode(png_b64, validate=False)
+                png_bytes_len = len(raw)
+                detected_width, detected_height = _image_dimensions_from_bytes(raw)
+                if detected_width and detected_height:
+                    width = detected_width
+                    height = detected_height
+            except Exception:
+                png_bytes_len = len(png_b64) * 3 // 4
+        return CaptureResult(
+            mode=mode,
+            width=width,
+            height=height,
+            png_b64=png_b64,
+            elements=[],
+            app="screen",
+            window_title="Desktop screenshot via cua-driver get_desktop_state",
+            png_bytes_len=png_bytes_len,
+            image_mime_type=image_mime_type,
+        )
+
     # ── Capture ────────────────────────────────────────────────────
     def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
         """Capture the frontmost on-screen window (optionally filtered by app name).
 
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
-        `get_window_state` (ax/som) or `screenshot` (vision).
+        `get_window_state` (ax/som) or `screenshot` (vision). Explicit
+        whole-screen requests (app="screen"/"desktop") bypass `list_windows`
+        and use `get_desktop_state` directly so Windows screenshot capture
+        still works when enumeration hangs.
         """
+        # Step 0: explicit screen/desktop capture — bypass window enumeration.
+        if app and app.strip().lower() in _SCREEN_CAPTURE_SENTINELS:
+            return self._capture_desktop_state(mode=mode)
+
         # Step 1: enumerate on-screen windows to find target pid/window_id.
         # Surface 3 of NousResearch/hermes-agent#47072: read the canonical
         # `structuredContent.windows` array directly. Pre-fix the wrapper

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3188,7 +3188,7 @@ def _sync_session_key_after_compress(
             pass
 
 
-def _get_usage(agent) -> dict:
+def _get_usage(agent, session: dict | None = None) -> dict:
     g = lambda k, fb=None: getattr(agent, k, 0) or (getattr(agent, fb, 0) if fb else 0)
     usage = {
         "model": getattr(agent, "model", "") or "",
@@ -3245,7 +3245,139 @@ def _get_usage(agent) -> dict:
                 usage["dev_credits_spent_micros"] = int(spent)
         except Exception:
             pass
+    _attach_block_logic_usage(usage, agent, session)
     return usage
+
+
+def _attach_block_logic_usage(usage: dict, agent, session: dict | None) -> None:
+    """Attach a Block Logic decision to live usage without authorizing writes.
+
+    The host integration is deliberately fail-open and transition-latched. In
+    ``observe_only`` mode it records level changes but never emits a user notice.
+    Temporary rescue remains advisory; canonical writes are always forbidden by
+    the pure evaluator.
+    """
+    if agent is None or not isinstance(session, dict):
+        return
+
+    raw = getattr(agent, "_block_logic_threshold_config", None)
+    if raw is None:
+        try:
+            from hermes_cli.config import load_config
+
+            loaded = load_config()
+            raw = (
+                loaded.get("block_logic_threshold", {})
+                if isinstance(loaded, dict)
+                else {}
+            )
+        except Exception:
+            raw = {}
+        agent._block_logic_threshold_config = raw
+    if not isinstance(raw, dict) or not raw.get("enabled", False):
+        return
+
+    context_used = int(usage.get("context_used") or 0)
+    context_limit = int(usage.get("context_max") or 0)
+    if context_used <= 0 or context_limit <= 0:
+        return
+
+    try:
+        from agent.block_logic_threshold import (
+            SessionMetrics,
+            ThresholdConfig,
+            ThresholdLevel,
+            evaluate,
+        )
+
+        extra = dict(session.get("block_logic_metrics") or {})
+        if "changed_files" not in extra:
+            cached = session.get("_block_logic_git_metrics")
+            now = time.monotonic()
+            if not isinstance(cached, tuple) or now - cached[0] >= 300.0:
+                porcelain = _git(_session_cwd(session), "status", "--porcelain")
+                changed_files = len(
+                    [line for line in porcelain.splitlines() if line.strip()]
+                )
+                cached = (now, changed_files)
+                session["_block_logic_git_metrics"] = cached
+            extra["changed_files"] = cached[1]
+        if "model_handoffs" not in extra:
+            extra["model_handoffs"] = sum(
+                1
+                for item in session.get("history") or []
+                if "active model for this chat has changed"
+                in str(item.get("content") or "").lower()
+            )
+        elapsed_hours = max(
+            0.0,
+            (time.time() - float(session.get("created_at") or time.time())) / 3600.0,
+        )
+        decision = evaluate(
+            SessionMetrics(
+                context_used=context_used,
+                context_limit=context_limit,
+                elapsed_hours=elapsed_hours,
+                message_count=len(session.get("history") or []),
+                decision_count=int(extra.get("decision_count") or 0),
+                changed_files=int(extra.get("changed_files") or 0),
+                compression_events=int(usage.get("compressions") or 0),
+                model_handoffs=int(extra.get("model_handoffs") or 0),
+            ),
+            ThresholdConfig.from_mapping(raw),
+        )
+    except Exception:
+        logger.debug("Block Logic threshold evaluation failed", exc_info=True)
+        return
+
+    mode = str(raw.get("mode") or "observe_only").strip().lower()
+    payload = decision.to_dict()
+    payload["mode"] = mode
+    usage["block_logic"] = payload
+
+    current_level = decision.level.value
+    previous_level = session.get("_block_logic_last_level")
+    if previous_level == current_level:
+        return
+    session["_block_logic_last_level"] = current_level
+
+    log_path = str(raw.get("log_path") or "").strip()
+    if log_path:
+        try:
+            from pathlib import Path
+
+            target = Path(log_path).expanduser()
+            target.parent.mkdir(parents=True, exist_ok=True)
+            record = {
+                "timestamp": time.time(),
+                "session_id": str(session.get("session_id") or ""),
+                **payload,
+            }
+            with target.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except Exception:
+            logger.debug("Block Logic threshold log write failed", exc_info=True)
+
+    if mode not in {"prompt", "active"} or not decision.should_notify:
+        return
+
+    callback = getattr(agent, "notice_callback", None)
+    if not callable(callback):
+        return
+    try:
+        from agent.credits_tracker import AgentNotice
+
+        level = "error" if decision.level is ThresholdLevel.RESCUE else "warn"
+        callback(
+            AgentNotice(
+                text=f"{decision.headline}. {decision.message}",
+                level=level,
+                kind="sticky",
+                key="block_logic.threshold",
+            )
+        )
+    except Exception:
+        logger.debug("Block Logic threshold notice emission failed", exc_info=True)
 
 
 def _probe_credentials(agent) -> str:
@@ -6476,7 +6608,7 @@ def _(rid, params: dict) -> dict:
         return err
     agent = session.get("agent")
     usage: dict = (
-        _get_usage(agent)
+        _get_usage(agent, session)
         if agent is not None
         else {"calls": 0, "input": 0, "output": 0, "total": 0}
     )
@@ -9144,7 +9276,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 raw = str(result)
                 status = "complete"
 
-            payload = {"text": raw, "usage": _get_usage(agent), "status": status}
+            payload = {"text": raw, "usage": _get_usage(agent, session), "status": status}
             if last_reasoning:
                 payload["reasoning"] = last_reasoning
             if status_note:


### PR DESCRIPTION
## Summary

Adds a Windows-resilient path for explicit `computer_use(... app="screen"|"desktop")` capture requests.

When CUA's Windows enumeration tools hang (`list_windows`, `list_apps`, UIA tree walk), the driver can still successfully capture the full desktop via `get_desktop_state`. The current Hermes wrapper routes every capture through `list_windows` first, so even explicit screen captures hang before reaching the healthy screenshot lane.

This patch makes explicit screen/desktop captures bypass `list_windows` and call `get_desktop_state` directly.

## Why

Fresh local evidence on Windows 11 Pro:

- `hermes computer-use doctor` passes after local signing/trust repair.
- `hermes mcp test cua-driver` passes.
- `cua-driver call get_screen_size '{}'` passes.
- `cua-driver call get_desktop_state ...` passes in ~0.13s and writes a real screenshot.
- `list_apps`, `list_windows`, and `get_accessibility_tree` still hang or time out.

Related CUA-side issues:

- trycua/cua#2110
- trycua/cua#2113
- trycua/cua#2118

This is not a full replacement for the CUA enumeration fix. It is a Hermes-side salvage path so explicit screen captures remain useful when enumeration is the broken layer.

## Implementation

- Adds `CuaDriverBackend._capture_desktop_state()`.
- For explicit screen sentinels (`screen`, `desktop`, `fullscreen`, etc.), `capture()` now calls `get_desktop_state` directly.
- Temporarily switches `capture_scope` to `desktop`, then restores the prior scope.
- Returns a normal `CaptureResult` with PNG bytes and no elements.
- Leaves app/window-specific capture behavior unchanged.

## Tests

```text
PYTHONPATH=. uv run --with pytest --with pytest-xdist --with pyyaml python -m pytest tests/tools/test_computer_use_desktop_fallback.py tests/tools/test_computer_use_capture_routing.py tests/tools/test_computer_use_vision_routing.py -q -n 0
45 passed in 2.89s
```

## Local smoke

Standalone backend smoke after patch:

```text
START 0.94
CAPTURE vision dt 0.09 size 1920 1080 png_len 1933076 bytes 1449805 elements 0 app screen
CAPTURE som dt 0.09 size 1920 1080 png_len 1933076 bytes 1449805 elements 0 app screen
```