### PR TITLE
Restore last desktop session when switching profiles

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -46,7 +46,7 @@ import {
   setPetOverlaySubmitHandler
 } from '../store/pet-overlay'
 import { $filePreviewTarget, $previewTarget, closeActiveRightRailTab } from '../store/preview'
-import { $activeGatewayProfile, $freshSessionRequest, $profileScope, refreshActiveProfile } from '../store/profile'
+import { $activeGatewayProfile, $profileScope, refreshActiveProfile } from '../store/profile'
 import { $startWorkSessionRequest, followActiveSessionCwd, resolveNewSessionCwd } from '../store/projects'
 import { $reviewOpen, REVIEW_PANE_ID } from '../store/review'
 import {
@@ -112,6 +112,7 @@ import { useHermesConfig } from './session/hooks/use-hermes-config'
 import { useMessageStream } from './session/hooks/use-message-stream'
 import { useModelControls } from './session/hooks/use-model-controls'
 import { usePreviewRouting } from './session/hooks/use-preview-routing'
+import { useProfileSessionRestore } from './session/hooks/use-profile-session-restore'
 import { usePromptActions } from './session/hooks/use-prompt-actions'
 import { useRouteResume } from './session/hooks/use-route-resume'
 import { useSessionActions } from './session/hooks/use-session-actions'
@@ -636,19 +637,12 @@ export function DesktopController() {
     toggleSelectedPin
   })
 
-  // A profile switch/create drops to a fresh new-session draft so the previously
-  // open session doesn't bleed across contexts. Skip the initial value.
-  const freshSessionRequest = useStore($freshSessionRequest)
-  const lastFreshRef = useRef(freshSessionRequest)
-
-  useEffect(() => {
-    if (freshSessionRequest === lastFreshRef.current) {
-      return
-    }
-
-    lastFreshRef.current = freshSessionRequest
-    startFreshSessionDraft()
-  }, [freshSessionRequest, startFreshSessionDraft])
+  useProfileSessionRestore({
+    resumeSession,
+    selectedStoredSessionId,
+    selectedStoredSessionIdRef,
+    startFreshSessionDraft
+  })
 
   // Swapping the live gateway to another profile must re-pull that profile's
   // global model + active-profile pill. Both are nanostores, so the blanket

