### PR TITLE
fix(browser): kill orphaned Chromium processes when daemon is dead

### DIFF
--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -181,6 +181,62 @@ class TestReapOrphanedBrowserSessions:
         assert not d.exists()
 
 
+class TestOrphanedChromiumCleanup:
+    """Tests for _kill_orphaned_chromium_for_session() — kills Chromium
+    processes left behind when the agent-browser daemon dies before cleanup.
+
+    When the daemon (Node process) crashes or is SIGKILLed, its Chromium
+    children are reparented to PID 1 and the normal tree-kill path (which
+    walks children of the daemon PID) never reaches them.  The reaper
+    discovers the dead daemon PID, removes the socket dir, and calls
+    _kill_orphaned_chromium_for_session to scan for surviving Chromium
+    processes by matching the ``agent-browser-chrome-`` pattern in their
+    command line.
+    """
+
+    def test_dead_daemon_triggers_chromium_scan(self, fake_tmpdir):
+        """When the daemon PID is dead, orphaned Chromium is scanned + killed."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(fake_tmpdir, "h_dead123456", pid=999999999)
+
+        chromium_killed = []
+
+        def mock_kill_chromium(socket_dir, session_name):
+            chromium_killed.append((socket_dir, session_name))
+            return 0
+
+        with patch("tools.browser_tool._kill_orphaned_chromium_for_session",
+                    side_effect=mock_kill_chromium):
+            _reap_orphaned_browser_sessions()
+
+        assert len(chromium_killed) == 1
+        assert chromium_killed[0][1] == "h_dead123456"
+        assert not d.exists()
+
+    def test_alive_daemon_does_not_trigger_chromium_scan(self, fake_tmpdir):
+        """When the daemon PID is alive, Chromium scan is NOT triggered
+        (the tree-kill path handles it)."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(fake_tmpdir, "h_alive1234567", pid=12345)
+
+        chromium_killed = []
+
+        def mock_kill_chromium(socket_dir, session_name):
+            chromium_killed.append(session_name)
+            return 0
+
+        with patch("gateway.status._pid_exists", return_value=True), \
+             patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid"), \
+             patch("tools.browser_tool._kill_orphaned_chromium_for_session",
+                   side_effect=mock_kill_chromium):
+            _reap_orphaned_browser_sessions()
+
+        assert len(chromium_killed) == 0
+
+
 class TestOwnerPidCrossProcess:
     """Tests for owner_pid-based cross-process safe reaping.
 

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -2,7 +2,7 @@
 daemons whose Python parent exited without cleaning up."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -235,6 +235,51 @@ class TestOrphanedChromiumCleanup:
             _reap_orphaned_browser_sessions()
 
         assert len(chromium_killed) == 0
+
+    def test_only_reparented_chromium_is_killed(self, fake_tmpdir):
+        """_kill_orphaned_chromium_for_session only kills Chromium whose
+        PPID==1 (reparented to init = true orphan), NOT Chromium whose
+        parent is a still-running daemon (live session).
+
+        Regression test for the cross-session kill issue raised in review:
+        without the PPID check, the function would terminate Chromium
+        belonging to *other* live agent-browser sessions.
+        """
+        from tools.browser_tool import _kill_orphaned_chromium_for_session
+
+        # Simulate two Chromium processes:
+        #  - orphan_proc: PPID=1 (daemon died, reparented to init) → should kill
+        #  - live_proc:   PPID=99999 (daemon alive) → must NOT kill
+        orphan_proc = MagicMock()
+        orphan_proc.info = {
+            "pid": 2001, "name": "chrome", "cmdline": [
+                "/usr/bin/chromium", "--headless",
+                "--user-data-dir=/tmp/agent-browser-chrome-aaaa1111",
+            ], "ppid": 1,
+        }
+        live_proc = MagicMock()
+        live_proc.info = {
+            "pid": 2002, "name": "chrome", "cmdline": [
+                "/usr/bin/chromium", "--headless",
+                "--user-data-dir=/tmp/agent-browser-chrome-bbbb2222",
+            ], "ppid": 99999,
+        }
+
+        terminated_pids = []
+
+        def fake_terminate():
+            terminated_pids.append(orphan_proc.info["pid"])
+
+        orphan_proc.terminate = fake_terminate
+        live_proc.terminate = MagicMock()  # should never be called
+
+        with patch("psutil.process_iter", return_value=[orphan_proc, live_proc]), \
+             patch("psutil.wait_procs", return_value=([], [])):
+            result = _kill_orphaned_chromium_for_session("/tmp/fake", "h_test1234")
+
+        assert result == 1  # only the orphan was killed
+        assert 2001 in terminated_pids
+        live_proc.terminate.assert_not_called()
 
 
 class TestOwnerPidCrossProcess:

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -182,16 +182,16 @@ class TestReapOrphanedBrowserSessions:
 
 
 class TestOrphanedChromiumCleanup:
-    """Tests for _kill_orphaned_chromium_for_session() — kills Chromium
+    """Tests for _kill_orphaned_chromium_processes() — kills Chromium
     processes left behind when the agent-browser daemon dies before cleanup.
 
     When the daemon (Node process) crashes or is SIGKILLed, its Chromium
     children are reparented to PID 1 and the normal tree-kill path (which
     walks children of the daemon PID) never reaches them.  The reaper
     discovers the dead daemon PID, removes the socket dir, and calls
-    _kill_orphaned_chromium_for_session to scan for surviving Chromium
-    processes by matching the ``agent-browser-chrome-`` pattern in their
-    command line.
+    _kill_orphaned_chromium_processes to scan for surviving orphaned
+    Chromium processes by matching PPID == 1 + the ``agent-browser-chrome-``
+    cmdline pattern.
     """
 
     def test_dead_daemon_triggers_chromium_scan(self, fake_tmpdir):
