### PR TITLE
fix(cron): add whatsapp_cloud to _KNOWN_DELIVERY_PLATFORMS (#59988)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -202,7 +202,7 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
-    "telegram", "discord", "slack", "whatsapp", "signal",
+    "telegram", "discord", "slack", "whatsapp", "whatsapp_cloud", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
     "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
     "qqbot", "yuanbao",


### PR DESCRIPTION
## Summary

`whatsapp_cloud` was present in `_HOME_TARGET_ENV_VARS` and `gateway/config.py` `Platform` enum, but was missing from `_KNOWN_DELIVERY_PLATFORMS` in `cron/scheduler.py`. This caused cron jobs targeting `whatsapp_cloud` as a delivery platform to fail `_is_known_delivery_platform()` validation.

## Fix

Add `"whatsapp_cloud"` to the `_KNOWN_DELIVERY_PLATFORMS` frozenset.

Closes #59988