### PR TITLE
fix: survive EIO on stdin in process_loop daemon thread

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15249,6 +15249,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         except Exception:
                             pass  # Non-fatal — don't break the main loop
 
+                except OSError as e:
+                    if getattr(e, "errno", None) == errno.EIO:
+                        logger.warning(
+                            "process_loop EIO on stdin (msg may be lost): %s — continuing loop", e
+                        )
+                        continue
+                    logger.warning("process_loop unhandled error (msg may be lost): %s", e)
                 except Exception as e:
                     logger.warning("process_loop unhandled error (msg may be lost): %s", e)
         


### PR DESCRIPTION
## Problem

When a child process receives SIGTERM (e.g., pytest gets killed mid-run), the controlling terminal's stdin can be left in an error state. The next iteration of the `process_loop` daemon thread raises `OSError(errno.EIO)` (`[Errno 5] Input/output error`), which the bare `except Exception` catch-all at the end of the loop body lets kill the thread.

The main CLI thread keeps running, but no user input is ever processed again — the session appears frozen. Only a restart recovers.

## Evidence

Observed 7 crashes in a single 4-hour session, 6 confirmed SIGTERM-triggered:

```
2026-07-07 19:26:10 WARNING agent.tool_executor: Tool terminal returned error: {"exit_code": -15, "canonical_command": "pytest"}
2026-07-07 19:26:12 WARNING cli: process_loop unhandled error (msg may be lost): [Errno 5] Input/output error
```

41 EIO occurrences in errors.log total across sessions.

## Fix

Insert an `except OSError` handler **above** the existing `except Exception` that checks `errno.EIO` specifically, logs a warning, and **continues** the loop instead of exiting the thread:

```python
except OSError as e:
    if getattr(e, "errno", None) == errno.EIO:
        logger.warning(
            "process_loop EIO on stdin (msg may be lost): %s — continuing loop", e
        )
        continue
    logger.warning("process_loop unhandled error (msg may be lost): %s", e)
except Exception as e:
    logger.warning("process_loop unhandled error (msg may be lost): %s", e)
```

- `errno` is already imported at line 35
- At most one user message is dropped when EIO fires; the session survives
- Non-EIO `OSError`s still log and follow the original path (thread exit)

## Verification

- Syntax check passes (pre-existing `SyntaxWarning` on unrelated line 11250)
- The fix has been running locally through multiple SIGTERM→EIO cycles and the session stays alive