@@ -202,16 +202,16 @@ class TestOrphanedChromiumCleanup:
 
         chromium_killed = []
 
-        def mock_kill_chromium(socket_dir, session_name):
-            chromium_killed.append((socket_dir, session_name))
+        def mock_kill_chromium(session_name):
+            chromium_killed.append(session_name)
             return 0
 
-        with patch("tools.browser_tool._kill_orphaned_chromium_for_session",
+        with patch("tools.browser_tool._kill_orphaned_chromium_processes",
                     side_effect=mock_kill_chromium):
             _reap_orphaned_browser_sessions()
 
         assert len(chromium_killed) == 1
-        assert chromium_killed[0][1] == "h_dead123456"
+        assert chromium_killed[0] == "h_dead123456"
         assert not d.exists()
 
     def test_alive_daemon_does_not_trigger_chromium_scan(self, fake_tmpdir):
@@ -223,33 +223,29 @@ class TestOrphanedChromiumCleanup:
 
         chromium_killed = []
 
-        def mock_kill_chromium(socket_dir, session_name):
+        def mock_kill_chromium(session_name):
             chromium_killed.append(session_name)
             return 0
 
         with patch("gateway.status._pid_exists", return_value=True), \
              patch("tools.browser_tool._verify_reapable_browser_daemon", return_value=True), \
              patch("tools.process_registry.ProcessRegistry._terminate_host_pid"), \
-             patch("tools.browser_tool._kill_orphaned_chromium_for_session",
+             patch("tools.browser_tool._kill_orphaned_chromium_processes",
                    side_effect=mock_kill_chromium):
             _reap_orphaned_browser_sessions()
 
         assert len(chromium_killed) == 0
 
-    def test_only_reparented_chromium_is_killed(self, fake_tmpdir):
-        """_kill_orphaned_chromium_for_session only kills Chromium whose
-        PPID==1 (reparented to init = true orphan), NOT Chromium whose
-        parent is a still-running daemon (live session).
+    def test_kill_orphaned_chromium_skips_non_orphan_active_session(self, fake_tmpdir):
+        """_kill_orphaned_chromium_processes only kills Chromium whose PPID
+        is 1 (reparented to init = true orphan).  It must NOT kill:
 
-        Regression test for the cross-session kill issue raised in review:
-        without the PPID check, the function would terminate Chromium
-        belonging to *other* live agent-browser sessions.
+        - Chromium whose parent is a still-running daemon (active session)
+        - Non-agent-browser Chromium (user-installed Chrome, even if PPID=1)
         """
-        from tools.browser_tool import _kill_orphaned_chromium_for_session
+        from tools.browser_tool import _kill_orphaned_chromium_processes
 
-        # Simulate two Chromium processes:
-        #  - orphan_proc: PPID=1 (daemon died, reparented to init) → should kill
-        #  - live_proc:   PPID=99999 (daemon alive) → must NOT kill
+        # 1. orphaned agent-browser Chromium (PPID=1) → should terminate
         orphan_proc = MagicMock()
         orphan_proc.info = {
             "pid": 2001, "name": "chrome", "cmdline": [
@@ -257,12 +253,20 @@ class TestOrphanedChromiumCleanup:
                 "--user-data-dir=/tmp/agent-browser-chrome-aaaa1111",
             ], "ppid": 1,
         }
+        # 2. active session Chromium (PPID=daemon) → must NOT terminate
         live_proc = MagicMock()
         live_proc.info = {
             "pid": 2002, "name": "chrome", "cmdline": [
                 "/usr/bin/chromium", "--headless",
                 "--user-data-dir=/tmp/agent-browser-chrome-bbbb2222",
             ], "ppid": 99999,
+        }
+        # 3. user-installed Chrome (PPID=1 but no agent-browser pattern) → must NOT terminate
+        user_chrome = MagicMock()
+        user_chrome.info = {
+            "pid": 2003, "name": "chrome", "cmdline": [
+                "/usr/bin/google-chrome", "--user-data-dir=/home/user/.config/chrome",
+            ], "ppid": 1,
         }
 
         terminated_pids = []
@@ -271,15 +275,18 @@ class TestOrphanedChromiumCleanup:
             terminated_pids.append(orphan_proc.info["pid"])
 
         orphan_proc.terminate = fake_terminate
-        live_proc.terminate = MagicMock()  # should never be called
+        live_proc.terminate = MagicMock()
+        user_chrome.terminate = MagicMock()
 
-        with patch("psutil.process_iter", return_value=[orphan_proc, live_proc]), \
+        with patch("psutil.process_iter",
+                   return_value=[orphan_proc, live_proc, user_chrome]), \
              patch("psutil.wait_procs", return_value=([], [])):
-            result = _kill_orphaned_chromium_for_session("/tmp/fake", "h_test1234")
+            result = _kill_orphaned_chromium_processes("h_test1234")
 
         assert result == 1  # only the orphan was killed
         assert 2001 in terminated_pids
         live_proc.terminate.assert_not_called()
+        user_chrome.terminate.assert_not_called()
 
 
 class TestOwnerPidCrossProcess:

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -271,22 +271,55 @@ class TestOrphanedChromiumCleanup:
 
         terminated_pids = []
 
-        def fake_terminate():
-            terminated_pids.append(orphan_proc.info["pid"])
-
-        orphan_proc.terminate = fake_terminate
-        live_proc.terminate = MagicMock()
-        user_chrome.terminate = MagicMock()
+        def fake_terminate(pid):
+            terminated_pids.append(pid)
 
         with patch("psutil.process_iter",
                    return_value=[orphan_proc, live_proc, user_chrome]), \
-             patch("psutil.wait_procs", return_value=([], [])):
+             patch(
+                 "tools.process_registry.ProcessRegistry._terminate_host_pid",
+                 side_effect=fake_terminate,
+             ):
             result = _kill_orphaned_chromium_processes("h_test1234")
 
-        assert result == 1  # only the orphan was killed
-        assert 2001 in terminated_pids
+        assert result == 1  # only the orphan root was selected
+        assert terminated_pids == [2001]
+        orphan_proc.terminate.assert_not_called()
         live_proc.terminate.assert_not_called()
         user_chrome.terminate.assert_not_called()
+
+    def test_kill_orphaned_chromium_uses_full_process_tree_termination(
+        self, fake_tmpdir
+    ):
+        """An orphan Chromium root is terminated together with its descendants.
+
+        The process registry owns the cross-platform tree-kill and escalation
+        behavior.  The browser orphan scanner must delegate to it rather than
+        terminating only the Chromium root object.
+        """
+        from tools.browser_tool import _kill_orphaned_chromium_processes
+
+        orphan_proc = MagicMock()
+        orphan_proc.info = {
+            "pid": 2001,
+            "name": "chrome",
+            "cmdline": [
+                "/usr/bin/chromium",
+                "--headless",
+                "--user-data-dir=/tmp/agent-browser-chrome-aaaa1111",
+            ],
+            "ppid": 1,
+        }
+
+        with patch("psutil.process_iter", return_value=[orphan_proc]), \
+             patch(
+                 "tools.process_registry.ProcessRegistry._terminate_host_pid"
+             ) as terminate_tree:
+            result = _kill_orphaned_chromium_processes("h_test1234")
+
+        assert result == 1
+        terminate_tree.assert_called_once_with(2001)
+        orphan_proc.terminate.assert_not_called()
 
 
 class TestOwnerPidCrossProcess:

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -206,13 +206,36 @@ class TestOrphanedChromiumCleanup:
             chromium_killed.append(session_name)
             return 0
 
-        with patch("tools.browser_tool._kill_orphaned_chromium_processes",
-                    side_effect=mock_kill_chromium):
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("tools.browser_tool._kill_orphaned_chromium_processes",
+                   side_effect=mock_kill_chromium):
             _reap_orphaned_browser_sessions()
 
         assert len(chromium_killed) == 1
         assert chromium_killed[0] == "h_dead123456"
         assert not d.exists()
+
+    def test_dead_daemons_trigger_chromium_scan_only_once(self, fake_tmpdir):
+        """Global Chromium scanning happens once per reaper invocation."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        first = _make_socket_dir(fake_tmpdir, "h_dead_first", pid=10001)
+        second = _make_socket_dir(fake_tmpdir, "h_dead_second", pid=10002)
+        chromium_scans = []
+
+        def mock_kill_chromium(session_name):
+            chromium_scans.append(session_name)
+            return 0
+
+        with patch("gateway.status._pid_exists", return_value=False), \
+             patch("tools.browser_tool._kill_orphaned_chromium_processes",
+                   side_effect=mock_kill_chromium):
+            _reap_orphaned_browser_sessions()
+
+        assert len(chromium_scans) == 1
+        assert set(chromium_scans) <= {"h_dead_first", "h_dead_second"}
+        assert not first.exists()
+        assert not second.exists()
 
     def test_alive_daemon_does_not_trigger_chromium_scan(self, fake_tmpdir):
         """When the daemon PID is alive, Chromium scan is NOT triggered

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1626,7 +1626,7 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
     return True
 
 
-def _kill_orphaned_chromium_for_session(socket_dir: str, session_name: str) -> int:
+def _kill_orphaned_chromium_processes(session_name: str) -> int:
     """Kill Chromium processes orphaned by a dead agent-browser daemon.
 
     When the agent-browser daemon (a Node process) dies before its owner
@@ -1636,19 +1636,24 @@ def _kill_orphaned_chromium_for_session(socket_dir: str, session_name: str) -> i
     process, so the reaper's normal tree-kill path (which walks children of
     the *daemon* PID) never reaches them.
 
-    This function scans running processes for Chromium instances whose
-    ``--user-data-dir`` command-line argument references the
-    ``agent-browser-chrome-*`` pattern that agent-browser assigns to its
-    spawned Chromium, **and whose parent PID is 1** (init — meaning the
-    daemon that spawned them is gone and they were reparented).  This
-    prevents killing Chromium instances belonging to *other* live
-    agent-browser sessions, whose parent PID is still the alive daemon.
+    We cannot map Chromium's ``--user-data-dir`` UUID back to a specific
+    session's socket directory, so this function targets **all** orphaned
+    agent-browser Chromium processes (PPID == 1 + ``agent-browser-chrome-``
+    cmdline pattern), not just those from ``session_name``.  This is safe
+    because any agent-browser Chromium with PPID 1 is a true orphan whose
+    daemon is gone — leaving it running is the same resource leak this fix
+    addresses.  Active sessions are unaffected: their Chromium still has
+    the live daemon as parent (PPID != 1).
 
     Security: the ``agent-browser-chrome-`` prefix is specific to
     agent-browser-spawned Chromium and distinct from user-installed
     Chrome/Chromium.  The PPID==1 check ensures we only kill true orphans,
     not Chromium children of a still-running daemon.  Same-user only
     (psutil can only signal same-user processes).
+
+    Args:
+        session_name: Used for logging context only; the actual kill
+            criteria are orphaned parent + agent-browser cmdline pattern.
 
     Returns the number of Chromium processes killed.
     """
@@ -1797,15 +1802,13 @@ def _reap_orphaned_browser_sessions():
         # is NOT a no-op — use the handle-based existence check.
         from gateway.status import _pid_exists
         if not _pid_exists(daemon_pid):
-            # The daemon (Node process) is gone, but it may have left behind
-            # orphaned Chromium child processes.  When the daemon dies
-            # unexpectedly (SIGKILL, crash, OOM), Chromium processes are
-            # reparented to PID 1 and the tree-kill path below never runs.
-            # Scan for Chromium processes whose --user-data-dir references
-            # this session's socket directory and terminate them before
-            # cleaning up the socket dir.  See issue: orphaned Chrome
-            # processes accumulate ~20% CPU / ~14 GB RAM over 10 days.
-            _kill_orphaned_chromium_for_session(socket_dir, session_name)
+            # The daemon is gone, but it may have left behind Chromium children.
+            # Once the daemon dies unexpectedly, those Chromium processes are
+            # reparented to PID 1.  We cannot map Chromium's --user-data-dir UUID
+            # back to this socket directory, so only terminate agent-browser
+            # Chromium processes that are already orphaned.  Active sessions still
+            # have a live daemon parent and are skipped.
+            _kill_orphaned_chromium_processes(session_name)
             shutil.rmtree(socket_dir, ignore_errors=True)
             continue
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1626,6 +1626,71 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
     return True
 
 
+def _kill_orphaned_chromium_for_session(socket_dir: str, session_name: str) -> int:
+    """Kill Chromium processes orphaned by a dead agent-browser daemon.
+
+    When the agent-browser daemon (a Node process) dies before its owner
+    cleans up, Chromium child processes it spawned are reparented to PID 1
+    and left running indefinitely — consuming CPU and memory with no one to
+    shut them down.  The daemon's ``.pid`` file points at the dead Node
+    process, so the reaper's normal tree-kill path (which walks children of
+    the *daemon* PID) never reaches them.
+
+    This function scans running processes for Chromium instances whose
+    ``--user-data-dir`` command-line argument references the
+    ``agent-browser-chrome-*`` pattern that agent-browser assigns to its
+    spawned Chromium, and terminates them via ``psutil``.
+
+    Security: matches on the ``agent-browser-chrome-`` prefix in the process
+    command line, which is specific to agent-browser-spawned Chromium and
+    distinct from user-installed Chrome/Chromium.  Same-user only (psutil
+    can only signal same-user processes).
+
+    Returns the number of Chromium processes killed.
+    """
+    try:
+        import psutil
+    except ImportError:
+        logger.warning(
+            "Cannot scan for orphaned Chromium (session %s): psutil unavailable",
+            session_name)
+        return 0
+
+    killed = 0
+    # Collect the actual proc objects we terminated so we can wait on them
+    # without re-scanning the entire process table.
+    terminated_procs = []
+
+    for proc in psutil.process_iter(["pid", "name", "cmdline"]):
+        try:
+            cmdline = " ".join(proc.info["cmdline"] or [])
+            if "agent-browser-chrome-" in cmdline and "--user-data-dir=" in cmdline:
+                proc.terminate()
+                terminated_procs.append(proc)
+                killed += 1
+                logger.info(
+                    "Killed orphaned Chromium PID %d (session %s, daemon gone)",
+                    proc.info["pid"], session_name)
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+        except Exception as exc:
+            logger.debug("Error scanning process %d for orphaned Chromium: %s",
+                         getattr(proc, 'pid', -1), exc)
+
+    # Give SIGTERM a moment, then escalate to SIGKILL for any survivors
+    if terminated_procs:
+        gone, alive = psutil.wait_procs(terminated_procs, timeout=3)
+        for proc in alive:
+            try:
+                proc.kill()
+                logger.info("Force-killed orphaned Chromium PID %d (session %s)",
+                            proc.pid, session_name)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+
+    return killed
+
+
 def _reap_orphaned_browser_sessions():
     """Scan for orphaned agent-browser daemon processes from previous runs.
 
