### PR TITLE
fix(oneshot): recover via fallback_providers when the primary provider fails auth at resolution time

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -31,49 +31,39 @@ class CLIAgentSetupMixin:
         """
         from cli import ChatConsole, _cprint, logger
         from hermes_cli.runtime_provider import (
-            resolve_runtime_provider,
+            resolve_runtime_provider_with_fallback,
             format_runtime_provider_error,
         )
 
-        _primary_exc = None
-        runtime = None
+        # Resolve the primary provider; on an auth failure at resolution time,
+        # walk the configured fallback chain before giving up. The recovery is
+        # shared with the oneshot and gateway paths — see
+        # ``resolve_runtime_provider_with_fallback``.
+        _fb_chain = self._fallback_model if isinstance(self._fallback_model, list) else []
+
+        def _announce_fallback(fb_provider: str, fb_model: str, primary_exc) -> None:
+            logger.warning(
+                "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
+                primary_exc, fb_provider, fb_model,
+            )
+            _cprint(f"⚠️  Primary auth failed — switching to fallback: {fb_provider} / {fb_model}")
+
         try:
-            runtime = resolve_runtime_provider(
+            runtime, _fb_provider, _fb_model = resolve_runtime_provider_with_fallback(
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                fallback_chain=_fb_chain,
+                on_fallback=_announce_fallback,
             )
         except Exception as exc:
-            _primary_exc = exc
-
-        # Primary provider auth failed — try fallback providers before giving up.
-        if runtime is None and _primary_exc is not None:
-            from hermes_cli.auth import AuthError
-            if isinstance(_primary_exc, AuthError):
-                _fb_chain = self._fallback_model if isinstance(self._fallback_model, list) else []
-                for _fb in _fb_chain:
-                    _fb_provider = (_fb.get("provider") or "").strip().lower()
-                    _fb_model = (_fb.get("model") or "").strip()
-                    if not _fb_provider or not _fb_model:
-                        continue
-                    try:
-                        runtime = resolve_runtime_provider(requested=_fb_provider)
-                        logger.warning(
-                            "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
-                            _primary_exc, _fb_provider, _fb_model,
-                        )
-                        _cprint(f"⚠️  Primary auth failed — switching to fallback: {_fb_provider} / {_fb_model}")
-                        self.requested_provider = _fb_provider
-                        self.model = _fb_model
-                        _primary_exc = None
-                        break
-                    except Exception:
-                        continue
-
-        if runtime is None:
-            message = format_runtime_provider_error(_primary_exc) if _primary_exc else "Provider resolution failed."
+            message = format_runtime_provider_error(exc)
             ChatConsole().print(f"[bold red]{message}[/]")
             return False
+
+        if _fb_provider:
+            self.requested_provider = _fb_provider
+            self.model = _fb_model
 
         api_key = runtime.get("api_key")
         base_url = runtime.get("base_url")

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -30,6 +30,8 @@ from typing import Optional
 
 from hermes_cli.fallback_config import get_fallback_chain
 
+logger = logging.getLogger(__name__)
+
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
     if not toolsets:
@@ -307,7 +309,7 @@ def _run_agent(
     # other commands (keeps top-level CLI startup cheap).
     from hermes_cli.config import load_config
     from hermes_cli.models import detect_provider_for_model
-    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from hermes_cli.runtime_provider import resolve_runtime_provider_with_fallback
     from hermes_cli.tools_config import _get_platform_tools
     from run_agent import AIAgent
 
@@ -366,11 +368,26 @@ def _run_agent(
                 if detected:
                     effective_provider, effective_model = detected
 
-    runtime = resolve_runtime_provider(
+    # Read the effective fallback chain from profile config so oneshot workers
+    # honour the same merge semantics as interactive CLI and gateway sessions.
+    # The chain serves double duty: a setup-time recovery when the primary
+    # provider cannot authenticate at resolution time (an AuthError raised
+    # before any inference call, which runtime failover can never catch), and
+    # the agent's own runtime failover chain below.
+    _fb = get_fallback_chain(cfg)
+
+    runtime, _fb_provider, _fb_model = resolve_runtime_provider_with_fallback(
         requested=effective_provider,
         target_model=effective_model or None,
         explicit_base_url=explicit_base_url_from_alias,
+        fallback_chain=_fb,
+        on_fallback=lambda p, m, exc: logger.warning(
+            "oneshot: primary provider auth failed (%s); switching to fallback %s/%s",
+            exc, p, m,
+        ),
     )
+    if _fb_provider:
+        effective_provider, effective_model = _fb_provider, _fb_model
 
     # Pull in explicit toolsets when provided; otherwise use whatever the user
     # has enabled for "cli". sorted() gives stable ordering for config-derived
@@ -380,9 +397,6 @@ def _run_agent(
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
     session_db = _create_session_db_for_oneshot()
-    # Read the effective fallback chain from profile config so oneshot workers
-    # honour the same merge semantics as interactive CLI and gateway sessions.
-    _fb = get_fallback_chain(cfg)
 
     agent = AIAgent(
         api_key=runtime.get("api_key"),

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 from urllib.parse import urlparse
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -2050,6 +2050,67 @@ def resolve_runtime_provider(
     )
     runtime["requested_provider"] = requested_provider
     return runtime
+
+
+def resolve_runtime_provider_with_fallback(
+    *,
+    requested: Optional[str] = None,
+    target_model: Optional[str] = None,
+    explicit_api_key: Optional[str] = None,
+    explicit_base_url: Optional[str] = None,
+    fallback_chain: Optional[list] = None,
+    on_fallback: Optional[Callable[[str, str, "AuthError"], None]] = None,
+) -> tuple[Dict[str, Any], Optional[str], Optional[str]]:
+    """Resolve the primary provider; on an ``AuthError`` walk *fallback_chain*.
+
+    A missing primary credential (e.g. an OAuth/managed provider that is not
+    logged in) raises :class:`AuthError` at resolution time — before any
+    inference call, so runtime failover (``try_activate_fallback``) can never
+    help. The gateway (``gateway/run.py``) and the interactive CLI
+    (``cli_agent_setup_mixin.py``) both recover by re-resolving against the
+    configured ``fallback_providers``; this helper centralizes that recovery so
+    oneshot workers (``hermes -z``) get the same behavior instead of dying.
+
+    ``fallback_chain`` is a list of ``{"provider": str, "model": str}`` dicts
+    (as produced by :func:`hermes_cli.fallback_config.get_fallback_chain`).
+    Each entry is tried in order via ``resolve_runtime_provider(requested=...)``;
+    the first that resolves wins. ``on_fallback(provider, model, primary_exc)``
+    is invoked once when a fallback is selected (for UI/logging).
+
+    Returns ``(runtime, provider, model)`` where ``provider``/``model`` name the
+    fallback entry that was selected, or ``(runtime, None, None)`` when the
+    primary resolved without a switch (so callers keep their own provider/model).
+
+    Recovery is auth-only: a non-``AuthError`` primary failure propagates
+    immediately without touching the chain. When the primary raises
+    ``AuthError`` and the chain is empty or every entry fails to resolve, the
+    original primary ``AuthError`` is re-raised.
+    """
+    try:
+        runtime = resolve_runtime_provider(
+            requested=requested,
+            target_model=target_model,
+            explicit_api_key=explicit_api_key,
+            explicit_base_url=explicit_base_url,
+        )
+        return runtime, None, None
+    except AuthError as primary_exc:
+        for entry in fallback_chain or []:
+            fb_provider = str((entry or {}).get("provider") or "").strip().lower()
+            fb_model = str((entry or {}).get("model") or "").strip()
+            if not fb_provider or not fb_model:
+                continue
+            try:
+                runtime = resolve_runtime_provider(requested=fb_provider)
+            except Exception:
+                continue
+            if on_fallback is not None:
+                try:
+                    on_fallback(fb_provider, fb_model, primary_exc)
+                except Exception:
+                    pass
+            return runtime, fb_provider, fb_model
+        raise
 
 
 def format_runtime_provider_error(error: Exception) -> str:

--- a/tests/hermes_cli/test_oneshot_provider_fallback.py
+++ b/tests/hermes_cli/test_oneshot_provider_fallback.py
@@ -1,0 +1,96 @@
+"""Setup-time provider fallback for the shared resolver helper.
+
+``resolve_runtime_provider_with_fallback`` centralizes the "primary provider
+failed to authenticate at resolution time -> walk ``fallback_providers``"
+recovery that the gateway and interactive CLI already perform, so oneshot
+(``hermes -z``) workers stop dying on a missing primary credential when a
+usable fallback is configured.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import runtime_provider as rp
+from hermes_cli.auth import AuthError
+
+
+def test_primary_success_returns_no_switch(monkeypatch):
+    monkeypatch.setattr(
+        rp, "resolve_runtime_provider", lambda **kw: {"provider": "zai", "api_key": "k"}
+    )
+    runtime, provider, model = rp.resolve_runtime_provider_with_fallback(
+        requested="zai",
+        fallback_chain=[{"provider": "opencode-go", "model": "qwen3.6-plus"}],
+    )
+    assert runtime["provider"] == "zai"
+    # No switch happened, so the caller keeps its own provider/model.
+    assert provider is None
+    assert model is None
+
+
+def test_autherror_falls_over_to_working_fallback(monkeypatch):
+    def fake_resolve(**kw):
+        requested = kw.get("requested")
+        if requested == "nous":
+            raise AuthError(
+                "No access token found for Nous Portal login.",
+                provider="nous",
+                relogin_required=True,
+            )
+        return {"provider": requested, "api_key": "k"}
+
+    monkeypatch.setattr(rp, "resolve_runtime_provider", fake_resolve)
+    switched: list[tuple[str, str]] = []
+
+    runtime, provider, model = rp.resolve_runtime_provider_with_fallback(
+        requested="nous",
+        fallback_chain=[
+            {"provider": "", "model": "skip-me"},  # invalid entry is skipped
+            {"provider": "zai", "model": "glm-5.2"},
+        ],
+        on_fallback=lambda p, m, exc: switched.append((p, m)),
+    )
+
+    assert provider == "zai"
+    assert model == "glm-5.2"
+    assert runtime["provider"] == "zai"
+    assert switched == [("zai", "glm-5.2")]
+
+
+def test_autherror_empty_chain_reraises_primary(monkeypatch):
+    def fake_resolve(**kw):
+        raise AuthError("no token", provider="nous", relogin_required=True)
+
+    monkeypatch.setattr(rp, "resolve_runtime_provider", fake_resolve)
+    with pytest.raises(AuthError):
+        rp.resolve_runtime_provider_with_fallback(requested="nous", fallback_chain=[])
+
+
+def test_autherror_all_fallbacks_fail_reraises_primary(monkeypatch):
+    def fake_resolve(**kw):
+        raise AuthError("every provider unusable", provider=kw.get("requested"))
+
+    monkeypatch.setattr(rp, "resolve_runtime_provider", fake_resolve)
+    with pytest.raises(AuthError):
+        rp.resolve_runtime_provider_with_fallback(
+            requested="nous",
+            fallback_chain=[{"provider": "zai", "model": "glm-5.2"}],
+        )
+
+
+def test_non_autherror_propagates_without_trying_fallback(monkeypatch):
+    calls: list[str | None] = []
+
+    def fake_resolve(**kw):
+        calls.append(kw.get("requested"))
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(rp, "resolve_runtime_provider", fake_resolve)
+    with pytest.raises(RuntimeError):
+        rp.resolve_runtime_provider_with_fallback(
+            requested="nous",
+            fallback_chain=[{"provider": "zai", "model": "glm-5.2"}],
+        )
+    # Fallback recovery is auth-only; a non-auth failure must not walk the chain.
+    assert calls == ["nous"]

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -863,13 +863,17 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
         "hermes_cli.runtime_provider",
         mod(
             "hermes_cli.runtime_provider",
-            resolve_runtime_provider=lambda **_kwargs: {
-                "api_key": "k",
-                "base_url": "u",
-                "provider": "p",
-                "api_mode": "chat_completions",
-                "credential_pool": None,
-            },
+            resolve_runtime_provider_with_fallback=lambda **_kwargs: (
+                {
+                    "api_key": "k",
+                    "base_url": "u",
+                    "provider": "p",
+                    "api_mode": "chat_completions",
+                    "credential_pool": None,
+                },
+                None,
+                None,
+            ),
         ),
     )
     monkeypatch.setitem(


### PR DESCRIPTION
## What does this PR do?

Oneshot mode (`hermes -z <prompt>`) died with the primary provider's `AuthError` and never consulted `fallback_providers` when the primary provider could not authenticate **at credential-resolution time** (e.g. an OAuth/managed provider that is not logged in). This makes oneshot fragile for unattended/subprocess use (cron, CI, external orchestrators) — exactly where it is most used and where there is no human to re-authenticate.

The gateway (`gateway/run.py`) and the interactive CLI (`hermes_cli/cli_agent_setup_mixin.py`) already recover from this by re-resolving against the configured `fallback_providers`. Oneshot only wired the chain for **runtime** failover (`try_activate_fallback`, driven by a `FailoverReason` on retryable API errors during a conversation), which can never fire here because the failure happens before the agent is even constructed.

This PR centralizes the setup-time "primary auth failed → walk the fallback chain" recovery into one shared helper and routes oneshot through it, so all three entry points behave consistently.

## Related Issue

Fixes #60167

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ♻️ Refactor (no behavior change)

## Changes Made

- `hermes_cli/runtime_provider.py`: new `resolve_runtime_provider_with_fallback()` — resolves the primary provider and, on an `AuthError`, walks a `fallback_providers` chain (first entry that resolves wins). Recovery is auth-only: a non-`AuthError` primary failure propagates immediately; an empty/exhausted chain re-raises the original `AuthError`. Returns `(runtime, provider, model)` where `provider`/`model` name the selected fallback (or `None` when the primary resolved).
- `hermes_cli/oneshot.py`: `_run_agent()` now resolves through the shared helper, so a primary auth failure at setup falls over to `fallback_providers` instead of aborting. The fallback chain is read once and still passed to `AIAgent(fallback_model=...)` for runtime failover.
- `hermes_cli/cli_agent_setup_mixin.py`: `_ensure_runtime_credentials()` now delegates its inline AuthError→fallback loop to the shared helper (behavior-neutral dedup).
- `tests/hermes_cli/test_oneshot_provider_fallback.py`: unit tests for the helper (primary success = no switch, AuthError → working fallback with invalid entries skipped, empty chain re-raises, all-fallbacks-fail re-raises the primary, non-AuthError propagates without touching the chain).

## How to Test

1. Configure a profile whose `model.provider` raises `AuthError` at resolution (an OAuth/managed provider with no stored token), and add a working provider to `fallback_providers`.
2. Before this change: `hermes -p <profile> -z "Reply with one word: PONG"` → `hermes -z: agent failed: <primary AuthError>`, exit 1.
3. After this change: the same command resolves the fallback provider and returns normally.
4. `pytest tests/hermes_cli/test_oneshot_provider_fallback.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the affected suites (runtime-provider, oneshot, cli provider resolution, gateway/auth-profile fallback, run_agent provider fallback) + the new tests — all green; full suite left to CI -->
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new helper) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python, no platform-specific calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
