### PR TITLE
feat(discord): configurable interactive view timeout (approvals.discord_prompt_timeout)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -743,6 +743,48 @@ def _read_dm_role_auth_guild() -> Optional[int]:
     return guild_id if guild_id > 0 else None
 
 
+# Default timeout for Discord interactive button views (exec approval, slash
+# confirm, update prompt, clarify choice). Used when the user has not set
+# ``approvals.discord_prompt_timeout`` in config.yaml. 300s (5 min) matches
+# the previous hardcoded value. Bounded to a sane range — Discord
+# interaction tokens expire from the API's side at ~15 minutes, so 900s is
+# the practical ceiling.
+_DISCORD_PROMPT_TIMEOUT_DEFAULT = 300
+_DISCORD_PROMPT_TIMEOUT_MIN = 30
+_DISCORD_PROMPT_TIMEOUT_MAX = 900
+
+
+def _read_discord_prompt_timeout() -> int:
+    """Return the timeout (in seconds) for Discord button views.
+
+    Reads ``approvals.discord_prompt_timeout`` from config.yaml. Falls back
+    to the historical 300s default for any missing / malformed value, and
+    clamps the result to ``[_DISCORD_PROMPT_TIMEOUT_MIN,
+    _DISCORD_PROMPT_TIMEOUT_MAX]`` so a typo can't accidentally make
+    interactive prompts disappear (too short) or outlive Discord's own
+    15-minute interaction-token expiry (too long).
+    """
+    raw: Any = None
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config() or {}
+        approvals_cfg = cfg.get("approvals", {}) or {}
+        raw = approvals_cfg.get("discord_prompt_timeout")
+    except Exception:
+        return _DISCORD_PROMPT_TIMEOUT_DEFAULT
+    if raw is None or raw == "":
+        return _DISCORD_PROMPT_TIMEOUT_DEFAULT
+    try:
+        seconds = int(raw)
+    except (TypeError, ValueError):
+        return _DISCORD_PROMPT_TIMEOUT_DEFAULT
+    if seconds < _DISCORD_PROMPT_TIMEOUT_MIN:
+        return _DISCORD_PROMPT_TIMEOUT_MIN
+    if seconds > _DISCORD_PROMPT_TIMEOUT_MAX:
+        return _DISCORD_PROMPT_TIMEOUT_MAX
+    return seconds
+
+
 class DiscordAdapter(BasePlatformAdapter):
     """
     Discord bot adapter.
@@ -6594,7 +6636,7 @@ def _define_discord_view_classes() -> None:
             require_admin: bool = False,
             admin_user_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)  # 5-minute timeout
+            super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
@@ -6748,7 +6790,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)
+            super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
             self.confirm_id = confirm_id
             self.allowed_user_ids = allowed_user_ids
@@ -6853,7 +6895,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)
+            super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
@@ -7286,7 +7328,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)  # 5-minute timeout
+            super().__init__(timeout=_read_discord_prompt_timeout())
             self.choices = list(choices)[:24]
             self.clarify_id = clarify_id
             self.allowed_user_ids = allowed_user_ids

--- a/tests/gateway/test_discord_prompt_timeout_config.py
+++ b/tests/gateway/test_discord_prompt_timeout_config.py
@@ -1,0 +1,150 @@
+"""Tests for the configurable Discord interactive-view timeout.
+
+Previously hardcoded to 300s on ExecApprovalView, SlashConfirmView,
+UpdatePromptView, and ClarifyChoiceView. Now reads
+``approvals.discord_prompt_timeout`` with the same 300s default, clamped to
+``[_DISCORD_PROMPT_TIMEOUT_MIN, _DISCORD_PROMPT_TIMEOUT_MAX]`` so a typo
+can't make prompts disappear (too short) or outlive Discord's 15-min
+interaction-token expiry (too long).
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    _DISCORD_PROMPT_TIMEOUT_DEFAULT,
+    _DISCORD_PROMPT_TIMEOUT_MAX,
+    _DISCORD_PROMPT_TIMEOUT_MIN,
+    _read_discord_prompt_timeout,
+)
+
+
+def _patch_config(monkeypatch, cfg):
+    """Stub ``hermes_cli.config.read_raw_config`` to return ``cfg``."""
+    import hermes_cli.config
+    monkeypatch.setattr(hermes_cli.config, "read_raw_config", lambda: cfg)
+
+
+def test_default_when_config_absent(monkeypatch):
+    _patch_config(monkeypatch, {})
+    assert _read_discord_prompt_timeout() == _DISCORD_PROMPT_TIMEOUT_DEFAULT
+
+
+def test_default_when_approvals_block_missing(monkeypatch):
+    _patch_config(monkeypatch, {"other": {}})
+    assert _read_discord_prompt_timeout() == _DISCORD_PROMPT_TIMEOUT_DEFAULT
+
+
+def test_default_when_key_missing(monkeypatch):
+    _patch_config(monkeypatch, {"approvals": {"mode": "manual"}})
+    assert _read_discord_prompt_timeout() == _DISCORD_PROMPT_TIMEOUT_DEFAULT
+
+
+def test_explicit_int_value(monkeypatch):
+    _patch_config(monkeypatch, {"approvals": {"discord_prompt_timeout": 600}})
+    assert _read_discord_prompt_timeout() == 600
+
+
+def test_numeric_string_accepted(monkeypatch):
+    """YAML parsers occasionally return numbers as strings; tolerate it."""
+    _patch_config(monkeypatch, {"approvals": {"discord_prompt_timeout": "450"}})
+    assert _read_discord_prompt_timeout() == 450
+
+
+def test_malformed_value_falls_back_to_default(monkeypatch):
+    _patch_config(
+        monkeypatch,
+        {"approvals": {"discord_prompt_timeout": "five minutes"}},
+    )
+    assert _read_discord_prompt_timeout() == _DISCORD_PROMPT_TIMEOUT_DEFAULT
+
+
+def test_value_clamped_to_minimum(monkeypatch):
+    """A typo of e.g. 5 seconds must not make prompts disappear."""
+    _patch_config(monkeypatch, {"approvals": {"discord_prompt_timeout": 5}})
+    assert _read_discord_prompt_timeout() == _DISCORD_PROMPT_TIMEOUT_MIN
+
+
+def test_value_clamped_to_maximum(monkeypatch):
+    """Discord interaction tokens expire at ~15 min — clamp larger values."""
+    _patch_config(monkeypatch, {"approvals": {"discord_prompt_timeout": 99999}})
+    assert _read_discord_prompt_timeout() == _DISCORD_PROMPT_TIMEOUT_MAX
+
+
+def test_zero_clamped_to_minimum(monkeypatch):
+    _patch_config(monkeypatch, {"approvals": {"discord_prompt_timeout": 0}})
+    assert _read_discord_prompt_timeout() == _DISCORD_PROMPT_TIMEOUT_MIN
+
+
+def test_negative_clamped_to_minimum(monkeypatch):
+    _patch_config(monkeypatch, {"approvals": {"discord_prompt_timeout": -300}})
+    assert _read_discord_prompt_timeout() == _DISCORD_PROMPT_TIMEOUT_MIN
+
+
+def test_empty_string_falls_back_to_default(monkeypatch):
+    _patch_config(monkeypatch, {"approvals": {"discord_prompt_timeout": ""}})
+    assert _read_discord_prompt_timeout() == _DISCORD_PROMPT_TIMEOUT_DEFAULT
+
+
+def test_config_read_exception_falls_back_to_default(monkeypatch):
+    """A crashing read_raw_config must not bring down view construction —
+    falling back to the historical 300s default preserves existing behavior.
+    """
+    import hermes_cli.config
+    def _boom():
+        raise RuntimeError("config file corrupt")
+    monkeypatch.setattr(hermes_cli.config, "read_raw_config", _boom)
+    assert _read_discord_prompt_timeout() == _DISCORD_PROMPT_TIMEOUT_DEFAULT
+
+
+def test_default_matches_previous_hardcoded_value():
+    """Behavioral parity assertion: existing installs (no new config) must
+    see exactly the 300s timeout the views were hardcoded to before this
+    change. Guards against the default drifting in a future refactor.
+    """
+    assert _DISCORD_PROMPT_TIMEOUT_DEFAULT == 300
+
+
+def test_clamp_range_includes_default():
+    """Sanity: the default must lie inside the clamp range, or every fresh
+    install would hit the clamp on its very first read.
+    """
+    assert _DISCORD_PROMPT_TIMEOUT_MIN <= _DISCORD_PROMPT_TIMEOUT_DEFAULT <= _DISCORD_PROMPT_TIMEOUT_MAX