@@ -1714,10 +1779,19 @@ def _reap_orphaned_browser_sessions():
             shutil.rmtree(socket_dir, ignore_errors=True)
             continue
 
-        # Check if the daemon is still alive. ``os.kill(pid, 0)`` on Windows
+        # Check if the daemon is still alive.  ``os.kill(pid, 0)`` on Windows
         # is NOT a no-op — use the handle-based existence check.
         from gateway.status import _pid_exists
         if not _pid_exists(daemon_pid):
+            # The daemon (Node process) is gone, but it may have left behind
+            # orphaned Chromium child processes.  When the daemon dies
+            # unexpectedly (SIGKILL, crash, OOM), Chromium processes are
+            # reparented to PID 1 and the tree-kill path below never runs.
+            # Scan for Chromium processes whose --user-data-dir references
+            # this session's socket directory and terminate them before
+            # cleaning up the socket dir.  See issue: orphaned Chrome
+            # processes accumulate ~20% CPU / ~14 GB RAM over 10 days.
+            _kill_orphaned_chromium_for_session(socket_dir, session_name)
             shutil.rmtree(socket_dir, ignore_errors=True)
             continue
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1639,12 +1639,16 @@ def _kill_orphaned_chromium_for_session(socket_dir: str, session_name: str) -> i
     This function scans running processes for Chromium instances whose
     ``--user-data-dir`` command-line argument references the
     ``agent-browser-chrome-*`` pattern that agent-browser assigns to its
