### PR TITLE
feat: profile-scoped gateway credentials

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1431,8 +1431,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             thread_id=getenv("TELEGRAM_HOME_CHANNEL_THREAD_ID") or None,
         )
     
-    # Discord
-    discord_token = getenv("DISCORD_BOT_TOKEN")
+    # Discord — prefer profile-scoped secret, fall back to process env
+    from agent.secret_scope import get_secret as _get_discord_secret
+    discord_token = (_get_discord_secret("DISCORD_BOT_TOKEN") or os.getenv("DISCORD_BOT_TOKEN") or "").strip()
     if discord_token:
         discord_config = _enable_from_env(Platform.DISCORD)
         discord_config.token = discord_token

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1427,7 +1427,13 @@ def _profile_runtime_scope(profile_home: "Path"):
     ``.env`` here does NOT mutate ``os.environ`` — ``build_profile_secret_scope``
     returns an isolated dict — which is what keeps subprocesses (MCP, kanban)
     from inheriting cross-profile secrets.
+
+    Additionally, profile-specific env overrides are injected into ``os.environ``
+    so that ``os.getenv()`` calls inside profile-scoped config loading (e.g.
+    ``load_gateway_config``) see profile values like ``API_SERVER_ENABLED=false``
+    rather than the main process's env. Original values are restored on exit.
     """
+    import os as _os
     from hermes_constants import set_hermes_home_override, reset_hermes_home_override
     from agent.secret_scope import (
         build_profile_secret_scope,
@@ -1437,9 +1443,29 @@ def _profile_runtime_scope(profile_home: "Path"):
 
     home_token = set_hermes_home_override(str(profile_home))
     secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+    # Inject profile .env overrides into os.environ so load_gateway_config's
+    # os.getenv() calls see profile-level env vars (e.g. API_SERVER_ENABLED).
+    _profile_env = {}
+    _profile_dotenv = Path(profile_home) / ".env"
+    if _profile_dotenv.exists():
+        try:
+            from dotenv import dotenv_values
+            _profile_env = dotenv_values(_profile_dotenv)
+        except Exception:
+            _profile_env = {}
+    _saved_env = {}
+    for _k, _v in _profile_env.items():
+        if _k in _os.environ:
+            _saved_env[_k] = _os.environ[_k]
+        _os.environ[_k] = _v
     try:
         yield
     finally:
+        for _k in _profile_env:
+            if _k in _saved_env:
+                _os.environ[_k] = _saved_env[_k]
+            else:
+                _os.environ.pop(_k, None)
         reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
 


### PR DESCRIPTION
## Summary

Discord token reads from profile secret scope before falling back to `os.environ.get`. Profile-specific env overrides are injected into `os.environ` during `_profile_runtime_scope` so `load_gateway_config`'s `os.getenv()` calls see profile-level values (e.g. `API_SERVER_ENABLED`). Original env restored on exit.

## Changes
- **gateway/config.py**: Discord token prefers `get_secret("DISCORD_BOT_TOKEN")` over bare `os.getenv`
- **gateway/run.py**: `_profile_runtime_scope` injects profile `.env` into `os.environ` with save/restore

## Context
Extracted from #58329 (split 1 of 3) per triage feedback from @alt-glitch: the original PR bundled 3 independent features. This PR contains only the profile-scoped credentials portion.

The `_adapter_credential_fingerprint` hunk from the original PR is already in main (checking `adapter.config.token`), so it's not included here.