### PR TITLE
fix(moa): prevent reference models from receiving tool definitions

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -275,6 +275,7 @@ def _run_reference(
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
+            tools=None,
             **runtime,
         )
         usage = CanonicalUsage()

--- a/tests/agent/test_moa_reference_no_tools.py
+++ b/tests/agent/test_moa_reference_no_tools.py
@@ -1,0 +1,82 @@
+"""Regression test: MoA reference models must not receive tool definitions.
+
+Reference models are advisory only and should never attempt to call tools.
+The system prompt (_REFERENCE_SYSTEM_PROMPT) instructs them not to, but
+the fix also explicitly passes tools=None to prevent providers from
+sending tool definitions in the first place.
+
+Issue: #60272
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _response(content="advice", tool_calls=None):
+    """Fake LLM response for testing."""
+    message = SimpleNamespace(content=content, tool_calls=tool_calls or [])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="fake")
+
+
+@pytest.fixture
+def captured_reference_calls(monkeypatch):
+    """Capture all call_llm invocations made by _run_reference."""
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response()
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+    return calls
+
+
+def test_reference_models_receive_no_tools(captured_reference_calls, monkeypatch):
+    """MoA reference model calls must pass tools=None to prevent tool calls."""
+    from agent import moa_loop
+
+    # Mock _slot_runtime to return a valid runtime (non-anthropic to avoid cache control)
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda slot: {
+            "provider": "openai",
+            "model": "gpt-5.5",
+            "base_url": "",
+            "api_mode": "openai_chat",
+        },
+    )
+
+    # Mock _extract_text to return content from response
+    monkeypatch.setattr(moa_loop, "_extract_text", lambda r: r.choices[0].message.content)
+
+    # Call _run_reference with a minimal slot and message
+    slot = {"provider": "openai", "model": "gpt-5.5"}
+    ref_messages = [{"role": "user", "content": "what should I do?"}]
+
+    label, text, usage = moa_loop._run_reference(slot, ref_messages)
+
+    # Verify call_llm was invoked exactly once
+    assert len(captured_reference_calls) == 1, "Expected exactly one call_llm invocation"
+
+    # Verify tools=None was passed
+    call_kwargs = captured_reference_calls[0]
+    assert "tools" in call_kwargs, "tools parameter must be present"
+    assert call_kwargs["tools"] is None, "tools must be explicitly None to prevent tool calls"
+
+    # Verify the call had the expected task marker
+    assert call_kwargs.get("task") == "moa_reference", "Task marker must be moa_reference"
+
+    # Verify system prompt was prepended
+    assert call_kwargs["messages"][0]["role"] == "system"
+    system_content = call_kwargs["messages"][0]["content"]
+    # For non-Anthropic routes, content is a string
+    if isinstance(system_content, str):
+        assert "Mixture of Agents" in system_content
+        assert "NOT the acting agent" in system_content
+    else:
+        # For Anthropic routes, content is a list of blocks
+        assert any("Mixture of Agents" in block.get("text", "") for block in system_content if isinstance(block, dict))
+        assert any("NOT the acting agent" in block.get("text", "") for block in system_content if isinstance(block, dict))


### PR DESCRIPTION
## What does this PR do?

Prevents MoA (Mixture of Agents) reference models from receiving tool definitions via the LLM API. Reference models are advisory-only and should never attempt to call tools. While the existing system prompt (`_REFERENCE_SYSTEM_PROMPT`) instructs them not to, the fix now explicitly passes `tools=None` to `_run_reference`'s `call_llm` invocation to prevent providers from sending tool definitions in the first place.

This addresses the root cause where reference models would still attempt to issue tool calls despite the system prompt instructions, leading to failures and context pollution in the aggregate model.

## Related Issue

Fixes #60272

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moa_loop.py`: Added `tools=None` parameter to `call_llm` invocation in `_run_reference` function (line 278)
- `tests/agent/test_moa_reference_no_tools.py`: Added regression test verifying that reference model calls pass `tools=None`

## How to Test

Run the new regression test to verify that reference models do not receive tool definitions:

```bash
pytest tests/agent/test_moa_reference_no_tools.py -v
```

Observed result: test passes, confirming `tools=None` is passed to `call_llm` for all reference model invocations.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A