-    spawned Chromium, and terminates them via ``psutil``.
+    spawned Chromium, **and whose parent PID is 1** (init — meaning the
+    daemon that spawned them is gone and they were reparented).  This
+    prevents killing Chromium instances belonging to *other* live
+    agent-browser sessions, whose parent PID is still the alive daemon.
 
-    Security: matches on the ``agent-browser-chrome-`` prefix in the process
-    command line, which is specific to agent-browser-spawned Chromium and
-    distinct from user-installed Chrome/Chromium.  Same-user only (psutil
-    can only signal same-user processes).
+    Security: the ``agent-browser-chrome-`` prefix is specific to
+    agent-browser-spawned Chromium and distinct from user-installed
+    Chrome/Chromium.  The PPID==1 check ensures we only kill true orphans,
+    not Chromium children of a still-running daemon.  Same-user only
+    (psutil can only signal same-user processes).
 
     Returns the number of Chromium processes killed.
     """
@@ -1661,16 +1665,26 @@ def _kill_orphaned_chromium_for_session(socket_dir: str, session_name: str) -> i
     # without re-scanning the entire process table.
     terminated_procs = []
 
-    for proc in psutil.process_iter(["pid", "name", "cmdline"]):
+    for proc in psutil.process_iter(["pid", "name", "cmdline", "ppid"]):
         try:
             cmdline = " ".join(proc.info["cmdline"] or [])
-            if "agent-browser-chrome-" in cmdline and "--user-data-dir=" in cmdline:
-                proc.terminate()
-                terminated_procs.append(proc)
-                killed += 1
-                logger.info(
-                    "Killed orphaned Chromium PID %d (session %s, daemon gone)",
-                    proc.info["pid"], session_name)
+            # Match agent-browser-spawned Chromium by its user-data-dir pattern.
+            if "agent-browser-chrome-" not in cmdline:
+                continue
+            if "--user-data-dir=" not in cmdline:
+                continue
+            # Only kill true orphans: Chromium whose parent (the daemon)
+            # has died, causing reparenting to PID 1 (init).  Chromium
+            # belonging to a *live* daemon still has the daemon as its
+            # parent and must not be touched.
+            if proc.info["ppid"] != 1:
+                continue
+            proc.terminate()
+            terminated_procs.append(proc)
+            killed += 1
+            logger.info(
+                "Killed orphaned Chromium PID %d (session %s, daemon gone)",
+                proc.info["pid"], session_name)
         except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
             continue
         except Exception as exc:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1667,6 +1667,7 @@ def _kill_orphaned_chromium_processes(session_name: str) -> int:
         return 0
 
     killed = 0
+    from tools.process_registry import ProcessRegistry
 
     for proc in psutil.process_iter(["pid", "name", "cmdline", "ppid"]):
         try:
@@ -1687,7 +1688,6 @@ def _kill_orphaned_chromium_processes(session_name: str) -> int:
             # so descendants (renderer, GPU, etc.) receive the same
             # SIGTERM→SIGKILL escalation as the root instead of surviving as
             # newly orphaned processes when the root is force-killed.
-            from tools.process_registry import ProcessRegistry
             ProcessRegistry._terminate_host_pid(proc.info["pid"])
             killed += 1
             logger.info(
@@ -1748,6 +1748,7 @@ def _reap_orphaned_browser_sessions():
         }
 
     reaped = 0
+    chromium_scan_done = False
     for socket_dir in socket_dirs:
         dir_name = os.path.basename(socket_dir)
         # dir_name is "agent-browser-{session_name}"
@@ -1801,7 +1802,9 @@ def _reap_orphaned_browser_sessions():
             # back to this socket directory, so only terminate agent-browser
             # Chromium processes that are already orphaned.  Active sessions still
             # have a live daemon parent and are skipped.
-            _kill_orphaned_chromium_processes(session_name)
+            if not chromium_scan_done:
+                chromium_scan_done = True
+                _kill_orphaned_chromium_processes(session_name)
             shutil.rmtree(socket_dir, ignore_errors=True)
             continue
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1655,7 +1655,8 @@ def _kill_orphaned_chromium_processes(session_name: str) -> int:
         session_name: Used for logging context only; the actual kill
             criteria are orphaned parent + agent-browser cmdline pattern.
 
-    Returns the number of Chromium processes killed.
+    Returns the number of orphaned Chromium roots handed to the process-tree
+    terminator.
     """
     try:
         import psutil
