### PR TITLE
fix(plugins): re-register config shell hooks after plugin force-reload (#60036)

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -292,6 +292,22 @@ def iter_configured_hooks(cfg: Optional[Dict[str, Any]]) -> List[ShellHookSpec]:
     return _parse_hooks_block(cfg.get("hooks"))
 
 
+def re_register_config_hooks() -> None:
+    """Re-register shell hooks from config after a plugin force-reload.
+
+    ``PluginManager.discover_and_load(force=True)`` clears the plugin
+    manager's ``_hooks`` dict, which silently drops shell hooks that were
+    registered from ``config.yaml`` at startup.  This function clears the
+    idempotence set and re-runs ``register_from_config()`` so the hooks
+    are wired up again.
+    """
+    with _registered_lock:
+        _registered.clear()
+    from hermes_cli.config import load_config
+
+    register_from_config(load_config())
+
+
 def reset_for_tests() -> None:
     """Clear the idempotence set.  Test-only helper."""
     with _registered_lock:


### PR DESCRIPTION
Shell hooks from config.yaml were lost after plugin force-reload because hook registration only ran once at startup. Now re-registers hooks after discover_and_load(force=True) completes. Closes #60036