### PR TITLE
[codex] Fix MCP dynamic dispatch arguments for Unreal toolsets

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -92,6 +92,24 @@ def _resolve_concurrent_tool_timeout() -> float | None:
     return value
 
 
+def _debug_tool_call_args(label: str, **fields: Any) -> None:
+    try:
+        from tools.mcp_debug import (
+            debug_args_enabled,
+            debug_args_log,
+            type_shape,
+        )
+        if not debug_args_enabled():
+            return
+        if "parsed_arguments" in fields:
+            fields.setdefault("types", type_shape(fields["parsed_arguments"]))
+        if "arguments_after" in fields:
+            fields.setdefault("types", type_shape(fields["arguments_after"]))
+        debug_args_log(label, **fields)
+    except Exception:
+        pass
+
+
 def _flush_session_db_after_tool_progress(
     agent,
     messages: list,
@@ -336,6 +354,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     parsed_calls = []  # list of (tool_call, function_name, function_args, middleware_trace, block_result, blocked_by_guardrail)
     for tool_call in tool_calls:
         function_name = tool_call.function.name
+        _raw_arguments = tool_call.function.arguments
+        _debug_tool_call_args(
+            "MODEL_TOOL_CALL_RAW",
+            name=function_name,
+            raw_arguments=_raw_arguments,
+        )
 
         # Reset nudge counters
         if function_name == "memory":
@@ -349,6 +373,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             function_args = {}
         if not isinstance(function_args, dict):
             function_args = {}
+        _debug_tool_call_args(
+            "MODEL_TOOL_CALL_PARSED",
+            name=function_name,
+            parsed_arguments=function_args,
+        )
 
         # ── Tool Search unwrap ────────────────────────────────────────
         # When the model invokes the tool_call bridge, peel it open so
@@ -373,6 +402,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
                 if not _err and _underlying:
                     if _underlying in _tool_search_scoped_names(agent):
+                        _debug_tool_call_args(
+                            "HERMES_TOOL_RESOLVED",
+                            original_name=function_name,
+                            resolved_name=_underlying,
+                            arguments_before=function_args,
+                            arguments_after=_underlying_args,
+                        )
                         function_name = _underlying
                         function_args = _underlying_args
                     else:
@@ -989,6 +1025,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             break
 
         function_name = tool_call.function.name
+        _raw_arguments = tool_call.function.arguments
+        _debug_tool_call_args(
+            "MODEL_TOOL_CALL_RAW",
+            name=function_name,
+            raw_arguments=_raw_arguments,
+        )
 
         try:
             function_args = json.loads(tool_call.function.arguments)
@@ -997,6 +1039,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             function_args = {}
         if not isinstance(function_args, dict):
             function_args = {}
+        _debug_tool_call_args(
+            "MODEL_TOOL_CALL_PARSED",
+            name=function_name,
+            parsed_arguments=function_args,
+        )
 
         # Tool Search unwrap — see execute_tool_calls_concurrent for full
         # rationale, including the scope gate (the unwrap dispatches the
@@ -1008,6 +1055,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
                 if not _err and _underlying:
                     if _underlying in _tool_search_scoped_names(agent):
+                        _debug_tool_call_args(
+                            "HERMES_TOOL_RESOLVED",
+                            original_name=function_name,
+                            resolved_name=_underlying,
+                            arguments_before=function_args,
+                            arguments_after=_underlying_args,
+                        )
                         function_name = _underlying
                         function_args = _underlying_args
                     else:

--- a/model_tools.py
+++ b/model_tools.py
@@ -22,6 +22,7 @@ Public API (signatures preserved from the original 2,400-line version):
 
 import os
 import json
+import copy
 import re
 import asyncio
 import logging
@@ -672,7 +673,27 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
     if not schema:
         return args
 
-    properties = (schema.get("parameters") or {}).get("properties")
+    return coerce_args_with_schema(args, schema.get("parameters") or {}, tool_name=tool_name)
+
+
+def coerce_args_with_schema(
+    args: Dict[str, Any],
+    parameters_schema: Dict[str, Any],
+    *,
+    tool_name: str = "<schema>",
+) -> Dict[str, Any]:
+    """Coerce an argument dict using a JSON-Schema parameters object.
+
+    This is the schema-first implementation behind :func:`coerce_tool_args`,
+    exposed so dynamic MCP dispatchers can prepare nested ``arguments`` with
+    the real target-tool schema instead of the outer meta-tool schema.
+    """
+    if not args or not isinstance(args, dict):
+        return args
+    if not isinstance(parameters_schema, dict):
+        return args
+
+    properties = (parameters_schema or {}).get("properties")
     if not properties:
         return args
 
@@ -695,7 +716,7 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
                 if coerced is not value:
                     # _coerce_value handled it (JSON-parsed list or
                     # nullable "null" → None).
-                    args[key] = coerced
+                    args[key] = _coerce_schema_value(coerced, prop_schema)
                     continue
                 # If the string looks like a JSON array but _coerce_value
                 # failed to parse it, warn clearly instead of silently wrapping.
@@ -728,21 +749,123 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
             # a JSON string. The top-level coercion above only repairs the
             # outermost value.
             if expected == "array" and isinstance(value, (list, tuple)):
-                args[key] = _normalize_json_strings_for_schema(value, prop_schema)
+                args[key] = _coerce_schema_value(value, prop_schema)
             elif expected == "object" and isinstance(value, dict):
-                args[key] = _normalize_json_strings_for_schema(value, prop_schema)
+                args[key] = _coerce_schema_value(value, prop_schema)
             continue
         if not expected and not _schema_allows_null(prop_schema):
             continue
-        coerced = _coerce_value(value, expected, schema=prop_schema)
+        coerced = _coerce_schema_value(value, prop_schema)
         if coerced is not value:
             args[key] = coerced
             # If we just JSON-parsed a string into a container, recurse so
             # nested JSON-encoded elements/fields get normalized as well.
             if isinstance(coerced, (list, tuple, dict)):
-                args[key] = _normalize_json_strings_for_schema(coerced, prop_schema)
+                args[key] = _coerce_schema_value(coerced, prop_schema)
 
     return args
+
+
+def _schema_type(schema: dict | None):
+    if not isinstance(schema, dict):
+        return None
+    return schema.get("type")
+
+
+def _schema_has_string_branch(schema: dict | None) -> bool:
+    if not isinstance(schema, dict):
+        return False
+    t = schema.get("type")
+    if t == "string" or (isinstance(t, list) and "string" in t):
+        return True
+    for union_key in ("anyOf", "oneOf"):
+        branches = schema.get(union_key)
+        if isinstance(branches, list) and any(_schema_has_string_branch(b) for b in branches):
+            return True
+    return False
+
+
+def _coerce_schema_value(value: Any, schema: Any) -> Any:
+    """Recursively coerce *value* according to a JSON-Schema fragment.
+
+    String parsing remains schema-guided: JSON-looking text is parsed only
+    when the schema expects an object/array, and numeric/bool coercion only
+    happens when the schema explicitly asks for that scalar type.
+    """
+    if not isinstance(schema, dict):
+        return value
+
+    # Meaningful unions: choose conservatively. If a string branch is allowed
+    # and the value is already a string, preserve it rather than guessing that
+    # "001" should become 1.
+    for union_key in ("anyOf", "oneOf"):
+        branches = schema.get(union_key)
+        if isinstance(branches, list) and branches:
+            if isinstance(value, str) and _schema_has_string_branch(schema):
+                return value
+            for branch in branches:
+                if not isinstance(branch, dict):
+                    continue
+                coerced = _coerce_schema_value(value, branch)
+                if coerced is not value:
+                    return coerced
+            return value
+
+    branches = schema.get("allOf")
+    if isinstance(branches, list) and branches:
+        out = value
+        for branch in branches:
+            if isinstance(branch, dict):
+                out = _coerce_schema_value(out, branch)
+        return out
+
+    expected = _schema_type(schema)
+
+    if isinstance(value, str):
+        if _schema_allows_null(schema) and value.strip().lower() == "null":
+            return None
+        if expected == "string":
+            return value
+        coerced = _coerce_value(value, expected, schema=schema)
+        if coerced is not value:
+            return _coerce_schema_value(coerced, schema)
+        return value
+
+    if expected == "array" and value is not None and not isinstance(value, (list, tuple)):
+        return [_coerce_schema_value(value, schema.get("items"))]
+
+    if isinstance(value, list):
+        items_schema = schema.get("items")
+        if not isinstance(items_schema, dict):
+            return value
+        changed = False
+        out = []
+        for item in value:
+            nxt = _coerce_schema_value(item, items_schema)
+            changed = changed or (nxt is not item)
+            out.append(nxt)
+        return out if changed else value
+
+    if isinstance(value, dict):
+        props = schema.get("properties")
+        additional = schema.get("additionalProperties")
+        if not isinstance(props, dict) and not isinstance(additional, dict):
+            return value
+        changed = False
+        out = dict(value)
+        for key, item in value.items():
+            prop_schema = props.get(key) if isinstance(props, dict) else None
+            if not isinstance(prop_schema, dict) and isinstance(additional, dict):
+                prop_schema = additional
+            if not isinstance(prop_schema, dict):
+                continue
+            nxt = _coerce_schema_value(item, prop_schema)
+            if nxt is not item:
+                out[key] = nxt
+                changed = True
+        return out if changed else value
+
+    return value
 
 
 def _schema_accepts_kind(schema: Any, kind: str) -> bool:
@@ -1057,9 +1180,40 @@ def handle_function_call(
         Function result as a JSON string.
     """
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
+    _debug_args = False
+    _debug_before_coerce = None
+    try:
+        from tools.mcp_debug import (
+            changed_type_paths as _mcp_debug_changed_type_paths,
+            debug_args_enabled as _mcp_debug_enabled,
+            debug_args_log as _mcp_debug_log,
+            type_shape as _mcp_debug_type_shape,
+        )
+        _debug_args = _mcp_debug_enabled()
+        if _debug_args:
+            _debug_before_coerce = copy.deepcopy(function_args)
+            _mcp_debug_log(
+                "TOOL_SCHEMA",
+                tool=function_name,
+                input_schema=(registry.get_schema(function_name) or {}).get("parameters"),
+            )
+    except Exception:
+        _debug_args = False
     function_args = coerce_tool_args(function_name, function_args)
     if not isinstance(function_args, dict):
         function_args = {}
+    if _debug_args:
+        try:
+            _mcp_debug_log(
+                "COERCION",
+                tool=function_name,
+                before=_debug_before_coerce,
+                after=function_args,
+                types=_mcp_debug_type_shape(function_args),
+                changed_paths=_mcp_debug_changed_type_paths(_debug_before_coerce, function_args),
+            )
+        except Exception:
+            pass
     _tool_middleware_trace = list(tool_request_middleware_trace or [])
 
     # ── Tool Search bridge dispatch ──────────────────────────────────
@@ -1120,6 +1274,18 @@ def handle_function_call(
                         "Use tool_search to find tools you can call."
                     ),
                 }, ensure_ascii=False)
+            if _debug_args:
+                try:
+                    _mcp_debug_log(
+                        "HERMES_TOOL_RESOLVED",
+                        original_name=function_name,
+                        resolved_name=underlying_name,
+                        arguments_before=function_args,
+                        arguments_after=underlying_args,
+                        types=_mcp_debug_type_shape(underlying_args),
+                    )
+                except Exception:
+                    pass
             # Recurse with the underlying tool. All hooks fire against the
             # real tool name. The bridge is invisible to hooks by design.
             return handle_function_call(

--- a/tests/tools/test_mcp_dynamic_dispatch_args.py
+++ b/tests/tools/test_mcp_dynamic_dispatch_args.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+
+EXPECTED_SPAWN_ARGS = {
+    "actor_name": "Cube",
+    "location": [0, 0, 100],
+    "rotation": {"pitch": 0, "yaw": 90, "roll": 0},
+    "visible": True,
+    "count": 2,
+}
+
+
+SPAWN_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "actor_name": {"type": "string"},
+        "location": {"type": "array", "items": {"type": "number"}},
+        "rotation": {
+            "type": "object",
+            "properties": {
+                "pitch": {"type": "number"},
+                "yaw": {"type": "number"},
+                "roll": {"type": "number"},
+            },
+        },
+        "visible": {"type": "boolean"},
+        "count": {"type": "integer"},
+        "label": {"type": "string"},
+    },
+    "required": ["actor_name"],
+    "additionalProperties": True,
+}
+
+
+def _tool(name: str, schema: dict, description: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        description=description or name,
+        inputSchema=schema,
+    )
+
+
+def _result(payload: dict, *, is_error: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        isError=is_error,
+        content=[SimpleNamespace(text=json.dumps(payload, ensure_ascii=False))],
+    )
+
+
+class FakeUnrealSearchSession:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self.actual_received: dict | None = None
+        self.meta_received: dict | None = None
+
+    async def call_tool(self, tool_name: str, arguments: dict):
+        recorded = copy.deepcopy(arguments)
+        self.calls.append((tool_name, recorded))
+        if tool_name == "spawn_actor":
+            self.actual_received = recorded
+            return _result({"ok": recorded == EXPECTED_SPAWN_ARGS, "received": recorded})
+        if tool_name == "list_toolsets":
+            return _result({"toolsets": [{"name": "Editor", "description": "Editor tools"}]})
+        if tool_name == "describe_toolset":
+            return _result({
+                "toolset": {
+                    "name": "Editor",
+                    "tools": [
+                        {
+                            "name": "spawn_actor",
+                            "description": "Spawn an actor",
+                            "inputSchema": SPAWN_SCHEMA,
+                        }
+                    ],
+                }
+            })
+        if tool_name == "call_tool":
+            self.meta_received = recorded
+            nested = recorded.get("arguments")
+            self.actual_received = copy.deepcopy(nested)
+            return _result({"ok": nested == EXPECTED_SPAWN_ARGS, "received": nested})
+        raise AssertionError(f"unexpected tool call: {tool_name}")
+
+
+@pytest.fixture()
+def fake_unreal_mcp(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+    from tools.registry import registry
+
+    server_name = f"argtest_{uuid4().hex[:8]}"
+    session = FakeUnrealSearchSession()
+    server = mcp_tool.MCPServerTask(server_name)
+    server.session = session
+    server._tools = [
+        _tool("spawn_actor", SPAWN_SCHEMA, "Spawn an actor"),
+        _tool("list_toolsets", {"type": "object", "properties": {}}, "List toolsets"),
+        _tool(
+            "describe_toolset",
+            {
+                "type": "object",
+                "properties": {"toolset_name": {"type": "string"}},
+                "required": ["toolset_name"],
+            },
+            "Describe a toolset",
+        ),
+        _tool(
+            "call_tool",
+            {
+                "type": "object",
+                "properties": {
+                    "toolset_name": {"type": "string"},
+                    "tool_name": {"type": "string"},
+                    "arguments": {
+                        "type": "object",
+                        "additionalProperties": True,
+                    },
+                },
+                "required": ["toolset_name", "tool_name", "arguments"],
+            },
+            "Call a tool from a toolset",
+        ),
+    ]
+
+    def run_coro(coro_or_factory, timeout=30):
+        coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+        return asyncio.run(coro)
+
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", run_coro)
+    with mcp_tool._lock:
+        mcp_tool._servers[server_name] = server
+    asyncio.run(mcp_tool._discover_dynamic_dispatch_tools(server_name, server))
+    registered = mcp_tool._register_server_tools(server_name, server, {})
+    virtual_spawn_tool = next(
+        name for name in registered
+        if name.endswith("__Editor__spawn_actor")
+    )
+
+    try:
+        yield SimpleNamespace(
+            server_name=server_name,
+            session=session,
+            toolset=f"mcp-{server_name}",
+            spawn_tool=mcp_tool.mcp_prefixed_tool_name(server_name, "spawn_actor"),
+            call_tool=mcp_tool.mcp_prefixed_tool_name(server_name, "call_tool"),
+            virtual_spawn_tool=virtual_spawn_tool,
+        )
+    finally:
+        for name in registered:
+            registry.deregister(name)
+        with mcp_tool._lock:
+            mcp_tool._servers.pop(server_name, None)
+            mcp_tool._dynamic_dispatch_tools_by_server.pop(server_name, None)
+
+
+def _dispatch(tool_name: str, args: dict, toolset: str) -> dict:
+    import model_tools
+
+    return json.loads(model_tools.handle_function_call(
+        tool_name,
+        copy.deepcopy(args),
+        enabled_toolsets=[toolset],
+    ))
+
+
+def test_direct_mcp_tool_call_preserves_object_args(fake_unreal_mcp):
+    result = _dispatch(
+        fake_unreal_mcp.spawn_tool,
+        EXPECTED_SPAWN_ARGS,
+        fake_unreal_mcp.toolset,
+    )
+
+    assert result["result"]
+    assert fake_unreal_mcp.session.actual_received == EXPECTED_SPAWN_ARGS
+
+
+def test_direct_mcp_tool_call_coerces_schema_guided_json_strings(fake_unreal_mcp):
+    result = _dispatch(
+        fake_unreal_mcp.spawn_tool,
+        {
+            "actor_name": "Cube",
+            "location": "[0, 0, 100]",
+            "rotation": "{\"pitch\":0,\"yaw\":90,\"roll\":0}",
+            "visible": "true",
+            "count": "2",
+        },
+        fake_unreal_mcp.toolset,
+    )
+
+    assert result["result"]
+    assert fake_unreal_mcp.session.actual_received == EXPECTED_SPAWN_ARGS
+
+
+def test_unreal_style_call_tool_preserves_nested_object_args(fake_unreal_mcp):
+    result = _dispatch(
+        fake_unreal_mcp.call_tool,
+        {
+            "toolset_name": "Editor",
+            "tool_name": "spawn_actor",
+            "arguments": EXPECTED_SPAWN_ARGS,
+        },
+        fake_unreal_mcp.toolset,
+    )
+
+    assert result["result"]
+    assert fake_unreal_mcp.session.meta_received["arguments"] == EXPECTED_SPAWN_ARGS
+    assert fake_unreal_mcp.session.actual_received == EXPECTED_SPAWN_ARGS
+
+
+def test_unreal_style_call_tool_parses_nested_arguments_json_string(fake_unreal_mcp):
+    result = _dispatch(
+        fake_unreal_mcp.call_tool,
+        {
+            "toolset_name": "Editor",
+            "tool_name": "spawn_actor",
+            "arguments": json.dumps(EXPECTED_SPAWN_ARGS),
+        },
+        fake_unreal_mcp.toolset,
+    )
+
+    assert result["result"]
+    assert fake_unreal_mcp.session.meta_received["arguments"] == EXPECTED_SPAWN_ARGS
+    assert fake_unreal_mcp.session.actual_received == EXPECTED_SPAWN_ARGS
+
+
+def test_tool_search_bridge_does_not_drop_nested_mcp_arguments(fake_unreal_mcp):
+    result = _dispatch(
+        "tool_call",
+        {
+            "name": fake_unreal_mcp.call_tool,
+            "arguments": {
+                "toolset_name": "Editor",
+                "tool_name": "spawn_actor",
+                "arguments": json.dumps(EXPECTED_SPAWN_ARGS),
+            },
+        },
+        fake_unreal_mcp.toolset,
+    )
+
+    assert result["result"]
+    assert fake_unreal_mcp.session.meta_received["arguments"] == EXPECTED_SPAWN_ARGS
+    assert fake_unreal_mcp.session.actual_received == EXPECTED_SPAWN_ARGS
+
+
+def test_unreal_style_call_tool_coerces_nested_double_encoded_fields(fake_unreal_mcp):
+    result = _dispatch(
+        fake_unreal_mcp.call_tool,
+        {
+            "toolset_name": "Editor",
+            "tool_name": "spawn_actor",
+            "arguments": {
+                "actor_name": "Cube",
+                "location": "[0,0,100]",
+                "rotation": "{\"pitch\":0,\"yaw\":90,\"roll\":0}",
+                "visible": "true",
+                "count": "2",
+            },
+        },
+        fake_unreal_mcp.toolset,
+    )
+
+    assert result["result"]
+    assert fake_unreal_mcp.session.actual_received == EXPECTED_SPAWN_ARGS
+
+
+def test_dynamic_dispatch_preserves_string_typed_numeric_values(fake_unreal_mcp):
+    _dispatch(
+        fake_unreal_mcp.call_tool,
+        {
+            "toolset_name": "Editor",
+            "tool_name": "spawn_actor",
+            "arguments": {
+                **EXPECTED_SPAWN_ARGS,
+                "label": "001",
+            },
+        },
+        fake_unreal_mcp.toolset,
+    )
+
+    assert fake_unreal_mcp.session.actual_received["label"] == "001"
+
+
+def test_dynamic_dispatch_virtual_tool_uses_real_schema(fake_unreal_mcp):
+    result = _dispatch(
+        fake_unreal_mcp.virtual_spawn_tool,
+        {
+            "actor_name": "Cube",
+            "location": "[0,0,100]",
+            "rotation": "{\"pitch\":0,\"yaw\":90,\"roll\":0}",
+            "visible": "true",
+            "count": "2",
+        },
+        fake_unreal_mcp.toolset,
+    )
+
+    assert result["result"]
+    assert fake_unreal_mcp.session.calls[-1][0] == "call_tool"
+    assert fake_unreal_mcp.session.meta_received["arguments"] == EXPECTED_SPAWN_ARGS
+    assert fake_unreal_mcp.session.actual_received == EXPECTED_SPAWN_ARGS
+
+
+def test_dynamic_dispatch_preserves_json_like_strings_when_schema_says_string(fake_unreal_mcp):
+    _dispatch(
+        fake_unreal_mcp.call_tool,
+        {
+            "toolset_name": "Editor",
+            "tool_name": "spawn_actor",
+            "arguments": {
+                **EXPECTED_SPAWN_ARGS,
+                "label": "{\"literal\":true}",
+            },
+        },
+        fake_unreal_mcp.toolset,
+    )
+
+    assert fake_unreal_mcp.session.actual_received["label"] == "{\"literal\":true}"
+
+
+def test_dynamic_dispatch_preserves_unknown_additional_properties(fake_unreal_mcp):
+    _dispatch(
+        fake_unreal_mcp.call_tool,
+        {
+            "toolset_name": "Editor",
+            "tool_name": "spawn_actor",
+            "arguments": {
+                **EXPECTED_SPAWN_ARGS,
+                "metadata": {"raw": "[1,2,3]"},
+            },
+        },
+        fake_unreal_mcp.toolset,
+    )
+
+    assert fake_unreal_mcp.session.actual_received["metadata"] == {"raw": "[1,2,3]"}
+
+
+def test_dynamic_dispatch_invalid_nested_json_string_is_not_blindly_parsed(fake_unreal_mcp):
+    result = _dispatch(
+        fake_unreal_mcp.call_tool,
+        {
+            "toolset_name": "Editor",
+            "tool_name": "spawn_actor",
+            "arguments": "{\"actor_name\":",
+        },
+        fake_unreal_mcp.toolset,
+    )
+
+    assert "result" in result
+    assert fake_unreal_mcp.session.actual_received == "{\"actor_name\":"

--- a/tools/mcp_debug.py
+++ b/tools/mcp_debug.py
@@ -1,0 +1,110 @@
+"""Debug logging helpers for MCP/tool-call argument plumbing.
+
+Enabled only when ``HERMES_MCP_DEBUG_ARGS`` is truthy.  The helpers keep the
+hot path cheap when disabled and redact secret-looking keys before anything is
+sent to logs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+_SECRET_KEY_PARTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "bearer",
+    "client_secret",
+    "cookie",
+    "password",
+    "secret",
+    "token",
+)
+_MAX_STRING = 1200
+
+
+def debug_args_enabled() -> bool:
+    raw = os.getenv("HERMES_MCP_DEBUG_ARGS", "")
+    return raw.strip().lower() in {"1", "true", "yes", "on", "debug"}
+
+
+def _is_secret_key(key: Any) -> bool:
+    lowered = str(key).lower()
+    return any(part in lowered for part in _SECRET_KEY_PARTS)
+
+
+def redact_debug_value(value: Any, *, key: Any = None) -> Any:
+    if _is_secret_key(key):
+        return "[REDACTED]"
+    if isinstance(value, dict):
+        return {str(k): redact_debug_value(v, key=k) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_debug_value(v) for v in value]
+    if isinstance(value, tuple):
+        return [redact_debug_value(v) for v in value]
+    if isinstance(value, str) and len(value) > _MAX_STRING:
+        return value[:_MAX_STRING] + f"...[truncated {len(value) - _MAX_STRING} chars]"
+    return value
+
+
+def type_shape(value: Any, *, depth: int = 4) -> Any:
+    """Return a compact tree of JSON-ish type names for diagnostics."""
+    if depth <= 0:
+        return type(value).__name__
+    if isinstance(value, dict):
+        return {str(k): type_shape(v, depth=depth - 1) for k, v in value.items()}
+    if isinstance(value, list):
+        if not value:
+            return []
+        return [type_shape(value[0], depth=depth - 1)]
+    if isinstance(value, tuple):
+        if not value:
+            return []
+        return [type_shape(value[0], depth=depth - 1)]
+    return type(value).__name__
+
+
+def changed_type_paths(before: Any, after: Any, *, path: str = "") -> list[dict[str, str]]:
+    """Return paths whose Python value type changed between two JSON-ish trees."""
+    changes: list[dict[str, str]] = []
+    before_type = type(before).__name__
+    after_type = type(after).__name__
+    if before_type != after_type:
+        changes.append({
+            "path": path or "$",
+            "from_type": before_type,
+            "to_type": after_type,
+        })
+        return changes
+    if isinstance(before, dict) and isinstance(after, dict):
+        for key in sorted(set(before) | set(after), key=lambda v: str(v)):
+            child_path = f"{path}.{key}" if path else str(key)
+            if key not in before or key not in after:
+                changes.append({
+                    "path": child_path,
+                    "from_type": type(before.get(key)).__name__ if key in before else "missing",
+                    "to_type": type(after.get(key)).__name__ if key in after else "missing",
+                })
+                continue
+            changes.extend(changed_type_paths(before[key], after[key], path=child_path))
+    elif isinstance(before, list) and isinstance(after, list):
+        for idx, (left, right) in enumerate(zip(before, after)):
+            changes.extend(changed_type_paths(left, right, path=f"{path}[{idx}]"))
+    return changes
+
+
+def debug_args_log(label: str, **fields: Any) -> None:
+    if not debug_args_enabled():
+        return
+    payload = {key: redact_debug_value(value, key=key) for key, value in fields.items()}
+    try:
+        rendered = json.dumps(payload, ensure_ascii=False, indent=2, default=str)
+    except Exception:
+        rendered = str(payload)
+    logger.info("%s:\n%s", label, rendered)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -88,6 +88,8 @@ Thread safety:
 import asyncio
 import contextvars
 import concurrent.futures
+import copy
+import hashlib
 import inspect
 import json
 import logging
@@ -2413,6 +2415,7 @@ class MCPServerTask:
             if hasattr(tools_result, "tools")
             else []
         )
