### PR TITLE
fix(secrets): fold OP_CONNECT_HOST/OP_CONNECT_TOKEN into 1Password auth cache-key

### DIFF
--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -172,16 +172,19 @@ def _validate_references(
 def _auth_fingerprint(token_env: str) -> str:
     """SHA-256 prefix over the auth material `op` would use.
 
-    Folds in the service-account token, ``OP_ACCOUNT``, and *all*
-    ``OP_SESSION_*`` vars (the names `op` actually exports for interactive
-    sessions — ``OP_SESSION_<account_shorthand>``).  Signing out and into a
-    different identity therefore changes the cache key, so a value cached under
-    a previous identity is never served under a new one.  Never logged or
+    Folds in the service-account token, ``OP_ACCOUNT``, the 1Password Connect
+    ``OP_CONNECT_HOST``/``OP_CONNECT_TOKEN``, and *all* ``OP_SESSION_*`` vars
+    (the names `op` actually exports for interactive sessions —
+    ``OP_SESSION_<account_shorthand>``).  Signing out and into a different
+    identity therefore changes the cache key, so a value cached under a
+    previous identity is never served under a new one.  Never logged or
     displayed; the raw token never leaves this hash.
     """
     parts: List[str] = [
         f"token={os.environ.get(token_env, '')}",
         f"account={os.environ.get('OP_ACCOUNT', '')}",
+        f"connect_host={os.environ.get('OP_CONNECT_HOST', '')}",
+        f"connect_token={os.environ.get('OP_CONNECT_TOKEN', '')}",
     ]
     for key in sorted(os.environ):
         if key.startswith("OP_SESSION_"):

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -41,6 +41,8 @@ def _clean_op_env(monkeypatch):
             monkeypatch.delenv(key, raising=False)
     monkeypatch.delenv("OP_SERVICE_ACCOUNT_TOKEN", raising=False)
     monkeypatch.delenv("OP_ACCOUNT", raising=False)
+    monkeypatch.delenv("OP_CONNECT_HOST", raising=False)
+    monkeypatch.delenv("OP_CONNECT_TOKEN", raising=False)
     yield
 
 
@@ -321,6 +323,35 @@ def test_session_change_invalidates_cache(monkeypatch, tmp_path):
     # Switch identity.
     monkeypatch.delenv("OP_SESSION_acctA", raising=False)
     monkeypatch.setenv("OP_SESSION_acctB", "sessB")
+    op._CACHE.clear()
+    op.fetch_onepassword_secrets(
+        references={"K": "op://V/I/F"}, cache_ttl_seconds=300,
+        binary=fake_op, home_path=tmp_path,
+    )
+    assert calls["n"] == 2  # cache key changed → refetch
+
+
+def test_connect_credential_change_invalidates_cache(monkeypatch, tmp_path):
+    """A different 1Password Connect identity must not reuse a cached value."""
+    fake_op = tmp_path / "op"
+    fake_op.write_text("")
+    calls = {"n": 0}
+
+    def fake_run(*a, **k):
+        calls["n"] += 1
+        return _ok("v")
+
+    monkeypatch.setattr(op.subprocess, "run", fake_run)
+    op._reset_cache_for_tests(tmp_path)
+
+    monkeypatch.setenv("OP_CONNECT_HOST", "https://connect.example.com")
+    monkeypatch.setenv("OP_CONNECT_TOKEN", "tokenA")
+    op.fetch_onepassword_secrets(
+        references={"K": "op://V/I/F"}, cache_ttl_seconds=300,
+        binary=fake_op, home_path=tmp_path,
+    )
+    # Rotate the Connect token → new identity.
+    monkeypatch.setenv("OP_CONNECT_TOKEN", "tokenB")
     op._CACHE.clear()
     op.fetch_onepassword_secrets(
         references={"K": "op://V/I/F"}, cache_ttl_seconds=300,


### PR DESCRIPTION
## What does this PR do?

`_auth_fingerprint()` in `agent/secret_sources/onepassword.py` builds the
1Password secret cache-key from the service-account token, `OP_ACCOUNT`, and all
`OP_SESSION_*` vars — but omits `OP_CONNECT_HOST`/`OP_CONNECT_TOKEN`, which are in
`_OP_ENV_ALLOWLIST` and are forwarded to the `op` child by `_op_child_env()`.
The Connect server is therefore a real auth identity that the fingerprint fails
to account for.

On a self-hosted 1Password **Connect** deployment (the standard headless/CI
setup), rotating `OP_CONNECT_TOKEN` or re-pointing `OP_CONNECT_HOST` at a
different Connect server leaves the fingerprint unchanged, so both the in-process
`_CACHE` and the disk `_DISK_CACHE` keep serving secrets resolved under the OLD
Connect credentials for the full TTL (default 300s, disk-persisted across
invocations). The docstring already promises "a value cached under a previous
identity is never served under a new one" — this closes the gap for the Connect
path, matching the `OP_SESSION_*` / service-account paths that are already
protected.

## Related Issue

<!-- Code-originated; no filed issue. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `agent/secret_sources/onepassword.py`: fold `OP_CONNECT_HOST`/`OP_CONNECT_TOKEN`
  into `_auth_fingerprint()`'s cache-key material (and update the docstring).
- `tests/test_onepassword_secrets.py`: add
  `test_connect_credential_change_invalidates_cache`; scrub `OP_CONNECT_*` in the
  `_clean_op_env` autouse fixture for hermeticity.

## How to Test

1. Cache a secret under `OP_CONNECT_HOST`/`OP_CONNECT_TOKEN=tokenA`.
2. Rotate `OP_CONNECT_TOKEN=tokenB` (new Connect identity) and clear the
   in-process cache.
3. Fetch again — before this change the disk cache serves the stale value
   (`op` is not re-invoked); after it, the fingerprint changes and the value is
   refetched. Covered by `test_connect_credential_change_invalidates_cache`
   (fails before, passes after). Full file: `pytest tests/test_onepassword_secrets.py -q` → 24 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_onepassword_secrets.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the `_auth_fingerprint` docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure env-var/hash logic, platform-independent