### PR TITLE
fix(discord): cap forum thread names by UTF-16 units, not code points

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7447,13 +7447,14 @@ def _probe_is_forum_cached(chat_id: str) -> Optional[bool]:
 
 
 def _derive_forum_thread_name(message: str) -> str:
-    """Derive a thread name from the first line of the message, capped at 100 chars."""
+    """Derive a thread name from the first line of the message, capped at 100
+    UTF-16 code units (Discord's thread-name limit)."""
     first_line = message.strip().split("\n", 1)[0].strip()
     # Strip common markdown heading prefixes
     first_line = first_line.lstrip("#").strip()
     if not first_line:
         first_line = "New Post"
-    return first_line[:100]
+    return _prefix_within_utf16_limit(first_line, 100)
 
 
 def _standalone_sanitize_error(text) -> str:

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -28,6 +28,7 @@ if _repo not in sys.path:
 from plugins.platforms.discord.adapter import (  # noqa: E402
     ClarifyChoiceView,
     DiscordAdapter,
+    _derive_forum_thread_name,
 )
 from gateway.config import PlatformConfig  # noqa: E402
 from gateway.platforms.base import utf16_len  # noqa: E402
@@ -76,6 +77,19 @@ def _make_interaction(*, user_id="42", display_name="Tester", roles=None,
     else:
         message = None
     return SimpleNamespace(user=user, response=response, message=message)
+
+
+# ===========================================================================
+# Forum thread-name derivation
+# ===========================================================================
+
+def test_forum_thread_name_capped_by_utf16_units():
+    # 100 emoji = 200 UTF-16 units; must be clamped to <= 100.
+    name = _derive_forum_thread_name("\U0001F600" * 100)
+    assert utf16_len(name) <= 100
+    # BMP text: 200 ASCII chars clamp to exactly 100 units.
+    ascii_name = _derive_forum_thread_name("x" * 200)
+    assert utf16_len(ascii_name) == 100
 
 
 # ===========================================================================


### PR DESCRIPTION
## This is a sibling follow-up to #60113

- **What #60113 covered:** bounded Discord component/button labels by UTF-16 code units (the field Discord actually validates), adding `test_truncates_emoji_choice_label_by_utf16_limit`.
- **What #60113 did NOT touch:** the forum thread-name derivation path, `_derive_forum_thread_name`, which still capped by Python code points.
- **What this adds:** migrates that one remaining `[:100]` code-point slice to the same `_prefix_within_utf16_limit` helper the adapter already imports, plus a regression test.

## What does this PR do?

`_derive_forum_thread_name` in `plugins/platforms/discord/adapter.py` caps the
derived Discord forum thread name with `first_line[:100]` — a code-point slice —
but Discord validates the thread `name` field in UTF-16 code units (100 max).

A message whose first line opens with emoji / non-BMP text (agents commonly lead
with an emoji header) can exceed 100 UTF-16 units while passing the code-point
cap, so `create_thread(name=...)` fails with error 50035 ("Must be 100 or fewer
in length") and the entire forum reply is dropped (`SendResult(success=False)`),
not merely clipped. This is the sibling the UTF-16 hardening in #60113 (component
labels) missed; the adapter already imports `_prefix_within_utf16_limit`/`utf16_len`
for exactly this purpose.

## Related Issue

<!-- Sibling of #60113; no separate filed issue. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/adapter.py`: `_derive_forum_thread_name` now returns
  `_prefix_within_utf16_limit(first_line, 100)` instead of `first_line[:100]`
  (and the docstring reflects the UTF-16 unit limit).
- `tests/gateway/test_discord_clarify_buttons.py`: add
  `test_forum_thread_name_capped_by_utf16_units`.

## How to Test

1. `_derive_forum_thread_name("\U0001F600" * 100)` — 100 emoji is 200 UTF-16
   units under the old code-point cap; after this change the result is clamped
   to <= 100 units without splitting a surrogate pair.
2. ASCII behavior is unchanged: 200 `x` still clamps to exactly 100 units.
3. `pytest tests/gateway/test_discord_clarify_buttons.py tests/gateway/test_discord_send.py -q` → 40 passed. The new test fails before the fix (200 > 100), passes after.

Follow-up (out of scope here): the `Choice.name` and describe-hint `[:100]` caps
in the same adapter are the remaining code-point siblings and can be migrated
separately.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_discord_clarify_buttons.py tests/gateway/test_discord_send.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the `_derive_forum_thread_name` docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure string logic, platform-independent