### PR TITLE
fix(gateway): decode + byte-truncate cached document filenames

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1550,6 +1550,41 @@ def cache_document_from_bytes(data: bytes, filename: str) -> str:
     safe_name = safe_name.replace("\x00", "").strip()
     if not safe_name or safe_name in {".", ".."}:
         safe_name = "document"
+    # Decode URL-encoded names (e.g. WeCom sends %E5%B8%82... for Chinese titles)
+    # so on-disk names stay human-readable AND short. Without this, one CJK char
+    # becomes 9 bytes and long titles overflow the 255-byte NAME_MAX on macOS/ext4.
+    try:
+        from urllib.parse import unquote as _unquote
+        decoded = _unquote(safe_name)
+        if decoded and decoded != safe_name:
+            safe_name = decoded.replace("\x00", "").strip() or safe_name
+    except Exception:
+        pass
+    # Enforce filesystem NAME_MAX (255 bytes on macOS/ext4). Reserve budget for
+    # the ``doc_{uuid12}_`` prefix (17 chars) and a safety margin.
+    MAX_NAME_BYTES = 200
+    ext = Path(safe_name).suffix
+    stem = Path(safe_name).stem or "document"
+    # Truncate stem in bytes (UTF-8-safe), keeping the extension intact.
+    stem_bytes = stem.encode("utf-8", errors="ignore")
+    ext_bytes = ext.encode("utf-8", errors="ignore")
+    budget = MAX_NAME_BYTES - len(ext_bytes)
+    if budget < 1:
+        # Extension itself is absurdly long; drop it.
+        ext = ""
+        budget = MAX_NAME_BYTES
+    if len(stem_bytes) > budget:
+        # Trim on a UTF-8 code-point boundary.
+        trimmed = stem_bytes[:budget]
+        for _ in range(4):
+            try:
+                stem = trimmed.decode("utf-8")
+                break
+            except UnicodeDecodeError:
+                trimmed = trimmed[:-1]
+        else:
+            stem = trimmed.decode("utf-8", errors="ignore") or "document"
+        safe_name = f"{stem}{ext}"
     cached_name = f"doc_{uuid.uuid4().hex[:12]}_{safe_name}"
     filepath = cache_dir / cached_name
     # Final safety check: ensure path stays inside cache dir

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -242,3 +242,67 @@ class TestCacheMediaBytes:
         from gateway.platforms.base import cache_media_bytes
         result = cache_media_bytes(b"<html>not an image</html>", filename="x.png", mime_type="image/png")
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestCacheDocumentFilenameLength — regression tests for URL-encoded CJK
+# filenames overflowing the 255-byte NAME_MAX limit on macOS/ext4.
+# ---------------------------------------------------------------------------
+
+class TestCacheDocumentFilenameLength:
+    def test_url_encoded_cjk_filename_is_decoded(self):
+        """WeCom-style %E5%B8%82... escapes are unquoted so the on-disk name
+        stays human-readable."""
+        # "报告.pdf" percent-encoded (utf-8): %E6%8A%A5%E5%91%8A.pdf
+        encoded = "%E6%8A%A5%E5%91%8A.pdf"
+        path = cache_document_from_bytes(b"data", encoded)
+        basename = os.path.basename(path)
+        # Percent escapes should not survive intact.
+        assert "%E6%8A%A5" not in basename
+        # Decoded CJK form appears.
+        assert "报告.pdf" in basename
+
+    def test_long_url_encoded_filename_truncated_under_255_bytes(self):
+        """A 40-char CJK filename URL-encodes to 360+ bytes; without
+        truncation the write fails with OSError [Errno 63]."""
+        long_cjk = "特" * 60 + ".pdf"  # 60 CJK + ".pdf" = ~184 bytes utf-8
+        # Simulate what WeCom would send: percent-encoded
+        from urllib.parse import quote
+        encoded = quote(long_cjk)  # ~540 bytes ASCII
+        assert len(encoded.encode("utf-8")) > 255
+
+        path = cache_document_from_bytes(b"data", encoded)
+        basename = os.path.basename(path)
+        # macOS HFS+/APFS NAME_MAX = 255 bytes per path component.
+        assert len(basename.encode("utf-8")) <= 255
+        # Extension is preserved.
+        assert basename.endswith(".pdf")
+        # File actually exists on disk (the whole point of the fix).
+        assert os.path.exists(path)
+
+    def test_ascii_long_filename_truncated(self):
+        """Non-CJK long filenames are also truncated to keep the cache
+        prefix ('doc_<uuid12>_') within budget."""
+        long_ascii = "a" * 400 + ".txt"
+        path = cache_document_from_bytes(b"data", long_ascii)
+        basename = os.path.basename(path)
+        assert len(basename.encode("utf-8")) <= 255
+        assert basename.endswith(".txt")
+        assert os.path.exists(path)
+
+    def test_truncation_preserves_utf8_boundary(self):
+        """Byte-level truncation must not split a multi-byte codepoint —
+        otherwise the resulting name would be undecodable."""
+        long_cjk_name = ("特殊设备使用管理规则若干问题的通知" * 12) + ".pdf"
+        path = cache_document_from_bytes(b"data", long_cjk_name)
+        basename = os.path.basename(path)
+        # Basename must be valid UTF-8.
+        basename.encode("utf-8").decode("utf-8")  # raises if broken
+        assert basename.endswith(".pdf")
+
+    def test_short_filename_untouched(self):
+        """Names already under the limit are left alone (except the uuid
+        prefix that cache_document_from_bytes always adds)."""
+        path = cache_document_from_bytes(b"data", "short.pdf")
+        basename = os.path.basename(path)
+        assert "short.pdf" in basename


