### PR TITLE
fix(dashboard): normalize Nous session status

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -19,6 +19,36 @@ function jsonFetchMock(body: unknown = { ok: true }) {
   );
 }
 
+describe("api.getStatus", () => {
+  it.each([
+    ["valid", "valid"],
+    ["terminal", "terminal"],
+    ["unknown", "unknown"],
+    [undefined, "unknown"],
+    [null, "unknown"],
+    ["unexpected", "unknown"],
+    [false, "unknown"],
+  ])("normalizes nous_session_valid=%s to %s", async (rawValue, expected) => {
+    vi.stubGlobal("window", {});
+
+    const body =
+      rawValue === undefined ? {} : { nous_session_valid: rawValue };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify(body), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        }),
+      ),
+    );
+
+    await expect(api.getStatus()).resolves.toMatchObject({
+      nous_session_valid: expected,
+    });
+  });
+});
+
 describe("api.getModelOptions", () => {
   it("requests a live model refresh when asked", async () => {
     vi.stubGlobal("window", {});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -304,9 +304,28 @@ function appendProfileParam(url: string, profile?: string): string {
   return `${url}${url.includes("?") ? "&" : "?"}profile=${encodeURIComponent(profile)}`;
 }
 
+type NousSessionValidity = "valid" | "terminal" | "unknown";
+type RawStatusResponse = Omit<StatusResponse, "nous_session_valid"> & {
+  nous_session_valid?: unknown;
+};
+
+function normalizeNousSessionValidity(value: unknown): NousSessionValidity {
+  return value === "valid" || value === "terminal" || value === "unknown"
+    ? value
+    : "unknown";
+}
+
+function normalizeStatusResponse(status: RawStatusResponse): StatusResponse {
+  return {
+    ...status,
+    nous_session_valid: normalizeNousSessionValidity(status.nous_session_valid),
+  };
+}
+
 export const api = {
   buildWsUrl,
-  getStatus: () => fetchJSON<StatusResponse>("/api/status"),
+  getStatus: () =>
+    fetchJSON<RawStatusResponse>("/api/status").then(normalizeStatusResponse),
   /**
    * Identity probe for the dashboard auth gate (Phase 7).
    *
@@ -1793,6 +1812,12 @@ export interface StatusResponse {
   /** False when the dashboard is running in a hosted/managed layout where
    * updates are handled by the outer launcher instead of ``hermes update``. */
   can_update_hermes?: boolean;
+  /** Nous bootstrap-session validity for hosted-agent health sweeps.
+   * ``terminal`` means the local auth store has a relogin-required Nous failure;
+   * ``valid`` means usable credentials are present; ``unknown`` means
+   * indeterminate, transient/non-terminal auth state, or a missing/unrecognized
+   * value normalized at the API boundary. */
+  nous_session_valid?: NousSessionValidity;
   config_path: string;
   config_version: number;
   env_path: string;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -305,6 +305,8 @@ function appendProfileParam(url: string, profile?: string): string {
 }
 
 type NousSessionValidity = "valid" | "terminal" | "unknown";
+// Untrusted wire shape from older or malformed agents. api.getStatus() converts
+// this into the normalized StatusResponse contract below.
 type RawStatusResponse = Omit<StatusResponse, "nous_session_valid"> & {
   nous_session_valid?: unknown;
 };
@@ -1799,6 +1801,7 @@ export interface PlatformStatus {
   updated_at: string;
 }
 
+/** Normalized dashboard status returned by api.getStatus(). */
 export interface StatusResponse {
   active_sessions: number;
   /** Phase 7: ``true`` when the dashboard's OAuth gate is engaged
@@ -1817,7 +1820,7 @@ export interface StatusResponse {
    * ``valid`` means usable credentials are present; ``unknown`` means
    * indeterminate, transient/non-terminal auth state, or a missing/unrecognized
    * value normalized at the API boundary. */
-  nous_session_valid?: NousSessionValidity;
+  nous_session_valid: NousSessionValidity;
   config_path: string;
   config_version: number;
   env_path: string;

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -412,7 +412,11 @@ a chat under the selected profile.
 
 ### GET /api/status
 
-Returns agent version, gateway status, platform states, and active session count.
+Returns agent version, gateway status, platform states, active session count, and
+`nous_session_valid` (`valid`, `terminal`, or `unknown`) so hosted-agent health
+checks can distinguish terminal Nous credential failures from a live gateway.
+Clients that can talk to older agents should treat a missing or unrecognized
+value as `unknown`.
 
 ### GET /api/sessions
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/web-dashboard.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/web-dashboard.md
@@ -198,7 +198,9 @@ Web Dashboard 暴露了一个供前端使用的 REST API。你也可以直接调
 
 ### GET /api/status
 
-返回 agent 版本、gateway 状态、平台状态和活跃会话数。
+返回 agent 版本、gateway 状态、平台状态、活跃会话数，以及供 hosted-agent 健康检查使用的
+`nous_session_valid`（`valid`、`terminal` 或 `unknown`），用于区分终止性的 Nous 凭据故障和仍在运行的 gateway。
+如果客户端可能连接旧版 agent，应将缺失值或无法识别的值视为 `unknown`。
 
 ### GET /api/sessions
 


### PR DESCRIPTION
## Summary

- normalize `api.getStatus()` so missing or unrecognized `nous_session_valid` values become `unknown`
- type the frontend status field as `valid | terminal | unknown`
- document the `/api/status` field in the English and zh-Hans dashboard docs

This follows the backend `/api/status` addition from #59969 and keeps older/experimental responses from leaking an ambiguous value into dashboard health checks.

## Checks

- `npm test --workspace web -- src/lib/api.test.ts`

## Review notes

Codex adversarial review initially flagged optional/required contract ambiguity and missing fallback coverage; both were reworked by adding the API-boundary normalizer and focused tests. The final remaining concern was low confidence (0.67): direct raw REST clients still need to apply the documented fallback for missing or unrecognized values.