+        await _discover_dynamic_dispatch_tools(self.name, self)
         self._register_discovered_tools_if_needed()
 
     def _register_discovered_tools_if_needed(self) -> None:
@@ -3214,12 +3217,26 @@ _parallel_safe_servers: set = set()
 # guessing.
 _mcp_tool_server_names: Dict[str, str] = {}
 
+# MCP servers such as Unreal can expose a dynamic-dispatch tool surface:
+# list_toolsets -> describe_toolset -> call_tool.  The real target schemas
+# live behind describe_toolset, so cache those descriptions and optionally
+# register virtual Hermes tools that call the meta-tool internally.
+_DYNAMIC_DISPATCH_META_TOOLS = frozenset({
+    "list_toolsets",
+    "describe_toolset",
+    "call_tool",
+})
+_dynamic_dispatch_tools_by_server: Dict[str, List[dict]] = {}
+
+_DEFAULT_DYNAMIC_DISPATCH_DISCOVERY_TIMEOUT_S = 5.0
+
 # Dedicated event loop running in a background daemon thread.
 _mcp_loop: Optional[asyncio.AbstractEventLoop] = None
 _mcp_thread: Optional[threading.Thread] = None
 
 # Protects _mcp_loop, _mcp_thread, _servers, MCP connection status maps,
