### PR TITLE
fix(discord): mirror interactive prompt payloads into visible message content

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5453,15 +5453,44 @@ class DiscordAdapter(BasePlatformAdapter):
             if not channel:
                 channel = await self._client.fetch_channel(int(target_id))
 
-            # Discord embed description limit is 4096; show full command up to that
-            max_desc = 4088
-            cmd_display = command if len(command) <= max_desc else command[: max_desc - 3] + "..."
+            # Keep the approval request self-contained in plain message content.
+            # Discord embeds can be invisible or visually separated from the
+            # component row on some clients (notably web/mobile), so the actual
+            # command and reason must be visible in the same content block as
+            # the approval buttons.
+            reason_budget = 300
+            reason_display = str(description or "dangerous command")
+            if len(reason_display) > reason_budget:
+                reason_display = reason_display[: reason_budget - 15] + "... [truncated]"
+
+            prompt_prefix = (
+                "⚠️ **Command Approval Required**\n\n"
+                "Do you want Hermes to run this command?\n\n"
+                "**Requested command:**\n```bash\n"
+            )
+            prompt_tail = f"\n```\n**Reason:** {reason_display}"
+            truncated_suffix = "\n... [truncated]"
+            command_budget = max(0, self.MAX_MESSAGE_LENGTH - len(prompt_prefix) - len(prompt_tail))
+            content_cmd_display = str(command or "")
+            if len(content_cmd_display) > command_budget:
+                content_cmd_display = (
+                    content_cmd_display[: max(0, command_budget - len(truncated_suffix))]
+                    + truncated_suffix
+                )
+            content = f"{prompt_prefix}{content_cmd_display}{prompt_tail}"
+
+            # Preserve the richer embed path and its larger description budget
+            # for clients where embeds render correctly.
+            max_embed_desc = 4088
+            embed_cmd_display = str(command or "")
+            if len(embed_cmd_display) > max_embed_desc:
+                embed_cmd_display = embed_cmd_display[: max_embed_desc - 3] + "..."
             embed = discord.Embed(
                 title="⚠️ Command Approval Required",
-                description=f"```\n{cmd_display}\n```",
+                description=f"```\n{embed_cmd_display}\n```",
                 color=discord.Color.orange(),
             )
-            embed.add_field(name="Reason", value=description, inline=False)
+            embed.add_field(name="Reason", value=reason_display, inline=False)
 
             require_admin, admin_user_ids = _resolve_exec_approval_admin_gate(
                 getattr(self.config, "extra", None)
@@ -5474,7 +5503,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 admin_user_ids=admin_user_ids,
             )
 
-            msg = await channel.send(embed=embed, view=view)
+            msg = await channel.send(content=content, embed=embed, view=view)
             view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5429,6 +5429,29 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return None
 
+    def _self_contained_prompt_content(
+        self, header: str, body: str, *, code_block: bool = False, tail: str = ""
+    ) -> str:
+        """Build plain message content that mirrors an embed's payload.
+
+        Discord embeds can be invisible or visually separated from the
+        component row on some clients (notably web/mobile), so interactive
+        prompts must carry their payload in plain ``content`` next to the
+        buttons. The embed stays as progressive enhancement.
+        """
+        body = str(body or "")
+        if code_block:
+            prefix = f"{header}\n```bash\n"
+            suffix = f"\n```{tail}"
+        else:
+            prefix = f"{header}\n\n"
+            suffix = tail
+        truncated_suffix = "\n... [truncated]"
+        budget = max(0, self.MAX_MESSAGE_LENGTH - len(prefix) - len(suffix))
+        if len(body) > budget:
+            body = body[: max(0, budget - len(truncated_suffix))] + truncated_suffix
+        return f"{prefix}{body}{suffix}"
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -5535,6 +5558,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 description=body,
                 color=discord.Color.orange(),
             )
+            # Mirror the payload in plain content — embeds are invisible on
+            # some clients (see send_exec_approval).
+            content = self._self_contained_prompt_content(
+                f"**{title or 'Confirm'}**", message
+            )
 
             view = SlashConfirmView(
                 session_key=session_key,
@@ -5543,7 +5571,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 allowed_role_ids=self._allowed_role_ids,
             )
 
