### PR TITLE
fix(wecom): deliver MEDIA attachments via _standalone_send

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -1688,6 +1688,12 @@ async def _standalone_send(
     succeed when cron runs separately from the gateway. Opens an ephemeral
     WeComAdapter, connects, sends, and disconnects. Replaces the legacy
     _send_wecom helper.
+
+    Supports optional media_files: list of (path, is_voice) tuples emitted by
+    ``BasePlatformAdapter.extract_media``. Each file is uploaded via the
+    aibot_upload_media_* protocol and delivered as a native attachment after
+    any text body. force_document is accepted for interface symmetry but
+    ignored — WeCom picks the media type from the file extension itself.
     """
     if not check_wecom_requirements():
         return {"error": "WeCom requirements not met. Need aiohttp + WECOM_BOT_ID/SECRET."}
@@ -1697,14 +1703,36 @@ async def _standalone_send(
         if not connected:
             return {"error": f"WeCom: failed to connect - {getattr(adapter, 'fatal_error_message', None) or 'unknown error'}"}
         try:
-            result = await adapter.send(chat_id, message)
-            if not result.success:
-                return {"error": f"WeCom send failed: {result.error}"}
+            last_result = None
+            if message and message.strip():
+                last_result = await adapter.send(chat_id, message)
+                if not last_result.success:
+                    return {"error": f"WeCom send failed: {last_result.error}"}
+            if media_files:
+                import os as _os
+                for entry in media_files:
+                    # entry is (path, is_voice) — is_voice is a hint we ignore
+                    # for WeCom (its aibot pipeline handles voice via the same
+                    # upload flow, driven by file extension).
+                    if isinstance(entry, (tuple, list)):
+                        media_path = entry[0]
+                    else:
+                        media_path = entry
+                    media_result = await adapter._send_media_source(
+                        chat_id=chat_id,
+                        media_source=media_path,
+                        file_name=_os.path.basename(media_path),
+                    )
+                    if not media_result.success:
+                        return {"error": f"WeCom media send failed ({media_path}): {media_result.error}"}
+                    last_result = media_result
+            if last_result is None:
+                return {"error": "WeCom send failed: neither text nor media provided"}
             return {
                 "success": True,
                 "platform": "wecom",
                 "chat_id": chat_id,
-                "message_id": result.message_id,
+                "message_id": last_result.message_id,
             }
         finally:
             await adapter.disconnect()

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -983,3 +983,150 @@ class TestTextBatchFlushRace:
         assert adapter._pending_text_batches.get(key) is None, (
             "active task must pop the event after processing"
         )
+
+
+# ---------------------------------------------------------------------------
+# TestStandaloneSendMedia — regression for MEDIA delivery on WeCom.
+#
+# _standalone_send is the standalone_sender_fn wired to WeCom in the platform
+# registry. Before the fix it accepted the ``media_files`` kwarg but ignored
+# it, so send_message_tool's MEDIA attachments were silently dropped for
+# every WeCom target. The tests below lock in the three behaviours the fix
+# introduces: text-only unchanged, text+media both delivered, media-only
+# skips the empty text send.
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneSendMedia:
+    @staticmethod
+    def _mock_adapter(send_ok: bool = True, media_ok: bool = True):
+        adapter = MagicMock()
+        adapter.connect = AsyncMock(return_value=True)
+        adapter.disconnect = AsyncMock(return_value=None)
+        adapter.fatal_error_message = None
+        adapter.send = AsyncMock(
+            return_value=SendResult(
+                success=send_ok,
+                message_id="msg-text" if send_ok else None,
+                error=None if send_ok else "text failure",
+            )
+        )
+        adapter._send_media_source = AsyncMock(
+            return_value=SendResult(
+                success=media_ok,
+                message_id="msg-media" if media_ok else None,
+                error=None if media_ok else "upload timeout",
+            )
+        )
+        return adapter
+
+    def _run(self, adapter, *args, **kwargs):
+        from plugins.platforms.wecom import adapter as wc_mod
+
+        with patch.object(wc_mod, "WeComAdapter", return_value=adapter), patch.object(
+            wc_mod, "check_wecom_requirements", return_value=True
+        ):
+            return asyncio.run(wc_mod._standalone_send(*args, **kwargs))
+
+    def test_text_only_still_uses_adapter_send(self):
+        adapter = self._mock_adapter()
+        result = self._run(adapter, PlatformConfig(enabled=True), "chat-1", "hello")
+        assert result == {
+            "success": True,
+            "platform": "wecom",
+            "chat_id": "chat-1",
+            "message_id": "msg-text",
+        }
+        adapter.send.assert_awaited_once_with("chat-1", "hello")
+        adapter._send_media_source.assert_not_called()
+
+    def test_text_plus_media_delivers_both(self, tmp_path):
+        pdf = tmp_path / "report.pdf"
+        pdf.write_bytes(b"%PDF-1.4 test")
+        adapter = self._mock_adapter()
+
+        result = self._run(
+            adapter,
+            PlatformConfig(enabled=True),
+            "chat-1",
+            "caption",
+            media_files=[(str(pdf), False)],
+        )
+        assert result["success"] is True
+        assert result["platform"] == "wecom"
+        # Text was sent first, media after.
+        adapter.send.assert_awaited_once_with("chat-1", "caption")
+        adapter._send_media_source.assert_awaited_once()
+        call_kwargs = adapter._send_media_source.await_args.kwargs
+        assert call_kwargs["chat_id"] == "chat-1"
+        assert call_kwargs["media_source"] == str(pdf)
+        assert call_kwargs["file_name"] == "report.pdf"
+        # Result reports the last message id (media), not the text one.
+        assert result["message_id"] == "msg-media"
+
+    def test_media_only_skips_text_send(self, tmp_path):
+        pdf = tmp_path / "invoice.pdf"
+        pdf.write_bytes(b"%PDF-1.4 x")
+        adapter = self._mock_adapter()
+
+        result = self._run(
+            adapter,
+            PlatformConfig(enabled=True),
+            "chat-1",
+            "   ",  # whitespace-only body: nothing to send as text
+            media_files=[(str(pdf), False)],
+        )
+        assert result["success"] is True
+        adapter.send.assert_not_called()
+        adapter._send_media_source.assert_awaited_once()
+
+    def test_bare_path_entries_supported(self, tmp_path):
+        """media_files entries may be bare strings, not just (path, is_voice)."""
+        pdf = tmp_path / "raw.pdf"
+        pdf.write_bytes(b"%PDF-1.4 y")
+        adapter = self._mock_adapter()
+
+        result = self._run(
+            adapter,
+            PlatformConfig(enabled=True),
+            "chat-1",
+            "",
+            media_files=[str(pdf)],
+        )
+        assert result["success"] is True
+        adapter._send_media_source.assert_awaited_once()
+        call_kwargs = adapter._send_media_source.await_args.kwargs
+        assert call_kwargs["media_source"] == str(pdf)
+
+    def test_multiple_media_files_each_uploaded(self, tmp_path):
+        adapter = self._mock_adapter()
+        files = []
+        for name in ("a.pdf", "b.png", "c.jpg"):
+            p = tmp_path / name
+            p.write_bytes(b"data")
+            files.append((str(p), False))
+
+        result = self._run(
+            adapter,
+            PlatformConfig(enabled=True),
+            "chat-1",
+            "",
+            media_files=files,
+        )
+        assert result["success"] is True
+        assert adapter._send_media_source.await_count == 3
+
+    def test_media_upload_failure_short_circuits(self, tmp_path):
+        pdf = tmp_path / "err.pdf"
+        pdf.write_bytes(b"data")
+        adapter = self._mock_adapter(media_ok=False)
+
+        result = self._run(
+            adapter,
+            PlatformConfig(enabled=True),
+            "chat-1",
+            "",
+            media_files=[(str(pdf), False)],
+        )
+        assert "error" in result
+        assert "upload timeout" in result["error"]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -932,11 +932,38 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # WeCom: like WhatsApp, native media attachments require going through the
+    # plugin's standalone_sender_fn (which uploads via aibot_upload_media_*).
+    # If we fell through to the text-only path below, media_files would be
+    # dropped. Route media + text together here. #wecom-media-2026-07
+    if platform == Platform.WECOM and media_files:
+        from gateway.platform_registry import platform_registry as _pr_wc
+        from hermes_cli.plugins import discover_plugins as _dp_wc
+        _dp_wc()
+        _wc_entry = _pr_wc.get("wecom")
+        if _wc_entry is None or _wc_entry.standalone_sender_fn is None:
+            return {"error": "WeCom plugin not registered or missing standalone_sender_fn"}
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _wc_entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else None,
+                thread_id=thread_id,
+                force_document=force_document,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and whatsapp; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and wecom; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -944,7 +971,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and whatsapp"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and wecom"
         )
 
     last_result = None


### PR DESCRIPTION
## What does this PR do?

The WeCom adapter already ships `_send_media_source` / `_upload_media_bytes` / `_send_media_message` (the three-phase `aibot_upload_media_*` protocol) for outbound file delivery. But nothing wires it up to `send_message_tool`:

- `_send_to_platform` has no WeCom-media branch, so `MEDIA:/path/x.pdf` directives targeting WeCom fall through to the "non-media platforms" path and get silently dropped with an allowlist warning.
- `_standalone_send` (the plugin's `standalone_sender_fn` implementation) accepts a `media_files` kwarg but ignores it entirely.

Net effect: any WeCom message with attachments loses the attachments. Text only. No native surfacing of the drop beyond a low-visibility warning.

## Related Issue

**Prior work on the same bug** (both target the pre-refactor `_send_wecom` helper, which has since been replaced by `_standalone_send`):

- #27967 — `fix(send_message): add WeCom native MEDIA attachment delivery` (author: @zccyman, May 2026)
- #43493 — `fix(wecom): add media attachment support to send_message tool` (author: @liuhao1024, June 2026)

Both PRs need a rebase onto the current `_standalone_send` architecture. Happy to close this in favour of a rebased version of either — filing here so the fix exists against `main` while the earlier PRs get reworked.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/wecom/adapter.py::_standalone_send`
  - Accept the `media_files` kwarg from the `standalone_sender_fn` contract.
  - Iterate each entry (both `(path, is_voice)` tuples from `BasePlatformAdapter.extract_media` and bare paths from other callers).
  - Forward each entry through `adapter._send_media_source` (which handles `aibot_upload_media_*`).
  - Skip the text send when the body is empty/whitespace so "media-only" delivery works.
- `tools/send_message_tool.py::_send_to_platform`
  - Add a WeCom media branch mirroring the WhatsApp one, dispatching through `platform_registry`'s `standalone_sender_fn` so the plugin's upload path handles the file.
  - Include `wecom` in the two allowlist warning strings so the error message no longer misleads.
- `tests/gateway/test_wecom.py::TestStandaloneSendMedia`
  - 6 regression cases: text-only unchanged, text+media both delivered, media-only skips empty text send, bare-string entries supported, multi-file upload, media failure short-circuits.

## How to Test

**Repro before the fix:**
```bash
hermes send --to 'wecom:wr<group>' 'MEDIA:/tmp/foo.pdf caption'
# Caption arrives. PDF dropped with warning:
#   'MEDIA attachments were omitted for wecom; native send_message media delivery
#    is currently only supported for telegram, discord, matrix, weixin, signal,
#    yuanbao, feishu and whatsapp'
```

**After the fix:**
```bash
hermes send --to 'wecom:wr<group>' 'MEDIA:/tmp/foo.pdf caption'
# Caption + PDF both arrive; PDF is a native WeCom attachment.
```

**Automated:**
```bash
pytest tests/gateway/test_wecom.py::TestStandaloneSendMedia -q
# 6 passed
```

Pre-existing async-test failures in `tests/gateway/test_wecom.py` are unrelated (they require `pytest-asyncio`, which is not installed in the test env by default). The 6 new tests do not use asyncio marks and run under vanilla pytest.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate (found #27967 and #43493; both need rebase onto the new `_standalone_send` architecture — this PR replaces them on current `main`)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_wecom.py::TestStandaloneSendMedia -q` and all 6 tests pass
- [x] I've added tests for my changes
