### PR TITLE
fix(cli): update Python version constraint from <3.14 to <3.15 (#59877)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 # wheel yet and fall back to a maturin source build that fails. Capping at
 # <3.14 makes uv refuse 3.14 with a clear error instead of attempting that
 # build. Raise the ceiling once our Rust transitives ship cp314 wheels.
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 authors = [{ name = "Nous Research" }]
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary

Python 3.14.6 is now available (Termux, etc.) but `requires-python = ">=3.11,<3.14"` blocked installation. Raised ceiling to `<3.15` to allow 3.14.x while maintaining a reasonable upper bound.

## Files Changed

| File | Δ |
|------|---|
| `pyproject.toml` | +1/-1 line |

Closes #59877