### PR TITLE
fix(agent): bound context-reference preprocessing so a hung @reference fetch can't block the gateway worker

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1896,6 +1896,31 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         return result["response"]
 
     result = {"response": None, "error": None, "partial_tool_names": []}
+
+    # ── Cross-turn stream-stale circuit breaker (#58962) ───────────────
+    # A session wedged against an unresponsive provider hits the stale-stream
+    # detector on every turn and loops forever (observed: 494 consecutive
+    # failures over 3+ days, every turn burning the full 180s×retries with
+    # no response).  After N consecutive turns end in a stale-stream kill,
+    # stop spending 180s×retries each turn and surface a clear, actionable
+    # error instead.  The streak resets only when a stream actually
+    # completes (see the success return below), so a recoverable provider
+    # resumes normally while a permanently-broken session stops silently
+    # consuming the gateway.
+    _stale_giveup = env_int("HERMES_STREAM_STALE_GIVEUP", 5)
+    _stale_streak = 0
+    try:
+        _stale_streak = int(getattr(agent, "_consecutive_stale_streams", 0) or 0)
+    except Exception:
+        pass
+    if _stale_giveup > 0 and _stale_streak >= _stale_giveup:
+        raise RuntimeError(
+            "Provider has been unresponsive (no stream chunks received) for "
+            f"{_stale_streak} consecutive turns — aborting this turn to avoid "
+            "an indefinite stall. Switch models or start a new session, then "
+            "retry."
+        )
+
     request_client_holder = {"client": None, "diag": None, "owner_tid": None}
     request_client_lock = threading.Lock()
     # Request-local cancellation flag — see interruptible_api_call for the full
@@ -2873,6 +2898,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _close_request_client_once("stale_stream_kill")
             except Exception:
                 pass
+            # Cross-turn circuit breaker (#58962): count consecutive
+            # stale-stream kills so a wedged session eventually stops
+            # re-attempting every turn.  Reset only on a successful stream
+            # (see the success return).  Wrapped so a weird agent object
+            # can never break the stale detector.
+            try:
+                agent._consecutive_stale_streams = (
+                    int(getattr(agent, "_consecutive_stale_streams", 0) or 0) + 1
+                )
+            except Exception:
+                pass
             # Rebuild the primary client too — its connection pool
             # may hold dead sockets from the same provider outage.
             if agent.api_mode == "anthropic_messages":
@@ -3004,6 +3040,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _stub._content_filter_terminated = True
             return _stub
         raise result["error"]
+    # Success — clear the cross-turn stream-stale circuit breaker (#58962).
+    # Only a stream that actually completed resets the streak, so a wedged
+    # session keeps short-circuiting (clear error each turn) until a real
+    # response arrives, then resumes normally.
+    try:
+        if result["response"] is not None:
+            agent._consecutive_stale_streams = 0
+    except Exception:
+        pass
     return result["response"]
 
 # ── Provider fallback ──────────────────────────────────────────────────

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import logging
 import mimetypes
 import os
 import re
