### PR TITLE
feat(guardrails): detect repeated tool results independent of args/failure

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -77,6 +77,9 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    repeated_result_warn_after: int = 3
+    repeated_result_halt_after: int = 5
+    repeated_result_min_chars: int = 200
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
     loop_caps: "LoopCapConfig" = field(default_factory=lambda: LoopCapConfig())
@@ -121,6 +124,18 @@ class ToolCallGuardrailConfig:
             no_progress_block_after=_positive_int(
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
+            ),
+            repeated_result_warn_after=_positive_int(
+                warn_after.get("repeated_result", data.get("repeated_result_warn_after")),
+                defaults.repeated_result_warn_after,
+            ),
+            repeated_result_halt_after=_positive_int(
+                hard_stop_after.get("repeated_result", data.get("repeated_result_halt_after")),
+                defaults.repeated_result_halt_after,
+            ),
+            repeated_result_min_chars=_positive_int(
+                data.get("repeated_result_min_chars"),
+                defaults.repeated_result_min_chars,
             ),
             loop_caps=LoopCapConfig.from_mapping(data.get("loop_caps")),
         )
@@ -281,6 +296,8 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._last_result_hash: str | None = None
+        self._result_streak: int = 0
         self._halt_decision: ToolGuardrailDecision | None = None
         # Per-turn runaway-loop cap counters. Reset every turn (this method
         # runs at the start of each run_conversation), so the caps bound a
@@ -351,7 +368,7 @@ class ToolCallGuardrailController:
         self,
         tool_name: str,
         args: Mapping[str, Any] | None,
-        result: str | None,
+        result: str | Mapping[str, Any] | None,
         *,
         failed: bool | None = None,
     ) -> ToolGuardrailDecision:
@@ -359,6 +376,17 @@ class ToolCallGuardrailController:
         signature = ToolCallSignature.from_call(tool_name, args)
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
+
+        # Result-repetition loop detection. This is deliberately independent of
+        # the tool name, its argument signature, and whether the call "failed":
+        # the worst observed loops are *successful* calls with *varying* args
+        # (e.g. execute_code wrapping web fetches) that keep returning the same
+        # blocked/404 body. The failure- and signature-keyed counters below all
+        # miss that shape, so we key purely on the result content here.
+        repeat_decision = self._track_result_repetition(tool_name, result, signature)
+        if repeat_decision is not None and repeat_decision.action == "halt":
+            self._halt_decision = repeat_decision
+            return repeat_decision
 
         if failed:
             exact_count = self._exact_failure_counts.get(signature, 0) + 1
@@ -407,14 +435,18 @@ class ToolCallGuardrailController:
                     signature=signature,
                 )
 
-            return ToolGuardrailDecision(tool_name=tool_name, count=exact_count, signature=signature)
+            return repeat_decision or ToolGuardrailDecision(
+                tool_name=tool_name, count=exact_count, signature=signature
+            )
 
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)
-            return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+            return repeat_decision or ToolGuardrailDecision(
+                tool_name=tool_name, signature=signature
+            )
 
         result_hash = _result_hash(result)
         previous = self._no_progress.get(signature)
@@ -437,7 +469,84 @@ class ToolCallGuardrailController:
                 signature=signature,
             )
 
