### PR TITLE
fix: show Anthropic scoped weekly usage limits

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -72,6 +72,59 @@ def _parse_dt(value: Any) -> Optional[datetime]:
     return None
 
 
+def _coerce_percent_value(value: Any) -> Optional[float]:
+    """Return an already-scaled percent value when numeric and finite."""
+
+    if value is None:
+        return None
+    try:
+        percent = float(value)
+    except (TypeError, ValueError):
+        return None
+    return percent if math.isfinite(percent) else None
+
+
+def _coerce_usage_percent(value: Any) -> Optional[float]:
+    """Return a percent value for legacy Anthropic utilization fields.
+
+    Anthropic's OAuth usage endpoint has emitted both fractional utilization
+    values (``0.41``) and already-scaled percentage values (``41``). Treat
+    utilization values in ``[0, 1]`` as fractions and larger values as
+    percentages. Do not use this for fields literally named ``percent``.
+    """
+
+    percent = _coerce_percent_value(value)
+    if percent is None:
+        return None
+    return percent * 100 if 0 <= percent <= 1 else percent
+
+
+def _anthropic_scoped_limit_label(limit: dict[str, Any]) -> Optional[str]:
+    """Human label for Anthropic ``limits[]`` scoped quota entries.
+
+    Newer Claude Code/Anthropic OAuth usage responses expose model-specific
+    weekly buckets (for example the Fable weekly bucket) under ``limits`` as
+    ``kind=weekly_scoped`` instead of the legacy ``seven_day_sonnet`` /
+    ``seven_day_opus`` top-level fields. Preserve those buckets so /usage does
+    not make the old all-models weekly limit look like the only weekly signal.
+    """
+
+    if limit.get("kind") != "weekly_scoped":
+        return None
+    scope = limit.get("scope")
+    if not isinstance(scope, dict):
+        return "Scoped week"
+    model = scope.get("model")
+    if isinstance(model, dict):
+        display = str(model.get("display_name") or model.get("id") or "").strip()
+        if display:
+            return f"{display} week"
+    surface = scope.get("surface")
+    if isinstance(surface, str) and surface.strip():
+        return f"{_title_case_slug(surface)} week"
+    return "Scoped week"
+
+
 def _format_reset(dt: Optional[datetime]) -> str:
     if not dt:
         return "unknown"
@@ -571,12 +624,12 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
         ("seven_day_opus", "Opus week"),
         ("seven_day_sonnet", "Sonnet week"),
     )
+    seen_labels: set[str] = set()
     for key, label in mapping:
         window = payload.get(key) or {}
-        util = window.get("utilization")
-        if util is None:
+        used = _coerce_usage_percent(window.get("utilization"))
+        if used is None:
             continue
-        used = float(util) * 100 if float(util) <= 1 else float(util)
         windows.append(
             AccountUsageWindow(
                 label=label,
@@ -584,6 +637,29 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
                 reset_at=_parse_dt(window.get("resets_at")),
             )
         )
