### PR TITLE
fix(desktop): persist profile session deletes

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -7,6 +7,7 @@ import {
   AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS,
   audioSpeakRequestTimeoutMs,
   audioTranscribeRequestTimeoutMs,
+  deleteSession,
   getCronJobs,
   getGlobalModelInfo,
   getGlobalModelOptions,
@@ -409,5 +410,17 @@ describe('Hermes REST helpers', () => {
         path: '/api/model/options?refresh=1&include_unconfigured=1'
       })
     )
+  })
+
+  it('tags session deletes for Electron routing and backend profile lookup', async () => {
+    api.mockResolvedValue({ ok: true })
+
+    await deleteSession('session-1', 'default')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/sessions/session-1?profile=default',
+      profile: 'default',
+      method: 'DELETE'
+    })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -643,9 +643,11 @@ export function getSessionMessages(id: string, profile?: string | null): Promise
 }
 
 export function deleteSession(id: string, profile?: string | null): Promise<{ ok: boolean }> {
+  const suffix = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+
   return window.hermesDesktop.api<{ ok: boolean }>({
     ...(profile ? { profile } : {}),
-    path: `/api/sessions/${encodeURIComponent(id)}`,
+    path: `/api/sessions/${encodeURIComponent(id)}${suffix}`,
     method: 'DELETE'
   })
 }

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -44,6 +44,7 @@ _open_session_db_for_profile = late("_open_session_db_for_profile")
 _prune_sessions = late("_prune_sessions")
 _read_session_import_body = late("_read_session_import_body")
 _session_latest_descendant = late("_session_latest_descendant")
+_sessions_dir_for_profile = late("_sessions_dir_for_profile")
 _strip_session_list_rows = late("_strip_session_list_rows")
 
 
