### PR TITLE
fix(agent): dedupe Codex gpt-5.5 autoraise notice

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -71,10 +71,8 @@ def _ra():
 def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
     """Build the one-time notice shown when Codex gpt-5.5 raises compaction.
 
-    ``autoraise`` is ``{"from": <old_ratio>, "to": <new_ratio>}``. The same
-    text is printed inline for CLI users and replayed via ``status_callback``
-    for gateway users, so it must be self-contained and include the exact
-    opt-back-out command.
+    ``autoraise`` is ``{"from": <old_ratio>, "to": <new_ratio>}`` and the text
+    includes the exact opt-back-out command.
     """
     from_pct = int(round(autoraise["from"] * 100))
     to_pct = int(round(autoraise["to"] * 100))
@@ -84,6 +82,51 @@ def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
         f"summarizing.\n"
         f"  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
     )
+
+
+def _codex_gpt55_autoraise_notice_if_unseen(
+    autoraise: Dict[str, float],
+    config: Dict[str, Any],
+    *,
+    config_path=None,
+) -> Optional[str]:
+    """Return the Codex gpt-5.5 autoraise notice once per profile.
+
+    The autoraise is informational: Hermes silently does the safe thing by
+    delaying compaction for the Codex OAuth route. Gateway processes can create
+    fresh ``AIAgent`` instances across turns, so replaying this as a normal
+    compression warning turns a first-touch explanation into a repeated nag.
+
+    Track the notice with the existing onboarding ``seen`` flags so users still
+    learn about the automatic threshold bump and opt-out command once, while
+    actionable compression warnings continue to show whenever they matter.
+    """
+    try:
+        from agent.onboarding import (
+            CODEX_GPT55_AUTORAISE_NOTICE_FLAG,
+            is_seen,
+            mark_seen,
+        )
+
+        if is_seen(config, CODEX_GPT55_AUTORAISE_NOTICE_FLAG):
+            return None
+
+        path = config_path or (get_hermes_home() / "config.yaml")
+        mark_seen(path, CODEX_GPT55_AUTORAISE_NOTICE_FLAG)
+
+        # Keep the already-loaded config mapping in sync for any later checks in
+        # this process. ``mark_seen`` persists best-effort; if it fails we still
+        # show the notice this turn rather than hiding a useful first-touch tip.
+        if isinstance(config, dict):
+            onboarding = config.setdefault("onboarding", {})
+            if isinstance(onboarding, dict):
+                seen = onboarding.setdefault("seen", {})
+                if isinstance(seen, dict):
+                    seen[CODEX_GPT55_AUTORAISE_NOTICE_FLAG] = True
+    except Exception as exc:
+        logger.debug("codex gpt-5.5 autoraise notice dedupe failed: %s", exc)
+
+    return _build_codex_gpt55_autoraise_notice(autoraise)
 
 
 def _normalized_custom_base_url(value: Any) -> str:
@@ -1713,30 +1756,34 @@ def init_agent(
             "Ollama num_ctx: will request %d tokens (model max from /api/show)",
             agent._ollama_num_ctx,
         )
+    # Informational one-time notice when the Codex gpt-5.5 autoraise kicks in.
+    # Dedup it per profile before both the CLI startup print and the gateway
+    # replay path so gateway users do not get re-nagged when fresh AIAgent
+    # instances are created across turns. Actionable compression warnings still
+    # use _compression_warning below and are not suppressed by this flag.
+    _autoraise_notice = None
+    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
+    if _autoraise and compression_enabled:
+        _autoraise_notice = _codex_gpt55_autoraise_notice_if_unseen(
+            _autoraise,
+            _agent_cfg,
+        )
 
     if not agent.quiet_mode:
         if compression_enabled:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
-        # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
-        # exact opt-back-out command. Printed inline at startup for CLI users;
-        # gateway users get the same text replayed via _compression_warning on
-        # turn 1 (set below, after the warning slot is initialized).
-        _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled:
-            print(_build_codex_gpt55_autoraise_notice(_autoraise))
+        if _autoraise_notice:
+            print(_autoraise_notice)
 
     # Check immediately so CLI users see the warning at startup.
     # Gateway status_callback is not yet wired, so any warning is stored
     # in _compression_warning and replayed in the first run_conversation().
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
-    # above only reaches the CLI, so stash the same text here to be replayed
-    # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
-        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
+    if _autoraise_notice:
+        agent._compression_warning = _autoraise_notice
+
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/agent/onboarding.py
+++ b/agent/onboarding.py
@@ -27,6 +27,7 @@ BUSY_INPUT_FLAG = "busy_input_prompt"
 TOOL_PROGRESS_FLAG = "tool_progress_prompt"
 OPENCLAW_RESIDUE_FLAG = "openclaw_residue_cleanup"
 PROFILE_BUILD_FLAG = "profile_build_offered"