-        return ToolGuardrailDecision(tool_name=tool_name, count=repeat_count, signature=signature)
+        return repeat_decision or ToolGuardrailDecision(
+            tool_name=tool_name, count=repeat_count, signature=signature
+        )
+
+    def _track_result_repetition(
+        self,
+        tool_name: str,
+        result: str | Mapping[str, Any] | None,
+        signature: ToolCallSignature,
+    ) -> ToolGuardrailDecision | None:
+        """Detect a consecutive streak of identical tool results regardless of args/outcome.
+
+        Returns a halt decision once the same result has recurred on
+        ``repeated_result_halt_after`` consecutive calls this turn, a warn
+        decision at the warn threshold, or ``None`` otherwise. Any different or
+        untracked result breaks the streak, so interleaved sequences (A/B/A/C/A)
+        never fire and the "last N calls" wording in the messages stays literal.
+
+        Short results are ignored so trivial outputs (``"[]"``, ``"OK"``, empty
+        strings) never trip it — with one exception: an empty-success envelope
+        (``{"success": true, "results": [], ...}``) from a non-mutating tool
+        counts, because a read-style tool returning the same "nothing found"
+        payload for ever-changing queries is exactly the loop shape from
+        issue #60084, and repeated empty successes from mutating tools are
+        legitimate (each call did its work).
+        """
+        if not result:
+            self._last_result_hash = None
+            self._result_streak = 0
+            return None
+        text = _repetition_text(result)
+        if len(text) < self.config.repeated_result_min_chars and not (
+            tool_name not in self.config.mutating_tools
+            and _is_empty_success_envelope(result)
+        ):
+            self._last_result_hash = None
+            self._result_streak = 0
+            return None
+
+        result_hash = _result_hash(text)
+        if result_hash == self._last_result_hash:
+            self._result_streak += 1
+        else:
+            self._last_result_hash = result_hash
+            self._result_streak = 1
+        count = self._result_streak
+
+        if self.config.hard_stop_enabled and count >= self.config.repeated_result_halt_after:
+            return ToolGuardrailDecision(
+                action="halt",
+                code="repeated_result_halt",
+                message=(
+                    f"Stopped: the last {count} tool calls returned the same result even "
+                    "though the arguments changed. You are looping without making progress "
+                    "(the data source is unavailable/blocking). Stop retrying variations; "
+                    "report what you already have and the blocker, or ask how to proceed."
+                ),
+                tool_name=tool_name,
+                count=count,
+                signature=signature,
+            )
+
+        if self.config.warnings_enabled and count >= self.config.repeated_result_warn_after:
+            return ToolGuardrailDecision(
+                action="warn",
+                code="repeated_result_warning",
+                message=(
+                    f"The last {count} tool calls returned an identical result despite "
+                    "changed arguments. This is a no-progress loop — the target likely "
+                    "isn't reachable. Use what you have or report the blocker instead of "
+                    "trying more variations of the same approach."
+                ),
+                tool_name=tool_name,
+                count=count,
+                signature=signature,
+            )
+
+        return None
 
     def _is_idempotent(self, tool_name: str) -> bool:
         if tool_name in self.config.mutating_tools:
@@ -518,16 +627,31 @@ def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:
     )
 
 
-def append_toolguard_guidance(result: str, decision: ToolGuardrailDecision) -> str:
-    """Append runtime guidance to the current tool result content."""
+def append_toolguard_guidance(result: Any, decision: ToolGuardrailDecision) -> Any:
+    """Append runtime guidance to the current tool result content.
+
+    Plain string results get the guidance appended in place. Multimodal results
+    (``{"_multimodal": True, "content": [...]}``) keep their dict shape — the
+    guidance is added as a trailing text part (and mirrored into
+    ``text_summary`` when present) so providers and the text-only fallback both
+    surface it; string concatenation would raise on the dict.
+    """
     if decision.action not in {"warn", "halt"} or not decision.message:
         return result
     label = "Tool loop hard stop" if decision.action == "halt" else "Tool loop warning"
