### PR TITLE
fix(web): follow symlinks in fs_list so dir symlinks show as folders

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2026,7 +2026,10 @@ async def fs_list(path: str):
                 entries.append({
                     "name": entry.name,
                     "path": str(target / entry.name),
-                    "isDirectory": entry.is_dir(follow_symlinks=False),
+                    # Follow symlinks so dir-links (e.g. project/windows →
+                    # windows-sync/...) report isDirectory=True. Without this,
+                    # Desktop treats them as files and the sidebar can't expand.
+                    "isDirectory": entry.is_dir(follow_symlinks=True),
                 })
         entries.sort(key=lambda item: (not item["isDirectory"], item["name"].lower(), item["name"]))
         return {"entries": entries}

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -45,6 +45,23 @@ def test_fs_list_sorts_and_hides_noise(client, tmp_path):
     assert all(entry["name"] not in {".git", "node_modules"} for entry in entries)
 
 
+def test_fs_list_follows_symlink_to_directory(client, tmp_path):
+    """A symlink pointing to a directory must report isDirectory=True."""
+    root = tmp_path / "project"
+    root.mkdir()
+    real_dir = tmp_path / "real_dir"
+    real_dir.mkdir()
+    link = root / "link_to_dir"
+    link.symlink_to(real_dir, target_is_directory=True)
+
+    response = client.get("/api/fs/list", params={"path": str(root)})
+
+    assert response.status_code == 200
+    entries = response.json()["entries"]
+    link_entry = next(e for e in entries if e["name"] == "link_to_dir")
+    assert link_entry["isDirectory"] is True
+
+
 def test_fs_list_accepts_relative_paths(client, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "rel").mkdir()


### PR DESCRIPTION
## Bug Description

Desktop file browser treats directory symlinks as files and cannot expand them. Clicking a project symlink (e.g. `windows` → `~/windows-sync/<project>`) tries to open a file preview and fails with:

> **Preview unavailable**
> `Path points to a directory`

Reproduced on remote Desktop (Hermes Desktop → `hermes serve` over Tailscale), where the tree is filled via `GET /api/fs/list`.

## Root Cause

`/api/fs/list` used `entry.is_dir(follow_symlinks=False)`, which inspects the symlink inode itself. A symlink is never a directory, so `isDirectory` was always `False` for dir-links.

Local Electron `readDir` already follows symlinks via `fs.stat`; only the web/remote listing path was wrong.

## Fix

- Switch to `entry.is_dir(follow_symlinks=True)` so the listing reports the target type.
- Add regression test `test_fs_list_follows_symlink_to_directory`.

## How to Verify

1. Create a project with a dir symlink:
   ```bash
   mkdir -p /tmp/real-dir && ln -s /tmp/real-dir /path/to/project/windows
   ```
2. Open the project in Desktop (remote mode) or hit `GET /api/fs/list?path=...`.
3. Confirm `windows` has `isDirectory: true` and expands in the sidebar.

## Test Plan

- [x] Added regression test for this bug
- [x] `pytest tests/hermes_cli/test_web_server_fs.py` — 14 passed
- [x] Manual: `os.scandir` on real `windows` symlink → False without follow, True with follow
- [x] Live `hermes-serve` restarted with the patch; desktop tree now treats `windows` as a folder

## Risk Assessment

**Low** — one-line boolean change in the listing endpoint; matches local Electron behavior already shipped in `apps/desktop/electron/fs-read-dir.cjs`. Broken symlinks still report `isDirectory: false` (same as `Path.is_dir()` when the target is missing).