-# _parallel_safe_servers, _mcp_tool_server_names, and _stdio_pids.
+# _parallel_safe_servers, _mcp_tool_server_names,
+# _dynamic_dispatch_tools_by_server, and _stdio_pids.
 _lock = threading.Lock()
 
 # PIDs of stdio MCP server subprocesses.  Tracked so we can force-kill
@@ -3577,6 +3594,549 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
 
 
 # ---------------------------------------------------------------------------
+# Dynamic-dispatch MCP tools (list_toolsets / describe_toolset / call_tool)
+# ---------------------------------------------------------------------------
+
+def _mcp_tool_names(server: MCPServerTask) -> set[str]:
+    """Return the raw MCP tool names advertised by *server*."""
+    return {
+        str(getattr(mcp_tool, "name", ""))
+        for mcp_tool in getattr(server, "_tools", []) or []
+        if getattr(mcp_tool, "name", None)
+    }
+
+
+def _supports_dynamic_dispatch(server: MCPServerTask) -> bool:
+    """Detect the generic dynamic-dispatch MCP meta-tool pattern."""
+    return _DYNAMIC_DISPATCH_META_TOOLS.issubset(_mcp_tool_names(server))
+
+
+def _dynamic_dispatch_discovery_timeout(server: MCPServerTask) -> float:
+    """Return the startup budget for dynamic toolset discovery.
+
+    Keep this small and best-effort: MCP connection readiness should not depend
+    on describing every dynamic toolset.  Operators can tune per server with
+    ``dynamic_tool_discovery_timeout`` or globally with
+    ``HERMES_MCP_DYNAMIC_DISCOVERY_TIMEOUT``; ``0`` disables eager discovery.
+    """
+    raw = (
+        getattr(server, "_config", {}) or {}
+    ).get(
+        "dynamic_tool_discovery_timeout",
+        os.getenv(
+            "HERMES_MCP_DYNAMIC_DISCOVERY_TIMEOUT",
+            str(_DEFAULT_DYNAMIC_DISPATCH_DISCOVERY_TIMEOUT_S),
+        ),
+    )
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        logger.warning(
+            "MCP server '%s': invalid dynamic_tool_discovery_timeout=%r; using %.1fs",
+            server.name,
+            raw,
+            _DEFAULT_DYNAMIC_DISPATCH_DISCOVERY_TIMEOUT_S,
+        )
+        return _DEFAULT_DYNAMIC_DISPATCH_DISCOVERY_TIMEOUT_S
+
+
+def _mcp_result_text(result: Any) -> str:
+    """Extract text content from an MCP CallToolResult-like object."""
+    parts: list[str] = []
+    for block in (getattr(result, "content", None) or []):
+        text = getattr(block, "text", None)
+        if text:
+            parts.append(text)
+    if parts:
+        return "\n".join(parts)
+    structured = getattr(result, "structuredContent", None)
+    if structured is not None:
+        try:
+            return json.dumps(structured, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return str(structured)
+    return ""
+
+
+def _loads_jsonish_text(text: str) -> Any:
+    """Best-effort parse for tool metadata returned as text.
+
+    Some MCP servers return pure JSON; others return prose with an embedded
+    JSON object.  This intentionally only runs on server metadata responses,
+    never on arbitrary model argument strings.
+    """
+    if not isinstance(text, str):
+        return text
+    stripped = text.strip()
+    if not stripped:
+        return None
+    try:
+        return json.loads(stripped)
+    except (TypeError, ValueError):
+        pass
+
+    candidates = []
+    obj_start, obj_end = stripped.find("{"), stripped.rfind("}")
+    if obj_start >= 0 and obj_end > obj_start:
+        candidates.append(stripped[obj_start:obj_end + 1])
+    arr_start, arr_end = stripped.find("["), stripped.rfind("]")
+    if arr_start >= 0 and arr_end > arr_start:
+        candidates.append(stripped[arr_start:arr_end + 1])
+
+    for candidate in candidates:
+        try:
+            return json.loads(candidate)
+        except (TypeError, ValueError):
+            continue
+    return stripped
+
+
+def _mcp_result_payload(result: Any) -> Any:
+    text = _mcp_result_text(result)
+    payload = _loads_jsonish_text(text)
+    if payload is not None:
+        return payload
+    return getattr(result, "structuredContent", None)
+
+
+def _parse_dynamic_toolsets(payload: Any) -> list[dict]:
+    """Parse list_toolsets output into ``[{name, description}]`` entries."""
+    if isinstance(payload, str):
+        parsed = _loads_jsonish_text(payload)
+        if parsed is not payload:
+            return _parse_dynamic_toolsets(parsed)
+        toolsets: list[dict] = []
+        for line in payload.splitlines():
+            match = re.match(r"\s*[-*]\s+`?([^`:\s]+)`?\s*(?::\s*(.*))?$", line)
+            if match:
+                toolsets.append({
+                    "name": match.group(1),
+                    "description": (match.group(2) or "").strip(),
+                })
+        return toolsets
+
+    if isinstance(payload, list):
+        toolsets = []
+        for item in payload:
+            if isinstance(item, str):
+                toolsets.append({"name": item, "description": ""})
+            elif isinstance(item, dict):
+                name = item.get("name") or item.get("toolset_name") or item.get("id")
+                if name:
+                    toolsets.append({
+                        "name": str(name),
+                        "description": str(item.get("description") or ""),
+                    })
+        return toolsets
+
+    if isinstance(payload, dict):
+        for key in ("toolsets", "tool_sets", "groups"):
+            if key in payload:
+                return _parse_dynamic_toolsets(payload.get(key))
+        if "result" in payload:
+            return _parse_dynamic_toolsets(payload.get("result"))
+        name = payload.get("name") or payload.get("toolset_name") or payload.get("id")
+        if name:
+            return [{
+                "name": str(name),
+                "description": str(payload.get("description") or ""),
+            }]
+
+    return []
+
+
+def _parse_dynamic_tools(payload: Any, fallback_toolset_name: str) -> list[dict]:
+    """Parse describe_toolset output into virtual tool descriptors."""
+    if isinstance(payload, str):
+        parsed = _loads_jsonish_text(payload)
+        if parsed is not payload:
+            return _parse_dynamic_tools(parsed, fallback_toolset_name)
+        return []
+
+    if isinstance(payload, dict):
+        if "result" in payload:
+            return _parse_dynamic_tools(payload.get("result"), fallback_toolset_name)
+        if "toolset" in payload and isinstance(payload.get("toolset"), dict):
+            return _parse_dynamic_tools(payload["toolset"], fallback_toolset_name)
+        toolset_name = str(
+            payload.get("name")
+            or payload.get("toolset_name")
+            or fallback_toolset_name
+        )
+        tools_payload = (
+            payload.get("tools")
+            or payload.get("tool_defs")
+            or payload.get("toolDefinitions")
+            or []
+        )
+    elif isinstance(payload, list):
+        toolset_name = fallback_toolset_name
+        tools_payload = payload
+    else:
+        return []
+
+    descriptors: list[dict] = []
+    if not isinstance(tools_payload, list):
+        return descriptors
+    for item in tools_payload:
+        if not isinstance(item, dict):
+            continue
+        tool_name = item.get("name") or item.get("tool_name") or item.get("id")
+        if not tool_name:
+            continue
+        input_schema = (
+            item.get("inputSchema")
+            or item.get("input_schema")
+            or item.get("parameters")
+            or item.get("schema")
+        )
+        descriptors.append({
+            "toolset_name": toolset_name,
+            "tool_name": str(tool_name),
+            "description": str(item.get("description") or ""),
+            "input_schema": _normalize_mcp_input_schema(input_schema),
+        })
+    return descriptors
+
+
+def _cache_dynamic_dispatch_tools(server_name: str, descriptors: list[dict]) -> None:
+    """Merge dynamic-dispatch descriptors into the per-server cache."""
+    if not descriptors:
+        return
+    with _lock:
+        existing = list(_dynamic_dispatch_tools_by_server.get(server_name, []))
+        by_key = {
+            (d.get("toolset_name"), d.get("tool_name")): d
+            for d in existing
+        }
+        for descriptor in descriptors:
+            by_key[(descriptor.get("toolset_name"), descriptor.get("tool_name"))] = descriptor
+        _dynamic_dispatch_tools_by_server[server_name] = list(by_key.values())
+
+
+def _dynamic_component_short_name(value: str) -> str:
+    """Keep virtual tool names readable while preserving uniqueness elsewhere."""
+    text = str(value or "")
+    if "." in text:
+        text = text.rsplit(".", 1)[-1]
+    return sanitize_mcp_name_component(text) or "tool"
+
+
+def _dynamic_virtual_tool_name(
+    server_name: str,
+    toolset_name: str,
+    tool_name: str,
+    used_names: set[str] | None = None,
+) -> str:
+    """Build a Hermes virtual tool name for a described dynamic MCP tool."""
+    used_names = used_names or set()
+    stripped_tool = str(tool_name or "")
+    prefix = f"{toolset_name}."
+    if stripped_tool.startswith(prefix):
+        stripped_tool = stripped_tool[len(prefix):]
+    toolset_component = _dynamic_component_short_name(toolset_name)
+    tool_component = _dynamic_component_short_name(stripped_tool)
+    raw_tool = f"{toolset_component}{_MCP_NAME_DELIM}{tool_component}"
+    candidate = mcp_prefixed_tool_name(server_name, raw_tool)
+    if candidate not in used_names:
+        return candidate
+    digest = hashlib.sha1(
+        f"{server_name}\0{toolset_name}\0{tool_name}".encode("utf-8")
+    ).hexdigest()[:8]
+    return mcp_prefixed_tool_name(server_name, f"{raw_tool}_{digest}")
+
+
+def _dynamic_toolset_matches(requested: Any, described: Any) -> bool:
+    if requested is None or described is None:
+        return False
+    requested_s = str(requested)
+    described_s = str(described)
+    if requested_s == described_s:
+        return True
+    return _dynamic_component_short_name(requested_s) == _dynamic_component_short_name(described_s)
+
+
+def _dynamic_tool_matches(requested: Any, described: Any) -> bool:
+    if requested is None or described is None:
+        return False
+    requested_s = str(requested)
+    described_s = str(described)
+    if requested_s == described_s:
+        return True
+    if described_s.endswith("." + requested_s) or requested_s.endswith("." + described_s):
+        return True
+    return _dynamic_component_short_name(requested_s) == _dynamic_component_short_name(described_s)
+
+
+def _lookup_dynamic_dispatch_schema(
+    server_name: str,
+    toolset_name: Any,
+    tool_name: Any,
+) -> dict | None:
+    with _lock:
+        descriptors = list(_dynamic_dispatch_tools_by_server.get(server_name, []))
+    for descriptor in descriptors:
+        if not _dynamic_toolset_matches(toolset_name, descriptor.get("toolset_name")):
+            continue
+        if not _dynamic_tool_matches(tool_name, descriptor.get("tool_name")):
+            continue
+        schema = descriptor.get("input_schema")
+        if isinstance(schema, dict):
+            return schema
+    return None
+
+
+async def _describe_dynamic_toolset(
+    server_name: str,
+    server: MCPServerTask,
+    toolset_name: str,
+) -> list[dict]:
+    """Describe one dynamic toolset and update the schema cache."""
+    if not server.session:
+        return []
+    async with server._rpc_lock:
+        result = await server.session.call_tool(
+            "describe_toolset",
+            arguments={"toolset_name": toolset_name},
+        )
+    if getattr(result, "isError", False):
+        logger.debug(
+            "MCP server '%s': describe_toolset(%s) returned an error: %.300s",
+            server_name,
+            toolset_name,
+            _mcp_result_text(result),
+        )
+        return []
+    descriptors = _parse_dynamic_tools(_mcp_result_payload(result), toolset_name)
+    _cache_dynamic_dispatch_tools(server_name, descriptors)
+    return descriptors
+
+
+def _ensure_dynamic_dispatch_schema(
+    server_name: str,
+    server: MCPServerTask,
+    toolset_name: Any,
+    tool_name: Any,
+    timeout: float,
+) -> dict | None:
+    """Return the real target schema for a dynamic call_tool payload."""
+    schema = _lookup_dynamic_dispatch_schema(server_name, toolset_name, tool_name)
+    if schema is not None:
+        return schema
+    if not toolset_name or not server.session or not _supports_dynamic_dispatch(server):
+        return None
+
+    async def _call():
+        return await _describe_dynamic_toolset(server_name, server, str(toolset_name))
+
+    try:
+        _run_on_mcp_loop(_call, timeout=min(float(timeout or 30.0), 30.0))
+    except Exception as exc:
+        logger.debug(
+            "MCP server '%s': dynamic describe_toolset(%s) failed: %s",
+            server_name,
+            toolset_name,
+            exc,
+        )
+        return None
+    return _lookup_dynamic_dispatch_schema(server_name, toolset_name, tool_name)
+
+
+def _prepare_dynamic_dispatch_arguments(
+    server_name: str,
+    server: MCPServerTask,
+    tool_name: str,
+    args: dict,
+    tool_timeout: float,
+) -> dict:
+    """Schema-prepare nested args for dynamic-dispatch MCP meta-tools.
+
+    This is generic to servers exposing ``call_tool`` with a nested
+    ``arguments`` object.  It does not parse arbitrary strings: nested JSON
+    text is parsed only at the dynamic-dispatch argument boundary, and nested
+    scalar/container coercion is delegated to the described target schema.
+    """
+    if (
+        tool_name != "call_tool"
+        or not isinstance(args, dict)
+        or "arguments" not in args
+        or "tool_name" not in args
+    ):
+        return args
+
+    prepared = copy.deepcopy(args)
+    nested = prepared.get("arguments")
+    if isinstance(nested, str):
+        parsed = _loads_jsonish_text(nested)
+        if isinstance(parsed, dict):
+            nested = parsed
+            prepared["arguments"] = nested
+
+    schema = _ensure_dynamic_dispatch_schema(
+        server_name,
+        server,
+        prepared.get("toolset_name"),
+        prepared.get("tool_name"),
+        tool_timeout,
+    )
+    if isinstance(schema, dict) and isinstance(nested, dict):
+        before = copy.deepcopy(nested)
+        try:
+            from model_tools import coerce_args_with_schema
+
+            prepared["arguments"] = coerce_args_with_schema(
+                copy.deepcopy(nested),
+                schema,
+                tool_name=(
+                    f"{server_name}:{prepared.get('toolset_name')}:"
+                    f"{prepared.get('tool_name')}"
+                ),
+            )
+        except Exception as exc:
+            logger.debug(
+                "MCP server '%s': dynamic argument coercion failed for %s/%s: %s",
+                server_name,
+                prepared.get("toolset_name"),
+                prepared.get("tool_name"),
+                exc,
+            )
+        else:
+            try:
+                from tools.mcp_debug import (
+                    changed_type_paths as _debug_changed_paths,
+                    debug_args_enabled as _debug_enabled,
+                    debug_args_log as _debug_log,
+                    type_shape as _debug_type_shape,
+                )
+
+                if _debug_enabled():
+                    _debug_log(
+                        "MCP_DYNAMIC_DISPATCH_COERCION",
+                        server=server_name,
+                        toolset_name=prepared.get("toolset_name"),
+                        tool_name=prepared.get("tool_name"),
+                        input_schema=schema,
+                        before=before,
+                        after=prepared.get("arguments"),
+                        before_types=_debug_type_shape(before),
+                        after_types=_debug_type_shape(prepared.get("arguments")),
+                        changed_paths=_debug_changed_paths(
+                            before,
+                            prepared.get("arguments"),
+                        ),
+                    )
+            except Exception:
+                pass
+
+    return prepared
+
+
+async def _discover_dynamic_dispatch_tools(
+    server_name: str,
+    server: MCPServerTask,
+) -> list[dict]:
+    """Discover and cache virtual tools behind a dynamic-dispatch MCP server."""
+    if not server.session or not _supports_dynamic_dispatch(server):
+        with _lock:
+            _dynamic_dispatch_tools_by_server.pop(server_name, None)
+        return []
+
+    budget = _dynamic_dispatch_discovery_timeout(server)
+    if budget <= 0:
+        logger.debug(
+            "MCP server '%s': eager dynamic tool discovery disabled",
+            server_name,
+        )
+        return []
+    deadline = time.monotonic() + budget
+
+    def _remaining_timeout() -> float:
+        return max(0.1, deadline - time.monotonic())
+
+    try:
+        async with server._rpc_lock:
+            result = await asyncio.wait_for(
+                server.session.call_tool("list_toolsets", arguments={}),
+                timeout=min(float(server.tool_timeout or 30.0), _remaining_timeout()),
+            )
+    except Exception as exc:
+        logger.debug(
+            "MCP server '%s': list_toolsets dynamic discovery failed: %s",
+            server_name,
+            exc,
+        )
+        return []
+
+    if getattr(result, "isError", False):
+        logger.debug(
+            "MCP server '%s': list_toolsets returned an error: %.300s",
+            server_name,
+            _mcp_result_text(result),
+        )
+        return []
+
+    toolsets = _parse_dynamic_toolsets(_mcp_result_payload(result))
+    descriptors: list[dict] = []
+    described_toolsets = 0
+    for toolset in toolsets:
+        if time.monotonic() >= deadline:
+            logger.info(
+                "MCP server '%s': dynamic discovery budget %.1fs exhausted "
+                "after %d/%d toolset(s); remaining schemas will be fetched lazily",
+                server_name,
+                budget,
+                described_toolsets,
+                len(toolsets),
+            )
+            break
+        toolset_name = toolset.get("name")
+        if not toolset_name:
+            continue
+        try:
+            described = await asyncio.wait_for(
+                _describe_dynamic_toolset(server_name, server, str(toolset_name)),
+                timeout=min(float(server.tool_timeout or 30.0), _remaining_timeout()),
+            )
+        except Exception as exc:
+            logger.debug(
+                "MCP server '%s': describe_toolset(%s) dynamic discovery failed: %s",
+                server_name,
+                toolset_name,
+                exc,
+            )
+            continue
+        described_toolsets += 1
+        descriptors.extend(described)
+
+    if descriptors:
+        logger.info(
+            "MCP server '%s': discovered %d dynamic tool(s) via toolsets",
+            server_name,
+            len(descriptors),
+        )
+    return descriptors
+
+
+def _make_dynamic_tool_handler(
+    server_name: str,
+    toolset_name: str,
+    target_tool_name: str,
+    tool_timeout: float,
+):
+    """Return a handler for a virtual dynamic MCP target tool."""
+    meta_handler = _make_tool_handler(server_name, "call_tool", tool_timeout)
+
+    def _handler(args: dict, **kwargs) -> str:
+        return meta_handler({
+            "toolset_name": toolset_name,
+            "tool_name": target_tool_name,
+            "arguments": copy.deepcopy(args) if isinstance(args, dict) else args,
+        }, **kwargs)
+
+    return _handler
+
+
+# ---------------------------------------------------------------------------
 # Handler / check-fn factories
 # ---------------------------------------------------------------------------
 
@@ -3656,6 +4216,32 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     "error": f"MCP server '{server_name}' is not connected"
                 }, ensure_ascii=False)
 
