### PR TITLE
fix(discord): survive expired slash defer interactions (error 10062)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1626,6 +1626,31 @@ class DiscordAdapter(BasePlatformAdapter):
             return True
         return False
 
+    @staticmethod
+    def _is_discord_unknown_interaction(exc: BaseException) -> bool:
+        """True for Discord's expired interaction token error."""
+        code = getattr(exc, "code", None)
+        if code is None:
+            data = getattr(exc, "data", None)
+            if isinstance(data, dict):
+                code = data.get("code")
+        try:
+            code = int(code)
+        except (TypeError, ValueError):
+            code = None
+
+        status = getattr(exc, "status", None)
+        response = getattr(exc, "response", None)
+        if status is None and response is not None:
+            status = getattr(response, "status", None) or getattr(response, "status_code", None)
+        try:
+            status = int(status)
+        except (TypeError, ValueError):
+            status = None
+
+        message = str(exc).lower()
+        return code == 10062 or (status == 404 and "unknown interaction" in message)
+
     def _command_sync_mutation_interval_seconds(self) -> float:
         return _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS
 
@@ -3964,9 +3989,22 @@ class DiscordAdapter(BasePlatformAdapter):
         if not await self._check_slash_authorization(interaction, command_text):
             return
 
-        await interaction.response.defer(ephemeral=True)
+        deferred_response = False
+        try:
+            await interaction.response.defer(ephemeral=True)
+            deferred_response = True
+        except Exception as e:
+            if not self._is_discord_unknown_interaction(e):
+                raise
+            logger.warning(
+                "[Discord] slash %s: interaction expired before defer. "
+                "Executing command anyway, skipping interaction followup.",
+                command_text,
+            )
         event = self._build_slash_event(interaction, command_text)
         await self.handle_message(event)
+        if not deferred_response:
+            return
         try:
             if followup_msg:
                 await interaction.edit_original_response(content=followup_msg)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4600,7 +4600,17 @@ class DiscordAdapter(BasePlatformAdapter):
         """Create a Discord thread from a slash command and start a session in it."""
         if not await self._check_slash_authorization(interaction, "/thread"):
             return
-        await interaction.response.defer(ephemeral=True)
+        deferred_response = False
+        try:
+            await interaction.response.defer(ephemeral=True)
+            deferred_response = True
+        except Exception as e:
+            if not self._is_discord_unknown_interaction(e):
+                raise
+            logger.warning(
+                "[Discord] /thread: interaction expired before defer. "
+                "Creating the thread anyway, skipping interaction followups.",
+            )
         result = await self._create_thread(
             interaction,
             name=name,
@@ -4610,7 +4620,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
         if not result.get("success"):
             error = result.get("error", "unknown error")
-            await interaction.followup.send(f"Failed to create thread: {error}", ephemeral=True)
+            if deferred_response:
+                await interaction.followup.send(f"Failed to create thread: {error}", ephemeral=True)
             return
 
         thread_id = result.get("thread_id")
@@ -4618,7 +4629,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
         # Tell the user where the thread is
         link = f"<#{thread_id}>" if thread_id else f"**{thread_name}**"
-        await interaction.followup.send(f"Created thread {link}", ephemeral=True)
+        if deferred_response:
+            await interaction.followup.send(f"Created thread {link}", ephemeral=True)
 
         # Track thread participation so follow-ups don't require @mention
         if thread_id:

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -158,6 +158,34 @@ async def test_registers_native_restart_slash_command(adapter):
     )
 
 
+@pytest.mark.asyncio
+async def test_run_simple_slash_executes_when_defer_interaction_expired(adapter):
+    class UnknownInteraction(Exception):
+        status = 404
+        code = 10062
+
+    interaction = SimpleNamespace(
+        channel=_FakeTextChannel(channel_id=123, name="general"),
+        channel_id=123,
+        guild_id=456,
+        user=SimpleNamespace(id=42, name="Jezza", display_name="Jezza"),
+        response=SimpleNamespace(defer=AsyncMock(side_effect=UnknownInteraction("Unknown interaction"))),
+        edit_original_response=AsyncMock(),
+        delete_original_response=AsyncMock(),
+    )
+    adapter.handle_message = AsyncMock()
+
+    await adapter._run_simple_slash(interaction, "/reset", "Session reset~")
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "/reset"
+    assert event.source.chat_id == "123"
+    interaction.edit_original_response.assert_not_awaited()
+    interaction.delete_original_response.assert_not_awaited()
+
+
 # ------------------------------------------------------------------
 # Auto-registration from COMMAND_REGISTRY
 # ------------------------------------------------------------------
