### PR TITLE
fix: auto-refresh member cache in _build_msg_body_with_mentions when stale

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -4853,20 +4853,32 @@ class MessageSender:
         reply_to: Optional[str] = None,
     ) -> dict:
         """Send group text message, auto-converting @nickname to TIMCustomElem."""
-        msg_body = self._build_msg_body_with_mentions(text, group_code)
+        msg_body = await self._build_msg_body_with_mentions(text, group_code)
         return await self.send_group_msg_body(group_code, msg_body, reply_to)
 
     # @mention pattern: (whitespace or start) + @ + nickname + (whitespace or end)
     _AT_USER_RE = re.compile(r'(?:(?<=\s)|(?<=^))@(\S+?)(?=\s|$)', re.MULTILINE)
 
-    def _build_msg_body_with_mentions(self, text: str, group_code: str) -> list:
+    async def _build_msg_body_with_mentions(self, text: str, group_code: str) -> list:
         """Parse @nickname patterns and build mixed TIMTextElem + TIMCustomElem msg_body."""
+        # Try cache first
         cached = self._adapter._member_cache.get(group_code)
+        members: list = []
         if cached:
             ts, member_list = cached
-            members = member_list if (time.time() - ts < self._adapter.MEMBER_CACHE_TTL_S) else []
-        else:
-            members = []
+            if time.time() - ts < self._adapter.MEMBER_CACHE_TTL_S:
+                members = member_list
+
+        # Cache empty or stale — refresh from server
+        if not members:
+            await self._adapter._group_query.get_group_member_list_raw(group_code)
+            cached = self._adapter._member_cache.get(group_code)
+            if cached:
+                ts, member_list = cached
+                if time.time() - ts < self._adapter.MEMBER_CACHE_TTL_S:
+                    members = member_list
+
+        # Still no data after refresh — fall back to plain text
         if not members:
             return [{"msg_type": "TIMTextElem", "msg_content": {"text": text}}]
 

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -4861,9 +4861,12 @@ class MessageSender:
 
     async def _build_msg_body_with_mentions(self, text: str, group_code: str) -> list:
         """Parse @nickname patterns and build mixed TIMTextElem + TIMCustomElem msg_body."""
-        # Fast path: no @-mention in text, return as-is
-        if "@" not in text:
-            return [{"msg_type": "TIMTextElem", "msg_content": {"text": text}}]
+        # Fast path: no mention-syntax @ in text, return as-is.
+        # Use the resolver's regex rather than a literal "@" check — a cold-cache
+        # message containing an email or other non-mention "@" must NOT trigger
+        # an unnecessary member-list request before delivery.
+        if not self._AT_USER_RE.search(text):
+            return [{"msg_type": "TIMTextElem", "msg_content": {"text": text}}]    
 
         # Try cache first
         cached = self._adapter._member_cache.get(group_code)

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -4861,6 +4861,10 @@ class MessageSender:
 
     async def _build_msg_body_with_mentions(self, text: str, group_code: str) -> list:
         """Parse @nickname patterns and build mixed TIMTextElem + TIMCustomElem msg_body."""
+        # Fast path: no @-mention in text, return as-is
+        if "@" not in text:
+            return [{"msg_type": "TIMTextElem", "msg_content": {"text": text}}]
+
         # Try cache first
         cached = self._adapter._member_cache.get(group_code)
         members: list = []

