### PR TITLE
fix(cron): support continuable execution sessions

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -454,6 +454,12 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     if not state:
         state = "scheduled" if normalized.get("enabled", True) else "paused"
     normalized["state"] = state
+    normalized["session_mode"] = _normalize_session_mode(
+        normalized.get("session_mode"),
+        normalized.get("target_session_id"),
+    )
+    target_session_id = _normalize_job_optional_text(normalized.get("target_session_id"))
+    normalized["target_session_id"] = target_session_id
 
     return normalized
 
@@ -1147,6 +1153,21 @@ def _normalize_job_optional_text(value: Any, *, strip_trailing_slash: bool = Fal
     return text or None
 
 
+def _normalize_session_mode(value: Any, target_session_id: Any = None) -> str:
+    if target_session_id:
+        return "target"
+    mode = str(value or "fresh").strip().lower()
+    if mode in {"", "new", "isolated"}:
+        return "fresh"
+    if mode in {"continue", "continuation", "reused"}:
+        return "reuse"
+    if mode in {"inject", "injected"}:
+        return "target"
+    if mode not in {"fresh", "reuse", "target"}:
+        raise ValueError("session_mode must be one of: fresh, reuse, target")
+    return mode
+
+
 def _compute_provider_model_snapshots(
     *,
     provider: Any,
@@ -1220,6 +1241,8 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    session_mode: Optional[str] = None,
+    target_session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1264,6 +1287,13 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        session_mode: Optional execution session behavior for agent jobs.
+                ``fresh`` (default) preserves one visible session per tick;
+                ``reuse`` continues a stable cron-owned ``cron_<job_id>``
+                session across ticks.
+        target_session_id: Optional existing Hermes session to inject this job
+                into. When set, the scheduler loads that transcript and appends
+                the cron turn to it instead of creating a cron-owned session.
 
     Returns:
         The created job dict
@@ -1296,6 +1326,17 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_target_session_id = (
+        str(target_session_id).strip() if target_session_id is not None else None
+    ) or None
+    normalized_session_mode = _normalize_session_mode(
+        session_mode,
+        normalized_target_session_id,
+    )
+    if normalized_target_session_id:
+        normalized_session_mode = "target"
+    elif normalized_session_mode == "target":
+        raise ValueError("session_mode='target' requires target_session_id")
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1385,6 +1426,8 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "session_mode": normalized_session_mode,
+        "target_session_id": normalized_target_session_id,
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
@@ -1488,9 +1531,20 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+            if "target_session_id" in updates:
+                _sid = updates["target_session_id"]
+                updates["target_session_id"] = (
+                    str(_sid).strip() if _sid is not None else None
+                ) or None
+            if "session_mode" in updates:
+                updates["session_mode"] = _normalize_session_mode(updates["session_mode"])
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
+            if updated.get("target_session_id"):
+                updated["session_mode"] = "target"
+            elif updated.get("session_mode") == "target":
+                raise ValueError("session_mode='target' requires target_session_id")
             schedule_changed = "schedule" in updates
             inference_fields_changed = bool(
                 {"provider", "model", "base_url", "no_agent"}.intersection(updates)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -52,6 +52,58 @@ from hermes_time import now as _hermes_now
 logger = logging.getLogger(__name__)
 
 
+_resolved_session_locks: dict[str, list[Any]] = {}
+_resolved_session_locks_guard = threading.Lock()
+
+
+class _ResolvedSessionAdmission:
+    """Exclusive scheduler admission for one reusable execution session."""
+
+    def __init__(self, session_id: str, lock: Any):
+        self._session_id = session_id
+        self._lock = lock
+        self._released = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._lock.release()
+        with _resolved_session_locks_guard:
+            entry = _resolved_session_locks.get(self._session_id)
+            if entry is None or entry[0] is not self._lock:
+                return
+            entry[1] -= 1
+            if entry[1] == 0:
+                _resolved_session_locks.pop(self._session_id, None)
+
+
+def _admit_resolved_cron_session(session_id: str) -> _ResolvedSessionAdmission:
+    """Serialize cron runs that append to the same durable session.
+
+    Every waiter increments the reference count before blocking, so the keyed
+    lock stays published until the final holder/waiter leaves. That prevents a
+    second lock from being created in the tiny handoff window between one run
+    releasing the lock and the next one acquiring it.
+    """
+    with _resolved_session_locks_guard:
+        entry = _resolved_session_locks.get(session_id)
+        if entry is None:
+            entry = [threading.Lock(), 0]
+            _resolved_session_locks[session_id] = entry
+        entry[1] += 1
+        lock = entry[0]
+    try:
+        lock.acquire()
+    except BaseException:
+        with _resolved_session_locks_guard:
+            entry[1] -= 1
+            if entry[1] == 0:
+                _resolved_session_locks.pop(session_id, None)
+        raise
+    return _ResolvedSessionAdmission(session_id, lock)
+
+
 def _set_cron_session_title(session_db, session_id, base_title):
     """Robustly title a finished cron session before it is closed.
 
@@ -2750,6 +2802,153 @@ def _guard_job_credential_exfil(job: dict) -> None:
         raise RuntimeError(f"Cron job '{job_id}' blocked for safety: {err}")
 
 
+def _normalize_cron_session_mode(job: dict) -> str:
+    """Return the cron execution session mode for a stored job.
+
+    Backward-compatible default is ``fresh``: each tick gets its own visible
+    run session. ``reuse`` keeps a stable cron-owned session per job. A
+    ``target_session_id`` means the cron tick is an injected continuation of an
+    existing user/profile session.
+    """
+    if job.get("target_session_id"):
+        return "target"
+    raw = str(job.get("session_mode") or "").strip().lower()
+    if not raw and job.get("session_reuse") is True:
+        raw = "reuse"
+    aliases = {
+        "": "fresh",
+        "new": "fresh",
+        "fresh": "fresh",
+        "isolated": "fresh",
+        "reuse": "reuse",
+        "reused": "reuse",
+        "continue": "reuse",
+        "continuation": "reuse",
+        "target": "target",
+        "inject": "target",
+        "injected": "target",
+    }
+    return aliases.get(raw, "fresh")
+
+
+_LOCAL_TARGET_SESSION_SOURCES = frozenset({"cli", "tui", "desktop", "webui", "dashboard"})
+
+
+def _validate_target_session_ownership(job: dict, session: dict) -> None:
+    """Refuse target sessions that are not owned by the job's origin.
+
+    Gateway-created jobs carry the platform/chat/thread/user tuple that
+    created them.  A target must match that tuple exactly, so a cron job from
+    one participant can never reopen another participant's transcript.  CLI
+    and authenticated dashboard jobs have no gateway origin; they may only
+    target a local UI session within the same Hermes profile.
+    """
+    target_source = str(session.get("source") or "").strip().lower()
+    origin = _resolve_origin(job)
+    if origin is None:
+        if target_source not in _LOCAL_TARGET_SESSION_SOURCES:
+            raise RuntimeError(
+                "target_session_id is a non-local session, but this cron job "
+                "has no saved gateway origin to authorize it. Create the job "
+                "from that conversation, or target a CLI/dashboard session in "
+                "the same profile."
+            )
+        return
+
+    expected_source = str(origin.get("platform") or "").strip().lower()
+    expected_chat_id = str(origin.get("chat_id") or "").strip()
+    target_chat_id = str(session.get("chat_id") or "").strip()
+    if target_source != expected_source or target_chat_id != expected_chat_id:
+        raise RuntimeError(
+            "target_session_id does not belong to this cron job's origin "
+            "conversation."
+        )
+
+    expected_thread_id = str(origin.get("thread_id") or "").strip()
+    target_thread_id = str(session.get("thread_id") or "").strip()
+    if target_thread_id != expected_thread_id:
+        raise RuntimeError(
+            "target_session_id does not belong to this cron job's origin thread."
+        )
+
+    expected_chat_type = str(origin.get("chat_type") or "").strip().lower()
+    target_chat_type = str(session.get("chat_type") or "").strip().lower()
+    if expected_chat_type and target_chat_type != expected_chat_type:
+        raise RuntimeError(
+            "target_session_id does not belong to this cron job's origin chat type."
+        )
+
+    expected_user_id = str(origin.get("user_id") or "").strip()
+    target_user_id = str(session.get("user_id") or "").strip()
+    if target_user_id != expected_user_id:
+        raise RuntimeError(
+            "target_session_id does not belong to this cron job's origin user."
+        )
+
+
+def _resolve_cron_execution_session(
+    job: dict,
+    session_db,
+) -> tuple[str, Optional[list[dict]], bool, Optional[_ResolvedSessionAdmission]]:
+    """Resolve a session and admit this run before loading its transcript."""
+    job_id = job["id"]
+    mode = _normalize_cron_session_mode(job)
+    if mode == "fresh":
+        return (
+            f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}",
+            None,
+            True,
+            None,
+        )
+
+    if session_db is None:
+        raise RuntimeError(
+            f"Cron job '{job_id}' requested session_mode={mode!r}, but the "
+            "SQLite session store is unavailable."
+        )
+
+    if mode == "target":
+        requested = str(job.get("target_session_id") or "").strip()
+        if not requested:
+            raise RuntimeError(
+                f"Cron job '{job_id}' has session_mode='target' but no target_session_id."
+            )
+        resolved = session_db.resolve_resume_session_id(requested)
+        admission = _admit_resolved_cron_session(resolved)
+        try:
+            target_session = session_db.get_session(resolved)
+            if not target_session:
+                raise RuntimeError(
+                    f"Cron job '{job_id}' target_session_id {requested!r} does not exist."
+                )
+            _validate_target_session_ownership(job, target_session)
+            session_db.reopen_session(resolved)
+            return (
+                resolved,
+                session_db.get_messages_as_conversation(resolved),
+                False,
+                admission,
+            )
+        except BaseException:
+            admission.release()
+            raise
+
+    session_id = f"cron_{job_id}"
+    if session_db.get_session(session_id):
+        session_id = session_db.resolve_resume_session_id(session_id)
+    admission = _admit_resolved_cron_session(session_id)
+    try:
+        if session_db.get_session(session_id):
+            session_db.reopen_session(session_id)
+            history = session_db.get_messages_as_conversation(session_id)
+        else:
+            history = None
+        return session_id, history, True, admission
+    except BaseException:
+        admission.release()
+        raise
+
+
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None
 ) -> tuple[bool, str, str, Optional[str]]:
@@ -3002,7 +3201,14 @@ def run_job(
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None
     origin = _resolve_origin(job)
-    _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    (
+        _cron_session_id,
+        _cron_session_history,
+        _cron_owns_session,
+        _cron_session_admission,
+    ) = (
+        _resolve_cron_execution_session(job, _session_db)
+    )
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
@@ -3568,7 +3774,13 @@ def run_job(
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+        _cron_future = _cron_pool.submit(
+            _cron_context.run,
+            agent.run_conversation,
+            prompt,
+            None,
+            _cron_session_history,
+        )
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:
@@ -3767,72 +3979,62 @@ def run_job(
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
-        if _session_db:
+        if _session_db and _cron_owns_session:
             # Compression can rotate the live agent onto a continuation while
             # this run is in flight. Finalize that continuation, not the stale
             # cron id captured before AIAgent started. SessionDB is the source
             # of truth for the lineage; agent.session_id is only a fail-safe
             # when the lookup itself is unavailable.
-            _final_cron_session_id = _cron_session_id
+            _final_session_id = _cron_session_id
             try:
-                _compression_tip = _session_db.get_compression_tip(
-                    _cron_session_id
-                )
+                _compression_tip = _session_db.get_compression_tip(_cron_session_id)
                 if _compression_tip:
-                    _final_cron_session_id = _compression_tip
+                    _final_session_id = _compression_tip
             except (Exception, KeyboardInterrupt) as e:
                 try:
                     _agent_session_id = getattr(agent, "session_id", None)
                     if _agent_session_id:
-                        _final_cron_session_id = _agent_session_id
+                        _final_session_id = _agent_session_id
                 except (Exception, KeyboardInterrupt):
                     pass
                 logger.debug(
-                    "Job '%s': failed to resolve cron compression tip: %s",
-                    job_id,
-                    e,
+                    "Job '%s': failed to resolve cron compression tip: %s", job_id, e
                 )
-            # Title the cron session from the job (name -> id) and PERSIST it
-            # BEFORE end_session()/close() tear the connection down, so the
-            # close can never run over an in-flight title write (#50536). The
-            # run-time suffix keeps it unique against the sessions.title index
-            # across runs; _set_cron_session_title dedupes (#50537) and the
-            # except-fallback below guarantees a non-blank title (#50535).
+
+            # Explicit target sessions are user-owned, so only cron-owned
+            # sessions are titled and closed here.
             try:
                 _title_base = " ".join(job_name.split())[:60].strip() or f"cron {job_id}"
-                _cron_title = f"{_title_base} · {_hermes_now().strftime('%b %d %H:%M')}"
+                if _normalize_cron_session_mode(job) == "reuse":
+                    _cron_title = f"{_title_base} · recurring cron"
+                else:
+                    _cron_title = f"{_title_base} · {_hermes_now().strftime('%b %d %H:%M')}"
                 if not _set_cron_session_title(
-                    _session_db, _final_cron_session_id, _cron_title
+                    _session_db, _final_session_id, _cron_title
                 ):
-                    # Helper returned None (blank base) -> use the id fallback.
                     _set_cron_session_title(
-                        _session_db, _final_cron_session_id, f"cron {job_id}"
+                        _session_db, _final_session_id, f"cron {job_id}"
                     )
             except (Exception, KeyboardInterrupt) as e:
-                logger.debug(
-                    "Job '%s': failed to set cron session title: %s", job_id, e
-                )
-                # Last-resort: never leave the session blank (#50535). Try the
-                # next free title in the lineage, then a bare id-stamped title.
+                logger.debug("Job '%s': failed to set cron session title: %s", job_id, e)
                 for _fallback in (
                     getattr(_session_db, "get_next_title_in_lineage", lambda b: b)(
                         f"cron {job_id}"
                     ),
-                    f"cron {job_id} {_final_cron_session_id[-6:]}",
+                    f"cron {job_id} {_final_session_id[-6:]}",
                 ):
                     try:
                         if _set_cron_session_title(
-                            _session_db, _final_cron_session_id, _fallback
+                            _session_db, _final_session_id, _fallback
                         ):
                             break
                     except (Exception, KeyboardInterrupt):
                         continue
             try:
-                _session_db.end_session(
-                    _final_cron_session_id, "cron_complete"
-                )
+                _session_db.end_session(_final_session_id, "cron_complete")
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)
+        if _session_db:
             try:
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:
@@ -3850,6 +4052,8 @@ def run_job(
                 defer_agent_teardown.append(agent)
         else:
             _teardown_cron_agent(agent, job_id)
+        if _cron_session_admission is not None:
+            _cron_session_admission.release()
 
 
 def _teardown_cron_agent(agent, job_id: str) -> None:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -352,6 +352,8 @@ def cron_create(args):
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        session_mode=getattr(args, "session_mode", None),
+        target_session_id=getattr(args, "target_session_id", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -368,6 +370,10 @@ def cron_create(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
+    if job_data.get("session_mode") and job_data.get("session_mode") != "fresh":
+        print(f"  Session mode: {job_data['session_mode']}")
+    if job_data.get("target_session_id"):
+        print(f"  Target session: {job_data['target_session_id']}")
     print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0
@@ -417,6 +423,8 @@ def cron_edit(args):
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
         no_agent=getattr(args, "no_agent", None),
+        session_mode=getattr(args, "session_mode", None),
+        target_session_id=getattr(args, "target_session_id", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -436,6 +444,10 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    if updated.get("session_mode") and updated.get("session_mode") != "fresh":
+        print(f"  Session mode: {updated['session_mode']}")
+    if updated.get("target_session_id"):
+        print(f"  Target session: {updated['target_session_id']}")
     return 0
 
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -83,6 +83,15 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="model_provider",
         help="Inference provider paired with --model (e.g. 'openrouter', 'nous').",
     )
+    cron_create.add_argument(
+        "--session-mode",
+        choices=("fresh", "reuse", "target"),
+        help="Execution session mode: fresh per tick (default), reuse cron_<job_id>, or target an existing session.",
+    )
+    cron_create.add_argument(
+        "--target-session-id",
+        help="Existing Hermes session id to inject this cron job into. Implies --session-mode target.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -159,6 +168,15 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--provider",
         dest="model_provider",
         help="Inference provider paired with --model. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--session-mode",
+        choices=("fresh", "reuse", "target"),
+        help="Execution session mode: fresh per tick, reuse cron_<job_id>, or target an existing session.",
+    )
+    cron_edit.add_argument(
+        "--target-session-id",
+        help="Existing Hermes session id to inject this cron job into. Pass empty string with --session-mode fresh/reuse to clear.",
     )
 
     # lifecycle actions

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -182,7 +182,7 @@ TIPS = [
     "Cron delivery targets include telegram, discord, slack, email, sms, and 12+ more platforms.",
     "If a cron response starts with [SILENT], delivery is suppressed — useful for monitoring-only jobs.",
     "Cron supports relative delays (30m), intervals (every 2h), cron expressions, and ISO timestamps.",
-    "Cron jobs run in completely fresh agent sessions — prompts must be self-contained.",
+    "Cron jobs default to fresh sessions; use --session-mode reuse when a recurring job should keep context.",
 
     # --- Voice ---
     "Voice mode works with zero API keys if faster-whisper is installed (free local speech-to-text).",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12227,6 +12227,8 @@ class CronJobCreate(BaseModel):
     enabled_toolsets: Optional[List[str]] = None
     workdir: Optional[str] = None
     no_agent: bool = False
+    session_mode: Optional[str] = None
+    target_session_id: Optional[str] = None
 
 
 class CronJobUpdate(BaseModel):
@@ -12329,6 +12331,10 @@ def _normalize_dashboard_cron_updates(
         normalized["context_from"] = _cron_string_list(normalized["context_from"])
     if "enabled_toolsets" in normalized:
         normalized["enabled_toolsets"] = _cron_string_list(normalized["enabled_toolsets"])
+    if "session_mode" in normalized:
+        normalized["session_mode"] = _cron_optional_text(normalized["session_mode"])
+    if "target_session_id" in normalized:
+        normalized["target_session_id"] = _cron_optional_text(normalized["target_session_id"])
     return normalized
 
 
@@ -12492,12 +12498,13 @@ async def get_cron_job(job_id: str, profile: Optional[str] = None):
 def _list_cron_job_runs_sync(job_id: str, profile: Optional[str] = None, limit: int = 20):
     """Run sessions produced by a cron job, newest first.
 
-    Cron runs are stored as ordinary sessions whose id is
-    ``cron_{job_id}_{timestamp}`` (see cron/scheduler.run_job). A job's history
-    is therefore every session whose id carries that prefix; ``source='cron'``
-    narrows it and the id prefix binds it to this job. Powers the run-history
-    list under each job in the desktop cron detail. Same row shape as
-    ``/api/sessions`` so the frontend can reuse SessionInfo.
+    Cron runs are stored as ordinary sessions. Fresh jobs use
+    ``cron_{job_id}_{timestamp}``; reusable jobs use the stable
+    ``cron_{job_id}`` session. Explicit target-session jobs append to a
+    user-owned session and are intentionally not surfaced as cron-owned run
+    history. Powers the run-history list under each job in the desktop cron
+    detail. Same row shape as ``/api/sessions`` so the frontend can reuse
+    SessionInfo.
 
     Backed by ``SessionDB.list_cron_job_runs`` — a bounded ``[prefix, hi)``
     id-range scan, not the compression-chain CTE used for the recents list,
@@ -12569,6 +12576,8 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),
             workdir=_cron_optional_text(body.workdir),
             no_agent=no_agent,
+            session_mode=_cron_optional_text(body.session_mode),
+            target_session_id=_cron_optional_text(body.target_session_id),
         )
     except HTTPException:
         raise

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6765,23 +6765,23 @@ class SessionDB:
     ) -> List[Dict[str, Any]]:
         """List the run sessions produced by a single cron job, newest first.
 
-        Cron runs are flat, independent sessions whose id is
-        ``cron_{job_id}_{timestamp}`` (see ``cron/scheduler.run_job``). They are
-        never compression roots and never branch, so this deliberately skips the
-        ``list_sessions_rich`` recursive compression-chain CTE / leading-wildcard
-        ``id_query`` path — that path seeds from *every* ``source='cron'`` row in
-        the DB and only filters to one job's runs after the scan, so it scales
-        with the whole cron pile (a heavy history makes the desktop run-history
-        endpoint time out before it eventually populates).
+        Fresh cron runs use ``cron_{job_id}_{timestamp}``; reusable cron runs
+        use the stable ``cron_{job_id}`` session. They are never compression
+        roots and never branch, so this deliberately skips the
+        ``list_sessions_rich`` recursive compression-chain CTE /
+        leading-wildcard ``id_query`` path — that path seeds from *every*
+        ``source='cron'`` row in the DB and only filters to one job's runs
+        after the scan, so it scales with the whole cron pile.
 
-        Instead this binds to one job with a ``[prefix, prefix_hi)`` range over
-        the id (an index range scan, not a ``%...%`` substring), filters
+        Instead this binds to one job with an exact stable id plus a
+        ``[prefix, prefix_hi)`` range over timestamped ids, filters
         ``source='cron'``, and orders by ``started_at DESC``. Work scales with
         the requested window, not the total cron history.
 
         Returns the same enriched row shape as ``list_sessions_rich`` (adds
         ``preview`` + ``last_active``) so callers can reuse it.
         """
