### PR TITLE
fix(cli): import existing Codex CLI session in `auth add openai-codex`

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -308,7 +308,26 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "openai-codex":
-        creds = auth_mod._codex_device_code_login()
+        # Offer to import an existing Codex CLI session (~/.codex/auth.json)
+        # instead of a fresh device-code login — the same option `hermes model`
+        # already provides. This is the escape hatch when the device-code flow
+        # is rate-limited (429) or the user is already signed in via the Codex
+        # CLI / VS Code and just wants Hermes to reuse that account.
+        creds = None
+        cli_tokens = auth_mod._import_codex_cli_tokens()
+        if cli_tokens and sys.stdin.isatty():
+            print("Found existing Codex CLI credentials at ~/.codex/auth.json")
+            print("Hermes will create its own session to avoid conflicts with Codex CLI / VS Code.")
+            try:
+                do_import = input(
+                    "Import these credentials? (a separate login is recommended) [y/N]: "
+                ).strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                do_import = "n"
+            if do_import in ("y", "yes"):
+                creds = {"tokens": cli_tokens, "base_url": auth_mod.DEFAULT_CODEX_BASE_URL}
+        if creds is None:
+            creds = auth_mod._codex_device_code_login()
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["tokens"]["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -77,6 +77,7 @@ AUTHOR_MAP = {
     "164521089+rainbowgits@users.noreply.github.com": "rainbowgore",  # PR #59405 salvage (mcp: bound stdio initialize handshake to stop subprocess/FD leak; #59349)
     "sage@Sages-Mac-mini.local": "thestudionorth",  # PR #60015 salvage (mcp: parent-death watchdog for stdio children; commit under unlinked local identity)
     "4087127+vampyren@users.noreply.github.com": "vampyren",  # PR #59830 salvage (kanban: grab-to-pan board scrolling; original commit under unlinked local identity)
+    "andryypaez@gmail.com": "zeapsu",  # auth: offer Codex CLI credential import in `auth add openai-codex`
     "spiky02plateau@users.noreply.github.com": "spiky02plateau",  # PR #32824 salvage (usage: fetch Codex account limits from the credential pool in pool-only setups; superseded by #60028)
     "taylorhp@gmail.com": "hwrdprkns",  # PR #36896 salvage (secrets: 1Password op:// secret source + shared _cache substrate, adapted onto the SecretSource interface)
     "ishengeqi@163.com": "isheng-eqi",  # PR #59428 salvage (cron: reject past one-shot timestamps in update_job fallback + resume_job; #59395). Also PR #59446 salvage (cron: advance one-shot next_run_at before dispatch so concurrent gateway+desktop schedulers can't double-execute; #59229).

--- a/tests/hermes_cli/test_auth_add_codex_import.py
+++ b/tests/hermes_cli/test_auth_add_codex_import.py
@@ -1,0 +1,93 @@
+"""Tests for `hermes auth add openai-codex` importing an existing Codex CLI session.
+
+Regression coverage for the device-code-only trap: when the OpenAI device-code
+flow is rate-limited (429), `auth add` should offer to import the credentials the
+Codex CLI already holds at ``~/.codex/auth.json`` — the same option `hermes model`
+provides — instead of forcing another device-code login.
+"""
+
+from types import SimpleNamespace
+
+import hermes_cli.auth as auth_mod
+from agent.credential_pool import load_pool
+from hermes_cli.auth_commands import auth_add_command
+
+
+CLI_TOKENS = {
+    "id_token": "id-xyz",
+    "access_token": "cli-access-token",
+    "refresh_token": "cli-refresh-token",
+    "account_id": "acct-123",
+}
+
+
+def _args():
+    return SimpleNamespace(provider="openai-codex", auth_type="", label=None, api_key=None)
+
+
+class _Tty:
+    def isatty(self):
+        return True
+
+
+def _boom(*a, **k):
+    raise AssertionError("_codex_device_code_login must not run when import is chosen")
+
+
+def test_import_accepted_skips_device_code(monkeypatch):
+    monkeypatch.setattr(auth_mod, "_import_codex_cli_tokens", lambda: dict(CLI_TOKENS))
+    monkeypatch.setattr(auth_mod, "_codex_device_code_login", _boom)
+    monkeypatch.setattr("hermes_cli.auth_commands.sys.stdin", _Tty())
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+
+    auth_add_command(_args())
+
+    entries = load_pool("openai-codex").entries()
+    assert len(entries) == 1
+    assert entries[0].access_token == "cli-access-token"
+    assert entries[0].refresh_token == "cli-refresh-token"
+
+
+def test_import_declined_falls_back_to_device_code(monkeypatch):
+    device_creds = {
+        "tokens": {"access_token": "device-access", "refresh_token": "device-refresh"},
+        "base_url": auth_mod.DEFAULT_CODEX_BASE_URL,
+        "last_refresh": None,
+    }
+    monkeypatch.setattr(auth_mod, "_import_codex_cli_tokens", lambda: dict(CLI_TOKENS))
+    monkeypatch.setattr(auth_mod, "_codex_device_code_login", lambda *a, **k: device_creds)
+    monkeypatch.setattr("hermes_cli.auth_commands.sys.stdin", _Tty())
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "n")
+
+    auth_add_command(_args())
+
+    entries = load_pool("openai-codex").entries()
+    assert len(entries) == 1
+    assert entries[0].access_token == "device-access"
+
+
+def test_non_interactive_does_not_prompt(monkeypatch):
+    """No TTY (piped/scripted) must not block on input(); falls back to device code."""
+    device_creds = {
+        "tokens": {"access_token": "device-access", "refresh_token": "device-refresh"},
+        "base_url": auth_mod.DEFAULT_CODEX_BASE_URL,
+        "last_refresh": None,
+    }
+
+    class _NoTty:
+        def isatty(self):
+            return False
+
+    def _no_input(*a, **k):
+        raise AssertionError("input() must not be called without a TTY")
+
+    monkeypatch.setattr(auth_mod, "_import_codex_cli_tokens", lambda: dict(CLI_TOKENS))
+    monkeypatch.setattr(auth_mod, "_codex_device_code_login", lambda *a, **k: device_creds)
+    monkeypatch.setattr("hermes_cli.auth_commands.sys.stdin", _NoTty())
+    monkeypatch.setattr("builtins.input", _no_input)
+
+    auth_add_command(_args())
+
+    entries = load_pool("openai-codex").entries()
+    assert len(entries) == 1
+    assert entries[0].access_token == "device-access"


