### PR TITLE
fix(moa): preserve slot credentials for custom_provider references

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -142,11 +142,21 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
     """
     provider = str(slot.get("provider") or "").strip()
     model = str(slot.get("model") or "").strip()
+    slot_api_key = str(slot.get("api_key") or "").strip() or None
+    slot_base_url = str(slot.get("base_url") or "").strip() or None
+    slot_api_mode = str(slot.get("api_mode") or "").strip() or None
     out: dict[str, Any] = {"provider": provider, "model": model}
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        rt = resolve_runtime_provider(requested=provider, target_model=model)
+        rt = resolve_runtime_provider(
+            requested=provider,
+            target_model=model,
+            explicit_api_key=slot_api_key,
+            explicit_base_url=slot_base_url,
+        )
+        if slot_api_mode:
+            out["api_mode"] = slot_api_mode
         # Forward the resolved endpoint through to call_llm unconditionally.
         # call_llm's _resolve_task_provider_model() is the single chokepoint that
         # decides whether an explicit base_url collapses a call to the generic
@@ -166,7 +176,8 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
             out["base_url"] = rt["base_url"]
         if rt.get("api_key"):
             out["api_key"] = rt["api_key"]
-        if rt.get("api_mode"):
+        # Slot's api_mode overrides resolver's detection when explicitly set
+        if rt.get("api_mode") and not slot_api_mode:
             out["api_mode"] = rt["api_mode"]
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("MoA slot runtime resolution failed for %s: %s", _slot_label(slot), exc)

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -153,7 +153,7 @@ def test_moa_slots_routed_through_resolve_runtime_provider(monkeypatch):
 
     resolved = []
 
-    def fake_resolve(*, requested, target_model=None):
+    def fake_resolve(*, requested, target_model=None, explicit_api_key=None, explicit_base_url=None):
         resolved.append((requested, target_model))
         return {
             "provider": requested,
@@ -186,7 +186,7 @@ def test_moa_codex_slot_preserves_provider_identity(monkeypatch):
     from agent import moa_loop
     from agent.auxiliary_client import _resolve_task_provider_model
 
-    def fake_resolve(*, requested, target_model=None):
+    def fake_resolve(*, requested, target_model=None, explicit_api_key=None, explicit_base_url=None):
         return {
             "provider": requested,
             "api_mode": "codex_responses",
@@ -235,7 +235,7 @@ def test_moa_provider_backed_slot_survives_aux_resolution(monkeypatch, provider)
     from agent import moa_loop
     from agent.auxiliary_client import _resolve_task_provider_model
 
-    def fake_resolve(*, requested, target_model=None):
+    def fake_resolve(*, requested, target_model=None, explicit_api_key=None, explicit_base_url=None):
         return {
             "provider": requested,
             "api_mode": "anthropic_messages",
@@ -266,7 +266,7 @@ def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):
     bare provider/model rather than aborting the whole MoA turn."""
     from agent import moa_loop
 
