### PR TITLE
fix(memory): check for existing content on ambiguous replace to prevent duplicate add (#60089)

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -418,6 +418,17 @@ class MemoryStore:
                 # If all matches are identical (exact duplicates), operate on the first one
                 unique_texts = {e for _, e in matches}
                 if len(unique_texts) > 1:
+                    # Check if new_content already exists verbatim among matched entries
+                    if any(e == new_content for _, e in matches):
+                        return {
+                            "success": False,
+                            "error": (
+                                f"'new_content' already exists verbatim among the matched entries. "
+                                f"Use 'remove' to delete stale entries, then try 'add' instead, or include "
+                                f"more identifying text in 'old_text' to disambiguate."
+                            ),
+                            "matches": self._previews([e for _, e in matches]),
+                        }
                     previews = self._previews([e for _, e in matches])
                     return {
                         "success": False,


### PR DESCRIPTION
## Summary

When `MemoryStore.replace()` matches multiple entries, the model falls back to `add()`, which creates a duplicate if the content differs even trivially. The model never gets a signal that the fact it wanted to record already exists.

## Fix

When multiple entries match `old_text` and one of them already contains the exact `new_content`, the method now returns a clear message: `"'new_content' already exists verbatim among the matched entries."` This prevents the model from falling into the `replace → ambiguous → add → duplicate` trap.

## Files Changed

| File | Δ |
|------|---|
| `tools/memory_tool.py` | +11 lines |

Closes #60089