### PR TITLE
fix(cron): harden delivery quality gates

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -790,6 +790,67 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     return str(resolved)
 
 
+def _validate_artifact_pattern_ref(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("artifact expectation path/glob cannot be empty")
+    if text.startswith("vault:"):
+        rel = Path(text[len("vault:"):].lstrip("/"))
+        prefix = "vault"
+    elif text.startswith("hermes:"):
+        rel = Path(text[len("hermes:"):].lstrip("/"))
+        prefix = "hermes"
+    else:
+        raise ValueError("artifact expectation path/glob must start with vault: or hermes:")
+    if rel.is_absolute() or ".." in rel.parts:
+        raise ValueError(f"artifact expectation escapes {prefix}: {text!r}")
+    return text
+
+
+def _normalize_artifact_expectations(expectations: Any) -> Optional[List[Dict[str, Any]]]:
+    if expectations in (None, "", False):
+        return None
+    if not isinstance(expectations, list):
+        raise ValueError("artifact_expectations must be a list")
+
+    normalized: List[Dict[str, Any]] = []
+    for index, raw in enumerate(expectations, start=1):
+        if isinstance(raw, str):
+            item: Dict[str, Any] = {"path": raw}
+        elif isinstance(raw, dict):
+            item = dict(raw)
+        else:
+            raise ValueError(
+                f"artifact_expectations[{index}] must be a string or object"
+            )
+
+        has_path = bool(str(item.get("path") or "").strip())
+        has_glob = bool(str(item.get("glob") or "").strip())
+        if has_path == has_glob:
+            raise ValueError(
+                f"artifact_expectations[{index}] must set exactly one of path or glob"
+            )
+
+        if has_path:
+            item["path"] = _validate_artifact_pattern_ref(item["path"])
+            item.pop("glob", None)
+        else:
+            item["glob"] = _validate_artifact_pattern_ref(item["glob"])
+            item.pop("path", None)
+
+        mode = str(item.get("mode") or "").strip()
+        if not mode:
+            mode = "warn_only" if item.pop("warn_only", False) else "required_for_delivery"
+        if mode not in {"required_for_delivery", "warn_only"}:
+            raise ValueError(
+                f"artifact_expectations[{index}] mode must be required_for_delivery or warn_only"
+            )
+        item["mode"] = mode
+        normalized.append(item)
+
+    return normalized or None
+
+
 def _resolve_default_model_snapshot() -> Optional[str]:
     """Resolve the global default model the same way the cron ticker does.
 
@@ -907,6 +968,7 @@ def create_job(
     base_url: Optional[str] = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
+    artifact_expectations: Optional[List[Any]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
@@ -938,6 +1000,11 @@ def create_job(
         context_from: Optional job ID (or list of job IDs) whose most recent output
                       is injected into the prompt as context before each run.
                       Useful for chaining cron jobs: job A finds data, job B processes it.
+        artifact_expectations: Optional list of file/glob expectations to verify
+                      after a successful run. Each entry may be a string path
+                      or an object with exactly one of ``path``/``glob`` and
+                      optional ``mode`` (``required_for_delivery`` or
+                      ``warn_only``). Paths must use ``vault:`` or ``hermes:``.
         enabled_toolsets: Optional list of toolset names to restrict the agent to.
                           When set, only tools from these toolsets are loaded, reducing
                           token overhead. When omitted, all default tools are loaded.
@@ -987,6 +1054,7 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_artifact_expectations = _normalize_artifact_expectations(artifact_expectations)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1055,6 +1123,7 @@ def create_job(
         "script": normalized_script,
         "no_agent": normalized_no_agent,
         "context_from": context_from,
+        "artifact_expectations": normalized_artifact_expectations,
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),
         "repeat": {
@@ -1171,6 +1240,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            if "artifact_expectations" in updates:
+                updates["artifact_expectations"] = _normalize_artifact_expectations(
+                    updates["artifact_expectations"]
+                )
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
@@ -1611,6 +1685,8 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
 
     for job in jobs:
         if not job.get("enabled", True):
+            continue
+        if job.get("state") == "paused":
             continue
 
         # Cross-process running-claim guard (#59229): if another scheduler

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -12,6 +12,7 @@ import asyncio
 import atexit
 import concurrent.futures
 import contextvars
+import glob
 import json
 import logging
 import os
@@ -20,6 +21,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -57,6 +59,19 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     job_name = job.get("name") or job.get("id") or "cron job"
     text = (error or "unknown error").strip()
     lower = text.lower()
+
+    if re.search(
+        r"(?m)^\s*(?:\[TEAM-IDENTITY\]|BYRON DIRECTIVES \(read FIRST\):|"
+        r"SELF-IMPROVEMENT \(read (?:FIRST|SECOND)\):|YOUR SOURCES \(read in this order\):|"
+        r"ABSOLUTE RULES:|ARTIFACT AND DELIVERY HYGIENE:|QUALITY GATES|DO NOT:|"
+        r"SKILL USE AND IMPROVEMENT LOOP:|WHAT YOU DO:|YOUR PROCEDURE:|"
+        r"SIGNAL FILE FORMAT|FINAL OUTPUT)",
+        text,
+    ):
+        return (
+            f"⚠️ Cron '{job_name}' failed. "
+            "Details were saved in cron output."
+        )
 
     # Provider/API failures are the common noisy path. Keep these short.
     if "429" in text or "rate limit" in lower or "usage limit" in lower:
@@ -287,6 +302,223 @@ def _is_cron_silence_response(text: str) -> bool:
     if upper.startswith("[SILENT]"):
         return True
     return False
+
+
+_SAFE_CONTEXT_JOB_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+_CRON_RESPONSE_HEADING_RE = re.compile(r"(?m)^## Response\s*$")
+_CRON_RESPONSE_TRAILING_SECTION_RE = re.compile(
+    r"(?m)^## (?:Runtime|Delivery Quality Gate|Artifact Expectation Gate|Artifact Expectation Warning)\s*$"
+)
+
+
+def _is_safe_context_job_id(job_id: object) -> bool:
+    """Return True for cron output directory names that cannot traverse paths."""
+    return isinstance(job_id, str) and bool(_SAFE_CONTEXT_JOB_ID_RE.fullmatch(job_id))
+
+
+def _extract_cron_response_context(output_doc: str) -> tuple[str, bool]:
+    """Return the final-response section from a saved cron markdown document."""
+    text = (output_doc or "").strip()
+    matches = list(_CRON_RESPONSE_HEADING_RE.finditer(text))
+    if not matches:
+        return text, False
+    response = text[matches[-1].end():]
+    trailing_section = _CRON_RESPONSE_TRAILING_SECTION_RE.search(response)
+    if trailing_section:
+        response = response[:trailing_section.start()]
+    return response.strip(), True
+
+
+def _replace_cron_response_context(output_doc: str, response: str) -> str:
+    """Replace the final ``## Response`` section in a saved cron document."""
+    text = output_doc or ""
+    matches = list(_CRON_RESPONSE_HEADING_RE.finditer(text))
+    if not matches:
+        return text
+    head = text[:matches[-1].end()].rstrip()
+    return f"{head}\n\n{(response or '').strip()}\n"
+
+
+_CRON_DELIVERY_BLOCK_PATTERNS: tuple[tuple[str, str, str], ...] = (
+    (r"(?im)^\s*\*{0,2}Step\s+[A-Z]\b.*\b(?:done|complete|is complete)\b", "visible step-progress text", "workbench"),
+    (r"(?i)Final checklist(?: verification)?", "visible checklist text", "workbench"),
+    (r"(?i)All (?:five )?(?:checklist )?boxes ticked", "visible checklist text", "workbench"),
+    (r"(?i)All five steps complete", "visible completion claim", "workbench"),
+    (r"(?i)Final output below", "visible workbench text", "workbench"),
+    (r"(?i)\bNow applying humanizer\b", "visible workbench text", "workbench"),
+    (r"(?im)^\s*Humanizer loaded\b", "visible workbench text", "workbench"),
+    (r"(?im)^\s*Draft:\s*$", "visible internal draft text", "internal_audit"),
+    (r"(?im)^\s*AI-tell audit:\s*$", "visible internal audit text", "internal_audit"),
+    (r"(?im)^\s*Final version\b", "visible internal audit text", "internal_audit"),
+    (r"(?i)\bNow the morning briefing\b", "visible workbench text", "workbench"),
+    (r"(?i)\bNow crafting\b", "visible workbench text", "workbench"),
+    (r"(?i)\bNow producing\b", "visible workbench text", "workbench"),
+    (r"(?i)\bNow let me compile\b", "visible workbench text", "workbench"),
+    (r"(?i)\bLet me draft\b", "visible workbench text", "workbench"),
+    (r"(?i)\bLet me compose\b", "visible workbench text", "workbench"),
+    (r"(?i)\bLet me apply (?:the )?humanizer\b", "visible workbench text", "workbench"),
+    (r"(?i)\bNow I have all the source material\b", "visible workbench text", "workbench"),
+    (r"(?i)\bNow I have the full picture\b", "visible workbench text", "workbench"),
+    (r"(?i)\bReply with\b", "visible workbench text", "workbench"),
+    (r"(?i)\bHere's the draft\b", "visible workbench text", "workbench"),
+    (r"(?i)\bHere's the Telegram relay\b", "visible workbench text", "workbench"),
+    (r"(?i)\bReport is complete\b", "visible completion claim", "workbench"),
+    (r"(?i)\bFinal \(humanized\)", "visible internal audit text", "internal_audit"),
+    (r"(?i)\bHumanizer final pass \(internal\)", "visible internal audit text", "internal_audit"),
+    (r"(?i)\bHumanizer self-audit\b", "visible internal audit text", "internal_audit"),
+    (r"(?i)\bDraft \(AI pattern scan\)", "visible internal audit text", "internal_audit"),
+    (r"(?i)What makes .*AI generated", "visible internal audit text", "internal_audit"),
+    (r"(?m)^\s*\[TEAM-IDENTITY\]", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*BYRON DIRECTIVES \(read FIRST\):", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*SELF-IMPROVEMENT \(read (?:FIRST|SECOND)\):", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*YOUR SOURCES \(read in this order\):", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*ABSOLUTE RULES:", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*ARTIFACT AND DELIVERY HYGIENE:", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*QUALITY GATES", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*DO NOT:", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*SKILL USE AND IMPROVEMENT LOOP:", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*WHAT YOU DO:", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*YOUR PROCEDURE:", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*SIGNAL FILE FORMAT", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^\s*FINAL OUTPUT", "prompt tail leaked into response", "prompt_tail"),
+    (r"(?m)^## Response\s*$", "duplicate response marker in final response", "duplicate_response"),
+    (r"(?i)File-mutation verifier", "file-mutation verifier warning leaked", "file_verifier"),
+)
+_NO_AGENT_DELIVERY_BLOCK_CATEGORIES = frozenset({"prompt_tail", "file_verifier"})
+_RECOVERABLE_CRON_RESPONSE_START_RE = re.compile(
+    r"(?m)^(Good morning\b|\[SILENT\]\s*$|"
+    r"(?:\*\*)?(?:Executive read|Objective|Task changes|Decision/ask|"
+    r"Default if no answer|Status|Adjustment|Observed|Learned|"
+    r"Tomorrow objective|Task changes/feed-forward)(?:\*\*)?[:.])"
+)
+
+
+def _recover_deliverable_cron_response(content: str) -> tuple[str, Optional[str]]:
+    """Extract a clean deliverable body from a response with workbench preface."""
+    text = (content or "").strip()
+    if not text:
+        return text, None
+
+    matches = list(_RECOVERABLE_CRON_RESPONSE_START_RE.finditer(text))
+    for match in matches:
+        candidate = text[match.start():].strip()
+        status, reason = _lint_cron_delivery_response(candidate)
+        if status in {"pass", "silent"}:
+            return candidate, "recovered deliverable response after workbench preface"
+        logger.debug("Rejected recovered cron response candidate: %s", reason)
+    return text, None
+
+
+def _lint_cron_delivery_response(content: str, *, no_agent: bool = False) -> tuple[str, Optional[str]]:
+    """Classify final cron content before external delivery."""
+    text = (content or "").strip()
+    if not text:
+        return "pass", None
+
+    normalized = " ".join(text.upper().split())
+    if normalized in _CRON_SILENCE_TOKENS:
+        return "silent", None
+    if not no_agent and _is_cron_silence_response(text):
+        return "block", "decorated [SILENT] marker"
+    if not no_agent and SILENT_MARKER in text.upper():
+        return "block", "decorated [SILENT] marker"
+
+    patterns = _CRON_DELIVERY_BLOCK_PATTERNS
+    if no_agent:
+        patterns = tuple(
+            item for item in patterns
+            if item[2] in _NO_AGENT_DELIVERY_BLOCK_CATEGORIES
+        )
+    for pattern, reason, _category in patterns:
+        if re.search(pattern, text):
+            return "block", reason
+    return "pass", None
+
+
+def _append_delivery_gate_note(output: str, reason: str) -> str:
+    note = (
+        "\n\n## Delivery Quality Gate\n\n"
+        f"External delivery blocked: {reason}\n"
+    )
+    return (output or "").rstrip() + note
+
+
+def _append_artifact_expectation_note(output: str, messages: list[str], *, blocked: bool) -> str:
+    title = "Artifact Expectation Gate" if blocked else "Artifact Expectation Warning"
+    status = "External delivery blocked" if blocked else "Artifact expectation warning"
+    body = "\n".join(f"- {message}" for message in messages)
+    return (output or "").rstrip() + f"\n\n## {title}\n\n{status}:\n{body}\n"
+
+
+def _render_artifact_pattern(pattern: str, run_started_at) -> str:
+    text = str(pattern or "").strip()
+    run_date = run_started_at.strftime("%Y-%m-%d") if run_started_at else _hermes_now().strftime("%Y-%m-%d")
+    text = text.replace("{date}", run_date)
+
+    if text.startswith("vault:"):
+        rel = Path(text[len("vault:"):].lstrip("/"))
+        if rel.is_absolute() or ".." in rel.parts:
+            raise ValueError(f"artifact path escapes vault prefix: {pattern}")
+        return str(Path.home() / "Documents" / "Obsidian Vault" / rel)
+    if text.startswith("hermes:"):
+        rel = Path(text[len("hermes:"):].lstrip("/"))
+        if rel.is_absolute() or ".." in rel.parts:
+            raise ValueError(f"artifact path escapes hermes prefix: {pattern}")
+        return str(_get_hermes_home() / rel)
+    raise ValueError(f"artifact path must use vault: or hermes: prefix: {pattern}")
+
+
+def _is_fresh_artifact(path: Path, run_started_at, *, tolerance_seconds: int = 300) -> bool:
+    try:
+        if not path.exists():
+            return False
+        if run_started_at is None:
+            return True
+        return path.stat().st_mtime >= (run_started_at.timestamp() - tolerance_seconds)
+    except OSError:
+        return False
+
+
+def _verify_cron_artifact_expectations(job: dict, run_started_at) -> tuple[list[str], list[str]]:
+    """Return (required_failures, warnings) for configured artifact expectations."""
+    expectations = job.get("artifact_expectations") or []
+    if not isinstance(expectations, list):
+        return [], [f"artifact_expectations must be a list, got {type(expectations).__name__}"]
+
+    required_failures: list[str] = []
+    warnings: list[str] = []
+    for index, expectation in enumerate(expectations, start=1):
+        if isinstance(expectation, str):
+            expectation = {"path": expectation}
+        if not isinstance(expectation, dict):
+            warnings.append(f"expectation #{index} ignored: expected object, got {type(expectation).__name__}")
+            continue
+
+        mode = str(expectation.get("mode") or "required_for_delivery").strip()
+        if mode not in {"required_for_delivery", "warn_only"}:
+            required_failures.append(f"expectation #{index} has invalid mode: {mode!r}")
+            continue
+        destination = required_failures if mode == "required_for_delivery" else warnings
+        raw_pattern = expectation.get("glob") or expectation.get("path")
+        if not raw_pattern:
+            destination.append(f"expectation #{index} missing path/glob")
+            continue
+
+        try:
+            rendered = _render_artifact_pattern(str(raw_pattern), run_started_at)
+        except ValueError as exc:
+            destination.append(str(exc))
+            continue
+        is_glob = "glob" in expectation
+        matches = [Path(p) for p in glob.glob(rendered)] if is_glob else [Path(rendered)]
+        fresh_matches = [p for p in matches if _is_fresh_artifact(p, run_started_at)]
+
+        if not matches or not any(p.exists() for p in matches):
+            destination.append(f"expected artifact missing: {rendered}")
+        elif not fresh_matches:
+            destination.append(f"expected artifact not updated during this run: {rendered}")
+
+    return required_failures, warnings
 
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
@@ -2121,8 +2353,8 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         if isinstance(context_from, str):
             context_from = [context_from]
         for source_job_id in context_from:
-            # Guard against path traversal — valid job IDs are 12-char hex strings
-            if not source_job_id or not all(c in "0123456789abcdef" for c in source_job_id):
+            # Guard against path traversal before touching the output tree.
+            if not _is_safe_context_job_id(source_job_id):
                 logger.warning(
                     "context_from: skipping invalid job_id %r for job_id=%r name=%r%s",
                     source_job_id,
@@ -2142,16 +2374,32 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 )
                 if not output_files:
                     continue  # silent skip — no output yet
-                latest_output = output_files[0].read_text(encoding="utf-8").strip()
+                latest_doc = output_files[0].read_text(encoding="utf-8").strip()
+                if (
+                    "## Delivery Quality Gate" in latest_doc
+                    or "## Artifact Expectation Gate" in latest_doc
+                ):
+                    logger.info(
+                        "context_from: skipping gated output for job %r",
+                        source_job_id,
+                    )
+                    continue
+                latest_output, extracted_response = _extract_cron_response_context(latest_doc)
                 # Truncate to 8K characters to avoid prompt bloat
                 _MAX_CONTEXT_CHARS = 8000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:
                     latest_output = latest_output[:_MAX_CONTEXT_CHARS] + "\n\n[... output truncated ...]"
                 if latest_output:
+                    context_label = "final response" if extracted_response else "most recent output"
+                    extraction_note = (
+                        "Context extracted from the preceding job's final response.\n\n"
+                        if extracted_response else ""
+                    )
                     prompt = (
                         f"## Output from job '{source_job_id}'\n"
-                        "The following is the most recent output from a preceding "
+                        f"The following is the {context_label} from a preceding "
                         "cron job. Use it as context for your analysis.\n\n"
+                        f"{extraction_note}"
                         f"```\n{latest_output}\n```\n\n"
                         f"{prompt}"
                     )
@@ -3279,6 +3527,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 job.get("name", job["id"]),
             )
             return True  # not an error — already handled/removed
