### PR TITLE
feat(achievements): count Kagi MCP web tools toward research badges

### DIFF
--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -52,6 +52,15 @@ FILE_RE = re.compile(r"(?:/home/|~/?|\./|/mnt/)[\w./-]+\.(?:py|js|ts|tsx|jsx|css
 
 TIER_NAMES = ["Copper", "Silver", "Gold", "Diamond", "Olympian"]
 
+# Some web-search/extract capabilities arrive via MCP servers whose tool names
+# do not contain the literal strings "web_search" or "web_extract". Map those
+# known aliases to the canonical built-in names so the research achievements
+# count behavior, not tool-prefix happenstance.
+_WEB_TOOL_ALIASES: Dict[str, str] = {
+    "mcp__kagi__kagi_search_fetch": "web_search",
+    "mcp__kagi__kagi_extract": "web_extract",
+}
+
 
 def tiers(values: List[int]) -> List[Dict[str, Any]]:
     return [{"name": name, "threshold": threshold} for name, threshold in zip(TIER_NAMES, values)]
@@ -270,6 +279,13 @@ def _tool_name_from_call(call: Any) -> Optional[str]:
     return call.get("name") or fn.get("name")
 
 
+def _normalized_tool_name(name: Optional[str]) -> Optional[str]:
+    """Return the canonical tool name for a known web-tool alias, else the original."""
+    if not name:
+        return name
+    return _WEB_TOOL_ALIASES.get(name, name)
+
+
 def _content(msg: Dict[str, Any]) -> str:
     content = msg.get("content")
     if content is None:
@@ -318,14 +334,15 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
         text = _content(msg)
         full_text_parts.append(text)
         if msg.get("tool_name"):
-            name = str(msg["tool_name"])
-            tool_names.add(name)
-            # Tool result rows name the tool that already appeared in the assistant tool_calls.
-            # Keep it for distinct-tool detection, but do not double-count it as a new call.
-            if msg.get("role") != "tool":
-                tool_sequence.append(name)
+            name = _normalized_tool_name(str(msg["tool_name"]))
+            if name:
+                tool_names.add(name)
+                # Tool result rows name the tool that already appeared in the assistant tool_calls.
+                # Keep it for distinct-tool detection, but do not double-count it as a new call.
+                if msg.get("role") != "tool":
+                    tool_sequence.append(name)
         for call in msg.get("tool_calls") or []:
-            name = _tool_name_from_call(call)
+            name = _normalized_tool_name(_tool_name_from_call(call))
             if name:
                 tool_names.add(name)
                 tool_sequence.append(name)

--- a/plugins/hermes-achievements/tests/test_achievement_engine.py
+++ b/plugins/hermes-achievements/tests/test_achievement_engine.py
@@ -151,6 +151,34 @@ class AchievementEngineTests(unittest.TestCase):
         stats = plugin_api.analyze_messages("s2", "Real config", [{"content": "edited config.yaml, manifest.json, and .env.local"}])
         self.assertGreaterEqual(stats["config_events"], 3)
 
+    def test_kagi_mcp_tools_count_as_web_search_and_extract(self):
+        messages = [
+            {"role": "assistant", "tool_calls": [{"function": {"name": "mcp__kagi__kagi_search_fetch"}}]},
+            {"role": "tool", "tool_name": "mcp__kagi__kagi_search_fetch", "content": "[results]"},
+            {"role": "assistant", "tool_calls": [{"function": {"name": "mcp__kagi__kagi_extract"}}]},
+            {"role": "tool", "tool_name": "mcp__kagi__kagi_extract", "content": "[markdown]"},
+        ]
+
+        stats = plugin_api.analyze_messages("s1", "Kagi research spiral", messages)
+
+        # Kagi calls should be normalized to the canonical web tool names.
+        self.assertEqual(stats["web_calls"], 2)
+        self.assertEqual(stats["web_extract_calls"], 1)
+        self.assertIn("web_search", stats["tool_names"])
+        self.assertIn("web_extract", stats["tool_names"])
+        self.assertNotIn("mcp__kagi__kagi_search_fetch", stats["tool_names"])
+        self.assertNotIn("mcp__kagi__kagi_extract", stats["tool_names"])
+
+        # Aggregate and achievement evaluation should credit the Kagi calls.
+        aggregate = plugin_api.aggregate_stats([stats])
+        self.assertEqual(aggregate["total_web_calls"], 2)
+        self.assertEqual(aggregate["total_web_extract_calls"], 1)
+
+        rabbit_hole = next(a for a in plugin_api.ACHIEVEMENTS if a["id"] == "rabbit_hole_certified")
+        citation_goblin = next(a for a in plugin_api.ACHIEVEMENTS if a["id"] == "citation_goblin")
+        self.assertTrue(plugin_api.evaluate_definition(rabbit_hole, aggregate)["discovered"])
+        self.assertTrue(plugin_api.evaluate_definition(citation_goblin, aggregate)["discovered"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Map the Kagi MCP tool names to the canonical Hermes web tool names before the achievement scanner counts them:
- `mcp__kagi__kagi_search_fetch` -> `web_search`
- `mcp__kagi__kagi_extract` -> `web_extract`

This lets research-oriented badges (`rabbit_hole_certified`, `citation_goblin`, `full_send`) credit users who search and extract via the Kagi MCP server instead of the built-in web tools.

Includes a unit test covering `analyze_messages`, `aggregate_stats`, and achievement evaluation for the Kagi aliases.