+CODEX_GPT55_AUTORAISE_NOTICE_FLAG = "codex_gpt55_autoraise_notice"
 
 
 # -------------------------------------------------------------------------
@@ -240,6 +241,7 @@ __all__ = [
     "TOOL_PROGRESS_FLAG",
     "OPENCLAW_RESIDUE_FLAG",
     "PROFILE_BUILD_FLAG",
+    "CODEX_GPT55_AUTORAISE_NOTICE_FLAG",
     "busy_input_hint_gateway",
     "busy_input_hint_cli",
     "tool_progress_hint_gateway",

--- a/tests/agent/test_codex_gpt55_autoraise_notice.py
+++ b/tests/agent/test_codex_gpt55_autoraise_notice.py
@@ -1,0 +1,60 @@
+"""Tests for Codex gpt-5.5 autoraise notice deduplication."""
+
+from __future__ import annotations
+
+import yaml
+
+from agent.agent_init import _codex_gpt55_autoraise_notice_if_unseen
+from agent.onboarding import CODEX_GPT55_AUTORAISE_NOTICE_FLAG
+
+
+def test_codex_gpt55_autoraise_notice_marks_seen(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("compression:\n  threshold: 0.5\n", encoding="utf-8")
+    config: dict[str, object] = {"compression": {"threshold": 0.5}}
+
+    notice = _codex_gpt55_autoraise_notice_if_unseen(
+        {"from": 0.5, "to": 0.85},
+        config,
+        config_path=config_path,
+    )
+
+    assert notice is not None
+    assert "auto-compaction was raised to 85%" in notice
+    onboarding = config["onboarding"]
+    assert isinstance(onboarding, dict)
+    seen = onboarding["seen"]
+    assert isinstance(seen, dict)
+    assert seen[CODEX_GPT55_AUTORAISE_NOTICE_FLAG] is True
+
+    persisted = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert persisted["onboarding"]["seen"][CODEX_GPT55_AUTORAISE_NOTICE_FLAG] is True
+
+    assert (
+        _codex_gpt55_autoraise_notice_if_unseen(
+            {"from": 0.5, "to": 0.85},
+            config,
+            config_path=config_path,
+        )
+        is None
+    )
+
+
+def test_codex_gpt55_autoraise_notice_respects_existing_seen_flag(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config = {
+        "onboarding": {
+            "seen": {
+                CODEX_GPT55_AUTORAISE_NOTICE_FLAG: True,
+            }
+        }
+    }
+
+    notice = _codex_gpt55_autoraise_notice_if_unseen(
+        {"from": 0.5, "to": 0.85},
+        config,
+        config_path=config_path,
+    )
+
+    assert notice is None
+    assert not config_path.exists()


### PR DESCRIPTION
## Bug Description

Codex gpt-5.5 auto-raises the compression threshold from the global default to 85% on the openai-codex route. That informational notice is replayed through gateway `status_callback` when a fresh `AIAgent` is initialized, so messaging users can see the same non-actionable reminder repeatedly.

## Root Cause

The autoraise notice was stored in `_compression_warning`, the same one-turn gateway replay slot used for actionable compression warnings. Since gateway sessions may construct fresh agents across turns, the "one-time" notice was only one-time per agent instance, not one-time per profile/user.

## Fix

- Track the Codex gpt-5.5 autoraise notice with the existing `onboarding.seen` profile flags.
- Show the informational notice at most once per profile, while keeping the opt-out command available in that first notice.
- Leave actionable compression warnings on `_compression_warning`, so they still surface when needed.
- Add regression tests for first-show, persisted seen flag, and suppression after the flag exists.

## How to Verify

1. Use openai-codex + gpt-5.5 with `compression.threshold` below 0.85.
2. Start a gateway/CLI session and observe the autoraise notice at most once.
3. Start another fresh agent from the same profile and confirm the informational autoraise notice is not replayed.

## Test Plan

- [x] `python -m pytest tests/agent/test_codex_gpt55_autoraise_notice.py tests/agent/test_arcee_trinity_overrides.py -q`
- [x] `python -m pytest tests/run_agent/test_compression_feasibility.py -q`
- [x] `python -m pytest tests/agent/test_codex_gpt55_autoraise_notice.py tests/agent/test_arcee_trinity_overrides.py tests/run_agent/test_compression_feasibility.py -q`

## Risk Assessment

Low — this only deduplicates an informational Codex gpt-5.5 autoraise notice. It does not change the threshold override itself, and it does not suppress actionable compression warnings.
