### PR TITLE
fix(auth): seed extra custom provider env keys

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2278,14 +2278,59 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
         def _is_suppressed(_p, _s):  # type: ignore[misc]
             return False
 
-    # Seed from the custom_providers config entry's api_key field
+    # Seed from the custom_providers config entry's configured keys.
     cp_config = _get_custom_provider_config(pool_key)
     if cp_config:
         api_key = str(cp_config.get("api_key") or "").strip()
         base_url = str(cp_config.get("base_url") or "").strip().rstrip("/")
         name = str(cp_config.get("name") or "").strip()
-        if api_key:
-            source = f"config:{name}"
+
+        key_specs: List[Tuple[str, str]] = []
+        seen_tokens: Set[str] = set()
+
+        def _add_key(source: str, token: str) -> None:
+            token = str(token or "").strip()
+            if not token or token in seen_tokens:
+                return
+            seen_tokens.add(token)
+            key_specs.append((source, token))
+
+        _add_key(f"config:{name}", api_key)
+
+        env_values: Optional[Dict[str, str]] = None
+
+        def _read_env_key(var_name: str) -> str:
+            nonlocal env_values
+            if env_values is None:
+                try:
+                    env_values = load_env()
+                except Exception:
+                    env_values = {}
+            return str(
+                env_values.get(var_name)
+                or _get_secret(var_name, "")
+                or os.environ.get(var_name)
+                or ""
+            ).strip()
+
+        env_names: List[str] = []
+        key_env = str(
+            cp_config.get("key_env") or cp_config.get("api_key_env") or ""
+        ).strip()
+        if key_env:
+            env_names.append(key_env)
+        extra_keys_env = cp_config.get("extra_keys_env")
+        if isinstance(extra_keys_env, list):
+            env_names.extend(str(item or "").strip() for item in extra_keys_env)
+
+        seen_env_names: Set[str] = set()
+        for env_name in env_names:
+            if not env_name or env_name in seen_env_names:
+                continue
+            seen_env_names.add(env_name)
+            _add_key(f"env:{env_name}", _read_env_key(env_name))
+
+        for source, token in key_specs:
             if not _is_suppressed(pool_key, source):
                 active_sources.add(source)
                 changed |= _upsert_entry(
@@ -2295,7 +2340,7 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
                     {
                         "source": source,
                         "auth_type": AUTH_TYPE_API_KEY,
-                        "access_token": api_key,
+                        "access_token": token,
                         "base_url": base_url,
                         "label": name or source,
                     },
@@ -2358,7 +2403,11 @@ def load_pool(provider: str) -> CredentialPool:
         # Custom endpoint pool — seed from custom_providers config and model config
         custom_changed, custom_sources = _seed_custom_pool(provider, entries)
         changed = raw_needs_sanitization or custom_changed
-        changed |= _prune_stale_seeded_entries(entries, custom_sources)
+        changed |= _prune_stale_seeded_entries(
+            entries,
+            custom_sources,
+            prune_env_sources=False,
+        )
     else:
         singleton_changed, singleton_sources = _seed_from_singletons(provider, entries)
         env_changed, env_sources = _seed_from_env(provider, entries)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2266,6 +2266,30 @@ def _prune_stale_seeded_entries(
     return True
 
 
+def _dedupe_active_seeded_entries(
+    entries: List[PooledCredential],
+    active_sources: Set[str],
+) -> bool:
+    """Keep one seeded entry per active source.
+
+    Older pools may already contain duplicate env/config entries. Upsert keeps
+    the first copy fresh; this drops stale twins without touching manual creds.
+    """
+    seen: Set[str] = set()
+    retained: List[PooledCredential] = []
+    changed = False
+    for entry in entries:
+        if entry.source in active_sources and not _is_manual_source(entry.source):
+            if entry.source in seen:
+                changed = True
+                continue
+            seen.add(entry.source)
+        retained.append(entry)
+    if changed:
+        entries[:] = retained
+    return changed
+
+
 def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
     """Seed a custom endpoint pool from custom_providers config and model config."""
     changed = False
@@ -2408,6 +2432,7 @@ def load_pool(provider: str) -> CredentialPool:
             custom_sources,
             prune_env_sources=False,
         )
+        changed |= _dedupe_active_seeded_entries(entries, custom_sources)
     else:
         singleton_changed, singleton_sources = _seed_from_singletons(provider, entries)
         env_changed, env_sources = _seed_from_env(provider, entries)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4601,6 +4601,7 @@ def _normalize_custom_provider_entry(
         "apiMode": "api_mode",
         "keyEnv": "key_env",
         "apiKeyEnv": "key_env",  # alias — OpenClaw-compatible + docs variant
+        "extraKeysEnv": "extra_keys_env",
         "defaultModel": "default_model",
         "contextLength": "context_length",
         "rateLimitDelay": "rate_limit_delay",
@@ -4621,7 +4622,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
-        "ssl_ca_cert", "ssl_verify",
+        "ssl_ca_cert", "ssl_verify", "extra_keys_env",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -4693,6 +4694,16 @@ def _normalize_custom_provider_entry(
     key_env = entry.get("key_env")
     if isinstance(key_env, str) and key_env.strip():
         normalized["key_env"] = key_env.strip()
+
+    extra_keys_env = entry.get("extra_keys_env")
+    if isinstance(extra_keys_env, list):
+        cleaned_extra_keys_env = [
+            item.strip()
+            for item in extra_keys_env
+            if isinstance(item, str) and item.strip()
+        ]
+        if cleaned_extra_keys_env:
+            normalized["extra_keys_env"] = cleaned_extra_keys_env
 
     api_mode = entry.get("api_mode") or entry.get("transport")
     if isinstance(api_mode, str) and api_mode.strip():

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1812,6 +1812,53 @@ def test_seed_custom_pool_uses_extra_env_keys(tmp_path, monkeypatch):
     assert active == {entry.source for entry in entries}
 
 
+def test_load_custom_pool_dedupes_seeded_env_sources(tmp_path, monkeypatch):
+    """Older pools may already contain duplicate env-backed custom entries."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("NVIDIA_KEY_1", "sk-one")
+    monkeypatch.setenv("NVIDIA_KEY_2", "sk-two")
+
+    import yaml
+    (hermes_home / "config.yaml").write_text(yaml.dump({
+        "model": {},
+        "custom_providers": [
+            {
+                "name": "nvidia-rotating",
+                "base_url": "https://integrate.api.nvidia.com/v1",
+                "key_env": "NVIDIA_KEY_1",
+                "extra_keys_env": ["NVIDIA_KEY_2"],
+            },
+        ],
+    }))
+
+    from agent.credential_pool import get_custom_provider_pool_key, load_pool
+    pool_key = get_custom_provider_pool_key("https://integrate.api.nvidia.com/v1")
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {
+            pool_key: {
+                "credential_pool": [
+                    {"source": "env:NVIDIA_KEY_1", "access_token": "old-one", "auth_type": "api_key"},
+                    {"source": "env:NVIDIA_KEY_1", "access_token": "stale-duplicate", "auth_type": "api_key"},
+                    {"source": "env:NVIDIA_KEY_2", "access_token": "old-two", "auth_type": "api_key"},
+                    {"source": "env:NVIDIA_KEY_2", "access_token": "stale-duplicate", "auth_type": "api_key"},
+                ],
+            },
+        },
+    }))
+
+    pool = load_pool(pool_key)
+    entries = pool.entries()
+
+    assert [entry.source for entry in entries] == [
+        "env:NVIDIA_KEY_1",
+        "env:NVIDIA_KEY_2",
+    ]
+    assert [entry.access_token for entry in entries] == ["sk-one", "sk-two"]
+
+
 def test_credential_sources_registry_has_expected_steps():
     """Sanity check — the registry contains the expected RemovalSteps.
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1769,6 +1769,49 @@ def test_seed_custom_pool_respects_config_suppression(tmp_path, monkeypatch):
     assert "config:my" not in active
 
 
+def test_seed_custom_pool_uses_extra_env_keys(tmp_path, monkeypatch):
+    """A custom provider can seed several env-backed keys into one pool."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("NVIDIA_KEY_1", "sk-one")
+    monkeypatch.setenv("NVIDIA_KEY_2", "sk-two")
+    monkeypatch.setenv("NVIDIA_KEY_DUP", "sk-one")
+
+    import yaml
+    (hermes_home / "config.yaml").write_text(yaml.dump({
+        "model": {},
+        "custom_providers": [
+            {
+                "name": "nvidia-rotating",
+                "base_url": "https://integrate.api.nvidia.com/v1",
+                "api_key": "sk-primary",
+                "key_env": "NVIDIA_KEY_1",
+                "extra_keys_env": ["NVIDIA_KEY_2", "", "NVIDIA_KEY_DUP"],
+            },
+        ],
+    }))
+
+    from agent.credential_pool import _seed_custom_pool, get_custom_provider_pool_key
+    pool_key = get_custom_provider_pool_key("https://integrate.api.nvidia.com/v1")
+
+    entries = []
+    changed, active = _seed_custom_pool(pool_key, entries)
+
+    assert changed is True
+    assert {entry.source for entry in entries} == {
+        "config:nvidia-rotating",
+        "env:NVIDIA_KEY_1",
+        "env:NVIDIA_KEY_2",
+    }
+    assert {entry.access_token for entry in entries} == {
+        "sk-primary",
+        "sk-one",
+        "sk-two",
+    }
+    assert active == {entry.source for entry in entries}
+
+
 def test_credential_sources_registry_has_expected_steps():
     """Sanity check — the registry contains the expected RemovalSteps.
 


### PR DESCRIPTION
## Summary
- preserve custom provider config:<name> seeding while adding key_env and extra_keys_env entries to the same credential pool
- deduplicate duplicate env names/tokens and keep env-seeded custom pool entries from being pruned by processes missing the env
- accept extra_keys_env / extraKeysEnv in custom provider config normalization

## Tests
- uv run --project C:\Users\chris\Documents\Codex\2026-07-06\he\work\hermes-agent-custom-extra-keys --extra dev pytest tests/hermes_cli/test_auth_commands.py::test_seed_custom_pool_respects_config_suppression tests/hermes_cli/test_auth_commands.py::test_seed_custom_pool_uses_extra_env_keys tests/agent/test_credential_pool.py -q
- uv run --project C:\Users\chris\Documents\Codex\2026-07-06\he\work\hermes-agent-custom-extra-keys --extra dev pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_model_switch_custom_providers.py tests/gateway/test_session_model_override_routing.py -k "api_key_env_normalizes or valid_fields_set_lists_key_env or named_custom_provider_uses_key_env_from_providers_dict or named_custom_provider_same_url_uses_matching_key_env_and_api_mode or resolve_custom_provider_passes_key_env or resolve_custom_provider_bare_custom_self_heal_passes_key_env or gateway_auth_fallback_resolves_key_env_for_custom_provider" -q
