### PR TITLE
feat(tui): add persistent todo panel

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1671,6 +1671,9 @@ DEFAULT_CONFIG = {
         # starts delegating, nudging the user toward the live spawn-tree
         # dashboard. Set false to suppress the hint.
         "tui_agents_nudge": True,
+        # Persistent bottom todo panel in the Ink TUI. Set false or run
+        # `/todos off` to hide it while keeping transcript todo archives.
+        "tui_todo_panel": True,
         "bell_on_complete": False,
         "show_reasoning": False,
         # When reasoning display is on, the post-response "Reasoning" recap box

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2751,6 +2751,34 @@ def test_config_busy_get_and_set(monkeypatch):
     assert ("display.busy_input_mode", "interrupt") in writes
 
 
+def test_config_todo_panel_get_and_set(monkeypatch):
+    writes = []
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"display": {"tui_todo_panel": False}},
+    )
+    monkeypatch.setattr(
+        server, "_write_config_key", lambda path, value: writes.append((path, value))
+    )
+
+    get_resp = server.handle_request(
+        {"id": "1", "method": "config.get", "params": {"key": "todo_panel"}}
+    )
+    assert get_resp["result"]["value"] == "off"
+
+    set_resp = server.handle_request(
+        {
+            "id": "2",
+            "method": "config.set",
+            "params": {"key": "todo_panel", "value": "on"},
+        }
+    )
+    assert set_resp["result"]["value"] == "on"
+    assert ("display.tui_todo_panel", True) in writes
+
+
 def test_config_set_yolo_process_scope_treats_false_like_env_as_disabled(monkeypatch):
     monkeypatch.setenv("HERMES_YOLO_MODE", "false")
 
@@ -3135,6 +3163,14 @@ def test_complete_slash_includes_tui_mouse_command():
     )
 
     assert any(item["text"] == "/mouse" for item in resp["result"]["items"])
+
+
+def test_complete_slash_includes_tui_todos_command():
+    resp = server.handle_request(
+        {"id": "1", "method": "complete.slash", "params": {"text": "/tod"}}
+    )
+
+    assert any(item["text"] == "/todos" for item in resp["result"]["items"])
 
 
 def test_complete_slash_details_args():
@@ -4240,6 +4276,19 @@ def test_commands_catalog_includes_tui_mouse_command():
 
     assert "/mouse" in pairs
     assert "/mouse" in tui_pairs
+
+
+def test_commands_catalog_includes_tui_todos_command():
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    pairs = dict(resp["result"]["pairs"])
+    tui_cat = next(c for c in resp["result"]["categories"] if c["name"] == "TUI")
+    tui_pairs = dict(tui_cat["pairs"])
+
+    assert "/todos" in pairs
+    assert "/todos" in tui_pairs
 
 
 def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2269,6 +2269,24 @@ def _coerce_statusbar(raw) -> str:
     return "top"
 
 
+_TODO_PANEL_FALSEY = frozenset({"0", "false", "no", "off"})
+_TODO_PANEL_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _coerce_todo_panel(raw) -> bool:
+    if raw is False or raw == 0:
+        return False
+    if raw is True or raw is None:
+        return True
+    if isinstance(raw, str):
+        s = raw.strip().lower()
+        if s in _TODO_PANEL_FALSEY:
+            return False
+        if s in _TODO_PANEL_TRUTHY:
+            return True
+    return True
+
+
 _MOUSE_TRACKING_ALIASES = {
     "0": "off",
     "1": "all",
@@ -10201,6 +10219,24 @@ def _(rid, params: dict) -> dict:
         _write_config_key("display.tui_statusbar", nv)
         return _ok(rid, {"key": key, "value": nv})
 
+    if key == "todo_panel":
+        raw = str(value or "").strip().lower()
+        display = _load_cfg().get("display")
+        d0 = display if isinstance(display, dict) else {}
+        current = _coerce_todo_panel(d0.get("tui_todo_panel", True))
+
+        if raw in {"", "toggle"}:
+            nv_b = not current
+        elif raw in _TODO_PANEL_TRUTHY:
+            nv_b = True
+        elif raw in _TODO_PANEL_FALSEY:
+            nv_b = False
+        else:
+            return _err(rid, 4002, f"unknown todo_panel value: {value}")
+
+        _write_config_key("display.tui_todo_panel", nv_b)
+        return _ok(rid, {"key": key, "value": "on" if nv_b else "off"})
+
     if key == "mouse":
         # Explicit None check rather than `value or ""` so falsy non-string
         # inputs (0, False) reach the alias map as themselves — both map to
@@ -10842,6 +10878,12 @@ def _(rid, params: dict) -> dict:
             display.get("tui_statusbar", "top") if isinstance(display, dict) else "top"
         )
         return _ok(rid, {"value": _coerce_statusbar(raw)})
