### PR TITLE
fix: report live Hindsight memory health

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -452,7 +452,29 @@ def cmd_status(args) -> None:
         if provider:
             print("\n  Plugin:    installed ✓")
             if provider.is_available():
-                print("  Status:    available ✓")
+                health = None
+                if hasattr(provider, "get_health_status"):
+                    try:
+                        health = provider.get_health_status()
+                    except Exception as e:
+                        health = {
+                            "ok": False,
+                            "label": "health check failed",
+                            "detail": str(e),
+                        }
+                if isinstance(health, dict):
+                    ok = bool(health.get("ok"))
+                    label = str(health.get("label") or ("healthy" if ok else "unhealthy"))
+                    mark = "✓" if ok else "✗"
+                    print(f"  Status:    {label} {mark}")
+                    detail = str(health.get("detail") or "").strip()
+                    if detail:
+                        print(f"    Detail:  {detail}")
+                    fix = str(health.get("fix") or "").strip()
+                    if fix:
+                        print(f"    Fix:     {fix}")
+                else:
+                    print("  Status:    available ✓")
             else:
                 print("  Status:    not available ✗")
                 schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -202,6 +202,76 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
     return str(version) if version else None
 
 
+def _hindsight_http_health(
+    api_url: str,
+    *,
+    timeout: float = 2.0,
+    api_key: str | None = None,
+) -> dict[str, Any]:
+    """Probe ``<api_url>/health`` without starting or mutating Hindsight.
+
+    ``is_available()`` intentionally answers only whether the plugin runtime is
+    installed/configured. ``hermes memory status`` also needs a live-readiness
+    check so a wedged local daemon cannot be reported as healthy just because
+    imports work.
+    """
+    import socket
+    import urllib.error
+    import urllib.request
+
+    if not api_url:
+        return {
+            "ok": False,
+            "label": "health endpoint missing",
+            "detail": "No Hindsight API URL is configured.",
+        }
+
+    url = api_url.rstrip("/") + "/health"
+    req = urllib.request.Request(url)
+    if api_key:
+        req.add_header("Authorization", f"Bearer {api_key}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            payload = resp.read(512).decode("utf-8", errors="replace").strip()
+            status = getattr(resp, "status", getattr(resp, "code", 200))
+    except (TimeoutError, socket.timeout) as exc:
+        return {
+            "ok": False,
+            "label": "daemon unresponsive",
+            "detail": f"GET {url} timed out after {timeout:g}s: {exc}",
+        }
+    except urllib.error.HTTPError as exc:
+        return {
+            "ok": False,
+            "label": "health check failed",
+            "detail": f"GET {url} returned HTTP {exc.code}",
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "label": "daemon unreachable",
+            "detail": f"GET {url} failed: {exc}",
+        }
+
+    if 200 <= int(status) < 300:
+        detail = f"GET {url} returned HTTP {status}"
+        if payload:
+            detail += f" ({payload[:160]})"
+        return {"ok": True, "label": "healthy", "detail": detail}
+    return {
+        "ok": False,
+        "label": "health check failed",
+        "detail": f"GET {url} returned HTTP {status}",
+    }
+
+
+def _embedded_daemon_manager():
+    """Return Hindsight's embedded daemon manager class instance."""
+    import hindsight_embed.daemon_embed_manager as dem
+
+    return dem.DaemonEmbedManager()
+
+
 def _check_api_supports_update_mode_append(api_url: str,
                                            api_key: str | None = None) -> bool:
     """Cached capability check for ``update_mode='append'`` on *api_url*.
@@ -735,6 +805,76 @@ class HindsightMemoryProvider(MemoryProvider):
             return has_key or has_url
         except Exception:
             return False
+
+    def get_health_status(self) -> dict[str, Any]:
+        """Return live readiness for ``hermes memory status``.
+
+        ``is_available`` is deliberately a cheap dependency/configuration check.
+        Local embedded Hindsight can still be wedged at runtime (for example, a
+        stale daemon process accepts TCP but never answers ``/health``). This
+        method performs a bounded live probe so status output reflects the
+        condition that the memory tools will actually hit.
+        """
+        cfg = _load_config()
+        mode = cfg.get("mode", "cloud")
+        if mode == "local":
+            mode = "local_embedded"
+
+        api_key = cfg.get("apiKey") or cfg.get("api_key") or os.environ.get("HINDSIGHT_API_KEY", "")
+        timeout = min(
+            max(
+                float(_parse_int_setting(cfg.get("health_timeout", 2), 2)),
+                0.1,
+            ),
+            10.0,
+        )
+
+        if mode == "local_embedded":
+            available, reason = _check_local_runtime()
+            if not available:
+                return {
+                    "ok": False,
+                    "label": "runtime unavailable",
+                    "detail": reason or "Hindsight local runtime could not be imported.",
+                    "fix": "Run 'hermes memory setup hindsight' and repair the local Hindsight installation.",
+                }
+
+            profile = _embedded_profile_name(cfg)
+            try:
+                manager = _embedded_daemon_manager()
+                api_url = manager.get_url(profile)
+            except Exception as exc:
+                return {
+                    "ok": False,
+                    "label": "daemon profile unavailable",
+                    "detail": str(exc),
+                    "fix": f"Run 'hindsight-embed -p {profile} daemon status' for details.",
+                }
+
+            status = _hindsight_http_health(api_url, timeout=timeout)
+            if not status.get("ok"):
+                status.setdefault(
+                    "fix",
+                    f"Run 'hindsight-embed -p {profile} daemon stop' then "
+                    f"'hindsight-embed -p {profile} daemon start', and inspect "
+                    f"~/.hindsight/profiles/{profile}.log.",
+                )
+            return status
+
+        if mode == "local_external":
+            api_url = cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", _DEFAULT_LOCAL_URL)
+            status = _hindsight_http_health(api_url, timeout=timeout, api_key=api_key or None)
+            if not status.get("ok"):
+                status.setdefault(
+                    "fix",
+                    "Start the external Hindsight API or update HINDSIGHT_API_URL / hermes memory setup.",
+                )
+            return status
+
+        # Cloud mode may not be reachable offline, and an API-key/config check is
+        # still the useful status signal there. Avoid adding a network dependency
+        # to `hermes memory status` for hosted providers.
+        return {"ok": True, "label": "available"}
 
     def save_config(self, values, hermes_home):
         """Write config to $HERMES_HOME/hindsight/config.json."""

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -165,6 +165,62 @@ def test_cmd_status_prefers_provider_status_config(monkeypatch, capsys):
     assert "http://stale.local" not in output
 
 
+def test_cmd_status_reports_provider_health_failure(monkeypatch, capsys):
+    class HealthProvider:
+        def is_available(self):
+            return True
+
+        def get_health_status(self):
+            return {
+                "ok": False,
+                "label": "daemon unresponsive",
+                "detail": "GET /health timed out after 2s",
+                "fix": "Run hermes memory setup or restart the Hindsight daemon.",
+            }
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"provider": "hindsight"}},
+    )
+    monkeypatch.setattr(
+        memory_setup,
+        "_get_available_providers",
+        lambda: [("hindsight", "API key / local", HealthProvider())],
+    )
+
+    memory_setup.cmd_status(SimpleNamespace())
+
+    output = capsys.readouterr().out
+    assert "Status:    daemon unresponsive ✗" in output
+    assert "GET /health timed out after 2s" in output
+    assert "Run hermes memory setup or restart the Hindsight daemon." in output
+
+
+def test_cmd_status_provider_health_exception_is_unhealthy(monkeypatch, capsys):
+    class BrokenHealthProvider:
+        def is_available(self):
+            return True
+
+        def get_health_status(self):
+            raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"provider": "hindsight"}},
+    )
+    monkeypatch.setattr(
+        memory_setup,
+        "_get_available_providers",
+        lambda: [("hindsight", "API key / local", BrokenHealthProvider())],
+    )
+
+    memory_setup.cmd_status(SimpleNamespace())
+
+    output = capsys.readouterr().out
+    assert "Status:    health check failed ✗" in output
+    assert "probe exploded" in output
+
+
 def test_cmd_setup_generic_choice_cancel_writes_nothing(tmp_path, monkeypatch):
     class ChoiceProvider:
         def __init__(self):

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -23,6 +23,7 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _hindsight_http_health,
     _normalize_observation_scopes,
     _normalize_retain_tags,
     _resolve_bank_id_template,
@@ -209,6 +210,59 @@ def test_normalize_retain_tags_accepts_csv_and_dedupes():
         "agent:fakeassistantname",
         "source_system:hermes-agent",
     ]
+
+
+def test_hindsight_http_health_reports_timeout(monkeypatch):
+    class TimeoutUrlopen:
+        def __call__(self, req, timeout=0):
+            raise TimeoutError("timed out")
+
+    monkeypatch.setattr("urllib.request.urlopen", TimeoutUrlopen())
+
+    result = _hindsight_http_health("http://127.0.0.1:9177", timeout=0.1)
+
+    assert result["ok"] is False
+    assert result["label"] == "daemon unresponsive"
+    assert "timed out" in result["detail"].lower()
+
+
+def test_hindsight_health_status_marks_unresponsive_embedded_daemon_unhealthy(tmp_path, monkeypatch):
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"mode": "local_embedded", "profile": "hermes"}))
+
+    monkeypatch.setattr(
+        "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+    )
+    monkeypatch.setattr(
+        "plugins.memory.hindsight._check_local_runtime", lambda: (True, None)
+    )
+
+    class FakeManager:
+        def get_url(self, profile):
+            assert profile == "hermes"
+            return "http://127.0.0.1:9177"
+
+    monkeypatch.setattr(
+        "plugins.memory.hindsight._embedded_daemon_manager",
+        lambda: FakeManager(),
+    )
+    monkeypatch.setattr(
+        "plugins.memory.hindsight._hindsight_http_health",
+        lambda url, timeout=2.0, api_key=None: {
+            "ok": False,
+            "label": "daemon unresponsive",
+            "detail": f"GET {url}/health timed out",
+        },
+    )
+
+    status = HindsightMemoryProvider().get_health_status()
+
+    assert status["ok"] is False
+    assert status["label"] == "daemon unresponsive"
+    assert "9177" in status["detail"]
+    assert "hindsight-embed -p hermes daemon stop" in status["fix"]
+    assert "hindsight-embed -p hermes daemon start" in status["fix"]
 
 
 def test_normalize_retain_tags_accepts_json_array_string():


### PR DESCRIPTION
## Summary
- add optional provider health reporting to `hermes memory status`
- teach Hindsight local/external modes to probe `/health` with a bounded timeout
- surface actionable detail/fix text when the embedded daemon is unresponsive instead of saying only `available`

## Validation
- `/Users/aso/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_memory_setup.py tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='`\n- `/Users/aso/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_memory_provider.py tests/run_agent/test_memory_provider_init.py tests/hermes_cli/test_memory_setup.py tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='`\n- `/Users/aso/.hermes/hermes-agent/venv/bin/python -m compileall hermes_cli/memory_setup.py plugins/memory/hindsight/__init__.py`\n- `PYTHONPATH=/tmp/hermes-hindsight-status-pr /Users/aso/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main memory status`