### PR TITLE
fix(lazy-deps): use distinctive marker packages to detect active features

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -326,6 +326,45 @@ class TestActiveFeatures:
         )
         assert "platform.slack" in ld.active_features()
 
+    # -- ACTIVE_FEATURE_MARKERS (#58458) -----------------------------------
+    # platform.matrix declares aiohttp as one of its specs (a shared CVE-floor
+    # pin), but aiohttp is commonly present as a transitive of unrelated
+    # packages (edge-tts, firecrawl-py, discord.py, ...). A marked feature
+    # must NOT be considered active just because that shared package is
+    # present — only its distinctive marker package (mautrix) should count.
+
+    def test_marked_feature_not_activated_by_shared_generic_package_alone(
+        self, monkeypatch,
+    ):
+        # Only aiohttp is present (as if pulled in transitively by an
+        # unrelated package) — mautrix itself was never installed.
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "aiohttp",
+        )
+        active = ld.active_features()
+        assert "platform.matrix" not in active
+
+    def test_marked_feature_activated_by_its_marker_package(self, monkeypatch):
+        # mautrix (the marker/distinctive package) is present — the feature
+        # should register as active even if none of its other specs are.
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "mautrix",
+        )
+        assert "platform.matrix" in ld.active_features()
+
+    def test_unmarked_feature_keeps_any_spec_present_semantics(self, monkeypatch):
+        # platform.slack has no marker entry — it must still be activated by
+        # ANY of its specs, including the shared aiohttp pin (backward
+        # compatibility with the pre-fix behavior for unmarked features).
+        assert "platform.slack" not in ld.ACTIVE_FEATURE_MARKERS
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) == "aiohttp",
+        )
+        assert "platform.slack" in ld.active_features()
+
 
 class TestRefreshActiveFeatures:
     def test_no_active_features_returns_empty(self, monkeypatch):

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -469,6 +469,37 @@ def _unsupported_feature_reason(feature: str) -> Optional[str]:
     return None
 
 
+# Some lazy feature groups include generic/shared packages (usually a CVE-
+# floor pin like ``aiohttp==3.14.1``) that can be installed for entirely
+# unrelated reasons — as a transitive of edge-tts, firecrawl-py, discord.py,
+# etc. `active_features()` (used by the `hermes update` refresh pass) must
+# NOT treat that shared package's mere presence as proof the user opted into
+# the feature. Without this, a shared dependency such as aiohttp can make
+# `hermes update` try to refresh the full Matrix stack on machines that never
+# enabled Matrix — which currently pulls python-olm and fails to build on
+# many toolchains (needs make/clang, no Windows wheels at all). See #58458.
+#
+# For any feature listed here, `active_features()` checks ONLY the marker
+# packages below instead of "any spec present". The actual install specs in
+# LAZY_DEPS are unchanged — `ensure()` / `feature_missing()` still install
+# every listed package for a feature once it's genuinely active.
+#
+# Scope: only `platform.matrix` is marked here. It is the one feature with a
+# transitive dependency (python-olm, via mautrix[encryption]) that is known
+# to hard-fail to build on common platforms, making the false-positive
+# genuinely destructive (a permanently-stuck `hermes update` warning).
+# `platform.slack` / `platform.discord` / `platform.teams` also share the
+# aiohttp floor pin, but their false-positive refresh is comparatively
+# harmless (aiohttp is already satisfied, so a false "active" flag for them
+# is a same-version no-op reinstall of packages that were probably going to
+# be present anyway) — so they're left on the original any-spec-present
+# semantics to keep this fix minimal and reviewable. Extend this dict if a
+# similar hard failure is found in one of those trees.
+ACTIVE_FEATURE_MARKERS: dict[str, tuple[str, ...]] = {
+    "platform.matrix": ("mautrix",),
+}
+
+
 def _spec_is_safe(spec: str) -> bool:
     """Reject pip specs that contain URLs, paths, or shell metacharacters."""
     if not spec or len(spec) > 200:
@@ -860,11 +891,23 @@ def active_features() -> list[str]:
     is currently installed in the venv (presence check, ignoring version).
     Features the user has never enabled stay quiet.
 
