### PR TITLE
fix(gateway): detect and recover wedged sessions with orphaned tool_call tails

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10103,6 +10103,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         message can race the restore turn immediately after ``handle_message``
         returns.
         """
+        # The scheduler reserves the runner slot before creating this task.
+        # Mark this synthetic event so the normal busy-session fast path does
+        # not queue it behind that reservation (there is no active adapter
+        # task to drain it).  A dedicated marker keeps unrelated internal
+        # completion events on their existing non-interrupting queue path.
+        try:
+            setattr(event, "_hermes_startup_resume", True)
+        except Exception:
+            pass
         try:
             await adapter.handle_message(event)
             session_tasks = getattr(adapter, "_session_tasks", {})
@@ -14841,7 +14850,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 self._release_running_agent_state(_quick_key)
 
-        if self._is_session_running(_quick_key):
+        _is_startup_resume = bool(
+            getattr(event, "_hermes_startup_resume", False)
+        )
+        if self._is_session_running(_quick_key) and not _is_startup_resume:
             # Resolve the command once; every command's mid-run behavior is
             # declared on its CommandDef (busy_policy / busy_handler in
             # hermes_cli/commands.py) and dispatched through the single

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -944,7 +944,9 @@ def build_resume_recovery_note(
     """Build the resume-pending recovery system note for an interrupted turn.
 
     ``reason`` is the session's ``resume_reason`` (``restart_timeout``,
-    ``shutdown_timeout``, or anything else → generic interruption phrasing).
+    ``shutdown_timeout``, ``orphaned_tool_call``, or anything else → generic
+    interruption phrasing). ``orphaned_tool_call`` deliberately avoids restart
+    wording because the gateway stayed online while the session was wedged.
     ``message`` is the user's NEW message text; empty means this is the
     startup auto-resume turn synthesized by
     ``_schedule_resume_pending_sessions`` with no human message attached.
