### PR TITLE
fix(runtime): resolve Copilot api mode from target model

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -311,13 +311,17 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(
+    model_cfg: Dict[str, Any],
+    api_key: str,
+    target_model: Optional[str] = None,
+) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
+    model_name = str(target_model or model_cfg.get("default") or "").strip()
     if not model_name:
         return "chat_completions"
 
@@ -443,7 +447,11 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
         base_url = _nous_inference_base_url_override() or base_url
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_mode = _copilot_runtime_api_mode(
+            model_cfg,
+            getattr(entry, "runtime_api_key", ""),
+            target_model=effective_model,
+        )
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
@@ -1358,6 +1366,7 @@ def _resolve_explicit_runtime(
     model_cfg: Dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
@@ -1480,7 +1489,7 @@ def _resolve_explicit_runtime(
 
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
+            api_mode = _copilot_runtime_api_mode(model_cfg, api_key, target_model=target_model)
         elif provider == "xai":
             api_mode = "codex_responses"
         else:
@@ -1661,6 +1670,7 @@ def resolve_runtime_provider(
         model_cfg=model_cfg,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     if explicit_runtime:
         return explicit_runtime
@@ -2000,7 +2010,11 @@ def resolve_runtime_provider(
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+            api_mode = _copilot_runtime_api_mode(
+                model_cfg,
+                creds.get("api_key", ""),
+                target_model=target_model,
+            )
         elif provider == "xai":
             api_mode = "codex_responses"
         else:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -260,6 +260,123 @@ def test_resolve_runtime_provider_codex(monkeypatch):
     assert resolved["requested_provider"] == "openai-codex"
 
 
+def test_resolve_runtime_provider_copilot_explicit_key_uses_target_model_for_api_mode(monkeypatch):
+    """MoA/delegation-style Copilot slots must derive api_mode from the slot model.
+
+    Regression: when the main persisted model was a GPT-5/Codex-family model,
+    resolving a Copilot slot for Claude/Gemini still looked at model.default and
+    incorrectly selected the Responses API. The explicit target model must win.
+    """
+    seen = {}
+
+    def _fake_copilot_mode(model_id, *, catalog=None, api_key=None):
+        seen["model_id"] = model_id
+        seen["api_key"] = api_key
+        return "chat_completions"
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "openai-codex", "default": "gpt-5.5"},
+    )
+    monkeypatch.setattr("hermes_cli.models.copilot_model_api_mode", _fake_copilot_mode)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="copilot",
+        explicit_api_key="copilot-token",
+        target_model="claude-sonnet-4.6",
+    )
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_mode"] == "chat_completions"
+    assert seen == {"model_id": "claude-sonnet-4.6", "api_key": "copilot-token"}
+
+
+def test_resolve_runtime_provider_copilot_pool_uses_target_model_for_api_mode(monkeypatch):
+    """Credential-pool Copilot resolution also needs target_model to avoid stale defaults."""
+
+    class _Entry:
+        runtime_api_key = "pool-copilot-token"
+        access_token = "pool-copilot-token"
+        source = "manual"
+        base_url = "https://api.githubcopilot.com"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    seen = {}
+
+    def _fake_copilot_mode(model_id, *, catalog=None, api_key=None):
+        seen["model_id"] = model_id
+        seen["api_key"] = api_key
+        return "chat_completions"
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "openai-codex", "default": "gpt-5.5"},
+    )
+    monkeypatch.setattr("hermes_cli.models.copilot_model_api_mode", _fake_copilot_mode)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="copilot",
+        target_model="gemini-2.5-pro",
+    )
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_mode"] == "chat_completions"
+    assert seen == {"model_id": "gemini-2.5-pro", "api_key": "pool-copilot-token"}
+
+
+def test_resolve_runtime_provider_copilot_env_creds_uses_target_model_for_api_mode(monkeypatch):
+    """The non-pool env/auth-store Copilot path must also honor target_model."""
+
+    class _Pool:
+        def has_credentials(self):
+            return False
+
+    seen = {}
+
+    def _fake_copilot_mode(model_id, *, catalog=None, api_key=None):
+        seen["model_id"] = model_id
+        seen["api_key"] = api_key
+        return "chat_completions"
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "api_key": "env-copilot-token",
+            "base_url": "https://api.githubcopilot.com",
+            "source": "env",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "openai-codex", "default": "gpt-5.5"},
+    )
+    monkeypatch.setattr("hermes_cli.models.copilot_model_api_mode", _fake_copilot_mode)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="copilot",
+        target_model="claude-sonnet-4.6",
+    )
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_mode"] == "chat_completions"
+    assert seen == {"model_id": "claude-sonnet-4.6", "api_key": "env-copilot-token"}
+
+
 def test_resolve_runtime_provider_qwen_oauth(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- derive Copilot runtime api_mode from the explicit `target_model` when present
- prevent stale persisted `model.default` from selecting the wrong Copilot wire mode for MoA/delegation-style slots
- cover explicit key, credential pool, and env/auth-store credential resolution paths

## Test
- `python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`