### PR TITLE
fix(agent): close Codex Responses swallow window in interruptible_api_call

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -597,6 +597,17 @@ def interruptible_api_call(agent, api_kwargs: dict):
             except Exception:
                 pass
             raise InterruptedError("Agent interrupted during API call")
+    # Worker thread exited before the poll loop's next iteration could check
+    # the interrupt flag. Codex Responses turns route through this function
+    # (_call() → agent._run_codex_stream() → _consume_codex_event_stream()),
+    # whose own interrupt_check() breaks the SSE loop and returns a PARTIAL
+    # response without raising — result["response"] is populated with
+    # error=None and the in-loop raise above never fires. Re-check here so
+    # /stop is not silently swallowed on the Codex Responses path — mirrors
+    # the post-worker guard already applied to the Bedrock and main
+    # streaming loops. (#59999 area)
+    if agent._interrupt_requested:
+        raise InterruptedError("Agent interrupted during API call (post-worker)")
     if result["error"] is not None:
         raise result["error"]
     return result["response"]

--- a/tests/agent/test_codex_interrupt_post_worker.py
+++ b/tests/agent/test_codex_interrupt_post_worker.py
@@ -1,0 +1,78 @@
+"""Regression: /stop must not be swallowed on the Codex Responses non-streaming
+poll loop (interruptible_api_call).
+
+Companion to the Bedrock/main-streaming post-worker guards
+(tests/agent/test_bedrock_interrupt_post_worker.py). Codex Responses turns
+route through interruptible_api_call() -> agent._run_codex_stream() ->
+_consume_codex_event_stream(), whose own interrupt_check() breaks the SSE
+loop and returns a PARTIAL response WITHOUT raising. The worker thread then
+sets result["response"] and exits cleanly with agent._interrupt_requested
+still True. Without a post-worker re-check, interruptible_api_call would
+return that partial response and silently swallow the /stop signal — the
+same bug class the Bedrock streaming loop had, just reached through the
+non-streaming poll loop that codex_responses turns (both "streaming" and
+"non-streaming") are dispatched into.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent import chat_completion_helpers as cch
+
+
+class _FakeAgent:
+    api_mode = "codex_responses"
+    provider = ""
+    _interrupt_requested = False  # not interrupted at entry
+
+    def _create_request_openai_client(self, *, reason, api_kwargs):
+        return SimpleNamespace()
+
+    def _close_request_openai_client(self, client, *, reason):
+        pass
+
+    def _abort_request_openai_client(self, client, *, reason):
+        pass
+
+    def _compute_non_stream_stale_timeout(self, api_kwargs):
+        return 300.0
+
+    def _touch_activity(self, message):
+        pass
+
+    def _buffer_status(self, message):
+        pass
+
+
+def test_codex_stream_interrupt_not_swallowed_post_worker():
+    """A /stop arriving mid-stream: _run_codex_stream's own interrupt_check
+    breaks the SSE loop and returns a partial response WITHOUT raising,
+    leaving _interrupt_requested True. The post-worker re-check in
+    interruptible_api_call must raise InterruptedError instead of returning
+    the partial."""
+    agent = _FakeAgent()
+
+    partial = SimpleNamespace(output=[], output_text="partial", status="incomplete")
+
+    # Simulate the real _consume_codex_event_stream: on interrupt it breaks
+    # out and returns a partial response WITHOUT raising.
+    def _fake_run_codex_stream(api_kwargs, client=None, on_first_delta=None):
+        agent._interrupt_requested = True
+        return partial
+
+    with patch.object(agent, "_run_codex_stream", side_effect=_fake_run_codex_stream, create=True):
+        with pytest.raises(InterruptedError):
+            cch.interruptible_api_call(agent, {"model": "gpt-5-codex"})
+
+
+def test_codex_stream_returns_normally_when_not_interrupted():
+    """Sanity: with no interrupt, the same path returns the response (guard
+    must not fire spuriously)."""
+    agent = _FakeAgent()
+
+    resp = SimpleNamespace(output=[], output_text="done", status="completed")
+
+    with patch.object(agent, "_run_codex_stream", return_value=resp, create=True):
+        out = cch.interruptible_api_call(agent, {"model": "gpt-5-codex"})
+        assert out is resp


### PR DESCRIPTION
## What does this PR do?

`interruptible_api_call()` (`agent/chat_completion_helpers.py`) polls a background worker thread with:

```python
while t.is_alive():
    t.join(timeout=0.3)
    ...
    if agent._interrupt_requested:
        raise InterruptedError("Agent interrupted during API call")
if result["error"] is not None:
    raise result["error"]
return result["response"]
```

Codex Responses turns (both "streaming" and "non-streaming") are dispatched into this exact function: `_call()` → `agent._run_codex_stream()` → `codex_runtime.run_codex_stream()` → `_consume_codex_event_stream()`, which accepts its own `interrupt_check` callback. On interrupt, that callback breaks the SSE consumption loop and **returns a partial response without raising** (`agent/codex_runtime.py:664-665`, `797`). If the worker thread finishes before the main thread's next `while t.is_alive()` evaluation — which is essentially guaranteed here since the fake/real worker can complete synchronously relative to the 0.3s poll — the loop body (including the in-loop `raise`) never runs at all, and the function falls through to `return result["response"]`, silently swallowing `/stop`.

This is the same bug class #60120 fixed for the Bedrock Converse and main OpenAI/Anthropic streaming loops. That PR's reasoning that `interruptible_api_call` is "structurally immune" holds for the `anthropic_messages`/`chat_completions` branches (their blocking workers only exit via the force-close exception the loop itself triggers on interrupt), but not for the `codex_responses` branch, which has its own internal interrupt-aware early return reachable independently of the poll loop's own check.

I verified this empirically before writing the fix: checked out the Bedrock loop's code as it stood *before* #60120/144457d80 (in-loop check only, no post-worker check) and ran that PR's own regression test against it — it fails with `DID NOT RAISE`, confirming the race is real and reliably reproducible, not just theoretical. The same mechanism applies unchanged to this loop.

Fix: add the identical post-worker re-check after the `while` loop, mirroring the guard already applied to the Bedrock and main streaming loops.

## Related Issue

No separate issue filed for this specific gap (found via sibling-site review after #60120).

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `agent/chat_completion_helpers.py`: `interruptible_api_call()` re-checks `agent._interrupt_requested` once more after the poll loop exits, before returning `result["response"]` (+11 lines, comment + guard)
- `tests/agent/test_codex_interrupt_post_worker.py` (new): mirrors `test_bedrock_interrupt_post_worker.py` — a fake `_run_codex_stream` flips `_interrupt_requested` and returns a partial response synchronously, reproducing the exact swallow window; plus a sanity test that a non-interrupted call still returns normally

## How to Test

```
uv run --frozen --extra dev python -m pytest tests/agent/test_codex_interrupt_post_worker.py -v --override-ini="addopts="
```

Mutation-verified: reverting the fix locally makes `test_codex_stream_interrupt_not_swallowed_post_worker` fail with `DID NOT RAISE`.

Also ran the full neighboring suites for regressions (all green): `test_bedrock_interrupt_post_worker.py`, `test_cascading_interrupt_6600.py`, `test_codex_ttfb_watchdog.py`, `test_interrupt_propagation.py`, `test_credential_pool_routing.py`, `test_credential_pool_interrupt.py`, `test_run_agent_codex_responses.py`, `test_codex_responses_adapter.py`, and others (219+13 passed total).

## Checklist
- [x] Contributing Guide okundu | Conventional Commits | Duplicate PR yok
- [x] Sadece bu fix | Tests eklendi | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A