### PR TITLE
fix(moa): pass Copilot initiator header to advisors

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6275,6 +6275,7 @@ def call_llm(
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
+    extra_headers: Optional[Dict[str, str]] = None,
     api_mode: str = None,
     stream: bool = False,
     stream_options: dict = None,
@@ -6298,6 +6299,9 @@ def call_llm(
         tools: Tool definitions (for function calling).
         timeout: Request timeout in seconds (None = read from auxiliary.{task}.timeout config).
         extra_body: Additional request body fields.
+        extra_headers: Additional per-request HTTP headers. These override
+            client-level defaults for providers that gate capabilities on
+            request attribution (for example Copilot's ``x-initiator``).
         stream: When True, return the raw SDK streaming iterator instead of a
             validated complete response. The caller is responsible for consuming
             chunks (and for any fallback). Used by the MoA aggregator so its
@@ -6403,6 +6407,8 @@ def call_llm(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         base_url=_base_info or resolved_base_url)
+    if extra_headers:
+        kwargs["extra_headers"] = dict(extra_headers)
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     _client_base = str(getattr(client, "base_url", "") or "")

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -270,11 +270,23 @@ def _run_reference(
         # (their caching is automatic; markers are ignored harmlessly, but we
         # only decorate when the policy says the route honors them).
         messages = _maybe_apply_moa_cache_control(messages, runtime)
+        extra_headers = None
+        if str(runtime.get("provider") or "").strip().lower() == "copilot":
+            # Copilot Pro/Pro+ gates some premium chat models on request
+            # attribution. The main agent marks the first API request of a
+            # user turn as ``x-initiator: user``; MoA reference fan-out is also
+            # directly serving the user's current turn, not a background agent
+            # task, so mirror that header here. Without it, Claude/Gemini
+            # Copilot advisors can be rejected as unavailable to the
+            # ``copilot-language-server`` integrator even though standalone
+            # Copilot calls work.
+            extra_headers = {"x-initiator": "user"}
         response = call_llm(
             task="moa_reference",
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
+            extra_headers=extra_headers,
             **runtime,
         )
         usage = CanonicalUsage()

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -261,6 +261,80 @@ def test_moa_provider_backed_slot_survives_aux_resolution(monkeypatch, provider)
     assert api_key == f"token-for-{provider}"
 
 
+def test_moa_copilot_reference_forwards_user_initiator_header(monkeypatch):
+    """Copilot MoA advisors must carry the same user-turn attribution as main calls.
+
+    Copilot Pro/Pro+ gates some premium chat models on the ``x-initiator``
+    request header. MoA references are direct fan-out for the user's current
+    turn, so Copilot advisors need ``x-initiator: user`` rather than inheriting
+    the Copilot language-server default attribution.
+    """
+    from agent import moa_loop
+
+    calls = []
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda _slot: {
+            "provider": "copilot",
+            "model": "claude-sonnet-4.6",
+            "api_mode": "chat_completions",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "copilot-token",
+        },
+    )
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("copilot advice")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+
+    _label, text, _acct = moa_loop._run_reference(
+        {"provider": "copilot", "model": "claude-sonnet-4.6"},
+        [{"role": "user", "content": "solve this"}],
+    )
+
+    assert text == "copilot advice"
+    assert calls[0]["task"] == "moa_reference"
+    assert calls[0]["extra_headers"] == {"x-initiator": "user"}
+
+
+def test_moa_non_copilot_reference_does_not_forward_initiator_header(monkeypatch):
+    """The Copilot attribution header must stay scoped to Copilot advisors."""
+    from agent import moa_loop
+
+    calls = []
+
+    monkeypatch.setattr(
+        moa_loop,
+        "_slot_runtime",
+        lambda _slot: {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4.6",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "openrouter-token",
+        },
+    )
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("openrouter advice")
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+
+    _label, text, _acct = moa_loop._run_reference(
+        {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+        [{"role": "user", "content": "solve this"}],
+    )
+
+    assert text == "openrouter advice"
+    assert calls[0]["task"] == "moa_reference"
+    assert calls[0]["extra_headers"] is None
+
+
 def test_moa_slot_runtime_falls_back_on_resolution_error(monkeypatch):
     """A slot whose provider can't be resolved still attempts the call with the
     bare provider/model rather than aborting the whole MoA turn."""


### PR DESCRIPTION
## Summary
- allow auxiliary `call_llm` callers to pass per-request `extra_headers`
- mark Copilot MoA reference fan-out with `x-initiator: user`
- add regression coverage proving Copilot advisors receive the header and non-Copilot advisors do not

## Test
- `python -m pytest tests/run_agent/test_moa_loop_mode.py -q`