-            msg = await channel.send(embed=embed, view=view)
+            msg = await channel.send(content=content, embed=embed, view=view)
             view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
@@ -5657,7 +5685,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
                 view = None
 
-            msg = await channel.send(embed=embed, view=view) if view else await channel.send(embed=embed)
+            # Mirror the question in plain content — embeds are invisible on
+            # some clients (see send_exec_approval).
+            clarify_tail = (
+                "\n\nPick one below, or click ✏️ Other to type a custom answer."
+                if clean_choices
+                else "\n\nReply in this channel with your answer."
+            )
+            content = self._self_contained_prompt_content(
+                "❓ **Hermes needs your input**", str(question or "").strip(),
+                tail=clarify_tail,
+            )
+            msg = await channel.send(content=content, embed=embed, view=view) if view else await channel.send(content=content, embed=embed)
             if view:
                 view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
@@ -5694,7 +5733,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 allowed_user_ids=self._allowed_user_ids,
                 allowed_role_ids=self._allowed_role_ids,
             )
-            msg = await channel.send(embed=embed, view=view)
+            # Mirror the prompt in plain content — embeds are invisible on
+            # some clients (see send_exec_approval).
+            content = self._self_contained_prompt_content(
+                "⚕ **Update Needs Your Input**", f"{prompt}{default_hint}"
+            )
+            msg = await channel.send(content=content, embed=embed, view=view)
             view._message = msg  # store for on_timeout expiration editing
             if _metadata_marks_nonconversational(metadata):
                 self._nonconversational_messages.mark_many([str(msg.id)])

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -191,6 +191,7 @@ def _ensure_discord_mock() -> None:
     discord_mod.Color = SimpleNamespace(
         orange=lambda: 1, green=lambda: 2, blue=lambda: 3,
         red=lambda: 4, purple=lambda: 5, greyple=lambda: 6,
+        gold=lambda: 7,
     )
 
     # app_commands — needed by _register_slash_commands auto-registration

--- a/tests/gateway/test_discord_exec_approval_content.py
+++ b/tests/gateway/test_discord_exec_approval_content.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _capture_channel(adapter):
+    sent = {}
+
+    async def fake_send(**kwargs):
+        sent.update(kwargs)
+        return SimpleNamespace(id=1234)
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_prompt_uses_visible_content_with_command_and_reason():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    command = "python scripts/deploy.py --env prod --force"
+    result = await adapter.send_exec_approval(
+        chat_id="555",
+        command=command,
+        session_key="discord:555",
+        description="script execution via -c flag",
+    )
+
+    assert result.success is True
+    assert sent["view"] is not None
+    assert sent["embed"] is not None
+
+    prompt_text = sent["content"]
+    assert "Command Approval Required" in prompt_text
+    assert "Do you want Hermes to run this command?" in prompt_text
+    assert "Requested command" in prompt_text
+    assert command in prompt_text
+    assert "Reason" in prompt_text
+    assert "script execution via -c flag" in prompt_text
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_prompt_truncates_long_command_in_content():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    long_command = "python -c '" + ("x" * 5000) + "'"
+    result = await adapter.send_exec_approval(
+        chat_id="555",
+        command=long_command,
+        session_key="discord:555",
+        description="long generated shell command",
+    )
+
+    assert result.success is True
+    assert len(sent["content"]) <= adapter.MAX_MESSAGE_LENGTH
+    assert "... [truncated]" in sent["content"]
+    assert "long generated shell command" in sent["content"]
+    assert len(sent["embed"].description) > len(sent["content"])