@@ -1666,9 +1667,6 @@ def _kill_orphaned_chromium_processes(session_name: str) -> int:
         return 0
 
     killed = 0
-    # Collect the actual proc objects we terminated so we can wait on them
-    # without re-scanning the entire process table.
-    terminated_procs = []
 
     for proc in psutil.process_iter(["pid", "name", "cmdline", "ppid"]):
         try:
@@ -1684,28 +1682,23 @@ def _kill_orphaned_chromium_processes(session_name: str) -> int:
             # parent and must not be touched.
             if proc.info["ppid"] != 1:
                 continue
-            proc.terminate()
-            terminated_procs.append(proc)
+
+            # Chromium is a process tree.  Reuse the shared termination path
+            # so descendants (renderer, GPU, etc.) receive the same
+            # SIGTERM→SIGKILL escalation as the root instead of surviving as
+            # newly orphaned processes when the root is force-killed.
+            from tools.process_registry import ProcessRegistry
+            ProcessRegistry._terminate_host_pid(proc.info["pid"])
             killed += 1
             logger.info(
-                "Killed orphaned Chromium PID %d (session %s, daemon gone)",
+                "Reaped orphaned Chromium process tree rooted at PID %d "
+                "(session %s, daemon gone)",
                 proc.info["pid"], session_name)
         except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
             continue
         except Exception as exc:
             logger.debug("Error scanning process %d for orphaned Chromium: %s",
                          getattr(proc, 'pid', -1), exc)
