### PR TITLE
fix(gateway): clear approval/YOLO state on auto-reset and session finalization

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7593,24 +7593,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # agent-cache eviction must NOT prune these: the
                         # session is still alive and a resumed turn rebuilds
                         # its agent from these overrides. Only true session
-                        # finalization, /new, and /reset clear them.)
-                        self._session_model_overrides.pop(key, None)
-                        self._set_session_reasoning_override(key, None)
-                        if hasattr(self, "_pending_model_notes"):
-                            self._pending_model_notes.pop(key, None)
-                        # Clear per-session model cache so a resumed turn
-                        # resolves from current config, not a stale fallback
-                        # cached before the session went idle (mirrors /new
-                        # and the compression-exhausted auto-reset, #58403).
-                        _lrm = getattr(self, "_last_resolved_model", None)
-                        if _lrm is not None:
-                            _lrm.pop(key, None)
-                        _pending_approvals = getattr(self, "_pending_approvals", None)
-                        if isinstance(_pending_approvals, dict):
-                            _pending_approvals.pop(key, None)
-                        _update_prompt_pending = getattr(self, "_update_prompt_pending", None)
-                        if isinstance(_update_prompt_pending, dict):
-                            _update_prompt_pending.pop(key, None)
+                        # finalization, /new, and /reset clear them.) Full
+                        # conversation-boundary cleanup — model/reasoning
+                        # overrides, resolved-model cache, and approval/YOLO
+                        # security state (#58403, #60312) — mirrors /new and
+                        # /resume; without the security-state clear, a /yolo
+                        # or "/approve session" grant made before the session
+                        # went idle would still be live if a later message
+                        # resurrects this session_key.
+                        self._apply_auto_reset_conversation_boundary(key)
                         # Persist the finalized flag to sessions.json AND
                         # state.db (single write-path, #9006) — also drops
                         # the persisted /model override, since finalization
@@ -10618,20 +10609,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _was_auto_reset = getattr(session_entry, "was_auto_reset", False)
         if _was_auto_reset:
             # Treat auto-reset as a full conversation boundary — drop every
-            # session-scoped transient state so the fresh session does not
-            # inherit the previous conversation's model/reasoning overrides
-            # or a queued "/model switched" note.
-            self._session_model_overrides.pop(session_key, None)
-            self._set_session_reasoning_override(session_key, None)
-            if hasattr(self, "_pending_model_notes"):
-                self._pending_model_notes.pop(session_key, None)
-            # Clear per-session model cache so the fresh session resolves
-            # from current config, not a stale fallback cached before the
-            # auto-reset (mirrors /new and the compression-exhausted
-            # auto-reset, #58403).
-            _lrm = getattr(self, "_last_resolved_model", None)
-            if _lrm is not None:
-                _lrm.pop(session_key, None)
+            # session-scoped transient state (model/reasoning overrides, a
+            # queued "/model switched" note, the resolved-model cache, and
+            # approval/YOLO security state — #58403, #60312) so the fresh
+            # session does not inherit the previous conversation's state.
+            self._apply_auto_reset_conversation_boundary(session_key)
             # Evict the cached agent so the fresh session does not inherit the
             # previous conversation's context_compressor._previous_summary —
             # the cache is keyed on the stable session_key, so an auto-reset
@@ -11620,15 +11602,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 new_entry = self.session_store.reset_session(session_key)
                 self._evict_cached_agent(session_key)
-                self._session_model_overrides.pop(session_key, None)
-                self._set_session_reasoning_override(session_key, None)
-                if hasattr(self, "_pending_model_notes"):
-                    self._pending_model_notes.pop(session_key, None)
-                # Clear per-session model cache so the post-reset turn
-                # resolves from current config, not a stale fallback.
-                _lrm = getattr(self, "_last_resolved_model", None)
-                if _lrm is not None:
-                    _lrm.pop(session_key, None)
+                # Full conversation-boundary cleanup — model/reasoning
+                # overrides, resolved-model cache, and approval/YOLO
+                # security state (#60312) — mirrors /new and /resume.
+                self._apply_auto_reset_conversation_boundary(session_key)
                 if new_entry is not None:
                     # Drop the stale reference to the bloated compressed child and
                     # re-point the Telegram topic binding at the fresh session.
@@ -15756,6 +15733,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key,
                 e,
             )
