### PR TITLE
docs(auth): scrub Fly.io host detail from quarantine-log comment

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4860,11 +4860,11 @@ def _quarantine_nous_oauth_state(
     reason: str,
 ) -> None:
     """Keep routing metadata but remove dead OAuth material so it is not replayed."""
-    # Forensic logging BEFORE we clear the token material. A NAS-hosted Fly agent
+    # Forensic logging BEFORE we clear the token material. A hosted agent
     # can take a terminal invalid_grant and get quarantined here silently: the
     # only downstream signal is a "No access token found" WARNING once the pool
-    # is already empty, which is too late to root-cause. The Fly log drain is
-    # WARNING-only, so this MUST be logger.warning (INFO never reaches the drain).
+    # is already empty, which is too late to root-cause. A managed log drain may
+    # be WARNING-only, so this MUST be logger.warning (INFO never reaches it).
     #
     # Redaction safety: emit ONLY the 12-char SHA-256 hex prefix of the refresh
     # token (correlates to NAS's refreshTokenHash without leaking the secret) plus


### PR DESCRIPTION
## Why

`hermes-agent` is the public/OSS repo. The forensic-logging comment added in #59976 (`_quarantine_nous_oauth_state` in `hermes_cli/auth.py`) named **Fly** — the specific managed-hosting compute provider — twice:

- `A NAS-hosted Fly agent can take a terminal invalid_grant…`
- `The Fly log drain is WARNING-only…`

That's a Hermes Cloud infrastructure detail that shouldn't be exposed in public source. The same scrub was applied to the boot re-seed helper (#59983) before it merged; this instance slipped through in #59976.

## What

Comment-only reword, behaviour unchanged:
- `A NAS-hosted Fly agent` → `A hosted agent`
- `The Fly log drain is WARNING-only` → `A managed log drain may be WARNING-only`

("NAS" / "hosted agent" are already normalized throughout the public repo — 13+ pre-existing references — so only the **Fly** host detail is scrubbed.)

## Tests

`tests/hermes_cli/test_quarantine_forensic_logging.py` — 5/5 still pass (comment-only change).

## Review lane

Touches `hermes_cli/auth.py` → Teknium's runtime-auth review lane.