### PR TITLE
fix(tui): improve light theme text contrast

### DIFF
--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -34,6 +34,31 @@ async function importThemeWithCleanEnv() {
   return importThemeWithEnv()
 }
 
+function hexRgb(hex: string): [number, number, number] {
+  const normalized = hex.replace(/^#/, '')
+
+  return [
+    Number.parseInt(normalized.slice(0, 2), 16),
+    Number.parseInt(normalized.slice(2, 4), 16),
+    Number.parseInt(normalized.slice(4, 6), 16)
+  ]
+}
+
+function hslSaturation(hex: string): number {
+  const [red, green, blue] = hexRgb(hex).map(channel => channel / 255)
+  const max = Math.max(red, green, blue)
+  const min = Math.min(red, green, blue)
+
+  if (max === min) {
+    return 0
+  }
+
+  const lightness = (max + min) / 2
+  const delta = max - min
+
+  return lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min)
+}
+
 afterEach(() => {
   vi.unstubAllEnvs()
   vi.resetModules()
@@ -64,6 +89,20 @@ describe('LIGHT_THEME', () => {
     expect(LIGHT_THEME.color.accent).not.toBe('#FFBF00')
     expect(LIGHT_THEME.color.muted).not.toBe('#B8860B')
     expect(LIGHT_THEME.color.statusWarn).not.toBe('#FFD700')
+  })
+
+  it('uses neutral dark foregrounds for readable assistant text on light terminals', async () => {
+    const { LIGHT_THEME } = await importThemeWithCleanEnv()
+
+    for (const color of [
+      LIGHT_THEME.color.text,
+      LIGHT_THEME.color.muted,
+      LIGHT_THEME.color.label,
+      LIGHT_THEME.color.sessionLabel,
+      LIGHT_THEME.color.sessionBorder
+    ]) {
+      expect(hslSaturation(color)).toBeLessThan(0.35)
+    }
   })
 
   it('keeps the same shape as DARK_THEME', async () => {

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -301,37 +301,36 @@ export const DARK_THEME: Theme = {
   bannerHero: ''
 }
 
-// Light-terminal palette: darker golds/ambers that stay legible on white
-// backgrounds. Same shape as DARK_THEME so `fromSkin` still layers on top
-// cleanly (#11300).
+// Light-terminal palette: neutral dark foregrounds with restrained amber
+// accents. Same shape as DARK_THEME so `fromSkin` still layers on top cleanly.
 export const LIGHT_THEME: Theme = {
   color: {
-    primary: '#8B6914',
-    accent: '#A0651C',
-    border: '#7A4F1F',
-    text: '#3D2F13',
-    muted: '#7A5A0F',
-    completionBg: '#F5F5F5',
-    completionCurrentBg: mix('#F5F5F5', '#A0651C', 0.25),
-    completionMetaBg: '#F5F5F5',
-    completionMetaCurrentBg: mix('#F5F5F5', '#A0651C', 0.25),
+    primary: '#6F4E00',
+    accent: '#8A4F12',
+    border: '#6B4A1F',
+    text: '#1F2933',
+    muted: '#52616B',
+    completionBg: '#FAFAF7',
+    completionCurrentBg: mix('#FAFAF7', '#6F8FB7', 0.26),
+    completionMetaBg: '#FAFAF7',
+    completionMetaCurrentBg: mix('#FAFAF7', '#D4A64C', 0.24),
 
-    label: '#7A5A0F',
+    label: '#5B6472',
     ok: '#2E7D32',
     error: '#C62828',
     warn: '#E65100',
 
-    prompt: '#2B2014',
-    sessionLabel: '#7A5A0F',
-    sessionBorder: '#7A5A0F',
+    prompt: '#1F2933',
+    sessionLabel: '#5B6472',
+    sessionBorder: '#5B6472',
 
-    statusBg: '#F5F5F5',
-    statusFg: '#333333',
+    statusBg: '#FAFAF7',
+    statusFg: '#1F2933',
     statusGood: '#2E7D32',
-    statusWarn: '#8B6914',
+    statusWarn: '#6F4E00',
     statusBad: '#D84315',
     statusCritical: '#B71C1C',
-    selectionBg: '#D4E4F7',
+    selectionBg: '#DCEAF7',
 
     diffAdded: 'rgb(200,240,200)',
     diffRemoved: 'rgb(240,200,200)',


### PR DESCRIPTION
## Summary

Fixes the TUI light palette so assistant replies stay readable in macOS Terminal.app light profiles. The old light theme still used saturated gold/brown foregrounds for body and label text, which could make the assistant reply panel look faint or empty on a white terminal background.

This moves the long-form foreground colors to a neutral dark ramp while keeping amber for accents, and adds a small regression test for the light-theme foreground palette.

Fixes #60141.

## Testing

- `npm test -- --run src/__tests__/theme.test.ts`
- `npx eslint src/theme.ts src/__tests__/theme.test.ts`
- `npm run typecheck`