+        try:
+            from tools.mcp_debug import (
+                debug_args_enabled as _mcp_debug_enabled,
+                debug_args_log as _mcp_debug_log,
+                type_shape as _mcp_debug_type_shape,
+            )
+            _debug_args = _mcp_debug_enabled()
+        except Exception:
+            _debug_args = False
+
+        try:
+            args = _prepare_dynamic_dispatch_arguments(
+                server_name,
+                server,
+                tool_name,
+                args,
+                tool_timeout,
+            )
+        except Exception as exc:
+            logger.debug(
+                "MCP server '%s': dynamic argument preparation failed for %s: %s",
+                server_name,
+                tool_name,
+                exc,
+            )
+
         async def _call():
             async with server._rpc_lock:
                 # Snapshot the agent's context so an elicitation callback
@@ -3664,9 +4250,54 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
+                    if _debug_args:
+                        try:
+                            from tools.registry import registry as _tool_registry
+
+                            _prefixed = mcp_prefixed_tool_name(server_name, tool_name)
+                            _schema = _tool_registry.get_schema(_prefixed)
+                            _mcp_debug_log(
+                                "MCP_CALL",
+                                server=server_name,
+                                tool=tool_name,
+                                registered_tool=_prefixed,
+                                input_schema=(_schema or {}).get("parameters"),
+                                arguments=args,
+                                types=_mcp_debug_type_shape(args),
+                            )
+                            if (
+                                tool_name == "call_tool"
+                                and isinstance(args, dict)
+                                and "arguments" in args
+                            ):
+                                _mcp_debug_log(
+                                    "MCP_DYNAMIC_DISPATCH_ARGUMENTS",
+                                    server=server_name,
+                                    tool=tool_name,
+                                    nested_arguments=args.get("arguments"),
+                                    nested_type=type(args.get("arguments")).__name__,
+                                    types=_mcp_debug_type_shape(args.get("arguments")),
+                                )
+                        except Exception:
+                            pass
                     result = await server.session.call_tool(tool_name, arguments=args)
                 finally:
                     server._pending_call_context = None
