### PR TITLE
fix(gateway): re-apply confirmation expiry on the cached-agent live-history path (#59607)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18135,7 +18135,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "conversation context (possible FTS write corruption)",
                         session_key, len(agent_history), len(_selected),
                     )
-                    agent_history = _selected
+                    # The live in-memory history bypassed the replay-cleanup
+                    # pass inside _build_gateway_agent_history — re-apply the
+                    # stale-confirmation expiry (#59607) so a dangerous
+                    # confirmation can't slip through this path either.
+                    # Idempotent; messages without timestamps are untouched.
+                    agent_history = _strip_stale_dangerous_confirmations(
+                        _selected, now=time.time()
+                    )
             
             # Collect MEDIA paths already in history so we can exclude them
             # from the current turn's extraction. This is compression-safe:


### PR DESCRIPTION
## Summary
Re-applies the stale-confirmation expiry (#59607) on the cached-agent live-history path, closing the one bypass left after #60110 merged.

When the FTS write-corruption guard (#50502) prefers the cached agent's live `_session_messages` over the reloaded transcript, that history bypasses the replay-cleanup pass inside `_build_gateway_agent_history()` — a stale dangerous confirmation could slip through unredacted on the same-process salvage path. The stripper is idempotent and leaves timestamp-less messages untouched, so re-applying it to the selected live history is safe.

This commit was part of the #60110 review findings but the auto-merge fired on green CI before the push synced; landing it as an immediate follow-up.

## Changes
- `gateway/run.py`: apply `_strip_stale_dangerous_confirmations()` to `_selected` in the cached-agent override branch

## Validation
| | Result |
|---|---|
| tests/gateway/test_stale_confirmation_expiry.py | 7 passed |
| py_compile gateway/run.py | clean |

Refs #59607. Follow-up to #60110.