### PR DESCRIPTION
## What does this PR do?

`hermes auth add openai-codex` only ran the OpenAI **device-code** flow. That flow
is easy to get rate-limited (`usage_limit_reached (429)`), and once it is, `auth add`
offered no way forward — even when the user was already signed in through the Codex
CLI / VS Code with a perfectly good session sitting at `~/.codex/auth.json`.

`hermes model` already handles this: it detects `~/.codex/auth.json` and offers to
import it. This PR mirrors that single behavior in `auth add openai-codex`, so both
entry points behave the same. It reuses the existing `_import_codex_cli_tokens()`
helper — no new auth logic — and falls back to the device-code flow when the import
is declined, when no CLI session exists, or when the command is non-interactive (no TTY).

## Related Issue

No existing issue — small, self-contained UX fix. Happy to open one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth_commands.py` — in the `openai-codex` branch of `auth_add_command`,
  offer to import `~/.codex/auth.json` (via the existing `auth_mod._import_codex_cli_tokens()`)
  before falling back to `_codex_device_code_login()`. Import is TTY-gated and defaults to
  "no" (a separate login stays recommended), matching the `hermes model` prompt wording.
- `tests/hermes_cli/test_auth_add_codex_import.py` — new tests: import accepted skips the
  device-code flow, import declined falls back to device code, and non-interactive input
  never blocks on `input()`.
- `scripts/release.py` — add my author-email → GitHub-username mapping to `AUTHOR_MAP`
  (per the contributor-attribution check).

## How to Test

1. Be signed in via the Codex CLI (`~/.codex/auth.json` exists and is valid).
2. Run `hermes auth add openai-codex`.
3. Observe the new prompt: `Import these credentials? (a separate login is recommended) [y/N]`.
4. Answer `y` → credentials are imported into the pool with no device code; `hermes status`
   shows `OpenAI Codex ✓ logged in`.
5. Answer `n` (or pipe input / run non-interactively) → the device-code flow runs as before.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my change
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've tested on my platform: Ubuntu 22.04 (aarch64, Jetson Orin Nano)

> **Test note:** I ran the auth/codex/credential-pool tests
> (`tests/hermes_cli/test_auth_add_codex_import.py`, `test_auth_codex_provider.py`,
> `test_auth_codex_self_heal.py`, `test_auth_commands.py`, `tests/agent/test_credential_pool.py`)
> — **179 passed**, including the 3 new tests. The full `tests/` suite has some
> pre-existing, environment-dependent failures on my aarch64 box that are unrelated to and
> untouched by this change (it only edits the `openai-codex` branch of `auth_add_command`).

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (prompt is self-describing; no config keys added)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — reuses existing helpers + `sys.stdin.isatty()`; no new path/process logic
- [x] Tool descriptions/schemas — N/A
