### PR TITLE
fix(auxiliary): cap concurrent async_call_llm to prevent provider 429 cascade

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -40,6 +40,7 @@ Payment / credit exhaustion fallback:
   their OpenRouter balance but has Codex OAuth or another provider available.
 """
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -2916,6 +2917,66 @@ def _transient_retry_count() -> int:
         return max(0, min(n, 6))
     except Exception:
         return _DEFAULT_TRANSIENT_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# Concurrency limit for async_call_llm
+# ---------------------------------------------------------------------------
+#
+# When context compression fires, it can spawn many parallel async LLM calls
+# (one per summarisation chunk). Without a cap, these exhaust rate-limited
+# providers — e.g. ZAI's 7-concurrent-slot limit produced 43 instant 429s
+# that cascaded through every fallback provider and crashed the gateway.
+#
+# The semaphore is lazily initialised from ``compression.processing.
+# max_concurrent_requests`` in config.yaml (default 3) so the limit can be
+# tuned per deployment without a code change.
+_DEFAULT_ASYNC_CONCURRENCY = 3
+_async_concurrency_sem: Optional[asyncio.Semaphore] = None
+
+
+def _get_async_concurrency_limit() -> int:
+    """Read the max concurrent async LLM calls from config.
+
+    Reads ``compression.processing.max_concurrent_requests`` (default 3).
+    Clamped to a minimum of 1. Best-effort: any config-read failure returns
+    the default.
+    """
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        val = cfg_get(
+            load_config(),
+            "compression", "processing", "max_concurrent_requests",
+        )
+        if val is None:
+            return _DEFAULT_ASYNC_CONCURRENCY
+        n = int(val)
+        return max(1, n)
+    except Exception:
+        return _DEFAULT_ASYNC_CONCURRENCY
+
+
+def _get_async_semaphore() -> asyncio.Semaphore:
+    """Return the module-level async concurrency semaphore.
+
+    Lazily initialises on first call so the config value is read at most
+    once per process lifetime. Callers that need to pick up a config change
+    can call :func:`_reset_async_semaphore` (used by tests).
+    """
+    global _async_concurrency_sem
+    if _async_concurrency_sem is None:
+        _async_concurrency_sem = asyncio.Semaphore(_get_async_concurrency_limit())
+    return _async_concurrency_sem
+
+
+def _reset_async_semaphore() -> None:
+    """Clear the cached semaphore so the next call re-reads config.
+
+    Primarily for tests that change the config value between cases.
+    """
+    global _async_concurrency_sem
+    _async_concurrency_sem = None
 
 
 def _is_auth_error(exc: Exception) -> bool:
@@ -6930,7 +6991,46 @@ async def async_call_llm(
     """Centralized asynchronous LLM call.
 
     Same as call_llm() but async. See call_llm() for full documentation.
