### PR TITLE
fix(telegram): report truncated mid-stream preview as partial delivery

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3895,7 +3895,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # stream trips flood control (200s+ penalties) and hangs the final
             # delivery. Skip silently until finalize.
             if self._last_overflow_preview.get(_preview_key) == content:
-                return SendResult(success=True, message_id=message_id)
+                return self._stream_preview_partial_result(message_id, content)
         elif not finalize:
             # Content shrank back under the cap (segment break / new message
             # id) — clear stale saturation state so dedup can't mask a real
@@ -3911,6 +3911,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = content
+                    return self._stream_preview_partial_result(message_id, content)
                 return SendResult(success=True, message_id=message_id)
 
             formatted = self.format_message(content)
@@ -3942,7 +3943,11 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as e:
             err_str = str(e).lower()
             # "Message is not modified" — content identical, treat as success
+            # (unless the screen holds only a truncated preview — then keep
+            # reporting partial delivery so the final send is not suppressed).
             if "not modified" in err_str:
+                if _saturated_preview:
+                    return self._stream_preview_partial_result(message_id, content)
                 return SendResult(success=True, message_id=message_id)
             # Reactive split-and-deliver: parse_mode formatting can inflate
             # the payload past the limit even when the raw text was under
@@ -3960,14 +3965,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 truncated = self._truncate_stream_overflow_preview(content)
                 if self._last_overflow_preview.get(_preview_key) == truncated:
                     # Saturated-preview dedup (see pre-flight path above).
-                    return SendResult(success=True, message_id=message_id)
-                await self._bot.edit_message_text(
-                    chat_id=normalize_telegram_chat_id(chat_id),
-                    message_id=int(message_id),
-                    text=truncated,
-                )
+                    return self._stream_preview_partial_result(message_id, truncated)
+                try:
+                    await self._bot.edit_message_text(
+                        chat_id=normalize_telegram_chat_id(chat_id),
+                        message_id=int(message_id),
+                        text=truncated,
+                    )
+                except Exception as retry_err:
+                    if "not modified" not in str(retry_err).lower():
+                        raise
                 self._last_overflow_preview[_preview_key] = truncated
-                return SendResult(success=True, message_id=message_id)
+                return self._stream_preview_partial_result(message_id, truncated)
             # Flood control / RetryAfter — short waits are retried inline,
             # long waits return a failure immediately so streaming can fall back
             # to a normal final send instead of leaving a truncated partial.
@@ -4031,6 +4040,33 @@ class TelegramAdapter(BasePlatformAdapter):
                 safe_error,
             )
             return SendResult(success=False, error=safe_error)