+    if key == "todo_panel":
+        display = _load_cfg().get("display")
+        raw = (
+            display.get("tui_todo_panel", True) if isinstance(display, dict) else True
+        )
+        return _ok(rid, {"value": "on" if _coerce_todo_panel(raw) else "off"})
     if key == "mouse":
         display = _load_cfg().get("display")
         return _ok(rid, {"value": _display_mouse_tracking(display)})
@@ -11130,6 +11172,7 @@ _TUI_EXTRA: list[tuple[str, str, str]] = [
         "TUI",
     ),
     ("/sessions", "Switch between live TUI sessions", "TUI"),
+    ("/todos", "Show or hide the persistent bottom todo panel", "TUI"),
 ]
 
 # Commands that queue messages onto _pending_input in the CLI.
@@ -12218,6 +12261,11 @@ def _(rid, params: dict) -> dict:
                 "text": "/mouse",
                 "display": "/mouse",
                 "meta": "Set mouse tracking preset [on|off|toggle|wheel|buttons|all]",
+            },
+            {
+                "text": "/todos",
+                "display": "/todos",
+                "meta": "Show or hide the persistent bottom todo panel",
             },
         ]
         for extra in extras:

--- a/ui-tui/src/__tests__/bottomTodoPanel.test.tsx
+++ b/ui-tui/src/__tests__/bottomTodoPanel.test.tsx
@@ -1,0 +1,72 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { BottomTodoPanel } from '../components/todoPanel.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const renderPanel = (element: React.ReactElement): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(element, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return stripAnsi(output)
+}
+
+describe('BottomTodoPanel', () => {
+  it('renders active, pending, and completed todos in a fixed bottom panel frame', () => {
+    const output = renderPanel(
+      <BottomTodoPanel
+        cols={80}
+        t={DEFAULT_THEME}
+        todos={[
+          { content: 'Gather context', id: 'context', status: 'completed' },
+          { content: 'Patch renderer', id: 'patch', status: 'in_progress' },
+          { content: 'Run harness', id: 'verify', status: 'pending' }
+        ]}
+        visible
+      />
+    )
+
+    expect(output).toContain('Todo (1/3)')
+    expect(output).toContain('[x] Gather context')
+    expect(output).toContain('[>] Patch renderer')
+    expect(output).toContain('[ ] Run harness')
+    expect(output).toContain('current: Patch renderer')
+  })
+
+  it('renders nothing when hidden or empty', () => {
+    expect(renderPanel(<BottomTodoPanel cols={80} t={DEFAULT_THEME} todos={[]} visible />).trim()).toBe('')
+    expect(
+      renderPanel(
+        <BottomTodoPanel
+          cols={80}
+          t={DEFAULT_THEME}
+          todos={[{ content: 'Hidden task', id: 'hidden', status: 'pending' }]}
+          visible={false}
+        />
+      ).trim()
+    ).toBe('')
+  })
+})

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -488,6 +488,36 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.sys).toHaveBeenCalledWith('details activity: hidden')
   })
 