+        stable_id = f"cron_{job_id}"
         prefix = f"cron_{job_id}_"
         # Half-open upper bound for an index range scan: increment the final
         # byte of the prefix so the range covers exactly the ids that start
@@ -6803,12 +6803,15 @@ class SessionDB:
                     s.started_at
                 ) AS last_active
             FROM sessions s
-            WHERE s.source = 'cron' AND s.id >= ? AND s.id < ?
+            WHERE s.source = 'cron' AND (s.id = ? OR (s.id >= ? AND s.id < ?))
             ORDER BY s.started_at DESC, s.id DESC
             LIMIT ? OFFSET ?
         """
         with self._lock:
-            cursor = self._conn.execute(query, (prefix, prefix_hi, limit, offset))
+            cursor = self._conn.execute(
+                query,
+                (stable_id, prefix, prefix_hi, limit, offset),
+            )
             rows = cursor.fetchall()
 
         runs: List[Dict[str, Any]] = []

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -341,6 +341,26 @@ class TestJobCRUD:
         job = create_job(prompt="Test", schedule="30m")
         assert job["deliver"] == "local"
 
+    def test_session_mode_fields_round_trip(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Watch project state",
+            schedule="every 1h",
+            session_mode="continue",
+        )
+        assert job["session_mode"] == "reuse"
+        assert job["target_session_id"] is None
+
+        updated = update_job(job["id"], {"target_session_id": "main-session"})
+        assert updated["session_mode"] == "target"
+        assert updated["target_session_id"] == "main-session"
+
+        updated = update_job(
+            job["id"],
+            {"target_session_id": "", "session_mode": "fresh"},
+        )
+        assert updated["session_mode"] == "fresh"
+        assert updated["target_session_id"] is None
+
 
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets, _resolve_cron_execution_session
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -1194,6 +1194,170 @@ class TestRunJobSessionPersistence:
         assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
+
+    def test_run_job_reuse_mode_continues_stable_cron_session(self, tmp_path):
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+            "session_mode": "reuse",
+        }
+        history = [{"role": "user", "content": "previous tick"}]
+        fake_db = MagicMock()
+        fake_db.get_session.return_value = {"id": "cron_test-job"}
+        fake_db.resolve_resume_session_id.return_value = "cron_test-job"
+        fake_db.get_messages_as_conversation.return_value = history
+        fake_db.get_compression_tip.side_effect = lambda session_id: session_id
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["session_id"] == "cron_test-job"
+        call_args = mock_agent.run_conversation.call_args.args
+        assert call_args[2] == history
+        fake_db.reopen_session.assert_called_once_with("cron_test-job")
+        fake_db.end_session.assert_called_once_with("cron_test-job", "cron_complete")
+
+    def test_run_job_target_session_injects_without_taking_ownership(self, tmp_path):
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "inspect the board",
+            "target_session_id": "main-session",
+        }
+        history = [{"role": "assistant", "content": "prior orchestrator context"}]
+        fake_db = MagicMock()
+        fake_db.resolve_resume_session_id.return_value = "main-session"
+        fake_db.get_session.return_value = {"id": "main-session", "source": "cli"}
+        fake_db.get_messages_as_conversation.return_value = history
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["session_id"] == "main-session"
+        call_args = mock_agent.run_conversation.call_args.args
+        assert call_args[2] == history
+        fake_db.reopen_session.assert_called_once_with("main-session")
+        fake_db.set_session_title.assert_not_called()
+        fake_db.end_session.assert_not_called()
+
+    def test_target_session_rejects_different_origin_user(self):
+        job = {
+            "id": "test-job",
+            "target_session_id": "other-user-session",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "123",
+                "thread_id": "42",
+                "user_id": "job-owner",
+            },
+        }
+        fake_db = MagicMock()
+        fake_db.resolve_resume_session_id.return_value = "other-user-session"
+        fake_db.get_session.return_value = {
+            "id": "other-user-session",
+            "source": "telegram",
+            "chat_id": "123",
+            "thread_id": "42",
+            "user_id": "different-user",
+        }
+
+        with pytest.raises(RuntimeError, match="origin user"):
+            _resolve_cron_execution_session(job, fake_db)
+
+        fake_db.reopen_session.assert_not_called()
+        fake_db.get_messages_as_conversation.assert_not_called()
+
+    def test_target_session_admission_serializes_transcript_loads(self):
+        import threading
+
+        job = {"id": "test-job", "target_session_id": "shared-session"}
+
+        class FakeSessionDB:
+            def __init__(self):
+                self.second_attempted = threading.Event()
+                self.history_loads = 0
+
+            def resolve_resume_session_id(self, _requested):
+                self.second_attempted.set()
+                return "shared-session"
+
+            def get_session(self, _session_id):
+                return {"id": "shared-session", "source": "cli"}
+
+            def reopen_session(self, _session_id):
+                return None
+
+            def get_messages_as_conversation(self, _session_id):
+                self.history_loads += 1
+                return [{"role": "user", "content": f"turn {self.history_loads}"}]
+
+        fake_db = FakeSessionDB()
+        _session_id, _history, _owned, first_admission = _resolve_cron_execution_session(
+            job, fake_db
+        )
+        assert first_admission is not None
+        fake_db.second_attempted.clear()
+
+        second = {}
+
+        def _load_second_session():
+            second["result"] = _resolve_cron_execution_session(job, fake_db)
+
+        worker = threading.Thread(target=_load_second_session)
+        worker.start()
+        assert fake_db.second_attempted.wait(timeout=1)
+        assert fake_db.history_loads == 1
+
+        first_admission.release()
+        worker.join(timeout=1)
+        assert not worker.is_alive()
+        assert fake_db.history_loads == 2
+        second["result"][3].release()
 
     def test_run_job_suppresses_empty_turn_explainer(self, tmp_path):
         """An empty model turn becomes the '⚠️ No reply…' explainer (#34452).
@@ -2766,9 +2930,11 @@ class TestRunJobSkillBacked:
             register_env_passthrough(["NOTION_API_KEY"])
             return json.dumps({"success": True, "content": "# notion\nUse Notion."})
 
-        def _run_conversation(prompt):
+        def _run_conversation(prompt, system_message=None, conversation_history=None):
             from tools.env_passthrough import get_all_passthrough
 
+            assert prompt
+            assert system_message is None
             assert "NOTION_API_KEY" in get_all_passthrough()
             return {"final_response": "ok"}
 
@@ -2824,9 +2990,11 @@ class TestRunJobSkillBacked:
             register_credential_file("credentials/google_token.json")
             return json.dumps({"success": True, "content": "# google-workspace\nUse Google."})
 
-        def _run_conversation(prompt):
+        def _run_conversation(prompt, system_message=None, conversation_history=None):
             from tools.credential_files import _get_registered
 
+            assert prompt
+            assert system_message is None
             registered = _get_registered()
             assert registered, "credential files must be visible in worker thread"
             assert any("google_token.json" in v for v in registered.values())

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -54,7 +54,8 @@ def test_cron_create_options():
         "cron", "create", "0 9 * * *", "daily task prompt",
         "--name", "daily", "--deliver", "origin", "--repeat", "3",
         "--skill", "a", "--skill", "b", "--no-agent",
-        "--workdir", "/tmp/x",
+        "--workdir", "/tmp/x", "--session-mode", "reuse",
+        "--target-session-id", "main-session",
     ])
     assert ns.schedule == "0 9 * * *"
     assert ns.prompt == "daily task prompt"
