### PR TITLE
fix(gateway): add Feishu to the own-policy open-startup fail-closed gate

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1790,6 +1790,13 @@ _OWN_POLICY_OPEN_ENV = {
     Platform.YUANBAO: ("YUANBAO_DM_POLICY", "YUANBAO_GROUP_POLICY", "YUANBAO_ALLOW_ALL_USERS"),
     Platform.QQBOT: (None, None, "QQ_ALLOW_ALL_USERS"),
     Platform.WHATSAPP: ("WHATSAPP_DM_POLICY", "WHATSAPP_GROUP_POLICY", "WHATSAPP_ALLOW_ALL_USERS"),
+    # Feishu has no dm_policy knob (DMs are gated by FEISHU_ALLOW_ALL_USERS
+    # directly, an unambiguous opt-in on its own) but its group_policy
+    # supports the same "open" footgun as the platforms above:
+    # FeishuAdapter._allow_group_message() returns True unconditionally for
+    # policy == "open" (plugins/platforms/feishu/adapter.py), with no
+    # secondary allow-all check the way WeCom's DM "open" path has.
+    Platform.FEISHU: (None, "FEISHU_GROUP_POLICY", "FEISHU_ALLOW_ALL_USERS"),
 }
 
 
@@ -1809,6 +1816,12 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
         ).strip().lower()
         group_policy = str(
             extra.get("group_policy")
+            # Feishu's config-file override for the ungated-groups default is
+            # named "default_group_policy", not "group_policy" — see
+            # FeishuAdapterSettings.default_group_policy /
+            # FeishuAdapter._apply_settings. Harmless no-op for every other
+            # platform in this dict, none of which read this key.
+            or extra.get("default_group_policy")
             or (os.getenv(group_env, "pairing") if group_env else "pairing")
         ).strip().lower()
         if dm_policy != "open" and group_policy != "open":

--- a/tests/gateway/test_own_policy_startup_gate.py
+++ b/tests/gateway/test_own_policy_startup_gate.py
@@ -58,3 +58,90 @@ async def test_gateway_allow_all_satisfies_yuanbao_open_gate(monkeypatch, tmp_pa
 
     assert ok is True
     assert runner.should_exit_cleanly is False
+
+
+@pytest.mark.asyncio
+async def test_unrelated_allow_all_does_not_bypass_feishu_open_gate(
+    monkeypatch, tmp_path,
+):
+    """TELEGRAM_ALLOW_ALL_USERS must not satisfy Feishu's open-policy opt-in.
+
+    Mirrors the Yuanbao gate above. Feishu's config-file key for this is
+    ``default_group_policy`` (not ``group_policy`` — see
+    FeishuAdapterSettings.default_group_policy), so this also pins that the
+    startup guard reads the key Feishu's adapter actually honors.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.setenv("TELEGRAM_ALLOW_ALL_USERS", "true")
+
+    config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={"default_group_policy": "open"},
+            ),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is True
+    assert "feishu" in (runner.exit_reason or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_feishu_group_policy_env_var_triggers_gate(monkeypatch, tmp_path):
+    """FEISHU_GROUP_POLICY=open (the interactive-setup-wizard path — see
+    plugins/platforms/feishu/adapter.py's interactive_setup, which calls
+    save_env_value("FEISHU_GROUP_POLICY", "open") for the recommended
+    "respond only when @mentioned" choice) must also require the allow-all
+    opt-in, not just the config.yaml extra key."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.setenv("FEISHU_GROUP_POLICY", "open")
+
+    config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(enabled=True, extra={}),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is True
+    assert "feishu" in (runner.exit_reason or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_gateway_allow_all_satisfies_feishu_open_gate(monkeypatch, tmp_path):
+    """GATEWAY_ALLOW_ALL_USERS is the intended global open-policy opt-in."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("TELEGRAM_ALLOW_ALL_USERS", raising=False)
+
+    config = GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={"default_group_policy": "open"},
+            ),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    monkeypatch.setattr(runner, "_create_adapter", lambda platform, cfg: None)
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert runner.should_exit_cleanly is False


### PR DESCRIPTION
## Summary
bb304b491 (SECURITY.md 2.6) added `_own_policy_open_startup_violation()` to refuse to boot when an own-policy adapter's `dm_policy`/`group_policy` is `"open"` without an explicit allow-all opt-in, and registered WeCom, Weixin, Yuanbao, QQBot, and WhatsApp in `_OWN_POLICY_OPEN_ENV`. Feishu has the identical footgun — `FeishuAdapter._allow_group_message()` returns `True` unconditionally for `policy == "open"` (mirroring WeCom's own group-policy `"open"` path, which likewise has no secondary allow-all check) — but was never added to the gate.

Feishu has no `dm_policy` knob (DMs are gated directly by `FEISHU_ALLOW_ALL_USERS`, an unambiguous opt-in on its own), so only the group side needs the guard. Feishu's config-file override for this is also named differently from the other platforms: `FeishuAdapterSettings` reads `extra.get("default_group_policy")`, not `extra.get("group_policy")`.

## Changes
- `gateway/run.py`: add `Platform.FEISHU: (None, "FEISHU_GROUP_POLICY", "FEISHU_ALLOW_ALL_USERS")` to `_OWN_POLICY_OPEN_ENV`, and extend `_own_policy_open_startup_violation()`'s `group_policy` resolution to also check `extra.get("default_group_policy")` — a harmless no-op for every other platform in the dict, none of which read that key.
- `tests/gateway/test_own_policy_startup_gate.py`: three new cases mirroring the existing Yuanbao tests — the `config.yaml` extra key, the `FEISHU_GROUP_POLICY` env var (the actual path the interactive setup wizard writes for its recommended "respond only when @mentioned" choice), and the `GATEWAY_ALLOW_ALL_USERS` opt-in satisfying the gate.

## Test plan
- [x] New tests reproduce the gap against pre-fix code (guard never fires for Feishu) and pass after the fix
- [x] Mutation-verified: reverting the fix (`git stash` on `gateway/run.py` alone) makes the two violation-expecting tests fail against the pre-fix code
- [x] Full regression sweep: `test_own_policy_startup_gate.py`, `test_config_driven_access_policy.py`, `test_multiplex_profile_authz.py`, and the full Feishu test suite — 515 passed
- [x] `ruff check` clean on both changed files