### PR TITLE
fix(web): force terminal viewport refresh after metrics settle to show full session transcript

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -598,7 +598,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       } catch {
         return;
       }
-      if (fontChanged && term.rows > 0) {
+      // Always refresh the viewport after fit, not only when fontSize changed.
+      // xterm.js may not paint all rows from the write buffer when a resumed
+      // session's transcript arrives in rapid succession via the PTY WebSocket;
+      // forcing a full viewport refresh here ensures the transcript renders
+      // correctly on initial load without requiring a theme change (#59591).
+      if (term.rows > 0) {
         try {
           term.refresh(0, term.rows - 1);
         } catch {


### PR DESCRIPTION
## Description

Fixes #59591 — the dashboard chat transcript appearing incomplete when resuming a session until a theme change forces a repaint.

### Root cause

In `ChatPage.tsx`, the `syncTerminalMetrics()` function (called via a double-rAF settle after terminal mount) conditionally called `term.refresh(0, rows-1)` only when the font size or line-height changed. On initial load the font is stable, so the refresh was skipped. When a large session transcript arrives in rapid succession over the PTY WebSocket, xterm.js may not paint all rows from the write buffer — leaving the transcript looking incomplete.

Changing the theme incidentally fixed this because the theme effect calls `term.options.theme = terminalTheme`, which internally triggers `refreshRows(0, rows-1)`.

### Fix

Changed the condition from `if (fontChanged && term.rows > 0)` to just `if (term.rows > 0)`, so the viewport is always refreshed after `fit.fit()` completes. This ensures the buffered transcript data is fully rendered on the first settle without requiring an external trigger.

### Testing

- [x] Verified the changed logic: `term.refresh()` is now called unconditionally after every `fit.fit()`, not just on font changes
- [x] The double-rAF settle fires once on mount (and on visibility changes), keeping the performance impact negligible
- [x] Matches the same code path (`refreshRows()`) that the theme-change workaround used incidentally

### Related

The `term.refresh()` call in xterm.js simply marks viewport rows as dirty and schedules a repaint — it is cheap and idempotent.