@@ -64,6 +65,8 @@ def test_cron_create_options():
     assert ns.skills == ["a", "b"]
     assert ns.no_agent is True
     assert ns.workdir == "/tmp/x"
+    assert ns.session_mode == "reuse"
+    assert ns.target_session_id == "main-session"
 
 
 def test_cron_edit_no_agent_tristate():

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -7412,6 +7412,20 @@ def test_refresh_cannot_resurrect_a_lock_already_reclaimed(db, monkeypatch):
     assert current == "holder-b"
 
 
+def test_list_cron_job_runs_includes_reused_stable_session(db):
+    db.create_session("cron_job123", "cron")
+    db.append_message("cron_job123", "user", "stable tick")
+    db.create_session("cron_job123_20260707_120000", "cron")
+    db.append_message("cron_job123_20260707_120000", "user", "fresh tick")
+    db.create_session("cron_other", "cron")
+    db.append_message("cron_other", "user", "other tick")
+
+    runs = db.list_cron_job_runs("job123", limit=10)
+
+    ids = {run["id"] for run in runs}
+    assert ids == {"cron_job123", "cron_job123_20260707_120000"}
+
+
 # =========================================================================
 # compact_rows — lightweight column projection (issue #47414)
 # =========================================================================
@@ -7809,9 +7823,6 @@ class TestDisplayMetadataReadPaths:
             }],
         )
         assert db.get_messages_as_conversation("s1")[0]["display_metadata"] == self.META
