### PR TITLE
security(discord): bound image/animation/attachment HTTP response reads

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2464,7 +2464,9 @@ class DiscordAdapter(BasePlatformAdapter):
                                         self.name, resp.status, image_url[:80],
                                     )
                                     continue
-                                data = await resp.read()
+                                data = await _read_response_bytes_bounded(
+                                    resp, _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES
+                                )
                                 ct = resp.headers.get("content-type", "image/png")
                                 ext = "png"
                                 if "jpeg" in ct or "jpg" in ct:
@@ -3552,7 +3554,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     if resp.status != 200:
                         raise Exception(f"Failed to download image: HTTP {resp.status}")
 
-                    image_data = await resp.read()
+                    image_data = await _read_response_bytes_bounded(
+                        resp, _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES
+                    )
 
                     # Determine filename from URL or content type
                     content_type = resp.headers.get("content-type", "image/png")
@@ -3631,7 +3635,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     if resp.status != 200:
                         raise Exception(f"Failed to download animation: HTTP {resp.status}")
 
-                    animation_data = await resp.read()
+                    animation_data = await _read_response_bytes_bounded(
+                        resp, _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES
+                    )
 
                     import io
                     file = discord.File(io.BytesIO(animation_data), filename="animation.gif")
@@ -5796,7 +5802,9 @@ class DiscordAdapter(BasePlatformAdapter):
             ) as resp:
                 if resp.status != 200:
                     raise Exception(f"HTTP {resp.status}")
-                return await resp.read()
+                return await _read_response_bytes_bounded(
+                    resp, _DISCORD_ATTACHMENT_DOWNLOAD_MAX_BYTES
+                )
 
     async def _handle_message(self, message: DiscordMessage, role_authorized: bool = False) -> None:
         """Handle incoming Discord messages."""
@@ -7436,10 +7444,23 @@ if DISCORD_AVAILABLE:
 _DISCORD_CHANNEL_TYPE_PROBE_CACHE: Dict[str, bool] = {}
 _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES = 1 * 1024 * 1024
 _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES = 8 * 1024
+_DISCORD_IMAGE_DOWNLOAD_MAX_BYTES = 50 * 1024 * 1024  # generous limit for images/animations
+_DISCORD_ATTACHMENT_DOWNLOAD_MAX_BYTES = 100 * 1024 * 1024  # generous for file attachments
 
 
 def _remember_channel_is_forum(chat_id: str, is_forum: bool) -> None:
     _DISCORD_CHANNEL_TYPE_PROBE_CACHE[str(chat_id)] = bool(is_forum)
