### PR TITLE
feat(agent): store image file path in session messages for follow-up re-analysis (#60038)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -529,6 +529,7 @@ def run_conversation(
     stream_callback: Optional[callable] = None,
     persist_user_message: Optional[str] = None,
     persist_user_timestamp: Optional[float] = None,
+    attachments: Optional[List[str]] = None,
     moa_config: Optional[dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
@@ -582,6 +583,7 @@ def run_conversation(
         stream_callback,
         persist_user_message,
         persist_user_timestamp,
+        attachments=attachments,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
         install_safe_stdio=_install_safe_stdio,
         sanitize_surrogates=_sanitize_surrogates,

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -673,7 +673,7 @@ def build_native_content_parts(
     user_text: str,
     image_paths: List[str],
     image_urls: Optional[List[str]] = None,
-) -> Tuple[List[Dict[str, Any]], List[str]]:
+) -> Tuple[List[Dict[str, Any]], List[str], List[str]]:
     """Build an OpenAI-style ``content`` list for a user turn.
 
     Shape:
@@ -703,9 +703,10 @@ def build_native_content_parts(
     ceiling), the agent's retry loop transparently shrinks and retries
     once — see ``run_agent._try_shrink_image_parts_in_messages``.
 
-    Returns (content_parts, skipped). Skipped entries are local paths
-    that couldn't be read from disk; URLs are never skipped (they're
-    not validated here).
+    Returns (content_parts, skipped, attachments). Skipped entries are local
+    paths that couldn't be read from disk; URLs are never skipped (they're
+    not validated here). Attachments are the successfully resolved local
+    file paths, stored for follow-up re-analysis.
     """
     skipped: List[str] = []
     image_parts: List[Dict[str, Any]] = []
@@ -749,13 +750,13 @@ def build_native_content_parts(
         combined_text = f"{base_text}\n\n" + "\n".join(hint_lines)
         parts: List[Dict[str, Any]] = [{"type": "text", "text": combined_text}]
         parts.extend(image_parts)
-        return parts, skipped
+        return parts, skipped, attached_paths
 
     # No images successfully attached — fall back to plain text-only behaviour.
     parts = []
     if text:
         parts.append({"type": "text", "text": text})
-    return parts, skipped
+    return parts, skipped, []
 
 
 __all__ = [

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -125,6 +125,7 @@ def build_turn_context(
     stream_callback,
     persist_user_message: Optional[str],
     persist_user_timestamp: Optional[float] = None,
+    attachments: Optional[List[str]] = None,
     *,
     restore_or_build_system_prompt,
     install_safe_stdio,
@@ -315,6 +316,8 @@ def build_turn_context(
 
     # Add user message.
     user_msg = {"role": "user", "content": user_message}
+    if attachments:
+        user_msg["attachments"] = attachments
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx

--- a/cli.py
+++ b/cli.py
@@ -12061,7 +12061,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 try:
                     _text_for_parts = message if isinstance(message, str) else ""
                     _img_str_paths = [str(p) for p in images]
-                    _parts, _skipped = build_native_content_parts(
+                    _parts, _skipped, _ = build_native_content_parts(
                         _text_for_parts,
                         _img_str_paths,
                     )
@@ -16027,7 +16027,7 @@ def main(
 
                         if _img_mode == "native" and _build_parts is not None:
                             try:
-                                _parts, _skipped = _build_parts(
+                                _parts, _skipped, _ = _build_parts(
                                     query if isinstance(query, str) else "",
                                     [str(p) for p in single_query_images],
                                     image_urls=list(single_query_image_urls) or None,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18516,7 +18516,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _native_imgs:
                     try:
                         from agent.image_routing import build_native_content_parts
-                        _parts, _skipped = build_native_content_parts(
+                        _parts, _skipped, _attachments = build_native_content_parts(
                             message,
                             _native_imgs,
                         )
@@ -18530,14 +18530,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         else:
                             # All images failed to read — fall back to plain text.
                             _run_message = message
+                            _attachments = []
                     except Exception as _img_exc:
                         logger.warning(
                             "Native image attachment failed, falling back to text: %s",
                             _img_exc,
                         )
                         _run_message = message
+                        _attachments = []
                 else:
                     _run_message = message
+                    _attachments = []
 
                 _api_run_message = _wrap_current_message_with_observed_context(
                     _run_message,
@@ -18547,6 +18550,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "conversation_history": agent_history,
                     "task_id": session_id,
                 }
+                if _attachments:
+                    _conversation_kwargs["attachments"] = _attachments
                 if _persist_user_message_override is not None:
                     _conversation_kwargs["persist_user_message"] = _persist_user_message_override
                 elif observed_group_context:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2280,6 +2280,7 @@ class SessionStore:
                         message.get("platform_message_id") or message.get("message_id")
                     ),
                     observed=bool(message.get("observed")),
+                    attachments=message.get("attachments"),
                     timestamp=message.get("timestamp"),
                 )
             except Exception as e:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -763,6 +763,7 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_message_items TEXT,
     platform_message_id TEXT,
     observed INTEGER DEFAULT 0,
+    attachments TEXT,
     active INTEGER NOT NULL DEFAULT 1,
     compacted INTEGER NOT NULL DEFAULT 0
 );
@@ -3420,6 +3421,7 @@ class SessionDB:
         codex_message_items: Any = None,
         platform_message_id: str = None,
         observed: bool = False,
+        attachments: Any = None,
         timestamp: Any = None,
     ) -> int:
         """
@@ -3448,6 +3450,7 @@ class SessionDB:
             if codex_message_items else None
         )
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+        attachments_json = json.dumps(attachments) if attachments else None
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
         stored_content = self._encode_content(content)
@@ -3472,8 +3475,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, attachments, active)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -3491,6 +3494,7 @@ class SessionDB:
                     codex_message_items_json,
                     platform_message_id,
                     1 if observed else 0,
+                    attachments_json,
                     1,
                 ),
             )
@@ -3554,6 +3558,9 @@ class SessionDB:
                 json.dumps(codex_message_items) if codex_message_items else None
             )
             tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+            attachments_json = (
+                json.dumps(msg.get("attachments")) if msg.get("attachments") else None
+            )
             # Accept either `platform_message_id` (new explicit name) or
             # `message_id` (yuanbao's existing convention on message dicts).
             platform_msg_id = (
@@ -3564,8 +3571,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, attachments, active)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -3583,6 +3590,7 @@ class SessionDB:
                     codex_message_items_json,
                     platform_msg_id,
                     1 if msg.get("observed") else 0,
+                    attachments_json,
                     1,
                 ),
             )

--- a/run_agent.py
+++ b/run_agent.py
@@ -1874,6 +1874,7 @@ class AIAgent:
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
                     timestamp=_row_timestamp,
+                    attachments=msg.get("attachments"),
                 )
                 msg[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -370,7 +370,7 @@ class TestBuildNativeContentParts:
     def test_text_then_image(self, tmp_path: Path):
         img = tmp_path / "cat.png"
         img.write_bytes(_png_bytes())
-        parts, skipped = build_native_content_parts("hello", [str(img)])
+        parts, skipped, _ = build_native_content_parts("hello", [str(img)])
         assert skipped == []
         assert len(parts) == 2
         assert parts[0]["type"] == "text"
@@ -384,7 +384,7 @@ class TestBuildNativeContentParts:
     def test_empty_text_inserts_default_prompt(self, tmp_path: Path):
         img = tmp_path / "cat.jpg"
         img.write_bytes(_png_bytes())
-        parts, skipped = build_native_content_parts("", [str(img)])
+        parts, skipped, _ = build_native_content_parts("", [str(img)])
         assert skipped == []
         # Even with empty user text, we insert a neutral prompt so the turn
         # isn't just pixels, and the path hint is appended after.
@@ -395,7 +395,7 @@ class TestBuildNativeContentParts:
         assert parts[1]["type"] == "image_url"
 
     def test_missing_file_is_skipped(self, tmp_path: Path):
-        parts, skipped = build_native_content_parts("hi", [str(tmp_path / "missing.png")])
+        parts, skipped, _ = build_native_content_parts("hi", [str(tmp_path / "missing.png")])
         assert skipped == [str(tmp_path / "missing.png")]
         # Skipped paths are NOT advertised in the path hints — the model
         # would otherwise be told a non-existent file is attached.
@@ -409,7 +409,7 @@ class TestBuildNativeContentParts:
         """
         img = tmp_path / "scan.png"
         img.write_bytes(_png_bytes())
-        parts, _ = build_native_content_parts("attach this", [str(img)])
+        parts, _, _ = build_native_content_parts("attach this", [str(img)])
         text_part = next(p for p in parts if p.get("type") == "text")
         assert "[Image attached at:" in text_part["text"]
         assert str(img) in text_part["text"]
@@ -423,7 +423,7 @@ class TestBuildNativeContentParts:
         good = tmp_path / "good.png"
         good.write_bytes(_png_bytes())
         missing = tmp_path / "missing.png"  # never created
-        parts, skipped = build_native_content_parts(
+        parts, skipped, _ = build_native_content_parts(
             "see attached", [str(good), str(missing)]
         )
         assert skipped == [str(missing)]
@@ -437,7 +437,7 @@ class TestBuildNativeContentParts:
         img2 = tmp_path / "b.png"
         img1.write_bytes(_png_bytes())
         img2.write_bytes(_png_bytes())
-        parts, skipped = build_native_content_parts("compare these", [str(img1), str(img2)])
+        parts, skipped, _ = build_native_content_parts("compare these", [str(img1), str(img2)])
         assert skipped == []
         image_parts = [p for p in parts if p.get("type") == "image_url"]
         assert len(image_parts) == 2
@@ -451,7 +451,7 @@ class TestBuildNativeContentParts:
         # Real JPEG bytes (SOI marker FF D8 FF): sniffing now wins over suffix.
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01" + b"\x00" * 32)
-        parts, _ = build_native_content_parts("x", [str(img)])
+        parts, _, _ = build_native_content_parts("x", [str(img)])
         url = parts[1]["image_url"]["url"]
         assert url.startswith("data:image/jpeg;base64,")
 
@@ -459,7 +459,7 @@ class TestBuildNativeContentParts:
         # Real WEBP bytes (RIFF....WEBP): sniffing now wins over suffix.
         img = tmp_path / "pic.webp"
         img.write_bytes(b"RIFF\x24\x00\x00\x00WEBPVP8 " + b"\x00" * 32)
-        parts, _ = build_native_content_parts("", [str(img)])
+        parts, _, _ = build_native_content_parts("", [str(img)])
         url = parts[1]["image_url"]["url"]
         assert url.startswith("data:image/webp;base64,")
 
@@ -470,7 +470,7 @@ class TestBuildNativeContentParts:
         """
         img = tmp_path / "discord_cached.webp"
         img.write_bytes(_png_bytes())  # bytes are PNG, suffix lies
-        parts, _ = build_native_content_parts("", [str(img)])
+        parts, _, _ = build_native_content_parts("", [str(img)])
         url = parts[1]["image_url"]["url"]
         assert url.startswith("data:image/png;base64,"), (
             f"Expected MIME sniffing to detect PNG bytes regardless of .webp suffix, got: {url[:60]}"
@@ -510,7 +510,7 @@ class TestLargeImageHandling:
 
         img = tmp_path / "cat.png"
         img.write_bytes(_png_bytes())
-        parts, skipped = _ir.build_native_content_parts("hi", [str(img)])
+        parts, skipped, _ = _ir.build_native_content_parts("hi", [str(img)])
         assert skipped == []
         assert len(parts) == 2
         assert parts[0]["type"] == "text"
@@ -647,7 +647,7 @@ class TestBuildNativeContentPartsURLs:
     inbound surfaces) can route remote image URLs straight to the model."""
 
     def test_url_only_no_local_paths(self):
-        parts, skipped = build_native_content_parts(
+        parts, skipped, _ = build_native_content_parts(
             "what is this?",
             [],
             image_urls=["https://example.com/diagram.png"],
@@ -665,7 +665,7 @@ class TestBuildNativeContentPartsURLs:
     def test_mixed_path_and_url(self, tmp_path: Path):
         img = tmp_path / "local.png"
         img.write_bytes(_png_bytes())
-        parts, skipped = build_native_content_parts(
+        parts, skipped, _ = build_native_content_parts(
             "compare these",
             [str(img)],
             image_urls=["https://example.com/remote.jpg"],
@@ -689,7 +689,7 @@ class TestBuildNativeContentPartsURLs:
         assert parts_no_urls == parts_empty_urls
 
     def test_blank_url_strings_are_dropped(self):
-        parts, _ = build_native_content_parts(
+        parts, _, _ = build_native_content_parts(
             "x", [], image_urls=["", "  ", "https://example.com/a.png"]
         )
         image_parts = [p for p in parts if p.get("type") == "image_url"]
@@ -697,7 +697,7 @@ class TestBuildNativeContentPartsURLs:
         assert image_parts[0]["image_url"]["url"] == "https://example.com/a.png"
 
     def test_url_only_inserts_default_prompt_when_text_empty(self):
-        parts, _ = build_native_content_parts(
+        parts, _, _ = build_native_content_parts(
             "", [], image_urls=["https://example.com/a.png"]
         )
         assert parts[0]["type"] == "text"
@@ -795,7 +795,7 @@ class TestFormatCompatibility:
         img_path = tmp_path / ".env.local"
         img_path.write_bytes(_png_bytes())
 
-        parts, skipped = build_native_content_parts("inspect this", [str(img_path)])
+        parts, skipped, _ = build_native_content_parts("inspect this", [str(img_path)])
 
         assert skipped == [str(img_path)]
         assert all(part.get("type") != "image_url" for part in parts)
@@ -813,7 +813,7 @@ class TestFormatCompatibility:
         except (OSError, NotImplementedError) as exc:
             pytest.skip(f"symlinks unavailable: {exc}")
 
-        parts, skipped = build_native_content_parts("inspect this", [str(img_link)])
+        parts, skipped, _ = build_native_content_parts("inspect this", [str(img_link)])
 
         assert skipped == [str(img_link)]
         assert all(part.get("type") != "image_url" for part in parts)

--- a/tests/hermes_cli/test_kanban_worker_image_extraction.py
+++ b/tests/hermes_cli/test_kanban_worker_image_extraction.py
@@ -141,7 +141,7 @@ class TestBuildPartsFromTaskBody:
         # Mirrors the cli.py wiring: pass the worker's literal -q argument
         # (the dispatcher uses ``"work kanban task <id>"``) plus the
         # extracted refs through build_native_content_parts.
-        parts, skipped = build_native_content_parts(
+        parts, skipped, _ = build_native_content_parts(
             f"work kanban task {tid}",
             paths,
             image_urls=urls or None,
@@ -163,7 +163,7 @@ class TestBuildPartsFromTaskBody:
         body = _read_body(tid)
         paths, urls = extract_image_refs(body)
 
-        parts, skipped = build_native_content_parts(
+        parts, skipped, _ = build_native_content_parts(
             f"work kanban task {tid}",
             paths,
             image_urls=urls or None,
@@ -187,7 +187,7 @@ class TestBuildPartsFromTaskBody:
         body = _read_body(tid)
         paths, urls = extract_image_refs(body)
 
-        parts, skipped = build_native_content_parts(
+        parts, skipped, _ = build_native_content_parts(
             f"work kanban task {tid}",
             paths,
             image_urls=urls or None,
@@ -207,7 +207,7 @@ class TestBuildPartsFromTaskBody:
         body = _read_body(tid)
         paths, urls = extract_image_refs(body)
 
-        parts, skipped = build_native_content_parts(
+        parts, skipped, _ = build_native_content_parts(
             f"work kanban task {tid}",
             paths,
             image_urls=urls or None,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8666,7 +8666,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
 
                 if _mode == "native":
                     try:
-                        _parts, _skipped = build_native_content_parts(
+                        _parts, _skipped, _ = build_native_content_parts(
                             prompt,
                             images,
                         )


### PR DESCRIPTION
Image files saved to composer-images/ now store file paths in session message attachments metadata, so the model can use vision_analyze to re-load images on follow-up questions without the user re-sending them.

## Changes
- hermes_state.py: Added attachments TEXT column to messages schema
- image_routing.py: build_native_content_parts() returns attachment paths
- gateway/run.py + session.py: Forward attachments through the pipeline
- conversation_loop.py + turn_context.py: Pass attachments to message builder

Closes #60038