### PR DESCRIPTION
## Summary
All four Discord interactive button views (exec approval, slash confirm, update prompt, clarify choice) now read their timeout from `approvals.discord_prompt_timeout` in config.yaml instead of a hardcoded 300s, so users who raise their approval window actually get longer-lived buttons. Fixes #30371.

Surgical reapply of the timeout portion of #45904 by @cruzanstx (credited via Co-authored-by — the PR's commit was authored under a placeholder identity, and it bundled unrelated channel-context changes we've excluded; those will be evaluated separately with the thread-context cluster).

## Changes
- `plugins/platforms/discord/adapter.py`: `_read_discord_prompt_timeout()` helper (default 300s, clamped 30–900s — Discord interaction tokens expire at ~15 min, so anything longer would render dead buttons) + all four `timeout=300` call sites swapped
- `tests/gateway/test_discord_prompt_timeout_config.py`: 14 tests (defaults, explicit values, malformed input, clamping)

## Validation
| config value | effective timeout |
|---|---|
| absent | 300 (unchanged default) |
| 600 | 600 |
| 99999 | 900 (clamped) |
| 5 | 30 (clamped) |

Verified E2E against a real config.yaml in an isolated HERMES_HOME (real loader path, not mocks). Targeted suite: 14/14 green.

## Infographic
![Configurable Discord Prompt Timeouts](https://v3b.fal.media/files/b/0aa14b83/c-nfn4GCGjBYFzkpq9Hhi_Hem9dsjh.png)
