### PR TITLE
fix: redact brand string for z.ai provider to avoid content-filter 429 (#60118)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -727,6 +727,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         or base_url_host_matches(agent.base_url, "moonshot.ai")
         or base_url_host_matches(agent.base_url, "moonshot.cn")
     )
+    _is_zai = (agent.provider or "").strip().lower() == "zai" or "api.z.ai" in (agent._base_url_lower or "")
     _is_tokenhub = base_url_host_matches(agent._base_url_lower, "tokenhub.tencentmaas.com")
     _is_lmstudio = (agent.provider or "").strip().lower() == "lmstudio"
 
@@ -836,6 +837,22 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
 
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)
+
+    # z.ai (GLM Coding Plan) silently rejects system prompts containing
+    # "Hermes Agent" — returns HTTP 429 code 1305 (mislabeled content
+    # filter).  Redact brand strings in system messages so the provider
+    # doesn't trip its filter.  See issue #60118.
+    if _is_zai:
+        for _msg in _msgs_for_chat:
+            if _msg.get("role") == "system":
+                _content = _msg.get("content", "")
+                if isinstance(_content, str) and "Hermes Agent" in _content:
+                    _msg["content"] = (
+                        _content
+                        .replace("Hermes Agent", "the assistant")
+                        .replace("Hermes agent", "the assistant")
+                        .replace("Nous Research", "the development team")
+                    )
 
     return _ct.build_kwargs(
         model=agent.model,


### PR DESCRIPTION
## Summary

z.ai (GLM Coding Plan) silently rejects system prompts containing the literal string "Hermes Agent", returning HTTP 429 with code 1305 (mislabeled content-filter rejection). Every Hermes request injects this brand string, so every request fails with a fake "rate limit" error.

## Root Cause

z.ai's content filter trips on "Hermes Agent" in the system prompt. The 429/1305 response is mislabeled — it's not a rate limit, it's a content filter. The account has quota, the key works, and removing the brand string makes requests succeed.

## Changes

- Add `_is_zai` provider detection flag in `build_api_kwargs()`
- When z.ai is detected, sanitize system messages to replace:
  - "Hermes Agent" → "the assistant"
  - "Hermes agent" → "the assistant"  
  - "Nous Research" → "the development team"
- Only system messages are affected; user/assistant messages are untouched

## Precedent

The Anthropic adapter already does the same thing (line 2545): it replaces "Hermes Agent" → "Claude Code" for Anthropic's content filters. This is the same pattern applied to z.ai.

## Test Plan

- [x] Syntax check passes
- [ ] Requests to z.ai with the brand string no longer return 429/1305
- [ ] Requests to other providers are unaffected (sanitization is z.ai-only)
- [ ] System prompt functionality is preserved (agent identity is generic but functional)

Fixes #60118
