### PR TITLE
fix(cron): warn when ticker heartbeat is missing

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -240,7 +240,16 @@ def cron_status():
         hb_age = get_ticker_heartbeat_age()
         ok_age = get_ticker_success_age()
 
-        if hb_age is not None and hb_age > STALE_AFTER:
+        if hb_age is None:
+            # A live gateway without a ticker heartbeat is not enough evidence
+            # that the scheduler thread is alive.
+            print(color(
+                "⚠ Gateway is running but the cron ticker heartbeat is missing.",
+                Colors.YELLOW,
+            ))
+            print(f"  PID: {', '.join(map(str, pids))}")
+            print("  Cron jobs may NOT be firing. Restart: hermes gateway restart")
+        elif hb_age > STALE_AFTER:
             # No heartbeat at all → the ticker thread is gone.
             print(color(
                 "⚠ Gateway is running but the cron ticker looks STALLED — "
@@ -249,7 +258,7 @@ def cron_status():
             ))
             print(f"  PID: {', '.join(map(str, pids))}")
             print("  Cron jobs may NOT be firing. Restart: hermes gateway restart")
-        elif hb_age is not None and ok_age is not None and ok_age > STALE_AFTER:
+        elif ok_age is not None and ok_age > STALE_AFTER:
             # Loop is alive (fresh heartbeat) but no tick has SUCCEEDED in a
             # long time → ticks are failing every iteration.
             print(color(

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -573,6 +573,21 @@ def test_cron_status_reports_stalled_when_no_heartbeat(tmp_path, monkeypatch, ca
     assert "will fire automatically" not in out
 
 
+def test_cron_status_warns_when_heartbeat_missing(tmp_path, monkeypatch, capsys):
+    import cron.jobs as jobs
+    from hermes_cli import cron as cron_cli
+
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [4321])
+    monkeypatch.setattr(jobs, "get_ticker_heartbeat_age", lambda: None)
+    monkeypatch.setattr(jobs, "get_ticker_success_age", lambda: None)
+    monkeypatch.setattr("cron.jobs.list_jobs", lambda **k: [])
+
+    cron_cli.cron_status()
+    out = capsys.readouterr().out
+    assert "heartbeat is missing" in out
+    assert "will fire automatically" not in out
+
+
 # ── F8: runtime backstop — never resolve a stored pair that exfiltrates a key ──
 
 


### PR DESCRIPTION
## Summary
- warn when the builtin cron gateway is running but ticker heartbeat age is unavailable
- keep the healthy status path only for fresh heartbeat/success evidence
- add a regression test for the missing-heartbeat case

## Test
- TMP=.tmp TEMP=.tmp python -m pytest tests/cron/test_scheduler_provider.py::test_cron_status_warns_when_heartbeat_missing tests/cron/test_scheduler_provider.py::test_cron_status_reports_stalled_when_no_heartbeat tests/cron/test_scheduler_provider.py::test_cron_status_healthy_when_both_fresh

Secret scan: diff-only secret_like_added_lines=0