### PR TITLE
fix(gateway): gate the no-home-channel onboarding notice

### DIFF
--- a/agent/onboarding.py
+++ b/agent/onboarding.py
@@ -27,6 +27,7 @@ BUSY_INPUT_FLAG = "busy_input_prompt"
 TOOL_PROGRESS_FLAG = "tool_progress_prompt"
 OPENCLAW_RESIDUE_FLAG = "openclaw_residue_cleanup"
 PROFILE_BUILD_FLAG = "profile_build_offered"
+SETHOME_NOTICE_FLAG_PREFIX = "sethome_notice"  # per-platform: sethome_notice_<platform>
 
 
 # -------------------------------------------------------------------------
@@ -184,6 +185,56 @@ def profile_build_directive() -> str:
 
 
 # -------------------------------------------------------------------------
+# Sethome-notice gate (the "📬 No home channel is set…" prompt)
+# -------------------------------------------------------------------------
+
+def sethome_notice_mode(config: Mapping[str, Any]) -> str:
+    """Resolve how the no-home-channel onboarding notice is shown.
+
+    Returns one of:
+      ``"once"``   — show at most once per platform per install (default).
+      ``"always"`` — legacy behavior: show in every chat with empty history.
+      ``"off"``    — never show.
+
+    Read from ``config.onboarding.sethome_notice``. The default is "once"
+    because on multi-user deployments (one bot, many DM chats) the legacy
+    per-chat behavior surfaced a staff-facing setup prompt to end users in
+    every fresh chat until someone set the home channel.
+    """
+    if not isinstance(config, Mapping):
+        return "once"
+    onboarding = config.get("onboarding")
+    if not isinstance(onboarding, Mapping):
+        return "once"
+    mode = onboarding.get("sethome_notice")
+    if isinstance(mode, str) and mode.strip().lower() in ("off", "always"):
+        return mode.strip().lower()
+    return "once"
+
+
+def sethome_notice_gate(
+    config: Mapping[str, Any], platform_name: str
+) -> tuple[bool, Optional[str]]:
+    """Decide whether to show the no-home-channel notice for a platform.
+
+    Returns ``(show, mark_flag)``. ``mark_flag`` is the seen-flag the caller
+    must persist via :func:`mark_seen` after actually delivering the notice —
+    it is only set in "once" mode; "always" never persists (and never
+    suppresses). The caller remains responsible for the cheap checks (home
+    env var unset, platform is real, chat history empty).
+    """
+    mode = sethome_notice_mode(config)
+    if mode == "off":
+        return False, None
+    flag = f"{SETHOME_NOTICE_FLAG_PREFIX}_{platform_name}"
+    if mode == "once":
+        if is_seen(config, flag):
+            return False, None
+        return True, flag
+    return True, None  # mode == "always"
+
+
+# -------------------------------------------------------------------------
 # State read / write
 # -------------------------------------------------------------------------
 
