### PR TITLE
feat(cron): conditional LLM invocation from no-agent scripts

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -909,7 +909,7 @@ def create_job(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
-    no_agent: bool = False,
+    no_agent: Union[bool, str] = False,
     attach_to_session: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2424,7 +2424,82 @@ def run_job(
     #   - wakeAgent=false gate    → treated like empty stdout (silent), since
     #                               the whole point of no_agent is that there
     #                               is no agent to wake
-    if job.get("no_agent"):
+    # ---------------------------------------------------------------
+    # Conditional agent mode — script gates LLM invocation.
+    # ---------------------------------------------------------------
+    # no_agent="conditional": script runs first. Empty stdout → silent
+    # (like no_agent=True). Non-empty → fall through to LLM path with
+    # script output as context (like default mode). Zero token cost
+    # when healthy, LLM sanity-check when not. See issue #60256.
+    _no_agent_val = job.get("no_agent")
+    _is_conditional = (
+        isinstance(_no_agent_val, str) and _no_agent_val.lower() == "conditional"
+    )
+    prerun_script: Optional[tuple] = None
+
+    if _is_conditional:
+        script_path = job.get("script")
+        if not script_path:
+            err = 'no_agent="conditional" but no script is set for this job'
+            logger.error("Job '%s': %s", job_id, err)
+            return False, "", "", err
+
+        _job_workdir = (job.get("workdir") or "").strip() or None
+        _prior_cwd = None
+        if _job_workdir and Path(_job_workdir).is_dir():
+            _prior_cwd = os.getcwd()
+            try:
+                os.chdir(_job_workdir)
+            except OSError:
+                _prior_cwd = None
+
+        try:
+            ok, output = _run_job_script(script_path)
+        finally:
+            if _prior_cwd is not None:
+                try:
+                    os.chdir(_prior_cwd)
+                except OSError:
+                    pass
+
+        now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+
+        if not ok:
+            alert = (
+                f"⚠ Cron watchdog '{job_name}' script failed\n\n"
+                f"{output}\n\n"
+                f"Time: {now_iso}"
+            )
+            doc = (
+                f"# Cron Job: {job_name}\n\n"
+                f"**Job ID:** {job_id}\n"
+                f"**Run Time:** {now_iso}\n"
+                f"**Mode:** conditional (script failed)\n\n"
+                f"{output}\n"
+            )
+            return False, doc, alert, output
+
+        if not output.strip():
+            logger.info(
+                "Job '%s' (conditional): empty stdout — silent, no LLM",
+                job_id,
+            )
+            silent_doc = (
+                f"# Cron Job: {job_name}\n\n"
+                f"**Job ID:** {job_id}\n"
+                f"**Run Time:** {now_iso}\n"
+                f"**Mode:** conditional (silent)\n"
+            )
+            return True, silent_doc, SILENT_MARKER, None
+
+        # Non-empty output — fall through to LLM path with script result
+        prerun_script = (ok, output)
+        logger.info(
+            "Job '%s' (conditional): non-empty stdout — waking LLM",
+            job_id,
+        )
+
+    if job.get("no_agent") and not _is_conditional:
         script_path = job.get("script")
         if not script_path:
             err = "no_agent=True but no script is set for this job"
@@ -2530,23 +2605,25 @@ def run_job(
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
     # the whole agent run. We pass the result into _build_job_prompt so
     # the script is only executed once.
-    prerun_script = None
-    script_path = job.get("script")
-    if script_path:
-        prerun_script = _run_job_script(script_path)
-        _ran_ok, _script_output = prerun_script
-        if _ran_ok and not _parse_wake_gate(_script_output):
-            logger.info(
-                "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
-                job_name, job_id,
-            )
-            silent_doc = (
-                f"# Cron Job: {job_name}\n\n"
-                f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
-                "Script gate returned `wakeAgent=false` — agent skipped.\n"
-            )
-            return True, silent_doc, SILENT_MARKER, None
+    # Skip for conditional mode — script already ran above.
+    if not _is_conditional:
+        prerun_script = None
+        script_path = job.get("script")
+        if script_path:
+            prerun_script = _run_job_script(script_path)
+            _ran_ok, _script_output = prerun_script
+            if _ran_ok and not _parse_wake_gate(_script_output):
+                logger.info(
+                    "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
+                    job_name, job_id,
+                )
+                silent_doc = (
+                    f"# Cron Job: {job_name}\n\n"
+                    f"**Job ID:** {job_id}\n"
+                    f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+                    "Script gate returned `wakeAgent=false` — agent skipped.\n"
+                )
+                return True, silent_doc, SILENT_MARKER, None
 
     try:
         prompt = _build_job_prompt(job, prerun_script=prerun_script)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -593,7 +593,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     if job.get("script"):
         result["script"] = job["script"]
     if job.get("no_agent"):
-        result["no_agent"] = True
+        result["no_agent"] = job["no_agent"]
     if job.get("enabled_toolsets"):
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
@@ -665,7 +665,7 @@ def cronjob(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
-    no_agent: Optional[bool] = None,
+    no_agent: Optional[Union[bool, str]] = None,
     attach_to_session: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
@@ -679,10 +679,16 @@ def cronjob(
             if not schedule:
                 return tool_error("schedule is required for create", success=False)
             canonical_skills = _canonical_skills(skill, skills)
-            _no_agent = bool(no_agent)
+            _no_agent_raw = no_agent
+            _no_agent = bool(no_agent) if not isinstance(no_agent, str) else False
+            _no_agent_conditional = (
+                isinstance(no_agent, str) and no_agent.lower() == "conditional"
+            )
             # Job-shape validation differs by mode:
             #   - no_agent=True → script is the job; prompt/skills are optional
             #     (and irrelevant to execution).
+            #   - no_agent="conditional" → script required, prompt/skills needed
+            #     for the LLM path that runs when script output is non-empty.
             #   - no_agent=False (default) → at least one of prompt/skills must
             #     be set, same as before.
             if _no_agent:
@@ -690,6 +696,19 @@ def cronjob(
                     return tool_error(
                         "create with no_agent=True requires a script — "
                         "the script is the job.",
+                        success=False,
+                    )
+            elif _no_agent_conditional:
+                if not script:
+                    return tool_error(
+                        'create with no_agent="conditional" requires a script — '
+                        'the script gates whether the LLM wakes up.',
+                        success=False,
+                    )
+                if not prompt and not canonical_skills:
+                    return tool_error(
+                        'create with no_agent="conditional" requires either '
+                        'prompt or at least one skill for the LLM path',
                         success=False,
                     )
             elif not prompt and not canonical_skills:
@@ -738,7 +757,7 @@ def cronjob(
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
-                no_agent=_no_agent,
+                no_agent=(_no_agent_raw if _no_agent_conditional else _no_agent),
                 attach_to_session=attach_to_session,
             )
             _notify_provider_jobs_changed_safe()


### PR DESCRIPTION
## Summary

Implements `no_agent: "conditional"` cron job mode per issue #60256.

Script runs first. Empty stdout → silent (zero token cost, like `no_agent: true`). Non-empty stdout → LLM wakes up with script output as context (like default mode). Zero cost when healthy, LLM sanity-check when not.

## Usage

```yaml
cronjob(action='create', schedule='every 4h', no_agent='conditional',
        script='check_cluster.sh', prompt='Evaluate cluster health alerts')
```

## Changes

- **cron/scheduler.py**: Conditional block before `no_agent=True` short-circuit. Script runs, empty → silent, non-empty → fall through to LLM path with `prerun_script` set. Skips duplicate script execution in the wake-gate block.
- **tools/cronjob_tools.py**: `no_agent` accepts `bool|str`. Validation for conditional mode (script + prompt/skills required). `_format_job` preserves the original value.
- **cron/jobs.py**: `create_job` `no_agent` type widened to `Union[bool, str]`.

Closes #60256