### PR DESCRIPTION
## What does this PR do?

`cache_document_from_bytes()` writes the caller-supplied filename verbatim after stripping path separators and null bytes. Two independent issues cause attachments to silently disappear:

1. Some adapters (WeCom, Line, etc.) hand off **URL-encoded** names — each CJK character becomes `%XX%XX%XX` (9 bytes). A 40-character Chinese title balloons past 360 bytes.
2. macOS HFS+/APFS and ext4 enforce **NAME_MAX = 255 bytes per path component**. Long names trigger `OSError: [Errno 63] File name too long` and the cached file is silently lost.

Net effect: user sends a PDF with a long Chinese title on WeCom, the adapter downloads the bytes, cache writes fail, downstream tools see "no attachment" — with no error surfaced to the user.

## Related Issue

No existing issue — filed here as a bug fix. Related PR #12616 addresses a **different** filename-sanitisation bug (Windows-reserved characters); the two changes are orthogonal and non-conflicting.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py::cache_document_from_bytes`:
  - URL-decode the sanitised name so the on-disk form matches what the sender sees.
  - Byte-truncate the stem to **200 bytes** (leaving room for the fixed `doc_<uuid12>_` prefix + safety margin), keeping the extension intact.
  - Trim on a UTF-8 code-point boundary so decoded strings stay valid.
- `tests/gateway/test_document_cache.py`:
  - Add `TestCacheDocumentFilenameLength` with 5 regression cases (decode, byte-truncation, ASCII path, UTF-8 boundary, no-op for short names).

## How to Test

**Repro on macOS before the fix:**
1. Send a WeCom message with a PDF whose filename is 40+ CJK characters (e.g. an official Chinese government document title).
2. Adapter downloads the file; `cache_document_from_bytes` raises `OSError [Errno 63]` on write.
3. Downstream tools see no attachment; no error is surfaced to the user.

**After the fix:**
- File lands as `doc_<uuid>_<trimmed-cjk-name>.pdf`.
- `basename.encode("utf-8")` is `<= 255` bytes.
- Downstream document processing succeeds.

**Automated:**
```bash
pytest tests/gateway/test_document_cache.py -q
# 38 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (PR #12616 addresses a different sanitisation angle)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_document_cache.py -q` and all 38 tests pass
- [x] I've added tests for my changes
