### PR TITLE
fix(mcp): drain parked tasks before closing loop

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ LEGACY_AUTHOR_MAP = {
     "declanbatesmith@outlook.com": "cat-thats-fat",  # PR #60489 (desktop: first-run remote connection option)
     "drbs2004@me.com": "cat-thats-fat",  # PR #60489 (desktop: first-run remote connection option; historical merge email)
     "122438640+ragingbulld@users.noreply.github.com": "ragingbulld",  # PR #65606 salvage (non-finite API wait deadlines; #65746)
+    "shady2k@gmail.com": "shady2k",  # PR #60104 salvage of #66143 (MCP loop-owned shutdown drain)
     "zzpigpinggai@users.noreply.github.com": "zzpigpinggai",  # PR #66017 salvage of #63617 (OpenRouter explicit-provider picker visibility)
     "stellarisw@users.noreply.github.com": "StellarisW",  # PR #66222 salvage (Discord WebSocket liveness + systemd watchdog; #26656 follow-up)
     "wx.xw@bytedance.com": "wxy-nlp",  # PR #66222 salvage (systemd event-loop watchdog co-author)

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -736,3 +736,75 @@ class TestMCPInitialConnectionRetry:
                 await task
 
         asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Fix: drain pending tasks before closing the MCP loop
+# ---------------------------------------------------------------------------
+
+class TestMCPLoopDrainOnStop:
+    """_stop_mcp_loop reaps pending tasks while the loop is still open."""
+
+    def test_pending_task_cleanup_runs_before_close(self):
+        """A task left on the loop must finish its cleanup before close.
+
+        Regression for #60197: a task still suspended when the loop closes is
+        resumed later by the GC, and its ``finally`` then drives ``cancel()``
+        -> ``call_soon()`` against the closed loop, surfacing as an ignored
+        ``RuntimeError: Event loop is closed``. Servers absent from
+        ``_servers`` (e.g. parked after an initial-connect failure) never get
+        ``shutdown()``, so this drain is their only reaper.
+        """
+        import time
+        import tools.mcp_tool as mcp_mod
+
+        state = {
+            "started": False,
+            "cleanup_ran": False,
+            "cleanup_error": None,
+            "task": None,
+        }
+
+        async def _parked():
+            state["task"] = asyncio.current_task()
+            state["started"] = True
+            try:
+                await asyncio.sleep(3600)
+            finally:
+                # Mirrors _wait_for_reconnect_or_shutdown's finally: cancelling
+                # a helper task needs call_soon(), which a closed loop rejects.
+                try:
+                    helper = asyncio.ensure_future(asyncio.sleep(0))
+                    helper.cancel()
+                    state["cleanup_ran"] = True
+                except BaseException as exc:
+                    state["cleanup_error"] = exc
+
+        with mcp_mod._lock:
+            mcp_mod._servers.clear()
+            mcp_mod._server_connecting.clear()
+        try:
+            mcp_mod._ensure_mcp_loop()
+            with mcp_mod._lock:
+                loop = mcp_mod._mcp_loop
+            assert loop is not None
+            asyncio.run_coroutine_threadsafe(_parked(), loop)
+
+            deadline = time.monotonic() + 5
+            while not state["started"] and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert state["started"], "task never started on the MCP loop"
+
+            mcp_mod._stop_mcp_loop()
+
+            assert state["task"] is not None
+            assert state["task"].done(), "task left pending when the loop closed"
+            assert state["cleanup_error"] is None, (
+                f"cleanup ran against a closed loop: {state['cleanup_error']!r}"
+            )
+            assert state["cleanup_ran"], "task cleanup never ran"
+        finally:
+            with mcp_mod._lock:
+                mcp_mod._servers.clear()
+                mcp_mod._server_connecting.clear()
+            mcp_mod._stop_mcp_loop()

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -795,7 +795,23 @@ class TestMCPLoopDrainOnStop:
                 time.sleep(0.01)
             assert state["started"], "task never started on the MCP loop"
 
-            mcp_mod._stop_mcp_loop()
+            stop_saw_cleanup = []
+            call_soon_threadsafe = loop.call_soon_threadsafe
+
+            def record_stop_order(callback, *args, **kwargs):
+                if (
+                    getattr(callback, "__self__", None) is loop
+                    and getattr(callback, "__name__", None) == "stop"
+                ):
+                    stop_saw_cleanup.append(state["cleanup_ran"])
+                return call_soon_threadsafe(callback, *args, **kwargs)
+
+            with patch.object(
+                loop,
+                "call_soon_threadsafe",
+                side_effect=record_stop_order,
+            ):
+                mcp_mod._stop_mcp_loop()
 
             assert state["task"] is not None
             assert state["task"].done(), "task left pending when the loop closed"
@@ -803,8 +819,79 @@ class TestMCPLoopDrainOnStop:
                 f"cleanup ran against a closed loop: {state['cleanup_error']!r}"
             )
             assert state["cleanup_ran"], "task cleanup never ran"