+        run_started_at = _hermes_now()
+        run_started_monotonic = time.monotonic()
 
         # Run the job under the profile's secret scope. get_secret() fails
         # closed outside a scope once profile isolation is in play (multiple
@@ -3328,27 +3578,69 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         delivery_error = None
         try:
-            output_file = save_job_output(job["id"], output)
-            if verbose:
-                logger.info("Output saved to: %s", output_file)
-
             # Deliver the final response to the origin/target chat.
-            # If the agent responded with [SILENT], skip delivery (but
-            # output is already saved above).  Failed jobs always deliver.
+            # If the agent produced a silent response, skip delivery (but save
+            # the output). Failed jobs always deliver a compact operator alert.
             deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
             should_deliver = bool(deliver_content.strip())
-            # Cron silence suppression — see _is_cron_silence_response.  Replaces the
-            # old `SILENT_MARKER in ...upper()` substring check, which both leaked
-            # bracketless near-markers ("SILENT" / "NO_REPLY") and wrongly swallowed
-            # a real report that merely quoted "[SILENT]" mid-sentence (#51438,
-            # #46917).  Keeps the intentional bracketed-prefix / trailing-line
-            # tolerance the cron contract relies on.
-            if should_deliver and success and _is_cron_silence_response(deliver_content):
-                logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-                should_deliver = False
+            if should_deliver and success:
+                lint_status, lint_reason = _lint_cron_delivery_response(
+                    deliver_content,
+                    no_agent=bool(job.get("no_agent")),
+                )
+                if lint_status == "block" and not job.get("no_agent"):
+                    recovered_content, recovery_note = _recover_deliverable_cron_response(deliver_content)
+                    if recovery_note and recovered_content != deliver_content:
+                        deliver_content = recovered_content
+                        final_response = recovered_content
+                        output = _replace_cron_response_context(output, recovered_content)
+                        lint_status, lint_reason = _lint_cron_delivery_response(deliver_content)
+                        logger.info("Job '%s': %s", job["id"], recovery_note)
+                if lint_status == "silent":
+                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                    should_deliver = False
+                elif lint_status == "block":
+                    delivery_error = f"delivery quality gate blocked output: {lint_reason}"
+                    output = _append_delivery_gate_note(output, delivery_error)
+                    should_deliver = False
+                    logger.warning("Job '%s': %s", job["id"], delivery_error)
+
+            if success:
+                artifact_failures, artifact_warnings = _verify_cron_artifact_expectations(
+                    job,
+                    run_started_at,
+                )
+                if artifact_failures:
+                    delivery_error = "artifact expectation gate blocked output: " + "; ".join(artifact_failures)
+                    output = _append_artifact_expectation_note(output, artifact_failures, blocked=True)
+                    should_deliver = False
+                    logger.warning("Job '%s': %s", job["id"], delivery_error)
+                if artifact_warnings:
+                    output = _append_artifact_expectation_note(output, artifact_warnings, blocked=False)
+                    logger.warning(
+                        "Job '%s': artifact expectation warning(s): %s",
+                        job["id"],
+                        "; ".join(artifact_warnings),
+                    )
+
+            elapsed_seconds = time.monotonic() - run_started_monotonic
+            output = (
+                f"{output.rstrip()}\n\n"
+                "## Runtime\n\n"
+                f"Elapsed seconds: {elapsed_seconds:.1f}\n"
+            )
+            logger.info(
+                "Job '%s' elapsed %.1fs",
+                job.get("name", job["id"]),
+                elapsed_seconds,
+            )
+
+            output_file = save_job_output(job["id"], output)
+            if verbose:
+                logger.info("Output saved to: %s", output_file)
 
             if should_deliver:
                 try:

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -102,6 +102,135 @@ class TestBuildJobPromptContextFrom:
         assert "Today's top story: AI is everywhere." in prompt
         assert f"Output from job '{job_a['id']}'" in prompt
 
