### PR TITLE
fix(hindsight): defer restart of a healthy shared embedded daemon

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1426,9 +1426,18 @@ class HindsightMemoryProvider(MemoryProvider):
                     if config_changed:
                         profile_env = _materialize_embedded_profile_env(self._config)
                         if client._manager.is_running(profile):
+                            # Do not kill a healthy shared embedded daemon from inside a
+                            # live gateway/session. Several Hermes profiles can share the
+                            # default Hindsight profile, and restarting here can terminate
+                            # in-flight retain/recall requests, surfacing as Hindsight HTTP
+                            # 500s to the caller. The updated env is materialized for the
+                            # next natural daemon start; explicit operational restarts can
+                            # still be performed outside an active request path.
                             with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
+                                f.write(
+                                    "\n=== Config changed; healthy daemon left running "
+                                    "(restart deferred) ===\n"
+                                )
 
                     client._ensure_started()
                     with open(log_path, "a", encoding="utf-8") as f:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1823,9 +1823,18 @@ class HindsightMemoryProvider(MemoryProvider):
                     if config_changed:
                         profile_env = _materialize_embedded_profile_env(self._config)
                         if client._manager.is_running(profile):
+                            # Do not kill a healthy shared embedded daemon from inside a
+                            # live gateway/session. Several Hermes profiles can share the
+                            # default Hindsight profile, and restarting here can terminate
+                            # in-flight retain/recall requests, surfacing as Hindsight HTTP
+                            # 500s to the caller. The updated env is materialized for the
+                            # next natural daemon start; explicit operational restarts can
+                            # still be performed outside an active request path.
                             with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
+                                f.write(
+                                    "\n=== Config changed; healthy daemon left running "
+                                    "(restart deferred) ===\n"
+                                )
 
                     client._ensure_started()
                     with open(log_path, "a", encoding="utf-8") as f:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -444,6 +444,115 @@ class TestConfig:
         assert captured["llm_provider"] == "openai"
 
 