-    def boom(*, requested, target_model=None):
+    def boom(*, requested, target_model=None, explicit_api_key=None, explicit_base_url=None):
         raise RuntimeError("unknown provider")
 
     monkeypatch.setattr(
@@ -716,7 +716,7 @@ def test_slot_runtime_anthropic_oauth_routes_through_provider_branch(monkeypatch
     from agent import moa_loop
     from agent.auxiliary_client import _resolve_task_provider_model
 
-    def fake_resolve(*, requested, target_model=None):
+    def fake_resolve(*, requested, target_model=None, explicit_api_key=None, explicit_base_url=None):
         return {
             "provider": requested,
             "base_url": "https://resolved.example/v1",

--- a/tests/run_agent/test_moa_slot_credentials.py
+++ b/tests/run_agent/test_moa_slot_credentials.py
@@ -1,0 +1,130 @@
+"""Test that _slot_runtime passes slot credentials to resolve_runtime_provider.
+
+Regression for #60064: MoA custom_provider credentials not passed to reference
+models (HTTP 401). When a slot contains api_key/base_url/api_mode, those must
+be passed as explicit_* args to resolve_runtime_provider so custom_providers
+get their configured credentials.
+"""
+
+
+def test_moa_slot_runtime_preserves_slot_credentials(monkeypatch):
+    """Slot api_key/base_url/api_mode must be passed through to the resolver.
+
+    Without this fix, a custom_provider slot configured with an inline api_key
+    would lose that key and fail with HTTP 401 (Missing Authentication header).
+    The fix extracts slot credentials and passes them as explicit_api_key/
+    explicit_base_url to resolve_runtime_provider.
+    """
+    from agent.moa_loop import _slot_runtime
+
+    def fake_resolve_runtime_provider(*, requested, target_model=None, explicit_api_key=None, explicit_base_url=None):
+        """Fake resolver that echoes back what it received."""
+        return {
+            "provider": requested,
+            "model": target_model or "default",
+            "api_key": explicit_api_key or "no-key",
+            "base_url": explicit_base_url or "https://default.api/v1",
+            "api_mode": "chat_completions",
+            "source": "test-fake",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+
+    # Slot with inline credentials (the issue case)
+    rt = _slot_runtime(
+        {
+            "provider": "custom:doubao",
+            "model": "ep-202412",
+            "api_key": "***",
+            "base_url": "https://doubao.example.com/v1",
+        }
+    )
+
+    assert rt["provider"] == "custom:doubao"
+    assert rt["model"] == "ep-202412"
+    assert rt["api_key"] == "***"  # Preserved from slot
+    assert rt["base_url"] == "https://doubao.example.com/v1"  # Preserved from slot
+    assert rt["api_mode"] == "chat_completions"
+
+
+def test_moa_slot_runtime_preserves_slot_api_mode(monkeypatch):
+    """Slot api_mode (when present) must be forwarded to call_llm.
+
+    Some custom endpoints require a specific api_mode (e.g., anthropic_messages
+    for certain providers). If the slot specifies it, it should be preserved
+    rather than being overridden by automatic detection.
+    """
+    from agent.moa_loop import _slot_runtime
+
+    def fake_resolve_runtime_provider(*, requested, target_model=None, explicit_api_key=None, explicit_base_url=None):
+        return {
+            "provider": requested,
+            "model": target_model or "default",
+            "api_key": explicit_api_key or "no-key",
+            "base_url": explicit_base_url or "https://default.api/v1",
+            "api_mode": "chat_completions",  # Default from resolver
+            "source": "test-fake",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+
+    # Slot with explicit api_mode
+    rt = _slot_runtime(
+        {
+            "provider": "custom:vendor-x",
+            "model": "x-1",
+            "api_mode": "anthropic_messages",
+        }
+    )
+
+    # Slot's api_mode overrides resolver's default
+    assert rt["api_mode"] == "anthropic_messages"
+
+
+def test_moa_slot_runtime_ignores_empty_slot_credentials(monkeypatch):
+    """Empty string credentials are treated as "not provided" (None).
+
+    When a slot has api_key="" or base_url="", we should not pass an explicit
+    empty string to resolve_runtime_provider — pass None instead so the resolver
+    can apply its normal fallback logic (env vars, credential pools, etc.).
+    """
+    from agent.moa_loop import _slot_runtime
+
+    called_with = {}
+
+    def tracking_resolver(*, requested, target_model=None, explicit_api_key=None, explicit_base_url=None):
+        called_with["api_key"] = explicit_api_key
+        called_with["base_url"] = explicit_base_url
+        return {
+            "provider": requested,
+            "model": target_model or "default",
+            "api_key": explicit_api_key or "pooled-key",
+            "base_url": explicit_base_url or "https://pooled.api/v1",
+            "api_mode": "chat_completions",
+            "source": "test-fake",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        tracking_resolver,
+    )
+
+    # Slot with empty credentials
+    _slot_runtime(
+        {
+            "provider": "openai",
+            "model": "gpt-5.5",
+            "api_key": "",
+            "base_url": "",
+        }
+    )
+
+    # Empty strings are converted to None (not passed as explicit args)
+    assert called_with["api_key"] is None
+    assert called_with["base_url"] is None


### PR DESCRIPTION
## What does this PR do?

When a MoA preset references a `custom_provider` as a reference model (or aggregator), credentials configured in the slot (`api_key`, `base_url`, `api_mode`) were not being passed to `resolve_runtime_provider`. The slot only forwarded `provider` and `model`, leaving the resolver to infer credentials from global config. This caused HTTP 401 errors when a custom_provider was configured with an inline `api_key` in the MoA preset — the key was silently ignored.

The fix extracts slot credentials and passes them as `explicit_api_key`/`explicit_base_url` to `resolve_runtime_provider`, matching how the rest of the codebase resolves custom endpoints (auxiliary_client.py, runtime_provider.py). When a slot explicitly sets `api_mode`, that value is preserved instead of being overridden by the resolver's automatic detection.

## Related Issue

Fixes #60064

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moa_loop.py`: Modified `_slot_runtime()` to extract and forward slot `api_key`, `base_url`, and `api_mode` to `resolve_runtime_provider` as explicit arguments. Added conditional logic so slot-specified `api_mode` overrides resolver detection when both are present.
- `tests/run_agent/test_moa_slot_credentials.py`: Added regression tests for credential preservation and empty-string handling.

## How to Test

1. Configure a custom_provider with inline credentials:
   ```yaml
   custom_providers:
     - name: doubao
       base_url: https://doubao.example.com/v1
       api_key: sk-***
   ```
2. Create a MoA preset that references this custom_provider:
   ```yaml
   moa:
     presets:
       test:
         reference_models:
           - provider: custom:doubao
             model: ep-202412
             api_key: sk-***
             base_url: https://doubao.example.com/v1
         aggregator:
           provider: openai
           model: gpt-4.1
   ```
3. Run `/moa test` — before the fix, the reference model fails with HTTP 401. After the fix, the slot's `api_key` is forwarded and the request succeeds.
4. Run `pytest tests/run_agent/test_moa_slot_credentials.py -v` — all three tests pass, verifying credential preservation, `api_mode` override, and empty-string handling.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
