### PR TITLE
fix(tui-gateway): finalize sessions on clean pipe exit

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2362,6 +2362,10 @@ def test_shutdown_sessions_persists_tool_tail_and_marks_tui_shutdown(monkeypatch
             pass
 
     class _FakeDB:
+        def get_session(self, session_id):
+            assert session_id == "agent-session-id"
+            return {"source": "tui"}
+
         def end_session(self, session_id, end_reason):
             ended.append((session_id, end_reason))
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2324,6 +2324,67 @@ def test_finalize_session_closes_slash_worker(monkeypatch):
     assert closed["count"] == 1
 
 
+def test_shutdown_sessions_persists_tool_tail_and_marks_tui_shutdown(monkeypatch):
+    """Gateway shutdown classifies an interrupted tool-tail as tui_shutdown.
+
+    Regression coverage for #60286: if the command pipe closes after a tool
+    result was incrementally persisted but before a final assistant response,
+    the shutdown path must explicitly end the session as a TUI shutdown instead
+    of leaving it around for a later WS-orphan reap.
+    """
+    persisted = []
+    ended = []
+
+    class _FakeAgent:
+        session_id = "agent-session-id"
+        model = "gpt-5.5"
+        platform = "tui"
+        _session_messages = [
+            {"role": "user", "content": "run a tool"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "done"},
+        ]
+
+        def _persist_session(self, messages, conversation_history=None):
+            persisted.append((list(messages), list(conversation_history or [])))
+
+        def close(self):
+            pass
+
+    class _FakeDB:
+        def end_session(self, session_id, end_reason):
+            ended.append((session_id, end_reason))
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+
+    server._sessions["live-sid"] = _session(
+        agent=_FakeAgent(),
+        history=[{"role": "user", "content": "run a tool"}],
+        running=True,
+        transport=server._detached_ws_transport,
+    )
+    try:
+        server._shutdown_sessions()
+    finally:
+        server._sessions.pop("live-sid", None)
+
+    assert "live-sid" not in server._sessions
+    assert ended == [("agent-session-id", "tui_shutdown")]
+    assert persisted
+    assert persisted[0][0][-1]["role"] == "tool"
+
+
 def test_ws_orphan_reap_spares_reattached_session(monkeypatch):
     """A session that rebinds a live transport is NOT considered orphaned."""
 

--- a/tests/tui_gateway/test_entry_shutdown.py
+++ b/tests/tui_gateway/test_entry_shutdown.py
@@ -1,0 +1,25 @@
+"""Regression tests for TUI gateway exit finalization."""
+
+import tui_gateway.entry as entry
+
+
+def test_log_exit_finalizes_sessions_before_return(monkeypatch, tmp_path, capsys):
+    """stdin EOF/broken-pipe exits must not rely only on atexit.
+
+    Regression for #60286: when the TUI command pipe closes after a tool result
+    but before the final assistant response, relying on interpreter atexit can
+    leave the live session to be classified later by the WS orphan reaper.  The
+    signal path already finalizes sessions explicitly; clean gateway-exit paths
+    should do the same before returning/exiting.
+    """
+
+    calls = []
+    crash_log = tmp_path / "tui_gateway_crash.log"
+    monkeypatch.setattr(entry, "_CRASH_LOG", str(crash_log))
+    monkeypatch.setattr(entry.server, "_shutdown_sessions", lambda: calls.append("shutdown"))
+
+    entry._log_exit("stdin EOF (TUI closed the command pipe)")
+
+    assert calls == ["shutdown"]
+    assert "stdin EOF (TUI closed the command pipe)" in crash_log.read_text()
+    assert "[gateway-exit] stdin EOF" in capsys.readouterr().err

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -201,6 +201,20 @@ def _log_exit(reason: str) -> None:
             )
     except Exception:
         pass
+
+    # Mirror the explicit shutdown performed by _log_signal().  The normal
+    # interpreter atexit hook also calls _shutdown_sessions(), but clean
+    # gateway-exit paths (broken stdout pipe, stdin EOF) are exactly where the
+    # parent transport has already disappeared.  Finalize live sessions now so
+    # an in-flight turn whose persisted tail is a tool result is marked as an
+    # interrupted TUI shutdown instead of being left for a later WS-orphan reap
+    # (#60286).  The shutdown path is idempotent: repeat atexit invocation sees
+    # no live sessions or an already-finalized session.
+    try:
+        server._shutdown_sessions()
+    except Exception:
+        pass
+
     print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
 
 


### PR DESCRIPTION
## What does this PR do?

Finalizes live TUI gateway sessions immediately when the gateway takes a clean pipe-exit path (`stdin EOF`, broken stdout write), instead of relying only on interpreter `atexit`.

The signal path already calls `_shutdown_sessions()` explicitly before exiting because a wedged worker/stdout path can prevent orderly interpreter shutdown from completing in time. The clean gateway-exit paths logged by `_log_exit()` had the same state-loss risk: the parent transport is already gone, but session finalization was left to `atexit`.

This matters for #60286: a TUI command pipe can close after a tool result has been incrementally persisted but before the final assistant response. The live session should be finalized as an interrupted TUI shutdown (`end_reason=tui_shutdown`) with the already-flushed tool tail preserved, rather than being left around to be classified later as a WS orphan reap.

## Related Issue

Fixes #60286

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tui_gateway/entry.py`
  - `_log_exit()` now mirrors the signal handler's explicit session shutdown and calls `server._shutdown_sessions()` before returning/exiting.
  - The call is best-effort and idempotent; the existing `atexit` hook may still run afterward, but there are no live sessions left to close.
- `tests/tui_gateway/test_entry_shutdown.py`
  - Adds a regression test proving `_log_exit("stdin EOF ...")` finalizes sessions immediately. This test fails on current `main` and passes with this PR.
- `tests/test_tui_gateway_server.py`
  - Adds coverage that `_shutdown_sessions()` persists a session snapshot whose tail is a `tool` message and marks the DB row with `end_reason=tui_shutdown`.

## How to Test

RED verification before the fix:

```bash
scripts/run_tests.sh tests/tui_gateway/test_entry_shutdown.py tests/test_tui_gateway_server.py::test_shutdown_sessions_persists_tool_tail_and_marks_tui_shutdown -q
```

Failed on `main` with:

```text
assert [] == ['shutdown']
```

GREEN verification after the fix:

```bash
scripts/run_tests.sh tests/tui_gateway/test_entry_shutdown.py tests/test_tui_gateway_server.py -q
```

Result:

```text
311 tests passed, 0 failed
```

Additional relevant suite:

```bash
scripts/run_tests.sh tests/tui_gateway/ -q
```

Result:

```text
276 tests passed, 0 failed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux aarch64 / Ubuntu 24.04-derived host

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, regression covered by tests/comments
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Failure this PR prevents:

```text
gateway exit · 2026-07-07 11:42:43 · reason=stdin EOF (TUI closed the command pipe)
last persisted message role=tool
ended_at=2026-07-07T12:08:11Z
end_reason=ws_orphan_reap
```

With this PR, `_log_exit()` explicitly runs `_shutdown_sessions()` on that clean pipe-exit path, so live sessions are finalized through the existing `tui_shutdown` path before `atexit`/orphan classification can race it.