-    suffix = (
-        f"\n\n[{label}: "
+    guidance = (
+        f"[{label}: "
         f"{decision.code}; count={decision.count}; {decision.message}]"
     )
-    return (result or "") + suffix
+    if isinstance(result, Mapping) and result.get("_multimodal"):
+        updated = dict(result)
+        updated["content"] = list(updated.get("content") or []) + [
+            {"type": "text", "text": guidance}
+        ]
+        if updated.get("text_summary"):
+            updated["text_summary"] = f"{updated['text_summary']}\n\n{guidance}"
+        return updated
+    return (result or "") + f"\n\n{guidance}"
 
 
 def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
@@ -552,6 +676,64 @@ def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
 
 def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:
     return args if isinstance(args, Mapping) else {}
+
+
+def _repetition_text(result: Any) -> str:
+    """Normalize a tool result for repetition tracking.
+
+    Multimodal results (``{"_multimodal": True, "content": [...]}``, e.g.
+    vision_analyze) embed base64 image payloads, so ``str(result)`` is unique
+    per image and identical *text* parts can never be seen as repetition —
+    the guard would otherwise be blind to a repeated "Image loaded into your
+    context" placeholder. Represent them as their text parts plus a short
+    digest of each non-text payload: re-loading the *same* image repeatedly
+    still counts as repetition, while distinct images (legitimate page-scroll
+    screenshots) still count as progress.
+    """
+    if isinstance(result, Mapping) and result.get("_multimodal"):
+        parts: list[str] = []
+        for part in result.get("content") or []:
+            if not isinstance(part, Mapping):
+                parts.append(str(part))
+                continue
+            if part.get("type") == "text":
+                parts.append(str(part.get("text") or ""))
+            else:
+                payload = part.get("image_url")
+                if isinstance(payload, Mapping):
+                    payload = payload.get("url")
+                parts.append(f"[media:{_sha256(str(payload or ''))[:16]}]")
+        return "\n".join(parts)
+    return result if isinstance(result, str) else str(result)
+
+
+_EMPTY_PAYLOAD_KEYS = ("results", "items", "matches", "entries", "sessions", "data")
+
+
+def _is_empty_success_envelope(result: Any) -> bool:
+    """True for a JSON success payload that carries no content.
+
+    The shape from issue #60084: ``{"success": true, "results": [], "count": 0}``
+    — too short for ``repeated_result_min_chars`` but a loop signal all the
+    same when it keeps coming back for different queries. Requires an explicit
+    emptiness marker (``count == 0`` or an empty payload list), so a bare
+    ``{"success": true}`` acknowledgment never qualifies, and any non-empty
+    payload key disqualifies.
+    """
+    if not isinstance(result, str):
+        return False
+    parsed = safe_json_loads(result)
+    if not isinstance(parsed, Mapping) or parsed.get("success") is not True:
+        return False
+    empty = parsed.get("count") == 0
+    for key in _EMPTY_PAYLOAD_KEYS:
+        if key not in parsed:
+            continue
+        if parsed[key] in (None, [], {}, ""):
+            empty = True
+        else:
+            return False
+    return empty
 
 
 def _result_hash(result: str | None) -> str:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -397,10 +397,15 @@ tool_loop_guardrails:
     exact_failure: 2
     same_tool_failure: 3
     idempotent_no_progress: 2
+    repeated_result: 3
   hard_stop_after:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+    repeated_result: 5
+  # Results shorter than this never count toward repeated_result (avoids
+  # tripping on trivial outputs like "[]" or "OK").
+  repeated_result_min_chars: 200
 
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -502,12 +502,16 @@ DEFAULT_CONFIG = {
             "exact_failure": 2,
             "same_tool_failure": 3,
             "idempotent_no_progress": 2,
+            "repeated_result": 3,
         },
         "hard_stop_after": {
             "exact_failure": 5,
             "same_tool_failure": 8,
             "idempotent_no_progress": 5,
+            "repeated_result": 5,
         },
+        # Results shorter than this never count toward repeated_result.
+        "repeated_result_min_chars": 200,
         # Per-turn runaway-loop caps (inspired by Claude Code v2.1.212,
         # Week 29, July 2026). Hard ceilings on how many times a runaway-prone
         # tool may be called within a SINGLE agent loop (turn); the counters

--- a/run_agent.py
+++ b/run_agent.py
@@ -6829,10 +6829,10 @@ class AIAgent:
         self,
         tool_name: str,
         function_args: dict,
-        function_result: str,
+        function_result: str | dict,
         *,
         failed: bool,
-    ) -> str:
+    ) -> str | dict:
         decision = self._tool_guardrails.after_call(
             tool_name,
             function_args,

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -6,6 +6,8 @@ from agent.tool_guardrails import (
     ToolCallGuardrailConfig,
     ToolCallGuardrailController,
     ToolCallSignature,
+    ToolGuardrailDecision,
+    append_toolguard_guidance,
     canonical_tool_args,
     classify_tool_failure,
 )
@@ -44,12 +46,15 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
                 "exact_failure": 3,
                 "same_tool_failure": 4,
                 "idempotent_no_progress": 5,
+                "repeated_result": 9,
             },
             "hard_stop_after": {
                 "exact_failure": 6,
                 "same_tool_failure": 7,
                 "idempotent_no_progress": 8,
+                "repeated_result": 10,
             },
+            "repeated_result_min_chars": 64,
         }
     )
 
