### PR TITLE
fix(desktop): handle Windows simple-git binary paths with spaces

### DIFF
--- a/apps/desktop/electron/git-review-ops.cjs
+++ b/apps/desktop/electron/git-review-ops.cjs
@@ -64,7 +64,10 @@ function runGh(args, cwd, ghBin) {
 }
 
 function gitFor(cwd, gitBin) {
-  return simpleGit({ baseDir: cwd, binary: gitBin || 'git', maxConcurrentProcesses: 4, trimmed: false })
+  // simple-git rejects Windows paths with spaces (C:\Program Files\Git\...).
+  // Fall back to PATH lookup — 'git' is on PATH on Windows regardless.
+  const binary = gitBin && !gitBin.includes(' ') ? gitBin : 'git'
+  return simpleGit({ baseDir: cwd, binary, maxConcurrentProcesses: 4, trimmed: false })
 }
 
 // simple-git reports renames as `old => new` (and `dir/{old => new}/f`); resolve


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-only bug where the desktop review pane shows "No diff to show" because `simple-git` rejects binary paths containing spaces (e.g. `C:\Program Files\Git\cmd\git.exe` — the default Git for Windows install path).

## Related Issue

Fixes the Windows half of the desktop review-pane diff bug. The other half (subdirectory-repo path handling) is split into a separate PR to keep this surgical.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/git-review-ops.cjs`: in `gitFor()`, detect spaces in the supplied binary path and fall back to `'git'` from PATH. `simple-git` then uses the resolved `git` binary from the user's PATH, which works on every platform.

## How to Test

**Reproduction (Windows, before fix):**
1. Install Git for Windows to default location (`C:\Program Files\Git\`)
2. Open a repo with uncommitted changes in the desktop app
3. Press `Ctrl+G` to open the review pane
4. Right-click any changed file → "Open Changes"
5. Bottom panel shows "No diff to show" — broken

**After fix:**
1. Same setup
2. Same action
3. Bottom panel shows the file's diff

**Non-Windows / PATH-only:** No change in behavior — `git` is still resolved from PATH.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` — no Python changes, no tests needed
- [x] I've added tests for my changes — N/A (single-line defensive check, covered by manual repro)
- [x] I've tested on my platform: Windows 11, Git for Windows 2.45 (default install path)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no doc references this code path)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — fix is a no-op on non-Windows; the fallback to `'git'` is platform-agnostic
- [x] I've updated tool descriptions/schemas — N/A