### PR TITLE
fix(plugins): allow update/read to follow shared-checkout symlinks

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -84,6 +84,7 @@ def _sanitize_plugin_name(
     plugins_dir: Path,
     *,
     allow_subdir: bool = False,
+    allow_symlink: bool = False,
 ) -> Path:
     """Validate a plugin name and return the safe target path inside *plugins_dir*.
 
@@ -98,6 +99,20 @@ def _sanitize_plugin_name(
     inside *plugins_dir*. Install paths leave this at the default ``False``
     because a freshly-cloned plugin always lands top-level under
     ``~/.hermes/plugins/<name>/``.
+
+    ``allow_symlink=True`` permits *name* to resolve to a symlink whose target
+    lives outside *plugins_dir*, without rejecting it as an escape. This
+    supports the operator-created pattern of sharing one plugin git checkout
+    across multiple profiles: ``~/.hermes/profiles/<profile>/plugins/<name>``
+    is a symlink to the shared install at ``~/.hermes/plugins/<name>``. The
+    symlink's *link path* is still validated character-by-character above
+    (no ``..``, no absolute paths, no unexpected subdirs) before we ever look
+    at the filesystem, so this cannot be used to smuggle a traversal through
+    *name* itself -- it only widens what an *already-installed, on-disk*
+    entry is allowed to be. Only pass this for operations on an
+    already-installed plugin (update, read) -- never for install/create,
+    where a symlink placed at the fresh target location would be a genuine
+    escape vector (redirecting where the clone's files get written).
     """
     if not name:
         raise ValueError("Plugin name must not be empty.")