@@ -957,6 +959,7 @@ def build_resume_recovery_note(
     silently abandoned behind a "restored" acknowledgement that goes
     nowhere (#57056).
     """
+    is_orphaned_tool_call = reason == "orphaned_tool_call"
     reason_phrase = (
         "a gateway restart"
         if reason == "restart_timeout"
@@ -994,12 +997,19 @@ def build_resume_recovery_note(
             "appear in the history — resume from the first step "
             "that has no recorded result."
         )
+    if is_orphaned_tool_call:
+        recovery_context = (
+            "The previous turn ended with a tool call that was never completed. "
+            "The session has been automatically recovered."
+        )
+    else:
+        recovery_context = (
+            f"The previous turn was interrupted by {reason_phrase}; the gateway "
+            "is now back online. Any restart/shutdown command in the history has "
+            "already run — do NOT re-execute or verify it."
+        )
     return (
-        f"[System note: The previous turn was interrupted by "
-        f"{reason_phrase}; the gateway is now back online. "
-        f"Any restart/shutdown command in the history has already "
-        f"run — do NOT re-execute or verify it. {resume_guidance} "
-        f"{tail_guidance}]"
+        f"[System note: {recovery_context} {resume_guidance} {tail_guidance}]"
         + (f"\n\n{message}" if message else "")
     )
 
@@ -10074,7 +10084,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # .clean_shutdown marker).  All three mean "the agent was mid-turn and
     # we killed it" — eligible for startup auto-resume.
     _AUTO_RESUME_REASONS = frozenset(
-        {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
+        {"restart_timeout", "shutdown_timeout", "restart_interrupted",
+         "orphaned_tool_call"}
     )
 
     async def _run_startup_resume_event(
@@ -11358,6 +11369,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Stall watchdog: pending inbound + stale agent activity → warn user
         # to /new (does not kill the turn; see agent.session_stall_timeout).
         self._spawn_supervised(self._session_stall_watcher, "session_stall_watcher")
+        # Start background session-health watcher — detects wedged sessions
+        # whose last persisted message is an unanswered assistant(tool_calls)
+        # (#58891).  The gateway is still alive but nothing wakes the session;
+        # this probe marks it resume_pending and schedules a synthetic recovery
+        # turn so the user does not have to manually restart the gateway.
+        self._spawn_supervised(self._session_health_watcher, "session_health_watcher")
 
         # Start background kanban notifier — each gateway delivers events for
         # subscriptions owned by the profiles whose adapters it hosts, even
@@ -12231,6 +12248,198 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if not self._running:
                     break
                 await asyncio.sleep(1)
+    async def _session_health_watcher(self, interval: float = 60.0) -> None:
+        """Background task that detects and recovers wedged sessions (#58891).
+
+        A session is **wedged** when its last persisted message is an
+        ``assistant(tool_calls)`` with no matching ``tool`` result and no
+        subsequent ``user`` message — the tool call was persisted but the
+        result was never written, and the gateway process is still alive (so
+        ``resume_pending`` was never set by the restart watchdog).  The session
+        sits idle indefinitely because nothing triggers a new turn.
+
+        This watcher runs every ``interval`` seconds (default 60s).  For each
+        non-expired, non-suspended, non-``resume_pending`` session that is not
+        currently running an agent, it checks
+        ``SessionDB.has_dangling_tool_call_tail()``.  When a wedged session is
+        found, it is marked ``resume_pending`` with reason
+        ``"orphaned_tool_call"`` and a synthetic recovery turn is scheduled via
+        ``_run_startup_resume_event`` — the same machinery used for
+        restart-interrupted sessions.  The recovery turn rebuilds history
+        (``strip_dangling_tool_call_tail`` removes the orphaned call), the
+        ``_is_resume_pending`` branch injects a recovery note, and the session
+        is back online without manual intervention.
+
+        The watcher is deliberately conservative:
+        - Sessions with an active agent (``_running_agents``) are skipped —
+          the turn may still be in progress.
+        - Sessions already marked ``resume_pending`` or ``suspended`` are
+          skipped — they are handled by the existing restart-recovery or
+          forced-wipe paths.
+        - Sessions whose adapter is unavailable are skipped — they will be
+          picked up when the platform reconnects (the reconnect watcher calls
+          ``_schedule_resume_pending_sessions`` which honours the new reason).
+        - At most one recovery is scheduled per session per watcher cycle;
+          the ``resume_pending`` flag prevents re-detection in the next cycle.
+        """
+        await asyncio.sleep(90)  # initial delay — let startup restore finish
+        while self._running:
+            try:
+                await self._session_health_probe()
+            except Exception as e:
+                logger.debug("Session health watcher error: %s", e)
+            # Sleep in small increments so we can stop quickly.
+            _slept = 0.0
+            while _slept < interval and self._running:
+                await asyncio.sleep(1)
+                _slept += 1
+
+    async def _session_health_probe(self) -> int:
+        """Run one wedge-detection + recovery pass.  Returns the count of
+        sessions scheduled for recovery.
+
+        Separated from ``_session_health_watcher`` so it can be called directly
+        in tests without the 90-second initial delay or the sleep loop.
+        """
+        # Don't schedule recovery turns while the gateway is draining —
+        # they would be immediately interrupted by the shutdown sequence.
+        if getattr(self, "_draining", False):
+            return 0
+        session_items = await self.async_session_store.list_session_items()
+        # A durable session may be reachable through multiple routing keys
+        # after /resume or conversation-scope rebinding (#64934).  Treat an
+        # agent running under any alias as active for the whole session.
+        _running_session_ids = {
+            entry.session_id
+            for key, entry in session_items
+            if key in self._running_agents
+        }
+        _pending_session_ids = {
+            entry.session_id for _, entry in session_items if entry.resume_pending
+        }
+        _wedge_state: dict[str, bool] = {}
+        _wedged: list = []
+        for key, entry in session_items:
+            # Skip sessions that are already being handled by another
+            # path or are not candidates for health recovery.
+            if entry.suspended or entry.resume_pending:
+                continue
+            if entry.expiry_finalized:
+                continue
+            if entry.session_id in _running_session_ids:
+                continue
+            if entry.session_id in _pending_session_ids:
+                continue
+            if entry.origin is None:
+                continue
+            # Skip sessions with a pending blocking approval — the agent
+            # is waiting for a /approve or /deny, not a recovery turn.
+            # A synthetic empty-text turn would spin up the agent only to
+            # block again on the same approval gate.
+            try:
+                from tools.approval import has_blocking_approval
+                if has_blocking_approval(key):
+                    continue
+            except Exception:
+                pass  # approval module unavailable — proceed
+            # DB check — is the last message an unanswered tool_call?
+            # The async SessionStore facade keeps its SQLite lock and query
+            # work off the gateway event loop.
+            if entry.session_id not in _wedge_state:
+                try:
+                    _wedge_state[entry.session_id] = (
+                        await self.async_session_store.has_dangling_tool_call_tail(
+                            entry.session_id
+                        )
+                    )
+                except Exception:
+                    _wedge_state[entry.session_id] = False
+            is_wedged = _wedge_state[entry.session_id]
+            if not is_wedged:
+                continue
+            _wedged.append((key, entry))
+
+        scheduled = 0
+        _scheduled_session_ids: set[str] = set()
+        for key, entry in _wedged:
+            if entry.session_id in _scheduled_session_ids:
+                continue
+            source = entry.origin
+            adapter = self._adapter_for_source(source)
+            if adapter is None:
+                logger.debug(
+                    "Session health: wedged session %s has no adapter "
+                    "(platform %s) — will retry on reconnect",
+                    entry.session_id,
+                    source.platform.value if source and source.platform else "?",
+                )
+                continue
+            # Validate the session owner against the current allowlist before
+            # auto-resuming — mirrors _schedule_resume_pending_sessions (#23778).
+            # A session whose owner has been removed from the allowlist must not
+            # silently receive an agent response from the health watcher.
+            try:
+                if not self._is_user_authorized(source):
+                    logger.debug(
+                        "Session health: skipping wedged session %s — "
+                        "owner no longer authorized",
+                        entry.session_id,
+                    )
+                    continue
+            except Exception as exc:
+                logger.debug(
+                    "Session health: skipping wedged session %s — "
+                    "authorization check failed: %s",
+                    entry.session_id,
+                    exc,
+                )
+                continue
+            # Mark resume_pending so the _is_resume_pending branch in
+            # _handle_message_with_agent injects the recovery note and
+            # strip_dangling_tool_call_tail fires during history rebuild.
+            if key in self._running_agents:
+                continue
+            if not await self.async_session_store.mark_resume_pending(
+                key, reason="orphaned_tool_call"
+            ):
+                continue
+            # The awaited persistence yields to inbound-message handling.
+            # Never replace a runner that claimed this key in that window.
+            if key in self._running_agents:
+                continue
+            # Pre-claim the runner slot so a real inbound message
+            # arriving between mark and dispatch queues behind us
+            # instead of spinning a duplicate agent (#45456).
+            self._running_agents[key] = _AGENT_PENDING_SENTINEL
+            self._running_agents_ts[key] = time.time()
+            self._persist_active_agents()
+            event = MessageEvent(
+                text="",
+                message_type=MessageType.TEXT,
+                source=source,
+                internal=True,
+            )
+            try:
+                task = asyncio.create_task(
+                    self._run_startup_resume_event(adapter, event, key)
+                )
+            except RuntimeError:
+                # Event loop closed between probe start and task creation
+                # (gateway shutting down).  Release the sentinel so the
+                # session is not permanently stuck; resume_pending stays
+                # set so the next boot picks it up.
+                self._release_running_agent_state(key)
+                continue
+            _scheduled_session_ids.add(entry.session_id)
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+            logger.info(
+                "Session health: detected wedged session %s "
+                "(orphaned tool_call tail) — scheduled recovery turn",
+                entry.session_id,
+            )
+            scheduled += 1
+        return scheduled
 
     def _active_profile_name(self) -> str:
         """Return the profile name this gateway represents."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1022,12 +1022,19 @@ def build_resume_recovery_note(
     reason: Optional[str], message: str = "", *, interactive: bool = True) -> str:
     """Build the resume-pending recovery system note for an interrupted turn (empty ``message`` = auto-resume).
 
-    Interactive platforms report the restore and ask what next; non-interactive ones finish the work.
+    ``reason`` is the session's ``resume_reason`` (``restart_timeout``,
+    ``shutdown_timeout``, ``orphaned_tool_call``, or anything else → generic
+    interruption phrasing). ``orphaned_tool_call`` deliberately avoids restart
+    wording because the gateway stayed online while the session was wedged.
+    ``message`` is the user's NEW message text; empty means this is the
+    startup auto-resume turn synthesized by
+    ``_schedule_resume_pending_sessions`` with no human message attached.
 
     On non-interactive event platforms (webhook, API server — adapters with ``interactive_resume = False``)
     nobody can answer; the resumed turn must instead complete the interrupted work, or the task is silently
     abandoned behind a "restored" acknowledgement that goes nowhere (#57056).
     """
+    is_orphaned_tool_call = reason == "orphaned_tool_call"
     reason_phrase = (
         "a gateway restart" if reason == "restart_timeout"
         else "a gateway shutdown" if reason == "shutdown_timeout" else "a gateway interruption")
@@ -1052,13 +1059,24 @@ def build_resume_recovery_note(
             "CONTINUE the interrupted task to completion.")
         tail_guidance = (
             "Do NOT re-run tool calls whose results already "
-            "appear in the history — resume from the first step that has no recorded result.")
+            "appear in the history — resume from the first step "
+            "that has no recorded result."
+        )
+    if is_orphaned_tool_call:
+        recovery_context = (
+            "The previous turn ended with a tool call that was never completed. "
+            "The session has been automatically recovered."
+        )
+    else:
+        recovery_context = (
+            f"The previous turn was interrupted by {reason_phrase}; the gateway "
+            "is now back online. Any restart/shutdown command in the history has "
+            "already run — do NOT re-execute or verify it."
+        )
     return (
-        f"[System note: The previous turn was interrupted by "
-        f"{reason_phrase}; the gateway is now back online. "
-        f"Any restart/shutdown command in the history has already "
-        f"run — do NOT re-execute or verify it. {resume_guidance} {tail_guidance}]"
-        + (f"\n\n{message}" if message else ""))
+        f"[System note: {recovery_context} {resume_guidance} {tail_guidance}]"
+        + (f"\n\n{message}" if message else "")
+    )
 
 
 def _prepare_resume_pending_message(
@@ -3924,7 +3942,7 @@ class GatewayRunner(
 
     # Reasons set by _stop_impl() on force-interrupt; "restart_interrupted" by suspend_recently_active()
     # on crash recovery (no .clean_shutdown marker). All mean "killed mid-turn" -> startup auto-resume.
-    _AUTO_RESUME_REASONS = frozenset({"restart_timeout", "shutdown_timeout", "restart_interrupted"})
+    _AUTO_RESUME_REASONS = frozenset({"restart_timeout", "shutdown_timeout", "restart_interrupted", "orphaned_tool_call"})
 
     _MAX_SUPERVISED_RESTARTS = 5
     # Ran this long before crashing = HEALTHY (isolated crash, not a crash-loop); restart counter resets.

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1206,7 +1206,10 @@ class GatewayInboundMixin:
         self._hm_evict_idle_stale_agent(_quick_key)
         if self._is_session_running(_quick_key):
             self._hm_evict_reaped_agent(_quick_key)
-        if self._is_session_running(_quick_key):
+        _is_startup_resume = bool(
+            getattr(event, "_hermes_startup_resume", False)
+        )
+        if self._is_session_running(_quick_key) and not _is_startup_resume:
             return await self._hm_handle_running_session_message(event, source, _quick_key)
 
         _handled, _result = await self._hm_dispatch_idle_commands(event, source, _quick_key)

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -44,6 +44,15 @@ class GatewayStartupMixin:
         """Dispatch one synthetic startup resume and wait for its agent turn (inbound stays queued
         until it finishes, else a user message can race it)."""
         from gateway.run import _AGENT_PENDING_SENTINEL
+        # The scheduler reserves the runner slot before creating this task.
+        # Mark this synthetic event so the normal busy-session fast path does
+        # not queue it behind that reservation (there is no active adapter
+        # task to drain it).  A dedicated marker keeps unrelated internal
+        # completion events on their existing non-interrupting queue path.
+        try:
+            setattr(event, "_hermes_startup_resume", True)
+        except Exception:
+            pass
         try:
             await adapter.handle_message(event)
             session_tasks = getattr(adapter, "_session_tasks", {})

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -1272,7 +1272,7 @@ class GatewayStartupMixin:
     # name minus the leading underscore.
     _PRE_RECONNECT_WATCHERS = (
         "_session_housekeeping_watcher", "_model_catalog_refresh_watcher", "_session_stall_watcher",
-        "_kanban_notifier_watcher", "_kanban_dispatcher_watcher",
+        "_kanban_notifier_watcher", "_kanban_dispatcher_watcher", "_session_health_watcher",
     )
     _POST_RECONNECT_WATCHERS = ("_handoff_watcher", "_async_delegation_watcher", "_loop_wakeup_watcher")
 

--- a/gateway/run_watchers.py
+++ b/gateway/run_watchers.py
@@ -291,7 +291,7 @@ class GatewaySessionWatchersMixin:
         in tests without the 90-second initial delay or the sleep loop.
         """
         from gateway.run import _AGENT_PENDING_SENTINEL
-        from gateway.session import MessageEvent, MessageType
+        from gateway.platforms.base import MessageEvent, MessageType
         # Don't schedule recovery turns while the gateway is draining —
         # they would be immediately interrupted by the shutdown sequence.
         if getattr(self, "_draining", False):

--- a/gateway/run_watchers.py
+++ b/gateway/run_watchers.py
@@ -236,3 +236,198 @@ class GatewaySessionWatchersMixin:
             except Exception as exc:
                 logger.debug("Session stall watcher error: %s", exc)
             await _interruptible_sleep(self, max(1, int(float(interval))))
+
+    async def _session_health_watcher(self, interval: float = 60.0) -> None:
+        """Background task that detects and recovers wedged sessions (#58891).
+
+        A session is **wedged** when its last persisted message is an
+        ``assistant(tool_calls)`` with no matching ``tool`` result and no
+        subsequent ``user`` message — the tool call was persisted but the
+        result was never written, and the gateway process is still alive (so
+        ``resume_pending`` was never set by the restart watchdog).  The session
+        sits idle indefinitely because nothing triggers a new turn.
+
+        This watcher runs every ``interval`` seconds (default 60s).  For each
+        non-expired, non-suspended, non-``resume_pending`` session that is not
+        currently running an agent, it checks
+        ``SessionDB.has_dangling_tool_call_tail()``.  When a wedged session is
+        found, it is marked ``resume_pending`` with reason
+        ``"orphaned_tool_call"`` and a synthetic recovery turn is scheduled via
+        ``_run_startup_resume_event`` — the same machinery used for
+        restart-interrupted sessions.  The recovery turn rebuilds history
+        (``strip_dangling_tool_call_tail`` removes the orphaned call), the
+        ``_is_resume_pending`` branch injects a recovery note, and the session
+        is back online without manual intervention.
+
+        The watcher is deliberately conservative:
+        - Sessions with an active agent (``_running_agents``) are skipped —
+          the turn may still be in progress.
+        - Sessions already marked ``resume_pending`` or ``suspended`` are
+          skipped — they are handled by the existing restart-recovery or
+          forced-wipe paths.
+        - Sessions whose adapter is unavailable are skipped — they will be
+          picked up when the platform reconnects (the reconnect watcher calls
+          ``_schedule_resume_pending_sessions`` which honours the new reason).
+        - At most one recovery is scheduled per session per watcher cycle;
+          the ``resume_pending`` flag prevents re-detection in the next cycle.
+        """
+        await asyncio.sleep(90)  # initial delay — let startup restore finish
+        while self._running:
+            try:
+                await self._session_health_probe()
+            except Exception as e:
+                logger.debug("Session health watcher error: %s", e)
+            # Sleep in small increments so we can stop quickly.
+            _slept = 0.0
+            while _slept < interval and self._running:
+                await asyncio.sleep(1)
+                _slept += 1
+
+    async def _session_health_probe(self) -> int:
+        """Run one wedge-detection + recovery pass.  Returns the count of
+        sessions scheduled for recovery.
+
+        Separated from ``_session_health_watcher`` so it can be called directly
+        in tests without the 90-second initial delay or the sleep loop.
+        """
+        from gateway.run import _AGENT_PENDING_SENTINEL
+        from gateway.session import MessageEvent, MessageType
+        # Don't schedule recovery turns while the gateway is draining —
+        # they would be immediately interrupted by the shutdown sequence.
+        if getattr(self, "_draining", False):
+            return 0
+        session_items = await self.async_session_store.list_session_items()
+        # A durable session may be reachable through multiple routing keys
+        # after /resume or conversation-scope rebinding (#64934).  Treat an
+        # agent running under any alias as active for the whole session.
+        _running_session_ids = {
+            entry.session_id
+            for key, entry in session_items
+            if key in self._running_agents
+        }
+        _pending_session_ids = {
+            entry.session_id for _, entry in session_items if entry.resume_pending
+        }
+        _wedge_state: dict[str, bool] = {}
+        _wedged: list = []
+        for key, entry in session_items:
+            # Skip sessions that are already being handled by another
+            # path or are not candidates for health recovery.
+            if entry.suspended or entry.resume_pending:
+                continue
+            if entry.expiry_finalized:
+                continue
+            if entry.session_id in _running_session_ids:
+                continue
+            if entry.session_id in _pending_session_ids:
+                continue
+            if entry.origin is None:
+                continue
+            # Skip sessions with a pending blocking approval — the agent
+            # is waiting for a /approve or /deny, not a recovery turn.
+            # A synthetic empty-text turn would spin up the agent only to
+            # block again on the same approval gate.
+            try:
+                from tools.approval import has_blocking_approval
+                if has_blocking_approval(key):
+                    continue
+            except Exception:
+                pass  # approval module unavailable — proceed
+            # DB check — is the last message an unanswered tool_call?
+            # The async SessionStore facade keeps its SQLite lock and query
+            # work off the gateway event loop.
+            if entry.session_id not in _wedge_state:
+                try:
+                    _wedge_state[entry.session_id] = (
+                        await self.async_session_store.has_dangling_tool_call_tail(
+                            entry.session_id
+                        )
+                    )
+                except Exception:
+                    _wedge_state[entry.session_id] = False
+            is_wedged = _wedge_state[entry.session_id]
+            if not is_wedged:
+                continue
+            _wedged.append((key, entry))
+
+        scheduled = 0
+        _scheduled_session_ids: set[str] = set()
+        for key, entry in _wedged:
+            if entry.session_id in _scheduled_session_ids:
+                continue
+            source = entry.origin
+            adapter = self._adapter_for_source(source)
+            if adapter is None:
+                logger.debug(
+                    "Session health: wedged session %s has no adapter "
+                    "(platform %s) — will retry on reconnect",
+                    entry.session_id,
+                    source.platform.value if source and source.platform else "?",
+                )
+                continue
+            # Validate the session owner against the current allowlist before
+            # auto-resuming — mirrors _schedule_resume_pending_sessions (#23778).
+            # A session whose owner has been removed from the allowlist must not
+            # silently receive an agent response from the health watcher.
+            try:
+                if not self._is_user_authorized(source):
+                    logger.debug(
+                        "Session health: skipping wedged session %s — "
+                        "owner no longer authorized",
+                        entry.session_id,
+                    )
+                    continue
+            except Exception as exc:
+                logger.debug(
+                    "Session health: skipping wedged session %s — "
+                    "authorization check failed: %s",
+                    entry.session_id,
+                    exc,
+                )
+                continue
+            # Mark resume_pending so the _is_resume_pending branch in
+            # _handle_message_with_agent injects the recovery note and
+            # strip_dangling_tool_call_tail fires during history rebuild.
+            if key in self._running_agents:
+                continue
+            if not await self.async_session_store.mark_resume_pending(
+                key, reason="orphaned_tool_call"
+            ):
+                continue
+            # The awaited persistence yields to inbound-message handling.
+            # Never replace a runner that claimed this key in that window.
+            if key in self._running_agents:
+                continue
+            # Pre-claim the runner slot so a real inbound message
+            # arriving between mark and dispatch queues behind us
+            # instead of spinning a duplicate agent (#45456).
+            self._running_agents[key] = _AGENT_PENDING_SENTINEL
+            self._running_agents_ts[key] = time.time()
+            self._persist_active_agents()
+            event = MessageEvent(
+                text="",
+                message_type=MessageType.TEXT,
+                source=source,
+                internal=True,
+            )
+            try:
+                task = asyncio.create_task(
+                    self._run_startup_resume_event(adapter, event, key)
+                )
+            except RuntimeError:
+                # Event loop closed between probe start and task creation
+                # (gateway shutting down).  Release the sentinel so the
+                # session is not permanently stuck; resume_pending stays
+                # set so the next boot picks it up.
+                self._release_running_agent_state(key)
+                continue
+            _scheduled_session_ids.add(entry.session_id)
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+            logger.info(
+                "Session health: detected wedged session %s "
+                "(orphaned tool_call tail) — scheduled recovery turn",
+                entry.session_id,
+            )
+            scheduled += 1
+        return scheduled

--- a/gateway/run_watchers.py
+++ b/gateway/run_watchers.py
@@ -11,7 +11,10 @@ import contextlib
 import logging
 import time
 from collections import Counter
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+if TYPE_CHECKING:
+    from gateway.run import GatewayRunner
 
 from gateway.session_stall import (
     format_session_stall_notification,
@@ -237,7 +240,7 @@ class GatewaySessionWatchersMixin:
                 logger.debug("Session stall watcher error: %s", exc)
             await _interruptible_sleep(self, max(1, int(float(interval))))
 
-    async def _session_health_watcher(self, interval: float = 60.0) -> None:
+    async def _session_health_watcher(self: GatewayRunner, interval: float = 60.0) -> None:
         """Background task that detects and recovers wedged sessions (#58891).
 
         A session is **wedged** when its last persisted message is an
@@ -283,7 +286,7 @@ class GatewaySessionWatchersMixin:
                 await asyncio.sleep(1)
                 _slept += 1
 
-    async def _session_health_probe(self) -> int:
+    async def _session_health_probe(self: GatewayRunner) -> int:
         """Run one wedge-detection + recovery pass.  Returns the count of
         sessions scheduled for recovery.
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3074,6 +3074,19 @@ class SessionStore:
 
         return entries
 
+    def list_session_items(self) -> List[tuple[str, SessionEntry]]:
+        """Return a lock-protected snapshot of session keys and entries."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return list(self._entries.items())
+
+    def has_dangling_tool_call_tail(self, session_id: str) -> bool:
+        """Return whether the persisted session ends in an unanswered tool call."""
+        db = self._db
+        if db is None:
+            return False
+        return db.has_dangling_tool_call_tail(session_id)
+
     def lookup_by_session_id(self, session_id: str) -> Optional[SessionEntry]:
         """Return the active session entry for a persisted session ID, if any."""
         if not session_id:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1144,6 +1144,19 @@ class SessionStore(
         entries.sort(key=lambda e: e.updated_at, reverse=True)
         return entries
 
+    def list_session_items(self) -> List[tuple[str, SessionEntry]]:
+        """Return a lock-protected snapshot of session keys and entries."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return list(self._entries.items())
+
+    def has_dangling_tool_call_tail(self, session_id: str) -> bool:
+        """Return whether the persisted session ends in an unanswered tool call."""
+        db = self._db
+        if db is None:
+            return False
+        return db.has_dangling_tool_call_tail(session_id)
+
     def lookup_by_session_id(self, session_id: str) -> Optional[SessionEntry]:
         """Return the active session entry for a persisted session ID, if any."""
         if not session_id:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6855,6 +6855,46 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return self._execute_write(_do)
 
+    def has_dangling_tool_call_tail(self, session_id: str) -> bool:
+        """Check whether a session's last active message is an unanswered ``assistant(tool_calls)``.
+
+        This is the DB-level signature of a **wedged session** (#58891): the
+        assistant emitted a ``tool_calls`` block that was persisted, but no
+        matching ``tool`` result row was ever written — and no subsequent
+        ``user`` message exists to trigger a natural resume turn.  The gateway
+        process is still alive (so ``resume_pending`` was never set by the
+        restart watchdog), yet the session is silently stuck because nothing
+        wakes it.
+
+        The check mirrors the in-memory ``strip_dangling_tool_call_tail()``
+        predicate in ``agent/replay_cleanup.py``: the last active message must
+        be ``role='assistant'`` with a non-empty ``tool_calls`` payload.  Being
+        the last message guarantees there is no ``tool`` or ``user`` row after
+        it (otherwise it would not be last).
+
+        Returns ``True`` when the dangling tail is present, ``False`` for an
+        empty session, a session whose last message is any other role, or a
+        session whose last assistant message has no ``tool_calls``.
+        """
+        with self._lock:
+            conn = self._conn
+            if conn is None:
+                return False
+            cursor = conn.execute(
+                "SELECT role, tool_calls FROM messages "
+                "WHERE session_id = ? AND active = 1 "
+                "ORDER BY id DESC LIMIT 1",
+                (session_id,),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return False
+        role = row["role"] if isinstance(row, sqlite3.Row) else row[0]
+        tool_calls = (
+            row["tool_calls"] if isinstance(row, sqlite3.Row) else row[1]
+        )
+        return role == "assistant" and bool(tool_calls)
+
     def get_messages(
         self,
         session_id: str,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -367,6 +367,8 @@ CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
 DEFERRED_INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_messages_session_active
     ON messages(session_id, active, timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_session_active_id
+    ON messages(session_id, active, id);
 CREATE INDEX IF NOT EXISTS idx_messages_active_null
     ON messages(active) WHERE active IS NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_session_key

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -583,6 +583,8 @@ BEGIN
     ) WHERE session_id = old.session_id AND (active = 1 OR compacted = 1)
       AND display_identity = old.display_identity;
 END;
+CREATE INDEX IF NOT EXISTS idx_messages_session_active_id
+    ON messages(session_id, active, id);
 CREATE INDEX IF NOT EXISTS idx_messages_active_null
     ON messages(active) WHERE active IS NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_session_key

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -7,7 +7,10 @@ import hashlib
 import json
 import logging
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from hermes_state import SessionDB
 
 from agent.context_compressor import _DB_PERSISTED_MARKER as _DB_PERSISTED_MARKER_KEY, split_user_originated_turn
 from agent.memory_manager import sanitize_context
@@ -890,7 +893,7 @@ class SessionMessagesMixin:
             f"FROM messages WHERE session_id IN ({_placeholders(session_ids)})"
             f"{active_clause} ORDER BY id", tuple(session_ids))
 
-    def has_dangling_tool_call_tail(self, session_id: str) -> bool:
+    def has_dangling_tool_call_tail(self: SessionDB, session_id: str) -> bool:
         """Check whether a session's last active message is an unanswered ``assistant(tool_calls)``.
 
         This is the DB-level signature of a **wedged session** (#58891): the

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -890,6 +890,37 @@ class SessionMessagesMixin:
             f"FROM messages WHERE session_id IN ({_placeholders(session_ids)})"
             f"{active_clause} ORDER BY id", tuple(session_ids))
 
+    def has_dangling_tool_call_tail(self, session_id: str) -> bool:
+        """Check whether a session's last active message is an unanswered ``assistant(tool_calls)``.
+
+        This is the DB-level signature of a **wedged session** (#58891): the
+        assistant emitted a ``tool_calls`` block that was persisted, but no
+        matching ``tool`` result row was ever written — and no subsequent
+        ``user`` message exists to trigger a natural resume turn.  The gateway
+        process is still alive (so ``resume_pending`` was never set by the
+        restart watchdog), yet the session is silently stuck because nothing
+        wakes it.
+
+        The check mirrors the in-memory ``strip_dangling_tool_call_tail()``
+        predicate in ``agent/replay_cleanup.py``: the last active message must
+        be ``role='assistant'`` with a non-empty ``tool_calls`` payload.  Being
+        the last message guarantees there is no ``tool`` or ``user`` row after
+        it (otherwise it would not be last).
+
+        Returns ``True`` when the dangling tail is present, ``False`` for an
+        empty session, a session whose last message is any other role, or a
+        session whose last assistant message has no ``tool_calls``.
+        """
+        row = self._read_one(
+            "SELECT role, tool_calls FROM messages "
+            "WHERE session_id = ? AND active = 1 "
+            "ORDER BY id DESC LIMIT 1",
+            (session_id,),
+        )
+        if row is None:
+            return False
+        return row["role"] == "assistant" and bool(row["tool_calls"])
+
     def get_messages_as_conversation(self, session_id: str, include_ancestors: bool = False,
                                      include_inactive: bool = False, repair_alternation: bool = False,
                                      include_row_ids: bool = False,

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -196,6 +196,54 @@ class TestSessionEntryResumeFields:
         assert entry.resume_reason is None
         assert entry.last_resume_marked_at is None
 
+    def test_roundtrip_with_resume_fields(self):
+        now = datetime(2026, 4, 18, 12, 0, 0)
+        entry = SessionEntry(
+            session_key="agent:main:telegram:dm:1",
+            session_id="sid",
+            created_at=now,
+            updated_at=now,
+            resume_pending=True,
+            resume_reason="restart_timeout",
+            last_resume_marked_at=now,
+        )
+        restored = SessionEntry.from_dict(entry.to_dict())
+        assert restored.resume_pending is True
+        assert restored.resume_reason == "restart_timeout"
+        assert restored.last_resume_marked_at == now
+
+    def test_from_dict_legacy_without_resume_fields(self):
+        """Old sessions.json without the new fields deserialize cleanly."""
+        now = datetime.now()
+        legacy = {
+            "session_key": "agent:main:telegram:dm:1",
+            "session_id": "sid",
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+            "chat_type": "dm",
+        }
+        restored = SessionEntry.from_dict(legacy)
+        assert restored.resume_pending is False
+        assert restored.resume_reason is None
+        assert restored.last_resume_marked_at is None
+
+    def test_malformed_timestamp_is_tolerated(self):
+        now = datetime.now()
+        data = {
+            "session_key": "k",
+            "session_id": "sid",
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+            "resume_pending": True,
+            "resume_reason": "restart_timeout",
+            "last_resume_marked_at": "not-a-timestamp",
+        }
+        restored = SessionEntry.from_dict(data)
+        # resume_pending still honoured, only the broken timestamp drops
+        assert restored.resume_pending is True
+        assert restored.resume_reason == "restart_timeout"
+        assert restored.last_resume_marked_at is None
+
 
 # ---------------------------------------------------------------------------
 # SessionStore.mark_resume_pending / clear_resume_pending
@@ -222,8 +270,48 @@ class TestMarkResumePending:
         store.mark_resume_pending(entry.session_key, reason="shutdown_timeout")
         assert store._entries[entry.session_key].resume_reason == "shutdown_timeout"
 
+    def test_returns_false_for_unknown_key(self, tmp_path):
+        store = _make_store(tmp_path)
+        assert store.mark_resume_pending("no-such-key") is False
+
+    def test_does_not_override_suspended(self, tmp_path):
+        """suspended wins — mark_resume_pending is a no-op on a suspended entry."""
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store.suspend_session(entry.session_key)
+
+        assert store.mark_resume_pending(entry.session_key) is False
+        e = store._entries[entry.session_key]
+        assert e.suspended is True
+        assert e.resume_pending is False
+
+    def test_survives_roundtrip_through_json(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store.mark_resume_pending(entry.session_key, reason="restart_timeout")
+
+        # Reload from disk
+        store2 = _make_store(tmp_path)
+        store2._ensure_loaded()
+        reloaded = store2._entries[entry.session_key]
+        assert reloaded.resume_pending is True
+        assert reloaded.resume_reason == "restart_timeout"
+
 
 class TestClearResumePending:
+    def test_clears_flag(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store.mark_resume_pending(entry.session_key)
+
+        assert store.clear_resume_pending(entry.session_key) is True
+        e = store._entries[entry.session_key]
+        assert e.resume_pending is False
+        assert e.resume_reason is None
+        assert e.last_resume_marked_at is None
 
     def test_returns_false_when_not_pending(self, tmp_path):
         store = _make_store(tmp_path)
@@ -232,6 +320,10 @@ class TestClearResumePending:
         # Not marked
         assert store.clear_resume_pending(entry.session_key) is False
 
+    def test_returns_false_for_unknown_key(self, tmp_path):
+        store = _make_store(tmp_path)
+        assert store.clear_resume_pending("no-such-key") is False
+
 
 # ---------------------------------------------------------------------------
 # SessionStore.get_or_create_session resume_pending behaviour
@@ -239,6 +331,20 @@ class TestClearResumePending:
 
 
 class TestGetOrCreateResumePending:
+    def test_resume_pending_preserves_session_id(self, tmp_path):
+        """This is THE core behavioural fix — resume_pending ≠ new session."""
+        store = _make_store(tmp_path)
+        source = _make_source()
+        first = store.get_or_create_session(source)
+        original_sid = first.session_id
+        store.mark_resume_pending(first.session_key)
+
+        second = store.get_or_create_session(source)
+        assert second.session_id == original_sid
+        assert second.was_auto_reset is False
+        assert second.auto_reset_reason is None
+        # Flag is NOT cleared on read — only on successful turn completion.
+        assert second.resume_pending is True
 
     def test_resume_pending_follows_compression_tip(self, tmp_path):
         """Interrupted platform mappings must not stay pinned to compressed roots."""
@@ -261,6 +367,42 @@ class TestGetOrCreateResumePending:
         assert second.resume_pending is True
         mock_tip.assert_called_with(original_sid)
 
+    def test_suspended_still_creates_new_session(self, tmp_path):
+        """Regression guard — suspended must still force a clean slate."""
+        store = _make_store(tmp_path)
+        source = _make_source()
+        first = store.get_or_create_session(source)
+        original_sid = first.session_id
+        store.suspend_session(first.session_key)
+
+        second = store.get_or_create_session(source)
+        assert second.session_id != original_sid
+        assert second.was_auto_reset is True
+        assert second.auto_reset_reason == "suspended"
+
+    def test_suspended_overrides_resume_pending(self, tmp_path):
+        """Terminal escalation: a session that somehow has BOTH flags must
+        behave like ``suspended`` — forced wipe + auto_reset_reason."""
+        store = _make_store(tmp_path)
+        source = _make_source()
+        first = store.get_or_create_session(source)
+        original_sid = first.session_id
+
+        # Force the pathological state directly (normally mark_resume_pending
+        # refuses to run when suspended=True, but a stuck-loop escalation
+        # can set suspended=True AFTER resume_pending is set).
+        with store._lock:
+            e = store._entries[first.session_key]
+            e.resume_pending = True
+            e.resume_reason = "restart_timeout"
+            e.suspended = True
+            store._save()
+
+        second = store.get_or_create_session(source)
+        assert second.session_id != original_sid
+        assert second.was_auto_reset is True
+        assert second.auto_reset_reason == "suspended"
+
 
 # ---------------------------------------------------------------------------
 # SessionStore.suspend_recently_active skip behaviour
@@ -279,6 +421,22 @@ class TestSuspendRecentlyActiveSkipsResumePending:
         e = store._entries[entry.session_key]
         assert e.suspended is False
         assert e.resume_pending is True
+
+    def test_non_resume_pending_gets_resume_pending(self, tmp_path):
+        """Non-resume sessions are now marked resume_pending (not suspended)."""
+        store = _make_store(tmp_path)
+        source_a = _make_source(chat_id="a")
+        source_b = _make_source(chat_id="b")
+        entry_a = store.get_or_create_session(source_a)
+        entry_b = store.get_or_create_session(source_b)
+        store.mark_resume_pending(entry_a.session_key)
+
+        count = store.suspend_recently_active()
+        # entry_a is already resume_pending → skipped. entry_b gets marked.
+        assert count == 1
+        assert store._entries[entry_a.session_key].suspended is False
+        assert store._entries[entry_b.session_key].resume_pending is True
+        assert store._entries[entry_b.session_key].suspended is False
 
 
 # ---------------------------------------------------------------------------
@@ -299,6 +457,39 @@ class TestResumePendingSystemNote:
             last_resume_marked_at=now,
         )
 
+    def test_resume_pending_restart_note_mentions_restart(self):
+        entry = self._pending_entry(reason="restart_timeout")
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "in progress", "timestamp": time.time()},
+            ],
+            user_message="what happened?",
+            resume_entry=entry,
+        )
+        assert "[System note:" in result
+        assert "gateway restart" in result
+        assert "NEW message" in result
+        assert "Do NOT re-execute" in result
+        assert "what happened?" in result
+
+    def test_resume_pending_shutdown_note_mentions_shutdown(self):
+        entry = self._pending_entry(reason="shutdown_timeout")
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "in progress", "timestamp": time.time()},
+            ],
+            user_message="ping",
+            resume_entry=entry,
+        )
+        assert "gateway shutdown" in result
+
+    def test_empty_message_interactive_note_asks_what_next(self):
+        """Interactive platforms: the startup auto-resume turn reports the
+        restore and asks the (present) human what to do next."""
+        note = build_resume_recovery_note("restart_timeout", "", interactive=True)
+        assert "session was restored" in note
+        assert "ask what they would like to do next" in note
+        assert "skip any unfinished work" in note
 
     def test_empty_message_noninteractive_note_continues_task(self):
         """Non-interactive platforms (webhook, API server): nobody can answer
@@ -313,6 +504,33 @@ class TestResumePendingSystemNote:
         # But still guards against re-running already-recorded tool calls.
         assert "already appear in the history" in note
 
+    def test_orphaned_tool_call_interactive_note_avoids_restart_claim(self):
+        note = build_resume_recovery_note(
+            "orphaned_tool_call", "", interactive=True
+        )
+        assert "tool call that was never completed" in note
+        assert "automatically recovered" in note
+        assert "ask what they would like to do next" in note
+        assert "gateway restart" not in note
+        assert "back online" not in note
+
+    def test_orphaned_tool_call_noninteractive_note_continues_task(self):
+        note = build_resume_recovery_note(
+            "orphaned_tool_call", "", interactive=False
+        )
+        assert "tool call that was never completed" in note
+        assert "CONTINUE the interrupted task" in note
+        assert "session was restored successfully" not in note
+        assert "ask what they would like to do next" not in note
+        assert "gateway restart" not in note
+        assert "back online" not in note
+
+    def test_new_message_guidance_identical_regardless_of_interactivity(self):
+        """A real NEW user message always wins — same guidance either way."""
+        a = build_resume_recovery_note("restart_timeout", "do the thing", interactive=True)
+        b = build_resume_recovery_note("restart_timeout", "do the thing", interactive=False)
+        assert a == b
+        assert "NEW message" in a
 
     def test_resume_pending_fires_without_tool_tail(self):
         """Key improvement over PR #9934: the restart-resume note fires
@@ -327,6 +545,22 @@ class TestResumePendingSystemNote:
         assert "gateway restart" in result
         assert "NEW message" in result
 
+    def test_resume_pending_subsumes_tool_tail_note(self):
+        """When BOTH conditions are true, the restart-resume note wins —
+        no duplicate notes."""
+        entry = self._pending_entry()
+        history = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
+            ], "timestamp": time.time() - 1},
+            {"role": "tool", "tool_call_id": "c1", "content": "result",
+             "timestamp": time.time()},
+        ]
+        result = _simulate_note_injection(history, "ping", resume_entry=entry)
+        assert result.count("[System note:") == 1
+        assert "gateway restart" in result
+        # Old tool-tail wording absent
+        assert "haven't responded to yet" not in result
 
     def test_no_resume_pending_preserves_tool_tail_note(self):
         """Regression: the old PR #9934 tool-tail behaviour is unchanged."""
