### PR TITLE
refactor(gateway): extract adapter-lifecycle helpers into a dedicated mixin

### DIFF
--- a/gateway/adapter_lifecycle_mixin.py
+++ b/gateway/adapter_lifecycle_mixin.py
@@ -1,0 +1,199 @@
+"""Adapter lifecycle helpers for ``GatewayRunner``.
+
+Extracted from ``gateway/run.py`` as part of the god-file decomposition
+campaign (Phase 4 mechanical mixin lift). This mixin holds the per-adapter
+connect/disconnect/teardown helpers:
+
+  - ``_safe_adapter_disconnect`` — defensive ``adapter.disconnect()``
+    used on failed-connect paths so partial-init resources (aiohttp
+    ClientSession, poll tasks, child subprocesses) don't leak as
+    "Unclosed client session" warnings at process exit (seen on the
+    2026-04-18 gateway restart).
+  - ``_bounded_adapter_teardown`` — shutdown-path teardown that wraps
+    both ``cancel_background_tasks()`` and ``disconnect()`` in the
+    per-adapter timeout budget so a wedged adapter (half-dead Feishu/Lark
+    WebSocket thread) doesn't stall shutdown past systemd's
+    ``TimeoutStopSec`` and trip a SIGKILL that skips ``atexit`` PID-file
+    cleanup (#14128).
+  - ``_adapter_disconnect_timeout_secs`` — env-tunable budget for the
+    two methods above.
+  - ``_platform_connect_timeout_secs`` — env-tunable budget for the
+    connect path below.
+  - ``_connect_adapter_with_timeout`` — wraps ``adapter.connect()`` so
+    one platform's slow boot can't block the others; forwards
+    ``is_reconnect`` so platforms can preserve server-side queues on a
+    watcher reconnect after an outage (#46621).
+
+Behavior-neutral: every method is lifted verbatim from ``GatewayRunner``.
+The five methods read only ``os.getenv`` and the two module-level default
+constants (``_ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT``,
+``_PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT``); they touch no ``self.*``
+state and so do not require ``GatewayRunner.__init__`` to have been
+called — bare ``object.__new__(GatewayRunner)`` shells in the regression
+suite continue to work. The constants continue to live in
+``gateway.run`` (their canonical home since they are tunable from
+``config.yaml`` documentation paths); this module imports them lazily at
+call time so there is no import cycle:
+
+    adapter_lifecycle_mixin.py  --(lazy import at call time)--> gateway.run
+
+The lazy import preserves the exact logger name (``"gateway.run"``) so log
+records emitted from these helpers keep their original logger name.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Optional
+
+logger = logging.getLogger("gateway.run")
+
+
+class GatewayAdapterLifecycleMixin:
+    """Adapter connect/disconnect/teardown helpers lifted from
+    ``GatewayRunner`` (god-file decomposition Phase 4)."""
+
+    async def _safe_adapter_disconnect(self, adapter, platform) -> None:
+        """Call adapter.disconnect() defensively, swallowing any error.
+
+        Used when adapter.connect() failed or raised — the adapter may
+        have allocated partial resources (aiohttp.ClientSession, poll
+        tasks, child subprocesses) that would otherwise leak and surface
+        as "Unclosed client session" warnings at process exit.
+
+        Must tolerate partial-init state and never raise, since callers
+        use it inside error-handling blocks.
+        """
+        timeout = self._adapter_disconnect_timeout_secs()
+        try:
+            if timeout <= 0:
+                await adapter.disconnect()
+            else:
+                await asyncio.wait_for(adapter.disconnect(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Timed out after %.1fs while disconnecting %s adapter; continuing shutdown",
+                timeout,
+                platform.value if platform is not None else "adapter",
+            )
+        except Exception as e:
+            logger.debug(
+                "Defensive %s disconnect after failed connect raised: %s",
+                platform.value if platform is not None else "adapter",
+                e,
+            )
+
+    async def _bounded_adapter_teardown(
+        self, adapter, platform, *, profile: Optional[str] = None
+    ) -> None:
+        """Tear down one adapter on the shutdown path with bounded awaits.
+
+        Both ``cancel_background_tasks()`` and ``disconnect()`` can block
+        indefinitely when a platform's network state is half-dead (e.g. a
+        wedged Feishu/Lark WebSocket thread waiting on I/O). An unbounded
+        await here stalls the entire shutdown sequence past systemd's
+        ``TimeoutStopSec``; the resulting SIGKILL skips ``atexit`` PID-file
+        cleanup, so the next start dies with "PID file race lost" (#14128).
+
+        Each await is wrapped in the existing per-adapter timeout budget
+        (``HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT``). On timeout we log
+        and force forward progress; the loop never hangs regardless of any
+        adapter's internal behavior. Never raises.
+        """
+        timeout = self._adapter_disconnect_timeout_secs()
+        suffix = f" (profile: {profile})" if profile else ""
+        started_at = time.monotonic()
+        try:
+            if timeout <= 0:
+                await adapter.cancel_background_tasks()
+            else:
+                await asyncio.wait_for(
+                    adapter.cancel_background_tasks(), timeout=timeout
+                )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "✗ %s background-task cancel timed out after %.1fs - forcing continue%s",
+                platform.value, timeout, suffix,
+            )
+        except Exception as e:
+            logger.debug("✗ %s background-task cancel error%s: %s", platform.value, suffix, e)
+        try:
+            if timeout <= 0:
+                await adapter.disconnect()
+            else:
+                await asyncio.wait_for(adapter.disconnect(), timeout=timeout)
+            logger.info(
+                "✓ %s disconnected (%.2fs)%s",
+                platform.value, time.monotonic() - started_at, suffix,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "✗ %s disconnect timed out after %.1fs - forcing continue%s",
+                platform.value, timeout, suffix,
+            )
+        except Exception as e:
+            logger.error(
+                "✗ %s disconnect error after %.2fs%s: %s",
+                platform.value, time.monotonic() - started_at, suffix, e,
+            )
+
+    def _adapter_disconnect_timeout_secs(self) -> float:
+        """Return the per-adapter disconnect timeout used during shutdown."""
+        raw = os.getenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "").strip()
+        if raw:
+            try:
+                timeout = float(raw)
+            except ValueError:
+                logger.warning(
+                    "Ignoring invalid HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT=%r",
+                    raw,
+                )
+            else:
+                return max(0.0, timeout)
+        # Default lives in gateway.run (canonical home for the constant);
+        # lazy import to avoid a module-level cycle.
+        from gateway.run import _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
+        return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
+
+    def _platform_connect_timeout_secs(self) -> float:
+        """Return the per-platform connect timeout used during startup/retry."""
+        raw = os.getenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
+        if raw:
+            try:
+                timeout = float(raw)
+            except ValueError:
+                logger.warning(
+                    "Ignoring invalid HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT=%r",
+                    raw,
+                )
+            else:
+                return max(0.0, timeout)
+        # Default lives in gateway.run; lazy import to avoid a cycle.
+        from gateway.run import _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
+        return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
+
+    async def _connect_adapter_with_timeout(
+        self, adapter, platform, *, is_reconnect: bool = False
+    ) -> bool:
+        """Connect an adapter without allowing one platform to block others.
+
+        ``is_reconnect`` is forwarded to ``adapter.connect()`` so platform
+        adapters can distinguish a cold first boot (drop any stale
+        server-side queue) from a watcher reconnect after a prolonged outage
+        (preserve the queue so messages sent during the outage are delivered
+        rather than silently dropped — #46621).
+        """
+        timeout = self._platform_connect_timeout_secs()
+        if timeout <= 0:
+            return await adapter.connect(is_reconnect=is_reconnect)
+        try:
+            return await asyncio.wait_for(
+                adapter.connect(is_reconnect=is_reconnect), timeout=timeout
+            )
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(
+                f"{platform.value} connect timed out after {timeout:g}s"
+            ) from exc

--- a/gateway/adapter_lifecycle_mixin.py
+++ b/gateway/adapter_lifecycle_mixin.py
@@ -2,7 +2,11 @@
 
 Extracted from ``gateway/run.py`` as part of the god-file decomposition
 campaign (Phase 4 mechanical mixin lift). This mixin holds the per-adapter
-connect/disconnect/teardown helpers:
+connect/disconnect/teardown helpers, plus the two module-level default
+constants (``_ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT``,
+``_PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT``) those helpers fall back to.
+After the constant lift, this module has no runtime dependency back into
+``gateway.run`` — the extraction is one-way:
 
   - ``_safe_adapter_disconnect`` — defensive ``adapter.disconnect()``
     used on failed-connect paths so partial-init resources (aiohttp
@@ -16,9 +20,11 @@ connect/disconnect/teardown helpers:
     ``TimeoutStopSec`` and trip a SIGKILL that skips ``atexit`` PID-file
     cleanup (#14128).
   - ``_adapter_disconnect_timeout_secs`` — env-tunable budget for the
-    two methods above.
+    two methods above; falls back to
+    ``_ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT``.
   - ``_platform_connect_timeout_secs`` — env-tunable budget for the
-    connect path below.
+    connect path below; falls back to
+    ``_PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT``.
   - ``_connect_adapter_with_timeout`` — wraps ``adapter.connect()`` so
     one platform's slow boot can't block the others; forwards
     ``is_reconnect`` so platforms can preserve server-side queues on a
@@ -26,19 +32,17 @@ connect/disconnect/teardown helpers:
 
 Behavior-neutral: every method is lifted verbatim from ``GatewayRunner``.
 The five methods read only ``os.getenv`` and the two module-level default
-constants (``_ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT``,
-``_PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT``); they touch no ``self.*``
-state and so do not require ``GatewayRunner.__init__`` to have been
-called — bare ``object.__new__(GatewayRunner)`` shells in the regression
-suite continue to work. The constants continue to live in
-``gateway.run`` (their canonical home since they are tunable from
-``config.yaml`` documentation paths); this module imports them lazily at
-call time so there is no import cycle:
+constants declared above; they touch no ``self.*`` state and so do not
+require ``GatewayRunner.__init__`` to have been called — bare
+``object.__new__(GatewayRunner)`` shells in the regression suite continue
+to work.
 
-    adapter_lifecycle_mixin.py  --(lazy import at call time)--> gateway.run
-
-The lazy import preserves the exact logger name (``"gateway.run"``) so log
-records emitted from these helpers keep their original logger name.
+The defaults live here (not in ``gateway.run``) because a repository-wide
+search showed they have no other consumer outside these two getters;
+keeping them alongside their getters makes the mixin extraction one-way
+and prevents a runtime dependency back into the god-file being extracted
+from. The lazy logger name (``"gateway.run"``) is preserved so log
+records emitted from these helpers keep their original namespace.
 """
 
 from __future__ import annotations
@@ -50,6 +54,17 @@ import time
 from typing import Optional
 
 logger = logging.getLogger("gateway.run")
+
+# Default per-adapter disconnect timeout (seconds). Used as the floor for the
+# env-var-overridable ``HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT`` getter and
+# as a bounds in shutdown-path teardown so a wedged adapter cannot stall the
+# gateway past systemd's ``TimeoutStopSec``.
+_ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+
+# Default per-platform connect timeout (seconds). Used as the floor for the
+# env-var-overridable ``HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT`` getter so
+# one slow platform boot cannot block the others during startup/retry.
+_PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 
 
 class GatewayAdapterLifecycleMixin:
@@ -153,9 +168,6 @@ class GatewayAdapterLifecycleMixin:
                 )
             else:
                 return max(0.0, timeout)
-        # Default lives in gateway.run (canonical home for the constant);
-        # lazy import to avoid a module-level cycle.
-        from gateway.run import _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
         return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
 
     def _platform_connect_timeout_secs(self) -> float:
@@ -171,8 +183,6 @@ class GatewayAdapterLifecycleMixin:
                 )
             else:
                 return max(0.0, timeout)