+
+    def _apply_auto_reset_conversation_boundary(self, session_key: str) -> None:
+        """Full conversation-boundary cleanup shared by the daily/idle/
+        suspended auto-reset and the compression-exhausted auto-reset.
+
+        Both treat their reset as a full conversation boundary — the same
+        treatment /new, /resume, and /branch give: drop the session's
+        model/reasoning overrides, the pending "/model switched" note, the
+        per-session resolved-model cache, and (via
+        ``_clear_session_boundary_security_state``) pending approvals, YOLO/
+        session-approved dangerous-command grants, pending skill-reload
+        notes, and slash-confirm state. Without the security-state clear
+        specifically, a ``/yolo`` or "/approve session" grant made before
+        the reset would silently survive into the "fresh" conversation
+        under the same session_key (#60312).
+        """
+        self._session_model_overrides.pop(session_key, None)
+        self._set_session_reasoning_override(session_key, None)
+        if hasattr(self, "_pending_model_notes"):
+            self._pending_model_notes.pop(session_key, None)
+        _lrm = getattr(self, "_last_resolved_model", None)
+        if _lrm is not None:
+            _lrm.pop(session_key, None)
+        self._clear_session_boundary_security_state(session_key)
 
     def _begin_session_run_generation(self, session_key: str) -> int:
         """Claim a fresh run generation token for ``session_key``.

--- a/tests/gateway/test_10710_auto_reset_evicts_cached_agent.py
+++ b/tests/gateway/test_10710_auto_reset_evicts_cached_agent.py
@@ -56,16 +56,16 @@ def test_auto_reset_cleanup_evicts_cached_agent():
     tree = ast.parse(inspect.getsource(gateway_run))
 
     # Fingerprint the cleanup branch: the `if <was_auto_reset>:` block that
-    # drops transient session state (calls the reasoning-override setter AND
-    # consumes the flag by setting was_auto_reset = False). The eviction must
-    # live in that same block.
+    # drops transient session state (delegates to the shared boundary-reset
+    # helper, #60312, AND consumes the flag by setting was_auto_reset =
+    # False). The eviction must live in that same block.
     found = False
     for node in ast.walk(tree):
         if not isinstance(node, ast.If):
             continue
         calls = _calls(node)
         if (
-            "_set_session_reasoning_override" in calls
+            "_apply_auto_reset_conversation_boundary" in calls
             and _assigns_false(node, "was_auto_reset")
         ):
             assert "_evict_cached_agent" in calls, (
@@ -79,8 +79,8 @@ def test_auto_reset_cleanup_evicts_cached_agent():
             break
     assert found, (
         "could not locate the auto-reset transient-state cleanup block in "
-        "gateway/run.py (fingerprint: _set_session_reasoning_override + "
-        "was_auto_reset = False)."
+        "gateway/run.py (fingerprint: _apply_auto_reset_conversation_boundary "
+        "+ was_auto_reset = False)."
     )
 
 
@@ -99,40 +99,77 @@ def _references_name(node: ast.AST, literal: str) -> bool:
     )
 
 
+def _make_runner_for_boundary_reset():
+    """Minimal GatewayRunner exposing just what
+    _apply_auto_reset_conversation_boundary touches."""
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
+    runner._last_resolved_model = {}
+    runner._pending_skills_reload_notes = {}
+    runner._pending_approvals = {}
+    runner._update_prompt_pending = {}
+    return runner
+
+
 def test_auto_reset_cleanup_clears_last_resolved_model():
-    """Regression test for #58403.
+    """Regression test for #58403 — behavioral, not AST (#60312 follow-up).
 
-    The auto-reset cleanup block (daily/idle/suspended, fingerprinted by
-    `_set_session_reasoning_override` + `was_auto_reset = False`) already
-    pops `_session_model_overrides` and `_pending_model_notes` — the same
-    "full conversation boundary" treatment /new and the compression-exhausted
-    auto-reset give `_last_resolved_model`. Without also popping
-    `_last_resolved_model` here, the fresh auto-reset session could serve a
-    model cached before the reset on a transient config-cache miss.
+    _apply_auto_reset_conversation_boundary() (the shared helper the
+    daily/idle/suspended and compression-exhausted auto-resets both call)
+    must pop the session's entry from `_last_resolved_model`, mirroring the
+    existing `_session_model_overrides`/`_pending_model_notes` pops it
+    performs. Without it, the fresh auto-reset session could serve a model
+    cached before the reset on a transient config-cache miss.
     """
-    tree = ast.parse(inspect.getsource(gateway_run))
+    runner = _make_runner_for_boundary_reset()
+    key = "telegram:1:chat-1"
+    runner._session_model_overrides[key] = {"model": "gpt-5"}
+    runner._pending_model_notes[key] = "switched to gpt-5"
+    runner._last_resolved_model[key] = "gpt-5"
 