@@ -364,6 +598,87 @@ class TestResumePendingSystemNote:
         )
         assert result == "start a new task"
 
+    def test_fresh_resume_mark_fires_despite_stale_transcript(self):
+        """Regression: the recovery note must fire when the restart
+        watchdog just stamped the session, even if the last persisted
+        transcript row is far older than the freshness window.
+
+        This is the exact gap that produced the blank-turn symptom: an
+        active thread returned to after >1h of silence has a stale
+        transcript clock, but the interruption itself (last_resume_marked_at)
+        is seconds old. The two freshness signals must agree.
+        """
+        entry = self._pending_entry()
+        entry.last_resume_marked_at = datetime.now()  # interrupted just now
+
+        history = [
+            {"role": "assistant", "content": "older context",
+             "timestamp": time.time() - 3600},  # transcript clock stale
+        ]
+        result = _simulate_note_injection(
+            history=history,
+            user_message="continue",
+            resume_entry=entry,
+            window_secs=1800,
+        )
+        assert "[System note:" in result
+        assert "gateway restart" in result
+
+    def test_empty_resume_turn_never_reaches_model_blank(self):
+        """Regression: a blank auto-resume turn on a resume_pending
+        session must be backfilled with a recovery note, never sent empty.
+
+        _schedule_resume_pending_sessions dispatches an empty-text internal
+        event. If the resume_pending branch did not fire, the safety net
+        must still produce non-blank text so the model does not reply with
+        confused 'the message came through blank' noise.
+        """
+        entry = self._pending_entry()
+        # Force the resume_pending branch to miss by making BOTH signals stale,
+        # so only the empty-turn safety net can save us.
+        entry.last_resume_marked_at = datetime.now() - timedelta(hours=2)
+        history = [
+            {"role": "assistant", "content": "old", "timestamp": time.time() - 7200},
+        ]
+        result = _simulate_note_injection(
+            history=history,
+            user_message="",  # the empty auto-resume event text
+            resume_entry=entry,
+            window_secs=1800,
+        )
+        assert result.strip(), "blank turn must never reach the model"
+        assert "[System note:" in result
+
+    def test_empty_turn_guard_only_applies_to_resume_pending(self):
+        """The empty-turn backfill must NOT fire for ordinary sessions —
+        a legitimately empty user turn (e.g. an uncaptioned image) on a
+        non-resume_pending session is left untouched.
+        """
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "hi", "timestamp": time.time()},
+            ],
+            user_message="",
+            resume_entry=None,
+        )
+        assert result == ""
+
+    def test_fresh_tool_tail_preserves_auto_continue_note(self):
+        history = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
+            ], "timestamp": time.time() - 1},
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": "result",
+                "timestamp": time.time(),
+            },
+        ]
+        result = _simulate_note_injection(history, "ping", resume_entry=None)
+        assert "[System note:" in result
+        assert "pending tool outputs" in result
+        assert "Do NOT re-execute" in result
 
     def test_stale_tool_tail_does_not_inject_auto_continue_note(self):
         """The core bug fix: stale tool-tail must not revive a dead task.
@@ -471,6 +786,55 @@ class TestResumePendingSystemNote:
         assert "pending tool outputs" in result
         assert "Do NOT re-execute" in result
 
+    def test_no_note_when_nothing_to_resume(self):
+        history = [
+            {"role": "user", "content": "hello", "timestamp": time.time() - 2},
+            {"role": "assistant", "content": "hi", "timestamp": time.time() - 1},
+        ]
+        result = _simulate_note_injection(history, "ping", resume_entry=None)
+        assert result == "ping"
+
+    def test_resume_pending_note_warns_against_reexecuting_restart(self):
+        """The resume-pending note tells the model any restart/shutdown
+        command in the history already ran and must not be re-executed or
+        verified — the cognitive backstop to the source-level tail strip.
+        """
+        entry = self._pending_entry(reason="restart_timeout")
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "in progress", "timestamp": time.time()},
+            ],
+            user_message="restarted!",
+            resume_entry=entry,
+        )
+        assert "[System note:" in result
+        assert "back online" in result
+        assert "already" in result and "do NOT re-execute or verify" in result
+        assert "restarted!" in result
+
+    def test_resume_pending_empty_message_reports_recovery(self):
+        """On the empty-message auto-resume startup turn there is no NEW user
+        message, so the note instructs the model to report recovery and ask
+        for instructions rather than 'address the user's NEW message'.
+        """
+        entry = self._pending_entry(reason="restart_timeout")
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "in progress", "timestamp": time.time()},
+            ],
+            user_message="",
+            resume_entry=entry,
+        )
+        assert "[System note:" in result
+        assert "gateway restart" in result
+        assert "restored successfully" in result
+        assert "ask what they would like to do next" in result
+        assert "do NOT re-execute or verify" in result
+        # No phantom "NEW message" instruction when there is no new message.
+        assert "NEW message" not in result
+        # Nothing appended after the closing bracket (no empty user text).
+        assert result.rstrip().endswith("]")
+
 
 # ---------------------------------------------------------------------------
 # Freshness helpers
@@ -478,13 +842,30 @@ class TestResumePendingSystemNote:
 
 
 class TestFreshnessHelpers:
+    def test_coerce_datetime(self):
+        now = datetime.now()
+        assert _coerce_gateway_timestamp(now) == pytest.approx(now.timestamp(), abs=1e-3)
 
+    def test_coerce_epoch_seconds(self):
+        assert _coerce_gateway_timestamp(1_700_000_000) == 1_700_000_000.0
+        assert _coerce_gateway_timestamp(1_700_000_000.5) == 1_700_000_000.5
+
+    def test_coerce_epoch_milliseconds(self):
+        # Values > 10^10 treated as ms
+        assert _coerce_gateway_timestamp(1_700_000_000_000) == 1_700_000_000.0
 
     def test_coerce_iso_string(self):
         iso = "2026-04-18T12:00:00+00:00"
         expected = datetime.fromisoformat(iso).timestamp()
         assert _coerce_gateway_timestamp(iso) == pytest.approx(expected, abs=1e-3)
 
+    def test_coerce_iso_string_with_z_suffix(self):
+        iso_z = "2026-04-18T12:00:00Z"
+        expected = datetime.fromisoformat("2026-04-18T12:00:00+00:00").timestamp()
+        assert _coerce_gateway_timestamp(iso_z) == pytest.approx(expected, abs=1e-3)
+
+    def test_coerce_numeric_string(self):
+        assert _coerce_gateway_timestamp("1700000000") == 1_700_000_000.0
 
     def test_coerce_rejects_garbage(self):
         assert _coerce_gateway_timestamp(None) is None
@@ -494,6 +875,10 @@ class TestFreshnessHelpers:
         assert _coerce_gateway_timestamp(False) is None
         assert _coerce_gateway_timestamp([1, 2, 3]) is None
 
+    def test_is_fresh_unknown_is_fresh(self):
+        """Legacy-compat: unknown timestamp → fresh."""
+        assert _is_fresh_gateway_interruption(None) is True
+        assert _is_fresh_gateway_interruption("not-a-timestamp") is True
 
     def test_is_fresh_window_bounds(self):
         now = 1_700_000_000.0
@@ -510,6 +895,14 @@ class TestFreshnessHelpers:
             now - 3600, now=now, window_secs=3600,
         ) is True
 
+    def test_is_fresh_zero_window_always_fresh(self):
+        """Opt-out: window_secs=0 disables the gate entirely."""
+        assert _is_fresh_gateway_interruption(
+            0.0, now=1_700_000_000.0, window_secs=0,
+        ) is True
+        assert _is_fresh_gateway_interruption(
+            -1.0, now=1_700_000_000.0, window_secs=-5,
+        ) is True
 
     def test_last_transcript_timestamp_skips_meta(self):
         history = [
@@ -520,6 +913,18 @@ class TestFreshnessHelpers:
         ]
         assert _last_transcript_timestamp(history) == 200.0
 
+    def test_last_transcript_timestamp_empty(self):
+        assert _last_transcript_timestamp([]) is None
+        assert _last_transcript_timestamp(None) is None
+
+    def test_last_transcript_timestamp_row_without_timestamp(self):
+        """Legacy transcript row (no timestamp) returns None → caller
+        treats as fresh."""
+        history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hey"},
+        ]
+        assert _last_transcript_timestamp(history) is None
 
     def test_auto_continue_freshness_window_reads_env(self, monkeypatch):
         monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "7200")
@@ -528,6 +933,14 @@ class TestFreshnessHelpers:
     def test_auto_continue_freshness_window_default_when_unset(self, monkeypatch):
         monkeypatch.delenv("HERMES_AUTO_CONTINUE_FRESHNESS", raising=False)
         # Default is 1 hour
+        assert _auto_continue_freshness_window() == 3600.0
+
+    def test_auto_continue_freshness_window_malformed_falls_back(self, monkeypatch):
+        monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "not-a-number")
+        assert _auto_continue_freshness_window() == 3600.0
+
+    def test_auto_continue_freshness_window_empty_falls_back(self, monkeypatch):
+        monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "")
         assert _auto_continue_freshness_window() == 3600.0
 
 
@@ -571,9 +984,243 @@ async def test_drain_timeout_marks_resume_pending():
         assert args[0][1] == "shutdown_timeout"
 
 
+@pytest.mark.asyncio
+async def test_drain_timeout_uses_restart_reason_when_restarting():
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._restart_drain_timeout = 0.05
+    runner._restart_requested = True
+
+    running_agent = MagicMock()
+    runner._running_agents = {"agent:main:telegram:dm:A": running_agent}
+
+    session_store = MagicMock()
+    session_store.mark_resume_pending = MagicMock(return_value=True)
+    runner.session_store = session_store
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop(restart=True, detached_restart=False, service_restart=True)
+
+    calls = session_store.mark_resume_pending.call_args_list
+    assert calls, "expected at least one mark_resume_pending call"
+    for args in calls:
+        assert args[0][1] == "restart_timeout"
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_skips_pending_sentinel_sessions():
+    """Pending sentinels — sessions whose AIAgent construction hasn't
+    produced a real agent yet — are skipped by
+    ``_interrupt_running_agents()``.  The resume_pending marking must
+    mirror that: no agent started means no turn was interrupted.
+    """
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._restart_drain_timeout = 0.05
+
+    session_key_real = "agent:main:telegram:dm:A"
+    session_key_sentinel = "agent:main:telegram:dm:B"
+    runner._running_agents = {
+        session_key_real: MagicMock(),
+        session_key_sentinel: _AGENT_PENDING_SENTINEL,
+    }
+
+    session_store = MagicMock()
+    session_store.mark_resume_pending = MagicMock(return_value=True)
+    runner.session_store = session_store
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    calls = session_store.mark_resume_pending.call_args_list
+    marked = {args[0][0] for args in calls}
+    assert marked == {session_key_real}
+
+
 # ---------------------------------------------------------------------------
 # Gateway startup auto-resume
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_schedules_fresh_pending_sessions():
+    """Fresh resume_pending sessions should continue automatically after startup.
+
+    This closes the UX gap where restart recovery only happened if the user sent
+    another message after the gateway came back.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat", thread_id="topic-1")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:group:resume-chat:topic-1",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert isinstance(event, MessageEvent)
+    assert event.internal is True
+    assert event.message_type == MessageType.TEXT
+    assert event.source == source
+    # Text is empty — the existing _is_resume_pending branch in
+    # _handle_message_with_agent owns the system-note injection so we don't
+    # double it up.
+    assert event.text == ""
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_includes_crash_recovery():
+    """Crash-recovered sessions (reason=restart_interrupted) are also auto-resumed.
+
+    suspend_recently_active() marks in-flight sessions with resume_reason
+    "restart_interrupted" when the previous gateway exit was not clean
+    (crash/SIGKILL/OOM).  These should get the same magic continuation as
+    drain-timeout interruptions.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="crash-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:crash-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_interrupted",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_skips_stale_entries():
+    """Entries older than the freshness window must not be auto-resumed."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="stale-chat")
+    stale_marker = datetime.now() - timedelta(
+        seconds=_auto_continue_freshness_window() + 60
+    )
+    stale_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:stale-chat",
+        session_id="sid",
+        created_at=stale_marker,
+        updated_at=stale_marker,
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=stale_marker,
+    )
+    runner.session_store._entries = {stale_entry.session_key: stale_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_skips_suspended_and_originless():
+    """suspended entries and entries with no origin are excluded."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="ok")
+    suspended_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:suspended",
+        session_id="sid-s",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        suspended=True,
+        last_resume_marked_at=datetime.now(),
+    )
+    originless = SessionEntry(
+        session_key="agent:main:telegram:dm:originless",
+        session_id="sid-o",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=None,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {
+        suspended_entry.session_key: suspended_entry,
+        originless.session_key: originless,
+    }
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_skips_disallowed_reasons():
+    """Reasons outside the auto-resume set (e.g. a future custom reason) are skipped.
+
+    These sessions still auto-resume on the next real user message via the
+    existing _is_resume_pending branch — we just don't synthesize a turn
+    for them at startup.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="other")
+    other_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:other",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="manual_resume_request",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {other_entry.session_key: other_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -614,6 +1261,118 @@ async def test_startup_auto_resume_skips_unauthorized_owner():
     # No slot was claimed and nothing was persisted for the skipped session.
     assert pending_entry.session_key not in runner._running_agents
     runner._persist_active_agents.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_fails_closed_on_auth_error():
