### PR TITLE
fix: keep initially blocked kanban cards sticky

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2680,7 +2680,23 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                if task_status == "blocked":
+                    # A task born blocked is an explicit human/ops gate, not a
+                    # transient circuit-breaker block.  Emit the same sticky
+                    # signal used by block_task() so recompute_ready() cannot
+                    # silently promote it on the next dispatcher tick.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": "initial_status=blocked",
+                            "kind": None,
+                            "recurrences": 1,
+                        },
+                    )
             return task_id
+
         except sqlite3.IntegrityError:
             if attempt == 1:
                 raise

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -272,6 +272,35 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Create-time blocked cards are also sticky
+# ---------------------------------------------------------------------------
+
+
+def test_initial_status_blocked_is_not_auto_promoted_by_recompute_ready(kanban_home: Path) -> None:
+    """A card created directly in ``blocked`` is an explicit human gate,
+    not a transient dependency/circuit-breaker block.
+
+    Regression for JT's 2026-07-05 board drift: ``hermes kanban create
+    --initial-status blocked`` wrote only a ``created`` event with
+    ``status='blocked'``.  Because no ``blocked`` event existed,
+    ``recompute_ready`` treated the task as non-sticky and silently
+    promoted it to ``ready`` on the next dispatcher tick.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="approval-gated reminder",
+            initial_status="blocked",
+        )
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        promoted = kb.recompute_ready(conn)
+
+        assert promoted == 0
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+# ---------------------------------------------------------------------------
 # Schema-init recovery on legacy DBs is covered by
 # tests/hermes_cli/test_kanban_db.py::test_connect_migrates_legacy_db_before_optional_column_indexes
 # (landed via #28754 / #28781).  The original PR shipped a duplicate test


### PR DESCRIPTION
## Summary
- emit a sticky `blocked` event when a Kanban task is created with `initial_status="blocked"`
- prevent `recompute_ready()` from silently promoting create-time blocked cards to `ready`
- add a regression test covering `--initial-status blocked` drift

## Root cause
`create_task(..., initial_status="blocked")` inserted `status="blocked"` but only emitted a `created` event. `_has_sticky_block()` distinguishes human/ops blocks from transient blocks by looking for latest `blocked`/`unblocked` events, so create-time blocked cards looked non-sticky and were auto-promoted.

## Test plan
- `uv run --with pytest --with pytest-xdist python -m pytest tests/hermes_cli/test_kanban_blocked_sticky.py::test_initial_status_blocked_is_not_auto_promoted_by_recompute_ready tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_db.py::test_recompute_ready_skips_tasks_at_failure_limit -q -n 0`

Result: `8 passed`.