+    def test_injects_output_from_custom_safe_job_id(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        source_job_id = "pmexec20260602"
+        output_dir = OUTPUT_DIR / source_job_id
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-06-03_09-33-53.md").write_text(
+            "Morning PM plan context", encoding="utf-8"
+        )
+
+        job_b = create_job(
+            prompt="Noon check-in",
+            schedule="every 2h",
+            context_from=source_job_id,
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "Morning PM plan context" in prompt
+        assert "Output from job 'pmexec20260602'" in prompt
+
+    def test_injects_final_response_section_from_saved_cron_doc(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Research", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-06-07_10-00-00.md").write_text(
+            "# Cron Job: Research\n\n"
+            "## Prompt\n\n"
+            "Internal prompt instructions that should not become context.\n\n"
+            "## Response\n\n"
+            "Final answer: change the launch plan.",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Use the prior answer",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "Final answer: change the launch plan." in prompt
+        assert "Internal prompt instructions" not in prompt
+        assert "Context extracted from the preceding job's final response." in prompt
+
+    def test_trims_scheduler_runtime_from_extracted_response_context(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Research", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-06-07_10-30-00.md").write_text(
+            "# Cron Job: Research\n\n"
+            "## Prompt\n\n"
+            "Internal prompt instructions.\n\n"
+            "## Response\n\n"
+            "Final answer only.\n\n"
+            "## Runtime\n\n"
+            "Elapsed seconds: 12.3\n",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Use the prior answer",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "Final answer only." in prompt
+        assert "Elapsed seconds" not in prompt
+        assert "## Runtime" not in prompt
+
+    def test_injects_last_response_section_when_transcript_has_multiple(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Research", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-06-07_11-00-00.md").write_text(
+            "# Cron Job: Research\n\n"
+            "## Response\n\n"
+            "Earlier draft.\n\n"
+            "## Response\n\n"
+            "Final answer wins.",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Use the prior answer",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "Final answer wins." in prompt
+        assert "Earlier draft" not in prompt
+
+    def test_skips_delivery_quality_gated_output(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Research", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-06-07_12-00-00.md").write_text(
+            "# Cron Job: Research\n\n"
+            "## Response\n\n"
+            "This should not become context.\n\n"
+            "## Delivery Quality Gate\n\n"
+            "External delivery blocked: prompt tail leaked into response\n",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Use only safe prior context",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "This should not become context." not in prompt
+        assert "Use only safe prior context" in prompt
+
     def test_uses_most_recent_output(self, cron_env):
         from cron.jobs import create_job, OUTPUT_DIR
         from cron.scheduler import _build_job_prompt
@@ -418,3 +547,83 @@ class TestUpdateContextFrom:
         reloaded = get_job(job_b["id"])
         assert reloaded["prompt"] == "Summarize v2"
         assert reloaded["context_from"] == [job_a["id"]]
+
+
+class TestArtifactExpectationsToolContract:
+    def test_create_lists_and_clears_artifact_expectations(self, cron_env):
+        from tools.cronjob_tools import cronjob
+        import json
+
+        expectation = {
+            "path": "vault:sources/{date}-ai-research-digest.md",
+            "mode": "required_for_delivery",
+        }
+        created = json.loads(cronjob(
+            action="create",
+            prompt="Research",
+            schedule="every 1h",
+            deliver="local",
+            artifact_expectations=[expectation],
+        ))
+        assert created["success"] is True
+        assert created["job"]["artifact_expectations"] == [expectation]
+
+        listing = json.loads(cronjob(action="list", include_disabled=True))
+        listed = next(job for job in listing["jobs"] if job["job_id"] == created["job_id"])
+        assert listed["artifact_expectations"] == [expectation]
+
+        cleared = json.loads(cronjob(
+            action="update",
+            job_id=created["job_id"],
+            artifact_expectations=[],
+        ))
+        assert cleared["success"] is True
+        assert "artifact_expectations" not in cleared["job"]
+
+    def test_update_rejects_invalid_artifact_expectation_mode(self, cron_env):
+        from cron.jobs import create_job
+        from tools.cronjob_tools import cronjob
+        import json
+
+        job = create_job(prompt="Research", schedule="every 1h", deliver="local")
+
+        result = json.loads(cronjob(
+            action="update",
+            job_id=job["id"],
+            artifact_expectations=[
+                {"path": "vault:sources/{date}.md", "mode": "required"}
+            ],
+        ))
+
+        assert result["success"] is False
+        assert "required_for_delivery" in result["error"]
+
+    def test_create_rejects_artifact_expectation_with_path_and_glob(self, cron_env):
+        from tools.cronjob_tools import cronjob
+        import json
+
+        result = json.loads(cronjob(
+            action="create",
+            prompt="Research",
+            schedule="every 1h",
+            deliver="local",
+            artifact_expectations=[
+                {"path": "vault:sources/{date}.md", "glob": "vault:sources/*.md"}
+            ],
+        ))
+
+        assert result["success"] is False
+        assert "exactly one of path or glob" in result["error"]
+
+    def test_direct_create_job_rejects_unprefixed_artifact_path(self, cron_env):
+        from cron.jobs import create_job
+
+        with pytest.raises(ValueError, match="vault: or hermes:"):
+            create_job(
+                prompt="Research",
+                schedule="every 1h",
+                deliver="local",
+                artifact_expectations=[
+                    {"path": "/Users/byron/.hermes/.env", "mode": "required_for_delivery"}
+                ],
+            )

--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -39,3 +39,16 @@ def test_cronjob_schema_required_array_unchanged():
     from tools.cronjob_tools import CRONJOB_SCHEMA
 
     assert CRONJOB_SCHEMA["parameters"]["required"] == ["action"]
+
+
+def test_cronjob_schema_exposes_artifact_expectations_contract():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    prop = CRONJOB_SCHEMA["parameters"]["properties"]["artifact_expectations"]
+    desc = prop["description"]
+    assert prop["type"] == "array"
+    assert "required_for_delivery" in desc
+    assert "warn_only" in desc
+    assert "path/glob" in desc
+    assert "vault:" in desc
+    assert "hermes:" in desc

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -434,6 +434,17 @@ class TestPauseResumeJob:
         assert paused["state"] == "paused"
         assert paused["paused_reason"] == "user paused"
 
+    def test_paused_state_is_not_due_even_if_enabled_true(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 7, 7, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Pause me", schedule="every 1h")
+        job["enabled"] = True
+        job["state"] = "paused"
+        job["next_run_at"] = (now - timedelta(minutes=1)).isoformat()
+        save_jobs([job])
+
+        assert get_due_jobs() == []
+
     def test_resume_reenables_job(self, tmp_cron_dir):
         job = create_job(prompt="Resume me", schedule="every 1h")
         pause_job(job["id"], reason="user paused")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -8,7 +8,20 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
+from cron.scheduler import (
+    _build_job_prompt,
+    _deliver_result,
+    _lint_cron_delivery_response,
+    _merge_mcp_into_per_job_toolsets,
+    _recover_deliverable_cron_response,
+    _resolve_cron_enabled_toolsets,
+    _resolve_delivery_target,
+    _resolve_origin,
+    _send_media_via_adapter,
+    _verify_cron_artifact_expectations,
+    run_job,
+    SILENT_MARKER,
+)
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -954,6 +967,341 @@ class TestDeliverResultErrorReturns:
         result = _deliver_result(job, "Output.")
         assert result is not None
         assert "no delivery target" in result
+
+
+class TestCronDeliveryQualityLint:
+    def test_exact_silent_marker_is_silent(self):
+        assert _lint_cron_delivery_response("[SILENT]") == ("silent", None)
+
+    def test_decorated_silent_marker_is_blocked(self):
+        status, reason = _lint_cron_delivery_response("[SILENT] - nothing new")
+        assert status == "block"
+        assert "decorated" in reason
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "**Step E done — signals archived**\n\nGood morning",
+            "**Step E is complete**\n\nGood morning",
+            "All five steps complete. Final briefing:\n\nGood morning",
+            "Final output below.\n\nGood morning",
+            "Humanizer loaded\n\nGood morning",
+            "Draft:\n\nGood morning",
+            "AI-tell audit:\n\nGood morning",
+            "Final version\n\nGood morning",
+            "Now I have all the source material. Let me compose both drafts.",
+            "Now I have the full picture. Let me compose the evening review.",
+            "Now producing the final Telegram briefing.",
+            "Now let me compile the final audit summary.",
+            "Let me apply the humanizer before final.",
+            "Humanizer final pass (internal): no issues.",
+            "Final (humanized): ready.",
+            "Reply with the following:",
+            "Here's the draft for Byron.",
+            "Here's the Telegram relay.",
+            "Report is complete.",
+            "[TEAM-IDENTITY] You are Friedrich Nietzsche.",
+            "BYRON DIRECTIVES (read FIRST):\n1. Read state.",
+            "SELF-IMPROVEMENT (read SECOND):\n1. Read audit flags.",
+            "ABSOLUTE RULES:\n1. Hard cap.",
+            "ARTIFACT AND DELIVERY HYGIENE:\n- Verify files.",
+            "DO NOT:\n- Deliver to Telegram.",
+            "SKILL USE AND IMPROVEMENT LOOP:\n- Run humanizer.",
+            "Good brief\n\n## Response\n\nSecond response",
+            "⚠️ File-mutation verifier: 1 file was NOT modified.",
+        ],
+    )
+    def test_observed_delivery_leaks_are_blocked(self, content):
+        status, reason = _lint_cron_delivery_response(content)
+        assert status == "block"
+        assert reason
+
+    def test_recovers_clean_briefing_after_workbench_preface(self):
+        content = (
+            "All five steps complete. Final checklist verified. "
+            "Now producing the Telegram summary.\n\n"
+            "Good morning — here's your AI briefing:\n\n"
+            "Useful item.\n\n"
+            "Skills used: ai-research"
+        )
+
+        recovered, note = _recover_deliverable_cron_response(content)
+
+        assert note
+        assert recovered.startswith("Good morning")
+        assert "All five steps complete" not in recovered
+        assert _lint_cron_delivery_response(recovered) == ("pass", None)
+
+    def test_recovers_pm_report_after_workbench_preface(self):
+        content = (
+            "Now I have the full picture. Let me compose the noon check-in.\n\n"
+            "**Status: blocked-by-system.**\n\n"
+            "**Adjustment.** Retry directly if the worker stays blocked.\n\n"
+            "Skills used: project-manager, ce-plan, evidence-led-output"
+        )
+
+        recovered, note = _recover_deliverable_cron_response(content)
+
+        assert note
+        assert recovered.startswith("**Status:")
+        assert "full picture" not in recovered
+        assert _lint_cron_delivery_response(recovered) == ("pass", None)
+
+    def test_no_agent_ordinary_script_output_passes(self):
+        assert _lint_cron_delivery_response(
+            "RAM 92% on host",
+            no_agent=True,
+        ) == ("pass", None)
+
+    def test_no_agent_markdown_response_heading_passes(self):
+        assert _lint_cron_delivery_response(
+            "## Response time\n\nAPI responded in 120ms",
+            no_agent=True,
+        ) == ("pass", None)
+
+    def test_no_agent_script_output_can_discuss_silence_marker(self):
+        assert _lint_cron_delivery_response(
+            "Healthcheck failed: expected exact [SILENT] output was missing.",
+            no_agent=True,
+        ) == ("pass", None)
+
+    def test_no_agent_prompt_tail_still_blocks(self):
+        status, reason = _lint_cron_delivery_response(
+            "[TEAM-IDENTITY] You are a prompt tail.",
+            no_agent=True,
+        )
+        assert status == "block"
+        assert reason == "prompt tail leaked into response"
+
+    def _job(self):
+        return {
+            "id": "job1",
+            "name": "quality-job",
+            "prompt": "run",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+            "enabled": True,
+            "schedule": {"kind": "interval", "minutes": 5},
+            "repeat": None,
+        }
+
+    def test_tick_blocks_contaminated_successful_output_before_delivery(self, tmp_path):
+        job = self._job()
+        contaminated = "Now I have all the source material. Let me compose both drafts."
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.claim_dispatch", return_value=True), \
+             patch("cron.scheduler.mark_job_run") as mock_mark, \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md") as mock_save, \
+             patch("cron.scheduler.run_job", return_value=(True, "# output\n\n## Response\n\n" + contaminated, contaminated, None)), \
+             patch("cron.scheduler._deliver_result") as mock_deliver:
+            from cron.scheduler import tick
+
+            assert tick(verbose=False) == 1
+
+        mock_deliver.assert_not_called()
+        saved_output = mock_save.call_args.args[1]
+        assert "## Delivery Quality Gate" in saved_output
+        assert "delivery quality gate blocked output" in mock_mark.call_args.kwargs["delivery_error"]
+        assert mock_mark.call_args.args[1] is True
+
+    def test_tick_recovers_prefaced_but_clean_briefing(self, tmp_path):
+        job = self._job()
+        contaminated = (
+            "All five steps complete. Final checklist verified. "
+            "Now producing the Telegram summary.\n\n"
+            "Good morning — here's your AI briefing:\n\n"
+            "Useful item.\n\n"
+            "Skills used: ai-research"
+        )
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.claim_dispatch", return_value=True), \
+             patch("cron.scheduler.mark_job_run") as mock_mark, \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md") as mock_save, \
+             patch("cron.scheduler.run_job", return_value=(True, "# output\n\n## Response\n\n" + contaminated, contaminated, None)), \
+             patch("cron.scheduler._deliver_result", return_value=None) as mock_deliver:
+            from cron.scheduler import tick
+
+            assert tick(verbose=False) == 1
+
+        mock_deliver.assert_called_once()
+        delivered = mock_deliver.call_args.args[1]
+        assert delivered.startswith("Good morning")
+        assert "All five steps complete" not in delivered
+        saved_output = mock_save.call_args.args[1]
+        assert "All five steps complete" not in saved_output.split("## Response", 1)[1]
+        assert mock_mark.call_args.kwargs["delivery_error"] is None
+
+    def test_tick_delivers_clean_successful_output(self, tmp_path):
+        job = self._job()
+        clean = "**Evening Review — Saturday, June 6**\n\nObserved: work moved."
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.claim_dispatch", return_value=True), \
+             patch("cron.scheduler.mark_job_run") as mock_mark, \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output\n\n## Response\n\n" + clean, clean, None)), \
+             patch("cron.scheduler._deliver_result", return_value=None) as mock_deliver:
+            from cron.scheduler import tick
+
+            assert tick(verbose=False) == 1
+
+        mock_deliver.assert_called_once()
+        assert mock_mark.call_args.kwargs["delivery_error"] is None
+
+    def test_tick_treats_decorated_silent_as_quality_failure(self, tmp_path):
+        job = self._job()
+        content = "[SILENT] - no vault signal today"
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.claim_dispatch", return_value=True), \
+             patch("cron.scheduler.mark_job_run") as mock_mark, \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", content, None)), \
+             patch("cron.scheduler._deliver_result") as mock_deliver:
+            from cron.scheduler import tick
+
+            assert tick(verbose=False) == 1
+
+        mock_deliver.assert_not_called()
+        assert "decorated [SILENT]" in mock_mark.call_args.kwargs["delivery_error"]
+
+
+class TestCronArtifactExpectations:
+    def _job(self, artifact_expectations):
+        return {
+            "id": "artifact-job",
+            "name": "artifact-job",
+            "prompt": "run",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+            "enabled": True,
+            "schedule": {"kind": "interval", "minutes": 5},
+            "repeat": None,
+            "artifact_expectations": artifact_expectations,
+        }
+
+    def test_fresh_expected_artifact_passes(self, tmp_path):
+        artifact = tmp_path / "2026-06-07-digest.md"
+        artifact.write_text("digest", encoding="utf-8")
+        started_at = MagicMock()
+        started_at.strftime.return_value = "2026-06-07"
+        started_at.timestamp.return_value = artifact.stat().st_mtime - 1
+
+        with patch("cron.scheduler._hermes_home", tmp_path):
+            failures, warnings = _verify_cron_artifact_expectations(
+                self._job([
+                    {"path": "hermes:{date}-digest.md", "mode": "required_for_delivery"}
+                ]),
+                started_at,
+            )
+
+        assert failures == []
+        assert warnings == []
+
+    def test_missing_required_artifact_blocks_delivery(self, tmp_path):
+        job = self._job([
+            {"path": "hermes:{date}-missing.md", "mode": "required_for_delivery"}
+        ])
+        clean = "Saved the digest."
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.claim_dispatch", return_value=True), \
+             patch("cron.scheduler.mark_job_run") as mock_mark, \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md") as mock_save, \
+             patch("cron.scheduler.run_job", return_value=(True, "# output\n\n## Response\n\n" + clean, clean, None)), \
+             patch("cron.scheduler._deliver_result") as mock_deliver:
+            from cron.scheduler import tick
+
+            assert tick(verbose=False) == 1
+
+        mock_deliver.assert_not_called()
+        saved_output = mock_save.call_args.args[1]
+        assert "## Artifact Expectation Gate" in saved_output
+        assert "expected artifact missing" in saved_output
+        assert "artifact expectation gate blocked output" in mock_mark.call_args.kwargs["delivery_error"]
+        assert mock_mark.call_args.args[1] is True
+
+    def test_warn_only_artifact_expectation_does_not_block_delivery(self, tmp_path):
+        job = self._job([
+            {"glob": "hermes:drafts/{date}-*.md", "mode": "warn_only"}
+        ])
+        clean = "Draft reviewed."
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.claim_dispatch", return_value=True), \
+             patch("cron.scheduler.mark_job_run") as mock_mark, \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md") as mock_save, \
+             patch("cron.scheduler.run_job", return_value=(True, "# output\n\n## Response\n\n" + clean, clean, None)), \
+             patch("cron.scheduler._deliver_result", return_value=None) as mock_deliver:
+            from cron.scheduler import tick
+
+            assert tick(verbose=False) == 1
+
+        mock_deliver.assert_called_once()
+        saved_output = mock_save.call_args.args[1]
+        assert "## Artifact Expectation Warning" in saved_output
+        assert mock_mark.call_args.kwargs["delivery_error"] is None
+
+    def test_invalid_artifact_mode_fails_closed(self):
+        job = self._job([
+            {"path": "hermes:{date}-digest.md", "mode": "required"}
+        ])
+        started_at = MagicMock()
+        started_at.strftime.return_value = "2026-06-07"
+        started_at.timestamp.return_value = 1000
+
+        failures, warnings = _verify_cron_artifact_expectations(job, started_at)
+
+        assert warnings == []
+        assert failures == ["expectation #1 has invalid mode: 'required'"]
+
+    def test_raw_absolute_artifact_path_fails_closed(self, tmp_path):
+        job = self._job([
+            {"path": str(tmp_path / "digest.md"), "mode": "required_for_delivery"}
+        ])
+        started_at = MagicMock()
+        started_at.strftime.return_value = "2026-06-07"
+        started_at.timestamp.return_value = 1000
+
+        failures, warnings = _verify_cron_artifact_expectations(job, started_at)
+
+        assert warnings == []
+        assert "vault: or hermes:" in failures[0]
+
+    def test_failed_job_delivers_concise_alert_not_raw_error(self, tmp_path):
+        job = self._job([])
+        raw_error = "[TEAM-IDENTITY] leaked prompt tail from stderr"
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.claim_dispatch", return_value=True), \
+             patch("cron.scheduler.mark_job_run"), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.run_job", return_value=(False, "# output\n" + raw_error, "", raw_error)), \
+             patch("cron.scheduler._deliver_result", return_value=None) as mock_deliver:
+            from cron.scheduler import tick
+
+            assert tick(verbose=False) == 1
+
+        delivered = mock_deliver.call_args.args[1]
+        assert "failed" in delivered
+        assert "Details were saved" in delivered
+        assert "[TEAM-IDENTITY]" not in delivered
 
 
 class TestRunJobSessionPersistence:
@@ -2496,18 +2844,18 @@ class TestSilentDelivery:
                 tick(verbose=False)
             deliver_mock.assert_not_called()
 
-    def test_report_quoting_marker_mid_sentence_still_delivers(self):
-        """A genuine report that merely mentions the token mid-sentence must
-        be delivered — the old substring check wrongly swallowed it."""
+    def test_report_quoting_marker_mid_sentence_is_quality_blocked(self):
+        """Agent content that mentions the delivery sentinel is held for review."""
         response = "I considered staying [SILENT] but here is the summary: 3 items merged."
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
-             patch("cron.scheduler.mark_job_run"):
+             patch("cron.scheduler.mark_job_run") as mark_mock:
             from cron.scheduler import tick
             tick(verbose=False)
-        deliver_mock.assert_called_once()
+        deliver_mock.assert_not_called()
+        assert "decorated [SILENT]" in mark_mock.call_args.kwargs["delivery_error"]
 
     def test_is_cron_silence_response_contract(self):
         """Direct behavior contract for the cron silence matcher."""
@@ -2549,7 +2897,10 @@ class TestSilentDelivery:
             save_mock.return_value = "/tmp/out.md"
             from cron.scheduler import tick
             tick(verbose=False)
-        save_mock.assert_called_once_with("monitor-job", "# full output")
+        save_mock.assert_called_once()
+        assert save_mock.call_args.args[0] == "monitor-job"
+        assert save_mock.call_args.args[1].startswith("# full output")
+        assert "## Runtime" in save_mock.call_args.args[1]
         deliver_mock.assert_not_called()
 
     def test_whitespace_only_response_is_marked_failed_not_delivered(self):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -598,6 +598,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("artifact_expectations"):