+            assert stop_saw_cleanup == [True], "loop.stop ran before task cleanup"
         finally:
             with mcp_mod._lock:
                 mcp_mod._servers.clear()
                 mcp_mod._server_connecting.clear()
             mcp_mod._stop_mcp_loop()
+
+    def test_drain_is_bounded_when_task_ignores_cancellation(self, caplog):
+        """A cancellation-resistant task must not hang final MCP shutdown."""
+        import tools.mcp_tool as mcp_mod
+
+        async def _run():
+            release = asyncio.Event()
+
+            async def cancellation_resistant():
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    await release.wait()
+
+            task = asyncio.create_task(cancellation_resistant())
+            await asyncio.sleep(0)
+            try:
+                with caplog.at_level("WARNING", logger=mcp_mod.logger.name):
+                    await mcp_mod._drain_mcp_loop_tasks(timeout=0.01)
+                assert not task.done(), "drain waited indefinitely for resistant task"
+            finally:
+                release.set()
+                if not task.done() and task.cancelling() == 0:
+                    task.cancel()
+                await task
+
+        asyncio.run(_run())
+
+        assert any(
+            "still pending after" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_stop_warns_when_drain_wait_times_out(self, caplog):
+        """A failed final drain must be visible instead of silently no-oping."""
+        import tools.mcp_tool as mcp_mod
+
+        class TimedOutFuture:
+            def result(self, timeout):
+                assert timeout > 0
+                raise TimeoutError("simulated drain timeout")
+
+            def cancel(self):
+                return True
+
+        def report_timeout(coro, _loop, **_kwargs):
+            coro.close()
+            return TimedOutFuture()
+
+        with mcp_mod._lock:
+            mcp_mod._servers.clear()
+            mcp_mod._server_connecting.clear()
+        mcp_mod._ensure_mcp_loop()
+        try:
+            with caplog.at_level("WARNING", logger=mcp_mod.logger.name):
+                with patch(
+                    "agent.async_utils.safe_schedule_threadsafe",
+                    side_effect=report_timeout,
+                ):
+                    mcp_mod._stop_mcp_loop()
+        finally:
+            with mcp_mod._lock:
+                mcp_mod._servers.clear()
+                mcp_mod._server_connecting.clear()
+            mcp_mod._stop_mcp_loop()
+
+        assert any(
+            "Timed out waiting for MCP loop drain" in record.getMessage()
+            for record in caplog.records
+        )

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -796,20 +796,32 @@ class TestMCPLoopDrainOnStop:
             assert state["started"], "task never started on the MCP loop"
 
             stop_saw_cleanup = []
+            call_soon = loop.call_soon
             call_soon_threadsafe = loop.call_soon_threadsafe
 
-            def record_stop_order(callback, *args, **kwargs):
+            def record_stop_order(schedule, callback, *args, **kwargs):
                 if (
                     getattr(callback, "__self__", None) is loop
                     and getattr(callback, "__name__", None) == "stop"
                 ):
                     stop_saw_cleanup.append(state["cleanup_ran"])
-                return call_soon_threadsafe(callback, *args, **kwargs)
+                return schedule(callback, *args, **kwargs)
 
-            with patch.object(
-                loop,
-                "call_soon_threadsafe",
-                side_effect=record_stop_order,
+            with (
+                patch.object(
+                    loop,
+                    "call_soon",
+                    side_effect=lambda callback, *args, **kwargs: record_stop_order(
+                        call_soon, callback, *args, **kwargs
+                    ),
+                ),
+                patch.object(
+                    loop,
+                    "call_soon_threadsafe",
+                    side_effect=lambda callback, *args, **kwargs: record_stop_order(
+                        call_soon_threadsafe, callback, *args, **kwargs
+                    ),
+                ),
             ):
                 mcp_mod._stop_mcp_loop()
 
@@ -843,7 +855,8 @@ class TestMCPLoopDrainOnStop:
             await asyncio.sleep(0)
             try:
                 with caplog.at_level("WARNING", logger=mcp_mod.logger.name):
-                    await mcp_mod._drain_mcp_loop_tasks(timeout=0.01)
+                    async with asyncio.timeout(0.5):
+                        await mcp_mod._drain_mcp_loop_tasks(timeout=0.01)
                 assert not task.done(), "drain waited indefinitely for resistant task"
             finally:
                 release.set()
@@ -858,34 +871,56 @@ class TestMCPLoopDrainOnStop:
             for record in caplog.records
         )
 
-    def test_stop_warns_when_drain_wait_times_out(self, caplog):
-        """A failed final drain must be visible instead of silently no-oping."""
+    def test_outer_timeout_still_allows_loop_owned_drain_before_stop(
+        self, caplog, monkeypatch
+    ):
+        """A blocked loop must drain after it resumes, not stop ahead of the drain."""
+        import threading
         import tools.mcp_tool as mcp_mod
 
-        class TimedOutFuture:
-            def result(self, timeout):
-                assert timeout > 0
-                raise TimeoutError("simulated drain timeout")
+        parked_started = threading.Event()
+        cleanup_ran = threading.Event()
+        blocker_started = threading.Event()
+        release_blocker = threading.Event()
 
-            def cancel(self):
-                return True
+        async def parked_task():
+            parked_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cleanup_ran.set()
 
-        def report_timeout(coro, _loop, **_kwargs):
-            coro.close()
-            return TimedOutFuture()
+        def block_loop():
+            blocker_started.set()
+            release_blocker.wait(timeout=5)
 
         with mcp_mod._lock:
             mcp_mod._servers.clear()
             mcp_mod._server_connecting.clear()
         mcp_mod._ensure_mcp_loop()
+        with mcp_mod._lock:
+            loop = mcp_mod._mcp_loop
+        assert loop is not None
+
+        future = asyncio.run_coroutine_threadsafe(parked_task(), loop)
+        assert parked_started.wait(timeout=2)
+        loop.call_soon_threadsafe(block_loop)
+        assert blocker_started.wait(timeout=2)
+
+        monkeypatch.setattr(mcp_mod, "_MCP_LOOP_DRAIN_TIMEOUT", 0.01)
+        release_timer = threading.Timer(1.2, release_blocker.set)
+        release_timer.start()
         try:
             with caplog.at_level("WARNING", logger=mcp_mod.logger.name):
-                with patch(
-                    "agent.async_utils.safe_schedule_threadsafe",
-                    side_effect=report_timeout,
-                ):
-                    mcp_mod._stop_mcp_loop()
+                mcp_mod._stop_mcp_loop()
+
+            assert cleanup_ran.is_set(), "drain was overtaken by loop.stop"
+            assert future.done(), "parked task remained pending after loop resumed"
+            assert loop.is_closed()
         finally:
+            release_timer.cancel()
+            release_blocker.set()
+            future.cancel()
             with mcp_mod._lock:
                 mcp_mod._servers.clear()
                 mcp_mod._server_connecting.clear()

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1587,6 +1587,79 @@ class TestShutdown:
         assert len(_servers) == 0
         mock_server.shutdown.assert_called_once()
 
+    def test_shutdown_drains_parked_server_after_bounded_wait_expires(self):
+        """The public shutdown path drains a parked server if graceful shutdown stalls.
+
+        This exercises the production ownership path: a real ``MCPServerTask``
+        is registered, its parked waiter owns child tasks on the shared loop,
+        and the bounded wait for the scheduled shutdown expires. The loop owner
+        must still cancel and drain that waiter before closing the loop.
+        """
+        import tools.mcp_tool as mcp_mod
+        from tools.mcp_tool import MCPServerTask, shutdown_mcp_servers
+
+        shutdown_started = threading.Event()
+        parked_task_done = threading.Event()
+        scheduled_shutdown = {}
+
+        class StalledShutdownServer(MCPServerTask):
+            async def shutdown(self):
+                shutdown_started.set()
+                await asyncio.Event().wait()
+
+        server = StalledShutdownServer("parked")
+        with mcp_mod._lock:
+            mcp_mod._servers.clear()
+            mcp_mod._server_connecting.clear()
+        mcp_mod._ensure_mcp_loop()
+        with mcp_mod._lock:
+            loop = mcp_mod._mcp_loop
+        assert loop is not None
+
+        async def install_parked_waiter():
+            task = asyncio.create_task(server._wait_for_reconnect_or_shutdown())
+            server._task = task
+            task.add_done_callback(lambda _task: parked_task_done.set())
+            await asyncio.sleep(0)
+            return task
+
+        parked_task = asyncio.run_coroutine_threadsafe(
+            install_parked_waiter(), loop
+        ).result(timeout=2)
+        with mcp_mod._lock:
+            mcp_mod._servers[server.name] = server
+
+        def schedule_then_report_timeout(coro, target_loop, **_kwargs):
+            future = asyncio.run_coroutine_threadsafe(coro, target_loop)
+            scheduled_shutdown["future"] = future
+
+            class TimedOutFuture:
+                def result(self, timeout):
+                    assert timeout > 0
+                    assert shutdown_started.wait(timeout=2)
+                    raise TimeoutError("simulated bounded MCP shutdown timeout")
+
+            return TimedOutFuture()
+
+        try:
+            with patch(
+                "agent.async_utils.safe_schedule_threadsafe",
+                side_effect=schedule_then_report_timeout,
+            ):
+                shutdown_mcp_servers()
+
+            assert loop.is_closed()
+            assert parked_task_done.is_set(), (
+                "parked MCPServerTask was not drained before its loop closed"
+            )
+            assert parked_task.done()
+            assert scheduled_shutdown["future"].done()
+        finally:
+            with mcp_mod._lock:
+                mcp_mod._servers.clear()
+                mcp_mod._server_connecting.clear()
+            mcp_mod._stop_mcp_loop()
+
     def test_shutdown_deregisters_registered_tools(self):
         """shutdown_mcp_servers removes MCP tools and their raw alias."""
         import tools.mcp_tool as mcp_mod

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1601,6 +1601,7 @@ class TestShutdown:
         shutdown_started = threading.Event()
         parked_task_done = threading.Event()
         scheduled_shutdown = {}
+        schedule_count = 0
 
         class StalledShutdownServer(MCPServerTask):
             async def shutdown(self):
@@ -1630,7 +1631,12 @@ class TestShutdown:
             mcp_mod._servers[server.name] = server
 
         def schedule_then_report_timeout(coro, target_loop, **_kwargs):
+            nonlocal schedule_count
+            schedule_count += 1
             future = asyncio.run_coroutine_threadsafe(coro, target_loop)
+            if schedule_count > 1:
+                return future
+
             scheduled_shutdown["future"] = future
 
             class TimedOutFuture:
@@ -1654,6 +1660,7 @@ class TestShutdown:
             )
             assert parked_task.done()
             assert scheduled_shutdown["future"].done()