+        seen_labels.add(label)
+
+    # Claude Code's newer /api/oauth/usage payload can carry scoped weekly
+    # buckets in a generic limits[] array while the older top-level fields (for
+    # example seven_day_sonnet) are null. This is how model-specific buckets
+    # like the Fable weekly allowance currently appear.
+    for limit in payload.get("limits") or []:
+        if not isinstance(limit, dict):
+            continue
+        label = _anthropic_scoped_limit_label(limit)
+        if not label or label in seen_labels:
+            continue
+        used = _coerce_percent_value(limit.get("percent"))
+        if used is None:
+            continue
+        windows.append(
+            AccountUsageWindow(
+                label=label,
+                used_percent=used,
+                reset_at=_parse_dt(limit.get("resets_at")),
+            )
+        )
+        seen_labels.add(label)
     details: list[str] = []
     extra = payload.get("extra_usage") or {}
     if extra.get("is_enabled"):

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -95,6 +95,82 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert "Credits balance: $12.50" in snapshot.details
 
 
+def test_fetch_account_usage_anthropic_includes_scoped_weekly_limits(monkeypatch):
+    reset = "2026-07-11T00:59:59.849583+00:00"
+    monkeypatch.setattr("agent.account_usage.resolve_anthropic_token", lambda: "sk-ant-oat-test")
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "five_hour": {"utilization": 30, "resets_at": "2026-07-07T10:39:59Z"},
+                "seven_day": {"utilization": 76, "resets_at": reset},
+                "seven_day_opus": None,
+                "seven_day_sonnet": None,
+                "limits": [
+                    {
+                        "kind": "session",
+                        "group": "session",
+                        "percent": 30,
+                        "resets_at": "2026-07-07T10:39:59Z",
+                    },
+                    {
+                        "kind": "weekly_all",
+                        "group": "weekly",
+                        "percent": 76,
+                        "resets_at": reset,
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "group": "weekly",
+                        "percent": 41,
+                        "resets_at": reset,
+                        "scope": {"model": {"id": None, "display_name": "Fable"}},
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "group": "weekly",
+                        "percent": 1,
+                        "resets_at": reset,
+                        "scope": {"model": {"id": None, "display_name": "Haiku"}},
+                    },
+                ],
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("Current session", 30.0),
+        ("Current week", 76.0),
+        ("Fable week", 41.0),
+        ("Haiku week", 1.0),
+    ]
+    assert snapshot.windows[2].reset_at == datetime.fromisoformat(reset)
+    assert snapshot.windows[3].reset_at == datetime.fromisoformat(reset)
+
+
+def test_fetch_account_usage_anthropic_accepts_fractional_legacy_utilization(monkeypatch):
+    monkeypatch.setattr("agent.account_usage.resolve_anthropic_token", lambda: "sk-ant-oat-test")
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "five_hour": {"utilization": 0.3, "resets_at": "2026-07-07T10:39:59Z"},
+                "seven_day": {"utilization": 0.76, "resets_at": "2026-07-11T00:59:59Z"},
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [window.used_percent for window in snapshot.windows] == [30.0, 76.0]
+
+
 def test_render_account_usage_lines_includes_reset_and_provider():
     snapshot = AccountUsageSnapshot(
         provider="openai-codex",

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -152,6 +152,48 @@ def test_fetch_account_usage_anthropic_includes_scoped_weekly_limits(monkeypatch
     assert snapshot.windows[3].reset_at == datetime.fromisoformat(reset)
 
 
+def test_fetch_account_usage_anthropic_scoped_limit_fallback_labels(monkeypatch):
+    reset = "2026-07-11T00:59:59Z"
+    monkeypatch.setattr("agent.account_usage.resolve_anthropic_token", lambda: "***")
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "limits": [
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 12,
+                        "resets_at": reset,
+                        "scope": {"model": {"id": "claude-opus-4-1"}},
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 7,
+                        "resets_at": reset,
+                        "scope": {"surface": "claude_code"},
+                    },
+                    {
+                        "kind": "weekly_scoped",
+                        "percent": 3,
+                        "resets_at": reset,
+                        "scope": {},
+                    },
+                ]
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert [(window.label, window.used_percent) for window in snapshot.windows] == [
+        ("claude-opus-4-1 week", 12.0),
+        ("Claude Code week", 7.0),
+        ("Scoped week", 3.0),
+    ]
+
+
 def test_fetch_account_usage_anthropic_accepts_fractional_legacy_utilization(monkeypatch):
     monkeypatch.setattr("agent.account_usage.resolve_anthropic_token", lambda: "sk-ant-oat-test")
     monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)


### PR DESCRIPTION
## Summary
- parse Anthropic OAuth `/api/oauth/usage` `limits[]` entries for scoped weekly buckets
- render model-scoped weekly limits using the API-provided display name when legacy `seven_day_sonnet`/`seven_day_opus` fields are null
- add tests for current percent-style payloads and older fractional utilization payloads

## Why
Claude Code/Anthropic now exposes some model-specific weekly buckets through the generic `limits[]` array. In one live Max account response, the API-provided display name for a scoped weekly bucket was `Fable`:

```json
{
  "kind": "weekly_scoped",
  "group": "weekly",
  "percent": 41,
  "scope": { "model": { "display_name": "Fable" } }
}
```

while `seven_day_sonnet` and `seven_day_opus` were null. Hermes only read the old top-level fields, so `/usage` could show the all-models weekly bucket but hide that a model-specific bucket still had room. That matters for operational decisions and fallback routing: if one weekly bucket is exhausted but another scoped bucket still has capacity, users need that signal before switching/failing over.

This is related to, but not the same as, #58226 / #58228: those handle percent-vs-fraction scaling for top-level utilization fields; this PR adds the missing scoped weekly bucket parsing.

## Test plan
- [x] `git diff --check origin/main..HEAD`
- [x] `python -m compileall -q agent/account_usage.py`
- [x] `python -m pytest tests/test_account_usage.py -q -o 'addopts='`
- [x] live smoke check against local OAuth account: `fetch_account_usage('anthropic')` returned `Current session`, `Current week`, and one API-named scoped weekly window
