### PR TITLE
fix(mcp): move t.cancel() inside try block to prevent RuntimeError on exit (#60197)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1837,10 +1837,12 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
-                    except (asyncio.CancelledError, Exception):
+                    except (asyncio.CancelledError, RuntimeError):
+                        pass
+                    except Exception:
                         pass
 
         if self._shutdown_event.is_set():
@@ -1881,10 +1883,12 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
-                    except (asyncio.CancelledError, Exception):
+                    except (asyncio.CancelledError, RuntimeError):
+                        pass
+                    except Exception:
                         pass
         if self._shutdown_event.is_set():
             return "shutdown"


### PR DESCRIPTION
Fix RuntimeError when /exit is called with MCP tasks running. Moved t.cancel() inside try block at both cleanup locations. Closes #60197