### PR TITLE
fix(installer): put node.exe on PATH for Windows npm lifecycle scripts

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -502,6 +502,26 @@ function Sync-EnvPath {
     $env:Path = [Environment]::GetEnvironmentVariable("Path", "User") + ";" + [Environment]::GetEnvironmentVariable("Path", "Machine")
 }
 
+# npm lifecycle scripts on Windows spawn ``cmd.exe /d /s /c node <script>``.
+# PowerShell can resolve ``node`` via Get-Command while the child cmd process
+# still sees a PATH without node.exe's directory (nvm4w shims, App Paths
+# aliases, stale cross-process PATH).  Prepend the resolved node.exe parent
+# directory so postinstall hooks (electron-winstaller, native modules, etc.)
+# can find ``node``.  Regression for #48130.
+function Ensure-NodeExeOnPath {
+    $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+    if (-not $nodeCmd) { return $false }
+
+    $nodeExeDir = Split-Path $nodeCmd.Source -Parent
+    if (-not $nodeExeDir) { return $false }
+
+    $pathParts = $env:Path -split ";"
+    if ($pathParts -notcontains $nodeExeDir) {
+        $env:Path = "$nodeExeDir;$env:Path"
+    }
+    return $true
+}
+
 # Re-discover uv without re-installing it.  Cross-process stage drivers
 # (the desktop GUI's onboarding wizard, CI step-runners) invoke each stage
 # in a fresh powershell process, so $script:UvCmd set by Install-Uv in a
@@ -920,6 +940,7 @@ function Test-Node {
     if (Get-Command node -ErrorAction SilentlyContinue) {
         $version = node --version
         if (Test-NodeVersionOk $version) {
+            Ensure-NodeExeOnPath | Out-Null
             Write-Success "Node.js $version found"
             $script:HasNode = $true
             return $true
@@ -2246,6 +2267,11 @@ function Install-NodeDeps {
             return
         }
     }
+
+    # npm lifecycle scripts need node.exe on the PATH visible to child
+    # cmd.exe processes.  Stage-Node may have run in a prior process, so
+    # re-apply here before any npm install (regression #48130).
+    Ensure-NodeExeOnPath | Out-Null
 
     # Resolve npm explicitly to npm.cmd, NOT npm.ps1.  Node.js on Windows
     # ships BOTH npm.cmd (a batch shim) and npm.ps1 (a PowerShell shim).

--- a/tests/test_install_ps1_node_path_for_npm.py
+++ b/tests/test_install_ps1_node_path_for_npm.py
@@ -1,0 +1,43 @@
+"""Regression tests for #48130: Windows npm lifecycle scripts need node on PATH.
+
+The desktop installer can resolve ``npm.cmd`` while postinstall hooks fail with
+``'node' is not recognized`` because child ``cmd.exe`` processes do not inherit
+a PATH that includes ``node.exe``'s directory.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _install_ps1() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def test_install_ps1_defines_ensure_node_exe_on_path_helper() -> None:
+    text = _install_ps1()
+    assert "function Ensure-NodeExeOnPath" in text
+    assert re.search(
+        r"\$env:Path\s*=\s*\"\$nodeExeDir;\$env:Path\"",
+        text,
+    ), "Ensure-NodeExeOnPath must prepend node.exe's directory to PATH"
+
+
+def test_test_node_prepends_node_dir_before_success() -> None:
+    text = _install_ps1()
+    assert re.search(
+        r"if \(Test-NodeVersionOk \$version\) \{[\s\S]{0,200}?Ensure-NodeExeOnPath",
+        text,
+    ), "Test-Node must call Ensure-NodeExeOnPath when a system Node passes the version floor"
+
+
+def test_install_node_deps_prepends_node_dir_before_npm() -> None:
+    text = _install_ps1()
+    assert re.search(
+        r"function Install-NodeDeps \{[\s\S]{0,900}?Ensure-NodeExeOnPath[\s\S]{0,900}?Resolve npm explicitly",
+        text,
+    ), "Install-NodeDeps must call Ensure-NodeExeOnPath before invoking npm"


### PR DESCRIPTION
## Summary
- Add `Ensure-NodeExeOnPath` so npm postinstall hooks can find `node.exe` on Windows
- Call it from `Test-Node` (desktop stage) and `Install-NodeDeps` (browser/TUI npm stages)
- Fixes desktop installer failure: `electron-winstaller` postinstall dies with `'node' is not recognized` (#48130)

## Test plan
- [x] `scripts/run_tests.sh tests/test_install_ps1_node_path_for_npm.py -q`
- [ ] Re-run Hermes-Setup.exe on Windows 11 with nvm/system Node and confirm desktop stage completes