+    """If the authorization check itself raises, the session is skipped
+    (fail-closed) rather than resumed — a broken auth check must never
+    default to granting a full agent turn.
+    """
+    runner, adapter = make_restart_runner()
+
+    def _boom(_source):
+        raise RuntimeError("allowlist backend down")
+
+    runner._is_user_authorized = _boom
+    runner._persist_active_agents = MagicMock()
+    source = make_restart_source(chat_id="err-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:err-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    assert pending_entry.session_key not in runner._running_agents
+    runner._persist_active_agents.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_skips_when_adapter_unavailable():
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:resume-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    runner.adapters = {}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_reschedules_pending_after_late_platform_connect():
+    """A platform offline at startup gets its pending sessions auto-resumed
+    once it reconnects.
+
+    Regression: the startup pass skips sessions whose adapter isn't connected
+    yet (see test_startup_auto_resume_skips_when_adapter_unavailable). Before
+    the fix those sessions were never rescheduled and recovered only if the
+    user sent a fresh message — the documented startup auto-resume silently
+    dropped. The reconnect watcher now retries the platform-scoped pass.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="late-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:late-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_interrupted",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    # Platform was not connected at gateway startup → session skipped.
+    runner.adapters = {}
+    assert runner._schedule_resume_pending_sessions() == 0
+    adapter.handle_message.assert_not_called()
+
+    # Platform reconnects → its pending session is retried.
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    scheduled = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert isinstance(event, MessageEvent)
+    assert event.internal is True
+    assert event.message_type == MessageType.TEXT
+    assert event.text == ""
+    assert event.source == source
 
 
 @pytest.mark.asyncio
@@ -665,6 +1424,54 @@ async def test_reconnect_reschedule_is_platform_scoped():
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.source == tg_source
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_skips_sessions_with_running_agent():
+    """A session already being resumed (agent in-flight) is not scheduled
+    again — guards against a double resume when a platform reconnects while a
+    startup-scheduled resume is still running."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="inflight-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:inflight-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_interrupted",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    runner._running_agents = {pending_entry.session_key: object()}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_restore_gate_queues_real_inbound_messages():
+    """Real inbound messages wait while startup restore is in progress."""
+    runner, _adapter = make_restart_runner()
+    runner._startup_restore_in_progress = True
+    runner._startup_restore_queue = []
+
+    inbound = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="restore-chat"),
+    )
+
+    result = await runner._handle_message(inbound)
+
+    assert result is None
+    assert runner._startup_restore_queue == [inbound]
 
 
 @pytest.mark.asyncio
@@ -734,6 +1541,23 @@ async def test_startup_restore_waits_for_resume_before_draining_inbound():
 
 
 @pytest.mark.asyncio
+async def test_restart_banner_uses_try_to_resume_wording():
+    """The notification sent before drain should hedge the resume promise
+    — the session-continuity fix is best-effort (stuck-loop counter can
+    still escalate to suspended)."""
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner._running_agents["agent:main:telegram:dm:999"] = MagicMock()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert len(adapter.sent) == 1
+    msg = adapter.sent[0]
+    assert "restarting" in msg
+    assert "try to resume" in msg
+
+
+@pytest.mark.asyncio
 async def test_restart_notifies_home_channel_even_without_active_sessions():
     runner, adapter = make_restart_runner()
     runner._restart_requested = True
@@ -749,6 +1573,22 @@ async def test_restart_notifies_home_channel_even_without_active_sessions():
         "⚠️ Gateway restarting — Your current task will be interrupted. "
         "Send any message after restart and I'll try to resume where you left off."
     ]
+
+
+@pytest.mark.asyncio
+async def test_restart_home_channel_notification_dedupes_active_chat():
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner._running_agents["agent:main:telegram:dm:999"] = MagicMock()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="999",
+        name="Ops Home",
+    )
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert len(adapter.sent) == 1
 
 
 @pytest.mark.asyncio
@@ -777,6 +1617,22 @@ async def test_restart_home_channel_notification_not_deduped_across_threads():
     assert len(adapter.sent) == 2
     assert adapter.sent_calls[0][2] == {"thread_id": "topic-7"}
     assert adapter.sent_calls[1][2] is None
+
+
+@pytest.mark.asyncio
+async def test_restart_home_channel_notification_ignores_false_send_result():
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=False, error="network down"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -822,6 +1678,95 @@ class TestStuckLoopEscalation:
         second = store.get_or_create_session(source)
         assert second.session_id != entry.session_id
         assert second.auto_reset_reason == "suspended"
+
+    def test_successful_turn_flow_clears_both_counter_and_resume_pending(
+        self, tmp_path, monkeypatch
+    ):
+        """The gateway's post-turn cleanup should clear both signals so a
+        future restart-interrupt starts with a fresh counter."""
+        import json
+
+        from gateway.run import GatewayRunner
+
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store.mark_resume_pending(entry.session_key, reason="restart_timeout")
+
+        counts_file = tmp_path / ".restart_failure_counts"
+        counts_file.write_text(json.dumps({entry.session_key: 2}))
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        runner = object.__new__(GatewayRunner)
+        runner.session_store = store
+
+        GatewayRunner._clear_restart_failure_count(runner, entry.session_key)
+        store.clear_resume_pending(entry.session_key)
+
+        assert store._entries[entry.session_key].resume_pending is False
+        assert not counts_file.exists()
+
+    def test_increment_restart_failure_counts_uses_atomic_json_write(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.run import GatewayRunner
+
+        source = _make_source()
+        session_key = _make_store(tmp_path).get_or_create_session(source).session_key
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        calls = []
+
+        def _fake_atomic_json_write(path, payload, **kwargs):
+            calls.append((path, payload, kwargs))
+
+        monkeypatch.setattr("gateway.run.atomic_json_write", _fake_atomic_json_write)
+
+        runner = object.__new__(GatewayRunner)
+        runner._increment_restart_failure_counts({session_key})
+
+        assert calls == [
+            (
+                tmp_path / ".restart_failure_counts",
+                {session_key: 1},
+                {"indent": None},
+            )
+        ]
+
+    def test_clear_restart_failure_count_uses_atomic_json_write_when_entries_remain(
+        self, tmp_path, monkeypatch
+    ):
+        import json
+
+        from gateway.run import GatewayRunner
+
+        source = _make_source()
+        session_key = _make_store(tmp_path).get_or_create_session(source).session_key
+        other_key = "agent:main:telegram:dm:other"
+        counts_file = tmp_path / ".restart_failure_counts"
+        counts_file.write_text(
+            json.dumps({session_key: 2, other_key: 1}),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        calls = []
+
+        def _fake_atomic_json_write(path, payload, **kwargs):
+            calls.append((path, payload, kwargs))
+
+        monkeypatch.setattr("gateway.run.atomic_json_write", _fake_atomic_json_write)
+
+        runner = object.__new__(GatewayRunner)
+        runner._clear_restart_failure_count(session_key)
+
+        assert calls == [
+            (
+                tmp_path / ".restart_failure_counts",
+                {other_key: 1},
+                {"indent": None},
+            )
+        ]
 
 
 @pytest.mark.asyncio
@@ -872,6 +1817,45 @@ async def test_auto_resume_sets_sentinel_before_task_execution():
     await asyncio.sleep(0.05)
 
     # After the task completes, the sentinel should be cleaned up.
+    assert pending_entry.session_key not in runner._running_agents
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_sentinel_cleaned_on_task_failure():
+    """If handle_message raises before _process_message_background, the
+    sentinel must still be released so the session is not locked forever.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="fail-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:fail-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_interrupted",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+
+    async def _failing_handle(event):
+        raise RuntimeError("adapter exploded")
+
+    adapter.handle_message = _failing_handle
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    assert scheduled == 1
+
+    # Sentinel is set immediately.
+    assert pending_entry.session_key in runner._running_agents
+
+    # Let the task run and fail.
+    await asyncio.sleep(0.05)
+
+    # The sentinel must be cleaned up despite the failure.
     assert pending_entry.session_key not in runner._running_agents
 
 
@@ -974,69 +1958,3 @@ async def test_auto_resume_runs_agent_exactly_once_through_full_path():
     # No leaked sentinel and no orphaned queued event.
     assert session_key not in runner._running_agents
     assert session_key not in getattr(adapter, "_pending_messages", {})
-
-
-# ---------------------------------------------------------------------------
-# Startup-restore inbound gate must be BOUNDED
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_startup_restore_gate_releases_when_resume_turn_outlives_timeout(
-    monkeypatch,
-):
-    """A single slow boot-resume turn must not hold the inbound gate shut.
-
-    While ``_startup_restore_in_progress`` is set, every inbound message is
-    QUEUED instead of answered.  The gate is opened by
-    ``_finish_startup_restore``, which waits on the synthetic boot
-    auto-resume turns.  Without a bound, one pathologically long resumed
-    turn holds the gate — and therefore every channel's inbound queue —
-    for the entire duration of that turn.
-    """
-    monkeypatch.setenv("HERMES_STARTUP_RESTORE_DRAIN_TIMEOUT", "0.05")
-
-    runner, adapter = make_restart_runner()
-    runner._startup_restore_in_progress = True
-    runner._startup_restore_queue = []
-    runner._background_tasks = set()
-
-    seen: list[str] = []
-    never_finishes = asyncio.Event()
-
-    async def slow_resume_turn() -> None:
-        await never_finishes.wait()
-
-    async def fake_handle_message(event: MessageEvent) -> None:
-        seen.append(f"inbound:{event.text}")
-
-    adapter.handle_message = fake_handle_message
-
-    slow_task = asyncio.create_task(slow_resume_turn())
-    runner._startup_restore_tasks = [slow_task]
-
-    inbound = MessageEvent(
-        text="hello",
-        message_type=MessageType.TEXT,
-        source=make_restart_source(chat_id="restore-chat"),
-    )
-    assert await runner._handle_message(inbound) is None
-    assert runner._startup_restore_queue == [inbound]
-
-    # The gate must release on the bound even though the resume turn is
-    # still running.
-    await asyncio.wait_for(runner._finish_startup_restore(), timeout=5)
-
-    assert seen == ["inbound:hello"], (
-        "startup-restore gate never released: queued inbound was not drained "
-        "while a slow boot-resume turn was still running"
-    )
-    assert runner._startup_restore_queue == []
-    assert runner._startup_restore_in_progress is False
-    # The slow turn is NOT cancelled — it finishes in the background.
-    assert not slow_task.done()
-
-    never_finishes.set()
-    await slow_task
-
-

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1851,7 +1851,7 @@ class TestStuckLoopEscalation:
         def _fake_atomic_json_write(path, payload, **kwargs):
             calls.append((path, payload, kwargs))
 
-        monkeypatch.setattr("gateway.run.atomic_json_write", _fake_atomic_json_write)
+        monkeypatch.setattr("utils.atomic_json_write", _fake_atomic_json_write)
 
         runner = object.__new__(GatewayRunner)
         runner._increment_restart_failure_counts({session_key})
@@ -1887,7 +1887,7 @@ class TestStuckLoopEscalation:
         def _fake_atomic_json_write(path, payload, **kwargs):
             calls.append((path, payload, kwargs))
 
-        monkeypatch.setattr("gateway.run.atomic_json_write", _fake_atomic_json_write)
+        monkeypatch.setattr("utils.atomic_json_write", _fake_atomic_json_write)
 
         runner = object.__new__(GatewayRunner)
         await runner._clear_restart_failure_count(session_key)

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1116,7 +1116,7 @@ async def test_startup_auto_resume_schedules_fresh_pending_sessions():
 
     assert scheduled == 1
     handle_message_mock.assert_awaited_once()
-    event = handle_message_mock.await_args.args[0]
+    event = handle_message_mock.await_args.args[0]  # type: ignore[union-attr]
     assert isinstance(event, MessageEvent)
     assert event.internal is True
     assert event.message_type == MessageType.TEXT
@@ -1416,7 +1416,7 @@ async def test_reconnect_reschedules_pending_after_late_platform_connect():
 
     assert scheduled == 1
     handle_message_mock.assert_awaited_once()
-    event = handle_message_mock.await_args.args[0]
+    event = handle_message_mock.await_args.args[0]  # type: ignore[union-attr]
     assert isinstance(event, MessageEvent)
     assert event.internal is True
     assert event.message_type == MessageType.TEXT
@@ -1472,7 +1472,7 @@ async def test_reconnect_reschedule_is_platform_scoped():
     # own reconnect.
     assert scheduled == 1
     handle_message_mock.assert_awaited_once()
-    event = handle_message_mock.await_args.args[0]
+    event = handle_message_mock.await_args.args[0]  # type: ignore[union-attr]
     assert event.source == tg_source
 
 

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -198,6 +198,54 @@ class TestSessionEntryResumeFields:
         assert entry.resume_reason is None
         assert entry.last_resume_marked_at is None
 
+    def test_roundtrip_with_resume_fields(self):
+        now = datetime(2026, 4, 18, 12, 0, 0)
+        entry = SessionEntry(
+            session_key="agent:main:telegram:dm:1",
+            session_id="sid",
+            created_at=now,
+            updated_at=now,
+            resume_pending=True,
+            resume_reason="restart_timeout",
+            last_resume_marked_at=now,
+        )
+        restored = SessionEntry.from_dict(entry.to_dict())
+        assert restored.resume_pending is True
+        assert restored.resume_reason == "restart_timeout"
+        assert restored.last_resume_marked_at == now
+
+    def test_from_dict_legacy_without_resume_fields(self):
+        """Old sessions.json without the new fields deserialize cleanly."""
+        now = datetime.now()
+        legacy = {
+            "session_key": "agent:main:telegram:dm:1",
+            "session_id": "sid",
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+            "chat_type": "dm",
+        }
+        restored = SessionEntry.from_dict(legacy)
+        assert restored.resume_pending is False
+        assert restored.resume_reason is None
+        assert restored.last_resume_marked_at is None
+
+    def test_malformed_timestamp_is_tolerated(self):
+        now = datetime.now()
+        data = {
+            "session_key": "k",
+            "session_id": "sid",
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+            "resume_pending": True,
+            "resume_reason": "restart_timeout",
+            "last_resume_marked_at": "not-a-timestamp",
+        }
+        restored = SessionEntry.from_dict(data)
+        # resume_pending still honoured, only the broken timestamp drops
+        assert restored.resume_pending is True
+        assert restored.resume_reason == "restart_timeout"
+        assert restored.last_resume_marked_at is None
+
 
 # ---------------------------------------------------------------------------
 # SessionStore.mark_resume_pending / clear_resume_pending
@@ -224,8 +272,48 @@ class TestMarkResumePending:
         store.mark_resume_pending(entry.session_key, reason="shutdown_timeout")
         assert store._entries[entry.session_key].resume_reason == "shutdown_timeout"
 
+    def test_returns_false_for_unknown_key(self, tmp_path):
+        store = _make_store(tmp_path)
+        assert store.mark_resume_pending("no-such-key") is False
+
+    def test_does_not_override_suspended(self, tmp_path):
+        """suspended wins — mark_resume_pending is a no-op on a suspended entry."""
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store.suspend_session(entry.session_key)
+
+        assert store.mark_resume_pending(entry.session_key) is False
+        e = store._entries[entry.session_key]
+        assert e.suspended is True
+        assert e.resume_pending is False
+
+    def test_survives_roundtrip_through_json(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store.mark_resume_pending(entry.session_key, reason="restart_timeout")
+
+        # Reload from disk
+        store2 = _make_store(tmp_path)
+        store2._ensure_loaded()
+        reloaded = store2._entries[entry.session_key]
+        assert reloaded.resume_pending is True
+        assert reloaded.resume_reason == "restart_timeout"
+
 
 class TestClearResumePending:
+    def test_clears_flag(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store.mark_resume_pending(entry.session_key)
+
+        assert store.clear_resume_pending(entry.session_key) is True
+        e = store._entries[entry.session_key]
+        assert e.resume_pending is False
+        assert e.resume_reason is None
+        assert e.last_resume_marked_at is None
 
     def test_returns_false_when_not_pending(self, tmp_path):
         store = _make_store(tmp_path)
@@ -234,6 +322,10 @@ class TestClearResumePending:
         # Not marked
         assert store.clear_resume_pending(entry.session_key) is False
 
+    def test_returns_false_for_unknown_key(self, tmp_path):
+        store = _make_store(tmp_path)
+        assert store.clear_resume_pending("no-such-key") is False
+
 
 # ---------------------------------------------------------------------------
 # SessionStore.get_or_create_session resume_pending behaviour
@@ -241,6 +333,20 @@ class TestClearResumePending:
 
 
 class TestGetOrCreateResumePending:
+    def test_resume_pending_preserves_session_id(self, tmp_path):
+        """This is THE core behavioural fix — resume_pending ≠ new session."""
+        store = _make_store(tmp_path)
+        source = _make_source()
+        first = store.get_or_create_session(source)
+        original_sid = first.session_id
+        store.mark_resume_pending(first.session_key)
+
+        second = store.get_or_create_session(source)
+        assert second.session_id == original_sid
+        assert second.was_auto_reset is False
+        assert second.auto_reset_reason is None
+        # Flag is NOT cleared on read — only on successful turn completion.
+        assert second.resume_pending is True
 
     def test_resume_pending_follows_compression_tip(self, tmp_path):
         """Interrupted platform mappings must not stay pinned to compressed roots."""
@@ -263,6 +369,42 @@ class TestGetOrCreateResumePending:
         assert second.resume_pending is True
         mock_tip.assert_called_with(original_sid)
 
+    def test_suspended_still_creates_new_session(self, tmp_path):
+        """Regression guard — suspended must still force a clean slate."""
+        store = _make_store(tmp_path)
+        source = _make_source()
+        first = store.get_or_create_session(source)
+        original_sid = first.session_id
+        store.suspend_session(first.session_key)
+
+        second = store.get_or_create_session(source)
+        assert second.session_id != original_sid
+        assert second.was_auto_reset is True
+        assert second.auto_reset_reason == "suspended"
+
+    def test_suspended_overrides_resume_pending(self, tmp_path):
+        """Terminal escalation: a session that somehow has BOTH flags must
+        behave like ``suspended`` — forced wipe + auto_reset_reason."""
+        store = _make_store(tmp_path)
+        source = _make_source()
+        first = store.get_or_create_session(source)
+        original_sid = first.session_id
+
+        # Force the pathological state directly (normally mark_resume_pending
+        # refuses to run when suspended=True, but a stuck-loop escalation
+        # can set suspended=True AFTER resume_pending is set).
+        with store._lock:
+            e = store._entries[first.session_key]
+            e.resume_pending = True
+            e.resume_reason = "restart_timeout"
+            e.suspended = True
+            store._save()
+
+        second = store.get_or_create_session(source)
+        assert second.session_id != original_sid
+        assert second.was_auto_reset is True
+        assert second.auto_reset_reason == "suspended"
+
 
 # ---------------------------------------------------------------------------
 # SessionStore.suspend_recently_active skip behaviour
@@ -281,6 +423,22 @@ class TestSuspendRecentlyActiveSkipsResumePending:
         e = store._entries[entry.session_key]
         assert e.suspended is False
         assert e.resume_pending is True
+
+    def test_non_resume_pending_gets_resume_pending(self, tmp_path):
+        """Non-resume sessions are now marked resume_pending (not suspended)."""
+        store = _make_store(tmp_path)
+        source_a = _make_source(chat_id="a")
+        source_b = _make_source(chat_id="b")
+        entry_a = store.get_or_create_session(source_a)
+        entry_b = store.get_or_create_session(source_b)
+        store.mark_resume_pending(entry_a.session_key)
+
+        count = store.suspend_recently_active()
+        # entry_a is already resume_pending → skipped. entry_b gets marked.
+        assert count == 1
+        assert store._entries[entry_a.session_key].suspended is False
+        assert store._entries[entry_b.session_key].resume_pending is True
+        assert store._entries[entry_b.session_key].suspended is False
 
 
 # ---------------------------------------------------------------------------
@@ -301,6 +459,39 @@ class TestResumePendingSystemNote:
             last_resume_marked_at=now,
         )
 
+    def test_resume_pending_restart_note_mentions_restart(self):
+        entry = self._pending_entry(reason="restart_timeout")
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "in progress", "timestamp": time.time()},
+            ],
+            user_message="what happened?",
+            resume_entry=entry,
+        )
+        assert "[System note:" in result
+        assert "gateway restart" in result
+        assert "NEW message" in result
+        assert "Do NOT re-execute" in result
+        assert "what happened?" in result
+
+    def test_resume_pending_shutdown_note_mentions_shutdown(self):
+        entry = self._pending_entry(reason="shutdown_timeout")
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "in progress", "timestamp": time.time()},
+            ],
+            user_message="ping",
+            resume_entry=entry,
+        )
+        assert "gateway shutdown" in result
+
+    def test_empty_message_interactive_note_asks_what_next(self):
+        """Interactive platforms: the startup auto-resume turn reports the
+        restore and asks the (present) human what to do next."""
+        note = build_resume_recovery_note("restart_timeout", "", interactive=True)
+        assert "session was restored" in note
+        assert "ask what they would like to do next" in note
+        assert "skip any unfinished work" in note
 
     def test_empty_message_noninteractive_note_continues_task(self):
         """Non-interactive platforms (webhook, API server): nobody can answer
@@ -315,6 +506,33 @@ class TestResumePendingSystemNote:
         # But still guards against re-running already-recorded tool calls.
         assert "already appear in the history" in note
 
+    def test_orphaned_tool_call_interactive_note_avoids_restart_claim(self):
+        note = build_resume_recovery_note(
+            "orphaned_tool_call", "", interactive=True
+        )
+        assert "tool call that was never completed" in note
+        assert "automatically recovered" in note
+        assert "ask what they would like to do next" in note
+        assert "gateway restart" not in note
+        assert "back online" not in note
+
+    def test_orphaned_tool_call_noninteractive_note_continues_task(self):
+        note = build_resume_recovery_note(
+            "orphaned_tool_call", "", interactive=False
+        )
+        assert "tool call that was never completed" in note
+        assert "CONTINUE the interrupted task" in note
+        assert "session was restored successfully" not in note
+        assert "ask what they would like to do next" not in note
+        assert "gateway restart" not in note
+        assert "back online" not in note
+
+    def test_new_message_guidance_identical_regardless_of_interactivity(self):
+        """A real NEW user message always wins — same guidance either way."""
+        a = build_resume_recovery_note("restart_timeout", "do the thing", interactive=True)
+        b = build_resume_recovery_note("restart_timeout", "do the thing", interactive=False)
+        assert a == b
+        assert "NEW message" in a
 
     def test_resume_note_is_persisted_instead_of_original_empty_message(self):
         """The auto-resume note must not leave an empty row in state.db."""
@@ -365,6 +583,22 @@ class TestResumePendingSystemNote:
         assert "gateway restart" in result
         assert "NEW message" in result
 
+    def test_resume_pending_subsumes_tool_tail_note(self):
+        """When BOTH conditions are true, the restart-resume note wins —
+        no duplicate notes."""
+        entry = self._pending_entry()
+        history = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
+            ], "timestamp": time.time() - 1},
+            {"role": "tool", "tool_call_id": "c1", "content": "result",
+             "timestamp": time.time()},
+        ]
+        result = _simulate_note_injection(history, "ping", resume_entry=entry)
+        assert result.count("[System note:") == 1
+        assert "gateway restart" in result
+        # Old tool-tail wording absent
+        assert "haven't responded to yet" not in result
 
     def test_no_resume_pending_preserves_tool_tail_note(self):
         """Regression: the old PR #9934 tool-tail behaviour is unchanged."""
