### PR TITLE
fix(matrix): sign own device with self-signing key on E2EE startup

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1428,6 +1428,47 @@ class MatrixAdapter(BasePlatformAdapter):
                                         exc,
                                     )
 
+                    # Sign our own device with the self-signing key so other
+                    # clients (Element, etc.) recognise it as cross-signed and
+                    # share megolm room keys to it.  Without this, the bot's
+                    # device is unsigned and Element withholds room keys
+                    # regardless of the user's "never send to unverified"
+                    # setting, because the device is not signed by its own
+                    # account's self-signing key.
+                    if client.device_id and self._user_id:
+                        try:
+                            priv = getattr(
+                                olm, "_cross_signing_private_keys", None
+                            )
+                            need_bootstrap = priv is None or getattr(
+                                priv, "self_signing_key", None
+                            ) is None
+                            if need_bootstrap:
+                                logger.info(
+                                    "Matrix: cross-signing private keys missing "
+                                    "— bootstrapping"
+                                )
+                                rk = await olm.generate_recovery_key()
+                                _handle_generated_matrix_recovery_key(
+                                    str(client.mxid), rk
+                                )
+                            own_dev = await olm.get_or_fetch_device(
+                                UserID(self._user_id), client.device_id
+                            )
+                            if own_dev is not None:
+                                await olm.sign_own_device(own_dev)
+                                logger.info(
+                                    "Matrix: signed own device %s with "
+                                    "self-signing key",
+                                    client.device_id,
+                                )
+                        except Exception as exc:
+                            logger.warning(
+                                "Matrix: failed to sign own device: %s",
+                                exc,
+                                exc_info=True,
+                            )
+
                     client.crypto = olm
                     logger.info(
                         "Matrix: E2EE enabled (store: %s%s)",


### PR DESCRIPTION
## Problem

Bots using E2EE with the Matrix adapter are missing a critical step: their device is never signed by their own account's self-signing key. Without this signature, Element (and other Matrix clients) see the device as 'unsigned by its owner' and **withhold all megolm room keys**, even when the user has 'never send encrypted messages to unverified sessions' **disabled**.

The result: the bot joins encrypted rooms, the gateway runs, the token is valid, but the bot can never decrypt a single message. The logs show:
```
mautrix.errors.crypto.DecryptionError: olm event doesn't contain ciphertext for this device
WARNING mau.client.crypto: Failed to decrypt megolm event: no session with given ID ... found
```

## Root cause

mautrix's `OlmMachine` has a `sign_own_device()` method, but the adapter never calls it during startup. After crypto init (loading the OlmMachine, recovering cross-signing keys from SSSS), the device's key is not signed by the account's own self-signing key.

## Fix

After crypto init, sign the bot's own device with the self-signing key. If cross-signing private keys are missing, bootstrap them first via `generate_recovery_key()`.

The call is idempotent — `sign_own_device()` re-signs and re-uploads the signature on every startup. This is correct: if the cross-signing identity changes (recovery key rotation, SSSS reset), the device signature is refreshed automatically.

## Testing

Tested on tchncs.de (Dendrite homeserver) with `@household_bot:tchncs.de`:

- **Before**: Element withheld all megolm keys to the bot's device. `keys/query` showed the device with only a self-signature (from the device's own ed25519 key). No cross-signing signature present.
- **After**: `sign_own_device()` uploaded the self-signing-key signature. Element immediately began sharing megolm room keys. Encrypted room messages decrypted successfully.

```
INFO hermes_plugins.matrix_platform.adapter: Matrix: signed own device hermes-household-gw with self-signing key
INFO hermes_plugins.matrix_platform.adapter: Matrix: E2EE enabled
```

## Scope

Minimal — 41 lines in `plugins/platforms/matrix/adapter.py`. No new files. Uses existing mautrix APIs (`get_or_fetch_device`, `sign_own_device`, `generate_recovery_key`). Wrapped in try/except so failures are non-fatal (logs a warning, continues without the signature).