@@ -650,7 +651,7 @@ async def delete_session_endpoint(session_id: str, profile: Optional[str] = None
             sid = db.resolve_session_id(session_id)
             if not sid:
                 return {"ok": True, "already_absent": True}
-            db.delete_session(sid)
+            db.delete_session(sid, sessions_dir=_sessions_dir_for_profile(profile))
             return {"ok": True}
         finally:
             db.close()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11235,6 +11235,14 @@ def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
         return _open_probed()
 
 
+def _sessions_dir_for_profile(profile: Optional[str]) -> Path:
+    """Return the transcript directory for a profile-scoped session."""
+    if not profile:
+        return get_hermes_home() / "sessions"
+    _name, home = _cron_profile_home(profile)
+    return Path(home) / "sessions"
+
+
 # In-process throttle for the opportunistic auto-archive trigger, keyed by
 # profile. Bounds the config.yaml read to at most once per this window per
 # profile; the actual sweep is throttled far more coarsely by state_meta

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7914,15 +7914,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def _remove_session_files(sessions_dir: Optional[Path], session_id: str) -> None:
         """Remove on-disk transcript files for a session.
 
-        Cleans up ``{session_id}.json``, ``{session_id}.jsonl``, and any
-        ``request_dump_{session_id}_*.json`` files left by the gateway.
+        Cleans up ``session_{session_id}.json``, ``{session_id}.json``,
+        ``{session_id}.jsonl``, and any ``request_dump_{session_id}_*.json``
+        files left by the gateway.
         Silently skips files that don't exist and swallows OSError so a
         filesystem hiccup never blocks a DB operation.
         """
         if sessions_dir is None:
             return
-        for suffix in (".json", ".jsonl"):
-            p = sessions_dir / f"{session_id}{suffix}"
+        for p in (
+            sessions_dir / f"session_{session_id}.json",
+            sessions_dir / f"{session_id}.json",
+            sessions_dir / f"{session_id}.jsonl",
+        ):
             try:
                 p.unlink(missing_ok=True)
             except OSError:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3047,6 +3047,60 @@ class TestDeleteSessionEndpoint:
         finally:
             db.close()
 
+    def test_delete_existing_session(self):
+        from hermes_constants import get_hermes_home
+
+        self._seed(["real_one"])
+        sessions_dir = get_hermes_home() / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        (sessions_dir / "session_real_one.json").write_text(
+            '{"messages":[{"content":"secret-token"}]}',
+            encoding="utf-8",
+        )
+        (sessions_dir / "real_one.jsonl").write_text("{}\n", encoding="utf-8")
+        (sessions_dir / "request_dump_real_one_001.json").write_text("{}", encoding="utf-8")
+
+        resp = self.auth_client.delete("/api/sessions/real_one")
+
+        assert resp.status_code == 200
+        assert resp.json().get("ok") is True
+        assert not self._exists("real_one")
+        assert not (sessions_dir / "session_real_one.json").exists()
+        assert not (sessions_dir / "real_one.jsonl").exists()
+        assert not (sessions_dir / "request_dump_real_one_001.json").exists()
+
+    def test_delete_named_profile_session_and_transcript(self):
+        from hermes_cli import profiles as profiles_mod
+        from hermes_state import SessionDB
+
+        profile_home = profiles_mod.get_profile_dir("worker")
+        sessions_dir = profile_home / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        db_path = profile_home / "state.db"
+
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(session_id="named_one", source="cli")
+        finally:
+            db.close()
+
+        transcript = sessions_dir / "session_named_one.json"
+        transcript.write_text(
+            '{"messages":[{"content":"secret-token"}]}',
+            encoding="utf-8",
+        )
+
+        resp = self.auth_client.delete("/api/sessions/named_one?profile=worker")
+
+        assert resp.status_code == 200
+        assert resp.json().get("ok") is True
+        db = SessionDB(db_path=db_path)
+        try:
+            assert db.get_session("named_one") is None
+        finally:
+            db.close()
+        assert not transcript.exists()
+
 
     def test_delete_absent_session_is_idempotent(self):
         # PREMISE / regression: deleting a row that no longer exists must NOT

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1158,11 +1158,13 @@ class TestBulkDeleteSessions:
         bulk-delete CLI / web flows don't leak files."""
         db.create_session(session_id="s1", source="cli")
         db.create_session(session_id="s2", source="cli")
+        (tmp_path / "session_s1.json").write_text("{}")
         (tmp_path / "s1.jsonl").write_text("")
         (tmp_path / "s2.json").write_text("{}")
 
         deleted = db.delete_sessions(["s1", "s2"], sessions_dir=tmp_path)
         assert deleted == 2
+        assert not (tmp_path / "session_s1.json").exists()
         assert not (tmp_path / "s1.jsonl").exists()
         assert not (tmp_path / "s2.json").exists()
 


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop/web session delete path so profile-scoped session deletes remove both the database row and the on-disk transcript snapshot. Desktop DELETE requests now include the same profile query used by message fetches, the web endpoint passes the matching profile sessions directory into `SessionDB.delete_session`, and session cleanup now removes `session_<id>.json` snapshots in addition to the older filename forms.

This addresses the issue where a deleted desktop session could reappear and leave a readable `session_<id>.json` file behind.

## Related Issue

Fixes #60207

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/hermes.ts`: include `?profile=` on session DELETE requests while preserving the Electron routing profile envelope.
- `hermes_cli/web_server.py`: resolve the correct profile sessions directory and pass it to `delete_session`.
- `hermes_state.py`: delete `session_<id>.json` files during session cleanup.
- `tests/hermes_cli/test_web_server.py`, `tests/test_hermes_state.py`, `apps/desktop/src/hermes.test.ts`: add regression coverage for file cleanup and profile-tagged deletes.

## How to Test

1. `./.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py::TestDeleteSessionEndpoint tests/test_hermes_state.py::TestBulkDeleteSessions::test_cleans_up_transcript_files -q`
2. `cd apps/desktop && npm run test:ui -- src/hermes.test.ts`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / local targeted Python and desktop unit tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted validation passed:

```text
./.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py::TestDeleteSessionEndpoint tests/test_hermes_state.py::TestBulkDeleteSessions::test_cleans_up_transcript_files -q
4 passed

cd apps/desktop && npm run test:ui -- src/hermes.test.ts
1 file passed, 8 tests passed

git diff --check
clean
```

Not run: full Electron desktop end-to-end UI delete flow; full `pytest tests/ -q`.