+            if _debug_args:
+                try:
+                    _mcp_debug_log(
+                        "MCP_RESULT_OR_ERROR",
+                        server=server_name,
+                        tool=tool_name,
+                        is_error=getattr(result, "isError", None),
+                        content_types=[
+                            type(block).__name__
+                            for block in (getattr(result, "content", None) or [])
+                        ],
+                        structuredContent=getattr(result, "structuredContent", None),
+                    )
+                except Exception:
+                    pass
             # MCP CallToolResult has .content (list of content blocks) and .isError
             if result.isError:
                 error_text = ""
@@ -3732,6 +4363,17 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
+            if _debug_args:
+                try:
+                    _mcp_debug_log(
+                        "MCP_RESULT_OR_ERROR",
+                        server=server_name,
+                        tool=tool_name,
+                        error_type=type(exc).__name__,
+                        error=str(exc),
+                    )
+                except Exception:
+                    pass
             # Auth-specific recovery path: consult the manager, signal
             # reconnect if viable, retry once. Returns None to fall
             # through for non-auth exceptions.
@@ -4498,6 +5140,78 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
         )
         _track_mcp_tool_server(tool_name_prefixed, name)
         registered_names.append(tool_name_prefixed)
+
+    with _lock:
+        dynamic_descriptors = list(_dynamic_dispatch_tools_by_server.get(name, []))
+    used_names = set(registered_names)
+    for descriptor in dynamic_descriptors:
+        target_tool_name = descriptor.get("tool_name")
+        toolset_for_target = descriptor.get("toolset_name")
+        if not target_tool_name or not toolset_for_target:
+            continue
+        if include_set and target_tool_name not in include_set:
+            logger.debug(
+                "MCP server '%s': skipping dynamic tool '%s' (filtered by include)",
+                name,
+                target_tool_name,
+            )
+            continue
+        if exclude_set and target_tool_name in exclude_set:
+            logger.debug(
+                "MCP server '%s': skipping dynamic tool '%s' (filtered by exclude)",
+                name,
+                target_tool_name,
+            )
+            continue
+
+        virtual_name = _dynamic_virtual_tool_name(
+            name,
+            str(toolset_for_target),
+            str(target_tool_name),
+            used_names,
+        )
+        used_names.add(virtual_name)
+        schema = {
+            "name": virtual_name,
+            "description": (
+                descriptor.get("description")
+                or f"MCP dynamic tool {target_tool_name} from {name}"
+            ),
+            "parameters": descriptor.get("input_schema") or {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": True,
+            },
+        }
+
+        existing_toolset = registry.get_toolset_for_tool(virtual_name)
+        if existing_toolset and not existing_toolset.startswith("mcp-"):
+            logger.warning(
+                "MCP server '%s': dynamic tool '%s' (в†’ '%s') collides with "
+                "built-in tool in toolset '%s' вЂ” skipping to preserve built-in",
+                name,
+                target_tool_name,
+                virtual_name,
+                existing_toolset,
+            )
+            continue
+
+        registry.register(
+            name=virtual_name,
+            toolset=toolset_name,
+            schema=schema,
+            handler=_make_dynamic_tool_handler(
+                name,
+                str(toolset_for_target),
+                str(target_tool_name),
+                server.tool_timeout,
+            ),
+            check_fn=_make_check_fn(name),
+            is_async=False,
+            description=schema["description"],
+        )
+        _track_mcp_tool_server(virtual_name, name)
+        registered_names.append(virtual_name)
 
     # Register MCP Resources & Prompts utility tools, filtered by config and
     # only when the server actually supports the corresponding capability.


