### PR TITLE
feat(dashboard): plugins can declare extra nav entries via manifest nav_items

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14557,6 +14557,39 @@ def _discover_dashboard_plugins() -> list:
                 slots: List[str] = []
                 if isinstance(slots_src, list):
                     slots = [s for s in slots_src if isinstance(s, str) and s]
+                # Nav items: optional extra navigation entries this plugin
+                # contributes beyond its own tab — a list of
+                # ``{"path": "/...", "label": "...", "icon": "..."}`` dicts.
+                # Consumed by shell/theme plugins (and available to any
+                # frontend) via /api/dashboard/plugins; the stock nav
+                # ignores it. Sanitized entry-by-entry so a malformed
+                # manifest can't 500 the plugins endpoint: ``path`` must be
+                # a string starting with "/", ``label`` a non-empty string;
+                # anything else is dropped. ``icon`` (optional) is a Lucide
+                # icon name like the top-level ``icon`` field.
+                nav_items_src = data.get("nav_items")
+                nav_items: List[Dict[str, str]] = []
+                if isinstance(nav_items_src, list):
+                    for raw_nav in nav_items_src:
+                        if not isinstance(raw_nav, dict):
+                            continue
+                        nav_path = raw_nav.get("path")
+                        nav_label = raw_nav.get("label")
+                        if (
+                            not isinstance(nav_path, str)
+                            or not nav_path.startswith("/")
+                            or not isinstance(nav_label, str)
+                            or not nav_label.strip()
+                        ):
+                            continue
+                        nav_item = {
+                            "path": nav_path,
+                            "label": nav_label.strip(),
+                        }
+                        nav_icon = raw_nav.get("icon")
+                        if isinstance(nav_icon, str) and nav_icon.strip():
+                            nav_item["icon"] = nav_icon.strip()
+                        nav_items.append(nav_item)
                 # Validate ``api`` at discovery time so the value cached
                 # on the plugin entry is already safe to feed into the
                 # importer.  An attacker-controlled manifest can name
@@ -14581,6 +14614,7 @@ def _discover_dashboard_plugins() -> list:
                     "icon": data.get("icon", "Puzzle"),
                     "version": data.get("version", "0.0.0"),
                     "tab": tab_info,
+                    "nav_items": nav_items,
                     "slots": slots,
                     "entry": data.get("entry", "dist/index.js"),
                     "css": data.get("css"),

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5860,6 +5860,85 @@ class TestDashboardPluginManifestExtensions:
             "chat:top",
         ]
 
+    def test_nav_items_carried_through(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "nav-plugin", {
+            "name": "nav-plugin",
+            "label": "Nav Plugin",
+            "tab": {"path": "/nav-plugin"},
+            "nav_items": [
+                {"path": "/nav-plugin/reports", "label": "Reports", "icon": "BarChart3"},
+                {"path": "/nav-plugin/inbox", "label": "  Inbox  "},
+            ],
+            "entry": "dist/index.js",
+        })
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "nav-plugin")
+        assert entry["nav_items"] == [
+            {"path": "/nav-plugin/reports", "label": "Reports", "icon": "BarChart3"},
+            {"path": "/nav-plugin/inbox", "label": "Inbox"},  # label stripped
+        ]
+
+    def test_nav_items_default_empty(self, tmp_path, monkeypatch):
+        """Manifests without nav_items get an empty list, not a KeyError."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "no-nav", {
+            "name": "no-nav",
+            "label": "No Nav",
+            "tab": {"path": "/no-nav"},
+            "entry": "dist/index.js",
+        })
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "no-nav")
+        assert entry["nav_items"] == []
+
+    def test_nav_items_drops_malformed_entries(self, tmp_path, monkeypatch):
+        """Malformed entries are dropped one-by-one; a bad manifest must
+        degrade to fewer nav items, never 500 the plugins endpoint."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "messy-nav", {
+            "name": "messy-nav",
+            "label": "Messy",
+            "tab": {"path": "/messy-nav"},
+            "nav_items": [
+                "not-a-dict",
+                42,
+                None,
+                {"path": "no-leading-slash", "label": "Bad Path"},
+                {"path": "/ok", "label": ""},            # empty label
+                {"path": "/ok", "label": "   "},         # whitespace label
+                {"path": "/ok"},                          # missing label
+                {"label": "Missing Path"},
+                {"path": "/ok", "label": 7},              # non-string label
+                {"path": "/good", "label": "Good", "icon": 3},  # bad icon dropped
+            ],
+            "entry": "dist/index.js",
+        })
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "messy-nav")
+        assert entry["nav_items"] == [{"path": "/good", "label": "Good"}]
+
+    def test_nav_items_non_list_ignored(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(tmp_path, "dict-nav", {
+            "name": "dict-nav",
+            "label": "Dict Nav",
+            "tab": {"path": "/dict-nav"},
+            "nav_items": {"path": "/x", "label": "X"},  # dict, not list
+            "entry": "dist/index.js",
+        })
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "dict-nav")
+        assert entry["nav_items"] == []
+
 
 # ---------------------------------------------------------------------------
 # /api/pty WebSocket — terminal bridge for the dashboard "Chat" tab.