-        # Default lives in gateway.run; lazy import to avoid a cycle.
-        from gateway.run import _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
         return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
 
     async def _connect_adapter_with_timeout(

--- a/gateway/adapter_lifecycle_mixin.py
+++ b/gateway/adapter_lifecycle_mixin.py
@@ -1,0 +1,196 @@
+"""Adapter lifecycle helpers for :class:`gateway.run.GatewayRunner`.
+
+This module is a mechanical extraction of the adapter connect, disconnect,
+teardown, and timeout helpers from ``gateway.run``.  The methods intentionally
+retain their original logger namespace, cancellation semantics, timeout
+messages, and public call signatures; ``GatewayRunner`` composes this mixin as
+its leftmost base so existing call sites continue to resolve through the MRO.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any, Awaitable, Optional
+
+from agent.async_utils import consume_detached_task_result
+from gateway.config import Platform
+
+logger = logging.getLogger("gateway.run")
+
+# Default per-adapter disconnect timeout (seconds).  The environment variable
+# ``HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT`` may override this value.
+_ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+
+# Default per-platform connect timeout (seconds).  The environment variable
+# ``HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT`` may override this value.
+_PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
+
+# Telegram cold polling proves one real getUpdates round trip before connect
+# returns, so it retains a larger readiness budget than other platforms.
+_TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
+
+
+class GatewayAdapterLifecycleMixin:
+    """Adapter connect/disconnect/teardown helpers lifted from the runner."""
+
+    async def _await_adapter_cleanup_with_timeout(
+        self, awaitable: Awaitable[Any], timeout: float
+    ) -> bool:
+        """Wait for adapter cleanup without letting cancellation swallowing hang us.
+
+        ``asyncio.wait_for`` cancels an overdue child but then waits for it to
+        exit.  An adapter close path that catches ``CancelledError`` can
+        therefore block recovery forever.  Keep ownership of the old task
+        through its done callback, but release the runner at the deadline.
+        """
+        if timeout <= 0:
+            await awaitable
+            return True
+
+        task = asyncio.ensure_future(awaitable)
+        try:
+            done, _pending = await asyncio.wait({task}, timeout=timeout)
+        except asyncio.CancelledError:
+            task.cancel()
+            task.add_done_callback(consume_detached_task_result)
+            raise
+        if task in done:
+            await task
+            return True
+
+        task.cancel()
+        task.add_done_callback(consume_detached_task_result)
+        return False
+
+    async def _safe_adapter_disconnect(self, adapter, platform) -> None:
+        """Call ``adapter.disconnect()`` defensively, swallowing any error."""
+        timeout = self._adapter_disconnect_timeout_secs()
+        try:
+            completed = await self._await_adapter_cleanup_with_timeout(
+                adapter.disconnect(), timeout
+            )
+            if not completed:
+                logger.warning(
+                    "Timed out after %.1fs while disconnecting %s adapter; continuing shutdown",
+                    timeout,
+                    platform.value if platform is not None else "adapter",
+                )
+        except Exception as e:
+            logger.debug(
+                "Defensive %s disconnect after failed connect raised: %s",
+                platform.value if platform is not None else "adapter",
+                e,
+            )
+
+    async def _bounded_adapter_teardown(
+        self, adapter, platform, *, profile: Optional[str] = None
+    ) -> None:
+        """Tear down one adapter on shutdown with bounded awaits."""
+        timeout = self._adapter_disconnect_timeout_secs()
+        suffix = f" (profile: {profile})" if profile else ""
+        started_at = time.monotonic()
+        try:
+            cancelled = await self._await_adapter_cleanup_with_timeout(
+                adapter.cancel_background_tasks(), timeout
+            )
+            if not cancelled:
+                logger.warning(
+                    "✗ %s background-task cancel timed out after %.1fs - forcing continue%s",
+                    platform.value,
+                    timeout,
+                    suffix,
+                )
+        except Exception as e:
+            logger.debug(
+                "✗ %s background-task cancel error%s: %s",
+                platform.value,
+                suffix,
+                e,
+            )
+        try:
+            disconnected = await self._await_adapter_cleanup_with_timeout(
+                adapter.disconnect(), timeout
+            )
+            if disconnected:
+                logger.info(
+                    "✓ %s disconnected (%.2fs)%s",
+                    platform.value,
+                    time.monotonic() - started_at,
+                    suffix,
+                )
+            else:
+                logger.warning(
+                    "✗ %s disconnect timed out after %.1fs - forcing continue%s",
+                    platform.value,
+                    timeout,
+                    suffix,
+                )
+        except Exception as e:
+            logger.error(
+                "✗ %s disconnect error after %.2fs%s: %s",
+                platform.value,
+                time.monotonic() - started_at,
+                suffix,
+                e,
+            )
+
+    def _adapter_disconnect_timeout_secs(self) -> float:
+        """Return the per-adapter disconnect timeout used during shutdown."""
+        raw = os.getenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "").strip()
+        if raw:
+            try:
+                timeout = float(raw)
+            except ValueError:
+                logger.warning(
+                    "Ignoring invalid HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT=%r",
+                    raw,
+                )
+            else:
+                return max(0.0, timeout)
+        return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
+
+    def _platform_connect_timeout_secs(self, platform=None) -> float:
+        """Return the per-platform connect timeout used during startup/retry."""
+        raw = os.getenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
+        if raw:
+            try:
+                timeout = float(raw)
+            except ValueError:
+                logger.warning(
+                    "Ignoring invalid HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT=%r",
+                    raw,
+                )
+            else:
+                return max(0.0, timeout)
+        if platform == Platform.TELEGRAM:
+            return _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT
+        return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
+
+    async def _connect_adapter_with_timeout(
+        self, adapter, platform, *, is_reconnect: bool = False
+    ) -> bool:
+        """Connect an adapter without allowing one platform to block others."""
+        timeout = self._platform_connect_timeout_secs(platform)
+        if timeout <= 0:
+            return await adapter.connect(is_reconnect=is_reconnect)
+
+        # Use the detach-on-timeout pattern instead of plain
+        # ``asyncio.wait_for``: an adapter connect that catches
+        # ``CancelledError`` must not block the next retry forever.
+        task = asyncio.ensure_future(adapter.connect(is_reconnect=is_reconnect))
+        try:
+            done, _pending = await asyncio.wait({task}, timeout=timeout)
+        except asyncio.CancelledError:
+            task.cancel()
+            task.add_done_callback(consume_detached_task_result)
+            raise
+        if task in done:
+            result = await task
+            return bool(result)
+
+        task.cancel()
+        task.add_done_callback(consume_detached_task_result)
+        raise TimeoutError(f"{platform.value} connect timed out after {timeout:g}s")

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -86,10 +86,10 @@ def _disconnect_drain_grace_s(budget_s: Optional[float] = None) -> float:
 
 def _env_disconnect_budget_s() -> float:
     """The runner's adapter-disconnect budget, read the same way
-    gateway/run.py:_adapter_disconnect_timeout_secs reads it (same env
+    GatewayAdapterLifecycleMixin._adapter_disconnect_timeout_secs reads it (same env
     variable, same default). Callers above the transport use this to
     apportion the budget across go_idle / monitor teardown / drain."""
-    budget = 5.0  # _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT in gateway/run.py
+    budget = 5.0  # _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT in the lifecycle mixin
     raw = os.getenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "").strip()
     if raw:
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -66,8 +66,6 @@ from hermes_cli.fallback_config import get_fallback_chain
 # from _enforce_agent_cache_cap() and _session_expiry_watcher() below.
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
-_PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
-_ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1719,6 +1719,7 @@ from gateway.session import (
     is_shared_multi_user_session,
 )
 from gateway.delivery import DeliveryRouter, looks_like_telegram_private_chat_id
+from gateway.adapter_lifecycle_mixin import GatewayAdapterLifecycleMixin
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
@@ -2735,7 +2736,7 @@ async def _dispose_unused_adapter(adapter: "BasePlatformAdapter | None") -> None
         )
 
 
-class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
+class GatewayRunner(GatewayAdapterLifecycleMixin, GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
     """
     Main gateway controller.
 
@@ -3286,142 +3287,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if mode in {"voice_only", "all"} and key.startswith(prefix)
             )
 
-    async def _safe_adapter_disconnect(self, adapter, platform) -> None:
-        """Call adapter.disconnect() defensively, swallowing any error.
-
-        Used when adapter.connect() failed or raised — the adapter may
-        have allocated partial resources (aiohttp.ClientSession, poll
-        tasks, child subprocesses) that would otherwise leak and surface
-        as "Unclosed client session" warnings at process exit.
-
-        Must tolerate partial-init state and never raise, since callers
-        use it inside error-handling blocks.
-        """
-        timeout = self._adapter_disconnect_timeout_secs()
-        try:
-            if timeout <= 0:
-                await adapter.disconnect()
-            else:
-                await asyncio.wait_for(adapter.disconnect(), timeout=timeout)
-        except asyncio.TimeoutError:
-            logger.warning(
-                "Timed out after %.1fs while disconnecting %s adapter; continuing shutdown",
-                timeout,
-                platform.value if platform is not None else "adapter",
-            )
-        except Exception as e:
-            logger.debug(
-                "Defensive %s disconnect after failed connect raised: %s",
-                platform.value if platform is not None else "adapter",
-                e,
-            )
-
-    async def _bounded_adapter_teardown(
-        self, adapter, platform, *, profile: Optional[str] = None
-    ) -> None:
-        """Tear down one adapter on the shutdown path with bounded awaits.
-
-        Both ``cancel_background_tasks()`` and ``disconnect()`` can block
-        indefinitely when a platform's network state is half-dead (e.g. a
-        wedged Feishu/Lark WebSocket thread waiting on I/O). An unbounded
-        await here stalls the entire shutdown sequence past systemd's
-        ``TimeoutStopSec``; the resulting SIGKILL skips ``atexit`` PID-file
-        cleanup, so the next start dies with "PID file race lost" (#14128).
-
-        Each await is wrapped in the existing per-adapter timeout budget
-        (``HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT``). On timeout we log
-        and force forward progress; the loop never hangs regardless of any
-        adapter's internal behavior. Never raises.
-        """
-        timeout = self._adapter_disconnect_timeout_secs()
-        suffix = f" (profile: {profile})" if profile else ""
-        started_at = time.monotonic()
-        try:
-            if timeout <= 0:
-                await adapter.cancel_background_tasks()
-            else:
-                await asyncio.wait_for(
-                    adapter.cancel_background_tasks(), timeout=timeout
-                )
-        except asyncio.TimeoutError:
-            logger.warning(
-                "✗ %s background-task cancel timed out after %.1fs - forcing continue%s",
-                platform.value, timeout, suffix,
-            )
-        except Exception as e:
-            logger.debug("✗ %s background-task cancel error%s: %s", platform.value, suffix, e)
-        try:
-            if timeout <= 0:
-                await adapter.disconnect()
-            else:
-                await asyncio.wait_for(adapter.disconnect(), timeout=timeout)
-            logger.info(
-                "✓ %s disconnected (%.2fs)%s",
-                platform.value, time.monotonic() - started_at, suffix,
-            )
-        except asyncio.TimeoutError:
-            logger.warning(
-                "✗ %s disconnect timed out after %.1fs - forcing continue%s",
-                platform.value, timeout, suffix,
-            )
-        except Exception as e:
-            logger.error(
-                "✗ %s disconnect error after %.2fs%s: %s",
-                platform.value, time.monotonic() - started_at, suffix, e,
-            )
-
-    def _adapter_disconnect_timeout_secs(self) -> float:
-        """Return the per-adapter disconnect timeout used during shutdown."""
-        raw = os.getenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "").strip()
-        if raw:
-            try:
-                timeout = float(raw)
-            except ValueError:
-                logger.warning(
-                    "Ignoring invalid HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT=%r",
-                    raw,
-                )
-            else:
-                return max(0.0, timeout)
-        return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
-
-    def _platform_connect_timeout_secs(self) -> float:
-        """Return the per-platform connect timeout used during startup/retry."""
-        raw = os.getenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
-        if raw:
-            try:
-                timeout = float(raw)
-            except ValueError:
-                logger.warning(
-                    "Ignoring invalid HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT=%r",
-                    raw,
-                )
-            else:
-                return max(0.0, timeout)
-        return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
-
-    async def _connect_adapter_with_timeout(
-        self, adapter, platform, *, is_reconnect: bool = False
-    ) -> bool:
-        """Connect an adapter without allowing one platform to block others.
-
-        ``is_reconnect`` is forwarded to ``adapter.connect()`` so platform
-        adapters can distinguish a cold first boot (drop any stale
-        server-side queue) from a watcher reconnect after a prolonged outage
-        (preserve the queue so messages sent during the outage are delivered
-        rather than silently dropped — #46621).
-        """
-        timeout = self._platform_connect_timeout_secs()
-        if timeout <= 0:
-            return await adapter.connect(is_reconnect=is_reconnect)
-        try:
-            return await asyncio.wait_for(
-                adapter.connect(is_reconnect=is_reconnect), timeout=timeout
-            )
-        except asyncio.TimeoutError as exc:
-            raise TimeoutError(
-                f"{platform.value} connect timed out after {timeout:g}s"
-            ) from exc
+    # ──────────────────────────────────────────────────────────────────
+    # Adapter lifecycle helpers (connect/disconnect/teardown timeouts) —
+    # lifted to ``GatewayAdapterLifecycleMixin`` (god-file decomposition
+    # Phase 4). The five methods (``_safe_adapter_disconnect``,
+    # ``_bounded_adapter_teardown``, ``_adapter_disconnect_timeout_secs``,
+    # ``_platform_connect_timeout_secs``, ``_connect_adapter_with_timeout``)
+    # are resolved through the MRO; see tests/gateway/
+    # test_adapter_lifecycle_mixin.py for the contract.
+    # ──────────────────────────────────────────────────────────────────
 
     @property
     def should_exit_cleanly(self) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -46,7 +46,7 @@ from pathlib import Path
 from datetime import datetime
 from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
 