### PR DESCRIPTION
﻿## What does this PR do?

Fixes MCP argument handling for dynamic-dispatch MCP servers such as Unreal MCP Tool Search Mode.

Unreal MCP can expose only meta-tools through `tools/list`:

- `list_toolsets`
- `describe_toolset`
- `call_tool`

The actual Unreal tool schemas are returned by `describe_toolset`, but Hermes previously registered only the outer `call_tool` schema. That meant nested `call_tool.arguments` could remain stringly typed (`"[0,0,100]"`, `"true"`, `"2"`, JSON object strings, etc.) because the real target schema was not available during Hermes's normal argument coercion pass.

This PR makes that path robust in a generic way:

- adds opt-in diagnostics for the MCP argument pipeline with `HERMES_MCP_DEBUG_ARGS=1`
- extracts reusable schema-guided recursive coercion
- detects the generic dynamic MCP pattern `list_toolsets` / `describe_toolset` / `call_tool`
- registers described dynamic tools as virtual Hermes tools with real schemas
- keeps compatibility for existing direct `call_tool` usage by lazily describing the target toolset and preparing nested `arguments` before `session.call_tool(...)`
- adds a fake Unreal-style MCP regression harness that reproduces the failing shape without requiring Unreal Editor

This is intentionally not an Unreal tool-name hardcode. It is a generic adapter for MCP servers that expose dynamic tool discovery/dispatch through meta-tools.