@@ -240,6 +291,7 @@ __all__ = [
     "TOOL_PROGRESS_FLAG",
     "OPENCLAW_RESIDUE_FLAG",
     "PROFILE_BUILD_FLAG",
+    "SETHOME_NOTICE_FLAG_PREFIX",
     "busy_input_hint_gateway",
     "busy_input_hint_cli",
     "tool_progress_hint_gateway",
@@ -248,6 +300,8 @@ __all__ = [
     "detect_openclaw_residue",
     "profile_build_mode",
     "profile_build_directive",
+    "sethome_notice_mode",
+    "sethome_notice_gate",
     "is_seen",
     "mark_seen",
 ]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10015,28 +10015,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 context_prompt += _intro_note
         
-        # One-time prompt if no home channel is set for this platform
+        # Prompt if no home channel is set for this platform. Gated by
+        # onboarding.sethome_notice ("once" default / "always" / "off") — on
+        # multi-user deployments the ungated prompt leaked a staff-facing
+        # setup message into every fresh end-user chat.
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
             if not os.getenv(env_key):
-                # Slack dispatches all Hermes commands through a single
-                # parent slash command `/hermes`; bare `/sethome` is not
-                # registered and would fail with "app did not respond".
-                sethome_cmd = (
-                    "/hermes sethome"
-                    if source.platform == Platform.SLACK
-                    else "/sethome"
-                )
-                notice = (
-                    f"📬 No home channel is set for {platform_name.title()}. "
-                    f"A home channel is where Hermes delivers cron job results "
-                    f"and cross-platform messages.\n\n"
-                    f"Type {sethome_cmd} to make this chat your home channel, "
-                    f"or ignore to skip."
-                )
-                await self._deliver_platform_notice(source, notice)
+                try:
+                    from agent.onboarding import mark_seen, sethome_notice_gate
+
+                    _show_notice, _notice_flag = sethome_notice_gate(
+                        _load_gateway_config(), platform_name
+                    )
+                except Exception as _sh_err:
+                    # Fail closed: suppressing an onboarding hint is strictly
+                    # safer than re-spamming it into customer-facing chats.
+                    logger.debug("sethome-notice gate failed, skipping: %s", _sh_err)
+                    _show_notice, _notice_flag = False, None
+                if _show_notice:
+                    # Slack dispatches all Hermes commands through a single
+                    # parent slash command `/hermes`; bare `/sethome` is not
+                    # registered and would fail with "app did not respond".
+                    sethome_cmd = (
+                        "/hermes sethome"
+                        if source.platform == Platform.SLACK
+                        else "/sethome"
+                    )
+                    notice = (
+                        f"📬 No home channel is set for {platform_name.title()}. "
+                        f"A home channel is where Hermes delivers cron job results "
+                        f"and cross-platform messages.\n\n"
+                        f"Type {sethome_cmd} to make this chat your home channel, "
+                        f"or ignore to skip."
+                    )
+                    await self._deliver_platform_notice(source, notice)
+                    if _notice_flag:
+                        mark_seen(_hermes_home / "config.yaml", _notice_flag)
         
         # -----------------------------------------------------------------
         # Voice channel awareness — inject current voice channel state

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2798,6 +2798,12 @@ DEFAULT_CONFIG = {
         # reads connected accounts silently). "off" -> plain intro only.
         # The offer fires at most once (latched under onboarding.seen).
         "profile_build": "ask",
+        # "📬 No home channel is set…" prompt shown when a platform has no
+        # home-target env var. "once" (default) -> at most once per platform
+        # per install (latched under onboarding.seen.sethome_notice_<platform>).
+        # "always" -> legacy per-empty-chat behavior. "off" -> never show
+        # (recommended for multi-user / customer-facing deployments).
+        "sethome_notice": "once",
     },
 
     # ``hermes update`` behaviour.

--- a/tests/agent/test_onboarding.py
+++ b/tests/agent/test_onboarding.py
@@ -309,3 +309,94 @@ class TestProfileBuildConfigDefault:
         from hermes_cli.config import DEFAULT_CONFIG
 
         assert DEFAULT_CONFIG["onboarding"]["profile_build"] == "ask"
+
+
+class TestSethomeNoticeGate:
+    """Gate for the '📬 No home channel is set…' onboarding notice.
+
+    Incident 2026-07-07 (multi-user Feishu deployment): the notice fired in
+    every chat whose session history was empty, so end users/customers kept
+    seeing a staff-facing setup prompt. Default mode is now "once" — at most
+    one showing per platform per install.
+    """
+
+    def test_default_mode_is_once(self):
+        from agent.onboarding import sethome_notice_mode
+
+        assert sethome_notice_mode({}) == "once"
+        assert sethome_notice_mode({"onboarding": {}}) == "once"
+        assert sethome_notice_mode({"onboarding": {"sethome_notice": "once"}}) == "once"
+
+    def test_off_and_always_modes(self):
+        from agent.onboarding import sethome_notice_mode
+
+        assert sethome_notice_mode({"onboarding": {"sethome_notice": "off"}}) == "off"
+        assert sethome_notice_mode({"onboarding": {"sethome_notice": "OFF"}}) == "off"
+        assert sethome_notice_mode({"onboarding": {"sethome_notice": "always"}}) == "always"
+
+    def test_unknown_value_falls_back_to_once(self):
+        from agent.onboarding import sethome_notice_mode
+
+        assert sethome_notice_mode({"onboarding": {"sethome_notice": "banana"}}) == "once"
+        assert sethome_notice_mode("not a dict") == "once"  # type: ignore[arg-type]
+
+    def test_gate_once_shows_then_marks(self):
+        from agent.onboarding import sethome_notice_gate
+
+        show, flag = sethome_notice_gate({}, "feishu")
+        assert show is True
+        assert flag == "sethome_notice_feishu"
+
+    def test_gate_once_suppresses_after_seen(self):
+        from agent.onboarding import sethome_notice_gate
+
+        cfg = {"onboarding": {"seen": {"sethome_notice_feishu": True}}}
+        show, flag = sethome_notice_gate(cfg, "feishu")
+        assert show is False
+        assert flag is None
+        # Other platforms are independent.
+        show, flag = sethome_notice_gate(cfg, "telegram")
+        assert show is True
+        assert flag == "sethome_notice_telegram"
+
+    def test_gate_off_never_shows(self):
+        from agent.onboarding import sethome_notice_gate
+
+        show, flag = sethome_notice_gate(
+            {"onboarding": {"sethome_notice": "off"}}, "feishu"
+        )
+        assert show is False
+        assert flag is None
+
+    def test_gate_always_shows_without_marking(self):
+        from agent.onboarding import sethome_notice_gate
+
+        cfg = {
+            "onboarding": {
+                "sethome_notice": "always",
+                "seen": {"sethome_notice_feishu": True},
+            }
+        }
+        show, flag = sethome_notice_gate(cfg, "feishu")
+        assert show is True
+        assert flag is None  # legacy mode: never persist, never suppress
+
+    def test_gate_roundtrip_with_mark_seen(self, tmp_path):
+        import yaml
+
+        from agent.onboarding import mark_seen, sethome_notice_gate
+
+        cfg_path = tmp_path / "config.yaml"
+        show, flag = sethome_notice_gate({}, "feishu")
+        assert show and flag
+        assert mark_seen(cfg_path, flag) is True
+        loaded = yaml.safe_load(cfg_path.read_text())
+        show, flag = sethome_notice_gate(loaded, "feishu")
+        assert show is False and flag is None
+
+
+class TestSethomeNoticeConfigDefault:
+    def test_default_config_carries_once(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["onboarding"]["sethome_notice"] == "once"


### PR DESCRIPTION
## Problem

The "📬 No home channel is set…" prompt fires in **every chat whose session history is empty** whenever the platform's home-target env var is unset. Two issues:

1. **Multi-user deployments leak a staff-facing setup prompt to end users.** With one bot serving many DM chats (e.g. a Feishu tenant), every user's first message gets the `/sethome` onboarding notice — we hit this in a customer-facing deployment where the notice was delivered mid-answer to a customer. Any user who follows the prompt also silently claims the *global* home channel for the whole install.
2. **It can re-fire indefinitely in the same chat.** Chats whose turns are answered upstream (deterministic fast paths that never reach the agent loop) accrue no gateway history, so `not history` stays true forever.

## Fix

New config key `onboarding.sethome_notice`:

| value | behavior |
|---|---|
| `once` *(new default)* | show at most once per platform per install, latched under `onboarding.seen.sethome_notice_<platform>` |
| `always` | legacy per-empty-chat behavior |
| `off` | never show (recommended for multi-user / customer-facing deployments) |

The gate decision lives in `agent/onboarding.py` (`sethome_notice_mode` / `sethome_notice_gate`), mirroring the existing `profile_build` config + seen-flag pattern. The gateway block fails **closed** — if the gate machinery errors, the notice is suppressed rather than re-spammed. Key documented in `DEFAULT_CONFIG`.

## Testing

- 9 new tests in `tests/agent/test_onboarding.py` (mode resolution, per-platform latching, `always`/`off` semantics, `mark_seen` roundtrip) — written first, watched fail, then implementation; 51/51 pass.
- `tests/gateway/test_notice_delivery.py` + `test_notice_rendering.py` pass (63 total with onboarding).
- Full `tests/gateway/` sweep: 7,113 passed; remaining failures (wecom callback, telegram picker/ws-retry flakes) reproduce identically on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