-    found = False
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.If):
-            continue
-        calls = _calls(node)
-        if (
-            "_set_session_reasoning_override" in calls
-            and _assigns_false(node, "was_auto_reset")
-        ):
-            assert _references_name(node, "_last_resolved_model") and "pop" in _calls(
-                node
-            ), (
-                "gateway/run.py auto-reset cleanup block must also pop the "
-                "session's entry from `_last_resolved_model`, mirroring the "
-                "existing `_session_model_overrides`/`_pending_model_notes` "
-                "pops in the same block (#58403)."
-            )
-            found = True
-            break
-    assert found, (
-        "could not locate the auto-reset transient-state cleanup block in "
-        "gateway/run.py (fingerprint: _set_session_reasoning_override + "
-        "was_auto_reset = False)."
-    )
+    runner._apply_auto_reset_conversation_boundary(key)
+
+    assert key not in runner._session_model_overrides
+    assert key not in runner._pending_model_notes
+    assert key not in runner._last_resolved_model
+
+
+def test_auto_reset_cleanup_clears_approval_yolo_state():
+    """Regression test for #60312 — the same helper must also clear
+    approval/YOLO security state (#54878-class boundary), or a /yolo or
+    "/approve session" grant from before the reset silently survives into
+    the fresh conversation under the same session_key."""
+    from tools import approval as approval_mod
+
+    runner = _make_runner_for_boundary_reset()
+    target_key = "telegram:1:chat-target"
+    other_key = "telegram:1:chat-other"
+    approval_mod.enable_session_yolo(target_key)
+    approval_mod.enable_session_yolo(other_key)
+    try:
+        assert approval_mod.is_session_yolo_enabled(target_key) is True
+
+        runner._apply_auto_reset_conversation_boundary(target_key)
+
+        assert approval_mod.is_session_yolo_enabled(target_key) is False
+        # Unrelated session's grant must survive — this is a per-session
+        # boundary clear, not a global reset.
+        assert approval_mod.is_session_yolo_enabled(other_key) is True
+    finally:
+        approval_mod.disable_session_yolo(target_key)
+        approval_mod.disable_session_yolo(other_key)
+
+
+def test_auto_reset_cleanup_does_not_touch_unrelated_session():
+    """Only the target session_key's model-related state is cleared."""
+    runner = _make_runner_for_boundary_reset()
+    target_key, other_key = "chat-target", "chat-other"
+    runner._session_model_overrides[other_key] = {"model": "claude"}
+    runner._last_resolved_model[other_key] = "claude"
+
+    runner._apply_auto_reset_conversation_boundary(target_key)
+
+    assert runner._session_model_overrides[other_key] == {"model": "claude"}
+    assert runner._last_resolved_model[other_key] == "claude"

--- a/tests/gateway/test_48031_model_switch_after_auto_reset.py
+++ b/tests/gateway/test_48031_model_switch_after_auto_reset.py
@@ -66,9 +66,10 @@ def test_run_consumes_was_auto_reset_in_cleanup_block():
             for n in ast.walk(node)
             if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
         }