@@ -1117,4 +1145,3 @@ def test_register_skill_command_autocomplete_filters_by_name_and_description(ada
     # (covered in other tests). The autocomplete filter itself is exercised
     # via direct function call in the real-discord integration path.
     assert skill_cmd.callback is not None
-

--- a/tests/gateway/test_discord_thread_slash_expired_defer.py
+++ b/tests/gateway/test_discord_thread_slash_expired_defer.py
@@ -1,0 +1,72 @@
+"""Sibling coverage for expired slash defer handling: /thread creation must
+still run when the interaction token has expired (Discord error 10062), just
+skipping the ephemeral followups."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+class _UnknownInteraction(Exception):
+    status = 404
+    code = 10062
+
+
+def _adapter():
+    a = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    a._check_slash_authorization = AsyncMock(return_value=True)
+    return a
+
+
+@pytest.mark.asyncio
+async def test_thread_create_slash_survives_expired_defer():
+    adapter = _adapter()
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(defer=AsyncMock(side_effect=_UnknownInteraction("Unknown interaction"))),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    adapter._create_thread = AsyncMock(
+        return_value={"success": True, "thread_id": "999", "thread_name": "t"}
+    )
+    adapter._threads = SimpleNamespace(mark=lambda _tid: None)
+
+    await adapter._handle_thread_create_slash(interaction, name="t")
+
+    adapter._create_thread.assert_awaited_once()
+    interaction.followup.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_thread_create_slash_normal_defer_still_follows_up():
+    adapter = _adapter()
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    adapter._create_thread = AsyncMock(
+        return_value={"success": True, "thread_id": "999", "thread_name": "t"}
+    )
+    adapter._threads = SimpleNamespace(mark=lambda _tid: None)
+
+    await adapter._handle_thread_create_slash(interaction, name="t")
+
+    interaction.followup.send.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_thread_create_slash_reraises_non_expiry_errors():
+    adapter = _adapter()
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(defer=AsyncMock(side_effect=RuntimeError("boom"))),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    adapter._create_thread = AsyncMock()
+
+    with pytest.raises(RuntimeError):
+        await adapter._handle_thread_create_slash(interaction, name="t")
+
+    adapter._create_thread.assert_not_awaited()


### PR DESCRIPTION
## Summary
Discord slash commands no longer die with a stack trace when the interaction token has already expired (Discord error 10062 "Unknown interaction") — the command executes anyway and only the ephemeral followup that requires a live token is skipped.

Salvage of #33639 by @Alix-007 (authorship preserved via cherry-pick), widened to the sibling defer site.

## Changes
- Cherry-picked: `_is_discord_unknown_interaction()` structural detector (code 10062, or 404 + "unknown interaction" — checks `code`, nested `data.code`, and response status) + expired-defer handling in `_run_simple_slash`, with test (@Alix-007)
- Follow-up (ours): same pattern applied to `_handle_thread_create_slash` — the other user-facing defer site — thread still gets created, followups skipped; 3 sibling tests (expired defer, normal path, non-expiry errors re-raise)

The two remaining `defer()` calls in the clarify view are already wrapped in their own try/except and were left alone.

## Validation
| | Before | After |
|---|---|---|
| Expired token on simple slash | stack trace, command dies | command runs, followup skipped, warning logged |
| Expired token on /thread | stack trace | thread created, followups skipped |
| Non-expiry defer error | raises | still raises |

Targeted suites: 41/41 green.

## Infographic
![Graceful Expired Interactions](https://v3b.fal.media/files/b/0aa14cbf/RQ8ch592Zt0Z-nazerSNY_8isPGqKV.png)