@@ -402,6 +636,87 @@ class TestResumePendingSystemNote:
         )
         assert result == "start a new task"
 
+    def test_fresh_resume_mark_fires_despite_stale_transcript(self):
+        """Regression: the recovery note must fire when the restart
+        watchdog just stamped the session, even if the last persisted
+        transcript row is far older than the freshness window.
+
+        This is the exact gap that produced the blank-turn symptom: an
+        active thread returned to after >1h of silence has a stale
+        transcript clock, but the interruption itself (last_resume_marked_at)
+        is seconds old. The two freshness signals must agree.
+        """
+        entry = self._pending_entry()
+        entry.last_resume_marked_at = datetime.now()  # interrupted just now
+
+        history = [
+            {"role": "assistant", "content": "older context",
+             "timestamp": time.time() - 3600},  # transcript clock stale
+        ]
+        result = _simulate_note_injection(
+            history=history,
+            user_message="continue",
+            resume_entry=entry,
+            window_secs=1800,
+        )
+        assert "[System note:" in result
+        assert "gateway restart" in result
+
+    def test_empty_resume_turn_never_reaches_model_blank(self):
+        """Regression: a blank auto-resume turn on a resume_pending
+        session must be backfilled with a recovery note, never sent empty.
+
+        _schedule_resume_pending_sessions dispatches an empty-text internal
+        event. If the resume_pending branch did not fire, the safety net
+        must still produce non-blank text so the model does not reply with
+        confused 'the message came through blank' noise.
+        """
+        entry = self._pending_entry()
+        # Force the resume_pending branch to miss by making BOTH signals stale,
+        # so only the empty-turn safety net can save us.
+        entry.last_resume_marked_at = datetime.now() - timedelta(hours=2)
+        history = [
+            {"role": "assistant", "content": "old", "timestamp": time.time() - 7200},
+        ]
+        result = _simulate_note_injection(
+            history=history,
+            user_message="",  # the empty auto-resume event text
+            resume_entry=entry,
+            window_secs=1800,
+        )
+        assert result.strip(), "blank turn must never reach the model"
+        assert "[System note:" in result
+
+    def test_empty_turn_guard_only_applies_to_resume_pending(self):
+        """The empty-turn backfill must NOT fire for ordinary sessions —
+        a legitimately empty user turn (e.g. an uncaptioned image) on a
+        non-resume_pending session is left untouched.
+        """
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "hi", "timestamp": time.time()},
+            ],
+            user_message="",
+            resume_entry=None,
+        )
+        assert result == ""
+
+    def test_fresh_tool_tail_preserves_auto_continue_note(self):
+        history = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
+            ], "timestamp": time.time() - 1},
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": "result",
+                "timestamp": time.time(),
+            },
+        ]
+        result = _simulate_note_injection(history, "ping", resume_entry=None)
+        assert "[System note:" in result
+        assert "pending tool outputs" in result
+        assert "Do NOT re-execute" in result
 
     def test_stale_tool_tail_does_not_inject_auto_continue_note(self):
         """The core bug fix: stale tool-tail must not revive a dead task.
@@ -509,6 +824,55 @@ class TestResumePendingSystemNote:
         assert "pending tool outputs" in result
         assert "Do NOT re-execute" in result
 
+    def test_no_note_when_nothing_to_resume(self):
+        history = [
+            {"role": "user", "content": "hello", "timestamp": time.time() - 2},
+            {"role": "assistant", "content": "hi", "timestamp": time.time() - 1},
+        ]
+        result = _simulate_note_injection(history, "ping", resume_entry=None)
+        assert result == "ping"
+
+    def test_resume_pending_note_warns_against_reexecuting_restart(self):
+        """The resume-pending note tells the model any restart/shutdown
+        command in the history already ran and must not be re-executed or
+        verified — the cognitive backstop to the source-level tail strip.
+        """
+        entry = self._pending_entry(reason="restart_timeout")
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "in progress", "timestamp": time.time()},
+            ],
+            user_message="restarted!",
+            resume_entry=entry,
+        )
+        assert "[System note:" in result
+        assert "back online" in result
+        assert "already" in result and "do NOT re-execute or verify" in result
+        assert "restarted!" in result
+
+    def test_resume_pending_empty_message_reports_recovery(self):
+        """On the empty-message auto-resume startup turn there is no NEW user
+        message, so the note instructs the model to report recovery and ask
+        for instructions rather than 'address the user's NEW message'.
+        """
+        entry = self._pending_entry(reason="restart_timeout")
+        result = _simulate_note_injection(
+            history=[
+                {"role": "assistant", "content": "in progress", "timestamp": time.time()},
+            ],
+            user_message="",
+            resume_entry=entry,
+        )
+        assert "[System note:" in result
+        assert "gateway restart" in result
+        assert "restored successfully" in result
+        assert "ask what they would like to do next" in result
+        assert "do NOT re-execute or verify" in result
+        # No phantom "NEW message" instruction when there is no new message.
+        assert "NEW message" not in result
+        # Nothing appended after the closing bracket (no empty user text).
+        assert result.rstrip().endswith("]")
+
 
 # ---------------------------------------------------------------------------
 # Freshness helpers
@@ -516,13 +880,30 @@ class TestResumePendingSystemNote:
 
 
 class TestFreshnessHelpers:
+    def test_coerce_datetime(self):
+        now = datetime.now()
+        assert _coerce_gateway_timestamp(now) == pytest.approx(now.timestamp(), abs=1e-3)
 
+    def test_coerce_epoch_seconds(self):
+        assert _coerce_gateway_timestamp(1_700_000_000) == 1_700_000_000.0
+        assert _coerce_gateway_timestamp(1_700_000_000.5) == 1_700_000_000.5
+
+    def test_coerce_epoch_milliseconds(self):
+        # Values > 10^10 treated as ms
+        assert _coerce_gateway_timestamp(1_700_000_000_000) == 1_700_000_000.0
 
     def test_coerce_iso_string(self):
         iso = "2026-04-18T12:00:00+00:00"
         expected = datetime.fromisoformat(iso).timestamp()
         assert _coerce_gateway_timestamp(iso) == pytest.approx(expected, abs=1e-3)
 
+    def test_coerce_iso_string_with_z_suffix(self):
+        iso_z = "2026-04-18T12:00:00Z"
+        expected = datetime.fromisoformat("2026-04-18T12:00:00+00:00").timestamp()
+        assert _coerce_gateway_timestamp(iso_z) == pytest.approx(expected, abs=1e-3)
+
+    def test_coerce_numeric_string(self):
+        assert _coerce_gateway_timestamp("1700000000") == 1_700_000_000.0
 
     def test_coerce_rejects_garbage(self):
         assert _coerce_gateway_timestamp(None) is None
@@ -532,6 +913,10 @@ class TestFreshnessHelpers:
         assert _coerce_gateway_timestamp(False) is None
         assert _coerce_gateway_timestamp([1, 2, 3]) is None
 
+    def test_is_fresh_unknown_is_fresh(self):
+        """Legacy-compat: unknown timestamp → fresh."""
+        assert _is_fresh_gateway_interruption(None) is True
+        assert _is_fresh_gateway_interruption("not-a-timestamp") is True
 
     def test_is_fresh_window_bounds(self):
         now = 1_700_000_000.0
@@ -548,6 +933,14 @@ class TestFreshnessHelpers:
             now - 3600, now=now, window_secs=3600,
         ) is True
 
+    def test_is_fresh_zero_window_always_fresh(self):
+        """Opt-out: window_secs=0 disables the gate entirely."""
+        assert _is_fresh_gateway_interruption(
+            0.0, now=1_700_000_000.0, window_secs=0,
+        ) is True
+        assert _is_fresh_gateway_interruption(
+            -1.0, now=1_700_000_000.0, window_secs=-5,
+        ) is True
 
     def test_last_transcript_timestamp_skips_meta(self):
         history = [
@@ -558,6 +951,18 @@ class TestFreshnessHelpers:
         ]
         assert _last_transcript_timestamp(history) == 200.0
 
+    def test_last_transcript_timestamp_empty(self):
+        assert _last_transcript_timestamp([]) is None
+        assert _last_transcript_timestamp(None) is None
+
+    def test_last_transcript_timestamp_row_without_timestamp(self):
+        """Legacy transcript row (no timestamp) returns None → caller
+        treats as fresh."""
+        history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hey"},
+        ]
+        assert _last_transcript_timestamp(history) is None
 
     def test_auto_continue_freshness_window_reads_env(self, monkeypatch):
         monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "7200")
@@ -566,6 +971,14 @@ class TestFreshnessHelpers:
     def test_auto_continue_freshness_window_default_when_unset(self, monkeypatch):
         monkeypatch.delenv("HERMES_AUTO_CONTINUE_FRESHNESS", raising=False)
         # Default is 1 hour
+        assert _auto_continue_freshness_window() == 3600.0
+
+    def test_auto_continue_freshness_window_malformed_falls_back(self, monkeypatch):
+        monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "not-a-number")
+        assert _auto_continue_freshness_window() == 3600.0
+
+    def test_auto_continue_freshness_window_empty_falls_back(self, monkeypatch):
+        monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "")
         assert _auto_continue_freshness_window() == 3600.0
 
 
@@ -609,9 +1022,243 @@ async def test_drain_timeout_marks_resume_pending():
         assert args[0][1] == "shutdown_timeout"
 
 
+@pytest.mark.asyncio
+async def test_drain_timeout_uses_restart_reason_when_restarting():
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._restart_drain_timeout = 0.05
+    runner._restart_requested = True
+
+    running_agent = MagicMock()
+    runner._running_agents = {"agent:main:telegram:dm:A": running_agent}
+
+    session_store = MagicMock()
+    session_store.mark_resume_pending = MagicMock(return_value=True)
+    runner.session_store = session_store
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop(restart=True, detached_restart=False, service_restart=True)
+
+    calls = session_store.mark_resume_pending.call_args_list
+    assert calls, "expected at least one mark_resume_pending call"
+    for args in calls:
+        assert args[0][1] == "restart_timeout"
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_skips_pending_sentinel_sessions():
+    """Pending sentinels — sessions whose AIAgent construction hasn't
+    produced a real agent yet — are skipped by
+    ``_interrupt_running_agents()``.  The resume_pending marking must
+    mirror that: no agent started means no turn was interrupted.
+    """
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._restart_drain_timeout = 0.05
+
+    session_key_real = "agent:main:telegram:dm:A"
+    session_key_sentinel = "agent:main:telegram:dm:B"
+    runner._running_agents = {
+        session_key_real: MagicMock(),
+        session_key_sentinel: _AGENT_PENDING_SENTINEL,
+    }
+
+    session_store = MagicMock()
+    session_store.mark_resume_pending = MagicMock(return_value=True)
+    runner.session_store = session_store
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    calls = session_store.mark_resume_pending.call_args_list
+    marked = {args[0][0] for args in calls}
+    assert marked == {session_key_real}
+
+
 # ---------------------------------------------------------------------------
 # Gateway startup auto-resume
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_schedules_fresh_pending_sessions():
+    """Fresh resume_pending sessions should continue automatically after startup.
+
+    This closes the UX gap where restart recovery only happened if the user sent
+    another message after the gateway came back.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat", thread_id="topic-1")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:group:resume-chat:topic-1",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert isinstance(event, MessageEvent)
+    assert event.internal is True
+    assert event.message_type == MessageType.TEXT
+    assert event.source == source
+    # Text is empty — the existing _is_resume_pending branch in
+    # _handle_message_with_agent owns the system-note injection so we don't
+    # double it up.
+    assert event.text == ""
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_includes_crash_recovery():
+    """Crash-recovered sessions (reason=restart_interrupted) are also auto-resumed.
+
+    suspend_recently_active() marks in-flight sessions with resume_reason
+    "restart_interrupted" when the previous gateway exit was not clean
+    (crash/SIGKILL/OOM).  These should get the same magic continuation as
+    drain-timeout interruptions.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="crash-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:crash-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_interrupted",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_skips_stale_entries():
+    """Entries older than the freshness window must not be auto-resumed."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="stale-chat")
+    stale_marker = datetime.now() - timedelta(
+        seconds=_auto_continue_freshness_window() + 60
+    )
+    stale_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:stale-chat",
+        session_id="sid",
+        created_at=stale_marker,
+        updated_at=stale_marker,
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=stale_marker,
+    )
+    runner.session_store._entries = {stale_entry.session_key: stale_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_skips_suspended_and_originless():
+    """suspended entries and entries with no origin are excluded."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="ok")
+    suspended_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:suspended",
+        session_id="sid-s",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        suspended=True,
+        last_resume_marked_at=datetime.now(),
+    )
+    originless = SessionEntry(
+        session_key="agent:main:telegram:dm:originless",
+        session_id="sid-o",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=None,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {
+        suspended_entry.session_key: suspended_entry,
+        originless.session_key: originless,
+    }
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_skips_disallowed_reasons():
+    """Reasons outside the auto-resume set (e.g. a future custom reason) are skipped.
+
+    These sessions still auto-resume on the next real user message via the
+    existing _is_resume_pending branch — we just don't synthesize a turn
+    for them at startup.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="other")
+    other_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:other",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="manual_resume_request",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {other_entry.session_key: other_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -652,6 +1299,118 @@ async def test_startup_auto_resume_skips_unauthorized_owner():
     # No slot was claimed and nothing was persisted for the skipped session.
     assert pending_entry.session_key not in runner._running_agents
     runner._persist_active_agents.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_fails_closed_on_auth_error():
