### PR TITLE
fix(cli): set HERMES_YOLO_MODE before _prepare_agent_startup() imports (#60328)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2325,10 +2325,6 @@ def cmd_chat(args):
     except Exception:
         pass
 
-    # --yolo: bypass all dangerous command approvals
-    if getattr(args, "yolo", False):
-        os.environ["HERMES_YOLO_MODE"] = "1"
-
     # --ignore-user-config: make load_cli_config() / load_config() skip the
     # user's ~/.hermes/config.yaml and return built-in defaults. Set BEFORE
     # importing cli (which runs `CLI_CONFIG = load_cli_config()` at module
@@ -14110,6 +14106,12 @@ def main():
     if args.version:
         cmd_version(args)
         return
+
+    # --yolo: set HERMES_YOLO_MODE before _prepare_agent_startup() imports
+    # tools.approval (which freezes _YOLO_MODE_FROZEN at import time).
+    # Must be set before any import that could trigger tools/approval.py.
+    if getattr(args, "yolo", False):
+        os.environ["HERMES_YOLO_MODE"] = "1"
 
     # Discover Python plugins and register shell hooks once, before any
     # command that can fire lifecycle hooks.  Both are idempotent; gated


### PR DESCRIPTION
## Summary

The `--yolo` flag was being set inside `cmd_chat()`, but `_prepare_agent_startup()` is called in `main()` **before** `cmd_chat()`. `_prepare_agent_startup()` triggers the import chain `tools.registry` → `tools.terminal_tool` → `tools.approval`, which freezes `_YOLO_MODE_FROZEN` from `os.getenv('HERMES_YOLO_MODE')` at import time. By the time `cmd_chat()` sets the env var, it is already too late.

## Fix

Move the `os.environ['HERMES_YOLO_MODE'] = '1'` assignment to **before** `_prepare_agent_startup()` in `main()`, matching the pattern already used for `HERMES_IGNORE_USER_CONFIG` and `HERMES_IGNORE_RULES`.

Closes #60328