-
-    # Give SIGTERM a moment, then escalate to SIGKILL for any survivors
-    if terminated_procs:
-        gone, alive = psutil.wait_procs(terminated_procs, timeout=3)
-        for proc in alive:
-            try:
-                proc.kill()
-                logger.info("Force-killed orphaned Chromium PID %d (session %s)",
-                            proc.pid, session_name)
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                pass
 
     return killed
 


### PR DESCRIPTION
## Problem

When the `agent-browser` daemon (Node process) dies before cleanup — via SIGKILL, crash, or OOM — its Chromium child processes are reparented to PID 1 and left running indefinitely.

The orphan reaper (`_reap_orphaned_browser_sessions`) discovers the dead daemon PID and removes the socket directory, but **never terminates the orphaned Chromium processes**, causing steady resource accumulation.

### Observed in production

A long-running Hermes gateway (10 days uptime, gateway mode) accumulated **371 orphaned Chromium processes**:
- **~20% CPU** (each process ~0.6%, matching Beszel monitoring)
- **~14 GB RSS** combined
- Oldest processes from 10 days prior

### Root cause

In `_reap_orphaned_browser_sessions()`, when the daemon PID is found dead:

```python
if not _pid_exists(daemon_pid):
    shutil.rmtree(socket_dir, ignore_errors=True)
    continue  # ← only removes the dir, never kills Chromium children
```

