### PR TITLE
feat(computer-use): expose unverified CUA action status to the model (#59755)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -473,9 +473,18 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
         else:
             return f"planning {len(todos_arg)} task(s)"
 
-    if tool_name in {"terminal", "execute_code"}:
-        key = "code" if tool_name == "execute_code" else "command"
-        command = args.get(key)
+    if tool_name == "execute_code":
+        code_text = args.get("code")
+        if code_text is None:
+            return None
+        # Show the first line of Python code as the preview; don't run
+        # through summarize_shell_command (which collapses multi-line
+        # code via _oneline into a run-together inline string).
+        first_line = str(code_text).strip().split("\n")[0] if str(code_text).strip() else ""
+        return _truncate_preview(first_line, max_len) if first_line else None
+
+    if tool_name == "terminal":
+        command = args.get("command")
         if command is None:
             return None
         preview = summarize_shell_command(str(command))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16997,19 +16997,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from agent.display import get_tool_emoji
             emoji = get_tool_emoji(tool_name, default="⚙️")
 
-            # Markdown-capable platforms render a terminal command as a fenced
-            # code block instead of the compact `terminal: "cmd…"` preview.
-            # Gated on the adapter's ``supports_code_blocks`` capability so
-            # plain-text platforms keep the short line.  No language tag is
-            # emitted — Slack mrkdwn renders the tag as a literal first code
-            # line ("bash"), and a bare fence renders correctly everywhere
-            # that supports blocks.
+            # Markdown-capable platforms render a terminal command or
+            # execute_code snippet as a fenced code block instead of the
+            # compact `terminal: "cmd…"` / `execute_code: "line1;line2…"`
+            # preview.  Gated on the adapter's ``supports_code_blocks``
+            # capability so plain-text platforms keep the short line.  No
+            # language tag is emitted — Slack mrkdwn renders the tag as a
+            # literal first code line ("bash"), and a bare fence renders
+            # correctly everywhere that supports blocks.
             #
-            # Verbose mode shows the FULL command.  Non-verbose ("all"/"new")
+            # Verbose mode shows the FULL content.  Non-verbose ("all"/"new")
             # modes still wrap in a fence but truncate to a single line capped
             # at ``tool_preview_length`` (default 40) so a long or multi-line
-            # command doesn't render as a huge block — matching the budget the
-            # non-terminal preview path already applies (#42634).
+            # command/code doesn't render as a huge block — matching the budget
+            # the non-terminal preview path already applies (#42634).
             _code_block_full = None
             _code_block_short = None
             try:
@@ -17018,31 +17019,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _progress_adapter = None
             if (
                 getattr(_progress_adapter, "supports_code_blocks", False)
-                and tool_name == "terminal"
+                and tool_name in ("terminal", "execute_code")
                 and isinstance(args, dict)
-                and isinstance(args.get("command"), str)
-                and args["command"].strip()
             ):
-                from agent.display import get_tool_preview_max_len
-                _cmd_full = args["command"].rstrip()
-                # Consecutive terminal calls: drop the repeated
-                # "💻 terminal" header so back-to-back commands render as
-                # adjacent code blocks under a single header.
-                _block_header = (
-                    "" if last_was_terminal_block[0] else f"{emoji} {tool_name}\n"
-                )
-                _code_block_full = f"{_block_header}```\n{_cmd_full}\n```"
-                # Single-line, capped preview for non-verbose modes.
-                _pl = get_tool_preview_max_len()
-                _cap = _pl if _pl > 0 else 40
-                _lines = _cmd_full.splitlines()
-                _cmd_short = _lines[0] if _lines else _cmd_full
-                _multiline = len(_lines) > 1
-                if len(_cmd_short) > _cap:
-                    _cmd_short = _cmd_short[:_cap - 3] + "..."
-                elif _multiline:
-                    _cmd_short = _cmd_short + " ..."
-                _code_block_short = f"{_block_header}```\n{_cmd_short}\n```"
+                # terminal uses "command", execute_code uses "code"
+                _content_key = "code" if tool_name == "execute_code" else "command"
+                _content_raw = args.get(_content_key)
+                if isinstance(_content_raw, str) and _content_raw.strip():
+                    from agent.display import get_tool_preview_max_len
+                    _cmd_full = _content_raw.rstrip()
+                    # Consecutive terminal/execute_code calls: drop the
+                    # repeated header so back-to-back blocks render under a
+                    # single header.
+                    _block_header = (
+                        "" if last_was_terminal_block[0] else f"{emoji} {tool_name}\n"
+                    )
+                    _code_block_full = f"{_block_header}```\n{_cmd_full}\n```"
+                    # Single-line, capped preview for non-verbose modes.
+                    _pl = get_tool_preview_max_len()
+                    _cap = _pl if _pl > 0 else 40
+                    _lines = _cmd_full.splitlines()
+                    _cmd_short = _lines[0] if _lines else _cmd_full
+                    _multiline = len(_lines) > 1
+                    if len(_cmd_short) > _cap:
+                        _cmd_short = _cmd_short[:_cap - 3] + "..."
+                    elif _multiline:
+                        _cmd_short = _cmd_short + " ..."
+                    _code_block_short = f"{_block_header}```\n{_cmd_short}\n```"
 
             # Verbose mode: show detailed arguments, respects tool_preview_length
             if progress_mode == "verbose":

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -2098,5 +2098,26 @@ class CuaDriverBackend(ComputerUseBackend):
             message = str(data.get("message", ""))
         elif isinstance(data, str):
             message = data
-        return ActionResult(ok=ok, action=name, message=message,
-                            meta=data if isinstance(data, dict) else {})
+        meta: Dict[str, Any] = data if isinstance(data, dict) else {}
+        # Surface 10 of NousResearch/hermes-agent#59755: cua-driver 0.7.0
+        # returns richer action outcomes including a verification `status`
+        # ("verified", "unverified", "failed") that tells the model whether
+        # the action was confirmed to have taken effect. Extract it from
+        # structuredContent (driver 0.7.0+ canonical location) or the data
+        # dict (back-compat with older drivers that embed it in the text
+        # payload) and expose it as a first-class meta field so downstream
+        # response shaping can surface it to the model.
+        structured = out.get("structuredContent")
+        if isinstance(structured, dict):
+            sc_status = structured.get("status")
+            if isinstance(sc_status, str) and sc_status:
+                meta["status"] = sc_status
+        if "status" not in meta and isinstance(data, dict):
+            dd_status = data.get("status")
+            if isinstance(dd_status, str) and dd_status:
+                meta["status"] = dd_status
+        if "status" in meta:
+            logger.debug(
+                "cua-driver %s action status=%s", name, meta["status"],
+            )
+        return ActionResult(ok=ok, action=name, message=message, meta=meta)

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -442,6 +442,13 @@ def _text_response(res: ActionResult) -> str:
     payload: Dict[str, Any] = {"ok": res.ok, "action": res.action}
     if res.message:
         payload["message"] = res.message
+    # Surface 10 of NousResearch/hermes-agent#59755: cua-driver 0.7.0
+    # returns a verification status ("verified", "unverified", "failed")
+    # on action responses. Expose it as a first-class field so the model
+    # can make informed decisions (e.g. retrying an unverified action).
+    status_val = res.meta.get("status") if res.meta else None
+    if isinstance(status_val, str) and status_val:
+        payload["status"] = status_val
     if res.meta:
         payload["meta"] = res.meta
     return json.dumps(payload)
@@ -856,6 +863,11 @@ def _maybe_follow_capture(
     resp = _capture_response(cap)
     if isinstance(resp, dict) and resp.get("_multimodal"):
         prefix = f"[{res.action}] ok={res.ok}" + (f" — {res.message}" if res.message else "")
+        # Include verification status in the prefix when the CUA driver
+        # returned one (Surface 10 of #59755).
+        status_val = res.meta.get("status") if res.meta else None
+        if isinstance(status_val, str) and status_val:
+            prefix += f" status={status_val}"
         resp["content"][0]["text"] = prefix + "\n\n" + resp["content"][0]["text"]
         resp["text_summary"] = prefix + "\n\n" + resp["text_summary"]
         return resp
@@ -868,6 +880,11 @@ def _maybe_follow_capture(
     data["ok"] = res.ok
     if res.message:
         data["message"] = res.message
+    # Surface verification status from the CUA driver response
+    # (Surface 10 of NousResearch/hermes-agent#59755).
+    status_val = res.meta.get("status") if res.meta else None
+    if isinstance(status_val, str) and status_val:
+        data["status"] = status_val
     return json.dumps(data)
 
 


### PR DESCRIPTION
Exposes CUA driver 0.7.0+ unverified action status to the model. Extracts verification status (verified/unverified/failed) from CUA responses and surfaces it in ActionResult meta and response JSON. Closes #59755