+    Exception: features listed in :data:`ACTIVE_FEATURE_MARKERS` are
+    activated ONLY by the presence of their marker package(s), not by any
+    of their other declared specs. This avoids false-positive activation
+    from a shared/generic package (e.g. ``aiohttp``) that got installed
+    for an unrelated reason — see the comment above
+    :data:`ACTIVE_FEATURE_MARKERS` and #58458.
+
     Used by ``hermes update`` to figure out which lazy backends need a
     refresh pass when pins move in :data:`LAZY_DEPS`.
     """
     active = []
     for feature, specs in LAZY_DEPS.items():
+        markers = ACTIVE_FEATURE_MARKERS.get(feature)
+        if markers is not None:
+            if any(_is_present(marker) for marker in markers):
+                active.append(feature)
+            continue
         if any(_is_present(s) for s in specs):
             active.append(feature)
     return active


### PR DESCRIPTION
## Problem

`tools/lazy_deps.py::active_features()` (used by the `hermes update` refresh pass) marks a feature "active" if **any** of its declared pip specs is already installed. Several lazy feature groups — `platform.matrix`, `platform.slack`, `platform.discord`, `platform.teams` — list a shared CVE-floor pin, `aiohttp==3.14.1`, alongside their real SDK, purely to keep an already-installed vulnerable aiohttp from silently satisfying their transitive range.

`aiohttp` is commonly present for totally unrelated reasons — it is a transitive dependency of `edge-tts`, `firecrawl-py`, `discord.py`, etc. So any-spec-present activation produces false positives: `platform.matrix` gets marked active on a machine that never enabled Matrix, just because some unrelated package pulled in aiohttp.

For `platform.matrix` specifically this is destructive, not just noisy: a false-positive activation makes `hermes update` try to refresh the full Matrix stack, including `mautrix[encryption]`, which pulls `python-olm`. `python-olm` needs a `make`/clang toolchain to build from source and ships **no Windows wheels at all**. The result is a persistent, never-resolving update warning on machines that never touched Matrix.

Tracked upstream as **#58458** ("lazy_deps: shared aiohttp pin marks never-enabled backends active; matrix refresh then fails on Windows (python-olm needs make)") — still open.

## Fix

Introduce `ACTIVE_FEATURE_MARKERS`, a small map from feature name to a tuple of distinctive/marker packages. For any feature listed there, `active_features()` checks **only** the marker package(s), instead of "any declared spec". `LAZY_DEPS` install specs are untouched — `ensure()` / `feature_missing()` still install every listed package for a feature once it is genuinely active. This only changes the *detection* heuristic used by the `hermes update` refresh pass.

```python
ACTIVE_FEATURE_MARKERS: dict[str, tuple[str, ...]] = {
    "platform.matrix": ("mautrix",),
}
```

**Scope decision:** only `platform.matrix` is marked. It is the one feature among the aiohttp-sharing group whose false-positive refresh has a hard, unrecoverable failure mode (`python-olm` build failure). `platform.slack` / `platform.discord` / `platform.teams` also share the aiohttp floor pin, but their false-positive refresh is a same-version no-op reinstall (aiohttp is already satisfied; nothing new gets pulled or fails to build) — not a build failure — so they are left on the original any-spec-present semantics to keep this change minimal, reviewable, and low blast-radius. The marker map is designed to be extended if a similarly hard failure turns up in one of those trees.

## Why an independent implementation

Two earlier community PRs for #58458 were opened and closed without merging:

- **#58488** ("only treat primary spec as activation trigger") and **#58575** ("use sentinel package for active-feature detection") both took the same approach: treat `specs[0]` in `LAZY_DEPS` as *the* activation trigger for **every** feature, rather than an opt-in marker map. Both PRs are tagged `duplicate` on the issue — they landed on essentially the same design independently and neither got picked, most likely because implicitly repurposing tuple-position-0 as a semantic "primary/sentinel" flag silently changes activation behavior for every multi-spec feature in `LAZY_DEPS` (order-dependent, easy to break on a future edit that reorders specs for readability), rather than being an explicit, self-documenting opt-in.

This fix instead scopes the marker mechanism explicitly and only to the feature(s) that actually need it (`platform.matrix`), leaving default any-spec-present behavior untouched and un-reordered for every other feature — no implicit semantics attached to list order.

## Tests

Added to `tests/tools/test_lazy_deps.py::TestActiveFeatures`:
- `test_marked_feature_not_activated_by_shared_generic_package_alone` — only `aiohttp` present → `platform.matrix` NOT active.
- `test_marked_feature_activated_by_its_marker_package` — only `mautrix` present → `platform.matrix` IS active.
- `test_unmarked_feature_keeps_any_spec_present_semantics` — `platform.slack` (no marker entry) is still activated by its shared aiohttp pin alone, confirming backward compatibility for unmarked features.

## Verification (real output, this worktree)

```
$ /Users/aiserver/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_lazy_deps.py -q
...................................................................      [100%]
67 passed in 2.15s

$ /Users/aiserver/.hermes/hermes-agent/venv/bin/python -c "import ast; ast.parse(open(\"tools/lazy_deps.py\").read())"
(no output — syntax OK)

$ /Users/aiserver/.hermes/hermes-agent/venv/bin/python -m ruff check tools/lazy_deps.py tests/tools/test_lazy_deps.py
All checks passed!
```

Closes: #58458