+class TestEmbeddedDaemonConfigChangeRestart:
+    """Regression tests: a config change detected during daemon start must
+    not kill a healthy, already-running embedded daemon from inside a live
+    request path.
+
+    Root cause: multiple Hermes profiles can share the same default
+    Hindsight embedded daemon/profile. Calling ``client._manager.stop(profile)``
+    the moment a config diff is detected can terminate in-flight
+    retain/recall calls for *other* profiles sharing that daemon, surfacing
+    as unexpected Hindsight HTTP 500s. The fix defers the restart: the
+    updated profile env is still materialized immediately (so it takes
+    effect on the daemon's next natural start), but a healthy running
+    daemon is left alone.
+
+    This is distinct from (and complementary to) upstream PR #51066, which
+    fixes a comparison bug in ``_persisted_profile_env_keys`` that made
+    ``config_changed`` spuriously always True. That PR is about *detecting*
+    config_changed correctly; these tests are about what happens once
+    config_changed is legitimately True.
+    """
+
+    def _run_start_daemon_and_wait(self, provider, tmp_path, monkeypatch, fake_client):
+        """Drive provider.initialize() in local_embedded mode, then block
+        until the background daemon-start thread it spawns has finished."""
+        import threading
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._materialize_embedded_profile_env",
+            lambda config, **kwargs: tmp_path / "hermes.env",
+        )
+
+        config = {
+            "mode": "local_embedded",
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+
+        provider = HindsightMemoryProvider()
+        monkeypatch.setattr(provider, "_get_client", lambda: fake_client)
+
+        threads_before = {t.ident for t in threading.enumerate()}
+        provider.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+        # initialize() spawns the daemon-start work on a background thread
+        # named "hindsight-daemon-start" (or resolves synchronously if
+        # local_embedded got disabled). Find and join it if present.
+        new_thread = None
+        for t in threading.enumerate():
+            if t.ident not in threads_before and t.name == "hindsight-daemon-start":
+                new_thread = t
+                break
+        assert new_thread is not None, "expected initialize() to spawn the daemon-start thread"
+        new_thread.join(timeout=5)
+        assert not new_thread.is_alive()
+
+        return provider
+
+    def test_healthy_running_daemon_not_stopped_on_config_change(self, tmp_path, monkeypatch):
+        """config_changed=True + a healthy running daemon => defer, don't stop."""
+        fake_manager = MagicMock()
+        fake_manager.is_running.return_value = True
+        fake_client = MagicMock()
+        fake_client._manager = fake_manager
+
+        # Force config_changed True: the saved profile env never matches
+        # the freshly-built expected env because no file exists on disk.
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._load_simple_env", lambda path: {"stale": "value"}
+        )
+
+        provider = self._run_start_daemon_and_wait(None, tmp_path, monkeypatch, fake_client)
+
+        fake_manager.is_running.assert_called_with("hermes")
+        fake_manager.stop.assert_not_called()
+        fake_client._ensure_started.assert_called_once()
+
+        log_path = tmp_path / "logs" / "hindsight-embed.log"
+        log_text = log_path.read_text(encoding="utf-8")
+        assert "restart deferred" in log_text
+        assert "Config changed, restarting daemon" not in log_text
+
+    def test_no_running_daemon_on_config_change_does_not_touch_manager_stop(self, tmp_path, monkeypatch):
+        """When no daemon is running yet, there's nothing to stop either way —
+        this just pins down that stop() is never reached along this path."""
+        fake_manager = MagicMock()
+        fake_manager.is_running.return_value = False
+        fake_client = MagicMock()
+        fake_client._manager = fake_manager
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._load_simple_env", lambda path: {"stale": "value"}
+        )
+
+        self._run_start_daemon_and_wait(None, tmp_path, monkeypatch, fake_client)
+
+        fake_manager.stop.assert_not_called()
+        fake_client._ensure_started.assert_called_once()
+
+
 class TestPostSetup:
     def test_setup_cancel_at_mode_picker_writes_nothing(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes-home"

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -372,6 +372,115 @@ class TestConfig:
         assert captured["llm_provider"] == "openai"
 
 
+class TestEmbeddedDaemonConfigChangeRestart:
+    """Regression tests: a config change detected during daemon start must
+    not kill a healthy, already-running embedded daemon from inside a live
+    request path.
+
+    Root cause: multiple Hermes profiles can share the same default
+    Hindsight embedded daemon/profile. Calling ``client._manager.stop(profile)``
+    the moment a config diff is detected can terminate in-flight
+    retain/recall calls for *other* profiles sharing that daemon, surfacing
+    as unexpected Hindsight HTTP 500s. The fix defers the restart: the
+    updated profile env is still materialized immediately (so it takes
+    effect on the daemon's next natural start), but a healthy running
+    daemon is left alone.
+
+    This is distinct from (and complementary to) upstream PR #51066, which
+    fixes a comparison bug in ``_persisted_profile_env_keys`` that made
+    ``config_changed`` spuriously always True. That PR is about *detecting*
+    config_changed correctly; these tests are about what happens once
+    config_changed is legitimately True.
+    """
+
+    def _run_start_daemon_and_wait(self, provider, tmp_path, monkeypatch, fake_client):
+        """Drive provider.initialize() in local_embedded mode, then block
+        until the background daemon-start thread it spawns has finished."""
+        import threading
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._materialize_embedded_profile_env",
+            lambda config, **kwargs: tmp_path / "hermes.env",
+        )
+
+        config = {
+            "mode": "local_embedded",
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+
+        provider = HindsightMemoryProvider()
+        monkeypatch.setattr(provider, "_get_client", lambda: fake_client)
+
+        threads_before = {t.ident for t in threading.enumerate()}
+        provider.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+        # initialize() spawns the daemon-start work on a background thread
+        # named "hindsight-daemon-start" (or resolves synchronously if
+        # local_embedded got disabled). Find and join it if present.
+        new_thread = None
+        for t in threading.enumerate():
+            if t.ident not in threads_before and t.name == "hindsight-daemon-start":
+                new_thread = t
+                break
+        assert new_thread is not None, "expected initialize() to spawn the daemon-start thread"
+        new_thread.join(timeout=5)
+        assert not new_thread.is_alive()
+
+        return provider
+
+    def test_healthy_running_daemon_not_stopped_on_config_change(self, tmp_path, monkeypatch):
+        """config_changed=True + a healthy running daemon => defer, don't stop."""
+        fake_manager = MagicMock()
+        fake_manager.is_running.return_value = True
+        fake_client = MagicMock()
+        fake_client._manager = fake_manager
+
+        # Force config_changed True: the saved profile env never matches
+        # the freshly-built expected env because no file exists on disk.
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._load_simple_env", lambda path: {"stale": "value"}
+        )
+
+        provider = self._run_start_daemon_and_wait(None, tmp_path, monkeypatch, fake_client)
+
+        fake_manager.is_running.assert_called_with("hermes")
+        fake_manager.stop.assert_not_called()
+        fake_client._ensure_started.assert_called_once()
+
+        log_path = tmp_path / "logs" / "hindsight-embed.log"
+        log_text = log_path.read_text(encoding="utf-8")
+        assert "restart deferred" in log_text
+        assert "Config changed, restarting daemon" not in log_text
+
+    def test_no_running_daemon_on_config_change_does_not_touch_manager_stop(self, tmp_path, monkeypatch):
+        """When no daemon is running yet, there's nothing to stop either way —
+        this just pins down that stop() is never reached along this path."""
+        fake_manager = MagicMock()
+        fake_manager.is_running.return_value = False
+        fake_client = MagicMock()
+        fake_client._manager = fake_manager
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._load_simple_env", lambda path: {"stale": "value"}
+        )
+
+        self._run_start_daemon_and_wait(None, tmp_path, monkeypatch, fake_client)
+
+        fake_manager.stop.assert_not_called()
+        fake_client._ensure_started.assert_called_once()
+
+
 class TestPostSetup:
     def test_setup_cancel_at_mode_picker_writes_nothing(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes-home"

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -396,7 +396,27 @@ class TestEmbeddedDaemonConfigChangeRestart:
     def _run_start_daemon_and_wait(self, provider, tmp_path, monkeypatch, fake_client):
         """Drive provider.initialize() in local_embedded mode, then block
         until the background daemon-start thread it spawns has finished."""
+        import sys
         import threading
+        import types
+
+        # hindsight_embed is an optional runtime dependency: the daemon-start
+        # thread imports hindsight_embed.daemon_embed_manager to redirect its
+        # Rich console. It is absent on CI, where the resulting ImportError is
+        # swallowed by the thread's blanket ``except Exception`` and the body
+        # silently never reaches the behavior under test. Stub the module so
+        # this test exercises the product path on any machine instead of
+        # passing only where the optional package happens to be installed.
+        if "hindsight_embed.daemon_embed_manager" not in sys.modules:
+            parent = sys.modules.get("hindsight_embed")
+            if parent is None:
+                parent = types.ModuleType("hindsight_embed")
+                monkeypatch.setitem(sys.modules, "hindsight_embed", parent)
+            dem = types.ModuleType("hindsight_embed.daemon_embed_manager")
+            monkeypatch.setitem(
+                sys.modules, "hindsight_embed.daemon_embed_manager", dem
+            )
+            monkeypatch.setattr(parent, "daemon_embed_manager", dem, raising=False)
 
         monkeypatch.setattr(
             "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -422,20 +422,32 @@ class TestEmbeddedDaemonConfigChangeRestart:
         provider = HindsightMemoryProvider()
         monkeypatch.setattr(provider, "_get_client", lambda: fake_client)
 
-        threads_before = {t.ident for t in threading.enumerate()}
+        # Capture the daemon-start thread at construction time rather than
+        # discovering it afterwards with threading.enumerate(). The mocked
+        # daemon path can finish before initialize() returns, in which case
+        # the thread is already gone from enumerate() and a discovery-based
+        # helper fails intermittently with no product regression behind it.
+        # Wrapping the constructor makes the handle available regardless of
+        # how fast the thread runs.
+        spawned: list[threading.Thread] = []
+        real_thread_cls = threading.Thread
+
+        class _CapturingThread(real_thread_cls):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                if kwargs.get("name") == "hindsight-daemon-start":
+                    spawned.append(self)
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.threading.Thread", _CapturingThread
+        )
+
         provider.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
 
-        # initialize() spawns the daemon-start work on a background thread
-        # named "hindsight-daemon-start" (or resolves synchronously if
-        # local_embedded got disabled). Find and join it if present.
-        new_thread = None
-        for t in threading.enumerate():
-            if t.ident not in threads_before and t.name == "hindsight-daemon-start":
-                new_thread = t
-                break
-        assert new_thread is not None, "expected initialize() to spawn the daemon-start thread"
+        assert spawned, "expected initialize() to spawn the daemon-start thread"
+        new_thread = spawned[0]
         new_thread.join(timeout=5)
-        assert not new_thread.is_alive()
+        assert not new_thread.is_alive(), "daemon-start thread did not finish in time"
 
         return provider
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -494,20 +494,32 @@ class TestEmbeddedDaemonConfigChangeRestart:
         provider = HindsightMemoryProvider()
         monkeypatch.setattr(provider, "_get_client", lambda: fake_client)
 
-        threads_before = {t.ident for t in threading.enumerate()}
+        # Capture the daemon-start thread at construction time rather than
+        # discovering it afterwards with threading.enumerate(). The mocked
+        # daemon path can finish before initialize() returns, in which case
+        # the thread is already gone from enumerate() and a discovery-based
+        # helper fails intermittently with no product regression behind it.
+        # Wrapping the constructor makes the handle available regardless of
+        # how fast the thread runs.
+        spawned: list[threading.Thread] = []
+        real_thread_cls = threading.Thread
+
+        class _CapturingThread(real_thread_cls):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                if kwargs.get("name") == "hindsight-daemon-start":
+                    spawned.append(self)
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.threading.Thread", _CapturingThread
+        )
+
         provider.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
 