@@ -61,6 +66,17 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
     assert cfg.exact_failure_block_after == 6
     assert cfg.same_tool_failure_halt_after == 7
     assert cfg.no_progress_block_after == 8
+    assert cfg.repeated_result_warn_after == 9
+    assert cfg.repeated_result_halt_after == 10
+    assert cfg.repeated_result_min_chars == 64
+
+
+def test_default_config_guardrail_block_matches_dataclass_defaults():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    cfg = ToolCallGuardrailConfig.from_mapping(DEFAULT_CONFIG["tool_loop_guardrails"])
+
+    assert cfg == ToolCallGuardrailConfig()
 
 
 def test_default_repeated_identical_failed_call_warns_without_blocking():
@@ -169,11 +185,218 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.should_halt is True
 
 
+def test_repeated_identical_result_halts_successful_varying_arg_loop():
+    """The real-world loop: execute_code 'succeeds' with different args every
+    call but returns the same blocked/404 body. Failure- and signature-keyed
+    counters miss it; result-repetition detection must catch it."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            repeated_result_warn_after=3,
+            repeated_result_halt_after=5,
+        )
+    )
+    blocked_body = (
+        '{"status": "success", "output": "=== SOME REMOTE API RESPONSE ==='
+        + "<!DOCTYPE html>" + "x" * 300 + '"}'
+    )
+
+    decisions = []
+    for i in range(5):
+        # Different arguments every call, never classified as a failure.
+        decisions.append(
+            controller.after_call(
+                "execute_code", {"code": f"fetch_attempt_{i}()"}, blocked_body, failed=False
+            )
+        )
+
+    assert decisions[2].action == "warn"
+    assert decisions[2].code == "repeated_result_warning"
+    assert decisions[4].action == "halt"
+    assert decisions[4].code == "repeated_result_halt"
+    assert controller.halt_decision is decisions[4]
 
 
+def test_repeated_result_ignores_short_and_distinct_outputs():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, repeated_result_halt_after=3)
+    )
+    # Short identical results must not trip the guard.
+    for _ in range(5):
+        d = controller.after_call("execute_code", {"code": "x"}, '{"ok":true}', failed=False)
+        assert d.action == "allow"
+    # Long but genuinely distinct results = real progress, never halts.
+    for i in range(5):
+        body = '{"status":"success","output":"' + f"unique-{i}-" + "y" * 300 + '"}'
+        d = controller.after_call("execute_code", {"code": f"c{i}"}, body, failed=False)
+        assert d.action == "allow"
+    assert controller.halt_decision is None
 
 
+def _multimodal_vision_result(image_b64: str, question: str = "Describe everything visible.") -> dict:
+    """Shape returned by a native vision-analysis tool result."""
+    return {
+        "_multimodal": True,
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    "Image loaded into your context — you can see it natively now. "
+                    "Use your built-in vision to answer the user."
+                    f"\n\nQuestion: {question}" + " " * 120
+                ),
+            },
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{image_b64}"}},
+        ],
+        "text_summary": "Image attached natively for the main model.",
+    }
 
 
+def test_repeated_multimodal_result_same_image_trips_guard():
+    """Multimodal results embed base64 image payloads, so a naive str(result)
+    hash is unique per image and identical *text* parts (the placeholder
+    caption) can never be seen as repetition. Re-loading the *same* image
+    repeatedly must still count as repetition."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            repeated_result_warn_after=3,
+            repeated_result_halt_after=5,
+        )
+    )
+    same = _multimodal_vision_result("A" * 4000)
+    decisions = [
+        controller.after_call("vision_analyze", {"image_url": f"/tmp/shot_{i}.png"}, same, failed=False)
+        for i in range(5)
+    ]
+    assert decisions[2].action == "warn"
+    assert decisions[2].code == "repeated_result_warning"
+    assert decisions[4].action == "halt"
+    assert decisions[4].code == "repeated_result_halt"
 
 
+def test_repeated_multimodal_result_distinct_images_is_progress():
+    """Distinct screenshots with an identical text part (scrolling through a long
+    page) are legitimate progress and must NOT halt, even past the threshold."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, repeated_result_halt_after=5)
+    )
+    for i in range(8):
+        result = _multimodal_vision_result(f"IMG{i}" * 1000)
+        d = controller.after_call(
+            "vision_analyze", {"image_url": f"/tmp/shot_{i}.png"}, result, failed=False
+        )
+        assert d.action == "allow"
+    assert controller.halt_decision is None
+
+
+def test_repeated_result_interleaved_sequences_never_warn():
+    """A/B/A/C/A must stay silent: the same result recurring non-consecutively
+    is not a loop, and the warn/halt messages promise 'the last N calls', so
+    only a consecutive streak may count."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, repeated_result_warn_after=3)
+    )
+    bodies = {
+        key: '{"status":"success","output":"' + key * 240 + '"}' for key in "ABC"
+    }
+    for key in "ABACA":
+        d = controller.after_call("execute_code", {"code": key}, bodies[key], failed=False)
+        assert d.action == "allow"
+    assert controller.halt_decision is None
+
+
+def test_repeated_result_streak_restarts_after_interruption():
+    """A different result breaks the streak; a fresh run of identical results
+    must reach the threshold on its own before warning, and the reported count
+    reflects only the consecutive run."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(repeated_result_warn_after=3)
+    )
+    body_a = '{"status":"success","output":"' + "A" * 240 + '"}'
+    body_b = '{"status":"success","output":"' + "B" * 240 + '"}'
+
+    decisions = [
+        controller.after_call("execute_code", {"code": f"c{i}"}, body, failed=False)
+        for i, body in enumerate([body_a, body_a, body_b, body_a, body_a, body_a])
+    ]
+
+    assert [d.action for d in decisions[:5]] == ["allow"] * 5
+    assert decisions[5].action == "warn"
+    assert decisions[5].code == "repeated_result_warning"
+    assert decisions[5].count == 3
+
+
+def test_empty_success_envelope_loop_from_read_tool_trips_guard():
+    """The production case from issue #60084's report thread: session_search
+    returning {"success": true, "results": [], "count": 0} for 16 different
+    hallucinated queries. Too short for repeated_result_min_chars, but an
+    identical no-content success from a non-mutating tool is still a loop."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            repeated_result_warn_after=3,
+            repeated_result_halt_after=5,
+        )
+    )
+    envelope = '{"success": true, "results": [], "count": 0}'
+    decisions = [
+        controller.after_call("session_search", {"query": f"q{i}"}, envelope, failed=False)
+        for i in range(5)
+    ]
+    assert decisions[2].action == "warn"
+    assert decisions[2].code == "repeated_result_warning"
+    assert decisions[4].action == "halt"
+    assert decisions[4].code == "repeated_result_halt"
+
+
+def test_empty_success_envelope_from_mutating_tool_is_ignored():
+    """Mutating tools legitimately return the same terse success envelope on
+    every call — each call did its work, so no loop may be inferred."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, repeated_result_warn_after=2)
+    )
+    envelope = '{"success": true, "results": [], "count": 0}'
+    for i in range(6):
+        d = controller.after_call("todo", {"add": f"item-{i}"}, envelope, failed=False)
+        assert d.action == "allow"
+    assert controller.halt_decision is None
+
+
+def test_bare_success_ack_is_not_an_empty_envelope():
+    """{"success": true} with no emptiness marker is an acknowledgment, not a
+    no-content result; repeated acks from varying calls must stay silent."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, repeated_result_warn_after=2)
+    )
+    for i in range(6):
+        d = controller.after_call(
+            "web_extract", {"url": f"https://x/{i}"}, '{"success": true}', failed=False
+        )
+        assert d.action == "allow"
+    assert controller.halt_decision is None
+
+
+def test_append_toolguard_guidance_keeps_multimodal_dict_shape():
+    """Guidance on a multimodal result must not string-concatenate the dict:
+    it lands as a trailing text part and in text_summary, and the image parts
+    survive untouched."""
+    decision = ToolGuardrailDecision(
+        action="warn",
+        code="repeated_result_warning",
+        message="Same result repeated.",
+        tool_name="vision_analyze",
+        count=3,
+    )
+    original = _multimodal_vision_result("A" * 64)
+
+    updated = append_toolguard_guidance(original, decision)
+
+    assert updated["_multimodal"] is True
+    assert updated["content"][-1]["type"] == "text"
+    assert "repeated_result_warning" in updated["content"][-1]["text"]
+    assert "Tool loop warning" in updated["content"][-1]["text"]
+    assert any(part.get("type") == "image_url" for part in updated["content"])
+    assert "repeated_result_warning" in updated["text_summary"]
+    # The caller's dict is not mutated in place.
+    assert "repeated_result_warning" not in str(original)

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -420,3 +420,66 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+def _multimodal_tool_result(image_b64: str) -> dict:
+    """Shape returned by a native vision-analysis tool."""
+    return {
+        "_multimodal": True,
+        "content": [
+            {"type": "text", "text": "Image loaded into your context." + " " * 250},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{image_b64}"}},
+        ],
+        "text_summary": "Image attached natively for the main model.",
+    }
+
+
+def _seed_repeated_multimodal(agent: AIAgent, result: dict, count: int = 2) -> None:
+    for i in range(count):
+        agent._tool_guardrails.after_call(
+            "vision_analyze", {"image_url": f"/tmp/seed_{i}.png"}, result, failed=False
+        )
+
+
+def test_sequential_path_appends_guidance_to_repeated_multimodal_result():
+    """A repeated-result warning on a multimodal (dict) tool result must keep
+    the dict shape all the way into the tool message instead of raising on
+    string concatenation, and the guidance must be visible in the content the
+    model receives."""
+    agent = _make_agent("vision_analyze")
+    same = _multimodal_tool_result("A" * 2000)
+    _seed_repeated_multimodal(agent, same)
+    tc = _mock_tool_call("vision_analyze", json.dumps({"image_url": "/tmp/s3.png"}), "c-mm-seq")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=dict(same)):
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    assert [m["role"] for m in messages] == ["tool"]
+    assert messages[0]["tool_call_id"] == "c-mm-seq"
+    content_str = str(messages[0]["content"])
+    assert "Tool loop warning" in content_str
+    assert "repeated_result_warning" in content_str
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_concurrent_path_appends_guidance_to_repeated_multimodal_result():
+    """Same as the sequential case but through the concurrent executor, which
+    routes results through its own _append_guardrail_observation call site."""
+    agent = _make_agent("vision_analyze")
+    same = _multimodal_tool_result("B" * 2000)
+    _seed_repeated_multimodal(agent, same)
+    tc = _mock_tool_call("vision_analyze", json.dumps({"image_url": "/tmp/s3.png"}), "c-mm-con")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=dict(same)):
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    assert [m["role"] for m in messages] == ["tool"]
+    assert messages[0]["tool_call_id"] == "c-mm-con"
+    content_str = str(messages[0]["content"])
+    assert "Tool loop warning" in content_str
+    assert "repeated_result_warning" in content_str
+    assert agent._tool_guardrail_halt_decision is None

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1495,7 +1495,7 @@ agent:
 
 ## Tool-Loop Guardrails
 
-Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, or an idempotent call returning the same result with no progress. By default it injects a **warning** into the tool result so the model self-corrects; it does not hard-stop, since a person watching the CLI/TUI can intervene.
+Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, an idempotent call returning the same result with no progress, or the same substantial result recurring across otherwise-different calls. By default it injects a **warning** into the tool result so the model self-corrects; it does not hard-stop, since a person watching the CLI/TUI can intervene.
 
 For unattended gateway / server deployments, enable hard stops so a stuck agent is circuit-broken instead of burning the iteration budget:
 
@@ -1507,16 +1507,21 @@ tool_loop_guardrails:
     exact_failure: 2           # identical failing call repeated N times
     same_tool_failure: 3       # same tool failing N times (different args)
     idempotent_no_progress: 2  # same result, no progress, N times
+    repeated_result: 3         # same result content, regardless of tool/args, N times
   hard_stop_after:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+    repeated_result: 5
+  repeated_result_min_chars: 200  # results shorter than this never count (default: 200)
   loop_caps:
     max_web_searches: 50       # max web_search calls per turn (0 = unlimited)
     max_subagents: 50          # max subagents spawned per turn (0 = unlimited)
 ```
 
 `hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. See also [Docker / unattended deployments](docker.md).
+
+The `repeated_result` axis is independent of tool name, arguments, and whether the call was classified as a failure — it catches the shape where a call keeps "succeeding" with different arguments each time but returns the same blocked/error body (e.g. a fetch tool retried against a source that consistently 404s or soft-blocks). It normalizes multimodal results before hashing so a repeated placeholder caption around a base64 image payload is still detected as repetition.
 
 ### Per-turn runaway-loop caps
 


