### PR TITLE
fix(desktop): pin current model in composer picker

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -1,9 +1,9 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { cleanup, findAllByText, findByText, fireEvent, render } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
-import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
+import { $activeSessionId, $currentModel, $currentProvider, $currentReasoningEffort } from '@/store/session'
 
 import { ModelMenuPanel } from './model-menu-panel'
 
@@ -25,10 +25,20 @@ vi.mock('@/hermes', () => ({
 // REST config.
 const MOA_PROVIDER = { models: ['default', 'BeastMode'], name: 'Mixture of Agents', slug: 'moa' }
 
+const ANTHROPIC_PROVIDER = {
+  capabilities: {
+    'anthropic/claude-sonnet-4-6': { fast: true, reasoning: true }
+  },
+  models: ['anthropic/claude-opus-4-8', 'anthropic/claude-sonnet-4-6'],
+  name: 'Anthropic',
+  slug: 'anthropic'
+}
+
 beforeEach(() => {
   $activeSessionId.set('runtime-1')
   $currentModel.set('')
   $currentProvider.set('')
+  $currentReasoningEffort.set('')
   getGlobalModelOptions.mockResolvedValue({ providers: [MOA_PROVIDER] })
 })
 
@@ -52,6 +62,37 @@ function renderPanel(onSelectModel = vi.fn()) {
 
   return { onSelectModel, content }
 }
+
+describe('ModelMenuPanel current model row', () => {
+  it('pins the current model below the scrollable model list and above MoA presets', async () => {
+    $currentProvider.set('anthropic')
+    $currentModel.set('anthropic/claude-sonnet-4-6')
+    $currentReasoningEffort.set('high')
+    getGlobalModelOptions.mockResolvedValue({
+      model: 'anthropic/claude-sonnet-4-6',
+      provider: 'anthropic',
+      providers: [ANTHROPIC_PROVIDER, MOA_PROVIDER]
+    })
+
+    renderPanel()
+
+    await findAllByText(document.body, 'Sonnet 4 6')
+    await findByText(document.body, 'Current')
+    await findByText(document.body, 'MoA presets')
+
+    const bodyText = document.body.textContent ?? ''
+    const listIndex = bodyText.indexOf('Anthropic')
+    const currentIndex = bodyText.indexOf('Current')
+    const moaIndex = bodyText.indexOf('MoA presets')
+    const currentSection = bodyText.slice(currentIndex, moaIndex)
+
+    expect(listIndex).toBeGreaterThanOrEqual(0)
+    expect(listIndex).toBeLessThan(currentIndex)
+    expect(currentIndex).toBeLessThan(moaIndex)
+    expect(currentSection).toContain('Sonnet 4 6')
+    expect(currentSection).toContain('High')
+  })
+})
 
 describe('ModelMenuPanel MoA presets', () => {
   it('selecting a MoA preset switches PERSISTENTLY via onSelectModel (not the one-shot dispatch)', async () => {

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -201,6 +201,94 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
     [pickerProviders, search, optionsModel, optionsProvider, effectiveVisibleModels]
   )
 
+  const currentFamily = useMemo(() => {
+    for (const group of groups) {
+      if (group.provider.slug !== optionsProvider) {
+        continue
+      }
+
+      const family = group.families.find(
+        candidate => candidate.id === optionsModel || candidate.fastId === optionsModel
+      )
+
+      if (family) {
+        return { family, provider: group.provider }
+      }
+    }
+
+    return null
+  }, [groups, optionsModel, optionsProvider])
+
+  const renderModelRow = (family: ModelFamily, provider: ModelOptionProvider, slot: 'current' | 'list') => {
+    // The active id may be the base or its -fast sibling; either way this one
+    // family row represents both.
+    const activeId =
+      provider.slug === optionsProvider && (optionsModel === family.id || optionsModel === family.fastId)
+        ? optionsModel
+        : null
+
+    const isCurrent = activeId !== null
+    const name = modelDisplayParts(family.id).name
+    // Capabilities are looked up against the active/base id; the -fast variant
+    // carries the same param support as its base.
+    const caps = provider.capabilities?.[family.id]
+
+    // Effective settings for this row: live session state when it's the active
+    // model, otherwise its remembered preset (Hermes defaults when unset). Row
+    // label AND submenu read from these so they never disagree.
+    const preset = modelPresets[modelPresetKey(provider.slug, family.id)] ?? {}
+    const effEffort = isCurrent ? currentReasoningEffort : (preset.effort ?? '')
+    const effFast = isCurrent ? currentFastMode : (preset.fast ?? false)
+
+    const fastControl = resolveFastControl(activeId ?? family.id, provider.models ?? [], caps?.fast ?? false, effFast)
+
+    const meta = [
+      fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
+      (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort) || copy.medium : null
+    ]
+      .filter(Boolean)
+      .join(' ')
+
+    const activate = () => {
+      if (!isCurrent) {
+        void selectFamily(family, provider)
+      }
+
+      closeMenu()
+    }
+
+    return (
+      <DropdownMenuSub key={`${provider.slug}:${family.id}:${slot}`}>
+        <DropdownMenuSubTrigger
+          className={dropdownMenuRow}
+          hideChevron
+          onClick={activate}
+          onKeyDown={event => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              activate()
+            }
+          }}
+        >
+          <span className="min-w-0 flex-1 truncate">
+            {name}
+            {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
+          </span>
+          {isCurrent ? <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" /> : null}
+        </DropdownMenuSubTrigger>
+        <ModelEditSubmenu
+          effort={effEffort}
+          fastControl={fastControl}
+          isActive={isCurrent}
+          model={family.id}
+          onSelectModel={nextModel => switchTo(nextModel, provider.slug)}
+          provider={provider.slug}
+          reasoning={caps?.reasoning ?? true}
+          requestGateway={requestGateway}
+        />
+      </DropdownMenuSub>
+    )
+  }
+
   return (
     <>
       <DropdownMenuSearch aria-label={copy.search} onValueChange={setSearch} placeholder={copy.search} value={search} />
@@ -233,96 +321,21 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
           {groups.map(group => (
             <DropdownMenuGroup className="py-0.5" key={group.provider.slug}>
               <DropdownMenuLabel className={dropdownMenuSectionLabel}>{group.provider.name}</DropdownMenuLabel>
-              {group.families.map(family => {
-                // The active id may be the base or its -fast sibling; either
-                // way this one family row represents both.
-                const activeId =
-                  group.provider.slug === optionsProvider &&
-                  (optionsModel === family.id || optionsModel === family.fastId)
-                    ? optionsModel
-                    : null
-
-                const isCurrent = activeId !== null
-                const name = modelDisplayParts(family.id).name
-                // Capabilities are looked up against the active/base id; the
-                // -fast variant carries the same param support as its base.
-                const caps = group.provider.capabilities?.[family.id]
-
-                // Effective settings for this row: live session state when it's
-                // the active model, otherwise its remembered preset (Hermes
-                // defaults when unset). Row label AND submenu read from these so
-                // they never disagree.
-                const preset = modelPresets[modelPresetKey(group.provider.slug, family.id)] ?? {}
-                const effEffort = isCurrent ? currentReasoningEffort : (preset.effort ?? '')
-                const effFast = isCurrent ? currentFastMode : (preset.fast ?? false)
-
-                const fastControl = resolveFastControl(
-                  activeId ?? family.id,
-                  group.provider.models ?? [],
-                  caps?.fast ?? false,
-                  effFast
-                )
-
-                const meta = [
-                  fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
-                  (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort) || copy.medium : null
-                ]
-                  .filter(Boolean)
-                  .join(' ')
-
-                // Every row is a hover-Edit submenu trigger. Activating it
-                // (pointer or keyboard) switches to the family's base model and
-                // restores its preset; the Fast toggle inside swaps to the -fast
-                // sibling (or flips the speed param). The sub-trigger has no
-                // `onSelect`, so wire both click and Enter/Space for keyboard parity.
-                // Clicking the row commits the model and closes the picker; the
-                // edit submenu (reasoning/fast) is reached by HOVER, so you can
-                // still tweak those without the click dismissing everything.
-                const activate = () => {
-                  if (!isCurrent) {
-                    void selectFamily(family, group.provider)
-                  }
-
-                  closeMenu()
-                }
-
-                return (
-                  <DropdownMenuSub key={`${group.provider.slug}:${family.id}`}>
-                    <DropdownMenuSubTrigger
-                      className={dropdownMenuRow}
-                      hideChevron
-                      onClick={activate}
-                      onKeyDown={event => {
-                        if (event.key === 'Enter' || event.key === ' ') {
-                          activate()
-                        }
-                      }}
-                    >
-                      <span className="min-w-0 flex-1 truncate">
-                        {name}
-                        {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
-                      </span>
-                      {isCurrent ? <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" /> : null}
-                    </DropdownMenuSubTrigger>
-                    <ModelEditSubmenu
-                      effort={effEffort}
-                      fastControl={fastControl}
-                      isActive={isCurrent}
-                      model={family.id}
-                      onSelectModel={nextModel => switchTo(nextModel, group.provider.slug)}
-                      provider={group.provider.slug}
-                      reasoning={caps?.reasoning ?? true}
-                      requestGateway={requestGateway}
-                    />
-                  </DropdownMenuSub>
-                )
-              })}
+              {group.families.map(family => renderModelRow(family, group.provider, 'list'))}
             </DropdownMenuGroup>
           ))}
         </div>
       )}
 
       <DropdownMenuSeparator className="mx-0" />
+
+      {currentFamily ? (
+        <>
+          <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.current}</DropdownMenuLabel>
+          {renderModelRow(currentFamily.family, currentFamily.provider, 'current')}
+          <DropdownMenuSeparator className="mx-0" />
+        </>
+      ) : null}
 
       {moaPresets.length > 0 ? (
         <>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -542,8 +542,7 @@ export const en: Translations = {
       localDesc: 'Start a private Hermes backend on localhost. This is the default and works offline.',
       remoteTitle: 'Remote gateway',
       remoteDesc: 'Connect this desktop shell to a remote Hermes backend.',
-      remoteAuthHint:
-        'Hosted gateways use OAuth or a username and password; self-hosted ones may use a session token.',
+      remoteAuthHint: 'Hosted gateways use OAuth or a username and password; self-hosted ones may use a session token.',
       cloudTitle: 'Hermes Cloud',
       cloudDesc: 'Sign in once to Hermes Cloud and pick from the agents on your account — no URL to paste.',
       cloudSignInTitle: 'Hermes Cloud',
@@ -2040,7 +2039,8 @@ export const en: Translations = {
       editModels: 'Edit Models…',
       refreshModels: 'Refresh Models',
       fast: 'Fast',
-      medium: 'Med'
+      medium: 'Med',
+      current: 'Current'
     },
     modelOptions: {
       noOptions: 'No options for this model',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -97,7 +97,8 @@ export const ja = defineLocale({
       remoteSignInHint: signInLabel =>
         `保存済みのリモートブラウザセッションからサインアウトし、${signInLabel}を開きます。代わりにバンドルされたバックエンドに切り替えるには「ローカルゲートウェイを使用」を選択してください。`,
       signOutAndSignIn: 'サインアウトして再サインイン',
-      remoteFailureHint: '「ゲートウェイ設定」でゲートウェイの URL とサインインを確認するか、ローカルゲートウェイに切り替えてください。',
+      remoteFailureHint:
+        '「ゲートウェイ設定」でゲートウェイの URL とサインインを確認するか、ローカルゲートウェイに切り替えてください。',
       hideRecentLogs: '最近のログを非表示',
       showRecentLogs: '最近のログを表示',
       signedInTitle: 'サインインしました',
@@ -1981,7 +1982,8 @@ export const ja = defineLocale({
       editModels: 'モデルを編集…',
       refreshModels: 'モデルを更新',
       fast: '高速',
-      medium: '中'
+      medium: '中',
+      current: '現在'
     },
     modelOptions: {
       noOptions: 'このモデルにはオプションがありません',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1672,6 +1672,7 @@ export interface Translations {
       refreshModels: string
       fast: string
       medium: string
+      current: string
     }
     modelOptions: {
       noOptions: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1917,7 +1917,8 @@ export const zhHant = defineLocale({
       editModels: '編輯模型…',
       refreshModels: '重新整理模型',
       fast: '快速',
-      medium: '中'
+      medium: '中',
+      current: '目前'
     },
     modelOptions: {
       noOptions: '此模型沒有可用選項',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2204,7 +2204,8 @@ export const zh: Translations = {
       editModels: '编辑模型…',
       refreshModels: '刷新模型',
       fast: '快速',
-      medium: '中'
+      medium: '中',
+      current: '当前'
     },
     modelOptions: {
       noOptions: '此模型没有可用选项',


### PR DESCRIPTION
## Summary

- Add a pinned Current row below the scrollable Desktop composer model list and above MoA presets
- Reuse the existing model row/submenu renderer so the pinned row exposes the same reasoning and fast controls as the normal list row
- Add localized copy and regression coverage for the row order

Fixes #58198

## Why bottom-pinned

The dropdown opens from the bottom composer/status model pill, so placing Current below the model list keeps the common reasoning/fast edit target close to the pointer without moving search or reshuffling provider/model ordering.

## Test Plan

- [x] `cd apps/desktop && npx vitest run src/app/shell/model-menu-panel.test.tsx` — 5 passed
- [x] `cd apps/desktop && npx prettier --check src/app/shell/model-menu-panel.tsx src/app/shell/model-menu-panel.test.tsx src/i18n/en.ts src/i18n/ja.ts src/i18n/zh.ts src/i18n/zh-hant.ts src/i18n/types.ts`
- [x] `cd apps/desktop && npm run typecheck`
- [x] `git diff --check`

## Screenshot

![Composer model picker with pinned Current row above MoA presets](https://raw.githubusercontent.com/whoislikemiha/hermes-agent/pr-assets/pr-assets/60158-current-model-row.png)
