### PR TITLE
fix(retry): back off NVIDIA NIM rate limits

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4123,6 +4123,8 @@ def run_conversation(
                         _policy_note = " (Z.AI Coding overload adaptive long backoff)"
                     elif _backoff_policy == "zai_coding_overload_short":
                         _policy_note = " (Z.AI Coding overload short retry)"
+                    elif _backoff_policy == "nvidia_nim_rate_limit":
+                        _policy_note = " (NVIDIA NIM rate-limit backoff)"
                     _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
                     _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
                     # Normal retries are buffered to avoid noisy transient chatter. Long

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -23,6 +23,7 @@ _jitter_lock = threading.Lock()
 # cap interactive-friendly: a simple TUI message should fail visibly in minutes,
 # not sit silent for 20+ minutes.
 _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
+_NVIDIA_NIM_RATE_LIMIT_BACKOFF = (15.0, 30.0, 60.0, 120.0)
 
 # Number of initial short retries before the adaptive long-backoff tier kicks
 # in. Shared by ``adaptive_rate_limit_backoff`` (which walks the long table
@@ -105,6 +106,28 @@ def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, err
     )
 
 
+def is_nvidia_nim_rate_limit_error(*, base_url: str | None, error: Any) -> bool:
+    """Return True for NVIDIA NIM endpoint 429s.
+
+    NVIDIA NIM can return a terse ``{"status":429,"title":"Too Many Requests"}``
+    body without a Retry-After header. Retrying after the generic 2s backoff
+    tends to create retry storms across concurrent workers, so use a wider
+    provider-specific window while keeping ordinary non-NVIDIA 429s unchanged.
+    """
+    base = (base_url or "").rstrip("/").lower()
+    status = getattr(error, "status_code", None)
+    text = _error_text(error)
+    return (
+        "integrate.api.nvidia.com/v1" in base
+        and (
+            status == 429
+            or "too many requests" in text
+            or '"status":429' in text
+            or "'status': 429" in text
+        )
+    )
+
+
 def adaptive_rate_limit_backoff(
     attempt: int,
     *,
@@ -125,16 +148,22 @@ def adaptive_rate_limit_backoff(
     Returns ``(wait_seconds, reason_label)`` where ``reason_label`` is suitable
     for status/log decoration when a provider-specific policy fired.
     """
-    if not is_zai_coding_overload_error(base_url=base_url, model=model, error=error):
-        return default_wait, None
-    if attempt <= short_attempts:
-        return default_wait, "zai_coding_overload_short"
+    if is_zai_coding_overload_error(base_url=base_url, model=model, error=error):
+        if attempt <= short_attempts:
+            return default_wait, "zai_coding_overload_short"
 
-    idx = min(attempt - short_attempts - 1, len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) - 1)
-    base_delay = _ZAI_CODING_OVERLOAD_LONG_BACKOFF[idx]
-    # A smaller jitter ratio keeps long waits readable while still avoiding
-    # synchronized retry storms across concurrent Hermes sessions.
-    return jittered_backoff(1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2), "zai_coding_overload_long"
+        idx = min(attempt - short_attempts - 1, len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) - 1)
+        base_delay = _ZAI_CODING_OVERLOAD_LONG_BACKOFF[idx]
+        # A smaller jitter ratio keeps long waits readable while still avoiding
+        # synchronized retry storms across concurrent Hermes sessions.
+        return jittered_backoff(1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2), "zai_coding_overload_long"
+
+    if is_nvidia_nim_rate_limit_error(base_url=base_url, error=error):
+        idx = min(max(attempt, 1) - 1, len(_NVIDIA_NIM_RATE_LIMIT_BACKOFF) - 1)
+        base_delay = _NVIDIA_NIM_RATE_LIMIT_BACKOFF[idx]
+        return jittered_backoff(1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2), "nvidia_nim_rate_limit"
+
+    return default_wait, None
 
 
 def zai_coding_overload_retry_ceiling(short_attempts: int = _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS) -> int:

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -5,7 +5,12 @@ import threading
 import agent.retry_utils as retry_utils
 from types import SimpleNamespace
 
-from agent.retry_utils import adaptive_rate_limit_backoff, is_zai_coding_overload_error, jittered_backoff
+from agent.retry_utils import (
+    adaptive_rate_limit_backoff,
+    is_nvidia_nim_rate_limit_error,
+    is_zai_coding_overload_error,
+    jittered_backoff,
+)
 
 
 def test_backoff_is_exponential():
@@ -198,6 +203,42 @@ def test_zai_coding_overload_backoff_grows_after_short_retries(monkeypatch):
         assert policy == "zai_coding_overload_long"
 
     assert waits == [30.0, 60.0, 90.0, 120.0, 120.0, 120.0]
+
+
+def test_nvidia_nim_rate_limit_classifier_is_endpoint_specific():
+    err = SimpleNamespace(status_code=429, body={"status": 429, "title": "Too Many Requests"})
+
+    assert is_nvidia_nim_rate_limit_error(
+        base_url="https://integrate.api.nvidia.com/v1",
+        error=err,
+    )
+    assert is_nvidia_nim_rate_limit_error(
+        base_url="https://integrate.api.nvidia.com/v1/",
+        error=SimpleNamespace(body='{"status":429,"title":"Too Many Requests"}'),
+    )
+    assert not is_nvidia_nim_rate_limit_error(
+        base_url="https://openrouter.ai/api/v1",
+        error=err,
+    )
+
+
+def test_nvidia_nim_rate_limit_backoff_uses_wider_window(monkeypatch):
+    monkeypatch.setattr(retry_utils, "jittered_backoff", lambda *a, **kw: kw["base_delay"])
+    err = SimpleNamespace(status_code=429, body={"status": 429, "title": "Too Many Requests"})
+
+    waits = []
+    for attempt in range(1, 6):
+        wait, policy = adaptive_rate_limit_backoff(
+            attempt,
+            base_url="https://integrate.api.nvidia.com/v1",
+            model="minimaxai/minimax-m3",
+            error=err,
+            default_wait=2.0,
+        )
+        waits.append(wait)
+        assert policy == "nvidia_nim_rate_limit"
+
+    assert waits == [15.0, 30.0, 60.0, 120.0, 120.0]
 
 
 def test_non_zai_backoff_returns_default_wait():


### PR DESCRIPTION
## Summary
- detect NVIDIA NIM 429 responses from integrate.api.nvidia.com/v1
- use a wider adaptive backoff window for those rate limits instead of the generic 2s retry
- show a status/log note when NVIDIA NIM rate-limit backoff is active

## Tests
- python -m pytest tests/test_retry_utils.py --basetemp <local-temp>

## Safety
- no credential values or secrets added
- non-NVIDIA 429 behavior is unchanged