### PR DESCRIPTION
## What does this PR do?

Adds a content-only repetition guard to `ToolCallGuardrailController`: detection of a tool-call loop where the **arguments vary on every call but the result never changes**.

The existing loop guards are keyed on tool-call signature (tool name + canonical args) or on classified failure. That misses a real loop shape observed running a local model in an unattended/gateway session: a tool call that "succeeds" with different arguments each time but keeps returning the same blocked/empty/error-page body — e.g. `execute_code` wrapping a web fetch against a source that consistently 404s or soft-blocks a scraper. Neither the exact-failure counter (never fires — `failed` is false) nor the `_no_progress` idempotent-result tracker (keyed by signature, and only applied to a fixed idempotent-tool allowlist) catches this.

A second, related gap: a repeated vision/multimodal tool result (shape `{"_multimodal": True, "content": [...]}`) was never detected as repetition because `str(result)` embeds a base64 image payload that's unique per call even when the meaningful content (a placeholder caption like "Image loaded into your context") is identical — one session re-loaded the same image via a vision tool 6 times with zero guard activity.

The guard follows the existing axes' design: soft warning by default, hard stop only when `hard_stop_enabled` is set.

## Related Issue

Fixes #60084

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/tool_guardrails.py`:
  - `_track_result_repetition()` — a content-hash-only repetition tracker, independent of tool name, arguments, and classified failure. Warns at `repeated_result` warn threshold (default 3), halts at the hard-stop threshold (default 5, only when `hard_stop_enabled`). Results under `repeated_result_min_chars` (default 200) are exempt so trivial outputs (`"[]"`, `"OK"`) never trip it.
  - `_repetition_text()` — normalizes a tool result before hashing. Multimodal results keep text parts verbatim and reduce each non-text payload (e.g. an `image_url` data URI) to a short digest, so re-loading the *same* image counts as repetition while distinct images (legitimate page-scroll screenshots) count as progress. Plain string results pass through unchanged.
  - Wired into `after_call()` ahead of the existing failure/no-progress branches; a halt short-circuits immediately, a warn is returned if no stronger decision applies.
- `hermes_cli/config.py`: `repeated_result` thresholds under `warn_after`/`hard_stop_after` plus `repeated_result_min_chars` in `DEFAULT_CONFIG["tool_loop_guardrails"]`.
- `cli-config.yaml.example`: document the new keys alongside the existing guardrail axes.
- `website/docs/user-guide/configuration.md`: short section for the new `repeated_result` keys.
- `tests/agent/test_tool_guardrails.py`: 5 new tests (see below) plus `repeated_result` coverage in the existing config-parsing test.

## How to Test

1. `pytest tests/agent/test_tool_guardrails.py -q` — 18 passed. New tests:
   - `test_repeated_identical_result_halts_successful_varying_arg_loop` (the varying-args/fixed-result loop shape)
   - `test_repeated_result_ignores_short_and_distinct_outputs` (no false positives on short or genuinely distinct results)
   - `test_repeated_multimodal_result_same_image_trips_guard` (the vision-result blind spot)
   - `test_repeated_multimodal_result_distinct_images_is_progress` (distinct images never halt)
   - `test_default_config_guardrail_block_matches_dataclass_defaults` (DEFAULT_CONFIG stays in sync with the parser defaults)
2. Downstream consumers unaffected: `pytest tests/agent/test_turn_context.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/hermes_cli/test_config.py -q` — all green (184 passed across the four files combined).
3. Manual: configure `tool_loop_guardrails.hard_stop_enabled: true`, then have an agent repeatedly fetch a URL that returns the same blocked/error page body with varying query args — the guard warns after 3 identical results and halts after 5.

Note: two pre-existing `tests/agent` failures on a clean `upstream/main` checkout (`test_anthropic_adapter.py`, `test_coding_context.py`) reproduce identically without this change — they're environment-related, not introduced here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python logic, no file I/O / process / terminal handling)