+
+    Wraps the implementation in a concurrency-limiting semaphore so that
+    burst callers (e.g. context compression spawning many parallel
+    summarisation chunks) cannot exhaust rate-limited providers. The limit
+    is read from ``compression.processing.max_concurrent_requests`` in
+    config.yaml (default 3).
     """
+    async with _get_async_semaphore():
+        return await _async_call_llm_impl(
+            task=task,
+            provider=provider,
+            model=model,
+            base_url=base_url,
+            api_key=api_key,
+            main_runtime=main_runtime,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            timeout=timeout,
+            extra_body=extra_body,
+        )
+
+
+async def _async_call_llm_impl(
+    task: str = None,
+    *,
+    provider: str = None,
+    model: str = None,
+    base_url: str = None,
+    api_key: str = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
+    messages: list,
+    temperature: Optional[float] = None,
+    max_tokens: int = None,
+    tools: list = None,
+    timeout: float = None,
+    extra_body: dict = None,
+) -> Any:
+    """Implementation of :func:`async_call_llm` (without the semaphore wrapper)."""
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
     effective_extra_body = _get_task_extra_body(task)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1393,6 +1393,16 @@ DEFAULT_CONFIG = {
                                       # session_search and recoverable, not deleted.
                                       # Default False during rollout; will flip on
                                       # after live validation.
+        "processing": {
+            # Max concurrent async LLM calls from auxiliary_client.async_call_llm.
+            # When context compression fires, it can spawn many parallel
+            # summarisation calls; without a cap these exhaust rate-limited
+            # providers (e.g. ZAI's 7-slot limit → instant 429 cascade →
+            # gateway crash). Default 3 is safe for most providers. Set to a
+            # higher value for providers with generous rate limits, or to 1
+            # for strict single-call-at-a-time behaviour.
+            "max_concurrent_requests": 3,
+        },
     },
 
     # Kanban subsystem (orchestrator workers + dispatcher-driven child tasks).

--- a/tests/agent/test_auxiliary_async_concurrency.py
+++ b/tests/agent/test_auxiliary_async_concurrency.py
@@ -1,0 +1,258 @@
+"""Tests for the async concurrency semaphore in auxiliary_client.
+
+When context compression fires, it can spawn many parallel ``async_call_llm``
+calls (one per summarisation chunk). Without a cap, these exhaust rate-limited
+providers — e.g. ZAI's 7-concurrent-slot limit produced 43 instant 429s that
+cascaded through every fallback provider and crashed the gateway.
+
+The fix wraps ``async_call_llm`` in an ``asyncio.Semaphore`` whose limit is
+read from ``compression.processing.max_concurrent_requests`` in config.yaml
+(default 3).
+
+These tests exercise the real ``async_call_llm`` production path with a mocked
+LLM client and assert the concurrency invariant: at most ``max_concurrent``
+calls are in-flight at any time, regardless of how many are dispatched
+concurrently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
+
+from agent.auxiliary_client import (
+    async_call_llm,
+    _get_async_semaphore,
+    _reset_async_semaphore,
+    _get_async_concurrency_limit,
+    _DEFAULT_ASYNC_CONCURRENCY,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ok_response():
+    return {"ok": True}
+
+
+def _make_async_client():
+    """A mock async client that records concurrency when create() is called."""
+    client = MagicMock()
+    client.base_url = "https://api.openai.com/v1"
+    client.chat.completions.create = AsyncMock(return_value=_ok_response())
+    return client
+
+
+def _patches(client):
+    """Common mocks: provider resolution, cached client, response validation."""
+    return (
+        patch("agent.auxiliary_client._resolve_task_provider_model",
+              return_value=("openai", "gpt-4o", None, None, None)),
+        patch("agent.auxiliary_client._get_cached_client",
+              return_value=(client, "gpt-4o")),
+        patch("agent.auxiliary_client._validate_llm_response",
+              side_effect=lambda resp, _task: resp),
+        patch("agent.auxiliary_client._get_task_extra_body",
+              return_value={}),
+        patch("agent.auxiliary_client._effective_aux_timeout",
+              return_value=60.0),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_sem_between_tests():
+    """Ensure each test gets a fresh semaphore."""
+    _reset_async_semaphore()
+    yield
+    _reset_async_semaphore()
+
+
+# ---------------------------------------------------------------------------
+# Config reading
+# ---------------------------------------------------------------------------
+
+class TestConcurrencyLimitConfig:
+    """The limit is read from config with a sensible default."""
+
+    def test_default_when_config_missing(self):
+        """When config.yaml has no compression.processing section, the
+        default (3) is returned."""
+        with patch("hermes_cli.config.load_config", return_value={}):
+            _reset_async_semaphore()
+            limit = _get_async_concurrency_limit()
+        assert limit == _DEFAULT_ASYNC_CONCURRENCY
+
+    def test_reads_config_value(self):
+        """A configured value is honoured."""
+        fake_cfg = {
+            "compression": {
+                "processing": {"max_concurrent_requests": 5},
+            },
+        }
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            _reset_async_semaphore()
+            limit = _get_async_concurrency_limit()
+        assert limit == 5
+
+    def test_clamps_to_minimum_1(self):
+        """A value below 1 is clamped to 1 (no deadlock)."""
+        fake_cfg = {
+            "compression": {
+                "processing": {"max_concurrent_requests": 0},
+            },
+        }
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            _reset_async_semaphore()
+            limit = _get_async_concurrency_limit()
+        assert limit == 1
+
+    def test_falls_back_on_config_error(self):
+        """A config-read failure returns the default, not an exception."""
+        with patch("hermes_cli.config.load_config", side_effect=Exception("boom")):
+            _reset_async_semaphore()
+            limit = _get_async_concurrency_limit()
+        assert limit == _DEFAULT_ASYNC_CONCURRENCY
+
+
+# ---------------------------------------------------------------------------
+# Concurrency invariant
+# ---------------------------------------------------------------------------
+
+class TestAsyncConcurrencySemaphore:
+    """At most ``max_concurrent`` calls are in-flight simultaneously."""
+
+    @pytest.mark.asyncio
+    async def test_default_limit_caps_concurrency(self):
+        """With the default limit (3), dispatching 10 concurrent calls
+        never exceeds 3 in-flight at once."""
+        client = _make_async_client()
+        p1, p2, p3, p4, p5 = _patches(client)
+
+        in_flight = 0
+        max_observed = 0
+
+        original_create = client.chat.completions.create
+
+        async def tracking_create(**kwargs):
+            nonlocal in_flight, max_observed
+            in_flight += 1
+            max_observed = max(max_observed, in_flight)
+            await asyncio.sleep(0.02)  # hold the slot briefly
+            in_flight -= 1
+            return await original_create(**kwargs)
+
+        client.chat.completions.create = tracking_create
+
+        with p1, p2, p3, p4, p5:
+            # Use default config (limit = 3)
+            await asyncio.gather(*[
+                async_call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": f"chunk {i}"}],
+                )
+                for i in range(10)
+            ])
+
+        assert max_observed <= _DEFAULT_ASYNC_CONCURRENCY, (
+            f"observed {max_observed} concurrent calls but limit is "
+            f"{_DEFAULT_ASYNC_CONCURRENCY}"
+        )
+        assert max_observed == _DEFAULT_ASYNC_CONCURRENCY, (
+            "expected the semaphore to actually be contended (all 3 slots used), "
+            f"but only {max_observed} were observed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_limit_1_serialises_all_calls(self):
+        """With limit=1, calls are fully serialised (max in-flight = 1)."""
+        fake_cfg = {
+            "compression": {
+                "processing": {"max_concurrent_requests": 1},
+            },
+        }
+        client = _make_async_client()
+        p1, p2, p3, p4, p5 = _patches(client)
+
+        in_flight = 0
+        max_observed = 0
+
+        original_create = client.chat.completions.create
+
+        async def tracking_create(**kwargs):
+            nonlocal in_flight, max_observed
+            in_flight += 1
+            max_observed = max(max_observed, in_flight)
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return await original_create(**kwargs)
+
+        client.chat.completions.create = tracking_create
+
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            _reset_async_semaphore()
+            with p1, p2, p3, p4, p5:
+                await asyncio.gather(*[
+                    async_call_llm(
+                        task="compression",
+                        messages=[{"role": "user", "content": f"chunk {i}"}],
+                    )
+                    for i in range(6)
+                ])
+
+        assert max_observed == 1, (
+            f"limit=1 should serialise all calls, but {max_observed} "
+            "were in-flight simultaneously"
+        )
+
+    @pytest.mark.asyncio
+    async def test_all_calls_complete_successfully(self):
+        """The semaphore limits concurrency but does not lose calls —
+        all dispatched calls return a result."""
+        client = _make_async_client()
+        p1, p2, p3, p4, p5 = _patches(client)
+
+        with p1, p2, p3, p4, p5:
+            results = await asyncio.gather(*[
+                async_call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": f"chunk {i}"}],
+                )
+                for i in range(8)
+            ])
+
+        assert len(results) == 8
+        assert all(r == _ok_response() for r in results)
+
+    @pytest.mark.asyncio
+    async def test_semaphore_is_reused_across_calls(self):
+        """The semaphore is module-level and lazily initialised once —
+        subsequent calls reuse the same instance."""
+        _reset_async_semaphore()
+        sem1 = _get_async_semaphore()
+        sem2 = _get_async_semaphore()
+        assert sem1 is sem2, "semaphore should be cached after first init"
+
+    @pytest.mark.asyncio
+    async def test_reset_picks_up_config_change(self):
+        """After _reset_async_semaphore(), the next call re-reads config."""
+        # Initialise with default
+        _reset_async_semaphore()
+        sem_before = _get_async_semaphore()
+
+        # Change config and reset
+        fake_cfg = {
+            "compression": {
+                "processing": {"max_concurrent_requests": 7},
+            },
+        }
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            _reset_async_semaphore()
+            sem_after = _get_async_semaphore()
+
+        assert sem_before is not sem_after, (
+            "after reset, a new semaphore should be created from updated config"
+        )


### PR DESCRIPTION
## Problem

`auxiliary_client.async_call_llm()` has no concurrency control. When context compression fires, it spawns many parallel async LLM calls (one per summarisation chunk). Without a cap, these exhaust rate-limited providers — e.g. ZAI's 7-concurrent-slot limit produces 43 instant 429s that cascade through every fallback provider and crash the gateway.

This was diagnosed from a real production outage: all providers dead simultaneously because compression flooded 50 parallel requests into 7 available slots.

## Fix

Add an `asyncio.Semaphore` around `async_call_llm` that reads its limit from `compression.processing.max_concurrent_requests` in config.yaml (default 3).

### Approach

- Module-level lazy semaphore (`_get_async_semaphore()`) — initialised once from config, reused for all calls
- Config reader (`_get_async_concurrency_limit()`) — reads `compression.processing.max_concurrent_requests`, clamps to min 1, best-effort fallback to default on any config error
- `async_call_llm` refactored into thin semaphore wrapper → `_async_call_llm_impl` (original body, unchanged). This avoids re-indenting 428 lines and produces a minimal reviewable diff
- Default config (`hermes_cli/config.py`) updated with the new `processing` subsection + comments

## Testing

`tests/agent/test_auxiliary_async_concurrency.py` — 9 tests:

**Config reading (4):**
- Default (3) when config section missing
- Honours configured value
- Clamps value < 1 to 1 (no deadlock)
- Falls back to default on config-read exception

**Concurrency invariant (5):**
- Default limit (3) caps 10 concurrent calls — never exceeds 3 in-flight
- Limit=1 fully serialises 6 calls — max 1 in-flight
- All dispatched calls complete successfully (no lost calls)
- Semaphore is module-level and reused across calls
- `_reset_async_semaphore()` picks up config changes (for tests)

All 9 tests passing.

## Config

```yaml
compression:
  processing:
    max_concurrent_requests: 3  # default
```

Tune higher for providers with generous rate limits, or set to 1 for strict serialisation.