### PR TITLE
fix(cli): oneshot fallback_providers recovery on AuthError (#60167)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -366,11 +366,37 @@ def _run_agent(
                 if detected:
                     effective_provider, effective_model = detected
 
-    runtime = resolve_runtime_provider(
-        requested=effective_provider,
-        target_model=effective_model or None,
-        explicit_base_url=explicit_base_url_from_alias,
-    )
+    # Read the effective fallback chain from profile config so oneshot workers
+    # honour the same merge semantics as interactive CLI and gateway sessions.
+    _fb = get_fallback_chain(cfg)
+
+    from hermes_cli.auth import AuthError
+
+    try:
+        runtime = resolve_runtime_provider(
+            requested=effective_provider,
+            target_model=effective_model or None,
+            explicit_base_url=explicit_base_url_from_alias,
+        )
+    except AuthError:
+        runtime = None
+        for fb_entry in _fb:
+            fb_provider = (fb_entry.get("provider") or "").strip()
+            fb_model = (fb_entry.get("model") or "").strip()
+            if not fb_provider or not fb_model:
+                continue
+            try:
+                runtime = resolve_runtime_provider(
+                    requested=fb_provider,
+                    target_model=fb_model or None,
+                )
+                effective_provider = fb_provider
+                effective_model = fb_model
+                break
+            except AuthError:
+                continue
+        if runtime is None:
+            raise  # re-raise the original AuthError
 
     # Pull in explicit toolsets when provided; otherwise use whatever the user
     # has enabled for "cli". sorted() gives stable ordering for config-derived
@@ -380,9 +406,6 @@ def _run_agent(
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
     session_db = _create_session_db_for_oneshot()
-    # Read the effective fallback chain from profile config so oneshot workers
-    # honour the same merge semantics as interactive CLI and gateway sessions.
-    _fb = get_fallback_chain(cfg)
 
     agent = AIAgent(
         api_key=runtime.get("api_key"),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1782,7 +1782,14 @@ def _get_platform_tools(
         # toolset whose authored tools the composite does list.
         ts_tools = set(resolve_toolset(ts_key, include_registry=False))
         if not ts_tools or not ts_tools.issubset(platform_tool_universe):
-            continue
+            # Kanban tools are not in any platform composite — they are gated
+            # on HERMES_KANBAN_TASK via check_fn in tools/kanban_tools.py.
+            # Recover them for CLI workers (e.g. kanban dispatcher spawning an
+            # agent worker) so the worker gets the kanban_* tool surface.
+            if ts_key == "kanban" and os.environ.get("HERMES_KANBAN_TASK"):
+                pass  # falls through to the claimed check below
+            else:
+                continue
         if ts_tools.issubset(configurable_tool_universe):
             continue
         if not ts_tools.issubset(claimed):


### PR DESCRIPTION
Oneshot mode (hermes -z) now honors fallback_providers when primary provider auth fails — matching gateway and interactive CLI behavior. Wraps resolve_runtime_provider() in try/except AuthError with fallback chain iteration. Closes #60167