## Related Issue

Fixes #60306

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/mcp_debug.py`
  - Adds redacted, opt-in MCP/tool argument diagnostics behind `HERMES_MCP_DEBUG_ARGS=1`.
  - Logs raw/parsed model args, schemas, coercion before/after, changed type paths, MCP calls, dynamic nested args, and MCP result/error.

- `agent/tool_executor.py`
  - Logs raw model tool calls and parsed outer arguments in both sequential and concurrent execution paths.
  - Logs Hermes `tool_call` bridge resolution when progressive tool disclosure/tool search is involved.

- `model_tools.py`
  - Extracts `coerce_args_with_schema(...)` so MCP dynamic dispatch can reuse the same canonical schema-aware coercion path.
  - Adds recursive, conservative coercion for nested objects and arrays.
  - Parses JSON strings only when the schema expects object/array.
  - Coerces booleans/numbers/integers only when the schema explicitly asks for those types.
  - Preserves normal strings, numeric-looking strings, and JSON-looking strings when schema says `string` or schema is unknown.
  - Preserves unknown additional properties unless the schema provides a typed `additionalProperties` schema.

- `tools/mcp_tool.py`
  - Detects dynamic-dispatch MCP servers that expose `list_toolsets`, `describe_toolset`, and `call_tool`.
  - Discovers described toolsets on a small best-effort startup budget, configurable by `dynamic_tool_discovery_timeout` or `HERMES_MCP_DYNAMIC_DISCOVERY_TIMEOUT`.
  - Registers described target tools as virtual Hermes tools using real target schemas.
  - Lazily fetches `describe_toolset` for direct `call_tool` invocations when a target schema was not eagerly discovered.
  - Prepares nested `call_tool.arguments` with the real target schema immediately before `session.call_tool(...)`.

- `tests/tools/test_mcp_dynamic_dispatch_args.py`
  - Adds a fake MCP server/session that exposes both direct MCP tools and Unreal-style Tool Search Mode meta-tools.
  - Covers direct object args, JSON-like string args, nested `call_tool.arguments` as dict and JSON string, Hermes `tool_call` bridge wrapping, double-encoded nested fields, virtual dynamic tools, string preservation, numeric-looking string preservation, unknown additional property preservation, and invalid nested JSON behavior.

## How to Test

1. Run the focused fake-Unreal regression harness:

```shell
python scripts\run_tests_parallel.py tests\tools\test_mcp_dynamic_dispatch_args.py -q
```

Expected result:

```text
11 tests passed
```

2. Run adjacent coercion and tool-search suites:

```shell
python scripts\run_tests_parallel.py tests\tools\test_mcp_dynamic_dispatch_args.py tests\run_agent\test_tool_arg_coercion.py tests\tools\test_tool_search.py -q
```

Expected result:

```text
127 tests passed
```

3. Compile the changed modules:

```shell
python -m py_compile model_tools.py tools\mcp_tool.py agent\tool_executor.py tools\mcp_debug.py tests\tools\test_mcp_dynamic_dispatch_args.py
```

4. Optional live Unreal MCP discovery probe:

With Unreal MCP running at:

```json
{
  "mcpServers": {
    "unreal-mcp": {
      "url": "http://127.0.0.1:8000/mcp"
    }
  }
}
```

Hermes now discovers virtual described tools in addition to the three meta-tools. In my local live probe this registered 99 tools, including examples like:

```text
mcp__unreal_mcp__EditorAppToolset__SelectActors
mcp__unreal_mcp__EditorAppToolset__GetSelectedActors
mcp__unreal_mcp__EditorAppToolset__CaptureViewport
```

5. Optional diagnostic check:

Set:

```shell
HERMES_MCP_DEBUG_ARGS=1
```

A formerly failing nested call now shows:

```text
MCP_DYNAMIC_DISPATCH_COERCION:
  changed_paths=[
    {"path": "location", "from_type": "str", "to_type": "list"},
    {"path": "rotation", "from_type": "str", "to_type": "dict"},
    {"path": "visible", "from_type": "str", "to_type": "bool"},
    {"path": "count", "from_type": "str", "to_type": "int"}
  ]