+            assert schedule_count == 2
         finally:
             with mcp_mod._lock:
                 mcp_mod._servers.clear()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6412,6 +6412,23 @@ def _stop_mcp_loop_if_idle() -> bool:
     return _stop_mcp_loop(only_if_idle=True)
 
 
+async def _drain_mcp_loop_tasks() -> None:
+    """Cancel every task still pending on the MCP loop and reap it.
+
+    Cancelling is not enough on its own: ``Task.cancel()`` only schedules the
+    throw, so the task must be awaited before the loop goes away. Gather them
+    here — while the loop is still open — so each one runs its own ``finally``.
+    """
+    current = asyncio.current_task()
+    pending = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
+    if not pending:
+        return
+    logger.debug("Draining %d pending task(s) from the MCP loop", len(pending))
+    for task in pending:
+        task.cancel()
+    await asyncio.gather(*pending, return_exceptions=True)
+
+
 def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
     """Stop the background event loop and join its thread."""
     global _mcp_loop, _mcp_thread
@@ -6424,6 +6441,24 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
         _mcp_loop = None
         _mcp_thread = None
     if loop is not None:
+        # Drain before stopping: closing the loop with tasks still suspended
+        # leaves their coroutines for the GC, whose finalizer then resumes them
+        # to run cleanup against a loop that is already closed -> "Event loop
+        # is closed" (#60197). ``shutdown_mcp_servers`` only reaps servers held
+        # in ``_servers``, so anything else left on this loop ends up here.
+        if loop.is_running():
+            from agent.async_utils import safe_schedule_threadsafe
+
+            future = safe_schedule_threadsafe(
+                _drain_mcp_loop_tasks(), loop,
+                logger=logger,
+                log_message="MCP loop drain: failed to schedule",
+            )
+            if future is not None:
+                try:
+                    future.result(timeout=5)
+                except BaseException as exc:
+                    logger.debug("Error draining MCP loop tasks: %s", exc)
         loop.call_soon_threadsafe(loop.stop)
         if thread is not None:
             thread.join(timeout=5)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -361,6 +361,11 @@ def _jittered(seconds: float) -> float:
 _DEFAULT_KEEPALIVE_INTERVAL = 180  # seconds between liveness pings
 _MIN_KEEPALIVE_INTERVAL = 5        # clamp floor for configured intervals
 