-        # initialize() spawns the daemon-start work on a background thread
-        # named "hindsight-daemon-start" (or resolves synchronously if
-        # local_embedded got disabled). Find and join it if present.
-        new_thread = None
-        for t in threading.enumerate():
-            if t.ident not in threads_before and t.name == "hindsight-daemon-start":
-                new_thread = t
-                break
-        assert new_thread is not None, "expected initialize() to spawn the daemon-start thread"
+        assert spawned, "expected initialize() to spawn the daemon-start thread"
+        new_thread = spawned[0]
         new_thread.join(timeout=5)
-        assert not new_thread.is_alive()
+        assert not new_thread.is_alive(), "daemon-start thread did not finish in time"
 
         return provider
 


### PR DESCRIPTION
## Problem

The embedded Hindsight daemon-start flow in `HindsightMemoryProvider` (`plugins/memory/hindsight/__init__.py`) detects config changes on every call to `initialize()`: if the persisted profile `.env` differs from the freshly-built expected env, `config_changed` is True. Previously, when `config_changed` was True **and** a healthy daemon was already running, the code immediately did:

```python
client._manager.stop(profile)
```

followed by a fresh `client._ensure_started()`.

The default embedded Hindsight profile/daemon can be **shared across multiple Hermes profiles** running in the same environment. Killing that daemon mid-request — from inside a live gateway/session `initialize()` call — can terminate in-flight `retain`/`recall` requests belonging to **other** profiles sharing the daemon. This surfaces to callers as unexpected Hindsight HTTP 500s. This is a request-path safety bug, not a bug in how `config_changed` is computed.

