### PR TITLE
fix(moa): pass custom extra_body to slots

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -168,9 +168,28 @@ def _slot_runtime(slot: dict[str, str]) -> dict[str, Any]:
             out["api_key"] = rt["api_key"]
         if rt.get("api_mode"):
             out["api_mode"] = rt["api_mode"]
+        request_overrides = rt.get("request_overrides")
+        if isinstance(request_overrides, dict):
+            extra_body = request_overrides.get("extra_body")
+            if isinstance(extra_body, dict) and extra_body:
+                out["extra_body"] = dict(extra_body)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("MoA slot runtime resolution failed for %s: %s", _slot_label(slot), exc)
     return out
+
+
+def _merge_slot_extra_body(
+    slot_extra_body: Any,
+    caller_extra_body: Any,
+) -> Any:
+    """Merge slot defaults with a caller override for ``call_llm``."""
+    if isinstance(slot_extra_body, dict) and slot_extra_body:
+        if isinstance(caller_extra_body, dict):
+            return {**slot_extra_body, **caller_extra_body}
+        if caller_extra_body:
+            return caller_extra_body
+        return dict(slot_extra_body)
+    return caller_extra_body
 
 
 def _maybe_apply_moa_cache_control(
@@ -1010,15 +1029,20 @@ class MoAChatCompletions:
             # actually governs the aggregator stream, not just call_llm's default.
             if api_kwargs.get("timeout") is not None:
                 stream_kwargs["timeout"] = api_kwargs["timeout"]
+        agg_runtime = _slot_runtime(aggregator)
+        agg_extra_body = _merge_slot_extra_body(
+            agg_runtime.pop("extra_body", None),
+            agg_kwargs.get("extra_body"),
+        )
         _agg_response = call_llm(
             task="moa_aggregator",
             messages=agg_messages,
             temperature=aggregator_temperature,
             max_tokens=agg_kwargs.get("max_tokens"),
             tools=agg_kwargs.get("tools"),
-            extra_body=agg_kwargs.get("extra_body"),
+            extra_body=agg_extra_body,
             **stream_kwargs,
-            **_slot_runtime(aggregator),
+            **agg_runtime,
         )
         # Non-streaming path (quiet mode / eval / subagents): the aggregator
         # output is available inline, so capture it into the pending trace now.

--- a/tests/agent/test_moa_slot_api_mode.py
+++ b/tests/agent/test_moa_slot_api_mode.py
@@ -7,9 +7,16 @@ so reference slots using providers that require a specific API surface
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
+
+
+def _response(content="ok"):
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fake")
 
 
 class TestSlotRuntimeApiMode:
@@ -60,6 +67,125 @@ class TestSlotRuntimeApiMode:
 
         result = _slot_runtime({"provider": "copilot", "model": "gpt-5.5"})
         assert "api_mode" not in result
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_slot_runtime_includes_request_override_extra_body(self, mock_resolve):
+        """Custom-provider extra_body is forwarded in call_llm's shape."""
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "model": "qwen3.7-max",
+            "base_url": "https://dashscope.example/v1",
+            "api_key": "test-key",
+            "api_mode": "chat_completions",
+            "request_overrides": {
+                "extra_body": {
+                    "enable_thinking": False,
+                    "reasoning": {"effort": "none"},
+                }
+            },
+        }
+        from agent.moa_loop import _slot_runtime
+
+        result = _slot_runtime({"provider": "dashscope", "model": "qwen3.7-max"})
+        assert result["extra_body"] == {
+            "enable_thinking": False,
+            "reasoning": {"effort": "none"},
+        }
+
+
+def test_run_reference_passes_slot_extra_body(monkeypatch):
+    """Reference advisors should receive custom provider extra_body."""
+    from agent import moa_loop
+
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return _response("advisor")
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {
+            "provider": "custom",
+            "model": "qwen3.7-max",
+            "base_url": "https://dashscope.example/v1",
+            "api_key": "test-key",
+            "extra_body": {"enable_thinking": False},
+        },
+    )
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    monkeypatch.setattr(moa_loop, "_maybe_apply_moa_cache_control", lambda messages, runtime: messages)
+
+    label, text, _usage = moa_loop._run_reference(
+        {"provider": "dashscope", "model": "qwen3.7-max"},
+        [{"role": "user", "content": "hello"}],
+    )
+
+    assert label == "dashscope:qwen3.7-max"
+    assert text == "advisor"
+    assert captured["extra_body"] == {"enable_thinking": False}
+
+
+def test_moa_aggregator_merges_slot_extra_body_with_caller_override(tmp_path, monkeypatch):
+    """Aggregator calls should merge slot defaults without duplicate kwargs."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: closed
+  presets:
+    closed:
+      enabled: true
+      reference_models: []
+      aggregator:
+        provider: dashscope
+        model: qwen3.7-max
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent import moa_loop
+
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return _response("acted")
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {
+            "provider": "custom",
+            "model": "qwen3.7-max",
+            "base_url": "https://dashscope.example/v1",
+            "api_key": "test-key",
+            "extra_body": {
+                "enable_thinking": False,
+                "metadata": {"source": "slot"},
+            },
+        },
+    )
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+
+    facade = moa_loop.MoAChatCompletions("closed")
+    facade.create(
+        model="closed",
+        messages=[{"role": "user", "content": "hello"}],
+        extra_body={
+            "metadata": {"source": "caller"},
+            "reasoning": {"effort": "none"},
+        },
+    )
+
+    assert captured["extra_body"] == {
+        "enable_thinking": False,
+        "metadata": {"source": "caller"},
+        "reasoning": {"effort": "none"},
+    }
 
 
 class TestCallLlmApiMode:


### PR DESCRIPTION
## Summary
- Forward custom provider `request_overrides.extra_body` from resolved MoA slots into `call_llm`.
- Merge aggregator slot defaults with caller-provided `extra_body`, keeping caller values authoritative and avoiding duplicate kwargs.
- Add regression coverage for reference advisors and the aggregator path.

## Why
Fixes #60153.

MoA already resolves each reference/aggregator slot through `resolve_runtime_provider`, where named `custom_providers` entries expose their `extra_body` as `request_overrides.extra_body`. The MoA slot adapter kept only provider/model/base URL/key/API mode, so reference model calls dropped provider-specific request body fields such as `enable_thinking: false`.

## Tests
- `scripts/run_tests.sh tests/agent/test_moa_slot_api_mode.py -q`
- `scripts/run_tests.sh tests/agent/test_moa_slot_api_mode.py tests/agent/test_moa_aggregator_cache_control.py tests/agent/test_moa_aggregator_cost_slot.py tests/hermes_cli/test_runtime_provider_resolution.py -q`
- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py -k TestAuxiliaryTaskExtraBody -q`
