### PR TITLE
fix(update): refresh runtime modules before lazy backends

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4434,6 +4434,38 @@ def _clear_bytecode_cache(root: Path) -> int:
     return removed
 
 
+_UPDATE_RUNTIME_RELOAD_MODULES = (
+    "hermes_constants",
+    "tools.environments.local",
+    "tools.lazy_deps",
+)
+
+
+def _reload_updated_runtime_modules() -> None:
+    """Reload update-sensitive modules after the checkout changes in-place.
+
+    ``hermes update`` keeps running in the pre-pull Python process. After a
+    large update, modules already present in ``sys.modules`` can still expose
+    old symbols even though their source files on disk are new. Refresh the
+    small module set used by lazy-backend refresh before that step imports
+    newly-updated code paths.
+    """
+    try:
+        import importlib
+
+        importlib.invalidate_caches()
+        for module_name in _UPDATE_RUNTIME_RELOAD_MODULES:
+            module = sys.modules.get(module_name)
+            if module is None:
+                continue
+            try:
+                importlib.reload(module)
+            except Exception as exc:
+                logger.debug("Could not reload updated module %s: %s", module_name, exc)
+    except Exception as exc:
+        logger.debug("Could not refresh update runtime modules: %s", exc)
+
+
 # Critical files that Hermes must be able to import immediately after an
 # update/install. Most are imported on every CLI startup; ``web_server.py``
 # is the desktop/dashboard backend path that a fresh Windows install launches
@@ -9900,6 +9932,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # UI, desktop rebuild) are non-core and can't brick the venv.
         _clear_update_incomplete_marker()
 
+        # The update process is still the old Python interpreter process. Run
+        # one final cache/module refresh immediately before lazy backend
+        # refresh, which imports newly-pulled modules that may depend on fresh
+        # symbols in hermes_constants or lazy_deps.
+        removed = _clear_bytecode_cache(PROJECT_ROOT)
+        if removed:
+            print(
+                f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}"
+            )
+        _reload_updated_runtime_modules()
+
         _refresh_active_lazy_features()
 
         _update_node_dependencies()
@@ -9956,18 +9999,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print("  ✓ Model catalog cache refreshed from checkout")
         except Exception as e:
             logger.debug("Model catalog seed during update failed: %s", e)
-
-        # After git pull, source files on disk are newer than cached Python
-        # modules in this process.  Reload hermes_constants so that any lazy
-        # import executed below (skills sync, gateway restart) sees new
-        # attributes like display_hermes_home() added since the last release.
-        try:
-            import importlib
-            import hermes_constants as _hc
-
-            importlib.reload(_hc)
-        except Exception:
-            pass  # non-fatal — worst case a lazy import fails gracefully
 
         # Sync bundled skills (copies new, updates changed, respects user deletions)
         try:

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -475,6 +475,60 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     assert ".[all]" in install_cmds[0]
 
 
+def test_cmd_update_reloads_runtime_modules_before_lazy_refresh(monkeypatch, tmp_path):
+    """Lazy refresh must not see pre-pull modules cached in this process."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(hermes_main, "_is_termux_env", lambda env=None: False)
+
+    events = []
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "fetch", "origin", "main"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+        if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
+            return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
+        if cmd == ["git", "pull", "--ff-only", "origin", "main"]:
+            events.append("pull")
+            return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
+        if "pip" in cmd and "install" in cmd:
+            events.append("install")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_reload_runtime_modules():
+        events.append("reload")
+
+    def fake_refresh_lazy_features():
+        events.append("lazy-refresh")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(hermes_main, "_reload_updated_runtime_modules", fake_reload_runtime_modules)
+    monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", fake_refresh_lazy_features)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    assert (
+        events.index("pull")
+        < events.index("install")
+        < events.index("reload")
+        < events.index("lazy-refresh")
+    )
+
+
+def test_reload_updated_runtime_modules_restores_new_hermes_constants_symbol(monkeypatch):
+    """A pre-pull module object missing a new helper is repaired by reload."""
+    import hermes_constants
+
+    monkeypatch.delattr(hermes_constants, "apply_subprocess_home_env", raising=False)
+    assert not hasattr(hermes_constants, "apply_subprocess_home_env")
+
+    hermes_main._reload_updated_runtime_modules()
+
+    assert callable(hermes_constants.apply_subprocess_home_env)
+
+
 def test_install_with_optional_fallback_honors_custom_group(monkeypatch):
     """Termux update path should target .[termux-all] when requested."""
     calls = []


### PR DESCRIPTION
## What does this PR do?

Fixes an update-time code-skew window where `hermes update` can refresh lazy backends from a Python process that still has pre-pull modules cached in `sys.modules`.

After a large git update, newly pulled lazy-backend code can import helpers that did not exist in the pre-update process. In #60242, lazy refresh imported a fresh `tools.environments.local` path that expects `hermes_constants.apply_subprocess_home_env`, while the running update process could still hold an old `hermes_constants` module object.

This moves the runtime refresh to the right side of the update sequence: after dependency install, but before active lazy backend refresh. It also repeats the bytecode sweep immediately before lazy refresh and reloads the small module set involved in the failure path.

## Related Issue

Fixes #60242

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: add `_reload_updated_runtime_modules()` for update-sensitive modules used by lazy refresh.
- `hermes_cli/main.py`: run a final bytecode sweep and runtime-module reload immediately before `_refresh_active_lazy_features()`.
- `tests/hermes_cli/test_update_autostash.py`: add regression coverage for the update ordering and for restoring a newly added `hermes_constants` helper on a cached module object.

## How to Test

1. `./.venv/bin/python -m pytest tests/hermes_cli/test_update_autostash.py::test_cmd_update_reloads_runtime_modules_before_lazy_refresh tests/hermes_cli/test_update_autostash.py::test_reload_updated_runtime_modules_restores_new_hermes_constants_symbol -q`
2. `./.venv/bin/python -m pytest tests/hermes_cli/test_update_autostash.py -q`
3. `./.venv/bin/python -m ruff check hermes_cli/main.py tests/hermes_cli/test_update_autostash.py`
4. `./.venv/bin/python -m py_compile hermes_cli/main.py tests/hermes_cli/test_update_autostash.py`
5. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / local targeted Python tests and static checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted validation passed:

```text
./.venv/bin/python -m pytest tests/hermes_cli/test_update_autostash.py::test_cmd_update_reloads_runtime_modules_before_lazy_refresh tests/hermes_cli/test_update_autostash.py::test_reload_updated_runtime_modules_restores_new_hermes_constants_symbol -q
2 passed

./.venv/bin/python -m pytest tests/hermes_cli/test_update_autostash.py -q
35 passed

./.venv/bin/python -m ruff check hermes_cli/main.py tests/hermes_cli/test_update_autostash.py
All checks passed!

./.venv/bin/python -m py_compile hermes_cli/main.py tests/hermes_cli/test_update_autostash.py
passed

git diff --check
clean
```

Not run: Windows v0.14.0 to v0.18.0 end-to-end update; full `pytest tests/ -q`.