The tree-kill path (`ProcessRegistry._terminate_host_pid(daemon_pid)`) only runs when the daemon PID is **alive** — it walks the process tree from the daemon downward. When the daemon is already dead, Chromium children (reparented to PID 1) are unreachable via tree-kill.

## Fix

Added `_kill_orphaned_chromium_for_session()` — called when the reaper finds a dead daemon, before removing the socket directory. It:

1. Scans running processes via `psutil.process_iter()` for Chromium instances whose command line contains `agent-browser-chrome-` and `--user-data-dir=`
2. Sends `SIGTERM` (via `proc.terminate()`)
3. Waits 3 seconds for graceful exit
4. Escalates to `SIGKILL` for any survivors

### Security

- The `agent-browser-chrome-` prefix is specific to agent-browser-spawned Chromium — distinct from user-installed Chrome/Chromium profiles
- `psutil` only signals same-user processes (same security boundary as the existing reaper)
- No new external dependencies (`psutil` is already a hard dependency)

## Tests

Two new tests in `TestOrphanedChromiumCleanup`:

| Test | What it verifies |
|---|---|
| `test_dead_daemon_triggers_chromium_scan` | Dead daemon PID → `_kill_orphaned_chromium_for_session` is called + socket dir removed |
| `test_alive_daemon_does_not_trigger_chromium_scan` | Alive daemon PID → Chromium scan NOT called (tree-kill path handles it) |

All 28 existing orphan-reaper tests continue to pass.