### PR TITLE
fix(oneshot): honor auth fallback providers

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -294,6 +294,57 @@ def _create_session_db_for_oneshot():
         return None
 
 
+def _fallback_entry_api_key(entry: dict) -> str | None:
+    explicit_api_key = entry.get("api_key")
+    if explicit_api_key:
+        return str(explicit_api_key).strip() or None
+
+    key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
+    if not key_env:
+        return None
+
+    return os.getenv(key_env, "").strip() or None
+
+
+def _resolve_runtime_with_auth_fallback(
+    *,
+    resolve_runtime_provider,
+    primary_kwargs: dict,
+    fallback_chain: list[dict],
+) -> tuple[dict, dict | None]:
+    """Resolve the primary runtime, falling back only for setup-time auth failures."""
+    try:
+        return resolve_runtime_provider(**primary_kwargs), None
+    except Exception as primary_exc:
+        from hermes_cli.auth import AuthError
+
+        if not isinstance(primary_exc, AuthError):
+            raise
+
+        for entry in fallback_chain:
+            fb_provider = str(entry.get("provider") or "").strip()
+            fb_model = str(entry.get("model") or "").strip()
+            if not fb_provider or not fb_model:
+                continue
+
+            fb_kwargs = {
+                "requested": fb_provider,
+                "target_model": fb_model,
+            }
+            if entry.get("base_url"):
+                fb_kwargs["explicit_base_url"] = entry.get("base_url")
+            fb_api_key = _fallback_entry_api_key(entry)
+            if fb_api_key:
+                fb_kwargs["explicit_api_key"] = fb_api_key
+
+            try:
+                return resolve_runtime_provider(**fb_kwargs), entry
+            except Exception:
+                continue
+
+        raise primary_exc
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
@@ -366,11 +417,21 @@ def _run_agent(
                 if detected:
                     effective_provider, effective_model = detected
 
-    runtime = resolve_runtime_provider(
-        requested=effective_provider,
-        target_model=effective_model or None,
-        explicit_base_url=explicit_base_url_from_alias,
+    # Read the effective fallback chain before provider resolution. The primary
+    # provider can fail while resolving credentials, before AIAgent exists and
+    # before runtime fallback can activate.
+    _fb = get_fallback_chain(cfg)
+    runtime, fallback_entry = _resolve_runtime_with_auth_fallback(
+        resolve_runtime_provider=resolve_runtime_provider,
+        primary_kwargs={
+            "requested": effective_provider,
+            "target_model": effective_model or None,
+            "explicit_base_url": explicit_base_url_from_alias,
+        },
+        fallback_chain=_fb,
     )
+    if fallback_entry is not None:
+        effective_model = str(fallback_entry.get("model") or "").strip() or effective_model
 
     # Pull in explicit toolsets when provided; otherwise use whatever the user
     # has enabled for "cli". sorted() gives stable ordering for config-derived
@@ -380,9 +441,6 @@ def _run_agent(
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
     session_db = _create_session_db_for_oneshot()
-    # Read the effective fallback chain from profile config so oneshot workers
-    # honour the same merge semantics as interactive CLI and gateway sessions.
-    _fb = get_fallback_chain(cfg)
 
     agent = AIAgent(
         api_key=runtime.get("api_key"),

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -886,6 +886,116 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert captured["prompt"] == "recall this"
 
 
+def test_oneshot_auth_error_uses_configured_fallback(monkeypatch):
+    """Credential-resolution AuthError should fall through before AIAgent exists."""
+    from hermes_cli.auth import AuthError
+    from hermes_cli.oneshot import _run_agent
+
+    captured = {}
+    resolve_calls = []
+    sentinel_db = object()
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def run_conversation(self, prompt, **_kwargs):
+            captured["prompt"] = prompt
+            return {"final_response": "fallback ok", "failed": False, "partial": False}
+
+    class FakeSessionDB:
+        def __new__(cls):
+            return sentinel_db
+
+    def fake_resolve_runtime_provider(**kwargs):
+        resolve_calls.append(kwargs)
+        if kwargs.get("requested") is None:
+            raise AuthError("primary credentials missing")
+        assert kwargs == {
+            "requested": "custom",
+            "target_model": "fallback-model",
+            "explicit_base_url": "https://fallback.example/v1",
+            "explicit_api_key": "fallback-secret",
+        }
+        return {
+            "api_key": "fallback-secret",
+            "base_url": "https://fallback.example/v1",
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        }
+
+    def mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setenv("FALLBACK_API_KEY", "fallback-secret")
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=FakeAgent))
+    monkeypatch.setitem(sys.modules, "hermes_state", mod("hermes_state", SessionDB=FakeSessionDB))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod(
+            "hermes_cli.config",
+            load_config=lambda: {
+                "model": {"default": "primary-model", "provider": "openai-codex"},
+                "fallback_providers": [
+                    {
+                        "provider": "custom",
+                        "model": "fallback-model",
+                        "base_url": "https://fallback.example/v1",
+                        "key_env": "FALLBACK_API_KEY",
+                    }
+                ],
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        mod("hermes_cli.models", detect_provider_for_model=lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod("hermes_cli.runtime_provider", resolve_runtime_provider=fake_resolve_runtime_provider),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: {"web"}),
+    )
+
+    text, result = _run_agent("hello")
+
+    assert text == "fallback ok"
+    assert not result.get("failed")
+    assert resolve_calls[0] == {
+        "requested": None,
+        "target_model": "primary-model",
+        "explicit_base_url": None,
+    }
+    assert captured["model"] == "fallback-model"
+    assert captured["provider"] == "custom"
+    assert captured["base_url"] == "https://fallback.example/v1"
+    assert captured["api_key"] == "fallback-secret"
+    assert captured["session_db"] is sentinel_db
+    assert captured["fallback_model"] == [
+        {
+            "provider": "custom",
+            "model": "fallback-model",
+            "base_url": "https://fallback.example/v1",
+            "key_env": "FALLBACK_API_KEY",
+        }
+    ]
+    assert captured["prompt"] == "hello"
+
+
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     captured = {}
     active_path_during_call = None


### PR DESCRIPTION
## Summary

- resolve the configured fallback chain before building the oneshot agent
- fall through to fallback providers when primary runtime credential resolution raises `AuthError`
- carry fallback `model`, `base_url`, and `key_env` / `api_key_env` into the resolved oneshot runtime

Fixes #60167.

## Why

`hermes -z` resolved the primary provider before constructing `AIAgent`. If that resolution failed due to missing or expired credentials, the configured `fallback_providers` chain was never reached. Interactive CLI and gateway paths already recover from this setup-time auth failure; this brings oneshot in line with those entry points.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py -k oneshot -q`
- `scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py -q`