--- a/tests/gateway/platforms/test_yuanbao_message_sender.py
+++ b/tests/gateway/platforms/test_yuanbao_message_sender.py
@@ -1,0 +1,225 @@
+"""
+test_yuanbao_message_sender.py - Unit tests for MessageSender._build_msg_body_with_mentions
+
+Tests the @-mention resolution logic, including automatic cache refresh
+when the member cache is empty or stale.
+"""
+
+import sys
+import os
+import time
+import json
+
+# Ensure hermes-agent root is in sys.path
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from gateway.platforms.yuanbao import MessageSender
+
+
+# Sample member list used in test scenarios
+_SAMPLE_MEMBERS = [
+    {"user_id": "user_abc123", "nickname": "元宝"},
+    {"user_id": "user_def456", "nickname": "张三"},
+    {"user_id": "user_ghi789", "nickname": "Alice"},
+]
+
+
+def _make_mock_adapter(member_cache: dict = None):
+    """Create a mock YuanbaoAdapter with controllable _member_cache and _group_query."""
+    adapter = MagicMock()
+    adapter._member_cache = member_cache or {}
+    adapter.MEMBER_CACHE_TTL_S = 300.0
+
+    # _group_query.get_group_member_list_raw is an async method
+    mock_group_query = MagicMock()
+    mock_group_query.get_group_member_list_raw = AsyncMock()
+    adapter._group_query = mock_group_query
+
+    return adapter
+
+
+def _make_sender(adapter):
+    """Create a MessageSender with a given mock adapter."""
+    return MessageSender(adapter)
+
+
+class TestBuildMsgBodyWithMentions:
+    """Tests for _build_msg_body_with_mentions cache + @-mention resolution."""
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_resolves_mention(self):
+        """Cache is fresh and populated → @-mention resolved to TIMCustomElem."""
+        cache = {
+            "group_001": (time.time(), _SAMPLE_MEMBERS),
+        }
+        adapter = _make_mock_adapter(cache)
+        sender = _make_sender(adapter)
+
+        result = await sender._build_msg_body_with_mentions(
+            "@元宝 你好", "group_001"
+        )
+
+        # Should produce 2 elements: TIMCustomElem for @元宝 + TIMTextElem for " 你好"
+        assert len(result) == 2
+        assert result[0]["msg_type"] == "TIMCustomElem"
+        assert result[0]["msg_content"]["data"]
+        data = json.loads(result[0]["msg_content"]["data"])
+        assert data["elem_type"] == 1002
+        assert data["user_id"] == "user_abc123"
+        assert data["text"] == "@元宝"
+        assert result[1]["msg_type"] == "TIMTextElem"
+        assert "你好" in result[1]["msg_content"]["text"]
+
+        # Cache was fresh → no network call
+        adapter._group_query.get_group_member_list_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_unknown_nickname_falls_back(self):
+        """Cache hit but nickname not found → @mention sent as plain text."""
+        cache = {
+            "group_001": (time.time(), _SAMPLE_MEMBERS),
+        }
+        adapter = _make_mock_adapter(cache)
+        sender = _make_sender(adapter)
+
+        result = await sender._build_msg_body_with_mentions(
+            "@不存在的昵称 测试", "group_001"
+        )
+
+        # Unknown nickname → split into TIMTextElem parts (no TIMCustomElem)
+        assert len(result) == 2
+        for elem in result:
+            assert elem["msg_type"] == "TIMTextElem"
+        assert "@不存在的昵称" in result[0]["msg_content"]["text"]
+        assert "测试" in result[1]["msg_content"]["text"]
+
+        adapter._group_query.get_group_member_list_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_empty_triggers_refresh_and_succeeds(self):
+        """Cache empty → refresh from server → cache populated → @ resolved."""
+        adapter = _make_mock_adapter({})  # empty cache
+        # Mock the refresh to populate the cache
+        async def _refresh_and_populate(group_code, offset=0, limit=200):
+            adapter._member_cache[group_code] = (time.time(), _SAMPLE_MEMBERS)
+            return {"members": _SAMPLE_MEMBERS}
+        adapter._group_query.get_group_member_list_raw.side_effect = _refresh_and_populate
+        sender = _make_sender(adapter)
+
+        result = await sender._build_msg_body_with_mentions(
+            "@元宝 你好", "group_001"
+        )
+
+        # Should have triggered a refresh
+        adapter._group_query.get_group_member_list_raw.assert_awaited_once_with("group_001")
+
+        # @-mention should be resolved
+        assert len(result) == 2
+        assert result[0]["msg_type"] == "TIMCustomElem"
+        data = json.loads(result[0]["msg_content"]["data"])
+        assert data["user_id"] == "user_abc123"
+
+    @pytest.mark.asyncio
+    async def test_cache_expired_triggers_refresh_and_succeeds(self):
+        """Cache expired → refresh from server → cache updated → @ resolved."""
+        old_time = time.time() - 600  # 10 minutes ago (past 300s TTL)
+        cache = {
+            "group_001": (old_time, _SAMPLE_MEMBERS),
+        }
+        adapter = _make_mock_adapter(cache)
+
+        async def _refresh_and_update(group_code, offset=0, limit=200):
+            fresh_members = [
+                {"user_id": "user_abc123", "nickname": "元宝"},
+            ]
+            adapter._member_cache[group_code] = (time.time(), fresh_members)
+            return {"members": fresh_members}
+        adapter._group_query.get_group_member_list_raw.side_effect = _refresh_and_update
+        sender = _make_sender(adapter)
+
+        result = await sender._build_msg_body_with_mentions(
+            "@元宝 你好", "group_001"
+        )
+
+        adapter._group_query.get_group_member_list_raw.assert_awaited_once_with("group_001")
+        assert len(result) == 2
+        assert result[0]["msg_type"] == "TIMCustomElem"
+        data = json.loads(result[0]["msg_content"]["data"])
+        assert data["user_id"] == "user_abc123"
+
+    @pytest.mark.asyncio
+    async def test_cache_empty_refresh_fails_falls_back(self):
+        """Cache empty → refresh fails (returns None) → fall back to plain text."""
+        adapter = _make_mock_adapter({})
+        adapter._group_query.get_group_member_list_raw.return_value = None
+        sender = _make_sender(adapter)
+
+        result = await sender._build_msg_body_with_mentions(
+            "@元宝 你好", "group_001"
+        )
+
+        adapter._group_query.get_group_member_list_raw.assert_awaited_once_with("group_001")
+        # Fall back to plain text
+        assert len(result) == 1
+        assert result[0]["msg_type"] == "TIMTextElem"
+        assert "@元宝 你好" in result[0]["msg_content"]["text"]
+
+    @pytest.mark.asyncio
+    async def test_cache_empty_refresh_returns_no_members_falls_back(self):
+        """Cache empty → refresh returns empty member list → fall back to plain text."""
+        adapter = _make_mock_adapter({})
+        async def _refresh_empty(group_code, offset=0, limit=200):
+            adapter._member_cache[group_code] = (time.time(), [])
+            return {"members": []}
+        adapter._group_query.get_group_member_list_raw.side_effect = _refresh_empty
+        sender = _make_sender(adapter)
+
+        result = await sender._build_msg_body_with_mentions(
+            "@元宝 你好", "group_001"
+        )
+
+        adapter._group_query.get_group_member_list_raw.assert_awaited_once_with("group_001")
+        assert len(result) == 1
+        assert result[0]["msg_type"] == "TIMTextElem"
+
+    @pytest.mark.asyncio
+    async def test_no_at_symbol_skips_entire_logic(self):
+        """No @ in text → entire method skipped, returns plain text."""
+        adapter = _make_mock_adapter({})  # empty cache, but shouldn't matter
+        sender = _make_sender(adapter)
+
+        result = await sender._build_msg_body_with_mentions(
+            "你好，世界", "group_001"
+        )
+
+        assert len(result) == 1
+        assert result[0]["msg_type"] == "TIMTextElem"
+        assert result[0]["msg_content"]["text"] == "你好，世界"
+        # No network call
+        adapter._group_query.get_group_member_list_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_multiple_mentions_in_one_message(self):
+        """Multiple @-mentions in one message all resolved from cache."""
+        cache = {
+            "group_001": (time.time(), _SAMPLE_MEMBERS),
+        }
+        adapter = _make_mock_adapter(cache)
+        sender = _make_sender(adapter)
+
+        result = await sender._build_msg_body_with_mentions(
+            "@元宝 和 @张三 一起", "group_001"
+        )
+
+        # 元宝 → TIMCustomElem, " 和 " → TIMTextElem, 张三 → TIMCustomElem, " 一起" → TIMTextElem
+        assert len(result) == 4
+        assert result[0]["msg_type"] == "TIMCustomElem"
+        assert json.loads(result[0]["msg_content"]["data"])["user_id"] == "user_abc123"
+        assert result[1]["msg_type"] == "TIMTextElem"
+        assert result[2]["msg_type"] == "TIMCustomElem"
+        assert json.loads(result[2]["msg_content"]["data"])["user_id"] == "user_def456"
+        assert result[3]["msg_type"] == "TIMTextElem"