+        result["artifact_expectations"] = job["artifact_expectations"]
     return result
 
 
@@ -663,6 +665,7 @@ def cronjob(
     reason: Optional[str] = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
+    artifact_expectations: Optional[List[Union[str, Dict[str, Any]]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
@@ -736,6 +739,7 @@ def cronjob(
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
                 script=_normalize_optional_job_value(script),
                 context_from=context_from,
+                artifact_expectations=artifact_expectations,
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
@@ -909,6 +913,8 @@ def cronjob(
                                 success=False,
                             )
                 updates["context_from"] = refs or None
+            if artifact_expectations is not None:
+                updates["artifact_expectations"] = artifact_expectations or None
             if enabled_toolsets is not None:
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
@@ -1054,13 +1060,40 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "items": {"type": "string"},
                 "description": (
                     "Optional job ID or list of job IDs whose most recent completed output is "
-                    "injected into the prompt as context before each run. "
+                    "injected into the prompt as context before each run. Gated outputs are skipped, "
+                    "and markdown cron documents contribute only their final ## Response section. "
                     "Use this to chain cron jobs: job A collects data, job B processes it. "
                     "Each entry must be a valid job ID (from cronjob action='list'). "
                     "Note: injects the most recent completed output — does not wait for "
                     "upstream jobs running in the same tick. "
                     "On update, pass an empty array to clear."
                 ),
+            },
+            "artifact_expectations": {
+                "type": "array",
+                "description": (
+                    "Optional artifact contract checked after a successful run and before delivery. "
+                    "Entries may be strings or objects with exactly one of path/glob, using vault: "
+                    "or hermes: prefixes and optional {date}. Add mode='warn_only' for non-blocking "
+                    "checks; the default mode is mode='required_for_delivery', which blocks external "
+                    "delivery when the artifact is missing or stale. On update, pass an empty array to clear."
+                ),
+                "items": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "path": {"type": "string"},
+                                "glob": {"type": "string"},
+                                "mode": {
+                                    "type": "string",
+                                    "enum": ["required_for_delivery", "warn_only"],
+                                },
+                            },
+                        },
+                    ],
+                },
             },
             "enabled_toolsets": {
                 "type": "array",
@@ -1127,9 +1160,11 @@ registry.register(
         reason=args.get("reason"),
         script=args.get("script"),
         context_from=args.get("context_from"),
+        artifact_expectations=args.get("artifact_expectations"),
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## Summary

Cron delivery now fails closed before external send when an agent final answer leaks workbench text, prompt tails, duplicate response markers, file-verifier warnings, or a decorated `[SILENT]` marker. Saved cron markdown keeps the gate and runtime evidence, while `context_from` now feeds downstream jobs only the prior final response and skips gated upstream outputs.

High-value jobs can also declare `artifact_expectations` so delivery is blocked when a required `vault:` or `hermes:` artifact is missing or stale. Paused jobs stay paused even if a malformed store record still has `enabled: true`.

## Validation

- `/Users/byron/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron/test_scheduler.py tests/cron/test_cron_context_from.py tests/cron/test_cronjob_schema.py tests/cron/test_jobs.py -q` — 415 passed, 2 warnings
- `/Users/byron/.hermes/hermes-agent/venv/bin/ruff check cron/scheduler.py cron/jobs.py tools/cronjob_tools.py tests/cron/test_scheduler.py tests/cron/test_cron_context_from.py tests/cron/test_cronjob_schema.py tests/cron/test_jobs.py`
- `git diff --check -- cron/scheduler.py cron/jobs.py tools/cronjob_tools.py tests/cron/test_scheduler.py tests/cron/test_cron_context_from.py tests/cron/test_cronjob_schema.py tests/cron/test_jobs.py`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
