### PR TITLE
fix(desktop): use default font-smoothing on Retina to fix faint text (#59751)

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -235,10 +235,10 @@
       var(--ui-accent) var(--theme-control-active-accent-mix),
       color-mix(in srgb, var(--ui-base) 5%, transparent)
     );
-    --ui-text-primary: color-mix(in srgb, var(--ui-base) 94%, transparent);
-    --ui-text-secondary: color-mix(in srgb, var(--ui-base) 74%, transparent);
-    --ui-text-tertiary: color-mix(in srgb, var(--ui-base) 54%, transparent);
-    --ui-text-quaternary: color-mix(in srgb, var(--ui-base) 36%, transparent);
+    --ui-text-primary: color-mix(in srgb, var(--ui-base) 100%, transparent);
+    --ui-text-secondary: color-mix(in srgb, var(--ui-base) 82%, transparent);
+    --ui-text-tertiary: color-mix(in srgb, var(--ui-base) 62%, transparent);
+    --ui-text-quaternary: color-mix(in srgb, var(--ui-base) 42%, transparent);
     --ui-stroke-primary: color-mix(
       in srgb,
       var(--ui-accent) var(--theme-stroke-primary-accent-mix),


### PR DESCRIPTION
Closes #59751