+# Final shutdown gives pending MCP-loop tasks one bounded cancellation cycle
+# before closing their owning loop. Cooperative parked/reconnect waiters finish
+# immediately; cancellation-resistant tasks must not hang process exit.
+_MCP_LOOP_DRAIN_TIMEOUT = 3.0
+
 # Environment variables that are safe to pass to stdio subprocesses
 _SAFE_ENV_KEYS = frozenset({
     "PATH", "HOME", "USER", "LANG", "LC_ALL", "TERM", "SHELL", "TMPDIR",
@@ -6412,12 +6417,16 @@ def _stop_mcp_loop_if_idle() -> bool:
     return _stop_mcp_loop(only_if_idle=True)
 
 
-async def _drain_mcp_loop_tasks() -> None:
+async def _drain_mcp_loop_tasks(
+    *,
+    timeout: float = _MCP_LOOP_DRAIN_TIMEOUT,
+) -> None:
     """Cancel every task still pending on the MCP loop and reap it.
 
     Cancelling is not enough on its own: ``Task.cancel()`` only schedules the
-    throw, so the task must be awaited before the loop goes away. Gather them
-    here — while the loop is still open — so each one runs its own ``finally``.
+    throw, so tasks need a cancellation cycle before the loop goes away. Wait
+    for them here — on their owning loop — but keep the final drain bounded so
+    a task that suppresses cancellation cannot hang process exit indefinitely.
     """
     current = asyncio.current_task()
     pending = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
@@ -6426,7 +6435,23 @@ async def _drain_mcp_loop_tasks() -> None:
     logger.debug("Draining %d pending task(s) from the MCP loop", len(pending))
     for task in pending:
         task.cancel()
-    await asyncio.gather(*pending, return_exceptions=True)
+
+    done, still_pending = await asyncio.wait(pending, timeout=timeout)
+    for task in done:
+        if task.cancelled():
+            continue
+        try:
+            task.exception()
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.debug("Pending MCP loop task ended during shutdown: %s", exc)
+
+    if still_pending:
+        logger.warning(
+            "%d MCP loop task(s) still pending after %.1fs drain",
+            len(still_pending), timeout,
+        )
 
 
 def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
@@ -6450,22 +6475,31 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
             from agent.async_utils import safe_schedule_threadsafe
 
             future = safe_schedule_threadsafe(
-                _drain_mcp_loop_tasks(), loop,
+                _drain_mcp_loop_tasks(timeout=_MCP_LOOP_DRAIN_TIMEOUT), loop,
                 logger=logger,
                 log_message="MCP loop drain: failed to schedule",
+                log_level=logging.WARNING,
             )
             if future is not None:
                 try:
-                    future.result(timeout=5)
+                    future.result(timeout=_MCP_LOOP_DRAIN_TIMEOUT + 1)
+                except TimeoutError:
+                    future.cancel()
+                    logger.warning(
+                        "Timed out waiting for MCP loop drain after %.1fs",
+                        _MCP_LOOP_DRAIN_TIMEOUT + 1,
+                    )
                 except BaseException as exc:
-                    logger.debug("Error draining MCP loop tasks: %s", exc)
+                    logger.warning("Error draining MCP loop tasks: %s", exc)
         loop.call_soon_threadsafe(loop.stop)
         if thread is not None:
             thread.join(timeout=5)
+            if thread.is_alive():
+                logger.warning("MCP event loop thread did not stop within 5.0s")
         try:
             loop.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Unable to close MCP event loop cleanly: %s", exc)
         # After closing the loop, any stdio subprocesses that survived the
         # graceful shutdown are now orphaned — include active PIDs too
         # since the loop is gone and no session can still be in flight.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6454,6 +6454,21 @@ async def _drain_mcp_loop_tasks(
         )
 
 
+async def _drain_and_stop_mcp_loop() -> None:
+    """Drain pending tasks, then stop the loop from its owning thread.
+
+    Keeping both operations in one loop-owned sequence matters when the caller
+    times out waiting for a blocked loop. Queuing ``loop.stop`` separately from
+    the caller can overtake the scheduled drain before it receives a loop cycle,
+    leaving the drain coroutine itself pending when the loop is closed.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        await _drain_mcp_loop_tasks(timeout=_MCP_LOOP_DRAIN_TIMEOUT)
+    finally:
+        loop.call_soon(loop.stop)
+
+
 def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
     """Stop the background event loop and join its thread."""
     global _mcp_loop, _mcp_thread
@@ -6471,27 +6486,37 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
         # to run cleanup against a loop that is already closed -> "Event loop
         # is closed" (#60197). ``shutdown_mcp_servers`` only reaps servers held
         # in ``_servers``, so anything else left on this loop ends up here.
+        stop_owned_by_loop = False
         if loop.is_running():
             from agent.async_utils import safe_schedule_threadsafe
 
             future = safe_schedule_threadsafe(
-                _drain_mcp_loop_tasks(timeout=_MCP_LOOP_DRAIN_TIMEOUT), loop,
+                _drain_and_stop_mcp_loop(), loop,
                 logger=logger,
                 log_message="MCP loop drain: failed to schedule",
                 log_level=logging.WARNING,
             )
             if future is not None:
+                stop_owned_by_loop = True
                 try:
                     future.result(timeout=_MCP_LOOP_DRAIN_TIMEOUT + 1)
                 except TimeoutError:
-                    future.cancel()
                     logger.warning(
                         "Timed out waiting for MCP loop drain after %.1fs",
                         _MCP_LOOP_DRAIN_TIMEOUT + 1,
                     )
                 except BaseException as exc:
                     logger.warning("Error draining MCP loop tasks: %s", exc)
-        loop.call_soon_threadsafe(loop.stop)
+        elif not loop.is_closed():
+            try:
+                loop.run_until_complete(
+                    _drain_mcp_loop_tasks(timeout=_MCP_LOOP_DRAIN_TIMEOUT)
+                )
+            except BaseException as exc:
+                logger.warning("Error draining stopped MCP loop tasks: %s", exc)
+
+        if not stop_owned_by_loop and loop.is_running():
+            loop.call_soon_threadsafe(loop.stop)
         if thread is not None:
             thread.join(timeout=5)
             if thread.is_alive():


### PR DESCRIPTION
## Summary

Fixes the MCP shutdown race that can print a noisy traceback like:

```text
Exception ignored in: <coroutine object MCPServerTask.run ...>
RuntimeError: Event loop is closed
```

This is the same failure mode discussed in #60032, but instead of only catching `RuntimeError` at individual `Task.cancel()` call sites, this drains pending MCP-loop tasks before the shared MCP event loop is stopped and closed.

## What changed

- Run the final pending-task drain on the owning MCP event-loop thread.
- Cancel parked/reconnect waiters while the loop is still alive so their `finally` cleanup gets a cancellation cycle.
- Keep cancellation bounded with an internal drain timeout and a bounded cross-thread wait.
- Keep drain and `loop.stop()` in one loop-owned sequence, so an outer wait timeout cannot queue `stop()` ahead of a drain that is still waiting for the loop to resume.
- Log scheduling failures, drain timeouts, drain errors, join timeouts, and close failures at warning level instead of silently swallowing them at debug level.
- Add direct, blocked-loop, and end-to-end regressions through `shutdown_mcp_servers()`.

## Why this is better than #60032's narrow catch

#60032 suppresses the symptom by catching `RuntimeError` around specific child-task cancellation sites. This PR fixes the lifecycle issue one layer higher: the MCP loop owner now gives pending parked tasks a final cancellation cycle before stopping and closing the loop, so their cleanup does not get deferred to coroutine GC after the loop is already closed.

The defensive exception handler for unrelated transport finalizer noise remains unchanged.

## Relationship to #72054

#72054 and this PR are complementary:

- #72054 reaps an `MCPServerTask` in `_connect_server()` when `server.start()` fails, preventing the known orphan at its source.
- This PR makes the MCP event-loop owner drain any tasks that are still pending before closing the loop, providing the final lifecycle backstop for parked/reconnect tasks and other future task sources.

The two branches merge without code conflicts. Their combined result was tested against current `main`; the full MCP test set passed.

The broader parked-task ownership/revival issue remains tracked in #60197 and is intentionally outside this PR's scope.

## Tests

```bash
scripts/run_tests.sh tests/tools/test_mcp_stability.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_cancelled_error_propagation.py -q
# 249 passed

scripts/run_tests.sh tests/tools/test_mcp*.py -q
# passed

# Current main + this PR + #72054
scripts/run_tests.sh tests/tools/test_mcp*.py -q
# 751 passed

python -m ruff check tools/mcp_tool.py tests/tools/test_mcp_stability.py tests/tools/test_mcp_tool.py
# All checks passed

git diff --check upstream/main...HEAD
# clean
```

A local full-suite run reached the end of the 45k-test matrix but could not produce a clean aggregate result because this workstation's `/tmp` quota and unrelated existing flaky tests interfered. The affected MCP suites above pass; the refreshed GitHub CI run is the clean-environment full-suite check.
