### PR TITLE
fix(moa): route Copilot slots by target model

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3301,19 +3301,11 @@ def copilot_model_api_mode(
     if _should_use_copilot_responses_api(normalized):
         return "codex_responses"
 
-    # Secondary: check catalog for non-GPT-5 models (Claude via /v1/messages, etc.)
-    if catalog:
-        catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
-        if isinstance(catalog_entry, dict):
-            supported_endpoints = {
-                str(endpoint).strip()
-                for endpoint in (catalog_entry.get("supported_endpoints") or [])
-                if str(endpoint).strip()
-            }
-            # For non-GPT-5 models, check if they only support messages API
-            if "/v1/messages" in supported_endpoints and "/chat/completions" not in supported_endpoints:
-                return "anthropic_messages"
-
+    # Copilot's Claude models are exposed through its OpenAI-compatible chat
+    # endpoint, not through Hermes' native Anthropic adapter. The live catalog may
+    # advertise /v1/messages, but the Copilot token/header scheme is handled by
+    # the OpenAI client path; selecting anthropic_messages would send the wrong
+    # auth/wire shape. Keep non-GPT Copilot slots on chat_completions.
     return "chat_completions"
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -311,13 +311,24 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(
+    model_cfg: Dict[str, Any],
+    api_key: str,
+    *,
+    target_model: Optional[str] = None,
+) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
+    # Use the model being resolved for this runtime, not the persisted global
+    # default. MoA slots, fallback models, and mid-session model switches all
+    # resolve credentials for a target model that can differ from config.yaml's
+    # model.default. If we derive Copilot api_mode from the stale default, a
+    # Claude/Gemini MoA slot can inherit codex_responses from a GPT-5 default and
+    # fail with "model ... does not support Responses API".
+    model_name = str(target_model or model_cfg.get("default") or "").strip()
     if not model_name:
         return "chat_completions"
 
@@ -443,7 +454,11 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
         base_url = _nous_inference_base_url_override() or base_url
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_mode = _copilot_runtime_api_mode(
+            model_cfg,
+            getattr(entry, "runtime_api_key", ""),
+            target_model=effective_model,
+        )
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1373,6 +1373,7 @@ def _resolve_explicit_runtime(
     model_cfg: Dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
@@ -1495,7 +1496,11 @@ def _resolve_explicit_runtime(
 
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
+            api_mode = _copilot_runtime_api_mode(
+                model_cfg,
+                api_key,
+                target_model=target_model,
+            )
         elif provider == "xai":
             api_mode = "codex_responses"
         else:
@@ -1676,6 +1681,7 @@ def resolve_runtime_provider(
         model_cfg=model_cfg,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     if explicit_runtime:
         return explicit_runtime
@@ -2015,7 +2021,11 @@ def resolve_runtime_provider(
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+            api_mode = _copilot_runtime_api_mode(
+                model_cfg,
+                creds.get("api_key", ""),
+                target_model=target_model,
+            )
         elif provider == "xai":
             api_mode = "codex_responses"
         else:

--- a/tests/hermes_cli/test_copilot_model_api_mode.py
+++ b/tests/hermes_cli/test_copilot_model_api_mode.py
@@ -1,0 +1,23 @@
+"""Tests for Copilot model API-mode routing."""
+
+from __future__ import annotations
+
+
+def test_copilot_claude_stays_on_chat_completions_even_if_catalog_lists_messages():
+    from hermes_cli.models import copilot_model_api_mode
+
+    catalog = [
+        {
+            "id": "claude-opus-4.8",
+            "supported_endpoints": ["/v1/messages"],
+        }
+    ]
+
+    assert copilot_model_api_mode("claude-opus-4.8", catalog=catalog) == "chat_completions"
+
+
+def test_copilot_gpt5_still_uses_responses_api():
+    from hermes_cli.models import copilot_model_api_mode
+
+    assert copilot_model_api_mode("gpt-5.5", catalog=[]) == "codex_responses"
+    assert copilot_model_api_mode("gpt-5-mini", catalog=[]) == "chat_completions"

--- a/tests/hermes_cli/test_copilot_runtime_api_mode.py
+++ b/tests/hermes_cli/test_copilot_runtime_api_mode.py
@@ -1,0 +1,40 @@
+"""Regression tests for Copilot runtime api_mode resolution."""
+
+from __future__ import annotations
+
+
+def test_copilot_runtime_api_mode_uses_target_model_over_stale_config_default(monkeypatch):
+    """MoA/fallback slots must derive Copilot api_mode from the slot model.
+
+    Repro: user's main/default Copilot model is GPT-5.5 (Responses API), but a
+    MoA reference slot is Copilot Claude Opus (Chat Completions). Runtime
+    resolution previously looked only at model.default and returned
+    codex_responses for the Claude slot, causing Copilot to reject it with
+    "model ... does not support Responses API".
+    """
+    from hermes_cli import runtime_provider as rp
+
+    monkeypatch.setattr(
+        "hermes_cli.models.copilot_model_api_mode",
+        lambda model, api_key=None: "codex_responses" if str(model).startswith("gpt-5") else "chat_completions",
+    )
+
+    assert rp._copilot_runtime_api_mode(
+        {"provider": "copilot", "default": "gpt-5.5"},
+        "token",
+        target_model="claude-opus-4.8",
+    ) == "chat_completions"
+
+
+def test_copilot_runtime_api_mode_still_uses_default_without_target(monkeypatch):
+    from hermes_cli import runtime_provider as rp
+
+    monkeypatch.setattr(
+        "hermes_cli.models.copilot_model_api_mode",
+        lambda model, api_key=None: "codex_responses" if str(model).startswith("gpt-5") else "chat_completions",
+    )
+
+    assert rp._copilot_runtime_api_mode(
+        {"provider": "copilot", "default": "gpt-5.5"},
+        "token",
+    ) == "codex_responses"

--- a/tests/hermes_cli/test_copilot_runtime_api_mode.py
+++ b/tests/hermes_cli/test_copilot_runtime_api_mode.py
@@ -1,6 +1,10 @@
-"""Regression tests for Copilot runtime api_mode resolution."""
+"""Tests for Copilot runtime api_mode resolution."""
 
 from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
 
 
 def test_copilot_runtime_api_mode_uses_target_model_over_stale_config_default(monkeypatch):
@@ -38,3 +42,70 @@ def test_copilot_runtime_api_mode_still_uses_default_without_target(monkeypatch)
         {"provider": "copilot", "default": "gpt-5.5"},
         "token",
     ) == "codex_responses"
+
+
+@pytest.mark.parametrize("credential_source", ["pool", "explicit", "env", "hermes-auth-store"])
+@pytest.mark.parametrize(
+    ("configured_model", "target_model", "expected_mode"),
+    [
+        ("gpt-5.5", "claude-opus-4.8", "chat_completions"),
+        ("gpt-5.5", "gemini-3-pro-preview", "chat_completions"),
+        ("claude-opus-4.8", "gpt-5.5", "codex_responses"),
+    ],
+)
+def test_resolver_routes_copilot_by_target_model_for_every_credential_path(
+    monkeypatch,
+    credential_source,
+    configured_model,
+    target_model,
+    expected_mode,
+):
+    """The public resolver must propagate the target through every auth path."""
+    from hermes_cli import models
+    from hermes_cli import runtime_provider as rp
+
+    model_cfg = {"provider": "copilot", "default": configured_model}
+    monkeypatch.setattr(rp, "_get_model_config", lambda: model_cfg)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *_args, **_kwargs: "copilot")
+    # Keep this a real copilot_model_api_mode decision without making a live
+    # catalog request. The API-mode contract is determined by the model family.
+    monkeypatch.setattr(models, "fetch_github_model_catalog", lambda **_kwargs: [])
+
+    kwargs = {"requested": "copilot", "target_model": target_model}
+    if credential_source == "pool":
+        entry = SimpleNamespace(
+            runtime_api_key="pool-token",
+            access_token="pool-token",
+            runtime_base_url="https://api.githubcopilot.com",
+            base_url="https://api.githubcopilot.com",
+            source="pool",
+        )
+        pool = SimpleNamespace(
+            has_credentials=lambda: True,
+            select=lambda: entry,
+        )
+        monkeypatch.setattr(rp, "load_pool", lambda _provider: pool)
+    elif credential_source == "explicit":
+        kwargs["explicit_api_key"] = "explicit-token"
+        monkeypatch.setattr(
+            rp,
+            "load_pool",
+            lambda _provider: pytest.fail("explicit credentials must bypass the pool"),
+        )
+    else:
+        monkeypatch.setattr(rp, "load_pool", lambda _provider: None)
+        monkeypatch.setattr(
+            rp,
+            "resolve_api_key_provider_credentials",
+            lambda _provider: {
+                "api_key": f"{credential_source}-token",
+                "base_url": "https://api.githubcopilot.com",
+                "source": credential_source,
+            },
+        )
+
+    runtime = rp.resolve_runtime_provider(**kwargs)
+
+    assert runtime["provider"] == "copilot"
+    assert runtime["api_mode"] == expected_mode
+    assert runtime["source"] == credential_source


### PR DESCRIPTION
## Summary

Fixes MoA Copilot presets that mix GPT-5.x slots with Copilot Claude/Opus slots.

The runtime provider resolver previously derived Copilot `api_mode` from the persisted global `model.default`. In MoA, each slot can target a different model, so a config default like `gpt-5.5` caused Copilot Claude/Opus slots to inherit `codex_responses` and fail with:

```text
model claude-opus-4.7 does not support Responses API
model claude-opus-4.8 does not support Responses API
```

This PR:

- threads `target_model` through pooled, explicit-key, and env/auth-store Copilot runtime resolution, so selection is based on the slot/model being resolved
- keeps non-GPT Copilot models on the OpenAI-compatible chat-completions path instead of selecting Hermes' native Anthropic adapter based on catalog `/v1/messages`
- adds resolver-level regression coverage for every Copilot credential path, including GPT-5 default → Claude/Gemini target and the inverse Claude default → GPT-5 target

## Why

MoA slots are per-model runtime selections. A mixed Copilot preset such as:

- reference: `copilot:gpt-5.5`
- reference: `copilot:claude-opus-4.7`
- aggregator: `copilot:claude-opus-4.8`

must route GPT-5.x slots through `codex_responses`, while Claude/Opus slots stay on `chat_completions`. Reusing the global default model's API mode makes the preset order/config dependent and breaks non-GPT slots.

## Test plan

- On the PR branch:
  - `python3 -m pytest tests/hermes_cli/test_copilot_runtime_api_mode.py tests/hermes_cli/test_copilot_model_api_mode.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_anthropic_oauth_routes_to_messages_api.py -q -o 'addopts='`
  - `172 passed`
- Clean latest `origin/main` with both PR commits cherry-picked:
  - `python3 -m pytest tests/hermes_cli/test_copilot_runtime_api_mode.py tests/hermes_cli/test_copilot_model_api_mode.py tests/agent/test_moa_slot_api_mode.py tests/run_agent/test_moa_loop_mode.py tests/hermes_cli/test_runtime_provider_resolution.py -q -o 'addopts='`
  - `205 passed`
- `python3 -m ruff check hermes_cli/runtime_provider.py tests/hermes_cli/test_copilot_runtime_api_mode.py`
  - `All checks passed!`
- Live smoke with local worktree via `PYTHONPATH`:
  - MoA preset: `copilot:gpt-5.5` + `copilot:claude-opus-4.7` references, `copilot:claude-opus-4.8` aggregator
  - `hermes chat -Q --provider moa -m default -q 'Say OK only.'`
  - Both references and aggregator completed; final output `OK`

## Related work

#60294 overlaps the `target_model` propagation portion. This PR predates it and additionally fixes the Copilot Claude/non-GPT transport decision plus covers both forward and inverse routing across pooled, explicit, env, and auth-store credentials.

Fixes #57395.



## Infographic

![moa-copilot-slot-routing](https://v3b.fal.media/files/b/0aa36b86/sLhEkc1jFRYbUf88iOQxH_AaMFCRGC.png)
