### PR TITLE
hindsight: optional recall_min_score abstain floor (default-off, fail-open)

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -87,6 +87,92 @@ def _parse_int_setting(value: Any, default: int) -> int:
         return default
 
 
+def _finite_float(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    score = float(value)
+    if score != score or score in (float("inf"), float("-inf")):
+        return None
+    return score
+
+
+def _parse_recall_min_score(value: Any) -> float | None:
+    """Parse optional recall score floor.
+
+    Blank/unset disables the floor. Invalid, non-finite, or negative values also
+    disable it fail-open so a bad config never silently hides memories.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        logger.warning("Invalid Hindsight recall_min_score %r; disabling score floor", value)
+        return None
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid Hindsight recall_min_score %r; disabling score floor", value)
+        return None
+    if score != score or score in (float("inf"), float("-inf")) or score < 0:
+        logger.warning("Invalid Hindsight recall_min_score %r; disabling score floor", value)
+        return None
+    return score
+
+
+def _filter_results_by_trace_score(resp: Any, floor: float | None) -> list[Any]:
+    """Filter recall results by trace rerank score when complete signal exists.
+
+    The filter is fail-open. If trace is missing/malformed, a result has no id,
+    or any returned result lacks a numeric finite rerank score, all original
+    results are preserved. The opt-in floor must never infer relevance from
+    result count or partial trace data.
+    """
+    results = list(getattr(resp, "results", None) or [])
+    if floor is None or not results:
+        return results
+
+    def _fail_open(reason: str) -> list[Any]:
+        logger.warning(
+            "Hindsight recall_min_score fail-open (%s); preserving %d result(s)",
+            reason,
+            len(results),
+        )
+        return results
+
+    trace = getattr(resp, "trace", None)
+    if not isinstance(trace, dict):
+        return _fail_open("missing trace")
+    reranked = trace.get("reranked")
+    if not isinstance(reranked, list):
+        return _fail_open("missing reranked scores")
+
+    scores_by_id: dict[str, float] = {}
+    for item in reranked:
+        if not isinstance(item, dict):
+            return _fail_open("malformed reranked item")
+        node_id = item.get("node_id")
+        if node_id is None:
+            return _fail_open("missing node id")
+        score = _finite_float(item.get("rerank_score"))
+        if score is None:
+            return _fail_open("missing numeric score")
+        scores_by_id[str(node_id)] = score
+
+    for result in results:
+        result_id = getattr(result, "id", None)
+        if result_id is None:
+            return _fail_open("result missing id")
+        if str(result_id) not in scores_by_id:
+            return _fail_open("result missing score")
+
+    filtered = [result for result in results if scores_by_id[str(getattr(result, "id"))] >= floor]
+    logger.debug(
+        "Hindsight recall_min_score filtered %d -> %d result(s)",
+        len(results),
+        len(filtered),
+    )
+    return filtered
+
+
 # Env var the embedded daemon manager reads (at import time, as a module-level
 # constant) to size the grace window it waits for a slow /health before
 # declaring a daemon stale and killing it. Default upstream is 30s; on
@@ -986,6 +1072,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
             {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
+            {"key": "recall_min_score", "description": "Optional relevance floor for recall results. Blank/unset preserves current behavior. When set, Hermes requests Hindsight trace scores in-process and fail-opens if complete scores are unavailable.", "default": ""},
             {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
             {"key": "recall_prefetch_method", "description": "Auto-recall method", "default": "recall", "choices": ["recall", "reflect"]},
             {"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated)", "default": ""},
@@ -1338,6 +1425,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # Recall controls
         self._auto_recall = self._config.get("auto_recall", True)
         self._recall_max_tokens = int(self._config.get("recall_max_tokens", 4096))
+        self._recall_min_score = _parse_recall_min_score(self._config.get("recall_min_score"))
         # Default narrows recall to observation-only; pass an explicit
         # `recall_types` list in config.json to broaden (e.g. include
         # "world" / "experience") or to disable the filter entirely.
@@ -1481,6 +1569,28 @@ class HindsightMemoryProvider(MemoryProvider):
         )
         return f"{header}\n\n{result}"
 
+    def _recall_with_optional_trace(self, recall_kwargs: dict) -> Any:
+        """Run recall, requesting trace only when a score floor is configured.
+
+        If trace-enabled recall is unsupported or otherwise fails, retry without
+        trace and return the unfiltered response. That preserves fail-open
+        semantics: enabling an optional score floor must not make recall fail
+        merely because a backend cannot provide the score signal.
+        """
+        if self._recall_min_score is None:
+            return self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
+
+        trace_kwargs = dict(recall_kwargs)
+        trace_kwargs["trace"] = True
+        try:
+            return self._run_hindsight_operation(lambda client: client.arecall(**trace_kwargs))
+        except Exception:
+            logger.warning(
+                "Hindsight recall_min_score trace recall failed; retrying without trace fail-open",
+                exc_info=True,
+            )
+            return self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
+
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         if self._memory_mode == "tools":
             logger.debug("Prefetch: skipped (tools-only mode)")
@@ -1513,10 +1623,11 @@ class HindsightMemoryProvider(MemoryProvider):
                         recall_kwargs["types"] = self._recall_types
                     logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
                                  self._bank_id, len(query), self._budget)
-                    resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                    num_results = len(resp.results) if resp.results else 0
+                    resp = self._recall_with_optional_trace(recall_kwargs)
+                    results = _filter_results_by_trace_score(resp, self._recall_min_score)
+                    num_results = len(results)
                     logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    text = "\n".join(f"- {r.text}" for r in results if r.text)
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
@@ -1742,12 +1853,13 @@ class HindsightMemoryProvider(MemoryProvider):
                     recall_kwargs["types"] = self._recall_types
                 logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
-                resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                num_results = len(resp.results) if resp.results else 0
+                resp = self._recall_with_optional_trace(recall_kwargs)
+                results = _filter_results_by_trace_score(resp, self._recall_min_score)
+                num_results = len(results)
                 logger.debug("Tool hindsight_recall: %d results", num_results)
-                if not resp.results:
+                if not results:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
+                lines = [f"{i}. {r.text}" for i, r in enumerate(results, 1)]
                 return json.dumps({"result": "\n".join(lines)})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -83,6 +83,18 @@ def _make_mock_client():
     return client
 
 
+def _recall_response(pairs, *, trace=None):
+    """Build a mock recall response.
+
+    ``pairs`` is an iterable of ``(id, text)``. The text values are test
+    fixtures only; real recall/trace payloads must not be persisted.
+    """
+    return SimpleNamespace(
+        results=[SimpleNamespace(id=result_id, text=text) for result_id, text in pairs],
+        trace=trace,
+    )
+
+
 def _provider_for_mode(tmp_path, monkeypatch, mode: str):
     """Create an initialized provider without pre-seeding its client."""
     config = {
@@ -306,6 +318,7 @@ class TestConfig:
         assert provider._retain_every_n_turns == 1
         assert provider._recall_max_tokens == 4096
         assert provider._recall_max_input_chars == 800
+        assert provider._recall_min_score is None
         assert provider._tags is None
         assert provider._observation_scopes is None
         assert provider._recall_tags is None
@@ -359,6 +372,7 @@ class TestConfig:
             retain_context="custom-ctx",
             bank_retain_mission="Extract key facts",
             recall_max_tokens=2048,
+            recall_min_score=0.75,
             recall_types=["world", "experience"],
             recall_prompt_preamble="Custom preamble:",
             recall_max_input_chars=500,
@@ -377,6 +391,7 @@ class TestConfig:
         assert p._retain_context == "custom-ctx"
         assert p._bank_retain_mission == "Extract key facts"
         assert p._recall_max_tokens == 2048
+        assert p._recall_min_score == 0.75
         assert p._recall_types == ["world", "experience"]
         assert p._recall_prompt_preamble == "Custom preamble:"
         assert p._recall_max_input_chars == 500
@@ -715,6 +730,120 @@ class TestToolHandlers:
         call_kwargs = p._client.arecall.call_args.kwargs
         assert call_kwargs["types"] == ["world", "experience"]
 
+    def test_recall_min_score_disabled_does_not_request_trace(self, provider):
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "dark mode"}
+        ))
+        call_kwargs = provider._client.arecall.call_args.kwargs
+        assert "trace" not in call_kwargs
+        assert "Memory 1" in result["result"]
+        assert "Memory 2" in result["result"]
+
+    def test_recall_min_score_invalid_config_disables_trace(self, provider_with_config):
+        p = provider_with_config(recall_min_score="not-a-number")
+        assert p._recall_min_score is None
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "trace" not in call_kwargs
+
+    def test_recall_min_score_boolean_config_disables_trace(self, provider_with_config):
+        p = provider_with_config(recall_min_score=True)
+        assert p._recall_min_score is None
+        p.handle_tool_call("hindsight_recall", {"query": "test"})
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert "trace" not in call_kwargs
+
+    def test_recall_min_score_trace_unsupported_retries_without_trace(self, provider_with_config):
+        p = provider_with_config(recall_min_score=0.5)
+
+        async def _arecall(**kwargs):
+            if kwargs.get("trace") is True:
+                raise TypeError("unexpected keyword argument 'trace'")
+            return _recall_response([("node-a", "Memory A"), ("node-b", "Memory B")])
+
+        p._client.arecall = AsyncMock(side_effect=_arecall)
+
+        result = json.loads(p.handle_tool_call("hindsight_recall", {"query": "test"}))
+
+        assert "Memory A" in result["result"]
+        assert "Memory B" in result["result"]
+        assert p._client.arecall.call_count == 2
+        assert p._client.arecall.call_args_list[0].kwargs["trace"] is True
+        assert "trace" not in p._client.arecall.call_args_list[1].kwargs
+
+    def test_recall_min_score_filters_results_by_trace_rerank_score(self, provider_with_config):
+        p = provider_with_config(recall_min_score=0.5)
+        p._client.arecall.return_value = _recall_response(
+            [("node-high", "High relevance memory"), ("node-low", "Low relevance memory")],
+            trace={
+                "reranked": [
+                    {"node_id": "node-high", "rerank_score": 0.91},
+                    {"node_id": "node-low", "rerank_score": 0.12},
+                ]
+            },
+        )
+
+        result = json.loads(p.handle_tool_call("hindsight_recall", {"query": "test"}))
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["trace"] is True
+        assert result["result"] == "1. High relevance memory"
+
+    def test_recall_min_score_all_below_floor_returns_no_relevant_memory(self, provider_with_config):
+        p = provider_with_config(recall_min_score=0.5)
+        p._client.arecall.return_value = _recall_response(
+            [("node-a", "Memory A"), ("node-b", "Memory B")],
+            trace={
+                "reranked": [
+                    {"node_id": "node-a", "rerank_score": 0.49},
+                    {"node_id": "node-b", "rerank_score": 0.01},
+                ]
+            },
+        )
+
+        result = json.loads(p.handle_tool_call("hindsight_recall", {"query": "test"}))
+
+        assert result["result"] == "No relevant memories found."
+
+    def test_recall_min_score_missing_trace_fail_opens_all_results(self, provider_with_config):
+        p = provider_with_config(recall_min_score=0.5)
+        p._client.arecall.return_value = _recall_response(
+            [("node-a", "Memory A"), ("node-b", "Memory B")],
+            trace=None,
+        )
+
+        result = json.loads(p.handle_tool_call("hindsight_recall", {"query": "test"}))
+
+        assert "Memory A" in result["result"]
+        assert "Memory B" in result["result"]
+
+    def test_recall_min_score_missing_score_fail_opens_all_results(self, provider_with_config):
+        p = provider_with_config(recall_min_score=0.5)
+        p._client.arecall.return_value = _recall_response(
+            [("node-a", "Memory A"), ("node-b", "Memory B")],
+            trace={
+                "reranked": [
+                    {"node_id": "node-a", "rerank_score": 0.9},
+                ]
+            },
+        )
+
+        result = json.loads(p.handle_tool_call("hindsight_recall", {"query": "test"}))
+
+        assert "Memory A" in result["result"]
+        assert "Memory B" in result["result"]
+
+    def test_recall_min_score_result_without_id_fail_opens_all_results(self, provider_with_config):
+        p = provider_with_config(recall_min_score=0.5)
+        p._client.arecall.return_value = SimpleNamespace(
+            results=[SimpleNamespace(text="Memory without id")],
+            trace={"reranked": [{"node_id": "node-a", "rerank_score": 0.9}]},
+        )
+
+        result = json.loads(p.handle_tool_call("hindsight_recall", {"query": "test"}))
+
+        assert result["result"] == "1. Memory without id"
+
     def test_recall_no_results(self, provider):
         provider._client.arecall.return_value = SimpleNamespace(results=[])
         result = json.loads(provider.handle_tool_call(
@@ -854,6 +983,81 @@ class TestPrefetch:
         assert call_kwargs["tags"] == ["t1"]
         assert call_kwargs["tags_match"] == "all"
         assert call_kwargs["types"] == ["world"]
+
+    def test_queue_prefetch_min_score_disabled_does_not_request_trace(self, provider):
+        provider.queue_prefetch("test query")
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = provider._client.arecall.call_args.kwargs
+        assert "trace" not in call_kwargs
+        result = provider.prefetch("test query")
+        assert "Memory 1" in result
+        assert "Memory 2" in result
+
+    def test_queue_prefetch_min_score_passes_trace_and_filters(self, provider_with_config):
+        p = provider_with_config(recall_min_score=0.5)
+        p._client.arecall.return_value = _recall_response(
+            [("node-high", "High relevance memory"), ("node-low", "Low relevance memory")],
+            trace={
+                "reranked": [
+                    {"node_id": "node-high", "rerank_score": 0.91},
+                    {"node_id": "node-low", "rerank_score": 0.12},
+                ]
+            },
+        )
+
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["trace"] is True
+        result = p.prefetch("test query")
+        assert "High relevance memory" in result
+        assert "Low relevance memory" not in result
+
+    def test_queue_prefetch_min_score_trace_unsupported_retries_without_trace(self, provider_with_config):
+        p = provider_with_config(recall_min_score=0.5)
+
+        async def _arecall(**kwargs):
+            if kwargs.get("trace") is True:
+                raise TypeError("unexpected keyword argument 'trace'")
+            return _recall_response([("node-a", "Memory A")])
+
+        p._client.arecall = AsyncMock(side_effect=_arecall)
+
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        assert p._client.arecall.call_count == 2
+        assert p._client.arecall.call_args_list[0].kwargs["trace"] is True
+        assert "trace" not in p._client.arecall.call_args_list[1].kwargs
+        assert "Memory A" in p.prefetch("test query")
+
+    def test_queue_prefetch_min_score_all_below_floor_injects_no_context(self, provider_with_config):
+        p = provider_with_config(recall_min_score=0.5)
+        p._client.arecall.return_value = _recall_response(
+            [("node-a", "Memory A")],
+            trace={"reranked": [{"node_id": "node-a", "rerank_score": 0.1}]},
+        )
+
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        assert p.prefetch("test query") == ""
+
+    def test_queue_prefetch_reflect_method_does_not_request_recall_trace(self, provider_with_config):
+        p = provider_with_config(recall_min_score=0.5, recall_prefetch_method="reflect")
+
+        p.queue_prefetch("test query")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        p._client.areflect.assert_called_once()
+        p._client.arecall.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds an optional, default-off recall abstain floor for the Hindsight memory provider on stacks where the public recall API exposes trace rerank scores but no direct threshold surface.

Motivation:
- The current pinned client can return nearest candidates even when no candidate is strong enough.
- A default-off `recall_min_score` lets operators opt into abstaining instead of surfacing low-quality nearest-neighbor memory.

Safety and behavior invariants:
- Default behavior is unchanged when `recall_min_score` is unset, invalid, boolean, negative, or non-finite.
- `trace=True` is requested only when a valid floor is configured.
- If trace support is unavailable, recall retries without trace and fails open.
- If trace/result correlation is incomplete, the whole response fails open rather than partially filtering on incomplete signal.
- Trace payload is used in-process only and is not persisted.
- Reflect behavior is unchanged.

Tests:
- Provider unit tests cover disabled/invalid floor behavior, unsupported trace retry, rerank-score filtering, all-below-floor abstention, and fail-open cases for incomplete trace metadata.
- Existing Hindsight memory-provider test suite remains green locally.