MCP_CALL:
  tool=call_tool
  arguments.arguments={... native array/object/bool/int values ...}
```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow the project convention closely enough for this repository (`fix ...`).
- [x] I searched existing issues/PRs for duplicates.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Windows 11.

Notes on full test suite:

- I ran the focused and adjacent suites listed above: 127 tests passed.
- I did not run the entire `pytest tests/ -q` suite.
- One broader existing suite has an unrelated Windows environment-filtering failure in `tests/tools/test_mcp_tool.py::TestBuildSafeEnv::test_windows_location_vars_passed_without_secrets`; it is not on the MCP dynamic-dispatch argument path.
- The in-repo parallel test runner prints a Windows `cp1251` Unicode callback exception after successful summaries; the test summaries themselves are clean.

### Documentation & Housekeeping

- [x] I've updated relevant documentation or N/A. Runtime diagnostics are documented in code and tests; no user-facing docs existed for this internal MCP path.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A. The new `dynamic_tool_discovery_timeout` is optional and has an env-var fallback; no required config migration.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture/workflows or N/A.
- [x] I've considered cross-platform impact. The fix is Python-only MCP/tool execution logic; the fake tests run on Windows.
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A. Virtual dynamic MCP tools reuse server-provided schemas.

## For New Skills

N/A

## Screenshots / Logs

Before the fix, the fake Unreal-style actual tool received nested strings:

```json
{
  "actor_name": "Cube",
  "location": "[0,0,100]",
  "rotation": "{\"pitch\":0,\"yaw\":90,\"roll\":0}",
  "visible": "true",
  "count": "2"
}
```

After the fix, the actual tool receives native values:

```json
{
  "actor_name": "Cube",
  "location": [0, 0, 100],
  "rotation": {"pitch": 0, "yaw": 90, "roll": 0},
  "visible": true,
  "count": 2
}
```

The important debug signature is:

```text
COERCION:
  tool=mcp__debug__call_tool
  changed_paths=[]

MCP_DYNAMIC_DISPATCH_COERCION:
  toolset_name=Editor
  tool_name=spawn_actor
  changed_paths=[location, rotation, visible, count]

MCP_CALL:
  tool=call_tool
  arguments.arguments is a dict with native nested values
```