+
+    def _stream_preview_partial_result(
+        self, message_id: str, delivered_prefix: str,
+    ) -> SendResult:
+        """Report a truncated mid-stream preview as partial delivery.
+
+        The preview edit succeeded (or deduped), but the screen holds only a
+        truncated prefix of the accumulated text.  Returning plain success
+        lets the stream consumer record the full text as visible; the gateway
+        then matches the final response against that bookkeeping and
+        suppresses the normal final send, so the truncated preview becomes
+        the only delivery the user ever sees.  Reuse the ``partial_overflow``
+        contract (see ``SendResult.raw_response`` docs): the consumer's
+        existing branch switches into fallback-final mode and delivers the
+        missing tail on completion.
+        """
+        return SendResult(
+            success=False,
+            message_id=message_id,
+            error="mid-stream preview truncated at platform limit",
+            error_kind="too_long",
+            raw_response={
+                "partial_overflow": True,
+                "last_message_id": message_id,
+                "delivered_prefix": delivered_prefix,
+            },
+        )
 
     def _truncate_stream_overflow_preview(self, content: str) -> str:
         """Return a one-message preview for oversized streaming edits.

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -992,7 +992,6 @@ class TestEditMessageStreamingSafety:
         result = await adapter.edit_message("123", "456", oversized, finalize=False)
 
         # Must NOT create continuation messages during streaming.
-        assert result.success is True
         assert adapter._bot.send_message.await_count == 0, (
             "mid-stream overflow must not send continuation messages"
         )
@@ -1001,6 +1000,16 @@ class TestEditMessageStreamingSafety:
         # The edit must contain truncated content (≤ MAX_MESSAGE_LENGTH).
         edited_text = adapter._bot.edit_message_text.call_args.kwargs["text"]
         assert len(edited_text) <= adapter.MAX_MESSAGE_LENGTH
+        # The screen holds only a truncated prefix — the adapter must report
+        # partial delivery (not success), otherwise the stream consumer
+        # records the full text as visible and the gateway suppresses the
+        # real final send, leaving the truncated preview as the only
+        # delivery the user ever sees.
+        assert result.success is False
+        assert result.error_kind == "too_long"
+        assert result.raw_response["partial_overflow"] is True
+        assert result.raw_response["delivered_prefix"] == edited_text
+        assert result.raw_response["last_message_id"] == "456"
 
     @pytest.mark.asyncio
     async def test_saturated_preview_dedups_repeat_oversized_edits(self):
@@ -1016,8 +1025,11 @@ class TestEditMessageStreamingSafety:
         adapter._bot.send_message = AsyncMock()
 
         # First oversized edit: delivers the truncated preview (1 API call).
+        # Truncated previews report partial delivery (partial_overflow) so
+        # the gateway never mistakes them for the full response.
         r1 = await adapter.edit_message("123", "456", "x" * 6000, finalize=False)
-        assert r1.success is True
+        assert r1.success is False
+        assert r1.raw_response["partial_overflow"] is True
         assert adapter._bot.edit_message_text.await_count == 1
 
         # Stream keeps growing within the same chunk count: previews truncate
@@ -1027,7 +1039,8 @@ class TestEditMessageStreamingSafety:
         # instead of one per 0.8s tick.)
         for grow in (7000, 8000):
             r = await adapter.edit_message("123", "456", "x" * grow, finalize=False)
-            assert r.success is True
+            assert r.success is False
+            assert r.raw_response["partial_overflow"] is True
             assert r.message_id == "456"
         assert adapter._bot.edit_message_text.await_count == 1, (
             "identical saturated previews must not be re-sent"
@@ -1099,12 +1112,37 @@ class TestEditMessageStreamingSafety:
         content = "x" * adapter.MAX_MESSAGE_LENGTH
         result = await adapter.edit_message("123", "456", content, finalize=False)
 
-        assert result.success is True
         assert result.message_id == "456"
         adapter._bot.send_message.assert_not_called()
         assert adapter._bot.edit_message_text.await_count == 2
         retry_text = adapter._bot.edit_message_text.await_args_list[1].kwargs["text"]
         assert len(retry_text) <= adapter.MAX_MESSAGE_LENGTH
+        # Reactive truncation is partial delivery too — same contract as the
+        # pre-flight path so the consumer sends the missing tail on finalize.
+        assert result.success is False
+        assert result.raw_response["partial_overflow"] is True
+        assert result.raw_response["delivered_prefix"] == retry_text
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_truncated_preview_not_modified_stays_partial(self):
+        """A repeated oversized tick edits the same truncated preview and
+        Telegram answers "message is not modified".  That must still be
+        reported as partial delivery — success here would restore the lying
+        bookkeeping that made the gateway suppress the real final send."""
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+        adapter._bot = MagicMock()
+        adapter._bot.edit_message_text = AsyncMock(
+            side_effect=Exception("Bad Request: message is not modified")
+        )
+        adapter._bot.send_message = AsyncMock()
+
+        result = await adapter.edit_message("123", "456", "x" * 6000, finalize=False)
+
+        adapter._bot.send_message.assert_not_called()
+        assert result.success is False
+        assert result.raw_response["partial_overflow"] is True
+        assert result.raw_response["delivered_prefix"]
+        assert result.message_id == "456"
 
 
 # =========================================================================


### PR DESCRIPTION
## Problem

During streaming (`finalize=False`), `edit_message` truncates oversized previews to fit Telegram's 4096 UTF-16 limit (#48648) but returns `success=True` with no truncation marker — including from the saturated-preview dedup skips. The stream consumer then records the **full** accumulated text in `_last_sent_text`, `has_delivered_text()` matches the final response against that stale bookkeeping, and the gateway suppresses the normal final send:

```
Suppressing normal final send ... (streamed=True previewed=True content_delivered=False)
```

The truncated preview becomes the only delivery the user ever sees — long answers arrive permanently cut off.

## Fix

Reuse the existing `partial_overflow` contract (already documented on `SendResult.raw_response`): return `success=False` with `raw_response={"partial_overflow": True, "delivered_prefix": ..., "last_message_id": ...}` from every mid-stream truncation site:

- pre-flight truncation,
- the saturated-preview dedup skip,
- the reactive `message too long` retry,
- `message is not modified` on an already-truncated preview.

The consumer's existing `partial_overflow` branch switches into fallback-final mode and delivers the missing tail on completion — **no consumer changes needed**.

This also composes well with the saturated-preview dedup: the consumer stops progressive edits after the first partial result, so saturated previews no longer burn flood budget at all.

## Tests

Existing truncation/dedup/reactive tests updated to the partial-delivery contract; new test covers the not-modified path. `tests/gateway/test_telegram_format.py` (110), `tests/gateway/test_stream_consumer.py` + `tests/gateway/test_telegram_overflow_partial.py` (126) — all pass.

Found and battle-tested running the Telegram gateway against a local Ollama brain with streaming enabled.