### PR TITLE
feat(skins): support banner tagline branding

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -55,6 +55,15 @@ def _skin_color(key: str, fallback: str) -> str:
         return get_active_skin().get_color(key, fallback)
     except Exception:
         return fallback
+
+
+def _skin_branding(key: str, fallback: str = "") -> str:
+    """Get a branding string from the active skin, or return fallback."""
+    try:
+        from hermes_cli.skin_engine import get_active_skin
+        return get_active_skin().get_branding(key, fallback)
+    except Exception:
+        return fallback
 # =========================================================================
 # ASCII Art & Branding
 # =========================================================================
@@ -676,7 +685,11 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
             preset_name = preset_name[:25] + "..."
         agg_str = f" [dim {dim}]·[/] [dim {dim}]agg {agg_label}[/]" if agg_label else ""
         ctx_str = f" [dim {dim}]·[/] [dim {dim}]{_format_context_length(context_length)} context[/]" if context_length else ""
-        left_lines.append(f"[{accent}]MoA: {preset_name}[/]{agg_str}{ctx_str} [dim {dim}]·[/] [dim {dim}]Nous Research[/]")
+        tagline = _skin_branding("tagline", "Nous Research")
+        if tagline:
+            left_lines.append(f"[{accent}]MoA: {preset_name}[/]{agg_str}{ctx_str} [dim {dim}]·[/] [dim {dim}]{tagline}[/]")
+        else:
+            left_lines.append(f"[{accent}]MoA: {preset_name}[/]{agg_str}{ctx_str}")
     else:
         model_short = model.split("/")[-1] if "/" in model else model
         if model_short.endswith(".gguf"):
@@ -684,7 +697,11 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
         if len(model_short) > 28:
             model_short = model_short[:25] + "..."
         ctx_str = f" [dim {dim}]·[/] [dim {dim}]{_format_context_length(context_length)} context[/]" if context_length else ""
-        left_lines.append(f"[{accent}]{model_short}[/]{ctx_str} [dim {dim}]·[/] [dim {dim}]Nous Research[/]")
+        tagline = _skin_branding("tagline", "Nous Research")
+        if tagline:
+            left_lines.append(f"[{accent}]{model_short}[/]{ctx_str} [dim {dim}]·[/] [dim {dim}]{tagline}[/]")
+        else:
+            left_lines.append(f"[{accent}]{model_short}[/]{ctx_str}")
 
     if os.getenv("HERMES_YOLO_MODE"):
         left_lines.append(f"[bold red]⚠ YOLO mode[/] [dim {dim}]— all approval prompts bypassed[/]")

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -70,6 +70,33 @@ def test_build_welcome_banner_uses_normalized_toolset_names():
     assert "web_tools:" not in output
 
 