+    """If the authorization check itself raises, the session is skipped
+    (fail-closed) rather than resumed — a broken auth check must never
+    default to granting a full agent turn.
+    """
+    runner, adapter = make_restart_runner()
+
+    def _boom(_source):
+        raise RuntimeError("allowlist backend down")
+
+    runner._is_user_authorized = _boom
+    runner._persist_active_agents = MagicMock()
+    source = make_restart_source(chat_id="err-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:err-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    await asyncio.sleep(0)
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+    assert pending_entry.session_key not in runner._running_agents
+    runner._persist_active_agents.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_skips_when_adapter_unavailable():
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="resume-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:resume-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    runner.adapters = {}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_reschedules_pending_after_late_platform_connect():
+    """A platform offline at startup gets its pending sessions auto-resumed
+    once it reconnects.
+
+    Regression: the startup pass skips sessions whose adapter isn't connected
+    yet (see test_startup_auto_resume_skips_when_adapter_unavailable). Before
+    the fix those sessions were never rescheduled and recovered only if the
+    user sent a fresh message — the documented startup auto-resume silently
+    dropped. The reconnect watcher now retries the platform-scoped pass.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="late-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:late-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_interrupted",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    adapter.handle_message = AsyncMock()
+
+    # Platform was not connected at gateway startup → session skipped.
+    runner.adapters = {}
+    assert runner._schedule_resume_pending_sessions() == 0
+    adapter.handle_message.assert_not_called()
+
+    # Platform reconnects → its pending session is retried.
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    scheduled = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
+    await asyncio.sleep(0)
+
+    assert scheduled == 1
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert isinstance(event, MessageEvent)
+    assert event.internal is True
+    assert event.message_type == MessageType.TEXT
+    assert event.text == ""
+    assert event.source == source
 
 
 @pytest.mark.asyncio
@@ -703,6 +1462,54 @@ async def test_reconnect_reschedule_is_platform_scoped():
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.source == tg_source
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_skips_sessions_with_running_agent():
+    """A session already being resumed (agent in-flight) is not scheduled
+    again — guards against a double resume when a platform reconnects while a
+    startup-scheduled resume is still running."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="inflight-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:inflight-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_interrupted",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    runner._running_agents = {pending_entry.session_key: object()}
+    adapter.handle_message = AsyncMock()
+
+    scheduled = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
+
+    assert scheduled == 0
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_restore_gate_queues_real_inbound_messages():
+    """Real inbound messages wait while startup restore is in progress."""
+    runner, _adapter = make_restart_runner()
+    runner._startup_restore_in_progress = True
+    runner._startup_restore_queue = []
+
+    inbound = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="restore-chat"),
+    )
+
+    result = await runner._handle_message(inbound)
+
+    assert result is None
+    assert runner._startup_restore_queue == [inbound]
 
 
 @pytest.mark.asyncio
@@ -864,6 +1671,23 @@ async def test_warmup_disabled_by_nonpositive_timeout(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_restart_banner_uses_try_to_resume_wording():
+    """The notification sent before drain should hedge the resume promise
+    — the session-continuity fix is best-effort (stuck-loop counter can
+    still escalate to suspended)."""
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner._running_agents["agent:main:telegram:dm:999"] = MagicMock()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert len(adapter.sent) == 1
+    msg = adapter.sent[0]
+    assert "restarting" in msg
+    assert "try to resume" in msg
+
+
+@pytest.mark.asyncio
 async def test_restart_notifies_home_channel_even_without_active_sessions():
     runner, adapter = make_restart_runner()
     runner._restart_requested = True
@@ -879,6 +1703,22 @@ async def test_restart_notifies_home_channel_even_without_active_sessions():
         "⚠️ Gateway restarting — Your current task will be interrupted. "
         "Send any message after restart and I'll try to resume where you left off."
     ]
+
+
+@pytest.mark.asyncio
+async def test_restart_home_channel_notification_dedupes_active_chat():
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner._running_agents["agent:main:telegram:dm:999"] = MagicMock()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="999",
+        name="Ops Home",
+    )
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert len(adapter.sent) == 1
 
 
 @pytest.mark.asyncio
@@ -907,6 +1747,22 @@ async def test_restart_home_channel_notification_not_deduped_across_threads():
     assert len(adapter.sent) == 2
     assert adapter.sent_calls[0][2] == {"thread_id": "topic-7"}
     assert adapter.sent_calls[1][2] is None
+
+
+@pytest.mark.asyncio
+async def test_restart_home_channel_notification_ignores_false_send_result():
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=False, error="network down"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -952,6 +1808,95 @@ class TestStuckLoopEscalation:
         second = store.get_or_create_session(source)
         assert second.session_id != entry.session_id
         assert second.auto_reset_reason == "suspended"
+
+    def test_successful_turn_flow_clears_both_counter_and_resume_pending(
+        self, tmp_path, monkeypatch
+    ):
+        """The gateway's post-turn cleanup should clear both signals so a
+        future restart-interrupt starts with a fresh counter."""
+        import json
+
+        from gateway.run import GatewayRunner
+
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store.mark_resume_pending(entry.session_key, reason="restart_timeout")
+
+        counts_file = tmp_path / ".restart_failure_counts"
+        counts_file.write_text(json.dumps({entry.session_key: 2}))
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        runner = object.__new__(GatewayRunner)
+        runner.session_store = store
+
+        GatewayRunner._clear_restart_failure_count(runner, entry.session_key)
+        store.clear_resume_pending(entry.session_key)
+
+        assert store._entries[entry.session_key].resume_pending is False
+        assert not counts_file.exists()
+
+    def test_increment_restart_failure_counts_uses_atomic_json_write(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.run import GatewayRunner
+
+        source = _make_source()
+        session_key = _make_store(tmp_path).get_or_create_session(source).session_key
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        calls = []
+
+        def _fake_atomic_json_write(path, payload, **kwargs):
+            calls.append((path, payload, kwargs))
+
+        monkeypatch.setattr("gateway.run.atomic_json_write", _fake_atomic_json_write)
+
+        runner = object.__new__(GatewayRunner)
+        runner._increment_restart_failure_counts({session_key})
+
+        assert calls == [
+            (
+                tmp_path / ".restart_failure_counts",
+                {session_key: 1},
+                {"indent": None},
+            )
+        ]
+
+    def test_clear_restart_failure_count_uses_atomic_json_write_when_entries_remain(
+        self, tmp_path, monkeypatch
+    ):
+        import json
+
+        from gateway.run import GatewayRunner
+
+        source = _make_source()
+        session_key = _make_store(tmp_path).get_or_create_session(source).session_key
+        other_key = "agent:main:telegram:dm:other"
+        counts_file = tmp_path / ".restart_failure_counts"
+        counts_file.write_text(
+            json.dumps({session_key: 2, other_key: 1}),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        calls = []
+
+        def _fake_atomic_json_write(path, payload, **kwargs):
+            calls.append((path, payload, kwargs))
+
+        monkeypatch.setattr("gateway.run.atomic_json_write", _fake_atomic_json_write)
+
+        runner = object.__new__(GatewayRunner)
+        runner._clear_restart_failure_count(session_key)
+
+        assert calls == [
+            (
+                tmp_path / ".restart_failure_counts",
+                {other_key: 1},
+                {"indent": None},
+            )
+        ]
 
 
 @pytest.mark.asyncio
@@ -1002,6 +1947,45 @@ async def test_auto_resume_sets_sentinel_before_task_execution():
     await asyncio.sleep(0.05)
 
     # After the task completes, the sentinel should be cleaned up.
+    assert pending_entry.session_key not in runner._running_agents
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_sentinel_cleaned_on_task_failure():
+    """If handle_message raises before _process_message_background, the
+    sentinel must still be released so the session is not locked forever.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="fail-chat")
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:fail-chat",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_interrupted",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+
+    async def _failing_handle(event):
+        raise RuntimeError("adapter exploded")
+
+    adapter.handle_message = _failing_handle
+
+    scheduled = runner._schedule_resume_pending_sessions()
+    assert scheduled == 1
+
+    # Sentinel is set immediately.
+    assert pending_entry.session_key in runner._running_agents
+
+    # Let the task run and fail.
+    await asyncio.sleep(0.05)
+
+    # The sentinel must be cleaned up despite the failure.
     assert pending_entry.session_key not in runner._running_agents
 
 
@@ -1257,5 +2241,6 @@ async def test_startup_boot_sends_still_run_when_they_finish_quickly(monkeypatch
     runner._send_restart_notification.assert_awaited_once()
     runner._claim_pending_obligations.assert_awaited_once()
     runner._redeliver_claimed_obligations.assert_awaited_once()
+
 
 

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1809,7 +1809,8 @@ class TestStuckLoopEscalation:
         assert second.session_id != entry.session_id
         assert second.auto_reset_reason == "suspended"
 
-    def test_successful_turn_flow_clears_both_counter_and_resume_pending(
+    @pytest.mark.asyncio
+    async def test_successful_turn_flow_clears_both_counter_and_resume_pending(
         self, tmp_path, monkeypatch
     ):
         """The gateway's post-turn cleanup should clear both signals so a
@@ -1830,7 +1831,7 @@ class TestStuckLoopEscalation:
         runner = object.__new__(GatewayRunner)
         runner.session_store = store
 
-        GatewayRunner._clear_restart_failure_count(runner, entry.session_key)
+        await GatewayRunner._clear_restart_failure_count(runner, entry.session_key)
         store.clear_resume_pending(entry.session_key)
 
         assert store._entries[entry.session_key].resume_pending is False
@@ -1863,7 +1864,8 @@ class TestStuckLoopEscalation:
             )
         ]
 
