### PR TITLE
fix(dashboard): auto-scroll chat terminal to bottom on session open

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -688,6 +688,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       ws.binaryType = "arraybuffer";
       wsRef.current = ws;
 
+    // Track whether the user has manually scrolled up. When at bottom,
+    // auto-scroll on new data so the latest messages stay visible.
+    let scrolledUp = false;
+    term.onScroll(() => {
+      const buffer = term.buffer.active;
+      scrolledUp = buffer.viewportY < buffer.baseY;
+    });
+
     ws.onopen = () => {
       clearReconnectTimer();
       reconnectAttemptRef.current = 0;
@@ -724,6 +732,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         term.write(ev.data);
       } else {
         term.write(new Uint8Array(ev.data as ArrayBuffer));
+      }
+      // Auto-scroll unless user scrolled up to read history.
+      // xterm.js doesn't auto-follow programmatic writes with VT100 cursor
+      // positioning (used by Ink's full-screen rendering), so the viewport
+      // can lag behind the session content without this explicit push.
+      if (!scrolledUp) {
+        term.scrollToBottom();
       }
     };
 


### PR DESCRIPTION
## Problem

When opening a conversation in the Hermes Studio dashboard, the xterm.js terminal viewport stays at the top instead of scrolling to the bottom (latest messages). The user has to manually scroll down every time.

## Root Cause

The dashboard chat (`web/src/pages/ChatPage.tsx`) embeds a TUI via xterm.js. When a session is loaded, the TUI outputs the full conversation through the WebSocket → `term.write()` path. However, Ink (the TUI framework) uses VT100 absolute cursor positioning (`ESC[row;colH`) for full-screen rendering, not simple line-by-line appending. xterm.js only auto-scrolls on line-feed output — cursor-positioned writes don't trigger the follow-bottom behavior.

The result: the session history is fully written to the terminal buffer, but the viewport stays wherever it was (top of scrollback), and the user must manually scroll down.

## Fix

After each `term.write(data)` in the WebSocket `onmessage` handler, call `term.scrollToBottom()` — but only when the user hasn't manually scrolled up. Track scroll intent via `term.onScroll()`:

```typescript
let scrolledUp = false;
term.onScroll(() => {
    const buffer = term.buffer.active;
    scrolledUp = buffer.viewportY < buffer.baseY;
});

ws.onmessage = (ev) => {
    // ... existing term.write() ...
    if (!scrolledUp) {
        term.scrollToBottom();
    }
};
```

Behavior:
- **At bottom** → auto-follow to show latest messages
- **Scrolled up** → stay put, don't fight the user
- **Scrolled back to bottom** → re-arm auto-follow

## Testing

- Opened long sessions → viewport correctly scrolls to bottom
- Scrolled up to read history → viewport stays, no auto-scroll
- Scrolled back to bottom → auto-scroll resumes
- `npm run build` passed (vite build production bundle)