### PR TITLE
fix(tools): decode cua-driver subprocess output as UTF-8

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1572,8 +1572,11 @@ class TestCuaDriverSessionReconnect:
             returncode = 0
             stderr = ""
             # Daemon returns a path, not inline base64.
-            stdout = ('{"element_count": 7, "tree_markdown": "- [0] AXButton",'
-                      ' "screenshot_file_path": "%s"}' % str(shot))
+            stdout = json.dumps({
+                "element_count": 7,
+                "tree_markdown": "- [0] AXButton",
+                "screenshot_file_path": str(shot),
+            })
 
         import subprocess as _sp
         orig_run = _sp.run
@@ -1685,6 +1688,44 @@ class TestCaptureEmptyResultClipFallback:
         # CLI recovered the window list; capture resolved the Finder window.
         assert "list_windows" in cli_calls
         assert cap.app == "Finder"
+
+
+class TestCliFallbackUtf8Decoding:
+    """Bug A: `_call_tool_via_cli` must force UTF-8 decoding for cua-driver
+    stdout so non-cp932 window titles do not break Japanese Windows hosts."""
+
+    def test_call_tool_via_cli_uses_utf8_with_replace(self):
+        from typing import Any, cast
+        from tools.computer_use.cua_backend import _CuaDriverSession
+
+        session = cast(Any, _CuaDriverSession.__new__(_CuaDriverSession))
+        captured_kw = {}
+
+        class FakeProc:
+            returncode = 0
+            stderr = ""
+            stdout = ('{"element_count": 2, "tree_markdown": '
+                      '"- [0] AXWindow \\"⛂ Claude Code\\""}')
+
+        import subprocess as _sp
+        orig_run = _sp.run
+
+        def fake_run(cmd, **kw):
+            captured_kw.update(kw)
+            return FakeProc()
+
+        _sp.run = fake_run
+        try:
+            out = session._call_tool_via_cli(
+                "get_window_state", {"pid": 1, "window_id": 2}, 30.0
+            )
+        finally:
+            _sp.run = orig_run
+
+        assert captured_kw.get("encoding") == "utf-8"
+        assert captured_kw.get("errors") == "replace"
+        assert "2 elements" in out["data"]
+        assert out["isError"] is False
 
 
 class TestCaptureAppFilterNoMatch:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -163,7 +163,9 @@ def _resolve_mcp_invocation(
         from tools.environments.local import _sanitize_subprocess_env
         proc = subprocess.run(
             [driver_cmd, "manifest"],
-            capture_output=True, text=True, timeout=timeout,
+            capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+            timeout=timeout,
             stdin=subprocess.DEVNULL,
             # cua-driver is a third-party binary — never hand it provider
             # API keys via inherited env (same policy as the MCP and CLI
@@ -254,7 +256,9 @@ def cua_driver_update_check(*, timeout: float = 8.0) -> Optional[Dict[str, Any]]
         from tools.environments.local import _sanitize_subprocess_env
         proc = subprocess.run(
             [_CUA_DRIVER_CMD, "check-update", "--json"],
-            capture_output=True, text=True, timeout=timeout,
+            capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+            timeout=timeout,
             # Some older drivers don't have the verb and fall through to a
             # stdin-reading mode rather than erroring — DEVNULL gives them EOF
             # so they exit fast instead of blocking until the timeout.
@@ -920,7 +924,9 @@ class _CuaDriverSession:
             for attempt in range(attempts):
                 try:
                     proc = _subprocess.run(
-                        cmd, capture_output=True, text=True, timeout=max(15.0, timeout),
+                        cmd, capture_output=True, text=True,
+                        encoding="utf-8", errors="replace",
+                        timeout=max(15.0, timeout),
                         env=_sanitize_subprocess_env(cua_driver_child_env()),
                     )
                 except Exception as e:  # pragma: no cover - subprocess spawn failure


### PR DESCRIPTION
## Summary

- On Japanese-locale Windows (ANSI cp932), `subprocess.run(text=True)` decodes pipes as cp932/strict. Any window title containing non-cp932 bytes (e.g. `#vrc写真 | Concord - Discord`) kills the reader thread with `UnicodeDecodeError: 'cp932' codec can't decode byte 0x94`, `proc.stdout` becomes None, and the whole CLI fallback transport reports "got no JSON" even though cua-driver emitted valid UTF-8 JSON (verified by redirecting the same call to a file).
- Fixes all three `subprocess.run` call sites with `encoding="utf-8", errors="replace"`: `_resolve_mcp_invocation` (manifest probe), `cua_driver_update_check`, and `_CuaDriverSession._call_tool_via_cli`.
- Aligns with the project's own Windows guidance enforced by `scripts/check-windows-footguns.py` for file I/O. Cross-platform impact: none — cua-driver always emits UTF-8.
- Also fixes `TestCuaDriverSessionReconnect.test_cli_fallback_reads_screenshot_from_file` to build the FakeProc.stdout JSON payload via `json.dumps()` so Windows backslash paths are properly escaped and the test passes on Windows hosts.

## Test plan

- [ ] `PYTHONUTF8=1 uv run --extra dev python -m pytest tests/tools/test_computer_use.py -q`
  - Result: **175 passed**, 1 warning (pre-existing ProactorEventLoop issue on Windows, unrelated to this PR), 1 error (pre-existing `:(){ :|: & };:` fork bomb pattern test, Windows-only EventLoop teardown issue)
- [ ] `uv run --extra dev python scripts/check-windows-footguns.py tools/computer_use/cua_backend.py`
  - Result: ✓ No Windows footguns found (1 file scanned)
- [ ] Live desktop smoke test on Windows 11 (Japanese locale): capture of Discord window with `#vrc写真` channel visible — no UnicodeDecodeError, full JSON returned

## Part of a series

- `fix(tools): decode cua-driver subprocess output as UTF-8` (this PR)
- `fix(tools): surface cua-driver UIA-timeout errors instead of retrying CLI transport`
- `fix(tools): bound get_window_state UIA walk and re-fetch dropped som/ax screenshots via CLI`

Co-Authored-By: Claude <noreply@anthropic.com>
