### PR TITLE
fix(kanban): include kanban toolset for cli workers when kanban mode is active (#60119)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1782,7 +1782,14 @@ def _get_platform_tools(
         # toolset whose authored tools the composite does list.
         ts_tools = set(resolve_toolset(ts_key, include_registry=False))
         if not ts_tools or not ts_tools.issubset(platform_tool_universe):
-            continue
+            # Kanban tools are not in any platform composite — they are gated
+            # on HERMES_KANBAN_TASK via check_fn in tools/kanban_tools.py.
+            # Recover them for CLI workers (e.g. kanban dispatcher spawning an
+            # agent worker) so the worker gets the kanban_* tool surface.
+            if ts_key == "kanban" and os.environ.get("HERMES_KANBAN_TASK"):
+                pass  # falls through to the claimed check below
+            else:
+                continue
         if ts_tools.issubset(configurable_tool_universe):
             continue
         if not ts_tools.issubset(claimed):


### PR DESCRIPTION
Kanban workers now receive kanban_* tools when HERMES_KANBAN_TASK is set. _get_platform_tools() was dropping the kanban toolset for platform cli because kanban tools are not in any platform composite. Added a recovery path that checks for kanban mode. Closes #60119