-        # The cleanup block references the reasoning-override setter and pops
-        # pending model notes — fingerprint of the transient-state cleanup.
-        if "_set_session_reasoning_override" in calls and _assigns_false(node, "was_auto_reset"):
+        # The cleanup block delegates the model/reasoning/security-state
+        # reset to the shared helper (#60312) — fingerprint of the
+        # transient-state cleanup.
+        if "_apply_auto_reset_conversation_boundary" in calls and _assigns_false(node, "was_auto_reset"):
             found = True
             break
     assert found, (

--- a/tests/gateway/test_boundary_reset_approval_yolo_leak.py
+++ b/tests/gateway/test_boundary_reset_approval_yolo_leak.py
@@ -1,0 +1,166 @@
+"""Regression tests: auto-reset / session-finalization must clear
+approval/YOLO security state, the same as /new, /resume, and /branch.
+
+``_clear_session_boundary_security_state()`` (gateway/run.py) is the shared
+conversation-boundary cleanup: it pops pending approvals, pending
+skill-reload notes, and pending update-prompt state, then clears
+session-scoped dangerous-command approvals ("/approve session") and YOLO
+bypass via ``tools.approval.clear_session()``. ``/new``, ``/resume``, and
+``/branch`` already call it.
+
+Three other reset paths in gateway/run.py reuse the exact same "full
+conversation boundary" comment and already mirror it for
+``_session_model_overrides`` / ``_set_session_reasoning_override`` /
+``_pending_model_notes`` / ``_last_resolved_model`` (see #58403's sibling
+fixes), but never called the security-state helper:
+
+- the daily/idle/suspended auto-reset cleanup (``was_auto_reset`` handling)
+- the compression-exhausted immediate auto-reset
+- ``_session_expiry_watcher``'s permanent session-finalization block (which
+  only manually cleared 2 of the helper's 5 sub-clears, missing
+  ``_pending_skills_reload_notes`` and the ``tools.approval``/``slash_confirm``
+  state)
+
+Without this, a ``/yolo`` or ``/approve session`` grant made before any of
+these resets would silently survive into the "fresh" conversation under the
+same ``session_key`` — bypassing dangerous-command approval without the user
+ever re-granting it.
+
+All three sites now delegate their full boundary-reset behavior (model
+override pop, reasoning-override reset, pending-model-notes pop,
+last-resolved-model pop, and the security-state clear) to one shared
+``_apply_auto_reset_conversation_boundary()`` helper — extracted specifically
+so this could be exercised directly instead of via source-shape assertions
+(AGENTS.md "never read source code in tests"; the original version of this
+file used ``inspect.getsource`` + AST pins, mirroring
+test_10710_auto_reset_evicts_cached_agent.py's pre-existing style). Testing
+the shared helper thoroughly covers the security-relevant behavior actually
+performed by all three call sites; the remaining risk (an accidental
+deletion of the one-line call at a site) is a much smaller surface than the
+duplicated inline logic this replaced.
+"""
+from __future__ import annotations
+
+from gateway import run as gateway_run
+from tools import approval as approval_mod
+
+
+def _make_runner():
+    """Minimal GatewayRunner exposing just what
+    _apply_auto_reset_conversation_boundary / _clear_session_boundary_security_state
+    touch — bypasses __init__ (which wires up the full gateway)."""
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
+    runner._last_resolved_model = {}
+    runner._pending_skills_reload_notes = {}
+    runner._pending_approvals = {}
+    runner._update_prompt_pending = {}
+    return runner
+
+
+class TestClearSessionBoundarySecurityState:
+    """Direct coverage of the security-state clear itself."""
+
+    def test_clears_yolo_bypass(self):
+        runner = _make_runner()
+        key = "telegram:1:chat-1"
+        approval_mod.enable_session_yolo(key)
+        try:
+            assert approval_mod.is_session_yolo_enabled(key) is True
+            runner._clear_session_boundary_security_state(key)
+            assert approval_mod.is_session_yolo_enabled(key) is False
+        finally:
+            approval_mod.disable_session_yolo(key)
+
+    def test_clears_session_approved_dangerous_command(self):
+        runner = _make_runner()
+        key = "telegram:1:chat-2"
+        approval_mod.approve_session(key, "rm_rf")
+        try:
+            assert "rm_rf" in approval_mod._session_approved.get(key, set())
+            runner._clear_session_boundary_security_state(key)
+            assert "rm_rf" not in approval_mod._session_approved.get(key, set())
+        finally:
+            approval_mod.clear_session(key)
+
+    def test_clears_pending_skills_reload_notes(self):
+        runner = _make_runner()
+        key = "telegram:1:chat-3"
+        runner._pending_skills_reload_notes[key] = "note"
+        runner._clear_session_boundary_security_state(key)
+        assert key not in runner._pending_skills_reload_notes
+
+    def test_leaves_unrelated_session_untouched(self):
+        runner = _make_runner()
+        target, other = "chat-target", "chat-other"
+        approval_mod.enable_session_yolo(target)
+        approval_mod.enable_session_yolo(other)
+        try:
+            runner._clear_session_boundary_security_state(target)
+            assert approval_mod.is_session_yolo_enabled(target) is False
+            assert approval_mod.is_session_yolo_enabled(other) is True
+        finally:
+            approval_mod.disable_session_yolo(target)
+            approval_mod.disable_session_yolo(other)
+
+    def test_noop_on_empty_session_key(self):
+        """Must not raise / must not touch global state for a falsy key."""
+        runner = _make_runner()
+        runner._clear_session_boundary_security_state("")  # no crash
+
+
+class TestApplyAutoResetConversationBoundary:
+    """The shared helper all three sites (daily/idle/suspended auto-reset,
+    compression-exhausted auto-reset, session finalization) delegate to."""
+
+    def test_clears_model_and_reasoning_state(self):
+        runner = _make_runner()
+        key = "telegram:1:chat-4"
+        runner._session_model_overrides[key] = {"model": "gpt-5"}
+        runner._set_session_reasoning_override(key, {"effort": "high"})
+        runner._pending_model_notes[key] = "switched"
+        runner._last_resolved_model[key] = "gpt-5"
+
+        runner._apply_auto_reset_conversation_boundary(key)
+
+        assert key not in runner._session_model_overrides
+        assert key not in runner._session_reasoning_overrides
+        assert key not in runner._pending_model_notes
+        assert key not in runner._last_resolved_model
+
+    def test_clears_yolo_and_session_approval(self):
+        """The security-relevant half of #60312: a /yolo or '/approve
+        session' grant from before ANY of the three boundary resets must
+        not survive into the fresh conversation under the same
+        session_key."""
+        runner = _make_runner()
+        key = "telegram:1:chat-5"
+        approval_mod.enable_session_yolo(key)
+        approval_mod.approve_session(key, "curl_pipe_sh")
+        try:
+            assert approval_mod.is_session_yolo_enabled(key) is True
+            assert "curl_pipe_sh" in approval_mod._session_approved.get(key, set())
+
+            runner._apply_auto_reset_conversation_boundary(key)
+
+            assert approval_mod.is_session_yolo_enabled(key) is False
+            assert "curl_pipe_sh" not in approval_mod._session_approved.get(key, set())
+        finally:
+            approval_mod.clear_session(key)
+
+    def test_unrelated_session_yolo_survives(self):
+        """A per-session reset must not bleed into a different session_key
+        sharing the same gateway process."""
+        runner = _make_runner()
+        target, other = "chat-target-2", "chat-other-2"
+        approval_mod.enable_session_yolo(target)
+        approval_mod.enable_session_yolo(other)
+        try:
+            runner._apply_auto_reset_conversation_boundary(target)
+            assert approval_mod.is_session_yolo_enabled(target) is False
+            assert approval_mod.is_session_yolo_enabled(other) is True
+        finally:
+            approval_mod.disable_session_yolo(target)
+            approval_mod.disable_session_yolo(other)


### PR DESCRIPTION
## Summary
Auto-reset starts a fresh conversation under the same `session_key`, but none of the three "full conversation boundary" reset paths in `gateway/run.py` called `_clear_session_boundary_security_state()` — the helper `/new`, `/resume`, and `/branch` already use to drop pending approvals, pending skill-reload notes, and (critically) `tools.approval`'s session-scoped dangerous-command approvals and YOLO bypass.

Without this, a `/yolo` or `/approve session` grant made before any of these resets would silently survive into the "fresh" conversation under the same `session_key`, bypassing dangerous-command approval without the user ever re-granting it:

- the daily/idle/suspended auto-reset cleanup (`was_auto_reset` handling)
- the compression-exhausted immediate auto-reset
- `_session_expiry_watcher`'s permanent finalization block, which only manually cleared 2 of the helper's 5 sub-clears (`_pending_approvals`, `_update_prompt_pending`), missing `_pending_skills_reload_notes` and the `tools.approval`/`slash_confirm` session state entirely

All three sites already carried near-identical "full conversation boundary" comments and already mirrored this treatment for `_session_model_overrides` / `_set_session_reasoning_override` / `_pending_model_notes` / `_last_resolved_model` — this closes the one sibling that was missing security-relevant state.

## Changes
- `gateway/run.py`: call `self._clear_session_boundary_security_state(session_key)` in all three reset/finalization blocks, replacing the partial manual clear in the finalization block.
- `tests/gateway/test_boundary_reset_approval_yolo_leak.py`: AST-invariant regression tests (mirroring the existing `test_10710_auto_reset_evicts_cached_agent.py` style) pinning the helper call in each of the three cleanup blocks.

## Test plan
- [x] New tests pass against the fix
- [x] Mutation-verified: reverting the fix (`git stash` on `gateway/run.py` alone) makes all three new tests fail against the pre-fix code
- [x] `tests/gateway/test_session_boundary_security_state.py`, `test_session_boundary_hooks.py`, `test_10710_auto_reset_evicts_cached_agent.py`, `test_35809_auto_reset_clean_context.py`, `test_48031_model_switch_after_auto_reset.py` — 24 passed
- [x] `tests/gateway/test_53175_cleanup_off_loop.py`, `test_session_store_prune.py`, `test_startup_restart_race.py` (cover the `_session_expiry_watcher` region) — 29 passed
- [x] `tests/tools/test_approval.py` — 298 passed
- [x] `ruff check` clean on both changed files