### PR TITLE
fix(install): capture Windows version probes safely

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -245,6 +245,43 @@ function Invoke-NativeWithRelaxedErrorAction {
         $ErrorActionPreference = $prevEAP
     }
 }
+
+function Invoke-NativeCaptureSafe {
+    param(
+        [Parameter(Mandatory=$true)][string]$FilePath,
+        [string[]]$ArgumentList = @(),
+        [string]$WorkingDirectory = (Get-Location).Path
+    )
+
+    $stdoutFile = [System.IO.Path]::GetTempFileName()
+    $stderrFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $proc = Start-Process -FilePath $FilePath `
+            -ArgumentList $ArgumentList `
+            -WorkingDirectory $WorkingDirectory `
+            -NoNewWindow -Wait -PassThru `
+            -RedirectStandardOutput $stdoutFile `
+            -RedirectStandardError $stderrFile
+        $global:LASTEXITCODE = $proc.ExitCode
+        return [pscustomobject]@{
+            ExitCode = $proc.ExitCode
+            Stdout = [System.IO.File]::ReadAllText($stdoutFile)
+            Stderr = [System.IO.File]::ReadAllText($stderrFile)
+        }
+    } finally {
+        Remove-Item $stdoutFile, $stderrFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Format-NativeCaptureDetail {
+    param($Result)
+
+    if (-not $Result) { return "" }
+    $detail = (($Result.Stdout, $Result.Stderr) -join "`n").Trim()
+    if ($detail) { return ": $detail" }
+    return ""
+}
+
 function Discard-LockfileChurn {
     param([string]$Repo = $InstallDir)
 
@@ -450,10 +487,14 @@ function Install-Uv {
     $managedUv = Join-Path $HermesHome "bin\uv.exe"
 
     if (Test-Path $managedUv) {
-        $script:UvCmd = $managedUv
-        $version = & $managedUv --version
-        Write-Success "Managed uv found ($version)"
-        return $true
+        $uvVersionProbe = Invoke-NativeCaptureSafe -FilePath $managedUv -ArgumentList @("--version")
+        if ($uvVersionProbe.ExitCode -eq 0) {
+            $script:UvCmd = $managedUv
+            $version = $uvVersionProbe.Stdout.Trim()
+            Write-Success "Managed uv found ($version)"
+            return $true
+        }
+        Write-Warn "Managed uv exists but failed to run --version$((Format-NativeCaptureDetail $uvVersionProbe))"
     }
 
     Write-Info "Installing managed uv into $HermesHome\bin ..."
@@ -473,10 +514,17 @@ function Install-Uv {
         $ErrorActionPreference = $prevEAP
 
         if (Test-Path $managedUv) {
-            $script:UvCmd = $managedUv
-            $version = & $managedUv --version
-            Write-Success "Managed uv installed ($version)"
-            return $true
+            $uvVersionProbe = Invoke-NativeCaptureSafe -FilePath $managedUv -ArgumentList @("--version")
+            if ($uvVersionProbe.ExitCode -eq 0) {
+                $script:UvCmd = $managedUv
+                $version = $uvVersionProbe.Stdout.Trim()
+                Write-Success "Managed uv installed ($version)"
+                return $true
+            }
+
+            Write-Err "uv installed at $managedUv but --version failed$((Format-NativeCaptureDetail $uvVersionProbe))"
+            Write-Info "Install manually: https://docs.astral.sh/uv/getting-started/installation/"
+            return $false
         }
 
         Write-Err "uv installed but not found at $managedUv"
@@ -601,9 +649,12 @@ function Test-Python {
     try {
         $pythonPath = & $UvCmd python find $PythonVersion 2>$null
         if ($pythonPath) {
-            $ver = & $pythonPath --version 2>$null
-            Write-Success "Python found: $ver"
-            return $true
+            $pythonVersionProbe = Invoke-NativeCaptureSafe -FilePath $pythonPath -ArgumentList @("--version")
+            if ($pythonVersionProbe.ExitCode -eq 0) {
+                $ver = $pythonVersionProbe.Stdout.Trim()
+                Write-Success "Python found: $ver"
+                return $true
+            }
         }
     } catch { }
     
@@ -632,9 +683,12 @@ function Test-Python {
         # since uv may return non-zero due to "already installed" etc.)
         $pythonPath = & $UvCmd python find $PythonVersion 2>$null
         if ($pythonPath) {
-            $ver = & $pythonPath --version 2>$null
-            Write-Success "Python installed: $ver"
-            return $true
+            $pythonVersionProbe = Invoke-NativeCaptureSafe -FilePath $pythonPath -ArgumentList @("--version")
+            if ($pythonVersionProbe.ExitCode -eq 0) {
+                $ver = $pythonVersionProbe.Stdout.Trim()
+                Write-Success "Python installed: $ver"
+                return $true
+            }
         }
 
         # uv ran but Python still not findable -- show what happened
@@ -654,10 +708,13 @@ function Test-Python {
         try {
             $pythonPath = & $UvCmd python find $fallbackVer 2>$null
             if ($pythonPath) {
-                $ver = & $pythonPath --version 2>$null
-                Write-Success "Found fallback: $ver"
-                $script:PythonVersion = $fallbackVer
-                return $true
+                $pythonVersionProbe = Invoke-NativeCaptureSafe -FilePath $pythonPath -ArgumentList @("--version")
+                if ($pythonVersionProbe.ExitCode -eq 0) {
+                    $ver = $pythonVersionProbe.Stdout.Trim()
+                    Write-Success "Found fallback: $ver"
+                    $script:PythonVersion = $fallbackVer
+                    return $true
+                }
             }
         } catch { }
     }
@@ -684,16 +741,13 @@ function Test-Python {
 
         if (-not $isStoreStub) {
             try {
-                $prevEAP2 = $ErrorActionPreference
-                $ErrorActionPreference = "Continue"
-                $sysVer = & python --version 2>&1
-                $ErrorActionPreference = $prevEAP2
+                $sysVersionProbe = Invoke-NativeCaptureSafe -FilePath $pythonSource -ArgumentList @("--version")
+                $sysVer = $sysVersionProbe.Stdout.Trim()
                 if ($sysVer -match "Python 3\.(1[0-9]|[1-9][0-9])") {
                     Write-Success "Using system Python: $sysVer"
                     return $true
                 }
             } catch {
-                if ($prevEAP2) { $ErrorActionPreference = $prevEAP2 }
             }
         }
     }
@@ -834,26 +888,33 @@ function Install-Git {
     $script:GitInstallFailureReason = $null
     Write-Info "Checking Git..."
 
-    if (Get-Command git -ErrorAction SilentlyContinue) {
-        $version = git --version
-        Write-Success "Git found ($version)"
-        Set-GitBashEnvVar
-        if ($script:GitBashPath -and (Test-GitBashCompatibility -BashPath $script:GitBashPath)) {
-            Write-Success "Git Bash can launch MSYS programs"
-            return $true
-        }
+    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($gitCmd) {
+        $gitVersionProbe = Invoke-NativeCaptureSafe -FilePath $gitCmd.Source -ArgumentList @("--version")
+        if ($gitVersionProbe.ExitCode -eq 0) {
+            $version = $gitVersionProbe.Stdout.Trim()
+            Write-Success "Git found ($version)"
+            Set-GitBashEnvVar
 
-        if ($script:GitBashPath -and (Test-MandatoryAslrEnabled)) {
-            $script:GitInstallFailureReason = New-GitBashAslrFailureReason -BashPath $script:GitBashPath
-            Write-Err $script:GitInstallFailureReason
-            return $false
-        }
+            if ($script:GitBashPath -and (Test-GitBashCompatibility -BashPath $script:GitBashPath)) {
+                Write-Success "Git Bash can launch MSYS programs"
+                return $true
+            }
 
-        if ($script:GitBashPath) {
-            $probeDetail = if ($script:GitBashProbeOutput) { ": $script:GitBashProbeOutput" } else { "" }
-            Write-Warn "System Git Bash could not launch required MSYS programs$probeDetail"
+            if ($script:GitBashPath -and (Test-MandatoryAslrEnabled)) {
+                $script:GitInstallFailureReason = New-GitBashAslrFailureReason -BashPath $script:GitBashPath
+                Write-Err $script:GitInstallFailureReason
+                return $false
+            }
+
+            if ($script:GitBashPath) {
+                $probeDetail = if ($script:GitBashProbeOutput) { ": $script:GitBashProbeOutput" } else { "" }
+                Write-Warn "System Git Bash could not launch required MSYS programs$probeDetail"
+            } else {
+                Write-Warn "Git is on PATH, but its Git Bash installation could not be located."
+            }
         } else {
-            Write-Warn "Git is on PATH, but its Git Bash installation could not be located."
+            Write-Warn "Git was found but failed to run --version$((Format-NativeCaptureDetail $gitVersionProbe))"
         }
         Write-Info "Trying a Hermes-managed PortableGit install instead..."
     }
@@ -963,7 +1024,11 @@ function Install-Git {
             [Environment]::SetEnvironmentVariable("Path", ($userPathItems -join ";"), "User")
         }
 
-        $version = & $gitExe --version
+        $gitVersionProbe = Invoke-NativeCaptureSafe -FilePath $gitExe -ArgumentList @("--version")
+        if ($gitVersionProbe.ExitCode -ne 0) {
+            throw "Git installed at $gitExe but --version failed$((Format-NativeCaptureDetail $gitVersionProbe))"
+        }
+        $version = $gitVersionProbe.Stdout.Trim()
         Write-Success "Git $version installed to $gitDir (portable, user-scoped)"
         Set-GitBashEnvVar
         if (-not $script:GitBashPath) {
@@ -1068,25 +1133,39 @@ function Test-NodeVersionOk {
 function Test-Node {
     Write-Info "Checking Node.js (for browser tools)..."
 
-    if (Get-Command node -ErrorAction SilentlyContinue) {
-        $version = node --version
-        if (Test-NodeVersionOk $version) {
-            Ensure-NodeExeOnPath | Out-Null
-            Write-Success "Node.js $version found"
-            $script:HasNode = $true
-            return $true
+    $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+    if ($nodeCmd) {
+        $nodeVersionProbe = Invoke-NativeCaptureSafe -FilePath $nodeCmd.Source -ArgumentList @("--version")
+        if ($nodeVersionProbe.ExitCode -eq 0) {
+            $version = $nodeVersionProbe.Stdout.Trim()
+            if (Test-NodeVersionOk $version) {
+                Ensure-NodeExeOnPath | Out-Null
+                Write-Success "Node.js $version found"
+                $script:HasNode = $true
+                return $true
+            }
+            Write-Warn "Node.js $version is too old for the desktop build (need ^20.19 or >=22.12)"
+        } else {
+            Write-Warn "Node.js was found but failed to run --version$((Format-NativeCaptureDetail $nodeVersionProbe))"
         }
-        Write-Warn "Node.js $version is too old for the desktop build (need ^20.19 or >=22.12)"
     }
 
     # Prefer a Hermes-managed Node from a previous run over a too-old system one.
     $managedNode = "$HermesHome\node\node.exe"
-    if ((Test-Path $managedNode) -and (Test-NodeVersionOk (& $managedNode --version))) {
-        $version = & $managedNode --version
-        $env:Path = "$HermesHome\node;$env:Path"
-        Write-Success "Node.js $version found (Hermes-managed)"
-        $script:HasNode = $true
-        return $true
+    if (Test-Path $managedNode) {
+        $managedNodeVersionProbe = Invoke-NativeCaptureSafe -FilePath $managedNode -ArgumentList @("--version")
+        if (($managedNodeVersionProbe.ExitCode -eq 0) -and (Test-NodeVersionOk $managedNodeVersionProbe.Stdout.Trim())) {
+            $version = $managedNodeVersionProbe.Stdout.Trim()
+            $env:Path = "$HermesHome\node;$env:Path"
+            Write-Success "Node.js $version found (Hermes-managed)"
+            $script:HasNode = $true
+            return $true
+        }
+        if ($managedNodeVersionProbe.ExitCode -ne 0) {
+            Write-Warn "Hermes-managed Node exists but failed to run --version$((Format-NativeCaptureDetail $managedNodeVersionProbe))"
+        } else {
+            Write-Warn "Hermes-managed Node $($managedNodeVersionProbe.Stdout.Trim()) is too old for the desktop build (need ^20.19 or >=22.12)"
+        }
     }
 
     Write-Info "Installing Hermes-managed Node.js $NodeVersion LTS..."
@@ -1135,7 +1214,11 @@ function Test-Node {
                     [Environment]::SetEnvironmentVariable("Path", ($userPathItems -join ";"), "User")
                 }
 
-                $version = & "$HermesHome\node\node.exe" --version
+                $nodeVersionProbe = Invoke-NativeCaptureSafe -FilePath "$HermesHome\node\node.exe" -ArgumentList @("--version")
+                if ($nodeVersionProbe.ExitCode -ne 0) {
+                    throw "Node installed at $HermesHome\node\node.exe but --version failed$((Format-NativeCaptureDetail $nodeVersionProbe))"
+                }
+                $version = $nodeVersionProbe.Stdout.Trim()
                 Write-Success "Node.js $version installed to $HermesHome\node\ (portable, user-scoped)"
                 $script:HasNode = $true
 
@@ -1180,8 +1263,13 @@ function Test-Node {
             $ErrorActionPreference = $prevEAP
             # Refresh PATH
             $env:Path = [Environment]::GetEnvironmentVariable("Path", "User") + ";" + [Environment]::GetEnvironmentVariable("Path", "Machine")
-            if (Get-Command node -ErrorAction SilentlyContinue) {
-                $version = node --version
+            $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+            if ($nodeCmd) {
+                $nodeVersionProbe = Invoke-NativeCaptureSafe -FilePath $nodeCmd.Source -ArgumentList @("--version")
+                if ($nodeVersionProbe.ExitCode -ne 0) {
+                    throw "Node installed via winget but --version failed$((Format-NativeCaptureDetail $nodeVersionProbe))"
+                }
+                $version = $nodeVersionProbe.Stdout.Trim()
                 Write-Success "Node.js $version installed via winget"
                 $script:HasNode = $true
                 return $true
@@ -1240,10 +1328,17 @@ function Install-SystemPackages {
     $needFfmpeg = $false
 
     Write-Info "Checking ripgrep (fast file search)..."
-    if (Get-Command rg -ErrorAction SilentlyContinue) {
-        $version = rg --version | Select-Object -First 1
-        Write-Success "$version found"
-        $script:HasRipgrep = $true
+    $rgCmd = Get-Command rg -ErrorAction SilentlyContinue
+    if ($rgCmd) {
+        $rgVersionProbe = Invoke-NativeCaptureSafe -FilePath $rgCmd.Source -ArgumentList @("--version")
+        if ($rgVersionProbe.ExitCode -eq 0) {
+            $version = ($rgVersionProbe.Stdout -split "\r?\n" | Select-Object -First 1).Trim()
+            Write-Success "$version found"
+            $script:HasRipgrep = $true
+        } else {
+            Write-Warn "ripgrep was found but failed to run --version$((Format-NativeCaptureDetail $rgVersionProbe))"
+            $needRipgrep = $true
+        }
     } else {
         $needRipgrep = $true
     }
@@ -3625,6 +3720,11 @@ function Main {
 # All branches funnel through one try/catch so errors don't kill an `irm |
 # iex` PowerShell session, and so failures in stage-driver mode produce a
 # structured JSON error frame instead of a bare exception.
+
+# Dot-sourcing is the supported library seam for executing installer helpers
+# in isolation. Loading the script this way defines functions and stage data
+# without starting an installation.
+if ($MyInvocation.InvocationName -eq ".") { return }
 
 try {
     if ($Ensure -ne "") {

--- a/tests/test_install_ps1_native_version_capture.py
+++ b/tests/test_install_ps1_native_version_capture.py
@@ -1,0 +1,116 @@
+"""Runtime regression for #60132: safe native capture in install.ps1."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+POWERSHELL = next(
+    (
+        executable
+        for name in ("powershell.exe", "pwsh.exe", "pwsh")
+        if (executable := shutil.which(name))
+    ),
+    None,
+)
+
+pytestmark = pytest.mark.skipif(
+    POWERSHELL is None,
+    reason="PowerShell is required to execute the Windows installer helper",
+)
+
+
+def test_native_capture_reports_streams_exit_status_and_cleans_temp_files(
+    tmp_path: Path,
+) -> None:
+    """Execute the real helper against a controlled native Python process."""
+    capture_temp = tmp_path / "capture-temp"
+    capture_temp.mkdir()
+    install_home = tmp_path / "hermes-home"
+    install_dir = tmp_path / "hermes-agent"
+    install_dir.mkdir()
+
+    probe = tmp_path / "native_probe.py"
+    probe.write_text(
+        "import sys\n"
+        "print('native-stdout')\n"
+        "print('native-stderr', file=sys.stderr)\n"
+        "raise SystemExit(7)\n",
+        encoding="utf-8",
+    )
+    harness = tmp_path / "capture_harness.ps1"
+    harness.write_text(
+        r'''
+$ErrorActionPreference = "Stop"
+. $env:HERMES_TEST_INSTALLER `
+    -HermesHome $env:HERMES_TEST_HOME `
+    -InstallDir $env:HERMES_TEST_INSTALL_DIR
+
+$before = @(Get-ChildItem -LiteralPath $env:HERMES_TEST_CAPTURE_TEMP -Force |
+    ForEach-Object { $_.FullName })
+$quotedProbe = '"' + $env:HERMES_TEST_PROBE.Replace('"', '\"') + '"'
+$result = Invoke-NativeCaptureSafe `
+    -FilePath $env:HERMES_TEST_PYTHON `
+    -ArgumentList @($quotedProbe) `
+    -WorkingDirectory $env:HERMES_TEST_WORK_DIR
+$after = @(Get-ChildItem -LiteralPath $env:HERMES_TEST_CAPTURE_TEMP -Force |
+    ForEach-Object { $_.FullName })
+$leaked = @($after | Where-Object { $before -notcontains $_ })
+
+[pscustomobject]@{
+    ExitCode = $result.ExitCode
+    LastExitCode = $global:LASTEXITCODE
+    Stdout = $result.Stdout
+    Stderr = $result.Stderr
+    LeakedTempFiles = $leaked
+} | ConvertTo-Json -Compress | Write-Output
+''',
+        encoding="utf-8",
+    )
+
+    env = {
+        **os.environ,
+        "TEMP": str(capture_temp),
+        "TMP": str(capture_temp),
+        "TMPDIR": str(capture_temp),
+        "HERMES_TEST_INSTALLER": str(INSTALL_PS1),
+        "HERMES_TEST_HOME": str(install_home),
+        "HERMES_TEST_INSTALL_DIR": str(install_dir),
+        "HERMES_TEST_CAPTURE_TEMP": str(capture_temp),
+        "HERMES_TEST_PYTHON": os.fspath(Path(os.sys.executable).resolve()),
+        "HERMES_TEST_PROBE": str(probe),
+        "HERMES_TEST_WORK_DIR": str(tmp_path),
+    }
+    completed = subprocess.run(
+        [
+            str(POWERSHELL),
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(harness),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=True,
+    )
+
+    payload = json.loads(completed.stdout.strip().splitlines()[-1])
+    assert payload["ExitCode"] == 7
+    assert payload["LastExitCode"] == 7
+    assert payload["Stdout"].strip() == "native-stdout"
+    assert payload["Stderr"].strip() == "native-stderr"
+    assert payload["LeakedTempFiles"] == []


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows installer false-negative from #60132 by avoiding direct PowerShell native-command capture for simple dependency `--version` probes. On some corporate-managed PowerShell hosts, captures like `$version = & $managedUv --version` can fail before the installer sees the real process result.

This adds a small `Invoke-NativeCaptureSafe` helper that runs native probes with `Start-Process`, redirects stdout/stderr to temp files, mirrors the process exit code into `$global:LASTEXITCODE`, and returns structured stdout/stderr. `Install-Uv` now uses that path for both existing and freshly installed managed uv checks, and the adjacent Python/Git/Node/ripgrep version probes use the same safe capture path so the same host behavior does not resurface under another dependency name.

## Related Issue

Fixes #60132

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `scripts/install.ps1`: added `Invoke-NativeCaptureSafe` plus diagnostic formatting for native probe failures.
- `scripts/install.ps1`: routed uv/Python/Git/Node/ripgrep `--version` probes through the safe capture helper instead of assigning directly from native command invocation.
- `tests/test_install_ps1_native_version_capture.py`: added source-level regression coverage for the helper and the uv/version-probe call sites.

## How to Test

1. `.venv/bin/python -m pytest tests/test_install_ps1_*.py -q`
2. `git diff --check`
3. Confirm `scripts/install.ps1` no longer contains direct `& $managedUv --version` captures.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 / source-level installer tests; Windows PowerShell runtime execution not available in this lane

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered: this is Windows installer-specific and covered with source-level tests on non-Windows CI
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

```text
$ .venv/bin/python -m pytest tests/test_install_ps1_*.py -q
................                                                         [100%]
16 passed in 0.30s

$ git diff --check
# no output
```