### PR TITLE
fix(gateway): return bare callable in pop_post_delivery_callback when generation mismatch

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4004,6 +4004,14 @@ class BasePlatformAdapter(ABC):
             self._post_delivery_callbacks.pop(session_key, None)
             return callback if callable(callback) else None
         if generation is not None:
+            # Bare callable stored without generation: the caller has
+            # generation context but the entry doesn't — treat as
+            # "any generation is acceptable" and pop it.  Otherwise
+            # callers that register before a session is active
+            # (generation=None) lose their callback.
+            if callable(entry):
+                self._post_delivery_callbacks.pop(session_key, None)
+                return entry
             return None
         self._post_delivery_callbacks.pop(session_key, None)
         return entry if callable(entry) else None

--- a/tests/gateway/test_post_delivery_callback_chaining.py
+++ b/tests/gateway/test_post_delivery_callback_chaining.py
@@ -125,6 +125,22 @@ class TestPostDeliveryCallbackChaining:
         # Correct generation still finds it.
         assert adapter.pop_post_delivery_callback("s", generation=5) is not None
 
+    def test_bare_callback_popped_with_generation(self, adapter):
+        """A callback registered without generation (bare callable) should
+        still be returned when popped with a generation — registration
+        before session activation means "any generation is acceptable"."""
+        fired = []
+        adapter.register_post_delivery_callback(
+            "s", lambda: fired.append("bare"), generation=None
+        )
+        # Pop with a generation value — should still get the callback.
+        cb = adapter.pop_post_delivery_callback("s", generation=5)
+        assert cb is not None
+        _invoke(cb)
+        assert fired == ["bare"]
+        # One-shot: callback should be removed after pop.
+        assert adapter.pop_post_delivery_callback("s") is None
+
     def test_empty_session_key_is_noop(self, adapter):
         adapter.register_post_delivery_callback("", lambda: None)
         assert adapter._post_delivery_callbacks == {}


### PR DESCRIPTION
## Summary

The chained wrapper in register_post_delivery_callback was a synchronous function that called async callbacks without awaiting them, silently discarding the coroutines. Any async callback registered when another callback already existed for the same session_key would never execute.

## Changes

### Fix 1: Make chained async-aware
chained is now async def and uses inspect.isawaitable() to handle both sync and async callbacks correctly, awaiting async ones.

### Fix 2: pop_post_delivery_callback bare callable handling
When a bare callable was stored without a generation (registration happened before the session was active), the pop caller with a generation value would get None instead of the callback. Now pop returns the bare callable instead of dropping it.

## Testing
Verified on OneBot QQ group chat with message queueing. Before: async idle callbacks were silently dropped when chained. After: idle frame is correctly awaited and sent to the adapter, dequeue works as expected.