+def test_build_welcome_banner_uses_skin_tagline():
+    """The classic/Rich banner reads branding.tagline instead of hardcoding Nous Research."""
+    with (
+        patch.object(model_tools, "check_tool_availability", return_value=(["web"], [])),
+        patch.object(banner, "get_available_skills", return_value={}),
+        patch.object(banner, "get_update_result", return_value=None),
+        patch.object(tools.mcp_tool, "get_mcp_status", return_value=[]),
+        patch.object(
+            banner,
+            "_skin_branding",
+            side_effect=lambda key, fallback="": "Custom subtitle" if key == "tagline" else fallback,
+        ),
+    ):
+        console = Console(record=True, force_terminal=False, color_system=None, width=160)
+        banner.build_welcome_banner(
+            console=console,
+            model="anthropic/test-model",
+            cwd="/tmp/project",
+            tools=[{"function": {"name": "read_file"}}],
+            get_toolset_for_tool=lambda n: "file",
+        )
+
+    output = console.export_text()
+    assert "Custom subtitle" in output
+    assert "Nous Research" not in output
+
+
 def test_build_welcome_banner_title_is_hyperlinked_to_release():
     """Panel title (version label) is wrapped in an OSC-8 hyperlink to the GitHub release."""
     import io

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -46,6 +46,7 @@ describe('DEFAULT_THEME', () => {
     expect(DEFAULT_THEME.brand.name).toBe('Hermes Agent')
     expect(DEFAULT_THEME.brand.prompt).toBe('❯')
     expect(DEFAULT_THEME.brand.tool).toBe('┊')
+    expect(DEFAULT_THEME.brand.tagline).toBe('Nous Research · Messenger of the Digital Gods')
   })
 
   it('has color palette', async () => {
@@ -242,10 +243,11 @@ describe('fromSkin', () => {
 
   it('overrides branding', async () => {
     const { fromSkin } = await importThemeWithCleanEnv()
-    const { brand } = fromSkin({}, { agent_name: 'TestBot', prompt_symbol: '$' })
+    const { brand } = fromSkin({}, { agent_name: 'TestBot', prompt_symbol: '$', tagline: 'Custom subtitle' })
 
     expect(brand.name).toBe('TestBot')
     expect(brand.prompt).toBe('$')
+    expect(brand.tagline).toBe('Custom subtitle')
   })
 
   it('normalizes skin prompt symbols to trimmed single-line text', async () => {

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -44,9 +44,6 @@ export function ArtLines({ lines }: { lines: [string, string][] }) {
 // Terminals can't scale glyphs, so "responsive" means picking a layout that
 // fits the available columns. Thresholds are picked so each tier reads
 // comfortably without forcing wrap or truncation drift on box-drawing edges.
-const TAG_FULL = 'Nous Research · Messenger of the Digital Gods'
-const TAG_MID = 'Messenger of the Digital Gods'
-const TAG_TINY = 'Nous Research'
 const HIDE_BELOW = 34
 const COMPACT_FROM = 58
 
@@ -77,7 +74,7 @@ function CompactBanner({ cols, t }: { cols: number; t: Theme }) {
       <Text bold color={t.color.primary}>
         {ruleIn(t.brand.name, w)}
       </Text>
-      <Text color={t.color.muted}>{centerIn(TAG_FULL, w)}</Text>
+      <Text color={t.color.muted}>{centerIn(t.brand.tagline, w)}</Text>
       <Text color={t.color.primary}>{'─'.repeat(w)}</Text>
     </Box>
   )
@@ -99,7 +96,7 @@ export function Banner({ maxWidth, t }: { maxWidth?: number; t: Theme }) {
       <Box flexDirection="column" marginBottom={1}>
         <ArtLines lines={logoLines} />
         <Text color={t.color.muted} wrap="truncate-end">
-          {t.brand.icon} {TAG_FULL}
+          {t.brand.icon} {t.brand.tagline}
         </Text>
       </Box>
     )
@@ -110,7 +107,7 @@ export function Banner({ maxWidth, t }: { maxWidth?: number; t: Theme }) {
   }
 
   const name = cols >= 52 ? t.brand.name : (t.brand.name.split(' ')[0] ?? t.brand.name)
-  const tag = cols >= 64 ? TAG_FULL : cols >= 46 ? TAG_MID : TAG_TINY
+  const tag = t.brand.tagline
 
   return (
     <Box flexDirection="column" marginBottom={1}>

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -40,6 +40,7 @@ export interface ThemeBrand {
   prompt: string
   welcome: string
   goodbye: string
+  tagline: string
   tool: string
   helpHeader: string
 }
@@ -239,6 +240,7 @@ const BRAND: ThemeBrand = {
   prompt: '❯',
   welcome: 'Type your message or /help for commands.',
   goodbye: 'Goodbye! ⚕',
+  tagline: 'Nous Research · Messenger of the Digital Gods',
   tool: '┊',
   helpHeader: '(^_^)? Commands'
 }
@@ -580,6 +582,7 @@ export function fromSkin(
         prompt: cleanPromptSymbol(branding.prompt_symbol, d.brand.prompt),
         welcome: branding.welcome ?? d.brand.welcome,
         goodbye: branding.goodbye ?? d.brand.goodbye,
+        tagline: branding.tagline ?? d.brand.tagline,
         tool: toolPrefix || d.brand.tool,
         helpHeader: branding.help_header ?? (helpHeader || d.brand.helpHeader)
       },


### PR DESCRIPTION
## Summary
- add skin-backed `branding.tagline` support to the classic/Rich startup banner
- thread `branding.tagline` through the TUI theme and banner component
- preserve the existing default tagline when skins do not specify one

## Testing
- `python3 -m py_compile hermes_cli/banner.py`
- `uv run --with pytest --with rich --with pyyaml pytest tests/hermes_cli/test_banner.py -q`
- `cd ui-tui && npm run -s typecheck`
- `cd ui-tui && npm test -- --run src/__tests__/theme.test.ts`
- `cd ui-tui && npm run -s build`

## Notes
This lets user skins set a persistent banner subtitle/tagline via:

```yaml
branding:
  tagline: "Custom subtitle"
```

The default remains `Nous Research · Messenger of the Digital Gods` for skins that do not set the field.
