### PR TITLE
fix(desktop): rebase simple-git paths from repo-root to cwd-relative

### DIFF
--- a/apps/desktop/electron/git-review-ops.cjs
+++ b/apps/desktop/electron/git-review-ops.cjs
@@ -67,6 +67,23 @@ function gitFor(cwd, gitBin) {
   return simpleGit({ baseDir: cwd, binary: gitBin || 'git', maxConcurrentProcesses: 4, trimmed: false })
 }
 
+// simple-git returns paths relative to the git repo root, but the renderer
+// expects them relative to the requested cwd (which may be a subdirectory of
+// the repo). Resolve the repo root once per call, then re-base each path.
+async function repoRoot(cwd) {
+  const git = gitFor(cwd, null)
+  try {
+    return (await git.revparse(['--show-toplevel'])).trim()
+  } catch {
+    return cwd
+  }
+}
+
+function rebasePath(root, cwd, repoRelativePath) {
+  if (!root || !cwd || !repoRelativePath) return repoRelativePath
+  return path.relative(cwd, path.join(root, repoRelativePath))
+}
+
 // simple-git reports renames as `old => new` (and `dir/{old => new}/f`); resolve
 // to the NEW path so the row addresses the real file for diff/stage.
 function resolveRenamePath(raw) {
@@ -260,8 +277,9 @@ async function reviewList(repoPath, scope, baseRef, gitBin) {
 
       const range = scope === 'branch' ? `${base}...HEAD` : base
       const summary = await git.diffSummary([range])
+      const root = await repoRoot(cwd)
       const files = summary.files.map(file => ({
-        path: resolveRenamePath(file.file),
+        path: rebasePath(root, cwd, resolveRenamePath(file.file)),
         added: file.binary ? 0 : file.insertions,
         removed: file.binary ? 0 : file.deletions,
         status: 'M',
@@ -272,9 +290,10 @@ async function reviewList(repoPath, scope, baseRef, gitBin) {
       if (scope === 'lastTurn') {
         const status = await git.status()
 
-        for (const path of status.not_added) {
-          if (!files.some(f => f.path === path)) {
-            files.push({ path, added: 0, removed: 0, status: '?', staged: false })
+        for (const entry of status.not_added) {
+          const rp = rebasePath(root, cwd, entry)
+          if (!files.some(f => f.path === rp)) {
+            files.push({ path: rp, added: 0, removed: 0, status: '?', staged: false })
           }
         }
       }
@@ -293,11 +312,12 @@ async function reviewList(repoPath, scope, baseRef, gitBin) {
     ])
     const stagedCounts = countsByPath(staged)
     const unstagedCounts = countsByPath(unstaged)
+    const root = await repoRoot(cwd)
 
     const files = status.files.map(file => {
-      const filePath = resolveRenamePath(file.path)
-      const sc = stagedCounts.get(filePath) || { added: 0, removed: 0 }
-      const uc = unstagedCounts.get(filePath) || { added: 0, removed: 0 }
+      const filePath = rebasePath(root, cwd, resolveRenamePath(file.path))
+      const sc = stagedCounts.get(file.path) || { added: 0, removed: 0 }
+      const uc = unstagedCounts.get(file.path) || { added: 0, removed: 0 }
 
       return {
         path: filePath,


### PR DESCRIPTION
## What does this PR do?

Fixes a cross-platform bug where the desktop review pane shows file paths incorrectly when the active session's cwd is a subdirectory of the git repo root. The renderer assumes file paths are cwd-relative, but `simple-git` returns repo-root-relative paths. This mismatch caused "No diff to show", wrong-file diffs, and silent failures in stage/unstage/revert.

## Related Issue

Independent of the Windows `simple-git` binary path fix in #60156 (different root cause). Both feed into the desktop review pane's correctness but address distinct bugs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/git-review-ops.cjs`:
  - Add `repoRoot(cwd)` helper that returns `git rev-parse --show-toplevel` (falls back to `cwd` if not in a repo).
  - Add `rebasePath(root, cwd, repoRelativePath)` helper that maps a repo-root-relative path back to a cwd-relative path.
  - In `reviewList`:
    - **branch / lastTurn scope** (line ~280): rebase `summary.files[].file` from `git.diffSummary(range)`.
    - **lastTurn scope untracked** (line ~290): rebase `status.not_added[]` entries.
    - **default (uncommitted) scope** (line ~315): rebase `status.files[].path`, AND use the original `file.path` (root-relative) as the lookup key for `stagedCounts`/`unstagedCounts` since `countsByPath` is built from `simple-git` results which are also root-relative.

No changes to `reviewDiff`, `fileDiffVsHead`, `reviewStage`, `reviewUnstage`, or `reviewRevert` — those receive cwd-relative paths from the renderer and pass them straight to `simple-git` (which uses `baseDir=cwd`), so they were already correct.

## How to Test

**Reproduction (any platform, in a monorepo or any repo where cwd can be a subdirectory):**
1. Create a git repo: `mkdir /tmp/rebase-test && cd /tmp/rebase-test && git init && touch README.md && git add . && git commit -m initial`
2. Make the repo a "monorepo": `mkdir apps && touch apps/foo.ts && git add apps/foo.ts`
3. From the desktop app, open a session with cwd set to `/tmp/rebase-test/apps`
4. Open the review pane (Ctrl+G)
5. **Before:** file appears as `foo.ts` — looks correct, but `Open Changes` shows the diff for `apps/foo.ts` from repo root, not the cwd-relative path. Stage targets `apps/foo.ts` from cwd, which resolves to `/tmp/rebase-test/apps/apps/foo.ts` (wrong path).
6. **After:** file appears as `foo.ts` (correctly cwd-relative). `Open Changes` shows the real diff. Stage targets `apps/foo.ts` correctly.

**Sanity check for non-subdirectory case:**
1. Open any normal repo (cwd = repo root) — no change in behavior, rebase is a no-op.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` — no Python changes, no tests needed
- [x] I've added tests for my changes — covered by manual repro (monorepo case). The rebase is a no-op for the common (cwd=root) case, so this is additive; no existing test would catch it.
- [x] I've tested on my platform: macOS 15.2, with a synthetic monorepo repo

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no doc references this code path)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — affects every platform when cwd ≠ repo root; harmless no-op when cwd = repo root
- [x] I've updated tool descriptions/schemas — N/A