### PR TITLE
fix(tools): treat WeCom native IDs as explicit send targets

### DIFF
--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -90,3 +90,59 @@ def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
         force_document=False,
     )
 
+
+# ---------------------------------------------------------------------------
+# WeCom native ID routing — regression tests for #wecom-group-route (2026-07)
+#
+# Before the fix _parse_target_ref had no wecom branch, so 'wecom:wr<groupid>'
+# fell through to resolve_channel_name; the resolver's step-0 exact-id lookup
+# would return the same id, which the caller then re-parsed and still saw as
+# non-explicit, ultimately delivering the message to the home DM channel
+# instead of the target group.
+# ---------------------------------------------------------------------------
+
+
+def test_wecom_group_id_is_explicit() -> None:
+    """WeCom open_chatid (group) starts with 'wr' — must route as explicit."""
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "wecom", "wrFQbCAAA0_qNz5FZGaKcXauJTU7U3Q"
+    )
+    assert chat_id == "wrFQbCAAA0_qNz5FZGaKcXauJTU7U3Q"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_wecom_user_id_is_explicit() -> None:
+    """WeCom open_userid (DM) starts with 'wo' — also explicit."""
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "wecom", "wofFQbCAAAW20pGpj4fHwyCCz2WyUYCA"
+    )
+    assert chat_id == "wofFQbCAAAW20pGpj4fHwyCCz2WyUYCA"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_wecom_wm_prefix_is_explicit() -> None:
+    """'wm' covers ancillary WeCom IDs (media/message tokens, misc)."""
+    assert _parse_target_ref("wecom", "wmXYZ12345")[2] is True
+
+
+def test_wecom_leading_whitespace_ignored() -> None:
+    """Callers occasionally splat 'wecom:  wr...' after string concat."""
+    chat_id, _, is_explicit = _parse_target_ref("wecom", "  wrABCDEF  ")
+    assert is_explicit is True
+    assert chat_id == "wrABCDEF"
+
+
+def test_wecom_friendly_name_still_uses_directory_resolution() -> None:
+    """Non-native names (aliases, group titles) must NOT be treated as
+    explicit so the channel-directory resolver still runs."""
+    assert _parse_target_ref("wecom", "工作群")[2] is False
+    assert _parse_target_ref("wecom", "engineering")[2] is False
+
+
+def test_wecom_prefix_only_matches_wecom_platform() -> None:
+    """The wr/wo/wm heuristic must not leak into other platforms."""
+    assert _parse_target_ref("telegram", "wrFQbCAAA0_qNz5FZGa")[2] is False
+    assert _parse_target_ref("weixin", "wofFQbCAAAW20pGpj4fH")[2] is False
+

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -516,6 +516,16 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
+    if platform_name == "wecom":
+        # WeCom native IDs: user ID starts with "wo" (open_userid), group/room
+        # ID starts with "wr" (open_chatid). Both are opaque tokens made of
+        # letters/digits/underscore, typically 30-40 chars. Treat them as
+        # explicit so `wecom:wrXXXX` routes to the group instead of falling
+        # through to resolve_channel_name (which then loops back to the
+        # home DM channel — bug #wecom-group-route, 2026-07-07).
+        trimmed = target_ref.strip()
+        if trimmed and (trimmed.startswith("wr") or trimmed.startswith("wo") or trimmed.startswith("wm")):
+            return trimmed, None, True
     if platform_name == "yuanbao":
         match = _YUANBAO_TARGET_RE.fullmatch(target_ref)
         if match:


### PR DESCRIPTION
## What does this PR do?

`_parse_target_ref` has explicit-target branches for `weixin`, `yuanbao`, `feishu`, `whatsapp`, etc., but **not for `wecom`**. When a caller passes an explicit WeCom native ID — e.g. `hermes send --to wecom:wrFQbCAAA0_qNz5FZGaKcXauJTU7U3Q` — the function returns `is_explicit=False`, the target falls through to `resolve_channel_name`, which then matches the id via step-0 exact-id lookup and returns the same id. The caller re-parses it, again sees non-explicit, and finally **falls back to the home DM channel**.

Net effect: `hermes send --to wecom:<group_id>` silently delivers the message to the sender's own DM instead of the target group. The CLI even prints a helpful "Sent to wecom home channel (chat_id: wo...)" note, but by then it's too late — the message is in the wrong place. Same failure mode for any explicit `wo...` user id a caller supplies.

## Related Issue

No existing issue — filing directly as a bug fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_tool.py::_parse_target_ref`:
  - Add a `wecom` branch mirroring the existing `weixin` / `yuanbao` / `feishu` pattern.
  - Recognise WeCom native prefixes as explicit refs: `wo` (open_userid / DM), `wr` (open_chatid / group), `wm` (ancillary media/msg tokens).
  - Whitespace-trim before the prefix check so `wecom:  wr...` after string concat still routes correctly.
- `tests/tools/test_send_message_target_parse.py`:
  - Add 6 cases: group id, user id, wm prefix, whitespace tolerance, friendly-name fallthrough (still resolves via directory), prefix isolation (does not leak into other platforms).

## How to Test

**Repro before the fix:**
```bash
hermes send --to 'wecom:wrABCDEFG...' 'hello'
# Returns success=true, note says:
#   'Sent to wecom home channel (chat_id: wo<sender>)'
# Message actually lands in the sender's DM, NOT the group.
```

**After the fix:**
```bash
hermes send --to 'wecom:wrABCDEFG...' 'hello'
# Message lands in the group with chat_id wrABCDEFG...
```

**Automated:**
```bash
pytest tests/tools/test_send_message_target_parse.py -q
# 13 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/tools/test_send_message_target_parse.py -q` and all 13 tests pass
- [x] I've added tests for my changes