-from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
+from agent.async_utils import safe_schedule_threadsafe
 from agent.conversation_compression import (
     COMPACTION_STATUS,
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
@@ -79,12 +79,6 @@ from hermes_cli.fallback_config import get_fallback_chain
 # (see gateway/agent_cache_pressure.py).
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
-_PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
-# Telegram cold polling now proves one real getUpdates round trip before connect
-# returns. Leave enough outer budget for initialize/deleteWebhook/start_polling
-# wall deadlines plus readiness; other platforms retain the 30s isolation bound.
-_TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
-_ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 # End reasons that mean the USER deliberately closed this thread of work
 # (/new -> session_reset / new_session, an explicit exit, or a /switch).
 # Shared by _classify_completion_target (pre-flight verdict) and
@@ -2458,6 +2452,7 @@ from gateway.session_state import (
     legacy_dict_property,
     legacy_lease_token_property,
 )
+from gateway.adapter_lifecycle_mixin import GatewayAdapterLifecycleMixin
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
@@ -5883,7 +5878,12 @@ class TurnRunner:
 
 
 
-class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
+class GatewayRunner(
+    GatewayAdapterLifecycleMixin,
+    GatewayAuthorizationMixin,
+    GatewayKanbanWatchersMixin,
+    GatewaySlashCommandsMixin,
+):
     """
     Main gateway controller.
 
@@ -6596,185 +6596,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if mode in {"voice_only", "all"} and key.startswith(prefix)
             )
 
-    async def _await_adapter_cleanup_with_timeout(
-        self, awaitable: Awaitable[Any], timeout: float
-    ) -> bool:
-        """Wait for adapter cleanup without letting cancellation swallowing hang us.
-
-        ``asyncio.wait_for`` cancels an overdue child but then waits for it to
-        exit. An adapter close path that catches ``CancelledError`` can therefore
-        block recovery forever. Keep ownership of the old task through its done
-        callback, but release the runner at the deadline.
-        """
-        if timeout <= 0:
-            await awaitable
-            return True
-
-        task = asyncio.ensure_future(awaitable)
-        try:
-            done, _pending = await asyncio.wait({task}, timeout=timeout)
-        except asyncio.CancelledError:
-            task.cancel()
-            task.add_done_callback(consume_detached_task_result)
-            raise
-        if task in done:
-            await task
-            return True
-
-        task.cancel()
-        task.add_done_callback(consume_detached_task_result)
-        return False
-
-    async def _safe_adapter_disconnect(self, adapter, platform) -> None:
-        """Call adapter.disconnect() defensively, swallowing any error.
-
-        Used when adapter.connect() failed or raised — the adapter may
-        have allocated partial resources (aiohttp.ClientSession, poll
-        tasks, child subprocesses) that would otherwise leak and surface
-        as "Unclosed client session" warnings at process exit.
-
-        Must tolerate partial-init state and never raise, since callers
-        use it inside error-handling blocks.
-        """
-        timeout = self._adapter_disconnect_timeout_secs()
-        try:
-            completed = await self._await_adapter_cleanup_with_timeout(
-                adapter.disconnect(), timeout
-            )
-            if not completed:
-                logger.warning(
-                    "Timed out after %.1fs while disconnecting %s adapter; continuing shutdown",
-                    timeout,
-                    platform.value if platform is not None else "adapter",
-                )
-        except Exception as e:
-            logger.debug(
-                "Defensive %s disconnect after failed connect raised: %s",
-                platform.value if platform is not None else "adapter",
-                e,
-            )
-
-    async def _bounded_adapter_teardown(
-        self, adapter, platform, *, profile: Optional[str] = None
-    ) -> None:
-        """Tear down one adapter on the shutdown path with bounded awaits.
-
-        Both ``cancel_background_tasks()`` and ``disconnect()`` can block
-        indefinitely when a platform's network state is half-dead (e.g. a
-        wedged Feishu/Lark WebSocket thread waiting on I/O). An unbounded
-        await here stalls the entire shutdown sequence past systemd's
-        ``TimeoutStopSec``; the resulting SIGKILL skips ``atexit`` PID-file
-        cleanup, so the next start dies with "PID file race lost" (#14128).
-
-        Each await uses the existing per-adapter timeout budget
-        (``HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT``). On timeout the old
-        task is cancelled and detached, then teardown forces forward progress;
-        the loop never hangs even if an adapter swallows cancellation. Never
-        raises.
-        """
-        timeout = self._adapter_disconnect_timeout_secs()
-        suffix = f" (profile: {profile})" if profile else ""
-        started_at = time.monotonic()
-        try:
-            cancelled = await self._await_adapter_cleanup_with_timeout(
-                adapter.cancel_background_tasks(), timeout
-            )
-            if not cancelled:
-                logger.warning(
-                    "✗ %s background-task cancel timed out after %.1fs - forcing continue%s",
-                    platform.value, timeout, suffix,
-                )
-        except Exception as e:
-            logger.debug("✗ %s background-task cancel error%s: %s", platform.value, suffix, e)
-        try:
-            disconnected = await self._await_adapter_cleanup_with_timeout(
-                adapter.disconnect(), timeout
-            )
-            if disconnected:
-                logger.info(
-                    "✓ %s disconnected (%.2fs)%s",
-                    platform.value, time.monotonic() - started_at, suffix,
-                )
-            else:
-                logger.warning(
-                    "✗ %s disconnect timed out after %.1fs - forcing continue%s",
-                    platform.value, timeout, suffix,
-                )
-        except Exception as e:
-            logger.error(
-                "✗ %s disconnect error after %.2fs%s: %s",
-                platform.value, time.monotonic() - started_at, suffix, e,
-            )
-
-    def _adapter_disconnect_timeout_secs(self) -> float:
-        """Return the per-adapter disconnect timeout used during shutdown."""
-        raw = os.getenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "").strip()
-        if raw:
-            try:
-                timeout = float(raw)
-            except ValueError:
-                logger.warning(
-                    "Ignoring invalid HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT=%r",
-                    raw,
-                )
-            else:
-                return max(0.0, timeout)
-        return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
-
-    def _platform_connect_timeout_secs(self, platform=None) -> float:
-        """Return the per-platform connect timeout used during startup/retry."""
-        raw = os.getenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
-        if raw:
-            try:
-                timeout = float(raw)
-            except ValueError:
-                logger.warning(
-                    "Ignoring invalid HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT=%r",
-                    raw,
-                )
-            else:
-                return max(0.0, timeout)
-        if platform == Platform.TELEGRAM:
-            return _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT
-        return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
-
-    async def _connect_adapter_with_timeout(
-        self, adapter, platform, *, is_reconnect: bool = False
-    ) -> bool:
-        """Connect an adapter without allowing one platform to block others.
-
-        ``is_reconnect`` is forwarded to ``adapter.connect()`` so platform
-        adapters can distinguish a cold first boot (drop any stale
-        server-side queue) from a watcher reconnect after a prolonged outage
-        (preserve the queue so messages sent during the outage are delivered
-        rather than silently dropped — #46621).
-        """
-        timeout = self._platform_connect_timeout_secs(platform)
-        if timeout <= 0:
-            return await adapter.connect(is_reconnect=is_reconnect)
-        # Use the detach-on-timeout pattern instead of plain asyncio.wait_for:
-        # asyncio.wait_for cancels the overdue task but then waits for it to
-        # exit. An adapter connect() that catches CancelledError can therefore
-        # block recovery forever (the watcher never reaches the next retry).
-        # Keep ownership of the old task through its done callback, but
-        # release the runner at the deadline (#70344).
-        task = asyncio.ensure_future(
-            adapter.connect(is_reconnect=is_reconnect)
-        )
-        try:
-            done, _pending = await asyncio.wait({task}, timeout=timeout)
-        except asyncio.CancelledError:
-            task.cancel()
-            task.add_done_callback(consume_detached_task_result)
-            raise
-        if task in done:
-            result = await task
-            return bool(result)
-        task.cancel()
-        task.add_done_callback(consume_detached_task_result)
-        raise TimeoutError(
-            f"{platform.value} connect timed out after {timeout:g}s"
-        )
+    # Adapter lifecycle helpers live in GatewayAdapterLifecycleMixin.  The
+    # mixin is the leftmost base of GatewayRunner, so existing call sites
+    # continue to resolve them through the MRO without changes.
 
     async def _connect_initial_adapter_with_timeout(self, adapter, platform) -> bool:
         """Connect one cold-start adapter with tightly scoped replace intent.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1358,11 +1358,11 @@ class DiscordAdapter(BasePlatformAdapter):
         gateway's outer ``asyncio.wait_for`` (which wraps this whole method) does
         not cancel an in-progress flush before we get a chance to cancel our own
         stragglers gracefully. Mirrors the env var the gateway reads in
-        ``GatewayRunner._adapter_disconnect_timeout_secs`` (lifted to
-        ``gateway.adapter_lifecycle_mixin`` per PR #fixme; reachable on a
-        ``GatewayRunner`` instance through the MRO — runtime contract unchanged).
+        ``GatewayAdapterLifecycleMixin._adapter_disconnect_timeout_secs``;
+        reachable on a ``GatewayRunner`` instance through the MRO — runtime
+        contract unchanged.
         """
-        budget = 5.0  # mirrors gateway _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
+        budget = 5.0  # mirrors GatewayAdapterLifecycleMixin._ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
         raw = os.getenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "").strip()
         if raw:
             try:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1358,7 +1358,9 @@ class DiscordAdapter(BasePlatformAdapter):
         gateway's outer ``asyncio.wait_for`` (which wraps this whole method) does
         not cancel an in-progress flush before we get a chance to cancel our own
         stragglers gracefully. Mirrors the env var the gateway reads in
-        ``GatewayRunner._adapter_disconnect_timeout_secs``.
+        ``GatewayRunner._adapter_disconnect_timeout_secs`` (lifted to
+        ``gateway.adapter_lifecycle_mixin`` per PR #fixme; reachable on a
+        ``GatewayRunner`` instance through the MRO — runtime contract unchanged).
         """
         budget = 5.0  # mirrors gateway _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
         raw = os.getenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "").strip()

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1760,9 +1760,9 @@ class DiscordAdapter(BasePlatformAdapter):
         gateway's outer ``asyncio.wait_for`` (which wraps this whole method) does
         not cancel an in-progress flush before we get a chance to cancel our own
         stragglers gracefully. Mirrors the env var the gateway reads in
-        ``GatewayRunner._adapter_disconnect_timeout_secs``.
+        ``GatewayAdapterLifecycleMixin._adapter_disconnect_timeout_secs``.
         """
-        budget = 5.0  # mirrors gateway _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
+        budget = 5.0  # mirrors GatewayAdapterLifecycleMixin's default
         raw = os.getenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "").strip()
         if raw:
             try:

--- a/tests/gateway/test_adapter_lifecycle_mixin.py
+++ b/tests/gateway/test_adapter_lifecycle_mixin.py
@@ -1,0 +1,130 @@
+"""Mixin contract tests: GatewayRunner inherits adapter-lifecycle helpers via MRO.
+
+After the adapter-lifecycle mixin extraction (god-file decomposition Phase 4),
+the five adapter lifecycle helpers live on ``GatewayAdapterLifecycleMixin``:
+
+  - ``_safe_adapter_disconnect``
+  - ``_bounded_adapter_teardown``
+  - ``_adapter_disconnect_timeout_secs``
+  - ``_platform_connect_timeout_secs``
+  - ``_connect_adapter_with_timeout``
+
+The existing ``GatewayRunner.__init__`` is unchanged at the call sites, so
+runtime behavior is preserved. These tests assert behavior contracts
+(invariants), not snapshots:
+
+  - The methods must resolve on a ``GatewayRunner`` instance via the MRO
+    (mixin wired into the class bases), even without a real ``__init__``.
+  - The mixin itself must expose the same five methods (so direct subclassing
+    or ``object.__new__(GatewayAdapterLifecycleMixin)`` shells — like the
+    existing regression tests do with ``GatewayRunner`` — keep working).
+  - The mixin must NOT depend on any ``self.*`` state for these five methods
+    (they read ``os.getenv`` + the module-level timeout constants only). That
+    is the invariant that makes this a safe pure-move: there is nothing in
+    ``__init__`` the methods need that a bare ``object.__new__`` shell lacks.
+
+Per AGENTS.md, this is a behavior-contract test (invariant), not a
+change-detector test (snapshot of a current value).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.adapter_lifecycle_mixin import GatewayAdapterLifecycleMixin
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+
+_METHOD_NAMES = (
+    "_safe_adapter_disconnect",
+    "_bounded_adapter_teardown",
+    "_adapter_disconnect_timeout_secs",
+    "_platform_connect_timeout_secs",
+    "_connect_adapter_with_timeout",
+)
+
+
+def test_mixin_exposes_all_five_methods():
+    """Each named method must exist as an attribute on the mixin."""
+    missing = [n for n in _METHOD_NAMES if not hasattr(GatewayAdapterLifecycleMixin, n)]
+    assert not missing, f"Mixin missing methods: {missing}"
+
+
+def test_runner_resolves_methods_via_mro():
+    """A bare ``object.__new__(GatewayRunner)`` shell (no ``__init__``) must
+    still resolve each method through the MRO — proves the mixin is wired into
+    ``GatewayRunner``'s bases and the helpers do not depend on ``__init__``."""
+    shell = object.__new__(GatewayRunner)
+    missing = [n for n in _METHOD_NAMES if not hasattr(shell, n)]
+    assert not missing, f"GatewayRunner shell missing methods via MRO: {missing}"
+
+
+def test_methods_resolve_to_mixin_not_runner():
+    """The methods must resolve to the *mixin*'s function objects, not stale
+    copies left on ``GatewayRunner`` itself. After extraction, run.py must
+    not re-declare them."""
+    for name in _METHOD_NAMES:
+        runner_attr = getattr(GatewayRunner, name, None)
+        mixin_attr = getattr(GatewayAdapterLifecycleMixin, name, None)
+        assert runner_attr is not None, f"{name} not reachable on GatewayRunner"
+        assert mixin_attr is not None, f"{name} not defined on the mixin"
+        # The function object on GatewayRunner must BE the mixin's function
+        # (MRO resolution), not a separate def left in run.py.
+        assert runner_attr is mixin_attr, (
+            f"{name} on GatewayRunner is not the mixin's implementation — "
+            f"either a stale duplicate was left in run.py or the mixin is "
+            f"not in the MRO. Expected identical function objects."
+        )
+
+
+def test_timeout_secs_methods_dont_require_init_state():
+    """The two ``_..._timeout_secs`` methods read only ``os.getenv`` and the
+    module-level constants, so a bare shell (no config, no adapters dict)
+    must return the default values with no AttributeError."""
+    shell = object.__new__(GatewayRunner)
+    # Defaults match the module constants in run.py:
+    #   _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+    #   _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT   = 30.0
+    # We assert the contract (env-var override wins; absent env-var returns
+    # a positive float), not the exact default literal — that would freeze a
+    # current value and become a change-detector test.
+    assert isinstance(shell._adapter_disconnect_timeout_secs(), float)
+    assert shell._adapter_disconnect_timeout_secs() > 0
+    assert isinstance(shell._platform_connect_timeout_secs(), float)
+    assert shell._platform_connect_timeout_secs() > 0
+
+
+@pytest.mark.asyncio
+async def test_connect_helper_forwards_is_reconnect_kwarg():
+    """``_connect_adapter_with_timeout`` must forward ``is_reconnect`` through
+    to ``adapter.connect`` unchanged. This is the behavior that preserves
+    messages sent during an outage (#46621) — a regression here silently
+    drops messages on reconnect."""
+    shell = object.__new__(GatewayRunner)
+    adapter = MagicMock()
+    adapter.connect = AsyncMock(return_value=True)
+
+    # Use a generous timeout so the test itself is not racy on slow CI.
+    os.environ.pop("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", None)
+    result = await shell._connect_adapter_with_timeout(
+        adapter, Platform.TELEGRAM, is_reconnect=True
+    )
+    assert result is True
+    adapter.connect.assert_awaited_once_with(is_reconnect=True)
+
+
+@pytest.mark.asyncio
+async def test_safe_disconnect_forward_progress_on_partial_init():
+    """The defensive disconnect must never raise, even when adapter.disconnect
+    raises — the caller is on a failure path and cannot propagate."""
+    shell = object.__new__(GatewayRunner)
+    adapter = MagicMock()
+    adapter.disconnect = AsyncMock(side_effect=RuntimeError("partial init"))
+
+    # Must NOT raise.
+    await shell._safe_adapter_disconnect(adapter, Platform.TELEGRAM)
+    adapter.disconnect.assert_awaited_once()

--- a/tests/gateway/test_adapter_lifecycle_mixin.py
+++ b/tests/gateway/test_adapter_lifecycle_mixin.py
@@ -29,7 +29,6 @@ change-detector test (snapshot of a current value).
 
 from __future__ import annotations
 
-import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -99,7 +98,7 @@ def test_timeout_secs_methods_dont_require_init_state():
 
 
 @pytest.mark.asyncio
-async def test_connect_helper_forwards_is_reconnect_kwarg():
+async def test_connect_helper_forwards_is_reconnect_kwarg(monkeypatch):
     """``_connect_adapter_with_timeout`` must forward ``is_reconnect`` through
     to ``adapter.connect`` unchanged. This is the behavior that preserves
     messages sent during an outage (#46621) — a regression here silently
@@ -109,7 +108,10 @@ async def test_connect_helper_forwards_is_reconnect_kwarg():
     adapter.connect = AsyncMock(return_value=True)
 
     # Use a generous timeout so the test itself is not racy on slow CI.
-    os.environ.pop("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", None)
+    # ``monkeypatch.delenv(..., raising=False)`` handles both "unset" and
+    # "set" cases (suppresses KeyError if the var was never in os.environ)
+    # and restores the inherited process environment for later tests.
+    monkeypatch.delenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", raising=False)
     result = await shell._connect_adapter_with_timeout(
         adapter, Platform.TELEGRAM, is_reconnect=True
     )

--- a/tests/gateway/test_adapter_lifecycle_mixin.py
+++ b/tests/gateway/test_adapter_lifecycle_mixin.py
@@ -1,0 +1,73 @@
+"""Behavior contracts for the gateway adapter-lifecycle mixin."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.adapter_lifecycle_mixin import GatewayAdapterLifecycleMixin
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+
+_METHOD_NAMES = (
+    "_await_adapter_cleanup_with_timeout",
+    "_safe_adapter_disconnect",
+    "_bounded_adapter_teardown",
+    "_adapter_disconnect_timeout_secs",
+    "_platform_connect_timeout_secs",
+    "_connect_adapter_with_timeout",
+)
+
+
+def test_mixin_exposes_all_lifecycle_methods():
+    missing = [name for name in _METHOD_NAMES if not hasattr(GatewayAdapterLifecycleMixin, name)]
+    assert not missing
+
+
+def test_runner_resolves_lifecycle_methods_via_mro():
+    shell = object.__new__(GatewayRunner)
+    missing = [name for name in _METHOD_NAMES if not hasattr(shell, name)]
+    assert not missing
+
+
+def test_methods_resolve_to_mixin_not_runner_copy():
+    for name in _METHOD_NAMES:
+        assert getattr(GatewayRunner, name) is getattr(GatewayAdapterLifecycleMixin, name)
+
+
+def test_timeout_getters_do_not_require_init_state(monkeypatch):
+    shell = object.__new__(GatewayRunner)
+    monkeypatch.delenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", raising=False)
+
+    assert shell._adapter_disconnect_timeout_secs() > 0
+    assert shell._platform_connect_timeout_secs() > 0
+    assert shell._platform_connect_timeout_secs(Platform.TELEGRAM) > 0
+
+
+@pytest.mark.asyncio
+async def test_connect_helper_forwards_is_reconnect_kwarg(monkeypatch):
+    shell = object.__new__(GatewayRunner)
+    adapter = MagicMock()
+    adapter.connect = AsyncMock(return_value=True)
+    monkeypatch.delenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", raising=False)
+
+    result = await shell._connect_adapter_with_timeout(
+        adapter, Platform.TELEGRAM, is_reconnect=True
+    )
+
+    assert result is True
+    adapter.connect.assert_awaited_once_with(is_reconnect=True)
+
+
+@pytest.mark.asyncio
+async def test_safe_disconnect_forwards_progress_on_partial_init():
+    shell = object.__new__(GatewayRunner)
+    adapter = MagicMock()
+    adapter.disconnect = AsyncMock(side_effect=RuntimeError("partial init"))
+
+    await shell._safe_adapter_disconnect(adapter, Platform.TELEGRAM)
+
+    adapter.disconnect.assert_awaited_once()


### PR DESCRIPTION
## What does this PR do?

Refactors the existing adapter lifecycle helpers out of gateway/run.py into a focused AdapterLifecycleMixin, preserving behavior and the current GatewayRunner MRO contract.

This is a behavior-preserving extraction, not a new lifecycle implementation.

## Scope

- Moves the existing adapter lifecycle constants and six helper methods into gateway/adapter_lifecycle_mixin.py.
- Keeps GatewayRunner(AdapterLifecycleMixin, ...) leftmost so the existing method-resolution contract remains explicit.
- Preserves _await_adapter_cleanup_with_timeout cancellation semantics, including the shielded cleanup task and bounded wait behavior; it is not replaced with a plain asyncio.wait_for.
- Preserves Telegram's longer connect budget and timeout detach behavior.
- Updates stale helper-location references in adjacent docs/comments.
- Adds focused MRO, no-init, reconnect-forwarding, and safe-disconnect tests.

## Non-goals

- No behavior, timeout, cancellation, logging, config, dependency, public API, or platform changes.
- No topic-mode or Remote Session Continuity work.
- No new abstraction beyond the concrete extraction seam needed to make the existing lifecycle code reviewable.

## Verification on current main

This branch was rebased onto current origin/main (1d3d02128) before push.

- Focused lifecycle contract tests: 30 passed.
  - tests/gateway/test_adapter_lifecycle_mixin.py
  - tests/gateway/test_adapter_connect_is_reconnect_contract.py
- Adjacent reconnect/startup/fatal/shutdown/Discord tests: 43 passed.
  - tests/gateway/test_platform_reconnect.py
  - tests/gateway/test_startup_restart_race.py
  - tests/gateway/test_runner_fatal_adapter.py
  - tests/gateway/test_gateway_shutdown.py
  - tests/gateway/test_discord_connect.py
- Ruff on changed Python files: passed.
- Compile check and git diff --check: passed.

The work was performed in an isolated worktree; the live Hermes CMD checkout was not modified.