### PR TITLE
fix(cron): suppress standalone silence markers after preambles

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -275,10 +275,14 @@ def _is_cron_silence_response(text: str) -> bool:
     # Whole response is exactly a token.
     if _is_token(stripped):
         return True
-    # Marker on its own first or last line (trailing/leading note on a
-    # separate line — e.g. "2 deals filtered\n\n[SILENT]").
+    # Marker on its own line anywhere in the response. This intentionally
+    # accepts a leading cron/policy preamble before the marker: scheduled
+    # watchers often have mandatory policy boilerplate, and that boilerplate
+    # must not turn an explicit silence sentinel into a chat delivery. Keep the
+    # match line-scoped so mid-sentence mentions such as
+    # "I considered staying [SILENT]..." still deliver normally.
     lines = [ln for ln in stripped.splitlines() if ln.strip()]
-    if lines and (_is_token(lines[0]) or _is_token(lines[-1])):
+    if any(_is_token(ln) for ln in lines):
         return True
     # Bracketed sentinel used as a same-line prefix — the documented cron
     # pattern "[SILENT] No changes detected".  Restricted to the bracketed

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2512,7 +2512,8 @@ class TestSilentDelivery:
     def test_is_cron_silence_response_contract(self):
         """Direct behavior contract for the cron silence matcher."""
         from cron.scheduler import _is_cron_silence_response as sil
-        # Suppress: bare/bracketed/bracketless tokens, prefix, trailing-line.
+        # Suppress: bare/bracketed/bracketless tokens, prefix, and standalone
+        # marker lines even when mandatory cron/policy boilerplate appears first.
         assert sil("[SILENT]")
         assert sil("[silent] nothing new")
         assert sil("[SILENT] No changes detected")
@@ -2521,6 +2522,7 @@ class TestSilentDelivery:
         assert sil("NO_REPLY")
         assert sil("NO REPLY")
         assert sil("Summary.\nSILENT")
+        assert sil("Policy: read required rules first.\n[SILENT]\nNo matching PR found.")
         # Deliver: real content, mid-sentence quotes, bare words, junk.
         assert not sil("Daily report: 4 PRs merged.")
         assert not sil("I stayed [SILENT] but here is the report: 3 items.")


### PR DESCRIPTION
## Summary
- suppress cron delivery when a standalone silence marker appears after mandatory preamble/boilerplate lines
- keep matcher line-scoped so mid-sentence `[SILENT]` mentions still deliver normally
- add regression coverage for the preamble + `[SILENT]` + explanation shape

## Verification
- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/cron/test_scheduler.py::TestSilentDelivery::test_is_cron_silence_response_contract tests/cron/test_run_one_job.py::test_run_one_job_silent_skips_delivery`