+  it('toggles the persistent bottom todo panel locally and persists the setting', () => {
+    patchUiState({ todoPanel: true })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/todos off')).toBe(true)
+    expect(getUiState().todoPanel).toBe(false)
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', {
+      key: 'todo_panel',
+      value: 'off'
+    })
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('todo panel off')
+
+    expect(createSlashHandler(ctx)('/todos on')).toBe(true)
+    expect(getUiState().todoPanel).toBe(true)
+    expect(ctx.gateway.rpc).toHaveBeenLastCalledWith('config.set', {
+      key: 'todo_panel',
+      value: 'on'
+    })
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('todo panel on')
+  })
+
+  it('rejects unknown /todos arguments before hitting the gateway', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/todos sideways')).toBe(true)
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('usage: /todos [on|off|toggle]')
+  })
+
   it('clears a per-section override on /details <section> reset', () => {
     const ctx = buildCtx()
     createSlashHandler(ctx)('/details tools expanded')

--- a/ui-tui/src/__tests__/turnStore.test.ts
+++ b/ui-tui/src/__tests__/turnStore.test.ts
@@ -51,6 +51,20 @@ describe('turnStore live progress helpers', () => {
     expect(getTurnState().todos).toEqual([])
   })
 
+  it('keeps a bottom-panel snapshot when archiving clears the live anchor', () => {
+    const todos = [
+      { content: 'cook', id: 'cook', status: 'completed' },
+      { content: 'serve', id: 'serve', status: 'in_progress' }
+    ] as const
+
+    patchTurnState({ todoPanelTodos: [...todos], todos: [...todos] })
+
+    archiveTodosAtTurnEnd()
+
+    expect(getTurnState().todos).toEqual([])
+    expect(getTurnState().todoPanelTodos).toEqual(todos)
+  })
+
   it('returns nothing when there are no todos at turn end', () => {
     expect(archiveTodosAtTurnEnd()).toEqual([])
     expect(archiveDoneTodos()).toEqual([])

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -7,7 +7,8 @@ import {
   normalizeBusyInputMode,
   normalizeIndicatorStyle,
   normalizeMouseTracking,
-  normalizeStatusBar
+  normalizeStatusBar,
+  normalizeTodoPanel
 } from '../app/useConfigSync.js'
 
 describe('applyDisplay', () => {
@@ -28,6 +29,7 @@ describe('applyDisplay', () => {
             show_reasoning: true,
             streaming: false,
             tui_compact: true,
+            tui_todo_panel: false,
             tui_statusbar: false
           }
         }
@@ -43,6 +45,7 @@ describe('applyDisplay', () => {
     expect(s.showReasoning).toBe(true)
     expect(s.statusBar).toBe('off')
     expect(s.streaming).toBe(false)
+    expect(s.todoPanel).toBe(false)
   })
 
   it('coerces legacy true + "on" alias to top', () => {
@@ -66,6 +69,7 @@ describe('applyDisplay', () => {
     expect(s.showReasoning).toBe(false)
     expect(s.statusBar).toBe('top')
     expect(s.streaming).toBe(true)
+    expect(s.todoPanel).toBe(true)
     expect(s.sections).toEqual({})
   })
 
@@ -188,6 +192,25 @@ describe('normalizeStatusBar', () => {
     expect(normalizeStatusBar('TOP')).toBe('top')
     expect(normalizeStatusBar('  on  ')).toBe('top')
     expect(normalizeStatusBar('OFF')).toBe('off')
+  })
+})
+
+describe('normalizeTodoPanel', () => {
+  it('defaults to visible and accepts on/off aliases', () => {
+    expect(normalizeTodoPanel(undefined)).toBe(true)
+    expect(normalizeTodoPanel(null)).toBe(true)
+    expect(normalizeTodoPanel(true)).toBe(true)
+    expect(normalizeTodoPanel(false)).toBe(false)
+    expect(normalizeTodoPanel('on')).toBe(true)
+    expect(normalizeTodoPanel('true')).toBe(true)
+    expect(normalizeTodoPanel('off')).toBe(false)
+    expect(normalizeTodoPanel('false')).toBe(false)
+  })
+
+  it('trims and lowercases strings, falling back to visible for unknown values', () => {
+    expect(normalizeTodoPanel(' OFF ')).toBe(false)
+    expect(normalizeTodoPanel('YES')).toBe(true)
+    expect(normalizeTodoPanel('later')).toBe(true)
   })
 })
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -181,6 +181,7 @@ export interface UiState {
   statusBar: StatusBarMode
   streaming: boolean
   theme: Theme
+  todoPanel: boolean
   usage: Usage
 }
 

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -106,6 +106,7 @@ export const coreCommands: SlashCommand[] = [
               '/details <section> [hidden|collapsed|expanded|reset]',
               'override one section (thinking/tools/subagents/activity)'
             ],
+            ['/todos [on|off|toggle]', 'show or hide the persistent bottom todo panel'],
             ['/fortune [random|daily]', 'show a random or daily local fortune']
           ],
           title: 'TUI'
@@ -576,6 +577,24 @@ export const coreCommands: SlashCommand[] = [
       ctx.gateway.rpc<ConfigSetResponse>('config.set', { key: 'statusbar', value: next }).catch(() => {})
 
       queueMicrotask(() => ctx.transcript.sys(`status bar ${next}`))
+    }
+  },
+
+  {
+    aliases: ['todo-list', 'todo-panel'],
+    help: 'show or hide the persistent bottom todo panel',
+    name: 'todos',
+    run: (arg, ctx) => {
+      const next = flagFromArg(arg, ctx.ui.todoPanel)
+
+      if (next === null) {
+        return ctx.transcript.sys('usage: /todos [on|off|toggle]')
+      }
+
+      patchUiState({ todoPanel: next })
+      ctx.gateway.rpc<ConfigSetResponse>('config.set', { key: 'todo_panel', value: next ? 'on' : 'off' }).catch(() => {})
+
+      ctx.transcript.sys(`todo panel ${next ? 'on' : 'off'}`)
     }
   },
 

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -446,7 +446,7 @@ class TurnController {
     const todos = parseTodos(value)
 
     if (todos !== null) {
-      patchTurnState({ todos })
+      patchTurnState({ todoPanelTodos: todos, todos })
     }
   }
 

--- a/ui-tui/src/app/turnStore.ts
+++ b/ui-tui/src/app/turnStore.ts
@@ -16,6 +16,7 @@ const buildTurnState = (): TurnState => ({
   streaming: '',
   subagents: [],
   todoCollapsed: false,
+  todoPanelTodos: [],
   todos: [],
   toolTokens: 0,
   tools: [],
@@ -78,6 +79,7 @@ export interface TurnState {
   streaming: string
   subagents: SubagentProgress[]
   todoCollapsed: boolean
+  todoPanelTodos: TodoItem[]
   todos: TodoItem[]
   toolTokens: number
   tools: ActiveTool[]

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -29,6 +29,7 @@ const buildUiState = (): UiState => ({
   statusBar: 'top',
   streaming: true,
   theme: DEFAULT_THEME,
+  todoPanel: true,
   usage: ZERO
 })
 

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -27,6 +27,39 @@ const STATUSBAR_ALIAS: Record<string, StatusBarMode> = {
 export const normalizeStatusBar = (raw: unknown): StatusBarMode =>
   raw === false ? 'off' : typeof raw === 'string' ? (STATUSBAR_ALIAS[raw.trim().toLowerCase()] ?? 'top') : 'top'
 
+const TODO_PANEL_FALSEY = new Set(['0', 'false', 'no', 'off'])
+const TODO_PANEL_TRUTHY = new Set(['1', 'true', 'yes', 'on'])
+
+export const normalizeTodoPanel = (raw: unknown): boolean => {
+  if (raw === false || raw === 0) {
+    return false
+  }
+
+  if (raw === true || raw === undefined || raw === null) {
+    return true
+  }
+
+  if (typeof raw === 'number') {
+    return true
+  }
+
+  if (typeof raw !== 'string') {
+    return true
+  }
+
+  const v = raw.trim().toLowerCase()
+
+  if (TODO_PANEL_FALSEY.has(v)) {
+    return false
+  }
+
+  if (TODO_PANEL_TRUTHY.has(v)) {
+    return true
+  }
+
+  return true
+}
+
 const BUSY_MODES = new Set<BusyInputMode>(['interrupt', 'queue', 'steer'])
 
 // TUI defaults to `queue` even though the framework default
@@ -229,7 +262,8 @@ export const applyDisplay = (
     sections: resolveSections(d.sections),
     showReasoning: !!d.show_reasoning,
     statusBar: normalizeStatusBar(d.tui_statusbar),
-    streaming: d.streaming !== false
+    streaming: d.streaming !== false,
+    todoPanel: normalizeTodoPanel(d.tui_todo_panel)
   })
 }
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -6,6 +6,7 @@ import { useGateway } from '../app/gatewayContext.js'
 import type { AppLayoutProps } from '../app/interfaces.js'
 import { $isBlocked, $overlayState, patchOverlayState } from '../app/overlayStore.js'
 import { $petBox } from '../app/petFlashStore.js'
+import { useTurnSelector } from '../app/turnStore.js'
 import { $uiState } from '../app/uiStore.js'
 import { usePet } from '../app/usePet.js'
 import { INLINE_MODE, SHOW_FPS, TERMUX_TUI_MODE } from '../config/env.js'
@@ -30,8 +31,9 @@ import { Journey } from './journey.js'
 import { MessageLine } from './messageLine.js'
 import { PetKitty, PetSprite } from './petSprite.js'
 import { QueuedMessages } from './queuedMessages.js'
-import { LiveTodoPanel, StreamingAssistant } from './streamingAssistant.js'
+import { StreamingAssistant } from './streamingAssistant.js'
 import { TextInput, type TextInputMouseApi } from './textInput.js'
+import { BottomTodoPanel } from './todoPanel.js'
 
 // Box geometry, kept here so the transcript's reservation math matches the
 // rendered overlay exactly.
@@ -142,21 +144,6 @@ const TranscriptPane = memo(function TranscriptPane({
   const bodyCols = useGutter && petBox ? composer.cols - petBox.width : composer.cols
   const petBandRows = petBox && !useGutter ? petBox.height : 0
 
-  // LiveTodoPanel rides as a child of the latest user-message row so it
-  // visually belongs to the prompt and follows it during scroll. -1 when
-  // empty → row.index === -1 is always false → no render.
-  const lastUserIdx = useMemo(() => {
-    const items = transcript.historyItems
-
-    for (let i = items.length - 1; i >= 0; i--) {
-      if (items[i].role === 'user') {
-        return i
-      }
-    }
-
-    return -1
-  }, [transcript.historyItems])
-
   // Index of the first user-role message; every later user message gets a
   // small dash above it so multi-turn transcripts visually segment by
   // turn. -1 when no user message has been sent yet → no separator ever
@@ -223,7 +210,6 @@ const TranscriptPane = memo(function TranscriptPane({
                 />
               )}
 
-              {row.index === lastUserIdx && <LiveTodoPanel />}
             </Box>
           ))}
 
@@ -255,6 +241,17 @@ const TranscriptPane = memo(function TranscriptPane({
         scrollRef={transcript.scrollRef}
       />
     </>
+  )
+})
+
+const BottomTodoPanelPane = memo(function BottomTodoPanelPane({ cols }: { cols: number }) {
+  const ui = useStore($uiState)
+  const todos = useTurnSelector(state => state.todoPanelTodos)
+
+  return (
+    <Box flexShrink={0} paddingX={1}>
+      <BottomTodoPanel cols={cols} t={ui.theme} todos={todos} visible={ui.todoPanel} />
+    </Box>
   )
 })
 
@@ -536,6 +533,10 @@ export const AppLayout = memo(function AppLayout({
                 onSecretSubmit={actions.answerSecret}
                 onSudoSubmit={actions.answerSudo}
               />
+            </PerfPane>
+
+            <PerfPane id="todo-panel">
+              <BottomTodoPanelPane cols={composer.cols} />
             </PerfPane>
 
             <PerfPane id="composer">

--- a/ui-tui/src/components/todoPanel.tsx
+++ b/ui-tui/src/components/todoPanel.tsx
@@ -12,6 +12,9 @@ const rowColor = (t: Theme, status: TodoItem['status']) => {
   return tone === 'active' ? t.color.text : tone === 'body' ? t.color.statusFg : t.color.muted
 }
 
+const currentTodo = (todos: readonly TodoItem[]) =>
+  todos.find(todo => todo.status === 'in_progress') ?? todos.find(todo => todo.status === 'pending') ?? null
+
 export const TodoPanel = memo(function TodoPanel({
   collapsed,
   defaultCollapsed = false,
@@ -88,6 +91,74 @@ export const TodoPanel = memo(function TodoPanel({
           })}
         </Box>
       )}
+    </Box>
+  )
+})
+
+export const BottomTodoPanel = memo(function BottomTodoPanel({
+  cols,
+  t,
+  todos,
+  visible
+}: {
+  cols: number
+  t: Theme
+  todos: TodoItem[]
+  visible: boolean
+}) {
+  if (!visible || !todos.length) {
+    return null
+  }
+
+  const done = todos.filter(todo => todo.status === 'completed').length
+  const current = currentTodo(todos)
+  const maxRows = Math.max(2, Math.min(5, Math.floor(cols / 24)))
+  const rows = todos.slice(0, maxRows)
+  const hidden = Math.max(0, todos.length - rows.length)
+
+  return (
+    <Box
+      borderColor={t.color.border}
+      borderStyle="round"
+      flexDirection="column"
+      flexShrink={0}
+      paddingX={1}
+      width={Math.max(1, cols - 2)}
+    >
+      <Text color={t.color.muted} wrap="truncate-end">
+        <Text bold color={t.color.text}>
+          Todo
+        </Text>{' '}
+        <Text color={t.color.statusFg} dim>
+          ({done}/{todos.length})
+        </Text>
+        {current && (
+          <Text color={t.color.muted} dim>
+            {' '}
+            · current: {current.content}
+          </Text>
+        )}
+      </Text>
+
+      <Box flexDirection="column">
+        {rows.map(todo => {
+          const tone = todoTone(todo.status)
+          const color = rowColor(t, todo.status)
+
+          return (
+            <Text color={color} dim={tone === 'dim'} key={todo.id} wrap="truncate-end">
+              <Text color={color}>{todoGlyph(todo.status)} </Text>
+              {todo.content}
+            </Text>
+          )
+        })}
+
+        {hidden > 0 && (
+          <Text color={t.color.muted} dim>
+            +{hidden} more
+          </Text>
+        )}
+      </Box>
     </Box>
   )
 })

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -172,6 +172,7 @@ export interface ConfigDisplayConfig {
   tui_compact?: boolean
   /** Legacy alias for display.mouse_tracking. */
   tui_mouse?: boolean | null | number | string
+  tui_todo_panel?: boolean | null | number | string
   // Forward-compat: backend may send styles this client doesn't know yet —
   // `normalizeIndicatorStyle` falls back to 'kaomoji' for those — but the
   // wire type is documented as `string` so consumers don't get a false


### PR DESCRIPTION
Adds a persistent bottom Todo panel to the Hermes Ink TUI so active tasks stay visible above the composer.\n\nVerification run locally on /usr/local/lib/hermes-agent:\n- targeted ui-tui vitest, 4 files, 111 tests passed\n- npm run typecheck --workspace ui-tui passed\n- backend pytest todo panel selection, 3 passed\n- changed-file ESLint passed\n- git diff --check passed\n- /root/.hermes/scripts/selftest-all.sh --quiet exited 0\n\nNotes: local checkout has unrelated dirty agent/redact/file_safety backup files that are not included in this PR.