--- a/tests/gateway/platforms/test_yuanbao_message_sender.py
+++ b/tests/gateway/platforms/test_yuanbao_message_sender.py
@@ -223,3 +223,65 @@ class TestBuildMsgBodyWithMentions:
         assert result[2]["msg_type"] == "TIMCustomElem"
         assert json.loads(result[2]["msg_content"]["data"])["user_id"] == "user_def456"
         assert result[3]["msg_type"] == "TIMTextElem"
+
+    @pytest.mark.asyncio
+    async def test_cold_cache_email_only_does_not_trigger_refresh(self):
+        """Cold cache + literal '@' in an email address must NOT trigger a refresh.
+
+        Regression for tek/sweeper review on PR #60324: the previous fast path
+        used `if "@" not in text`, which matched any literal '@' — including
+        emails like `user@example.com`. That forced an unnecessary
+        `get_group_member_list_raw` await before delivery, even though no real
+        mention could ever be produced. The fix gates refresh on the actual
+        mention regex `_AT_USER_RE`.
+        """
+        adapter = _make_mock_adapter({})  # cold cache
+        sender = _make_sender(adapter)
+
+        result = await sender._build_msg_body_with_mentions(
+            "请联系 user@example.com 获取资料", "group_001"
+        )
+
+        # Email '@' is not mention syntax → no refresh, no member lookup
+        adapter._group_query.get_group_member_list_raw.assert_not_called()
+
+        # Text returned as plain TIMTextElem, untouched
+        assert len(result) == 1
+        assert result[0]["msg_type"] == "TIMTextElem"
+        assert result[0]["msg_content"]["text"] == "请联系 user@example.com 获取资料"
+
+    @pytest.mark.asyncio
+    async def test_send_group_message_propagates_async_builder(self):
+        """send_group_message must await _build_msg_body_with_mentions correctly.
+
+        Regression for tek/sweeper review on PR #60324: the sync→async builder
+        boundary added by this PR requires a top-level test. We assert that
+        send_group_message ends up calling send_group_msg_body with the builder's
+        output, not a coroutine object.
+        """
+        cache = {
+            "group_001": (time.time(), _SAMPLE_MEMBERS),
+        }
+        adapter = _make_mock_adapter(cache)
+        sender = _make_sender(adapter)
+
+        # Spy on send_group_msg_body, return a sentinel so we can assert it was called
+        async def _spy_send_group_msg_body(group_code, msg_body, reply_to=None):
+            return {"_spy_called_with_group": group_code, "_spy_msg_body": msg_body}
+
+        sender.send_group_msg_body = _spy_send_group_msg_body
+
+        result = await sender.send_group_message(
+            "group_001", "@元宝 你好"
+        )
+
+        # The async builder's TIMCustomElem output should have been passed through
+        assert result["_spy_called_with_group"] == "group_001"
+        body = result["_spy_msg_body"]
+        assert len(body) == 2
+        assert body[0]["msg_type"] == "TIMCustomElem"
+        assert json.loads(body[0]["msg_content"]["data"])["user_id"] == "user_abc123"
+        assert body[1]["msg_type"] == "TIMTextElem"
+
+        # Cache was fresh → no refresh side-effect
+        adapter._group_query.get_group_member_list_raw.assert_not_called()


### PR DESCRIPTION
### Problem

`_build_msg_body_with_mentions` silently falls back to plain text when the member cache is empty or expired, making `@`-mentions invisible to the target bot. The cache has no automatic population mechanism — it only gets filled when someone manually queries group members — so `@`-mentions almost never work in practice.

### Root Cause

The method checks `self._adapter._member_cache[group_code]` and, if the entry is missing or older than `MEMBER_CACHE_TTL_S` (300s), immediately returns the original text as a plain `TIMTextElem`. There was no fallback to fetch fresh data from the server.

### Fix

1. Changed `_build_msg_body_with_mentions` from `def` to `async def` so it can call the async `get_group_member_list_raw`.
2. Added an automatic refresh: when the cache is empty or stale, the method calls `get_group_member_list_raw(group_code)` to populate the cache, then re-checks before falling back to plain text.
3. Updated the sole caller `send_group_message` to `await` the result.

### Testing

Manually verified the logic path: cache miss → `get_group_member_list_raw` called → cache populated → `@`-mention resolved to `TIMCustomElem`.