--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -458,6 +458,9 @@ None of them are required; include only the layers you need.
     "hidden": false
   },
   "slots": ["sidebar", "header-left"],
+  "nav_items": [
+    { "path": "/my-plugin/reports", "label": "Reports", "icon": "BarChart3" }
+  ],
   "entry": "dist/index.js",
   "css": "dist/style.css",
   "api": "plugin_api.py"
@@ -476,6 +479,7 @@ None of them are required; include only the layers you need.
 | `tab.override` | No | Set to a built-in route path (`"/"`, `"/sessions"`, `"/config"`, ...) to **replace** that page instead of adding a new tab. See [Replacing built-in pages](#replacing-built-in-pages-taboverride). |
 | `tab.hidden` | No | When true, register the component and any slots without adding a tab to the nav. Used by slot-only plugins. See [Slot-only plugins](#slot-only-plugins-tabhidden). |
 | `slots` | No | Named shell slots this plugin populates. **Documentation aid only** — actual registration happens from the JS bundle via `registerSlot()`. Listing slots here makes discovery surfaces more informative. |
+| `nav_items` | No | Extra navigation entries this plugin contributes beyond its own tab — a list of `{ "path", "label", "icon"? }` objects (`path` must start with `/`; `icon` is a Lucide icon name). Served verbatim on `/api/dashboard/plugins` for shell/theme plugins and custom navs to render (the built-in nav bar ignores it). Malformed entries are dropped at discovery time rather than failing the endpoint. |
 | `entry` | Yes | Path to the JS bundle relative to `dashboard/`. Defaults to `dist/index.js`. |
 | `css` | No | Path to a CSS file to inject as a `<link>` tag. |
 | `api` | No | Path to a Python file with FastAPI routes. Mounted at `/api/plugins/<name>/`. |


### PR DESCRIPTION
## Problem

A dashboard plugin currently contributes exactly **one** navigation entry — its own tab. Two kinds of plugins outgrow that:

- Plugins that host several pages (a hidden tab registering client-side routes) have no way to surface those pages in any navigation.
- Shell/theme plugins that render a custom nav (e.g. via the `sidebar` shell slot or a `tab.override` shell) have to hardcode other plugins' paths, because nothing in `/api/dashboard/plugins` describes them.

## Change

Adds an optional `nav_items` key to the dashboard plugin manifest:

```json
"nav_items": [
  { "path": "/my-plugin/reports", "label": "Reports", "icon": "BarChart3" }
]
```

`_discover_dashboard_plugins()` sanitizes the list at discovery time and serves it verbatim on `/api/dashboard/plugins`, so shells and custom navs can render richer navigation declaratively.

## Behavior before / after

| | before | after |
|---|---|---|
| manifest without `nav_items` | field silently dropped | served as `[]` |
| manifest with `nav_items` | field silently dropped | validated entries served |
| malformed entry (non-dict, missing/empty `label`, `path` without leading `/`, non-string `icon`) | n/a | entry dropped one-by-one; the plugins endpoint never 500s |

## Why it's additive / back-compat

- No manifest is required to change; absent key → `[]`.
- The built-in nav bar ignores the field entirely — consumers are shell-slot plugins and custom navs reading `/api/dashboard/plugins` (or `SDK.api`).
- Follows the existing sanitization pattern for `slots` / `tab.override` in the same function.

## Tests

Four new tests in `tests/hermes_cli/test_web_server.py::TestDashboardPluginManifestExtensions` (carried-through incl. label trimming, absent-key default, malformed-entry filtering, non-list value). Ran on this branch vs pristine `upstream/main` with `scripts/run_tests.sh tests/hermes_cli/test_web_server.py tests/hermes_cli/test_web_server_host_header.py`:

- pristine `main` (aaeba213d): **353 passed, 0 failed**
- this branch: **357 passed, 0 failed**

Docs: manifest-reference row + example added to `website/docs/user-guide/features/extending-the-dashboard.md`.

Platforms tested: macOS (discovery logic is pure-Python path/JSON handling, no OS-specific code).

Extracted from a fork where this has been running in production since 2026-06 (source commit `d85cb9c4d`, generalized: fork-specific `iconImg`/`group` keys were left out).

😸 Generated with The Gray Cat