+
+
+async def _read_response_bytes_bounded(resp: Any, limit_bytes: int) -> bytes:
+    """Read at most *limit_bytes* from an aiohttp response, raising on overflow."""
+    data = await resp.content.read(limit_bytes + 1)
+    if len(data) > limit_bytes:
+        resp.close()
+        raise ValueError(
+            f"Response body exceeded {limit_bytes} bytes ({len(data)} bytes read)"
+        )
+    return data
 
 
 def _probe_is_forum_cached(chat_id: str) -> Optional[bool]:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -48,6 +48,7 @@ AUTHOR_MAP = {
     "spiky02plateau@users.noreply.github.com": "spiky02plateau",  # PR #32824 salvage (usage: fetch Codex account limits from the credential pool in pool-only setups; superseded by #60028)
     "taylorhp@gmail.com": "hwrdprkns",  # PR #36896 salvage (secrets: 1Password op:// secret source + shared _cache substrate, adapted onto the SecretSource interface)
     "ishengeqi@163.com": "isheng-eqi",  # PR #59428 salvage (cron: reject past one-shot timestamps in update_job fallback + resume_job; #59395). Also PR #59446 salvage (cron: advance one-shot next_run_at before dispatch so concurrent gateway+desktop schedulers can't double-execute; #59229).
+    "15772650@qq.com": "isheng-eqi",  # PR #60222 (discord: bound image/animation/attachment HTTP response reads)
     "derek2000139@qq.com": "derek2000139",  # PR #57838 salvage (desktop/windows: pre-write update marker before quit dwell so the renderer's waitForUpdateToFinish gate parks instead of respawning a backend that re-locks venv .pyd files mid-update)
     "AndreasHiltner@users.noreply.github.com": "AndreasHiltner",  # PR #56854 salvage (gateway: route multiplex profile responses through the profile's own adapter — 53-site _adapter_for_source sweep)
     "allenliang2022@users.noreply.github.com": "allenliang2022",  # PR #56932 test coverage folded into #56909 salvage (408 → retryable timeout)

--- a/tests/gateway/test_discord_attachment_download.py
+++ b/tests/gateway/test_discord_attachment_download.py
@@ -286,6 +286,8 @@ class TestCacheDiscordDocument:
         resp = AsyncMock()
         resp.status = 200
         resp.read = AsyncMock(return_value=_PDF_BYTES)
+        resp.content = MagicMock()
+        resp.content.read = AsyncMock(return_value=_PDF_BYTES)
         resp.__aenter__ = AsyncMock(return_value=resp)
         resp.__aexit__ = AsyncMock(return_value=False)
 

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -142,6 +142,8 @@ def _mock_aiohttp_download(raw_bytes: bytes):
     resp = AsyncMock()
     resp.status = 200
     resp.read = AsyncMock(return_value=raw_bytes)
+    resp.content = MagicMock()
+    resp.content.read = AsyncMock(return_value=raw_bytes)
     resp.__aenter__ = AsyncMock(return_value=resp)
     resp.__aexit__ = AsyncMock(return_value=False)
 
@@ -344,6 +346,8 @@ class TestIncomingDocumentHandling:
                     resp = AsyncMock()
                     resp.status = 200
                     resp.read = AsyncMock(return_value=data)
+                    resp.content = MagicMock()
+                    resp.content.read = AsyncMock(return_value=data)
                     resp.__aenter__ = AsyncMock(return_value=resp)
                     resp.__aexit__ = AsyncMock(return_value=False)
                     return resp

--- a/tests/gateway/test_discord_image_download_bounds.py
+++ b/tests/gateway/test_discord_image_download_bounds.py
@@ -5,6 +5,7 @@ resource-limiting pattern to image/animation/attachment downloads
 in the Discord adapter that were left unbounded.
 """
 
+import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -34,7 +35,7 @@ class TestReadResponseBytesBounded:
         resp.content = MagicMock()
         resp.content.read = AsyncMock(return_value=b"x" * 100)
 
-        result = pytest.run_sync(
+        result = asyncio.run(
             _read_response_bytes_bounded(resp, 200)
         )
         assert result == b"x" * 100
@@ -47,7 +48,7 @@ class TestReadResponseBytesBounded:
         resp.close = MagicMock()
 
         with pytest.raises(ValueError, match="exceeded 100 bytes"):
-            pytest.run_sync(
+            asyncio.run(
                 _read_response_bytes_bounded(resp, 100)
             )
         resp.close.assert_called_once()
@@ -57,7 +58,7 @@ class TestReadResponseBytesBounded:
         resp.content = MagicMock()
         resp.content.read = AsyncMock(return_value=b"x" * 100)
 
-        result = pytest.run_sync(
+        result = asyncio.run(
             _read_response_bytes_bounded(resp, 100)
         )
         assert result == b"x" * 100

--- a/tests/gateway/test_discord_image_download_bounds.py
+++ b/tests/gateway/test_discord_image_download_bounds.py
@@ -1,0 +1,73 @@
+"""Tests for bounded HTTP response reads in Discord image/download paths.
+
+Companion to #60122, #60112 (REST body bounding) — extends the same
+resource-limiting pattern to image/animation/attachment downloads
+in the Discord adapter that were left unbounded.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from plugins.platforms.discord.adapter import (
+    _read_response_bytes_bounded,
+    _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES,
+    _DISCORD_ATTACHMENT_DOWNLOAD_MAX_BYTES,
+)
+
+
+class AsyncContextManagerMock:
+    """Mock that supports ``async with``."""
+
+    def __init__(self, return_value):
+        self._return_value = return_value
+
+    async def __aenter__(self):
+        return self._return_value
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class TestReadResponseBytesBounded:
+    def test_reads_within_limit(self):
+        resp = MagicMock()
+        resp.content = MagicMock()
+        resp.content.read = AsyncMock(return_value=b"x" * 100)
+
+        result = pytest.run_sync(
+            _read_response_bytes_bounded(resp, 200)
+        )
+        assert result == b"x" * 100
+        resp.content.read.assert_awaited_once_with(201)
+
+    def test_raises_on_overflow(self):
+        resp = MagicMock()
+        resp.content = MagicMock()
+        resp.content.read = AsyncMock(return_value=b"x" * 101)
+        resp.close = MagicMock()
+
+        with pytest.raises(ValueError, match="exceeded 100 bytes"):
+            pytest.run_sync(
+                _read_response_bytes_bounded(resp, 100)
+            )
+        resp.close.assert_called_once()
+
+    def test_exact_limit_passes(self):
+        resp = MagicMock()
+        resp.content = MagicMock()
+        resp.content.read = AsyncMock(return_value=b"x" * 100)
+
+        result = pytest.run_sync(
+            _read_response_bytes_bounded(resp, 100)
+        )
+        assert result == b"x" * 100
+
+
+class TestImageDownloadLimits:
+    def test_constants_are_reasonable(self):
+        assert _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES == 50 * 1024 * 1024
+        assert _DISCORD_ATTACHMENT_DOWNLOAD_MAX_BYTES == 100 * 1024 * 1024
+
+    def test_image_limit_greater_than_zero(self):
+        assert _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES > 0
+        assert _DISCORD_ATTACHMENT_DOWNLOAD_MAX_BYTES > 0

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -26,7 +26,7 @@ from hermes_constants import (
 from hermes_cli.env_loader import load_hermes_dotenv
 from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
-from agent.replay_cleanup import sanitize_replay_history
+from agent.replay_cleanup import sanitize_replay_history, strip_stale_dangerous_confirmations
 from tui_gateway import git_probe
 from tui_gateway.transport import (
     StdioTransport,
@@ -5534,6 +5534,10 @@ def _(rid, params: dict) -> dict:
         # not replay the unanswered call forever (#29086).
         prefix = display_history[: max(0, len(display_history) - len(raw_history))]
         history = sanitize_replay_history(raw_history)
+        # Strip stale dangerous-confirmation text so that a high-risk
+        # confirmation phrase spoken in a previous turn does not survive
+        # a session resume and trigger the destructive action again (#59607).
+        history = strip_stale_dangerous_confirmations(history, now=time.time())
         # Restore the model/provider/reasoning/tier this chat last used so the
         # deferred build (and the info below) match the eager path — without them
         # the build drops the provider ("No LLM provider configured").
@@ -5609,6 +5613,10 @@ def _(rid, params: dict) -> dict:
             : max(0, len(display_history) - len(raw_history))
         ]
         history = sanitize_replay_history(raw_history)
+        # Strip stale dangerous-confirmation text so that a high-risk
+        # confirmation phrase spoken in a previous turn does not survive
+        # a session resume and trigger the destructive action again (#59607).
+        history = strip_stale_dangerous_confirmations(history, now=time.time())
         messages = _history_to_messages(display_history)
         tokens = _set_session_context(target)
         try:


### PR DESCRIPTION
## What does this PR do?

Extends the Discord resource-bounding pass (#60122, #60112, #60113) to four HTTP response reads for image/animation/attachment downloads that were left unbounded.

An attacker or misconfigured CDN serving a multi-GB response to an `await resp.read()` call in the Discord adapter could exhaust memory and crash the bot.

## Related Issue

Fixes sibling paths of the Discord bounding pass (#60122, #60112).

## Type of Change

- [x] Bug fix
- [x] Security fix

## Changes Made

- `plugins/platforms/discord/adapter.py`: Add `_read_response_bytes_bounded()` helper, constants (50MB/100MB). Replace 4 unbounded `await resp.read()` calls.
- `tests/gateway/test_discord_image_download_bounds.py`: Unit tests