-
-
-
 class TestGatewayRoutingPkHeal:
     """Legacy gateway_routing tables (session_key-only PK) get rebuilt on open.
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -556,6 +556,10 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("session_mode"):
+        result["session_mode"] = job["session_mode"]
+    if job.get("target_session_id"):
+        result["target_session_id"] = job["target_session_id"]
     return result
 
 
@@ -635,6 +639,8 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    session_mode: Optional[str] = None,
+    target_session_id: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -708,6 +714,8 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                session_mode=_normalize_optional_job_value(session_mode),
+                target_session_id=_normalize_optional_job_value(target_session_id),
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -887,6 +895,10 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if session_mode is not None:
+                updates["session_mode"] = _normalize_optional_job_value(session_mode) or "fresh"
+            if target_session_id is not None:
+                updates["target_session_id"] = _normalize_optional_job_value(target_session_id)
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -941,7 +953,7 @@ Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing
 
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
 
-Jobs run in a fresh session with no current-chat context, so prompts must be self-contained.
+Jobs default to a fresh session with no current-chat context, so prompts must be self-contained unless session_mode='reuse' or target_session_id is explicitly set.
 If skills are provided on create, the future cron run loads those skills in order, then follows the prompt as the task instruction.
 On update, passing skills=[] clears attached skills.
 
@@ -1033,6 +1045,15 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             "attach_to_session": {
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
+            },
+            "session_mode": {
+                "type": "string",
+                "enum": ["fresh", "reuse", "target"],
+                "description": "Agent-execution session behavior. Default 'fresh' preserves one cron run session per tick. 'reuse' continues a stable cron-owned session id cron_<job_id> across ticks, so recurring monitoring jobs keep conversational state and avoid session-list spam. 'target' injects each tick into target_session_id; setting target_session_id automatically selects this mode."
+            },
+            "target_session_id": {
+                "type": "string",
+                "description": "Existing Hermes session id to wake/inject this cron job into. The scheduler loads that session transcript, runs the prompt as the next user turn, and appends the result to the same session without retitling or ending it as a cron-owned run. Use only when the user explicitly asks for an orchestrator/profile session to be woken by cron. On update, pass an empty string with session_mode='fresh' or 'reuse' to stop targeting a session."
             },
         },
         "required": ["action"]

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -54,7 +54,7 @@ These two tools live in the `browser` toolset but only register when a Chrome De
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `cronjob` | Unified scheduled-task manager. Use `action="create"`, `"list"`, `"update"`, `"pause"`, `"resume"`, `"run"`, or `"remove"` to manage jobs. Supports skill-backed jobs with one or more attached skills, and `skills=[]` on update clears attached skills. Cron runs happen in fresh sessions with no current-chat context. | — |
+| `cronjob` | Unified scheduled-task manager. Use `action="create"`, `"list"`, `"update"`, `"pause"`, `"resume"`, `"run"`, or `"remove"` to manage jobs. Supports skill-backed jobs with one or more attached skills, and `skills=[]` on update clears attached skills. Cron runs are fresh by default; `session_mode="reuse"` continues the job's cron-owned session, while `target_session_id` appends only to an authorized same-origin or local UI session. | — |
 
 ## `delegation` toolset
 
@@ -265,5 +265,4 @@ Registered only on the `hermes-yuanbao` platform toolset. Yuanbao is Tencent's c
 | `yb_send_dm` | Send a private/direct message to a user in a group, with optional media files. | Yuanbao credentials |
 | `yb_search_sticker` | Search the built-in Yuanbao sticker (TIM face) catalogue by keyword. | Yuanbao credentials |
 | `yb_send_sticker` | Send a built-in sticker to the current Yuanbao chat. | Yuanbao credentials |
-
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -233,7 +233,9 @@ What they do:
 
 ## How it works
 
-**Cron execution is handled by the gateway daemon.** The gateway ticks the scheduler every 60 seconds, running any due jobs in isolated agent sessions.
+**Cron execution is handled by the gateway daemon.** The gateway ticks the scheduler every 60 seconds. By default, each due job runs in a fresh, isolated agent session.
+
+For jobs that need continuity, set `session_mode: reuse` to keep one cron-owned session per job, or set `target_session_id` to append each run to an existing session. A target session must belong to the same saved gateway origin (platform, chat, thread, and user) as the job; CLI/dashboard-created jobs may target only local UI sessions in the same profile. Concurrent cron jobs targeting one session are admitted one at a time so transcript turns stay ordered.
 
 ```bash
 hermes gateway install     # Install as a user service
@@ -504,7 +506,7 @@ See the [Script-Only Cron Jobs guide](/guides/cron-script-only) for worked examp
 
 ## Chaining jobs with `context_from`
 
-Cron jobs run in isolated sessions with no memory of previous runs. But sometimes one job's output is exactly what the next job needs. The `context_from` parameter wires that connection automatically — Job B's prompt gets Job A's most recent output prepended as context at runtime.
+Fresh cron jobs run in isolated sessions with no memory of previous runs. For stateful runs, use `session_mode: reuse`; for a separate job's latest completed output, use `context_from`, which prepends Job A's output to Job B's prompt at runtime.
 
 ```python
 # Job 1: Collect raw data
@@ -639,7 +641,7 @@ For `update`, pass `skills=[]` to remove all attached skills.
 
 ## Toolsets available to cron jobs
 
-Cron runs each job in a fresh agent session with no chat platform attached. By default the cron agent gets **the toolset you configured for the `cron` platform in `hermes tools`** — not the CLI default, not everything under the sun.
+Cron runs each job without a live chat platform attached. Fresh mode starts a new agent session each tick, while reuse/target modes load an authorized prior transcript. By default the cron agent gets **the toolset you configured for the `cron` platform in `hermes tools`** — not the CLI default, not everything under the sun.
 
 ```bash
 hermes tools
@@ -790,7 +792,7 @@ The storage uses atomic file writes so interrupted writes do not leave a partial
 ## Self-contained prompts still matter
 
 :::warning Important
-Cron jobs run in a completely fresh agent session. The prompt must contain everything the agent needs that is not already provided by attached skills.
+Fresh cron jobs run in a completely new agent session. The prompt must contain everything the agent needs that is not already provided by attached skills. Reuse and authorized target sessions retain their prior transcript, but a clear self-contained task still makes scheduled runs safer and more predictable.
 :::
 
 **BAD:** `"Check on that server issue"`


### PR DESCRIPTION
Cron agent runs now have an explicit execution-session mode, so jobs can keep continuity without forcing every tick into a new visible session.

## What does this PR do?

Adds opt-in cron session continuity at the scheduler boundary:

- `session_mode: fresh` remains the default and preserves existing per-run `cron_<job_id>_<timestamp>` sessions.
- `session_mode: reuse` continues a stable cron-owned `cron_<job_id>` session and loads its prior transcript before each run.
- `target_session_id` injects the cron prompt into an existing Hermes session, loads that transcript, and appends the result without retitling or ending the user-owned session.

## Shared root cause

- Cron agent execution was always modeled as a new isolated visible session in `cron/scheduler.py`, so repeated jobs had no durable conversation continuity and produced session-list noise.
- Delivery mirroring could append final output to a chat session after the run, but it did not make the cron execution itself continue that session's transcript.

## How this fixes each issue

- #39701: recurring monitoring jobs can set `session_mode: reuse` to run in one stable `cron_<job_id>` session instead of creating timestamped sessions on every tick.
- #52073: cron output can be appended to a reusable cron session or an existing target session, and the dashboard run-history path now includes stable reused cron sessions.
- #55372: orchestrator profiles can configure `target_session_id` so cron wakes the existing session with its prior transcript instead of spawning an isolated cron context.

## Related Issue

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added cron job storage fields for `session_mode` and `target_session_id`, with alias normalization and CRUD round-trip coverage.
- Updated `cron/scheduler.py` to resolve fresh, reused, and target execution sessions and pass loaded history into `AIAgent.run_conversation`.
- Preserved user-owned target sessions by not applying cron titles or `cron_complete` end markers to them.
- Exposed the new fields through the `cronjob` tool schema, classic CLI flags, dashboard API model normalization, and user-facing tips.
- Updated `SessionDB.list_cron_job_runs` to include stable reused cron sessions alongside timestamped run sessions.

## How to Test

1. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` attempted; collection aborted before project tests because this environment lacks `fastapi` and lazy installation is blocked by PEP 668/external-management.
2. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/cron/test_scheduler.py::TestRunJobSessionPersistence tests/cron/test_jobs.py::TestJobCRUD::test_session_mode_fields_round_trip tests/test_hermes_state.py::test_list_cron_job_runs_includes_reused_stable_session tests/hermes_cli/test_cron_parser_builder.py tests/cron/test_cron_no_agent.py::test_cronjob_tool_create_no_agent_with_script_succeeds -q --timeout=60'`
3. `python -m py_compile cron/scheduler.py cron/jobs.py hermes_state.py tools/cronjob_tools.py hermes_cli/web_server.py hermes_cli/cron.py hermes_cli/subcommands/cron.py`
4. `ruff check` on changed Python files
5. `python scripts/check-windows-footguns.py` on changed Python files

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass; full suite was blocked by missing `fastapi` in this environment before collection completed
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation/tool text — cron tool schema, CLI flags, and tips
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, this is per-job state
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact; `scripts/check-windows-footguns.py` passes on changed files
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

N/A

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #39701
Refs #52073
Refs #55372

<!-- autocontrib:worker-id=pr-spanning-eaefc86a kind=pr-open -->