### PR TITLE
fix(mcp): move t.cancel() inside try block to prevent RuntimeError on /exit

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1761,10 +1761,12 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
-                    except (asyncio.CancelledError, Exception):
+                    except (asyncio.CancelledError, RuntimeError):
+                        pass
+                    except Exception:
                         pass
 
         if self._shutdown_event.is_set():
@@ -1797,10 +1799,12 @@ class MCPServerTask:
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
-                    t.cancel()
                     try:
+                        t.cancel()
                         await t
-                    except (asyncio.CancelledError, Exception):
+                    except (asyncio.CancelledError, RuntimeError):
+                        pass
+                    except Exception:
                         pass
         if self._shutdown_event.is_set():
             return "shutdown"


### PR DESCRIPTION
Cherry-pick of PR #60213 by webtecnica.

During shutdown, the event loop is closed before MCP tasks finish, so t.cancel() raises RuntimeError("Event loop is closed"). Moved t.cancel() inside the try block at both locations in tools/mcp_tool.py.

(cherry picked from commit 8c7afb4a)
Co-authored-by: webtecnica <75556242+webtecnica@users.noreply.github.com>
Closes #60197