### PR TITLE
fix(tools): bound get_window_state UIA walk and re-fetch dropped som/ax screenshots via CLI

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -83,6 +83,9 @@ class TestSchema:
         assert "max_elements" in props
         assert props["max_elements"]["type"] == "integer"
         assert props["max_elements"].get("minimum", 1) >= 1
+        assert "max_depth" in props
+        assert props["max_depth"]["type"] == "integer"
+        assert props["max_depth"].get("minimum", 1) >= 1
 
     def test_schema_max_elements_documents_default_and_upper_bound(self):
         """Schema description must agree with the runtime. The original PR
@@ -97,6 +100,9 @@ class TestSchema:
         prop = COMPUTER_USE_SCHEMA["parameters"]["properties"]["max_elements"]
         assert prop.get("default") == _DEFAULT_MAX_ELEMENTS
         assert prop.get("maximum") == _MAX_ALLOWED_MAX_ELEMENTS
+        depth_prop = COMPUTER_USE_SCHEMA["parameters"]["properties"]["max_depth"]
+        assert depth_prop.get("default") == 12
+        assert depth_prop.get("maximum") == 100
 
 
 class TestRegistration:
@@ -368,7 +374,7 @@ class TestCaptureResponse:
             def start(self): pass
             def stop(self): pass
             def is_available(self): return True
-            def capture(self, mode="som", app=None):
+            def capture(self, mode="som", app=None, **_kwargs):
                 return CaptureResult(
                     mode=mode, width=1024, height=768,
                     png_b64=fake_png, elements=[],
@@ -436,7 +442,7 @@ class TestCaptureResponse:
             def start(self): pass
             def stop(self): pass
             def is_available(self): return True
-            def capture(self, mode="som", app=None):
+            def capture(self, mode="som", app=None, **_kwargs):
                 return CaptureResult(
                     mode=mode, width=800, height=600,
                     png_b64=fake_png,
@@ -478,7 +484,7 @@ class TestCaptureResponse:
             def start(self): pass
             def stop(self): pass
             def is_available(self): return True
-            def capture(self, mode="som", app=None):
+            def capture(self, mode="som", app=None, **_kwargs):
                 return CaptureResult(
                     mode=mode, width=800, height=600,
                     png_b64="",
@@ -529,6 +535,20 @@ class TestCaptureResponse:
         parsed = json.loads(out)
         assert len(parsed["elements"]) == 250
         assert parsed["truncated_elements"] == 350
+
+    def test_capture_passes_driver_walk_bounds_to_backend(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        handle_computer_use({
+            "action": "capture",
+            "mode": "ax",
+            "max_elements": 250,
+            "max_depth": 7,
+        })
+
+        capture_calls = [c for c in noop_backend.calls if c[0] == "capture"]
+        assert capture_calls[-1][1]["max_elements"] == 250
+        assert capture_calls[-1][1]["max_depth"] == 7
 
     def test_capture_ax_below_cap_is_unchanged(self):
         """Backwards-compat: small captures keep the full elements array and
@@ -627,7 +647,7 @@ class TestCaptureResponse:
             def start(self): pass
             def stop(self): pass
             def is_available(self): return True
