### PR TITLE
fix(agent): guard _is_copilot_url() with getattr to prevent AttributeError (#59845)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1161,7 +1161,7 @@ def run_conversation(
                 # Copilot x-initiator: the first API call of a user turn is
                 # marked "user" so Copilot bills a premium request; tool-loop
                 # follow-ups keep the default "agent" header (#3040).
-                if getattr(agent, "_is_user_initiated_turn", False) and agent._is_copilot_url():
+                if getattr(agent, "_is_user_initiated_turn", False) and getattr(agent, "_is_copilot_url", lambda: False)():
                     _xh = dict(api_kwargs.get("extra_headers") or {})
                     _xh["x-initiator"] = "user"
                     api_kwargs["extra_headers"] = _xh

--- a/tests/test_copilot_initiator.py
+++ b/tests/test_copilot_initiator.py
@@ -52,7 +52,7 @@ def _make_agent(monkeypatch, base_url, api_mode="chat_completions"):
 
 def _inject(agent, api_kwargs):
     """Mirror the injection block in agent/conversation_loop.py."""
-    if getattr(agent, "_is_user_initiated_turn", False) and agent._is_copilot_url():
+    if getattr(agent, "_is_user_initiated_turn", False) and getattr(agent, "_is_copilot_url", lambda: False)():
         _xh = dict(api_kwargs.get("extra_headers") or {})
         _xh["x-initiator"] = "user"
         api_kwargs["extra_headers"] = _xh


### PR DESCRIPTION
## Summary

`agent/conversation_loop.py:1164` calls `agent._is_copilot_url()` without a `getattr` guard. The sibling property `_is_user_initiated_turn` is already guarded (line above), but the method call is not — causing `AttributeError` when the method is absent (certain construction paths / module-reload windows during cron jobs).

## Fix

Changed `agent._is_copilot_url()` → `getattr(agent, "_is_copilot_url", lambda: False)()` in both production (`conversation_loop.py`) and test (`test_copilot_initiator.py`).

## Files Changed

| File | Δ |
|------|---|
| `agent/conversation_loop.py` | +1/-1 line |
| `tests/test_copilot_initiator.py` | +1/-1 line |

Closes #59845