### PR TITLE
fix: use max_completion_tokens (not max_tokens) for OpenAI models in auxiliary LLM calls

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -878,7 +878,11 @@ def judge_goal(
         return "continue", "empty response (nothing to evaluate)", False, None
 
     try:
-        from agent.auxiliary_client import get_auxiliary_extra_body, get_text_auxiliary_client
+        from agent.auxiliary_client import (
+            auxiliary_max_tokens_param,
+            get_auxiliary_extra_body,
+            get_text_auxiliary_client,
+        )
     except Exception as exc:
         logger.debug("goal judge: auxiliary client import failed: %s", exc)
         return "continue", "auxiliary client unavailable", False, None
@@ -942,7 +946,9 @@ def judge_goal(
                 {"role": "user", "content": prompt},
             ],
             temperature=0,
-            max_tokens=_goal_judge_max_tokens(),
+            **auxiliary_max_tokens_param(
+                _goal_judge_max_tokens(), model=model
+            ),
             timeout=timeout,
             extra_body=get_auxiliary_extra_body() or None,
         )
@@ -999,7 +1005,11 @@ def draft_contract(objective: str, *, timeout: float = DEFAULT_JUDGE_TIMEOUT) ->
         return None
 
     try:
-        from agent.auxiliary_client import get_auxiliary_extra_body, get_text_auxiliary_client
+        from agent.auxiliary_client import (
+            auxiliary_max_tokens_param,
+            get_auxiliary_extra_body,
+            get_text_auxiliary_client,
+        )
     except Exception as exc:
         logger.debug("goal draft: auxiliary client import failed: %s", exc)
         return None
@@ -1021,7 +1031,9 @@ def draft_contract(objective: str, *, timeout: float = DEFAULT_JUDGE_TIMEOUT) ->
                 {"role": "user", "content": f"Objective:\n{_truncate(objective, 4000)}"},
             ],
             temperature=0,
-            max_tokens=_goal_judge_max_tokens(),
+            **auxiliary_max_tokens_param(
+                _goal_judge_max_tokens(), model=model
+            ),
             timeout=timeout,
             extra_body=get_auxiliary_extra_body() or None,
         )

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -45,8 +45,15 @@ from typing import Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import profiles as profiles_mod
+from utils import env_int
 
 logger = logging.getLogger(__name__)
+
+
+HERMES_KANBAN_DECOMPOSE_MAX_TOKENS = max(
+    1500,
+    env_int("HERMES_KANBAN_DECOMPOSE_MAX_TOKENS", 4000),
+)
 
 
 _SYSTEM_PROMPT = """You are the Kanban decomposer for the Hermes Agent board.
@@ -299,6 +306,7 @@ def decompose_task(
 
     try:
         from agent.auxiliary_client import (  # type: ignore
+            auxiliary_max_tokens_param,
             get_auxiliary_extra_body,
             get_text_auxiliary_client,
         )
@@ -331,7 +339,9 @@ def decompose_task(
                 {"role": "user", "content": user_msg},
             ],
             temperature=0.3,
-            max_tokens=4000,
+            **auxiliary_max_tokens_param(
+                HERMES_KANBAN_DECOMPOSE_MAX_TOKENS, model=model
+            ),
             timeout=timeout or 180,
             extra_body=get_auxiliary_extra_body() or None,
         )

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -162,7 +162,11 @@ def specify_task(
         )
 
     try:
-        from agent.auxiliary_client import get_auxiliary_extra_body, get_text_auxiliary_client
+        from agent.auxiliary_client import (
+            auxiliary_max_tokens_param,
+            get_auxiliary_extra_body,
+            get_text_auxiliary_client,
+        )
     except Exception as exc:  # pragma: no cover — import smoke test
         logger.debug("specify: auxiliary client import failed: %s", exc)
         return SpecifyOutcome(task_id, False, "auxiliary client unavailable")
@@ -192,7 +196,9 @@ def specify_task(
                 {"role": "user", "content": user_msg},
             ],
             temperature=0.3,
-            max_tokens=HERMES_KANBAN_SPECIFY_MAX_TOKENS,
+            **auxiliary_max_tokens_param(
+                HERMES_KANBAN_SPECIFY_MAX_TOKENS, model=model
+            ),
             timeout=timeout or 120,
             extra_body=get_auxiliary_extra_body() or None,
         )

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -211,6 +211,7 @@ def describe_profile(
 
     try:
         from agent.auxiliary_client import (  # type: ignore
+            auxiliary_max_tokens_param,
             get_auxiliary_extra_body,
             get_text_auxiliary_client,
         )
@@ -244,7 +245,7 @@ def describe_profile(
                 {"role": "user", "content": user_msg},
             ],
             temperature=0.3,
-            max_tokens=400,
+            **auxiliary_max_tokens_param(400, model=aux_model),
             timeout=timeout or 60,
             extra_body=get_auxiliary_extra_body() or None,
         )


### PR DESCRIPTION
This fixes auxiliary LLM calls (kanban decompose/specify, goal judge/draft, profile describe) that were sending the legacy `max_tokens` parameter to OpenAI models (and compatible endpoints) that require `max_completion_tokens` instead.

The helper `auxiliary_max_tokens_param()` already existed for this purpose but was not being used in these direct `chat.completions.create()` call sites.

Closes #60355

## Changes
- `hermes_cli/kanban_decompose.py`: Use `**auxiliary_max_tokens_param(HERMES_KANBAN_DECOMPOSE_MAX_TOKENS, model=model)`
- `hermes_cli/kanban_specify.py`: Same pattern
- `hermes_cli/goals.py`: Updated both judge and draft paths
- `hermes_cli/profile_describer.py`: Updated

## Testing
- Full test suite via `scripts/run_tests.sh` (relevant kanban/goals/profile + max_tokens tests all pass)
- Reproduced originally in Docker (linux/amd64)
- Verified fix with custom Docker image `drhayt/hermes-agent:fix-max-completion-tokens`

See the issue for full repro steps and logs.
