### PR TITLE
fix(weixin): add force_close to TCPConnector to mitigate aiohttp pool poisoning (#60025)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -123,6 +123,10 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     When ``certifi`` is installed, use its Mozilla CA bundle to guarantee
     verification. Otherwise fall back to aiohttp's default (which honors
     ``SSL_CERT_FILE`` env var via ``trust_env=True``).
+
+    ``force_close=True`` prevents the aiohttp 3.14.x connection pool regression
+    (aio-libs/aiohttp#12795) where stale keep-alive connections are handed out
+    to new requests, causing immediate ~2ms read timeouts (#60025).
     """
     try:
         import ssl
@@ -132,7 +136,7 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     if not AIOHTTP_AVAILABLE:
         return None
     ssl_ctx = ssl.create_default_context(cafile=certifi.where())
-    return aiohttp.TCPConnector(ssl=ssl_ctx)
+    return aiohttp.TCPConnector(ssl=ssl_ctx, force_close=True)
 
 ITEM_TEXT = 1
 ITEM_IMAGE = 2


### PR DESCRIPTION
## Problem
The aiohttp 3.14.x connection pool regression (aio-libs/aiohttp#12795) switched from LIFO to FIFO ordering, which amplifies stale keep-alive connection reuse. When the iLink server closes idle connections (server-side FIN after ~2-3 minutes), the stale connection remains in aiohttp's pool and gets handed out to the next request, causing an immediate ~2ms read timeout.

The upstream fix (PR #12798) was merged to main on 2026-06-04 but is not yet included in any aiohttp release — the current pin is 3.14.1 (tagged 2026-06-07 from a different branch).

## Fix
Adds `force_close=True` to the `TCPConnector` in `_make_ssl_connector()`. This prevents connections from being returned to the keep-alive pool after each request, eliminating stale connection reuse entirely.

Fixes #60025