@@ -118,8 +133,13 @@ def _sanitize_plugin_name(
         if bad in name:
             raise ValueError(f"Invalid plugin name '{name}': must not contain '{bad}'.")
 
-    target = (plugins_dir / name).resolve()
     plugins_resolved = plugins_dir.resolve()
+    unresolved_target = plugins_dir / name
+
+    if allow_symlink and unresolved_target.is_symlink():
+        return unresolved_target
+
+    target = unresolved_target.resolve()
 
     if target == plugins_resolved:
         raise ValueError(
@@ -428,9 +448,20 @@ def _display_removed(name: str, plugins_dir: Path) -> None:
     console.print()
 
 
-def _require_installed_plugin(name: str, plugins_dir: Path, console) -> Path:
-    """Return the plugin path if it exists, or exit with an error listing installed plugins."""
-    target = _sanitize_plugin_name(name, plugins_dir, allow_subdir=True)
+def _require_installed_plugin(
+    name: str, plugins_dir: Path, console, *, allow_symlink: bool = False
+) -> Path:
+    """Return the plugin path if it exists, or exit with an error listing installed plugins.
+
+    ``allow_symlink=True`` is for read/update operations on an already-installed
+    plugin, where the entry may legitimately be a symlink into a shared
+    checkout (see ``_sanitize_plugin_name``). Leave it ``False`` (default) for
+    destructive operations like remove, where following a symlink to decide
+    what gets deleted is ambiguous and risky.
+    """
+    target = _sanitize_plugin_name(
+        name, plugins_dir, allow_subdir=True, allow_symlink=allow_symlink
+    )
     if not target.exists():
         installed = ", ".join(d.name for d in plugins_dir.iterdir() if d.is_dir()) or "(none)"
         console.print(
@@ -641,7 +672,7 @@ def cmd_update(name: str) -> None:
     plugins_dir = _plugins_dir()
 
     try:
-        target = _require_installed_plugin(name, plugins_dir, console)
+        target = _require_installed_plugin(name, plugins_dir, console, allow_symlink=True)
     except ValueError as e:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
@@ -1898,11 +1929,19 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     return {"ok": True, "name": name, "unchanged": False}
 
 
-def _user_installed_plugin_dir(name: str) -> Optional[Path]:
-    """Resolved path under ``~/.hermes/plugins/<name>`` if it exists."""
+def _user_installed_plugin_dir(name: str, *, allow_symlink: bool = False) -> Optional[Path]:
+    """Resolved path under ``~/.hermes/plugins/<name>`` if it exists.
+
+    ``allow_symlink=True`` is for read/update callers where the entry may
+    legitimately be a symlink into a shared checkout (see
+    ``_sanitize_plugin_name``). Leave it ``False`` (default) for destructive
+    callers like remove.
+    """
     plugins_dir = _plugins_dir()
     try:
-        target = _sanitize_plugin_name(name, plugins_dir, allow_subdir=True)
+        target = _sanitize_plugin_name(
+            name, plugins_dir, allow_subdir=True, allow_symlink=allow_symlink
+        )
     except ValueError:
         return None
     return target if target.is_dir() else None
@@ -1910,7 +1949,7 @@ def _user_installed_plugin_dir(name: str) -> Optional[Path]:
 
 def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
     """``git pull`` inside ``~/.hermes/plugins/<name>``."""
-    target = _user_installed_plugin_dir(name)
+    target = _user_installed_plugin_dir(name, allow_symlink=True)
     if target is None:
         return {
             "ok": False,

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -157,6 +157,7 @@ def _sanitize_plugin_name(
     plugins_dir: Path,
     *,
     allow_subdir: bool = False,
+    allow_symlink: bool = False,
 ) -> Path:
     """Validate a plugin name and return the safe target path inside *plugins_dir*.
 
@@ -171,6 +172,20 @@ def _sanitize_plugin_name(
     inside *plugins_dir*. Install paths leave this at the default ``False``
     because a freshly-cloned plugin always lands top-level under
     ``~/.hermes/plugins/<name>/``.
+
+    ``allow_symlink=True`` permits *name* to resolve to a symlink whose target
+    lives outside *plugins_dir*, without rejecting it as an escape. This
+    supports the operator-created pattern of sharing one plugin git checkout
+    across multiple profiles: ``~/.hermes/profiles/<profile>/plugins/<name>``
+    is a symlink to the shared install at ``~/.hermes/plugins/<name>``. The
+    symlink's *link path* is still validated character-by-character above
+    (no ``..``, no absolute paths, no unexpected subdirs) before we ever look
+    at the filesystem, so this cannot be used to smuggle a traversal through
+    *name* itself -- it only widens what an *already-installed, on-disk*
+    entry is allowed to be. Only pass this for operations on an
+    already-installed plugin (update, read) -- never for install/create,
+    where a symlink placed at the fresh target location would be a genuine
+    escape vector (redirecting where the clone's files get written).
     """
     if not name:
         raise ValueError("Plugin name must not be empty.")
@@ -191,8 +206,13 @@ def _sanitize_plugin_name(
         if bad in name:
             raise ValueError(f"Invalid plugin name '{name}': must not contain '{bad}'.")
 
-    target = (plugins_dir / name).resolve()
     plugins_resolved = plugins_dir.resolve()
+    unresolved_target = plugins_dir / name
+
+    if allow_symlink and unresolved_target.is_symlink():
+        return unresolved_target
+
+    target = unresolved_target.resolve()
 
     if target == plugins_resolved:
         raise ValueError(
@@ -539,9 +559,20 @@ def _display_removed(name: str, plugins_dir: Path) -> None:
     console.print()
 
 
-def _require_installed_plugin(name: str, plugins_dir: Path, console) -> Path:
-    """Return the plugin path if it exists, or exit with an error listing installed plugins."""
-    target = _sanitize_plugin_name(name, plugins_dir, allow_subdir=True)
+def _require_installed_plugin(
+    name: str, plugins_dir: Path, console, *, allow_symlink: bool = False
+) -> Path:
+    """Return the plugin path if it exists, or exit with an error listing installed plugins.
+
+    ``allow_symlink=True`` is for read/update operations on an already-installed
+    plugin, where the entry may legitimately be a symlink into a shared
+    checkout (see ``_sanitize_plugin_name``). Leave it ``False`` (default) for
+    destructive operations like remove, where following a symlink to decide
+    what gets deleted is ambiguous and risky.
+    """
+    target = _sanitize_plugin_name(
+        name, plugins_dir, allow_subdir=True, allow_symlink=allow_symlink
+    )
     if not target.exists():
         installed = ", ".join(d.name for d in plugins_dir.iterdir() if d.is_dir()) or "(none)"
         console.print(
@@ -1089,7 +1120,7 @@ def cmd_update(name: str) -> None:
     plugins_dir = _plugins_dir()
 
     try:
-        target = _require_installed_plugin(name, plugins_dir, console)
+        target = _require_installed_plugin(name, plugins_dir, console, allow_symlink=True)
     except ValueError as e:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
@@ -2823,11 +2854,19 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     return {"ok": True, "name": name, "unchanged": False}
 
 
-def _user_installed_plugin_dir(name: str) -> Optional[Path]:
-    """Resolved path under ``~/.hermes/plugins/<name>`` if it exists."""
+def _user_installed_plugin_dir(name: str, *, allow_symlink: bool = False) -> Optional[Path]:
+    """Resolved path under ``~/.hermes/plugins/<name>`` if it exists.
+
+    ``allow_symlink=True`` is for read/update callers where the entry may
+    legitimately be a symlink into a shared checkout (see
+    ``_sanitize_plugin_name``). Leave it ``False`` (default) for destructive
+    callers like remove.
+    """
     plugins_dir = _plugins_dir()
     try:
-        target = _sanitize_plugin_name(name, plugins_dir, allow_subdir=True)
+        target = _sanitize_plugin_name(
+            name, plugins_dir, allow_subdir=True, allow_symlink=allow_symlink
+        )
     except ValueError:
         return None
     return target if target.is_dir() else None
@@ -2835,7 +2874,7 @@ def _user_installed_plugin_dir(name: str) -> Optional[Path]:
 
 def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
     """``git pull`` inside ``~/.hermes/plugins/<name>``."""
-    target = _user_installed_plugin_dir(name)
+    target = _user_installed_plugin_dir(name, allow_symlink=True)
     if target is None:
         return {
             "ok": False,

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -95,6 +95,55 @@ class TestSanitizePluginName:
         target = _sanitize_plugin_name("a/b/c", tmp_path, allow_subdir=True)
         assert target.is_relative_to(tmp_path.resolve())
 
+    # ── allow_symlink=True ──
+
+    def test_symlink_rejected_without_allow_symlink(self, tmp_path):
+        """Default behavior (install/create path): a symlink escaping
+        plugins_dir is still rejected as 'outside the plugins directory'."""
+        outside = tmp_path.parent / "shared-plugin-checkout"
+        outside.mkdir(exist_ok=True)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        (plugins_dir / "hermes-lcm").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="resolves outside the plugins directory"):
+            _sanitize_plugin_name("hermes-lcm", plugins_dir)
+
+    def test_symlink_allowed_with_allow_symlink(self, tmp_path):
+        """Update/read path: an operator-created symlink into a shared
+        checkout outside plugins_dir resolves to the symlink path itself
+        (not the plugins_dir-escaping realpath), matching the documented
+        cross-profile shared-plugin pattern."""
+        outside = tmp_path.parent / "shared-plugin-checkout"
+        outside.mkdir(exist_ok=True)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        link = plugins_dir / "hermes-lcm"
+        link.symlink_to(outside, target_is_directory=True)
+
+        target = _sanitize_plugin_name("hermes-lcm", plugins_dir, allow_symlink=True)
+        assert target == link
+
+    def test_allow_symlink_still_rejects_traversal_in_name(self, tmp_path):
+        """allow_symlink must not weaken the character-level traversal guard
+        on *name* itself -- only the on-disk symlink-resolution step."""
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        with pytest.raises(ValueError, match="must not contain"):
+            _sanitize_plugin_name("../../etc/passwd", plugins_dir, allow_symlink=True)
+
+    def test_allow_symlink_does_not_affect_non_symlink_targets(self, tmp_path):
+        """A regular (non-symlink) installed plugin still goes through the
+        normal resolve()-and-contain check even with allow_symlink=True."""
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        (plugins_dir / "regular-plugin").mkdir()
+
+        target = _sanitize_plugin_name(
+            "regular-plugin", plugins_dir, allow_symlink=True
+        )
+        assert target == (plugins_dir / "regular-plugin").resolve()
+
 
 # ── _resolve_git_url ──────────────────────────────────────────────────────
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -561,6 +561,87 @@ class TestCmdRemove:
 
         mock_rmtree.assert_called_once_with(mock_target)
 
+
+class TestUpdatePathsFollowSharedCheckoutSymlink:
+    """End-to-end regression coverage for both update callers with a real
+    on-disk symlink, per sweeper review on PR #60343: the sanitizer-level
+    tests exercised _sanitize_plugin_name directly but neither of the two
+    real update call sites (cmd_update, dashboard_update_user_plugin) were
+    covered against an actual symlinked shared-checkout install. The
+    cmd_remove case is asserted here too as the strict counterpart -- update
+    must follow the symlink, remove must still refuse to.
+    """
+
+    def _make_shared_checkout_symlink(self, tmp_path: Path) -> tuple[Path, Path]:
+        """Create <tmp_path>/shared-checkout (a real git-like dir with
+        .git/) and <tmp_path>/plugins/hermes-lcm as a symlink to it,
+        mirroring the operator cross-profile shared-plugin pattern.
+        """
+        shared_checkout = tmp_path / "shared-checkout"
+        (shared_checkout / ".git").mkdir(parents=True)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        link = plugins_dir / "hermes-lcm"
+        link.symlink_to(shared_checkout, target_is_directory=True)
+        return plugins_dir, link
+
+    @patch("hermes_cli.plugins_cmd._git_pull_plugin_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_cmd_update_follows_shared_checkout_symlink(
+        self, mock_plugins_dir, mock_git_pull, tmp_path
+    ):
+        from hermes_cli.plugins_cmd import cmd_update
+
+        plugins_dir, link = self._make_shared_checkout_symlink(tmp_path)
+        mock_plugins_dir.return_value = plugins_dir
+        mock_git_pull.return_value = (True, "Already up to date.")
+
+        cmd_update("hermes-lcm")
+
+        # Must pull inside the symlink path itself, not reject it or resolve
+        # through to the shared checkout's realpath under a different name.
+        mock_git_pull.assert_called_once_with(link)
+
+    @patch("hermes_cli.plugins_cmd._git_pull_plugin_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_dashboard_update_user_plugin_follows_shared_checkout_symlink(
+        self, mock_plugins_dir, mock_git_pull, tmp_path
+    ):
+        from hermes_cli.plugins_cmd import dashboard_update_user_plugin
+
+        plugins_dir, link = self._make_shared_checkout_symlink(tmp_path)
+        mock_plugins_dir.return_value = plugins_dir
+        mock_git_pull.return_value = (True, "Already up to date.")
+
+        result = dashboard_update_user_plugin("hermes-lcm")
+
+        mock_git_pull.assert_called_once_with(link)
+        assert result["ok"] is True
+        assert result["unchanged"] is True
+
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_cmd_remove_still_rejects_shared_checkout_symlink(
+        self, mock_plugins_dir, tmp_path, capsys
+    ):
+        """Strict counterpart: cmd_remove must NOT follow the symlink --
+        deleting through a shared-checkout symlink is exactly the
+        destructive-operation escape risk allow_symlink is scoped to avoid.
+        """
+        from hermes_cli.plugins_cmd import cmd_remove
+
+        plugins_dir, _link = self._make_shared_checkout_symlink(tmp_path)
+        mock_plugins_dir.return_value = plugins_dir
+
+        with pytest.raises(SystemExit):
+            cmd_remove("hermes-lcm")
+
+        captured = capsys.readouterr()
+        assert "resolves outside the plugins directory" in captured.out
+        # The shared checkout itself must be untouched.
+        assert (plugins_dir.parent / "shared-checkout" / ".git").is_dir()
+
+
+class TestCmdRemovePluginNotFound:
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     def test_remove_plugin_not_found(self, mock_plugins_dir, mock_sanitize):

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -52,6 +52,55 @@ class TestSanitizePluginName:
 
 
 
+    # ── allow_symlink=True ──
+
+    def test_symlink_rejected_without_allow_symlink(self, tmp_path):
+        """Default behavior (install/create path): a symlink escaping
+        plugins_dir is still rejected as 'outside the plugins directory'."""
+        outside = tmp_path.parent / "shared-plugin-checkout"
+        outside.mkdir(exist_ok=True)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        (plugins_dir / "hermes-lcm").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="resolves outside the plugins directory"):
+            _sanitize_plugin_name("hermes-lcm", plugins_dir)
+
+    def test_symlink_allowed_with_allow_symlink(self, tmp_path):
+        """Update/read path: an operator-created symlink into a shared
+        checkout outside plugins_dir resolves to the symlink path itself
+        (not the plugins_dir-escaping realpath), matching the documented
+        cross-profile shared-plugin pattern."""
+        outside = tmp_path.parent / "shared-plugin-checkout"
+        outside.mkdir(exist_ok=True)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        link = plugins_dir / "hermes-lcm"
+        link.symlink_to(outside, target_is_directory=True)
+
+        target = _sanitize_plugin_name("hermes-lcm", plugins_dir, allow_symlink=True)
+        assert target == link
+
+    def test_allow_symlink_still_rejects_traversal_in_name(self, tmp_path):
+        """allow_symlink must not weaken the character-level traversal guard
+        on *name* itself -- only the on-disk symlink-resolution step."""
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        with pytest.raises(ValueError, match="must not contain"):
+            _sanitize_plugin_name("../../etc/passwd", plugins_dir, allow_symlink=True)
+
+    def test_allow_symlink_does_not_affect_non_symlink_targets(self, tmp_path):
+        """A regular (non-symlink) installed plugin still goes through the
+        normal resolve()-and-contain check even with allow_symlink=True."""
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        (plugins_dir / "regular-plugin").mkdir()
+
+        target = _sanitize_plugin_name(
+            "regular-plugin", plugins_dir, allow_symlink=True
+        )
+        assert target == (plugins_dir / "regular-plugin").resolve()
+
 
 # ── _resolve_git_url ──────────────────────────────────────────────────────
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -509,6 +509,87 @@ class TestCmdRemove:
 
         mock_rmtree.assert_called_once_with(mock_target)
 
+
+class TestUpdatePathsFollowSharedCheckoutSymlink:
+    """End-to-end regression coverage for both update callers with a real
+    on-disk symlink, per sweeper review on PR #60343: the sanitizer-level
+    tests exercised _sanitize_plugin_name directly but neither of the two
+    real update call sites (cmd_update, dashboard_update_user_plugin) were
+    covered against an actual symlinked shared-checkout install. The
+    cmd_remove case is asserted here too as the strict counterpart -- update
+    must follow the symlink, remove must still refuse to.
+    """
+
+    def _make_shared_checkout_symlink(self, tmp_path: Path) -> tuple[Path, Path]:
+        """Create <tmp_path>/shared-checkout (a real git-like dir with
+        .git/) and <tmp_path>/plugins/hermes-lcm as a symlink to it,
+        mirroring the operator cross-profile shared-plugin pattern.
+        """
+        shared_checkout = tmp_path / "shared-checkout"
+        (shared_checkout / ".git").mkdir(parents=True)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        link = plugins_dir / "hermes-lcm"
+        link.symlink_to(shared_checkout, target_is_directory=True)
+        return plugins_dir, link
+
+    @patch("hermes_cli.plugins_cmd._git_pull_plugin_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_cmd_update_follows_shared_checkout_symlink(
+        self, mock_plugins_dir, mock_git_pull, tmp_path
+    ):
+        from hermes_cli.plugins_cmd import cmd_update
+
+        plugins_dir, link = self._make_shared_checkout_symlink(tmp_path)
+        mock_plugins_dir.return_value = plugins_dir
+        mock_git_pull.return_value = (True, "Already up to date.")
+
+        cmd_update("hermes-lcm")
+
+        # Must pull inside the symlink path itself, not reject it or resolve
+        # through to the shared checkout's realpath under a different name.
+        mock_git_pull.assert_called_once_with(link)
+
+    @patch("hermes_cli.plugins_cmd._git_pull_plugin_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_dashboard_update_user_plugin_follows_shared_checkout_symlink(
+        self, mock_plugins_dir, mock_git_pull, tmp_path
+    ):
+        from hermes_cli.plugins_cmd import dashboard_update_user_plugin
+
+        plugins_dir, link = self._make_shared_checkout_symlink(tmp_path)
+        mock_plugins_dir.return_value = plugins_dir
+        mock_git_pull.return_value = (True, "Already up to date.")
+
+        result = dashboard_update_user_plugin("hermes-lcm")
+
+        mock_git_pull.assert_called_once_with(link)
+        assert result["ok"] is True
+        assert result["unchanged"] is True
+
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_cmd_remove_still_rejects_shared_checkout_symlink(
+        self, mock_plugins_dir, tmp_path, capsys
+    ):
+        """Strict counterpart: cmd_remove must NOT follow the symlink --
+        deleting through a shared-checkout symlink is exactly the
+        destructive-operation escape risk allow_symlink is scoped to avoid.
+        """
+        from hermes_cli.plugins_cmd import cmd_remove
+
+        plugins_dir, _link = self._make_shared_checkout_symlink(tmp_path)
+        mock_plugins_dir.return_value = plugins_dir
+
+        with pytest.raises(SystemExit):
+            cmd_remove("hermes-lcm")
+
+        captured = capsys.readouterr()
+        assert "resolves outside the plugins directory" in captured.out
+        # The shared checkout itself must be untouched.
+        assert (plugins_dir.parent / "shared-checkout" / ".git").is_dir()
+
+
+class TestCmdRemovePluginNotFound:
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
     def test_remove_plugin_not_found(self, mock_plugins_dir, mock_sanitize):


### PR DESCRIPTION
## Problem

`hermes plugins update <name>` fails with `Invalid plugin name '<name>': resolves outside the plugins directory` for any plugin installed via the operator-created cross-profile symlink pattern:

`~/.hermes/profiles/<profile>/plugins/<name>` -> `~/.hermes/plugins/<name>`

This is a legitimate, common pattern for sharing one plugin git checkout across multiple Hermes profiles (avoids N duplicate clones + N duplicate `git pull`s to keep in sync). `_sanitize_plugin_name()` calls `Path.resolve()` on the target before checking it's contained within `plugins_dir`, which follows the symlink to its real target and then (correctly, for install/create) rejects it as escaping the plugins directory. But this same strict check is also applied to update/read operations on an *already-installed* plugin, where following the symlink is exactly the intended, safe behavior — we're not writing a fresh clone to an attacker-controlled location, we're `git pull`-ing inside a directory the operator explicitly symlinked.

Likely affects any plugin update flow (CLI `hermes plugins update`, and the dashboard's plugin-update endpoint) for any user sharing plugin installs across profiles via symlink.

## Fix

Add an `allow_symlink` parameter to `_sanitize_plugin_name()`. When set and the resolved-but-unresolved target path is itself a symlink, return the symlink path directly instead of resolving through it — the character-level traversal checks on `name` (no `..`, no absolute paths, no backslashes) still run first and are unaffected, so this cannot be used to smuggle a traversal through `name` itself. It only widens what an *already-installed, on-disk* entry is allowed to be.

Scoped narrowly:
- `cmd_update` / `dashboard_update_user_plugin` (read + git-pull an existing install) → `allow_symlink=True`
- `cmd_remove` / `dashboard_remove_user_plugin` (destructive) → left strict (default `False`), since following a symlink to decide what `shutil.rmtree` deletes is ambiguous and risky
- `_install_plugin_core` (fresh clone target) → left strict, since a symlink placed at the fresh target location before install is a genuine escape vector

## Testing

- Added 4 new regression tests covering: symlink still rejected on the default/strict path, symlink allowed with `allow_symlink=True`, traversal-in-name still rejected even with `allow_symlink=True`, and non-symlink targets unaffected by the new parameter.
- Full `tests/hermes_cli/test_plugins_cmd.py` suite: 103 passed.
- Live-verified against a real shared `hermes-lcm` plugin install (symlinked across 3 profiles): `hermes plugins update hermes-lcm` now succeeds instead of erroring.