--- a/apps/desktop/src/app/session/hooks/use-profile-session-restore.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-profile-session-restore.test.tsx
@@ -1,0 +1,143 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+import { $activeGatewayProfile, $freshSessionRequest, $profileSwitchTarget } from '@/store/profile'
+import { setSessions } from '@/store/session'
+
+import { useProfileSessionRestore } from './use-profile-session-restore'
+
+function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    ended_at: null,
+    id: 'stored-1',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    profile: 'default',
+    source: 'desktop',
+    started_at: 1,
+    title: 'stored',
+    tool_call_count: 0,
+    ...overrides
+  }
+}
+
+function Harness({
+  resumeSession,
+  selectedStoredSessionId,
+  selectedStoredSessionIdRef,
+  startFreshSessionDraft
+}: {
+  resumeSession: (id: string, replaceRoute?: boolean) => Promise<void>
+  selectedStoredSessionId: string | null
+  selectedStoredSessionIdRef: MutableRefObject<string | null>
+  startFreshSessionDraft: () => void
+}) {
+  useProfileSessionRestore({
+    resumeSession,
+    selectedStoredSessionId,
+    selectedStoredSessionIdRef,
+    startFreshSessionDraft
+  })
+
+  return null
+}
+
+function requestFreshForProfile(profile: string): void {
+  act(() => {
+    $profileSwitchTarget.set(profile)
+    $freshSessionRequest.set($freshSessionRequest.get() + 1)
+  })
+}
+
+describe('useProfileSessionRestore', () => {
+  afterEach(() => {
+    cleanup()
+    $activeGatewayProfile.set('default')
+    $freshSessionRequest.set(0)
+    $profileSwitchTarget.set(null)
+    setSessions([])
+    vi.restoreAllMocks()
+  })
+
+  it('restores the last opened session for a profile switch', async () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'session-a' }
+
+    setSessions([
+      storedSession({ id: 'session-a', profile: 'default', title: 'Default chat' }),
+      storedSession({ id: 'session-b', profile: 'coder', title: 'Coder chat' })
+    ])
+
+    const view = render(
+      <Harness
+        resumeSession={resumeSession}
+        selectedStoredSessionId="session-a"
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    act(() => {
+      $activeGatewayProfile.set('coder')
+      selectedStoredSessionIdRef.current = 'session-b'
+    })
+    view.rerender(
+      <Harness
+        resumeSession={resumeSession}
+        selectedStoredSessionId="session-b"
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    act(() => {
+      $activeGatewayProfile.set('default')
+      selectedStoredSessionIdRef.current = 'session-a'
+    })
+    view.rerender(
+      <Harness
+        resumeSession={resumeSession}
+        selectedStoredSessionId="session-a"
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    requestFreshForProfile('coder')
+
+    await waitFor(() => expect(resumeSession).toHaveBeenCalledWith('session-b', true))
+    expect(startFreshSessionDraft).not.toHaveBeenCalled()
+    expect($profileSwitchTarget.get()).toBeNull()
+  })
+
+  it('starts a fresh draft when the target profile has no remembered session', async () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'session-a' }
+
+    setSessions([storedSession({ id: 'session-a', profile: 'default' })])
+
+    render(
+      <Harness
+        resumeSession={resumeSession}
+        selectedStoredSessionId="session-a"
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    requestFreshForProfile('coder')
+
+    await waitFor(() => expect(startFreshSessionDraft).toHaveBeenCalledTimes(1))
+    expect(resumeSession).not.toHaveBeenCalled()
+    expect($profileSwitchTarget.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-profile-session-restore.ts
+++ b/apps/desktop/src/app/session/hooks/use-profile-session-restore.ts
@@ -1,0 +1,66 @@
+import { useStore } from '@nanostores/react'
+import type { MutableRefObject } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+
+import { $activeGatewayProfile, $freshSessionRequest, $profileSwitchTarget, normalizeProfileKey } from '@/store/profile'
+import { $sessions } from '@/store/session'
+
+interface UseProfileSessionRestoreArgs {
+  resumeSession: (id: string, replaceRoute?: boolean) => Promise<void>
+  selectedStoredSessionId: string | null
+  selectedStoredSessionIdRef: MutableRefObject<string | null>
+  startFreshSessionDraft: () => void
+}
+
+export function useProfileSessionRestore({
+  resumeSession,
+  selectedStoredSessionId,
+  selectedStoredSessionIdRef,
+  startFreshSessionDraft
+}: UseProfileSessionRestoreArgs): void {
+  const activeGatewayProfile = useStore($activeGatewayProfile)
+  const freshSessionRequest = useStore($freshSessionRequest)
+  const lastFreshRef = useRef(freshSessionRequest)
+  const lastSessionByProfileRef = useRef(new Map<string, string>())
+
+  const rememberSession = useCallback(
+    (sessionId: string | null) => {
+      if (!sessionId) {
+        return
+      }
+
+      const session = $sessions.get().find(row => row.id === sessionId || row._lineage_root_id === sessionId)
+      const profile = normalizeProfileKey(session?.profile ?? activeGatewayProfile)
+      lastSessionByProfileRef.current.set(profile, sessionId)
+    },
+    [activeGatewayProfile]
+  )
+
+  useEffect(() => {
+    rememberSession(selectedStoredSessionId)
+  }, [rememberSession, selectedStoredSessionId])
+
+  useEffect(() => {
+    if (freshSessionRequest === lastFreshRef.current) {
+      return
+    }
+
+    lastFreshRef.current = freshSessionRequest
+    rememberSession(selectedStoredSessionIdRef.current)
+
+    const target = $profileSwitchTarget.get()
+    $profileSwitchTarget.set(null)
+
+    if (target) {
+      const rememberedSession = lastSessionByProfileRef.current.get(normalizeProfileKey(target))
+
+      if (rememberedSession) {
+        void resumeSession(rememberedSession, true)
+
+        return
+      }
+    }
+
+    startFreshSessionDraft()
+  }, [freshSessionRequest, rememberSession, resumeSession, selectedStoredSessionIdRef, startFreshSessionDraft])
+}

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -159,6 +159,7 @@ export const $newChatProfile = atom<string | null>(null)
 // currently-open session (store/projects). The chat controller subscribes and
 // resets to the intro draft, so we never strand the user in an orphaned view.
 export const $freshSessionRequest = atom(0)
+export const $profileSwitchTarget = atom<string | null>(null)
 
 export function requestFreshSession(): void {
   $freshSessionRequest.set($freshSessionRequest.get() + 1)
@@ -307,6 +308,7 @@ export function selectProfile(name: string): void {
   $newChatProfile.set(target)
 
   if (switching) {
+    $profileSwitchTarget.set(target)
     requestFreshSession()
   }
 


### PR DESCRIPTION
## Summary
- remember the last opened stored session per desktop profile
- restore that session when switching back to a profile instead of always opening a fresh draft
- keep the existing fresh-draft fallback when the target profile has no remembered session

Fixes #60095

## Tested
- npm run test:ui -- src/store/profile.test.ts src/app/session/hooks/use-route-resume.test.tsx src/app/session/hooks/use-profile-session-restore.test.tsx
- npm run typecheck
- npm run lint -- src/app/desktop-controller.tsx src/store/profile.ts src/app/session/hooks/use-profile-session-restore.ts src/app/session/hooks/use-profile-session-restore.test.tsx

Note: lint currently reports the existing `src/app/settings/model-settings.tsx` exhaustive-deps warning.