-    def test_clear_restart_failure_count_uses_atomic_json_write_when_entries_remain(
+    @pytest.mark.asyncio
+    async def test_clear_restart_failure_count_uses_atomic_json_write_when_entries_remain(
         self, tmp_path, monkeypatch
     ):
         import json
@@ -1888,7 +1890,7 @@ class TestStuckLoopEscalation:
         monkeypatch.setattr("gateway.run.atomic_json_write", _fake_atomic_json_write)
 
         runner = object.__new__(GatewayRunner)
-        runner._clear_restart_failure_count(session_key)
+        await runner._clear_restart_failure_count(session_key)
 
         assert calls == [
             (

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -993,7 +993,7 @@ async def test_drain_timeout_marks_resume_pending():
     active session as resume_pending BEFORE the interrupt fires, so the
     next startup's suspend_recently_active() does not destroy them."""
     runner, adapter = make_restart_runner()
-    adapter.disconnect = AsyncMock()
+    adapter.disconnect = AsyncMock()  # type: ignore[assignment]
     runner._restart_drain_timeout = 0.05
 
     running_agent = MagicMock()
@@ -1025,7 +1025,7 @@ async def test_drain_timeout_marks_resume_pending():
 @pytest.mark.asyncio
 async def test_drain_timeout_uses_restart_reason_when_restarting():
     runner, adapter = make_restart_runner()
-    adapter.disconnect = AsyncMock()
+    adapter.disconnect = AsyncMock()  # type: ignore[assignment]
     runner._restart_drain_timeout = 0.05
     runner._restart_requested = True
 
@@ -1057,7 +1057,7 @@ async def test_drain_timeout_skips_pending_sentinel_sessions():
     from gateway.run import _AGENT_PENDING_SENTINEL
 
     runner, adapter = make_restart_runner()
-    adapter.disconnect = AsyncMock()
+    adapter.disconnect = AsyncMock()  # type: ignore[assignment]
     runner._restart_drain_timeout = 0.05
 
     session_key_real = "agent:main:telegram:dm:A"
@@ -1108,14 +1108,15 @@ async def test_startup_auto_resume_schedules_fresh_pending_sessions():
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
-    adapter.handle_message = AsyncMock()
+    handle_message_mock = AsyncMock()
+    adapter.handle_message = handle_message_mock  # type: ignore[assignment]
 
     scheduled = runner._schedule_resume_pending_sessions()
     await asyncio.sleep(0)
 
     assert scheduled == 1
-    adapter.handle_message.assert_awaited_once()
-    event = adapter.handle_message.await_args.args[0]
+    handle_message_mock.assert_awaited_once()
+    event = handle_message_mock.await_args.args[0]
     assert isinstance(event, MessageEvent)
     assert event.internal is True
     assert event.message_type == MessageType.TEXT
@@ -1150,13 +1151,14 @@ async def test_startup_auto_resume_includes_crash_recovery():
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
-    adapter.handle_message = AsyncMock()
+    handle_message_mock = AsyncMock()
+    adapter.handle_message = handle_message_mock  # type: ignore[assignment]
 
     scheduled = runner._schedule_resume_pending_sessions()
     await asyncio.sleep(0)
 
     assert scheduled == 1
-    adapter.handle_message.assert_awaited_once()
+    handle_message_mock.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1180,12 +1182,13 @@ async def test_startup_auto_resume_skips_stale_entries():
         last_resume_marked_at=stale_marker,
     )
     runner.session_store._entries = {stale_entry.session_key: stale_entry}
-    adapter.handle_message = AsyncMock()
+    handle_message_mock = AsyncMock()
+    adapter.handle_message = handle_message_mock  # type: ignore[assignment]
 
     scheduled = runner._schedule_resume_pending_sessions()
 
     assert scheduled == 0
-    adapter.handle_message.assert_not_called()
+    handle_message_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1222,12 +1225,13 @@ async def test_startup_auto_resume_skips_suspended_and_originless():
         suspended_entry.session_key: suspended_entry,
         originless.session_key: originless,
     }
-    adapter.handle_message = AsyncMock()
+    handle_message_mock = AsyncMock()
+    adapter.handle_message = handle_message_mock  # type: ignore[assignment]
 
     scheduled = runner._schedule_resume_pending_sessions()
 
     assert scheduled == 0
-    adapter.handle_message.assert_not_called()
+    handle_message_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1253,12 +1257,13 @@ async def test_startup_auto_resume_skips_disallowed_reasons():
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {other_entry.session_key: other_entry}
-    adapter.handle_message = AsyncMock()
+    handle_message_mock = AsyncMock()
+    adapter.handle_message = handle_message_mock  # type: ignore[assignment]
 
     scheduled = runner._schedule_resume_pending_sessions()
 
     assert scheduled == 0
-    adapter.handle_message.assert_not_called()
+    handle_message_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1273,8 +1278,9 @@ async def test_startup_auto_resume_skips_unauthorized_owner():
     after this gate passes.
     """
     runner, adapter = make_restart_runner()
-    runner._is_user_authorized = lambda _source: False
-    runner._persist_active_agents = MagicMock()
+    runner._is_user_authorized = lambda _source: False  # type: ignore[assignment]
+    persist_active_agents_mock = MagicMock()
+    runner._persist_active_agents = persist_active_agents_mock  # type: ignore[assignment]
     source = make_restart_source(chat_id="revoked-chat")
     pending_entry = SessionEntry(
         session_key="agent:main:telegram:dm:revoked-chat",
@@ -1289,16 +1295,17 @@ async def test_startup_auto_resume_skips_unauthorized_owner():
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
-    adapter.handle_message = AsyncMock()
+    handle_message_mock = AsyncMock()
+    adapter.handle_message = handle_message_mock  # type: ignore[assignment]
 
     scheduled = runner._schedule_resume_pending_sessions()
     await asyncio.sleep(0)
 
     assert scheduled == 0
-    adapter.handle_message.assert_not_called()
+    handle_message_mock.assert_not_called()
     # No slot was claimed and nothing was persisted for the skipped session.
     assert pending_entry.session_key not in runner._running_agents
-    runner._persist_active_agents.assert_not_called()
+    persist_active_agents_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1312,8 +1319,9 @@ async def test_startup_auto_resume_fails_closed_on_auth_error():
     def _boom(_source):
         raise RuntimeError("allowlist backend down")
 
-    runner._is_user_authorized = _boom
-    runner._persist_active_agents = MagicMock()
+    runner._is_user_authorized = _boom  # type: ignore[assignment]
+    persist_active_agents_mock = MagicMock()
+    runner._persist_active_agents = persist_active_agents_mock  # type: ignore[assignment]
     source = make_restart_source(chat_id="err-chat")
     pending_entry = SessionEntry(
         session_key="agent:main:telegram:dm:err-chat",
@@ -1328,15 +1336,16 @@ async def test_startup_auto_resume_fails_closed_on_auth_error():
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
-    adapter.handle_message = AsyncMock()
+    handle_message_mock = AsyncMock()
+    adapter.handle_message = handle_message_mock  # type: ignore[assignment]
 
     scheduled = runner._schedule_resume_pending_sessions()
     await asyncio.sleep(0)
 
     assert scheduled == 0
-    adapter.handle_message.assert_not_called()
+    handle_message_mock.assert_not_called()
     assert pending_entry.session_key not in runner._running_agents
-    runner._persist_active_agents.assert_not_called()
+    persist_active_agents_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1357,12 +1366,13 @@ async def test_startup_auto_resume_skips_when_adapter_unavailable():
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
     runner.adapters = {}
-    adapter.handle_message = AsyncMock()
+    handle_message_mock = AsyncMock()
+    adapter.handle_message = handle_message_mock  # type: ignore[assignment]
 
     scheduled = runner._schedule_resume_pending_sessions()
 
     assert scheduled == 0
-    adapter.handle_message.assert_not_called()
+    handle_message_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1391,12 +1401,13 @@ async def test_reconnect_reschedules_pending_after_late_platform_connect():
         last_resume_marked_at=datetime.now(),
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
-    adapter.handle_message = AsyncMock()
+    handle_message_mock = AsyncMock()
+    adapter.handle_message = handle_message_mock  # type: ignore[assignment]
 
     # Platform was not connected at gateway startup → session skipped.
     runner.adapters = {}
     assert runner._schedule_resume_pending_sessions() == 0
-    adapter.handle_message.assert_not_called()
+    handle_message_mock.assert_not_called()
 
     # Platform reconnects → its pending session is retried.
     runner.adapters = {Platform.TELEGRAM: adapter}
@@ -1404,8 +1415,8 @@ async def test_reconnect_reschedules_pending_after_late_platform_connect():
     await asyncio.sleep(0)
 
     assert scheduled == 1
-    adapter.handle_message.assert_awaited_once()
-    event = adapter.handle_message.await_args.args[0]
+    handle_message_mock.assert_awaited_once()
+    event = handle_message_mock.await_args.args[0]
     assert isinstance(event, MessageEvent)
     assert event.internal is True
     assert event.message_type == MessageType.TEXT
@@ -1450,7 +1461,8 @@ async def test_reconnect_reschedule_is_platform_scoped():
         tg_entry.session_key: tg_entry,
         discord_entry.session_key: discord_entry,
     }
-    adapter.handle_message = AsyncMock()
+    handle_message_mock = AsyncMock()
+    adapter.handle_message = handle_message_mock  # type: ignore[assignment]
     runner.adapters = {Platform.TELEGRAM: adapter}
 
     scheduled = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
@@ -1459,8 +1471,8 @@ async def test_reconnect_reschedule_is_platform_scoped():
     # Only the telegram session is resumed; the discord session waits for its
     # own reconnect.
     assert scheduled == 1
-    adapter.handle_message.assert_awaited_once()
-    event = adapter.handle_message.await_args.args[0]
+    handle_message_mock.assert_awaited_once()
+    event = handle_message_mock.await_args.args[0]
     assert event.source == tg_source
 
 
@@ -1485,12 +1497,13 @@ async def test_auto_resume_skips_sessions_with_running_agent():
     )
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
     runner._running_agents = {pending_entry.session_key: object()}
-    adapter.handle_message = AsyncMock()
+    handle_message_mock = AsyncMock()
+    adapter.handle_message = handle_message_mock  # type: ignore[assignment]
 
     scheduled = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
 
     assert scheduled == 0
-    adapter.handle_message.assert_not_called()
+    handle_message_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1681,8 +1694,8 @@ async def test_restart_banner_uses_try_to_resume_wording():
 
     await runner._notify_active_sessions_of_shutdown()
 
-    assert len(adapter.sent) == 1
-    msg = adapter.sent[0]
+    assert len(adapter.sent) == 1  # type: ignore[attr-defined]
+    msg = adapter.sent[0]  # type: ignore[attr-defined]
     assert "restarting" in msg
     assert "try to resume" in msg
 
@@ -1718,7 +1731,7 @@ async def test_restart_home_channel_notification_dedupes_active_chat():
 
     await runner._notify_active_sessions_of_shutdown()
 
-    assert len(adapter.sent) == 1
+    assert len(adapter.sent) == 1  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio
@@ -1758,11 +1771,12 @@ async def test_restart_home_channel_notification_ignores_false_send_result():
         chat_id="home-42",
         name="Ops Home",
     )
-    adapter.send = AsyncMock(return_value=SendResult(success=False, error="network down"))
+    send_mock = AsyncMock(return_value=SendResult(success=False, error="network down"))
+    adapter.send = send_mock  # type: ignore[assignment]
 
     await runner._notify_active_sessions_of_shutdown()
 
-    adapter.send.assert_called_once()
+    send_mock.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -1976,7 +1990,7 @@ async def test_auto_resume_sentinel_cleaned_on_task_failure():
     async def _failing_handle(event):
         raise RuntimeError("adapter exploded")
 
-    adapter.handle_message = _failing_handle
+    adapter.handle_message = _failing_handle  # type: ignore[assignment]
 
     scheduled = runner._schedule_resume_pending_sessions()
     assert scheduled == 1

--- a/tests/gateway/test_session_health_watcher.py
+++ b/tests/gateway/test_session_health_watcher.py
@@ -1,0 +1,773 @@
+"""Tests for the session-health watcher that detects and recovers wedged
+sessions (#58891).
+
+A session is **wedged** when its last persisted message is an
+``assistant(tool_calls)`` with no matching ``tool`` result and no subsequent
+``user`` message.  The gateway process is still alive (so ``resume_pending``
+was never set by the restart watchdog), yet the session is silently stuck
+because nothing triggers a new turn.
+
+The fix has three parts, each exercised here:
+
+1. ``SessionDB.has_dangling_tool_call_tail()`` — DB-level detection.
+2. ``GatewayRunner._session_health_watcher()`` — periodic background probe
+   that marks wedged sessions ``resume_pending`` with reason
+   ``"orphaned_tool_call"`` and schedules a synthetic recovery turn.
+3. The ``_is_resume_pending`` branch in ``_handle_message_with_agent`` —
+   injects a recovery note that does NOT claim a restart happened (the
+   gateway was never down).
+"""
+
+import asyncio
+import json
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import (
+    _AGENT_PENDING_SENTINEL,
+    _is_fresh_gateway_interruption,
+    _auto_continue_freshness_window,
+)
+from gateway.session import SessionEntry, SessionSource, SessionStore
+from hermes_state import SessionDB
+from tests.gateway.restart_test_helpers import (
+    make_restart_runner,
+    make_restart_source,
+)
+
+
+# ---------------------------------------------------------------------------
+# SessionDB.has_dangling_tool_call_tail — unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_db(tmp_path: Path) -> SessionDB:
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def _make_session(db: SessionDB, sid: str = "20260705_114503_d11bcb") -> str:
+    db.create_session(sid, source="telegram")
+    return sid
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = _make_db(tmp_path)
+    _make_session(d)
+    return d
+
+
+class TestHasDanglingToolCallTail:
+    """Unit tests for the DB-level wedge detection query."""
+
+    def test_query_uses_insertion_order_index(self, db):
+        columns = [
+            row[2]
+            for row in db._conn.execute(
+                "PRAGMA index_info(idx_messages_session_active_id)"
+            ).fetchall()
+        ]
+        assert columns == ["session_id", "active", "id"]
+
+        plan = db._conn.execute(
+            "EXPLAIN QUERY PLAN "
+            "SELECT role, tool_calls FROM messages "
+            "WHERE session_id = ? AND active = 1 "
+            "ORDER BY id DESC LIMIT 1",
+            ("20260705_114503_d11bcb",),
+        ).fetchall()
+        detail = " ".join(row[-1] for row in plan)
+        assert "idx_messages_session_active_id" in detail, detail
+        assert "USE TEMP B-TREE" not in detail, detail
+
+    def test_empty_session_returns_false(self, db):
+        assert db.has_dangling_tool_call_tail("20260705_114503_d11bcb") is False
+
+    def test_dangling_assistant_tool_calls_returns_true(self, db):
+        """Last message is assistant(tool_calls) with no tool result → wedged."""
+        db.append_message("20260705_114503_d11bcb", "user", "hello")
+        db.append_message(
+            "20260705_114503_d11bcb",
+            "assistant",
+            "Let me check",
+            tool_calls=[{"id": "call_abc", "function": {"name": "patch", "arguments": "{}"}}],
+        )
+        assert db.has_dangling_tool_call_tail("20260705_114503_d11bcb") is True
+
+    def test_matched_tool_result_returns_false(self, db):
+        """assistant(tool_calls) + tool result → not wedged."""
+        db.append_message("20260705_114503_d11bcb", "user", "hello")
+        db.append_message(
+            "20260705_114503_d11bcb",
+            "assistant",
+            "Let me check",
+            tool_calls=[{"id": "call_abc", "function": {"name": "patch", "arguments": "{}"}}],
+        )
+        db.append_message(
+            "20260705_114503_d11bcb",
+            "tool",
+            "patched successfully",
+            tool_call_id="call_abc",
+        )
+        assert db.has_dangling_tool_call_tail("20260705_114503_d11bcb") is False
+
+    def test_user_message_after_dangling_returns_false(self, db):
+        """User message after the dangling tool_call → not wedged (user will trigger turn)."""
+        db.append_message("20260705_114503_d11bcb", "user", "hello")
+        db.append_message(
+            "20260705_114503_d11bcb",
+            "assistant",
+            "Let me check",
+            tool_calls=[{"id": "call_abc", "function": {"name": "patch", "arguments": "{}"}}],
+        )
+        db.append_message("20260705_114503_d11bcb", "user", "any update?")
+        assert db.has_dangling_tool_call_tail("20260705_114503_d11bcb") is False
+
+    def test_assistant_without_tool_calls_returns_false(self, db):
+        """Last message is assistant without tool_calls → not wedged."""
+        db.append_message("20260705_114503_d11bcb", "user", "hello")
+        db.append_message("20260705_114503_d11bcb", "assistant", "Hi there!")
+        assert db.has_dangling_tool_call_tail("20260705_114503_d11bcb") is False
+
+    def test_tool_result_as_last_message_returns_false(self, db):
+        """Last message is a tool result → not wedged (turn completed)."""
+        db.append_message(
+            "20260705_114503_d11bcb",
+            "assistant",
+            "Checking",
+            tool_calls=[{"id": "call_abc", "function": {"name": "read_file", "arguments": "{}"}}],
+        )
+        db.append_message(
+            "20260705_114503_d11bcb",
+            "tool",
+            "file contents",
+            tool_call_id="call_abc",
+        )
+        assert db.has_dangling_tool_call_tail("20260705_114503_d11bcb") is False
+
+    def test_inactive_dangling_tail_returns_false(self, db):
+        """A soft-deleted (active=0) dangling tail must not count as wedged."""
+        db.append_message("20260705_114503_d11bcb", "user", "hello")
+        msg_id = db.append_message(
+            "20260705_114503_d11bcb",
+            "assistant",
+            "Let me check",
+            tool_calls=[{"id": "call_abc", "function": {"name": "patch", "arguments": "{}"}}],
+        )
+        # Soft-delete the dangling assistant message
+        with db._lock:
+            db._conn.execute(
+                "UPDATE messages SET active = 0 WHERE id = ?", (msg_id,)
+            )
+            db._conn.commit()
+        assert db.has_dangling_tool_call_tail("20260705_114503_d11bcb") is False
+
+    def test_nonexistent_session_returns_false(self, db):
+        assert db.has_dangling_tool_call_tail("nonexistent_session") is False
+
+    def test_multiple_tool_calls_all_unanswered_returns_true(self, db):
+        """Multiple tool_calls in one assistant message, none answered → wedged."""
+        db.append_message("20260705_114503_d11bcb", "user", "do two things")
+        db.append_message(
+            "20260705_114503_d11bcb",
+            "assistant",
+            "On it",
+            tool_calls=[
+                {"id": "call_1", "function": {"name": "read_file", "arguments": "{}"}},
+                {"id": "call_2", "function": {"name": "patch", "arguments": "{}"}},
+            ],
+        )
+        assert db.has_dangling_tool_call_tail("20260705_114503_d11bcb") is True
+
+    def test_empty_tool_calls_string_returns_false(self, db):
+        """tool_calls column is empty string (not NULL) → not dangling."""
+        db.append_message("20260705_114503_d11bcb", "user", "hello")
+        msg_id = db.append_message("20260705_114503_d11bcb", "assistant", "Hi")
+        # The append_message above stores tool_calls as NULL when not passed.
+        # Manually set it to empty string to test the edge case.
+        with db._lock:
+            db._conn.execute(
+                "UPDATE messages SET tool_calls = '' WHERE id = ?",
+                (msg_id,),
+            )
+            db._conn.commit()
+        assert db.has_dangling_tool_call_tail("20260705_114503_d11bcb") is False
+
+    def test_assistant_tool_calls_followed_by_assistant_no_tool_calls(self, db):
+        """assistant(tool_calls) → assistant(text) → not wedged (turn continued)."""
+        db.append_message(
+            "20260705_114503_d11bcb",
+            "assistant",
+            "Checking",
+            tool_calls=[{"id": "call_abc", "function": {"name": "read_file", "arguments": "{}"}}],
+        )
+        db.append_message(
+            "20260705_114503_d11bcb",
+            "tool",
+            "contents",
+            tool_call_id="call_abc",
+        )
+        db.append_message("20260705_114503_d11bcb", "assistant", "Here is the result")
+        assert db.has_dangling_tool_call_tail("20260705_114503_d11bcb") is False
+
+
+# ---------------------------------------------------------------------------
+# _session_health_watcher — integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_store(tmp_path) -> SessionStore:
+    return SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+
+def _add_wedged_session(store: SessionStore, db: SessionDB, session_key: str, sid: str):
+    """Create a session entry + DB state that simulates a wedged session."""
+    source = make_restart_source(chat_id=session_key)
+    entry = store.get_or_create_session(source)
+    entry.session_id = sid
+    store._save()
+    db.create_session(sid, source="telegram")
+    db.append_message(sid, "user", "hello")
+    db.append_message(
+        sid,
+        "assistant",
+        "Let me check",
+        tool_calls=[{"id": "call_abc", "function": {"name": "patch", "arguments": "{}"}}],
+    )
+    return entry
+
+
+class TestSessionHealthWatcher:
+    """Integration tests for the _session_health_probe (one pass of the
+    _session_health_watcher).  Tests call _session_health_probe directly to
+    avoid the 90-second initial delay and the sleep loop."""
+
+    def _setup_runner(self, tmp_path, chat_id="wedged_chat", platform=Platform.TELEGRAM):
+        runner, adapter = make_restart_runner()
+        store = _make_store(tmp_path)
+        db = _make_db(tmp_path)
+        runner.session_store = store
+        store._db = db
+        store._ensure_loaded()
+
+        source = SessionSource(
+            platform=platform,
+            chat_id=chat_id,
+            chat_type="dm",
+            user_id="u1",
+        )
+        entry = store.get_or_create_session(source)
+        entry.session_id = f"session_{chat_id}"
+        store._save()
+        return runner, adapter, store, db, source, entry
+
+    def _add_wedged_messages(self, db, sid):
+        db.create_session(sid, source="telegram")
+        db.append_message(sid, "user", "hello")
+        db.append_message(
+            sid,
+            "assistant",
+            "Let me check",
+            tool_calls=[{"id": "call_abc", "function": {"name": "patch", "arguments": "{}"}}],
+        )
+
+    @pytest.mark.asyncio
+    async def test_probe_detects_and_marks_wedged_session(self, tmp_path):
+        """A wedged session is detected, marked resume_pending, and scheduled for recovery."""
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path)
+        self._add_wedged_messages(db, entry.session_id)
+
+        resume_called = asyncio.Event()
+        resume_args = {}
+
+        async def _fake_resume(adapter_arg, event_arg, key_arg):
+            resume_args["adapter"] = adapter_arg
+            resume_args["event"] = event_arg
+            resume_args["key"] = key_arg
+            resume_called.set()
+            runner._release_running_agent_state(key_arg)
+
+        runner._run_startup_resume_event = _fake_resume
+        runner._persist_active_agents = MagicMock()
+
+        scheduled = await runner._session_health_probe()
+        # Yield control so the scheduled asyncio.create_task can run
+        await asyncio.sleep(0.1)
+
+        assert scheduled == 1
+        session_key = runner._session_key_for_source(source)
+        updated = store._entries.get(session_key)
+        assert updated.resume_pending is True
+        assert updated.resume_reason == "orphaned_tool_call"
+        assert resume_called.is_set()
+        assert resume_args["key"] == session_key
+        assert resume_args["event"].text == ""
+        assert resume_args["event"].internal is True
+
+    @pytest.mark.asyncio
+    async def test_probe_uses_async_store_before_claiming_runner_slot(self, tmp_path):
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path)
+        self._add_wedged_messages(db, entry.session_id)
+        session_key = runner._session_key_for_source(source)
+        real_facade = runner.async_session_store
+
+        async def mark_resume_pending(key, reason):
+            assert key not in runner._running_agents
+            return await real_facade.mark_resume_pending(key, reason)
+
+        facade = MagicMock()
+        facade._store = store
+        facade.list_session_items = AsyncMock(
+            side_effect=real_facade.list_session_items
+        )
+        facade.has_dangling_tool_call_tail = AsyncMock(
+            side_effect=real_facade.has_dangling_tool_call_tail
+        )
+        facade.mark_resume_pending = AsyncMock(side_effect=mark_resume_pending)
+        runner._async_session_store = facade
+        runner._persist_active_agents = MagicMock()
+
+        async def release_slot(_adapter, _event, key):
+            runner._release_running_agent_state(key)
+
+        runner._run_startup_resume_event = release_slot
+
+        assert await runner._session_health_probe() == 1
+        await asyncio.sleep(0)
+
+        facade.list_session_items.assert_awaited_once_with()
+        facade.has_dangling_tool_call_tail.assert_awaited_once_with(entry.session_id)
+        facade.mark_resume_pending.assert_awaited_once_with(
+            session_key, reason="orphaned_tool_call"
+        )
+
+    @pytest.mark.asyncio
+    async def test_probe_does_not_replace_runner_claimed_during_persistence(
+        self, tmp_path
+    ):
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path)
+        self._add_wedged_messages(db, entry.session_id)
+        session_key = runner._session_key_for_source(source)
+        active_runner = asyncio.create_task(asyncio.sleep(0))
+        real_facade = runner.async_session_store
+
+        async def mark_and_claim(key, reason):
+            marked = await real_facade.mark_resume_pending(key, reason)
+            runner._running_agents[key] = active_runner
+            return marked
+
+        facade = MagicMock()
+        facade._store = store
+        facade.list_session_items = AsyncMock(
+            side_effect=real_facade.list_session_items
+        )
+        facade.has_dangling_tool_call_tail = AsyncMock(
+            side_effect=real_facade.has_dangling_tool_call_tail
+        )
+        facade.mark_resume_pending = AsyncMock(side_effect=mark_and_claim)
+        runner._async_session_store = facade
+        runner._run_startup_resume_event = AsyncMock()
+        runner._persist_active_agents = MagicMock()
+
+        assert await runner._session_health_probe() == 0
+        assert runner._running_agents[session_key] is active_runner
+        runner._run_startup_resume_event.assert_not_awaited()
+        await active_runner
+
+    @pytest.mark.asyncio
+    async def test_probe_skips_running_sessions(self, tmp_path):
+        """A session with an active agent must not be flagged as wedged."""
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path, "active_chat")
+        self._add_wedged_messages(db, "session_active_chat")
+
+        session_key = runner._session_key_for_source(source)
+        runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+
+        resume_called = AsyncMock()
+        runner._run_startup_resume_event = resume_called
+        runner._persist_active_agents = MagicMock()
+
+        scheduled = await runner._session_health_probe()
+
+        assert scheduled == 0
+        resume_called.assert_not_called()
+        updated = store._entries.get(session_key)
+        assert updated.resume_pending is False
+
+    @pytest.mark.asyncio
+    async def test_probe_skips_suspended_sessions(self, tmp_path):
+        """A suspended session must not be flagged as wedged."""
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path, "suspended_chat")
+        entry.suspended = True
+        store._save()
+        self._add_wedged_messages(db, "session_suspended_chat")
+
+        resume_called = AsyncMock()
+        runner._run_startup_resume_event = resume_called
+        runner._persist_active_agents = MagicMock()
+
+        scheduled = await runner._session_health_probe()
+
+        assert scheduled == 0
+        resume_called.assert_not_called()
+        session_key = runner._session_key_for_source(source)
+        updated = store._entries.get(session_key)
+        assert updated.resume_pending is False
+
+    @pytest.mark.asyncio
+    async def test_probe_skips_already_resume_pending(self, tmp_path):
+        """A session already marked resume_pending must not be re-detected."""
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path, "already_pending")
+        entry.resume_pending = True
+        entry.resume_reason = "restart_timeout"
+        store._save()
+        self._add_wedged_messages(db, "session_already_pending")
+
+        resume_called = AsyncMock()
+        runner._run_startup_resume_event = resume_called
+        runner._persist_active_agents = MagicMock()
+
+        scheduled = await runner._session_health_probe()
+
+        assert scheduled == 0
+        resume_called.assert_not_called()
+        session_key = runner._session_key_for_source(source)
+        updated = store._entries.get(session_key)
+        assert updated.resume_reason == "restart_timeout"
+
+    @pytest.mark.asyncio
+    async def test_probe_skips_healthy_session(self, tmp_path):
+        """A session with a normal last message must not be flagged."""
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path, "healthy_chat")
+        db.create_session("session_healthy_chat", source="telegram")
+        db.append_message("session_healthy_chat", "user", "hello")
+        db.append_message("session_healthy_chat", "assistant", "Hi there!")
+
+        resume_called = AsyncMock()
+        runner._run_startup_resume_event = resume_called
+        runner._persist_active_agents = MagicMock()
+
+        scheduled = await runner._session_health_probe()
+
+        assert scheduled == 0
+        resume_called.assert_not_called()
+        session_key = runner._session_key_for_source(source)
+        updated = store._entries.get(session_key)
+        assert updated.resume_pending is False
+
+    @pytest.mark.asyncio
+    async def test_probe_skips_session_without_adapter(self, tmp_path):
+        """A wedged session whose adapter is unavailable is skipped."""
+        runner, adapter, store, db, source, entry = self._setup_runner(
+            tmp_path, "no_adapter_chat", platform=Platform.DISCORD
+        )
+        self._add_wedged_messages(db, "session_no_adapter_chat")
+
+        resume_called = AsyncMock()
+        runner._run_startup_resume_event = resume_called
+        runner._persist_active_agents = MagicMock()
+
+        scheduled = await runner._session_health_probe()
+
+        assert scheduled == 0
+        resume_called.assert_not_called()
+        session_key = runner._session_key_for_source(source)
+        updated = store._entries.get(session_key)
+        assert updated.resume_pending is False
+
+    @pytest.mark.asyncio
+    async def test_probe_skips_expired_sessions(self, tmp_path):
+        """An expiry-finalized session must not be flagged as wedged."""
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path, "expired_chat")
+        entry.expiry_finalized = True
+        store._save()
+        self._add_wedged_messages(db, "session_expired_chat")
+
+        resume_called = AsyncMock()
+        runner._run_startup_resume_event = resume_called
+        runner._persist_active_agents = MagicMock()
+
+        scheduled = await runner._session_health_probe()
+
+        assert scheduled == 0
+        resume_called.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_probe_returns_count_of_scheduled_recoveries(self, tmp_path):
+        """Multiple wedged sessions are all detected and scheduled in one pass."""
+        runner, adapter, store, db, _, _ = self._setup_runner(tmp_path, "chat_1")
+        runner._run_startup_resume_event = AsyncMock()
+        runner._persist_active_agents = MagicMock()
+
+        # Add three wedged sessions
+        for i, chat_id in enumerate(["chat_1", "chat_2", "chat_3"]):
+            source = make_restart_source(chat_id=chat_id)
+            entry = store.get_or_create_session(source)
+            entry.session_id = f"session_{chat_id}"
+            store._save()
+            sid = f"session_{chat_id}"
+            db.create_session(sid, source="telegram")
+            db.append_message(sid, "user", "hello")
+            db.append_message(
+                sid,
+                "assistant",
+                "Working",
+                tool_calls=[{"id": f"call_{i}", "function": {"name": "patch", "arguments": "{}"}}],
+            )
+
+        scheduled = await runner._session_health_probe()
+        assert scheduled == 3
+
+    @pytest.mark.asyncio
+    async def test_probe_recovers_shared_session_id_only_once(self, tmp_path):
+        """Routing-key aliases for one durable session must not start duplicate recoveries."""
+        runner, adapter, store, db, source, entry = self._setup_runner(
+            tmp_path, "alias_chat_1"
+        )
+        self._add_wedged_messages(db, entry.session_id)
+
+        alias_source = make_restart_source(chat_id="alias_chat_2")
+        alias_entry = store.get_or_create_session(alias_source)
+        alias_entry.session_id = entry.session_id
+        store._save()
+
+        release_resume = asyncio.Event()
+
+        async def _hold_resume(_adapter, _event, key):
+            await release_resume.wait()
+            runner._release_running_agent_state(key)
+
+        runner._run_startup_resume_event = _hold_resume
+        runner._persist_active_agents = MagicMock()
+        facade = runner.async_session_store
+        facade.has_dangling_tool_call_tail = AsyncMock(
+            side_effect=facade.has_dangling_tool_call_tail
+        )
+
+        try:
+            assert await runner._session_health_probe() == 1
+            await asyncio.sleep(0)
+            facade.has_dangling_tool_call_tail.assert_awaited_once_with(
+                entry.session_id
+            )
+
+            # While recovery is active under either routing key, the shared
+            # durable session remains ineligible through every alias.
+            assert await runner._session_health_probe() == 0
+        finally:
+            release_resume.set()
+            await asyncio.gather(*runner._background_tasks)
+
+    @pytest.mark.asyncio
+    async def test_probe_does_not_re_detect_in_second_pass(self, tmp_path):
+        """After a session is marked resume_pending, a second probe pass skips it."""
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path)
+        self._add_wedged_messages(db, entry.session_id)
+
+        runner._run_startup_resume_event = AsyncMock(
+            side_effect=lambda a, e, k: runner._release_running_agent_state(k)
+        )
+        runner._persist_active_agents = MagicMock()
+
+        first = await runner._session_health_probe()
+        assert first == 1
+
+        # Second pass — session is now resume_pending, should be skipped
+        second = await runner._session_health_probe()
+        assert second == 0
+
+    @pytest.mark.asyncio
+    async def test_probe_skips_unauthorized_session(self, tmp_path):
+        """A wedged session whose owner is no longer authorized must not be
+        auto-resumed (#23778 parity with _schedule_resume_pending_sessions)."""
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path)
+        self._add_wedged_messages(db, entry.session_id)
+
+        resume_called = AsyncMock()
+        runner._run_startup_resume_event = resume_called
+        runner._persist_active_agents = MagicMock()
+        # Override the allow-all default from make_restart_runner
+        runner._is_user_authorized = lambda _source: False
+
+        scheduled = await runner._session_health_probe()
+
+        assert scheduled == 0
+        resume_called.assert_not_called()
+        session_key = runner._session_key_for_source(source)
+        updated = store._entries.get(session_key)
+        assert updated.resume_pending is False
+
+    @pytest.mark.asyncio
+    async def test_probe_skips_during_drain(self, tmp_path):
+        """The probe must not schedule recovery turns while the gateway is
+        draining — they would be immediately interrupted by shutdown."""
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path)
+        self._add_wedged_messages(db, entry.session_id)
+
+        resume_called = AsyncMock()
+        runner._run_startup_resume_event = resume_called
+        runner._persist_active_agents = MagicMock()
+        runner._draining = True
+
+        scheduled = await runner._session_health_probe()
+
+        assert scheduled == 0
+        resume_called.assert_not_called()
+        session_key = runner._session_key_for_source(source)
+        updated = store._entries.get(session_key)
+        assert updated.resume_pending is False
+
+    @pytest.mark.asyncio
+    async def test_probe_skips_session_with_blocking_approval(self, tmp_path):
+        """A wedged session with a pending blocking approval must not be
+        auto-resumed — the agent is waiting for /approve or /deny, not a
+        recovery turn.  A synthetic empty-text turn would spin up the agent
+        only to block again on the same approval gate."""
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path)
+        self._add_wedged_messages(db, entry.session_id)
+
+        resume_called = AsyncMock()
+        runner._run_startup_resume_event = resume_called
+        runner._persist_active_agents = MagicMock()
+
+        session_key = runner._session_key_for_source(source)
+        with patch(
+            "tools.approval.has_blocking_approval",
+            return_value=True,
+        ):
+            scheduled = await runner._session_health_probe()
+
+        assert scheduled == 0
+        resume_called.assert_not_called()
+        updated = store._entries.get(session_key)
+        assert updated.resume_pending is False
+
+
+# ---------------------------------------------------------------------------
+# Recovery note for orphaned_tool_call reason
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanedToolCallRecoveryNote:
+    """Verify the recovery note injected for the orphaned_tool_call reason
+    does NOT claim a restart happened (the gateway was never down)."""
+
+    def test_note_for_orphaned_tool_call_does_not_mention_restart(self):
+        """The orphaned_tool_call note must not say 'gateway restart' or 'back online'."""
+        from tests.gateway.test_restart_resume_pending import _simulate_note_injection
+
+        history = [
+            {"role": "user", "content": "hello", "timestamp": time.time()},
+            {
+                "role": "assistant",
+                "content": "Let me check",
+                "tool_calls": [{"id": "call_abc", "function": {"name": "patch", "arguments": "{}"}}],
+                "timestamp": time.time(),
+            },
+        ]
+
+        now = datetime.now()
+        entry = SessionEntry(
+            session_key="agent:main:telegram:dm:1",
+            session_id="test_session",
+            created_at=now,
+            updated_at=now,
+            resume_pending=True,
+            resume_reason="orphaned_tool_call",
+            last_resume_marked_at=now,
+        )
+
+        result = _simulate_note_injection(history, "", entry)
+
+        assert "never completed" in result
+        assert "automatically recovered" in result
+        # Must NOT claim a restart happened
+        assert "gateway restart" not in result
+        assert "back online" not in result
+        assert "shutdown" not in result
+
+    def test_note_for_orphaned_tool_call_with_user_message(self):
+        """When a real user message is present, the note addresses it first."""
+        from tests.gateway.test_restart_resume_pending import _simulate_note_injection
+
+        history = [
+            {"role": "user", "content": "hello", "timestamp": time.time()},
+            {
+                "role": "assistant",
+                "content": "Let me check",
+                "tool_calls": [{"id": "call_abc", "function": {"name": "patch", "arguments": "{}"}}],
+                "timestamp": time.time(),
+            },
+        ]
+
+        now = datetime.now()
+        entry = SessionEntry(
+            session_key="agent:main:telegram:dm:1",
+            session_id="test_session",
+            created_at=now,
+            updated_at=now,
+            resume_pending=True,
+            resume_reason="orphaned_tool_call",
+            last_resume_marked_at=now,
+        )
+
+        result = _simulate_note_injection(history, "what happened?", entry)
+
+        assert "never completed" in result
+        assert "what happened?" in result
+        assert "NEW message" in result
+
+    def test_standard_restart_note_unchanged(self):
+        """The existing restart_timeout note must not be affected by the new branch."""
+        from tests.gateway.test_restart_resume_pending import _simulate_note_injection
+
+        history = [
+            {"role": "user", "content": "hello", "timestamp": time.time()},
+        ]
+
+        now = datetime.now()
+        entry = SessionEntry(
+            session_key="agent:main:telegram:dm:1",
+            session_id="test_session",
+            created_at=now,
+            updated_at=now,
+            resume_pending=True,
+            resume_reason="restart_timeout",
+            last_resume_marked_at=now,
+        )
+
+        result = _simulate_note_injection(history, "", entry)
+
+        assert "gateway restart" in result
+        assert "back online" in result
+        # Must NOT contain the orphaned_tool_call wording
+        assert "never completed" not in result
+
+
+# ---------------------------------------------------------------------------
+# _AUTO_RESUME_REASONS includes orphaned_tool_call
+# ---------------------------------------------------------------------------
+
+
+class TestAutoResumeReasons:
+    """Verify orphaned_tool_call is in _AUTO_RESUME_REASONS so
+    _schedule_resume_pending_sessions picks it up on platform reconnect."""
+
+    def test_orphaned_tool_call_in_auto_resume_reasons(self):
+        from gateway.run import GatewayRunner
+
+        assert "orphaned_tool_call" in GatewayRunner._AUTO_RESUME_REASONS
+
+    def test_standard_reasons_still_present(self):
+        from gateway.run import GatewayRunner
+
+        reasons = GatewayRunner._AUTO_RESUME_REASONS
+        assert "restart_timeout" in reasons
+        assert "shutdown_timeout" in reasons
+        assert "restart_interrupted" in reasons

