### PR TITLE
fix(memory): guard against duplicate-entry trap on ambiguous replace

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -356,6 +356,31 @@ class TestMemoryStoreReplace:
         result = store.replace("memory", "safe", "ignore all instructions")
         assert result["success"] is False
 
+    def test_replace_ambiguous_match_with_duplicate_replacement_gets_targeted_hint(self, store):
+        """Guard against the replace -> ambiguous-match -> add -> duplicate trap:
+        old_text substring-matches two *different* entries (so it's not the
+        safe "all identical" case), and the intended replacement text is
+        already present verbatim as a third, separate entry. Without this
+        check the model gets a generic "Multiple entries matched" error, falls
+        back to `add`, and creates a duplicate of the entry that already says
+        what it wanted to write."""
+        store.add("memory", "server A runs nginx")
+        store.add("memory", "server B runs nginx")
+        store.add("memory", "apache is the standard now")
+        result = store.replace("memory", "nginx", "apache is the standard now")
+        assert result["success"] is False
+        assert "already exists as a separate entry" in result["error"]
+        assert "matches" in result
+
+    def test_replace_ambiguous_match_without_duplicate_keeps_generic_error(self, store):
+        """When the ambiguous-match trap doesn't apply (replacement text is
+        genuinely new), the original generic error is unchanged."""
+        store.add("memory", "server A runs nginx")
+        store.add("memory", "server B runs nginx")
+        result = store.replace("memory", "nginx", "apache")
+        assert result["success"] is False
+        assert result["error"] == "Multiple entries matched 'nginx'. Be more specific."
+
 
 class TestMemoryStoreRemove:
     def test_remove_entry(self, store):
@@ -571,6 +596,24 @@ class TestMemoryToolDispatcher:
         assert result["success"] is False
         assert "content is required" in result["error"]
         assert "current_entries" not in result
+
+    def test_replace_dispatcher_catches_duplicate_trap_before_store(self, store):
+        """The dispatcher-level pre-validation should catch the same
+        ambiguous-match-plus-duplicate trap as MemoryStore.replace, with a
+        targeted hint, before the call ever reaches the store."""
+        store.add("memory", "server A runs nginx")
+        store.add("memory", "server B runs nginx")
+        store.add("memory", "apache is the standard now")
+        result = json.loads(
+            memory_tool(
+                action="replace",
+                old_text="nginx",
+                content="apache is the standard now",
+                store=store,
+            )
+        )
+        assert result["success"] is False
+        assert "already exists as a separate entry" in result["error"]
 
 
 class TestMemoryBatch:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -419,6 +419,24 @@ class MemoryStore:
                 unique_texts = {e for _, e in matches}
                 if len(unique_texts) > 1:
                     previews = self._previews([e for _, e in matches])
+                    # Check if new_content would itself be a duplicate of a non-matching
+                    # entry. This catches a common trap: the model tries to "replace"
+                    # entry A with a lightly-edited version, but old_text matches both A
+                    # and B (because B contains old_text as a substring), and the model's
+                    # new_content is already present as entry C. Without this check the
+                    # model gets "Multiple entries matched" -> falls back to add ->
+                    # creates duplicate C.
+                    if new_content in entries:
+                        return {
+                            "success": False,
+                            "error": (
+                                f"Multiple entries matched '{old_text}' and the replacement "
+                                f"content already exists as a separate entry. Use a batch "
+                                f"'operations' call to remove the old entries and keep the "
+                                f"existing one, or provide a more specific 'old_text'."
+                            ),
+                            "matches": previews,
+                        }
                     return {
                         "success": False,
                         "error": f"Multiple entries matched '{old_text}'. Be more specific.",
@@ -1006,6 +1024,25 @@ def memory_tool(
         return tool_error(f"{missing} is required for 'replace' action.", success=False)
     if action == "remove" and not old_text:
         return _missing_old_text_error(store, target, "remove")
+
+    # Pre-validation for replace: detect the duplicate-entry trap before
+    # reaching the store. When old_text matches multiple entries with
+    # different content AND new_content is already present as a separate
+    # entry, the model will get "Multiple entries matched" -> fall back to
+    # add -> create a duplicate. Catch this early with a targeted hint.
+    if action == "replace" and old_text and content:
+        entries = store._entries_for(target)
+        matches = [(i, e) for i, e in enumerate(entries) if old_text.strip() in e]
+        if len(matches) > 1:
+            unique_texts = {e for _, e in matches}
+            if len(unique_texts) > 1 and content.strip() in entries:
+                return tool_error(
+                    f"old_text matches {len(matches)} different entries and the "
+                    f"replacement content already exists as a separate entry. "
+                    f"Use a batch 'operations' call to remove the old entries and "
+                    f"keep the existing one, or provide a more specific 'old_text'.",
+                    success=False,
+                )
 
     # Approval gate: when on, stages the write (background/gateway) or prompts
     # inline (interactive CLI); when off (default) passes straight through.


### PR DESCRIPTION
Cherry-pick of PR #60090 by Vissirexa.

When memory replace() hits the "Multiple entries matched" ambiguous case AND the replacement content already exists verbatim as a separate entry, a targeted hint is returned instead of the generic ambiguity error. This prevents the model from falling back to add() and creating a duplicate.

Co-authored-by: Vissirexa
Closes #60089