## Fix

When a healthy daemon is already running and a config change is detected, no longer stop it immediately. The updated profile env is still materialized right away (via `_materialize_embedded_profile_env`), so it takes effect the next time the daemon starts naturally (idle-timeout restart, or an explicit operational restart performed outside an active request path). Only the immediate in-request stop+restart is removed; a log line now records that the restart was deferred instead of firing.

```diff
                     if config_changed:
                         profile_env = _materialize_embedded_profile_env(self._config)
                         if client._manager.is_running(profile):
+                            # Do not kill a healthy shared embedded daemon from inside a
+                            # live gateway/session. ...
                             with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
+                                f.write(
+                                    "\n=== Config changed; healthy daemon left running "
+                                    "(restart deferred) ===\n"
+                                )
 
                     client._ensure_started()
```

## Relation to PR #51066

This is **complementary to, not a duplicate of**, open upstream PR #51066 ("fix(hindsight): stop embedded daemon restarting every session"), which fixes a *different* root cause: a comparison bug in `_persisted_profile_env_keys` that made `config_changed` spuriously always evaluate to True.

- **#51066** improves how `config_changed` is *detected* (fewer false positives).
- **This PR** changes what happens once `config_changed` is *legitimately* True — defer instead of killing a live shared daemon.

Both changes are independently correct and do not conflict; #51066 reduces how often this code path triggers at all, and this PR makes the path itself safe when it does trigger.

## Tests

Added `TestEmbeddedDaemonConfigChangeRestart` in `tests/plugins/memory/test_hindsight_provider.py`. It drives `HindsightMemoryProvider.initialize()` in `local_embedded` mode with a mocked `client._manager`, forces `config_changed` via a forged saved env, joins the background daemon-start thread, and asserts:

- `client._manager.stop` is **never** called when a healthy daemon is running
- `client._ensure_started()` still runs (daemon start proceeds normally)
- the log records the "restart deferred" message instead of the old "Config changed, restarting daemon" message
- when no daemon is running yet, `stop()` is still never touched along this path

### Verification (real pytest run from /tmp/wt-hindsight)

```
$ /Users/aiserver/.hermes/hermes-agent/venv/bin/python -m pytest tests/plugins/memory/test_hindsight_provider.py -q
........................................................................ [ 61%]
..............................................                           [100%]
118 passed in 4.02s
```

Also verified:
- `python -c "import ast; ast.parse(open('plugins/memory/hindsight/__init__.py').read())"` → syntax OK
- `ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` → All checks passed, no new issues

## Scope

Only touches:
- `plugins/memory/hindsight/__init__.py`
- `tests/plugins/memory/test_hindsight_provider.py`

No unrelated files modified.