--- a/tests/gateway/test_session_health_watcher.py
+++ b/tests/gateway/test_session_health_watcher.py
@@ -311,6 +311,71 @@ class TestSessionHealthWatcher:
         assert resume_args["event"].internal is True
 
     @pytest.mark.asyncio
+    async def test_probe_recovers_through_real_adapter_pipeline_and_clears_pending(
+        self, tmp_path, monkeypatch
+    ):
+        """Health recovery must reach the real adapter/handler boundary.
+
+        The detection tests above intentionally replace the startup dispatcher
+        to isolate scheduling. This regression keeps the production
+        ``_run_startup_resume_event`` and ``BasePlatformAdapter`` background
+        pipeline intact, stubs only the model leaf, and verifies that a
+        successful agent result clears ``resume_pending``.
+        """
+        from gateway.run import GatewayRunner
+        from hermes_state import AsyncSessionDB
+
+        runner, adapter, store, db, source, entry = self._setup_runner(tmp_path)
+        self._add_wedged_messages(db, entry.session_id)
+        session_key = runner._session_key_for_source(source)
+
+        runner._session_db = AsyncSessionDB(db)
+        runner._handle_message = GatewayRunner._handle_message.__get__(
+            runner, GatewayRunner
+        )
+        runner._check_slash_access = lambda *args, **kwargs: None
+        runner._active_session_leases = {}
+        runner._busy_ack_ts = {}
+        runner._post_turn_goal_continuation = AsyncMock()
+        runner._run_agent = AsyncMock(
+            return_value={
+                "final_response": "Recovered successfully.",
+                "messages": [
+                    {"role": "user", "content": "Recovered context"},
+                    {"role": "assistant", "content": "Recovered successfully."},
+                ],
+                "tools": [],
+                "history_offset": 0,
+                "api_calls": 1,
+                "completed": True,
+                "interrupted": False,
+                "partial": False,
+                "failed": False,
+                "error": None,
+                "agent_persisted": True,
+                "session_id": entry.session_id,
+            }
+        )
+
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        adapter.set_message_handler(runner._handle_message)
+        adapter._keep_typing = AsyncMock()
+        adapter._stop_typing_refresh = AsyncMock()
+        adapter._run_processing_hook = AsyncMock()
+
+        assert await runner._session_health_probe() == 1
+        for _ in range(30):
+            await asyncio.sleep(0.02)
+            if session_key not in runner._running_agents:
+                break
+
+        assert runner._run_agent.await_count == 1
+        assert store._entries[session_key].resume_pending is False
+        assert session_key not in runner._running_agents
+        assert session_key not in adapter._pending_messages
+
+    @pytest.mark.asyncio
     async def test_probe_uses_async_store_before_claiming_runner_slot(self, tmp_path):
         runner, adapter, store, db, source, entry = self._setup_runner(tmp_path)
         self._add_wedged_messages(db, entry.session_id)


### PR DESCRIPTION
## What does this PR do?

Adds a session-health watcher that detects and recovers **wedged** sessions — sessions whose last persisted message is an `assistant(tool_calls)` with no matching `tool` result and no subsequent `user` message. The tool call was persisted but the result was never written, and the gateway process is still alive (so `resume_pending` was never set by the restart watchdog). The session sits idle indefinitely because nothing triggers a new turn.

The watcher runs every 60s. For each non-expired, non-suspended, non-`resume_pending` session that is not currently running an agent, it checks `SessionDB.has_dangling_tool_call_tail()`. When a wedged session is found, it is marked `resume_pending` with reason `orphaned_tool_call` and a synthetic recovery turn is scheduled via `_run_startup_resume_event` — the same machinery used for restart-interrupted sessions. The recovery turn rebuilds history (`strip_dangling_tool_call_tail` removes the orphaned call), the `_is_resume_pending` branch injects a recovery note, and the session is back online without manual intervention.

The watcher is deliberately conservative: sessions with an active agent are skipped, sessions already marked `resume_pending`/`suspended` are skipped, sessions whose adapter is unavailable are skipped (picked up on reconnect), sessions with a pending blocking approval are skipped, and the session owner is validated against the current allowlist before auto-resuming.

## Related Issue

Fixes #58891

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run_watchers.py` — `_session_health_watcher` (background loop) and `_session_health_probe` (one detection + recovery pass, callable directly in tests).
- `gateway/run_startup.py` — registered `_session_health_watcher` in `_PRE_RECONNECT_WATCHERS`; added `_hermes_startup_resume` marker on synthetic resume events so the busy-session fast path does not queue them behind the pre-claimed slot.
- `gateway/run_inbound.py` — busy-session fast path bypasses events with `_hermes_startup_resume=True`.
- `gateway/run.py` — `build_resume_recovery_note` now has a dedicated `orphaned_tool_call` branch that avoids restart wording; `orphaned_tool_call` added to `_AUTO_RESUME_REASONS`.
- `hermes_state_messages.py` — `has_dangling_tool_call_tail()` (SELECT-only, unlocked reader via `_read_one`).
- `gateway/session.py` — `AsyncSessionStore.list_session_items()` and `has_dangling_tool_call_tail()` facade methods (auto-merged).
- `hermes_state_common.py` — `idx_messages_session_active_id` index (auto-merged).
- `tests/gateway/test_session_health_watcher.py` (new, 32 tests) — detection, skip conditions, recovery dispatch, shared-session dedup, recovery note wording.
- `tests/gateway/test_restart_resume_pending.py` — resume-pending round-trip, stuck-loop escalation, atomic_json_write patch adapted to the utils decomposition.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_session_health_watcher.py tests/gateway/test_restart_resume_pending.py` — all tests pass.
2. Full project checker passes.
3. Manual: start a gateway session, trigger a tool call that crashes before writing its result, wait 60s — the session is automatically recovered without manual intervention.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing
- [x] No new core tools or env vars introduced
- [x] Prompt caching and role alternation preserved