--- a/tests/gateway/test_discord_prompt_content_siblings.py
+++ b/tests/gateway/test_discord_prompt_content_siblings.py
@@ -1,0 +1,123 @@
+"""Sibling coverage for the embed-invisibility fix (send_exec_approval got it
+in the same PR): slash confirm, clarify, and update prompts must also mirror
+their payload into plain message content, since embeds don't render on some
+Discord clients (web/mobile)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _capture_channel(adapter):
+    sent = {}
+
+    async def fake_send(**kwargs):
+        sent.update(kwargs)
+        return SimpleNamespace(id=1234)
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_slash_confirm_mirrors_message_into_content():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    result = await adapter.send_slash_confirm(
+        chat_id="555",
+        title="Reset session?",
+        message="This will clear the current conversation history.",
+        session_key="discord:555",
+        confirm_id="c1",
+    )
+
+    assert result.success is True
+    assert sent["view"] is not None
+    assert sent["embed"] is not None
+    assert "Reset session?" in sent["content"]
+    assert "clear the current conversation history" in sent["content"]
+
+
+@pytest.mark.asyncio
+async def test_slash_confirm_truncates_long_message_in_content():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    result = await adapter.send_slash_confirm(
+        chat_id="555",
+        title="Confirm",
+        message="y" * 5000,
+        session_key="discord:555",
+        confirm_id="c2",
+    )
+
+    assert result.success is True
+    assert len(sent["content"]) <= adapter.MAX_MESSAGE_LENGTH
+    assert "... [truncated]" in sent["content"]
+
+
+@pytest.mark.asyncio
+async def test_clarify_with_choices_mirrors_question_into_content():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    result = await adapter.send_clarify(
+        chat_id="555",
+        question="Which environment should I deploy to?",
+        choices=["staging", "production"],
+        clarify_id="cl1",
+        session_key="discord:555",
+    )
+
+    assert result.success is True
+    assert sent["view"] is not None
+    assert "Hermes needs your input" in sent["content"]
+    assert "Which environment should I deploy to?" in sent["content"]
+    assert "Pick one below" in sent["content"]
+
+
+@pytest.mark.asyncio
+async def test_clarify_without_choices_mirrors_question_and_reply_hint():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    result = await adapter.send_clarify(
+        chat_id="555",
+        question="What should the cron schedule be?",
+        choices=[],
+        clarify_id="cl2",
+        session_key="discord:555",
+    )
+
+    assert result.success is True
+    assert sent.get("view") is None
+    assert "What should the cron schedule be?" in sent["content"]
+    assert "Reply in this channel" in sent["content"]
+
+
+@pytest.mark.asyncio
+async def test_update_prompt_mirrors_prompt_into_content():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    result = await adapter.send_update_prompt(
+        chat_id="555",
+        prompt="Restore stashed changes?",
+        default="yes",
+        session_key="discord:555",
+    )
+
+    assert result.success is True
+    assert sent["view"] is not None
+    assert "Update Needs Your Input" in sent["content"]
+    assert "Restore stashed changes?" in sent["content"]
+    assert "(default: yes)" in sent["content"]


### PR DESCRIPTION
## Summary
Discord interactive prompts (exec approval, slash confirm, clarify, update prompt) now carry their payload in plain message content next to the buttons, so users on clients that don't render embeds (Discord web/mobile, #33681) can actually see the command they're being asked to approve. The embed stays as progressive enhancement.

Salvage of #52518 by @jakepresent (authorship preserved via cherry-pick), widened to the whole bug class. Fixes #33681.

## Changes
- Cherry-picked: `send_exec_approval` mirrors command + reason into content (@jakepresent, with tests)
- Follow-up (ours): shared `_self_contained_prompt_content()` helper extends the same fix to the three sibling surfaces the PR didn't cover — `send_slash_confirm`, `send_clarify`, `send_update_prompt` — plus sibling tests and a conftest `Color.gold` mock addition
- Truncation budgeted to the 2000-char content limit with a clean `[truncated]` marker

## Validation
| surface | payload visible in content |
|---|---|
| exec approval | ✓ (contributor tests) |
| slash confirm | ✓ |
| clarify (with + without choices) | ✓ |
| update prompt | ✓ |

Targeted suites: 65/65 green across the four affected test files.

## Infographic
![Visible Approval Prompts](https://v3b.fal.media/files/b/0aa14c14/Vn9YpicsZQ_AWtrfGoUpR_od5HikWz.png)