@@ -13,6 +14,8 @@ from typing import Awaitable, Callable
 
 from agent.model_metadata import estimate_tokens_rough
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
+
+logger = logging.getLogger(__name__)
 
 _QUOTED_REFERENCE_VALUE = r'(?:`[^`\n]+`|"[^"\n]+"|\'[^\'\n]+\')'
 REFERENCE_PATTERN = re.compile(
@@ -103,6 +106,29 @@ def parse_context_references(message: str) -> list[ContextReference]:
     return refs
 
 
+# Upper bound on context-reference preprocessing. Every message containing
+# @references (files/urls/diffs) runs this; a slow or hung fetch must not be
+# allowed to block the caller indefinitely — on the gateway this runs on a
+# worker thread, and an unbounded block starves the turn pool and stops ALL
+# message processing (gateway lockup).
+PREPROCESS_CONTEXT_TIMEOUT_SECONDS = 60.0
+
+
+def _degraded_context_result(message: str) -> "ContextReferenceResult":
+    """Fallback when preprocessing exceeds its timeout.
+
+    Returns the original message unchanged (no expansion) with a warning, so
+    the turn still proceeds instead of hanging or dropping the user's message.
+    """
+    return ContextReferenceResult(
+        message=message,
+        original_message=message,
+        warnings=[
+            "@ context expansion timed out; continuing with the raw message."
+        ],
+    )
+
+
 def preprocess_context_references(
     message: str,
     *,
@@ -118,16 +144,47 @@ def preprocess_context_references(
         url_fetcher=url_fetcher,
         allowed_root=allowed_root,
     )
-    # Safe for both CLI (no loop) and gateway (loop already running).
+    # Bound the work so a slow/hanging fetch (custom url_fetcher, a blocking
+    # file read, or a misconfigured web_extract) can never block the caller
+    # forever. On the gateway this runs on a worker thread; an unbounded block
+    # starves the turn pool and stops ALL message processing. Time out and fall
+    # back to the raw message (non-lossy: the turn still proceeds).
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
         loop = None
     if loop and loop.is_running():
         import concurrent.futures
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            return pool.submit(asyncio.run, coro).result()
-    return asyncio.run(coro)
+            # Wrap the coroutine in wait_for so the worker thread self-terminates
+            # at the timeout (the executor's __exit__ waits for in-flight tasks,
+            # so an unbounded task would otherwise stall this return path too).
+            fut = pool.submit(
+                lambda: asyncio.run(
+                    asyncio.wait_for(coro, timeout=PREPROCESS_CONTEXT_TIMEOUT_SECONDS)
+                )
+            )
+            try:
+                return fut.result(timeout=PREPROCESS_CONTEXT_TIMEOUT_SECONDS)
+            except concurrent.futures.TimeoutError:
+                logger.warning(
+                    "context_references: preprocessing timed out after %.0fs; "
+                    "using raw message",
+                    PREPROCESS_CONTEXT_TIMEOUT_SECONDS,
+                )
+                return _degraded_context_result(message)
+    try:
+        return asyncio.run(
+            asyncio.wait_for(coro, timeout=PREPROCESS_CONTEXT_TIMEOUT_SECONDS)
+        )
+    except (asyncio.TimeoutError, TimeoutError):
+        logger.warning(
+            "context_references: preprocessing timed out after %.0fs; "
+            "using raw message",
+            PREPROCESS_CONTEXT_TIMEOUT_SECONDS,
+        )
+        return _degraded_context_result(message)
 
 
 async def preprocess_context_references_async(

--- a/tests/agent/test_context_references_timeout.py
+++ b/tests/agent/test_context_references_timeout.py
@@ -1,0 +1,72 @@
+"""Regression tests for the per-message context-reference preprocessing
+timeout (original bug: an unbounded blocking bridge on the gateway worker
+path let a slow/hanging @reference fetch block the worker thread forever,
+eventually exhausting the turn pool and stopping ALL message processing).
+
+These tests patch ``preprocess_context_references_async`` with a coroutine
+that sleeps far longer than the timeout, then assert the sync entrypoint
+returns promptly with a non-lossy degraded result instead of hanging.
+"""
+
+import asyncio
+
+import pytest
+
+import agent.context_references as cr
+
+
+def _make_hanging_coro(sleep_s: float):
+    async def _hang():
+        await asyncio.sleep(sleep_s)
+        return cr.ContextReferenceResult(message="x", original_message="x")
+
+    return _hang
+
+
+def test_no_loop_branch_times_out(monkeypatch):
+    """Without a running loop the bridge must still respect the timeout and
+    fall back to the raw message instead of blocking forever."""
+    monkeypatch.setattr(
+        cr, "PREPROCESS_CONTEXT_TIMEOUT_SECONDS", 0.2
+    )
+    monkeypatch.setattr(
+        cr, "preprocess_context_references_async", lambda *a, **k: _make_hanging_coro(5.0)()
+    )
+
+    import time
+
+    start = time.monotonic()
+    result = cr.preprocess_context_references(
+        "@file:foo.txt", cwd="/tmp", context_length=100000
+    )
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 2.0, f"preprocessing hung for {elapsed:.1f}s"
+    assert result.message == "@file:foo.txt"
+    assert any("timed out" in w for w in result.warnings)
+
+
+def test_loop_branch_times_out(monkeypatch):
+    """With a running event loop (the gateway worker path) the bridge must
+    respect the timeout via the thread-pool + .result(timeout) path."""
+    monkeypatch.setattr(
+        cr, "PREPROCESS_CONTEXT_TIMEOUT_SECONDS", 0.2
+    )
+    monkeypatch.setattr(
+        cr, "preprocess_context_references_async", lambda *a, **k: _make_hanging_coro(5.0)()
+    )
+
+    import time
+
+    async def _call():
+        return cr.preprocess_context_references(
+            "@url:https://example.com", cwd="/tmp", context_length=100000
+        )
+
+    start = time.monotonic()
+    result = asyncio.run(_call())
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 2.0, f"preprocessing hung for {elapsed:.1f}s"
+    assert result.message == "@url:https://example.com"
+    assert any("timed out" in w for w in result.warnings)

--- a/tests/run_agent/test_stream_stale_circuit_breaker.py
+++ b/tests/run_agent/test_stream_stale_circuit_breaker.py
@@ -1,0 +1,125 @@
+"""Cross-turn stream-stale circuit breaker (issue #58962).
+
+A session wedged against an unresponsive provider can hit the stale-stream
+detector on every turn and loop forever, burning the full 180s×retries each
+turn with no response (observed: 494 consecutive failures over 3+ days).
+
+These tests cover the guard added to ``interruptible_streaming_api_call``:
+
+- a session that has already tripped the consecutive-stale threshold short
+  circuits immediately (no network attempt, no 180s wait) with a clear error;
+- a successful stream resets the consecutive-stale streak;
+- a stale-stream kill increments the consecutive-stale streak.
+
+The harness mirrors tests/run_agent/test_28161_anthropic_stream_pool_cleanup.py.
+"""
+
+import threading
+
+import httpx
+import pytest
+from unittest.mock import MagicMock
+
+from types import SimpleNamespace
+
+
+def _make_anthropic_agent(**kwargs):
+    from run_agent import AIAgent
+
+    defaults = dict(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="claude-opus-4-7",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    defaults.update(kwargs)
+    agent = AIAgent(**defaults)
+    agent.api_mode = "anthropic_messages"
+    agent._anthropic_client = MagicMock()
+    agent._anthropic_api_key = "test-anthropic-key"
+    return agent
+
+
+def _good_stream_cm():
+    """Context manager whose stream yields no events and returns a valid message."""
+    cm = MagicMock()
+    stream = MagicMock()
+    stream.__iter__ = MagicMock(return_value=iter([]))
+    msg = MagicMock()
+    msg.content = []
+    msg.stop_reason = "end_turn"
+    msg.usage = SimpleNamespace(input_tokens=10, output_tokens=5)
+    stream.get_final_message = MagicMock(return_value=msg)
+    cm.__enter__ = MagicMock(return_value=stream)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+class TestStreamStaleCircuitBreaker:
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_short_circuits_when_streak_at_threshold(self, monkeypatch):
+        """A session already past the consecutive-stale threshold must abort
+        immediately without opening a stream or waiting out the stale timeout."""
+        monkeypatch.setenv("HERMES_STREAM_STALE_GIVEUP", "3")
+
+        agent = _make_anthropic_agent()
+        agent._consecutive_stale_streams = 3  # simulate prior wedged turns
+
+        # The stream must never be opened on the short-circuit path.
+        with pytest.raises(RuntimeError, match="unresponsive"):
+            agent._interruptible_streaming_api_call({})
+
+        agent._anthropic_client.messages.stream.assert_not_called()
+        # The streak is NOT reset on the short-circuit so subsequent turns
+        # keep failing fast instead of re-attempting forever.
+        assert agent._consecutive_stale_streams == 3
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_success_resets_streak(self, monkeypatch):
+        """A stream that completes successfully clears the consecutive-stale
+        streak so a recovered provider resumes normally."""
+        monkeypatch.setenv("HERMES_STREAM_STALE_GIVEUP", "3")
+
+        agent = _make_anthropic_agent()
+        agent._consecutive_stale_streams = 2  # below the giveup=3 threshold
+        agent._anthropic_client.messages.stream.return_value = _good_stream_cm()
+
+        resp = agent._interruptible_streaming_api_call({})
+        assert resp is not None
+        assert agent._consecutive_stale_streams == 0
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_stale_kill_increments_streak(self, monkeypatch):
+        """Each stale-stream kill increments the consecutive-stale streak so a
+        wedged session eventually trips the breaker."""
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.1")
+        monkeypatch.setenv("HERMES_STREAM_STALE_GIVEUP", "50")
+
+        agent = _make_anthropic_agent()
+        agent._consecutive_stale_streams = 0
+        unblock = threading.Event()
+
+        def _blocking_gen():
+            unblock.wait(timeout=5.0)
+            raise httpx.ConnectError("connection dropped after close()")
+            yield  # make this a generator so next() triggers the wait
+
+        def _stream_side_effect(*args, **kwargs):
+            cm = MagicMock()
+            stream = MagicMock()
+            stream.__iter__ = MagicMock(return_value=_blocking_gen())
+            cm.__enter__ = MagicMock(return_value=stream)
+            cm.__exit__ = MagicMock(return_value=False)
+            return cm
+
+        # Every attempt blocks, trips the stale detector, and fails.
+        agent._anthropic_client.messages.stream.side_effect = _stream_side_effect
+        agent._anthropic_client.close.side_effect = unblock.set
+
+        with pytest.raises(Exception):
+            agent._interruptible_streaming_api_call({})
+
+        # At least one stale kill happened; the streak must have advanced.
+        assert agent._consecutive_stale_streams >= 1


### PR DESCRIPTION
## Summary
Bound the per-message context-reference preprocessing so a slow/hung `@reference`
fetch can no longer block the gateway worker thread indefinitely.

## Impact
- Every inbound message containing `@file`/`@url`/`@diff` runs
  `preprocess_context_references()`. The sync bridge that invokes the async
  expansion had **no timeout** on either branch, so a slow or hung fetch
  (custom `url_fetcher` without its own timeout, a blocking file read, or a
  misconfigured `web_extract`) blocked the calling thread forever.
- On the gateway this runs on a worker thread. With a small turn pool, a few
  such messages exhaust the pool and the gateway **stops processing all
  messages** (priority-#1 lockup) — no error, no log, silent stall.
- After this change the work is bounded (60s default) and degrades safely:
  the original message is returned unchanged with a warning, so the turn
  still proceeds (non-lossy).

## Root cause
`agent/context_references.py::preprocess_context_references` called
`pool.submit(asyncio.run, coro).result()` / `asyncio.run(coro)` with no
timeout. The submitted task also wasn't self-terminating, so even the
executor's `__exit__` (`shutdown(wait=True)`) waited for the hung task —
defeating any external timeout.

## Fix
- Add `PREPROCESS_CONTEXT_TIMEOUT_SECONDS = 60` and bound both branches.
- Wrap the worker-thread task in `asyncio.wait_for` so it self-terminates at
  the timeout (no orphaned thread, no stalled return path).
- On timeout return `_degraded_context_result(message)`: original message +
  warning, non-lossy.

## Tests
`tests/agent/test_context_references_timeout.py` (2 passing): a coroutine that
sleeps well past the timeout must return promptly with the degraded result, for
both the no-loop (CLI) and loop-running (gateway worker) branches.