### PR TITLE
fix(retry): treat NVIDIA degraded function as overload

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -165,6 +165,7 @@ _OVERLOADED_PATTERNS = [
     "currently overloaded",
     "at capacity",
     "over capacity",
+    "degraded function cannot be invoked",
 ]
 
 # Usage-limit patterns that need disambiguation (could be billing OR rate_limit)
@@ -1213,6 +1214,16 @@ def _classify_400(
             should_rotate_credential=True,
             should_fallback=True,
         )
+
+    # NVIDIA NIM can surface transient backend function health as a 400:
+    # "Function id '<uuid>': DEGRADED function cannot be invoked". The request
+    # shape is valid; retry/backoff is safer than killing cron as format_error.
+    if any(p in error_msg for p in _OVERLOADED_PATTERNS):
+        return result_fn(
+            FailoverReason.overloaded,
+            retryable=True,
+        )
+
     if any(p in error_msg for p in _BILLING_PATTERNS):
         return result_fn(
             FailoverReason.billing,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -422,6 +422,21 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_rotate_credential is False
 
+    def test_400_degraded_function_is_overloaded(self):
+        """NVIDIA NIM can report transient backend function health as HTTP 400.
+        This is not a malformed Hermes request, so cron should back off instead
+        of failing immediately as format_error."""
+        e = MockAPIError(
+            "HTTP 400: {\"status\":400,\"title\":\"Bad Request\","
+            "\"detail\":\"Function id '87ea0ddc-cff1-4bca-bf8b-3bd98a35ddd0': "
+            "DEGRADED function cannot be invoked\"}",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="custom:nvidia-rotating")
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
+
     def test_429_normal_rate_limit_still_rotates(self):
         """Guard: a genuine 429 rate limit (no overload language) must still
         classify as rate_limit and rotate the credential. (#14038)"""


### PR DESCRIPTION
## Summary
- classify NVIDIA NIM `DEGRADED function cannot be invoked` HTTP 400s as transient overloads
- prevent cron/agent turns from failing fast as malformed request when the provider backend is degraded
- add regression coverage for the NVIDIA error shape

## Tests
- `uv run --project C:\Users\chris\Documents\Codex\2026-07-06\he\work\hermes-agent-nvidia-degraded-fix --extra dev pytest tests/agent/test_error_classifier.py -q`