### PR TITLE
fix(auth): recover missing Nous access token from shared store before raising (#60035)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5566,8 +5566,19 @@ def resolve_nous_runtime_credentials(
             refresh_token = state.get("refresh_token")
 
             if not isinstance(access_token, str) or not access_token:
-                raise AuthError("No access token found for Nous Portal login.",
-                                provider="nous", relogin_required=True)
+                # Attempt recovery from shared store before giving up
+                with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
+                    if _merge_shared_nous_oauth_state(state):
+                        access_token = state.get("access_token")
+                        refresh_token = state.get("refresh_token")
+                        _persist_state("runtime_shared_merge_on_empty_token")
+
+            if not isinstance(access_token, str) or not access_token:
+                raise AuthError(
+                    "No access token found for Nous Portal login.",
+                    provider="nous",
+                    relogin_required=True,
+                )
 
             invoke_jwt_status = _nous_invoke_jwt_status(
                 access_token,


### PR DESCRIPTION
## Summary

When a profile's local `auth.json` has `providers.nous.access_token = None` but the shared Nous OAuth store holds a valid token, `resolve_nous_runtime_credentials()` raised `AuthError` before checking the shared store — causing a partial fleet outage on multi-profile deployments.

`resolve_nous_access_token()` (sibling function) already merges the shared store first and succeeds. The runtime path didn't.

## Fix

Added a shared-store recovery block before the `AuthError` raise that calls `_merge_shared_nous_oauth_state(state)` to pull the token from the shared store, matching the pattern in `resolve_nous_access_token()`.

## Files Changed

| File | Δ |
|------|---|
| `hermes_cli/auth.py` | +13/-2 lines |

Closes #60035