### PR TITLE
test(e2e): stub reset-notice session info to deflake test_new_resets_session

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -228,6 +228,13 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
     # Disable destructive slash confirm gate so /new executes immediately
     runner._read_user_config = lambda: {"approvals": {"destructive_slash_confirm": False}}
 
+    # Keep /new hermetic: the real _reset_notice_session_info resolves provider
+    # credentials and may probe model context length over the network. CI has no
+    # credentials, so resolution walks the whole fallback chain and can exceed
+    # send_and_capture's poll window on slow runners (flaked in run 28856659216,
+    # telegram param only — first parametrization pays the cold-resolution cost).
+    runner._reset_notice_session_info = lambda source: ""
+
     runner.pairing_store = MagicMock()
     runner.pairing_store._is_rate_limited = MagicMock(return_value=False)
     runner.pairing_store.generate_code = MagicMock(return_value="ABC123")


### PR DESCRIPTION
## Summary
`tests/e2e/test_platform_commands.py::test_new_resets_session` is now deterministic — the e2e runner fixture stubs `_reset_notice_session_info` so `/new` never resolves live provider credentials during the test.

Root cause: `/new`'s handler (`gateway/slash_commands.py::_handle_reset_command`) calls `_reset_notice_session_info` → `_format_session_info`, which resolves runtime provider credentials and may probe model context length over HTTP. CI has no credentials, so resolution walks the full fallback chain — the failed run's captured log shows `Primary provider auth failed ... trying fallback` inside the test — and on a slow runner the first parametrization (telegram) can exceed `send_and_capture`'s 2s poll window, so `adapter.send` appears never-called.

## Changes
- `tests/e2e/conftest.py`: `make_runner()` stubs `_reset_notice_session_info` to return an empty info block, with a comment explaining why. These tests exercise gateway command dispatch, not provider resolution.

## Validation
| | Before | After |
|---|---|---|
| `test_new_resets_session[telegram]` | flaky (run 28856659216) | deterministic, no network path |
| `tests/e2e/` | 1 flake | 57/57 passed locally |

Flake surfaced during the PR #48711 merge; fixed in a dedicated PR per policy.

## Infographic
![deflake infographic](https://v3b.fal.media/files/b/0aa1498d/2iFqShSsIlh13F5WVrCyi_QU7xpatA.png)
