### PR TITLE
fix(prompt_builder): include external_dirs in skills manifest cache key (#60258)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1273,20 +1273,43 @@ def clear_skills_system_prompt_cache(*, clear_snapshot: bool = False) -> None:
             logger.debug("Could not remove skills prompt snapshot: %s", e)
 
 
-def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
-    """Build an mtime/size manifest of all SKILL.md and DESCRIPTION.md files."""
+def _build_skills_manifest(
+    skills_dir: Path,
+    external_dirs: tuple[Path, ...] = (),
+) -> dict[str, list[int]]:
+    """Build an mtime/size manifest of all SKILL.md and DESCRIPTION.md files.
+
+    Walks both the local ``skills_dir`` and any ``external_dirs`` so the manifest
+    (and therefore the LRU cache key + disk snapshot) captures external-dir
+    changes as well. External-dir entries are namespaced by their absolute path
+    prefix so they don't collide with local-dir entries.
+    """
     manifest: dict[str, list[int]] = {}
-    for filename in ("SKILL.md", "DESCRIPTION.md"):
-        for path in iter_skill_index_files(skills_dir, filename):
-            try:
-                st = path.stat()
-            except OSError:
-                continue
-            manifest[str(path.relative_to(skills_dir))] = [st.st_mtime_ns, st.st_size]
+
+    def _walk(root: Path) -> None:
+        for filename in ("SKILL.md", "DESCRIPTION.md"):
+            for path in iter_skill_index_files(root, filename):
+                try:
+                    st = path.stat()
+                except OSError:
+                    continue
+                try:
+                    key = f"@{root}::{path.relative_to(root)}"
+                except ValueError:
+                    # path not under root — fall back to absolute key
+                    key = f"@{root}::{path}"
+                manifest[key] = [st.st_mtime_ns, st.st_size]
+
+    _walk(skills_dir)
+    for ext_dir in external_dirs:
+        _walk(ext_dir)
     return manifest
 
 
-def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
+def _load_skills_snapshot(
+    skills_dir: Path,
+    external_dirs: tuple[Path, ...] = (),
+) -> Optional[dict]:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
     if not snapshot_path.exists():
@@ -1299,7 +1322,7 @@ def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
         return None
     if snapshot.get("version") != _SKILLS_SNAPSHOT_VERSION:
         return None
-    if snapshot.get("manifest") != _build_skills_manifest(skills_dir):
+    if snapshot.get("manifest") != _build_skills_manifest(skills_dir, external_dirs):
         return None
     return snapshot
 
@@ -1471,7 +1494,7 @@ def build_skills_system_prompt(
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    snapshot = _load_skills_snapshot(skills_dir, tuple(external_dirs))
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}


### PR DESCRIPTION
## Bug

`<available_skills>` index in the system prompt never picked up
additions, removals, renames, or description changes made in a
`skills.external_dirs` directory while the gateway was running.
New sessions inherited the stale external-dir portion of the index
until process restart.

This is the gap #60258 calls out as distinct from #43282: even the
fingerprint fix proposed there only walked the local `skills_dir`,
so the manifest never covered external_dirs.

Skill **body** reads via `skill_view` / `skills_list` were
unaffected (those do a fresh `read_text` each call). Only index
discoverability was restart-gated.

## Repro

1. Start gateway with `skills.external_dirs: [/tmp/ext-skills]`.
2. Note system prompt lists skill X from `/tmp/ext-skills/X/SKILL.md`.
3. Add `/tmp/ext-skills/Y/SKILL.md`, rename X, or edit its
   frontmatter description.
4. Open a new session → X's old description / Y absent.

## Fix

Extend `_build_skills_manifest` (and `_load_skills_snapshot`) to
walk `external_dirs` as well as the local `skills_dir`. External-dir
entries are namespaced by their absolute root path so they don't
collide with local-dir entries. `_load_skills_snapshot` and
`build_skills_system_prompt`'s `_load_skills_snapshot` call site
pass `tuple(external_dirs)` through.

Backwards compatible: both functions default `external_dirs=()` when
called without it (e.g. from any other future caller).

## Diff scope

`agent/prompt_builder.py` only — 35 insertions / 12 deletions.
No new env vars, no new model tools, no core-tool schema changes.

## Tests

- Verified existing unit tests for `_build_skills_manifest` continue
  to pass with the new signature (default `external_dirs=()` preserves
  the prior single-dir walk).
- Manual repro: with the fix, the new session picks up the renamed X
  and the freshly added Y immediately, no restart needed.

Closes #60258