### PR TITLE
fix(qqbot): add missing is_reconnect parameter to QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Summary
The gateway passes `is_reconnect=True` when reconnecting platform adapters, but `QQAdapter.connect()` was missing this parameter in its signature.

## Error
```
✗ qqbot error: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

## Fix
Added `*, is_reconnect: bool = False` to `QQAdapter.connect()` to match the canonical adapter signature expected by `gateway/run.py`.

## Testing
- Cleared pyc cache
- Restarted gateway
- Confirmed: `✓ qqbot connected` + `Ready, session_id=...`