### PR TITLE
fix(auxiliary): use default 600s TTL when provider permanently unavailable (#59984)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1842,7 +1842,7 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:
-        _mark_provider_unhealthy("openrouter", ttl=60)
+        _mark_provider_unhealthy("openrouter")
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return _create_openai_client(api_key=or_key, base_url=OPENROUTER_BASE_URL,
@@ -1886,7 +1886,7 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
             "Auxiliary Nous client unavailable: no Nous authentication found "
             "(run: hermes auth)."
         )
-        _mark_provider_unhealthy("nous", ttl=60)
+        _mark_provider_unhealthy("nous")
         return None, None
     if runtime is None and nous:
         logger.debug(


### PR DESCRIPTION
## Summary

When OpenRouter or Nous credentials are not configured,  was called with  instead of the default 600s. The 60s TTL was designed for transient payment errors (402), but missing credentials are permanent configuration state — after 60s the unhealthy mark expires, the provider is retried, fails identically, and logs another WARNING. This floods  with thousands of identical lines.

## Fix

Remove the  override when marking OpenRouter and Nous as permanently unavailable (no credentials), allowing them to use the default 600s TTL instead.

Closes #59984