### PR TITLE
fix(cli): oneshot -z honors fallback_providers on AuthError

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -319,11 +319,37 @@ def _run_agent(
                 if detected:
                     effective_provider, effective_model = detected
 
-    runtime = resolve_runtime_provider(
-        requested=effective_provider,
-        target_model=effective_model or None,
-        explicit_base_url=explicit_base_url_from_alias,
-    )
+    # Read the effective fallback chain from profile config so oneshot workers
+    # honour the same merge semantics as interactive CLI and gateway sessions.
+    _fb = get_fallback_chain(cfg)
+
+    from hermes_cli.auth import AuthError
+
+    try:
+        runtime = resolve_runtime_provider(
+            requested=effective_provider,
+            target_model=effective_model or None,
+            explicit_base_url=explicit_base_url_from_alias,
+        )
+    except AuthError:
+        runtime = None
+        for fb_entry in _fb:
+            fb_provider = (fb_entry.get("provider") or "").strip()
+            fb_model = (fb_entry.get("model") or "").strip()
+            if not fb_provider or not fb_model:
+                continue
+            try:
+                runtime = resolve_runtime_provider(
+                    requested=fb_provider,
+                    target_model=fb_model or None,
+                )
+                effective_provider = fb_provider
+                effective_model = fb_model
+                break
+            except AuthError:
+                continue
+        if runtime is None:
+            raise  # re-raise the original AuthError
 
     # Pull in explicit toolsets when provided; otherwise use whatever the user
     # has enabled for "cli". sorted() gives stable ordering for config-derived
@@ -333,9 +359,6 @@ def _run_agent(
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
     session_db = _create_session_db_for_oneshot()
-    # Read the effective fallback chain from profile config so oneshot workers
-    # honour the same merge semantics as interactive CLI and gateway sessions.
-    _fb = get_fallback_chain(cfg)
 
     agent = AIAgent(
         api_key=runtime.get("api_key"),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1580,7 +1580,14 @@ def _get_platform_tools(
         # toolset whose authored tools the composite does list.
         ts_tools = set(resolve_toolset(ts_key, include_registry=False))
         if not ts_tools or not ts_tools.issubset(platform_tool_universe):
-            continue
+            # Kanban tools are not in any platform composite — they are gated
+            # on HERMES_KANBAN_TASK via check_fn in tools/kanban_tools.py.
+            # Recover them for CLI workers (e.g. kanban dispatcher spawning an
+            # agent worker) so the worker gets the kanban_* tool surface.
+            if ts_key == "kanban" and os.environ.get("HERMES_KANBAN_TASK"):
+                pass  # falls through to the claimed check below
+            else:
+                continue
         if ts_tools.issubset(configurable_tool_universe):
             continue
         if not ts_tools.issubset(claimed):


### PR DESCRIPTION
Cherry-pick of PR #60250.

hermes -z should walk the fallback_providers chain when the primary provider fails auth at resolution time, but AuthError was raised before the fallback chain was read.

Fix: Move get_fallback_chain() before resolve_runtime_provider(), wrap in try/except AuthError, iterate fallback entries and re-resolve each.

(cherry picked from upstream PR #60250)
Co-authored-by: webtecnica <75556242+webtecnica@users.noreply.github.com>
Closes #60167