-            def capture(self, mode="som", app=None):
+            def capture(self, mode="som", app=None, **_kwargs):
                 return CaptureResult(
                     mode=mode, width=800, height=600,
                     png_b64=fake_png, elements=list(elements),
@@ -1288,7 +1308,7 @@ class TestCaptureAfterAppContext:
             def is_available(self):
                 return True
 
-            def capture(self, mode="som", app=None):
+            def capture(self, mode="som", app=None, **_kwargs):
                 captured_app_args.append(app)
                 return CaptureResult(
                     mode=mode, width=100, height=100,
@@ -1354,7 +1374,7 @@ class TestCaptureAfterAppContext:
             def is_available(self):
                 return True
 
-            def capture(self, mode="som", app=None):
+            def capture(self, mode="som", app=None, **_kwargs):
                 captured_app_args.append(app)
                 return CaptureResult(
                     mode=mode, width=100, height=100,
@@ -1572,8 +1592,11 @@ class TestCuaDriverSessionReconnect:
             returncode = 0
             stderr = ""
             # Daemon returns a path, not inline base64.
-            stdout = ('{"element_count": 7, "tree_markdown": "- [0] AXButton",'
-                      ' "screenshot_file_path": "%s"}' % str(shot))
+            stdout = json.dumps({
+                "element_count": 7,
+                "tree_markdown": "- [0] AXButton",
+                "screenshot_file_path": str(shot),
+            })
 
         import subprocess as _sp
         orig_run = _sp.run
@@ -1685,6 +1708,73 @@ class TestCaptureEmptyResultClipFallback:
         # CLI recovered the window list; capture resolved the Finder window.
         assert "list_windows" in cli_calls
         assert cap.app == "Finder"
+
+
+class TestCaptureSomAxCliImageRefetch:
+    """U6: som/ax must re-fetch screenshot via CLI when MCP drops the image part
+    but structured elements (or tree text) arrived."""
+
+    _TINY_PNG_B64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    )
+
+    def test_som_refetches_png_when_mcp_has_elements_only(self):
+        from typing import Any, cast
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        windows = [{
+            "app_name": "Discord", "pid": 100, "window_id": 5,
+            "is_on_screen": True, "title": "Discord", "z_index": 0,
+        }]
+        backend = CuaDriverBackend()
+        sess = MagicMock()
+        backend._session = cast(Any, sess)
+
+        gws_mcp = {
+            "data": "Discord — 2 elements, turn 1\n",
+            "images": [],
+            "structuredContent": {
+                "elements": [{
+                    "element_index": 1, "role": "AXButton",
+                    "label": "btn", "frame": {"x": 1, "y": 2, "w": 3, "h": 4},
+                }],
+            },
+            "isError": False,
+        }
+        gws_cli = {
+            "data": "",
+            "images": [self._TINY_PNG_B64],
+            "image_mime_types": ["image/png"],
+            "structuredContent": None,
+            "isError": False,
+        }
+
+        def mcp_call(name, args, timeout=30.0):
+            if name == "list_windows":
+                return {"data": "", "images": [], "isError": False,
+                        "structuredContent": {"windows": windows}}
+            if name == "get_window_state":
+                return gws_mcp
+            return {"data": "", "images": [], "isError": False, "structuredContent": None}
+
+        sess.call_tool.side_effect = mcp_call
+        cli_calls = []
+
+        def cli_call(name, args, timeout):
+            cli_calls.append((name, args))
+            assert name == "get_window_state"
+            return gws_cli
+
+        sess._call_tool_via_cli.side_effect = cli_call
+
+        cap = backend.capture(mode="som", app="Discord")
+
+        assert len(cli_calls) == 1
+        assert cli_calls[0][1].get("max_elements") == 800
+        assert cli_calls[0][1].get("max_depth") == 12
+        assert cap.png_b64 == self._TINY_PNG_B64
+        assert cap.png_bytes_len > 0
+        assert len(cap.elements) == 1
 
 
 class TestCaptureAppFilterNoMatch:

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -99,7 +99,13 @@ class ComputerUseBackend(ABC):
 
     # ── Capture ─────────────────────────────────────────────────────
     @abstractmethod
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult: ...
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        max_elements: Optional[int] = None,
+        max_depth: Optional[int] = None,
+    ) -> CaptureResult: ...
 
     # ── Pointer actions ─────────────────────────────────────────────
     @abstractmethod

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1244,7 +1244,13 @@ class CuaDriverBackend(ComputerUseBackend):
         return cua_driver_binary_available()
 
     # ── Capture ────────────────────────────────────────────────────
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        max_elements: Optional[int] = None,
+        max_depth: Optional[int] = None,
+    ) -> CaptureResult:
         """Capture the frontmost on-screen window (optionally filtered by app name).
 
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
@@ -1453,14 +1459,14 @@ class CuaDriverBackend(ComputerUseBackend):
                     )
         else:
             # get_window_state: AX tree + screenshot.
-            gws_out = self._session.call_tool(
-                "get_window_state",
-                {
-                    "pid": self._active_pid,
-                    "window_id": self._active_window_id,
-                    "session": self._session_id,
-                },
-            )
+            gws_params: Dict[str, Any] = {
+                "pid": self._active_pid,
+                "window_id": self._active_window_id,
+                "session": self._session_id,
+                "max_elements": max_elements if max_elements is not None else 800,
+                "max_depth": max_depth if max_depth is not None else 12,
+            }
+            gws_out = self._session.call_tool("get_window_state", gws_params)
             # The persistent MCP session can return a degenerate result —
             # empty/partial data with NO exception — when the bridge is flaky
             # (e.g. it reconnected mid-call and dropped the heavy
@@ -1492,11 +1498,7 @@ class CuaDriverBackend(ComputerUseBackend):
                 try:
                     cli_out = self._session._call_tool_via_cli(
                         "get_window_state",
-                        {
-                            "pid": self._active_pid,
-                            "window_id": self._active_window_id,
-                            "session": self._session_id,
-                        },
+                        gws_params,
                         30.0,
                     )
                     if not _gws_is_empty(cli_out):
@@ -1538,6 +1540,24 @@ class CuaDriverBackend(ComputerUseBackend):
             # structuredContent (screenshot_png_b64) depending on the driver
             # build — _image_from_tool_result handles both.
             png_b64, image_mime_type = _image_from_tool_result(gws_out)
+
+            if not png_b64 and not gws_out.get("isError") and (elements or (tree and tree.strip())):
+                logger.warning(
+                    "cua-driver get_window_state returned elements but no image over MCP "
+                    "(pid=%s window_id=%s); re-fetching screenshot via CLI transport",
+                    self._active_pid, self._active_window_id,
+                )
+                try:
+                    cli_out = self._session._call_tool_via_cli(
+                        "get_window_state", gws_params, 30.0,
+                    )
+                    cli_png, cli_mime = _image_from_tool_result(cli_out)
+                    if cli_png:
+                        png_b64, image_mime_type = cli_png, cli_mime
+                except Exception as cli_exc:
+                    logger.error(
+                        "cua-driver CLI re-fetch for som/ax screenshot failed: %s", cli_exc,
+                    )
 
             # Extract window title from the AX tree first AXWindow line.
             wt = re.search(r'AXWindow\s+"([^"]+)"', tree)

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -84,8 +84,10 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
             "max_elements": {
                 "type": "integer",
                 "description": (
-                    "Optional cap on the AX `elements` array returned by "
-                    "`action='capture'`. Default 100, hard maximum 1000. "
+                    "Optional cap on the AX walk and the `elements` array "
+                    "returned by `action='capture'`. The driver AX-walk "
+                    "default is 800; the model-visible response default is "
+                    "100; hard maximum 1000. "
                     "Dense UIs (Electron apps such as Obsidian or VS Code, "
                     "JetBrains IDEs) can publish 500+ AX nodes — capping "
                     "prevents a single capture from blowing session "
@@ -102,6 +104,18 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                 "default": 100,
                 "minimum": 1,
                 "maximum": 1000,
+            },
+            "max_depth": {
+                "type": "integer",
+                "description": (
+                    "Optional maximum AX tree depth sent to cua-driver for "
+                    "`action='capture'`. Default 12, hard maximum 100. Lower "
+                    "values can avoid UIA provider timeouts in dense or "
+                    "unresponsive apps."
+                ),
+                "default": 12,
+                "minimum": 1,
+                "maximum": 100,
             },
             # ── click / drag / scroll targeting ────────────────────
             "element": {

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -193,8 +193,22 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
     def stop(self) -> None: self._started = False
     def is_available(self) -> bool: return True
 
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
-        self.calls.append(("capture", {"mode": mode, "app": app}))
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        max_elements: Optional[int] = None,
+        max_depth: Optional[int] = None,
+    ) -> CaptureResult:
+        self.calls.append((
+            "capture",
+            {
+                "mode": mode,
+                "app": app,
+                "max_elements": max_elements,
+                "max_depth": max_depth,
+            },
+        ))
         return CaptureResult(mode=mode, width=1024, height=768, png_b64=None,
                              elements=[], app=app or "", window_title="")
 
@@ -347,7 +361,12 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         mode = str(args.get("mode", "som"))
         if mode not in {"som", "vision", "ax"}:
             return json.dumps({"error": f"bad mode {mode!r}; use som|vision|ax"})
-        cap = backend.capture(mode=mode, app=args.get("app"))
+        cap = backend.capture(
+            mode=mode,
+            app=args.get("app"),
+            max_elements=_coerce_driver_max_elements(args.get("max_elements")),
+            max_depth=_coerce_max_depth(args.get("max_depth")),
+        )
         return _capture_response(cap, max_elements=_coerce_max_elements(args.get("max_elements")))
 
     if action == "wait":
@@ -452,10 +471,16 @@ def _text_response(res: ActionResult) -> str:
 # can exhaust session context after a single capture. The model-facing
 # `max_elements` argument lets callers raise this when they need the full tree.
 _DEFAULT_MAX_ELEMENTS = 100
+# Default AX walk cap sent to cua-driver. This is intentionally higher than the
+# response cap above so the backend can still draw SOM overlays for dense UIs
+# without dumping every element into the model-visible JSON.
+_DEFAULT_DRIVER_MAX_ELEMENTS = 800
+_DEFAULT_MAX_DEPTH = 12
 # Hard upper bound on caller-supplied `max_elements`. Without this, a tool
 # call passing a very large integer would silently disable the safeguard and
 # reintroduce the original unbounded behavior.
 _MAX_ALLOWED_MAX_ELEMENTS = 1000
+_MAX_ALLOWED_MAX_DEPTH = 100
 _MIN_PROVIDER_IMAGE_DIMENSION = 8
 
 
@@ -532,6 +557,26 @@ def _coerce_max_elements(value: Any) -> int:
         return _DEFAULT_MAX_ELEMENTS
     if n > _MAX_ALLOWED_MAX_ELEMENTS:
         return _MAX_ALLOWED_MAX_ELEMENTS
+    return n
+
+
+def _coerce_driver_max_elements(value: Any) -> int:
+    if value is None:
+        return _DEFAULT_DRIVER_MAX_ELEMENTS
+    return _coerce_max_elements(value)
+
+
+def _coerce_max_depth(value: Any) -> int:
+    if value is None:
+        return _DEFAULT_MAX_DEPTH
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_DEPTH
+    if n < 1:
+        return _DEFAULT_MAX_DEPTH
+    if n > _MAX_ALLOWED_MAX_DEPTH:
+        return _MAX_ALLOWED_MAX_DEPTH
     return n
 
 


### PR DESCRIPTION
## Summary

Two related capture-payload fixes for the som/ax branch of `CuaDriverBackend.capture()`:

**(1) Bound the UIA AX walk with `max_elements` / `max_depth`**

`capture()` never passed `max_elements` or `max_depth` to the driver although the driver recommends them for large Electron trees (driver `_note`, trycua/cua#22865). Large trees (Discord, VS Code, Obsidian with 200–800+ AX nodes) can cause slow UIA walks or partial results without any depth bound.

Both parameters are now forwarded to `get_window_state` with driver-side defaults of 800 elements and depth 12. They are exposed as new tool arguments through `schema.py`, `tool.py` (with `_coerce_max_depth` / `_coerce_driver_max_elements` helpers), and `backend.py`'s abstract method. The existing empty-result CLI fallback path reuses the consolidated `gws_params` dict.

**(2) Re-fetch dropped screenshots via CLI transport**

The som/ax branch never re-fetched the screenshot when the MCP stdio bridge dropped the image part while delivering `structuredContent.elements` — captures silently returned `png_bytes_len=0` with no error. The vision branch already had this CLI re-fetch pattern; this ports it to the som/ax branch. Condition: `isError` is false, elements or tree text are present, but no PNG was received.

Note: on cp932 hosts this CLI re-fetch path additionally requires the UTF-8 decoding fix (sibling PR `fix(tools): decode cua-driver subprocess output as UTF-8`). The two PRs are independent but this one is fully effective only with the sibling.

Also fixes `TestCuaDriverSessionReconnect.test_cli_fallback_reads_screenshot_from_file` to use `json.dumps()` so Windows backslash paths in the test fixture are properly escaped.

## Test plan

- [ ] `PYTHONUTF8=1 uv run --extra dev python -m pytest tests/tools/test_computer_use.py -q`
  - Result: **177 passed** in 75.59s
- [ ] `uv run --extra dev python scripts/check-windows-footguns.py tools/computer_use/cua_backend.py tools/computer_use/backend.py tools/computer_use/tool.py tools/computer_use/schema.py`
  - Result: ✓ No Windows footguns found (4 files scanned)
- [ ] Live desktop verification on Windows 11 (Japanese locale):
  - Discord som capture (1065×946, 200+ elements): PNG restored via CLI re-fetch
  - Self-capture of Hermes window with PNG present: single MCP call, no CLI re-fetch triggered

## Part of a series

- `fix(tools): decode cua-driver subprocess output as UTF-8`
- `fix(tools): surface cua-driver UIA-timeout errors instead of retrying CLI transport`
- `fix(tools): bound get_window_state UIA walk and re-fetch dropped som/ax screenshots via CLI` (this PR)

Co-Authored-By: Claude <noreply@anthropic.com>
