### PR TITLE
fix(tools): surface cua-driver UIA-timeout errors instead of retrying CLI transport

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1572,8 +1572,11 @@ class TestCuaDriverSessionReconnect:
             returncode = 0
             stderr = ""
             # Daemon returns a path, not inline base64.
-            stdout = ('{"element_count": 7, "tree_markdown": "- [0] AXButton",'
-                      ' "screenshot_file_path": "%s"}' % str(shot))
+            stdout = json.dumps({
+                "element_count": 7,
+                "tree_markdown": "- [0] AXButton",
+                "screenshot_file_path": str(shot),
+            })
 
         import subprocess as _sp
         orig_run = _sp.run
@@ -1685,6 +1688,47 @@ class TestCaptureEmptyResultClipFallback:
         # CLI recovered the window list; capture resolved the Finder window.
         assert "list_windows" in cli_calls
         assert cap.app == "Finder"
+
+
+class TestCaptureUiaTimeoutSurface:
+    """Bug B: UIA timeout errors from cua-driver must be surfaced immediately
+    instead of being treated as empty transport results and retried."""
+
+    def _backend_with_windows(self):
+        from typing import Any, cast
+        from tools.computer_use.cua_backend import CuaDriverBackend
+        windows = [{
+            "app_name": "Warp", "pid": 4242, "window_id": 77,
+            "is_on_screen": True, "z_index": 0, "title": "Warp",
+        }]
+        backend = CuaDriverBackend()
+        sess = MagicMock()
+        backend._session = cast(Any, sess)
+        return backend, sess, windows
+
+    def test_capture_surfaces_uia_timeout_without_cli_retry(self):
+        backend, sess, windows = self._backend_with_windows()
+
+        err_text = ("get_window_state timed out after 4s (UIA provider "
+                    "unresponsive on hwnd 0x1234, class 'Window Class').")
+
+        def mcp_call(name, args, timeout=30.0):
+            if name == "list_windows":
+                return {"data": "", "images": [], "isError": False,
+                        "structuredContent": {"windows": windows}}
+            if name == "get_window_state":
+                return {"data": err_text, "images": [], "isError": True,
+                        "structuredContent": None}
+            return {"data": "", "images": [], "isError": False,
+                    "structuredContent": None}
+        sess.call_tool.side_effect = mcp_call
+
+        cap = backend.capture(mode="som", app="Warp")
+
+        assert "cua-driver error" in cap.window_title
+        assert "timed out" in cap.window_title
+        assert cap.png_b64 is None
+        sess._call_tool_via_cli.assert_not_called()
 
 
 class TestCaptureAppFilterNoMatch:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1483,6 +1483,35 @@ class CuaDriverBackend(ComputerUseBackend):
                 _, tr = _split_tree_text(txt or "")
                 return not (tr and tr.strip())
 
+            def _gws_error_text(out: Dict[str, Any]) -> str:
+                data = out.get("data")
+                if isinstance(data, str):
+                    return data
+                if isinstance(data, list):
+                    return " ".join(
+                        str(chunk.get("text", ""))
+                        for chunk in data
+                        if isinstance(chunk, dict)
+                    )
+                if isinstance(data, dict):
+                    return str(data.get("message") or data.get("error") or data)
+                return ""
+
+            gws_error_text = _gws_error_text(gws_out).strip()
+            gws_error_text_lower = gws_error_text.lower()
+            if gws_out.get("isError") or any(
+                marker in gws_error_text_lower
+                for marker in ("timed out", "uia provider unresponsive")
+            ):
+                if not gws_error_text:
+                    gws_error_text = "unknown get_window_state error"
+                return CaptureResult(
+                    mode=mode, width=0, height=0, png_b64=None,
+                    elements=[], app=app or "",
+                    window_title=f"<cua-driver error: {gws_error_text}>",
+                    png_bytes_len=0,
+                )
+
             if _gws_is_empty(gws_out):
                 logger.warning(
                     "cua-driver get_window_state returned an empty result over MCP "


### PR DESCRIPTION
## Summary

- When cua-driver's `get_window_state` hits its 4s UIA provider timeout (common for apps whose UIA provider is unresponsive, e.g. Warp or dormant Electron windows), the MCP result carries `isError: true` with an actionable message including fallback options.
- Previously `_gws_is_empty()` ignored `isError`, misclassified this as a flaky-bridge empty result, and burned up to 4 CLI retries (each hitting the same 4s timeout + backoff, 30–60s total) before surfacing a generic "CLI fallback returned no JSON after 4 attempts" that hid the driver's guidance.
- This change adds a `_gws_error_text()` helper to extract the error message and checks it before `_gws_is_empty()`. On error (or when the data text contains "timed out" / "uia provider unresponsive"), it returns immediately with the driver's message embedded in `window_title` using the same `<cua-driver error: ...>` sentinel pattern as the existing `<no desktop/shell window found ...>` response.
- Before/after observed on a live desktop: 30–60s silent stall → ~5s with full driver guidance.
- Also fixes `TestCuaDriverSessionReconnect.test_cli_fallback_reads_screenshot_from_file` to use `json.dumps()` so Windows backslash paths in the test fixture are properly escaped.

## Test plan

- [ ] `PYTHONUTF8=1 uv run --extra dev python -m pytest tests/tools/test_computer_use.py -q`
  - Result: **176 passed** in 70.87s
- [ ] `uv run --extra dev python scripts/check-windows-footguns.py tools/computer_use/cua_backend.py`
  - Result: ✓ No Windows footguns found (1 file scanned)
- [ ] Live desktop verification on Windows 11: capture of Warp terminal (unresponsive UIA provider) returned `window_title="<cua-driver error: get_window_state timed out after 4s ...>"` in ~5s instead of 30–60s stall

## Part of a series

- `fix(tools): decode cua-driver subprocess output as UTF-8`
- `fix(tools): surface cua-driver UIA-timeout errors instead of retrying CLI transport` (this PR)
- `fix(tools): bound get_window_state UIA walk and re-fetch dropped som/ax screenshots via CLI`

Co-Authored-By: Claude <noreply@anthropic.com>
