### PR TITLE
fix(loop): detect thinking-budget exhaustion for structured reasoning fields

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -279,6 +279,31 @@ def _try_refresh_nous_paid_entitlement_credentials(agent) -> bool:
         return False
 
 
+def _structured_reasoning_only(msg, content) -> bool:
+    """True when an assistant turn carries reasoning ONLY as structured fields
+    with no visible content.
+
+    OpenAI-compatible backends (Ollama /v1 ``message.reasoning``, DeepSeek
+    ``reasoning_content``, OpenRouter ``reasoning_details``) never put
+    ``<think>`` tags in ``content`` — reasoning arrives as a separate field
+    and ``content`` stays empty, so the tag-based exhaustion detector in the
+    ``finish_reason == "length"`` branch misses them and the loop wastes
+    continuation retries on a response with no visible text to continue.
+    Live shape from Ollama hermes:latest (qwen35moe):
+    ``{"content": "", "reasoning": "…", "finish_reason": "length"}``.
+    """
+    if content is not None and str(content).strip():
+        return False
+    provider_data = getattr(msg, "provider_data", None) or {}
+    if not isinstance(provider_data, dict):
+        provider_data = {}
+    return bool(
+        getattr(msg, "reasoning", None)
+        or provider_data.get("reasoning_content")
+        or provider_data.get("reasoning_details")
+    )
+
+
 def _restore_or_build_system_prompt(agent, system_message, conversation_history):
     """Restore the cached system prompt from the session DB or build it fresh.
 
@@ -1794,10 +1819,18 @@ def run_conversation(
                     )
                     _thinking_exhausted = (
                         not _trunc_has_tool_calls
-                        and _has_think_tags
                         and (
-                            (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
-                            or _trunc_content is None
+                            (
+                                _has_think_tags
+                                and (
+                                    (_trunc_content is not None and not agent._has_content_after_think_block(_trunc_content))
+                                    or _trunc_content is None
+                                )
+                            )
+                            # Structured-reasoning variant of the same exhaustion
+                            # (Ollama /v1, DeepSeek, OpenRouter): reasoning lives in a
+                            # separate message field, content is empty, no tags above.
+                            or _structured_reasoning_only(_trunc_msg, _trunc_content)
                         )
                     )
 

--- a/tests/run_agent/test_reasoning_only_length_recovery.py
+++ b/tests/run_agent/test_reasoning_only_length_recovery.py
@@ -1,0 +1,60 @@
+"""Tests for structured-reasoning thinking-budget-exhaustion detection.
+
+Covers _structured_reasoning_only() in agent/conversation_loop.py — the
+companion to the <think>-tag detector in the finish_reason=="length" branch.
+OpenAI-compatible backends (Ollama /v1, DeepSeek, OpenRouter) return
+reasoning as a separate message field with content="" instead of inline
+tags, so the tag-based detector never fires and the loop used to waste
+continuation retries on responses with no visible text to continue.
+
+Live shape that motivated this (Ollama hermes:latest, qwen35moe):
+    {"content": "", "reasoning": "Here's a thinking process…",
+     "finish_reason": "length"}
+"""
+
+from types import SimpleNamespace
+
+from agent.conversation_loop import _structured_reasoning_only
+
+
+def _msg(reasoning=None, provider_data=None):
+    return SimpleNamespace(reasoning=reasoning, provider_data=provider_data)
+
+
+class TestStructuredReasoningOnly:
+
+    def test_ollama_v1_shape_reasoning_field_empty_content(self):
+        assert _structured_reasoning_only(_msg(reasoning="Here's a thinking process…"), "")
+
+    def test_none_content_with_reasoning(self):
+        assert _structured_reasoning_only(_msg(reasoning="cot"), None)
+
+    def test_whitespace_content_with_reasoning(self):
+        assert _structured_reasoning_only(_msg(reasoning="cot"), "  \n\t ")
+
+    def test_deepseek_reasoning_content_in_provider_data(self):
+        msg = _msg(provider_data={"reasoning_content": "chain of thought"})
+        assert _structured_reasoning_only(msg, "")
+
+    def test_openrouter_reasoning_details_in_provider_data(self):
+        msg = _msg(provider_data={"reasoning_details": [{"type": "reasoning.text"}]})
+        assert _structured_reasoning_only(msg, "")
+
+    def test_visible_content_wins_over_reasoning(self):
+        # Model produced BOTH reasoning and real text — normal truncation,
+        # continuation retries are appropriate.
+        assert not _structured_reasoning_only(_msg(reasoning="cot"), "partial answer")
+
+    def test_no_reasoning_no_content_is_not_exhaustion(self):
+        # Plain empty turn (network stub, refusal, …) — other handlers own it.
+        assert not _structured_reasoning_only(_msg(), "")
+
+    def test_empty_provider_data_dict(self):
+        assert not _structured_reasoning_only(_msg(provider_data={}), "")
+
+    def test_provider_data_not_a_dict_is_tolerated(self):
+        msg = SimpleNamespace(reasoning=None, provider_data="garbage")
+        assert not _structured_reasoning_only(msg, "")
+
+    def test_plain_dictless_object_without_attrs(self):
+        assert not _structured_reasoning_only(object(), "")


### PR DESCRIPTION
## Problem

When a thinking model served via an OpenAI-compatible endpoint (e.g. Ollama `/v1` with Qwen3.x) exhausts its completion budget mid-reasoning, the API returns the chain-of-thought in the **structured `message.reasoning` field** with an empty `content` — there are no inline `<think>` tags. The existing thinking-budget-exhaustion detection only looks for tag-based reasoning, so these responses are classified as plain empty completions and the conversation loop burns empty continuation retries instead of recovering.

Reproduced with hermes-agent + Ollama (Qwen3.6-35B-A3B, `/v1/chat/completions`, low `max_tokens`): every tool step spends the whole budget on `message.reasoning`, `content == ""`, `finish_reason == "length"` — the loop retries with no progress.

## Fix

Add `_structured_reasoning_only()` to `agent/conversation_loop.py`: a response whose `content` is empty but whose `message.reasoning` is non-empty is treated the same way as tag-based reasoning-only output by the length-recovery path.

## Tests

`tests/run_agent/test_reasoning_only_length_recovery.py` — 10 new tests covering: structured reasoning-only with `finish_reason=length`, empty-content-no-reasoning (must NOT trigger), tag-based path regression, `content=None` safety, and tool_calls precedence. All pass; neighbouring reasoning tests stay green.

Found and battle-tested while running hermes-agent on a fully local Ollama brain.