### PR TITLE
feat(gateway): add topic channel reasoning overrides

### DIFF
--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -8,6 +8,11 @@ from .session import (
     build_session_context_prompt,
 )
 from .delivery import DeliveryRouter, DeliveryTarget
+from .scoped_reasoning import install_scoped_reasoning_runtime
+
+# Gateway reasoning overrides are more specific than model/global defaults and
+# must stay fixed through same-turn provider/model route changes.
+install_scoped_reasoning_runtime()
 
 __all__ = [
     "GatewayConfig", "PlatformConfig", "HomeChannel", "load_gateway_config",

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -355,10 +355,11 @@ class SessionResetPolicy:
 
 @dataclass
 class ChannelOverride:
-    """Per-channel model/provider/system_prompt override (``platforms.<name>.channel_overrides[channel_id]``)."""
+    """Per-channel model/provider/system_prompt/reasoning override (``platforms.<name>.channel_overrides[channel_id]``)."""
     model: Optional[str] = None
     provider: Optional[str] = None
     system_prompt: Optional[str] = None
+    reasoning_effort: Optional[Any] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {k: v for k, v in asdict(self).items() if v is not None}
@@ -395,6 +396,7 @@ class PlatformConfig:
     typing_indicator: bool = True  # drives _keep_typing; False where unwanted (Slack setStatus blocks compose)
     # Working-state text for text-rendering indicators (Slack status, Google Chat marker); None = platform default.
     typing_status_text: Optional[str] = None
+    # Per-channel model/provider/system_prompt/reasoning overrides (channel_id -> ChannelOverride)
     channel_overrides: Dict[str, ChannelOverride] = field(default_factory=dict)
     extra: Dict[str, Any] = field(default_factory=dict)  # Platform-specific settings
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -543,7 +543,7 @@ class SessionResetPolicy:
 @dataclass
 class ChannelOverride:
     """
-    Per-channel override for model, provider, and system prompt.
+    Per-channel override for model, provider, system prompt, and reasoning effort.
 
     Used in config under platforms.<name>.channel_overrides[channel_id].
     Enables different channels (e.g. Discord #daily vs #dev) to use different
@@ -552,6 +552,7 @@ class ChannelOverride:
     model: Optional[str] = None
     provider: Optional[str] = None
     system_prompt: Optional[str] = None
+    reasoning_effort: Optional[Any] = None
 
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {}
@@ -561,6 +562,8 @@ class ChannelOverride:
             out["provider"] = self.provider
         if self.system_prompt is not None:
             out["system_prompt"] = self.system_prompt
+        if self.reasoning_effort is not None:
+            out["reasoning_effort"] = self.reasoning_effort
         return out
 
     @classmethod
@@ -571,6 +574,7 @@ class ChannelOverride:
             model=data.get("model"),
             provider=data.get("provider"),
             system_prompt=data.get("system_prompt"),
+            reasoning_effort=data.get("reasoning_effort"),
         )
 
 
@@ -629,7 +633,7 @@ class PlatformConfig:
     # Telegram, Matrix, …) ignore it.
     typing_status_text: Optional[str] = None
 
-    # Per-channel model/provider/system_prompt overrides (channel_id -> ChannelOverride)
+    # Per-channel model/provider/system_prompt/reasoning overrides (channel_id -> ChannelOverride)
     channel_overrides: Dict[str, ChannelOverride] = field(default_factory=dict)
 
     # Platform-specific settings

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2804,14 +2804,17 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
 def _channel_override_lookup_keys(
     chat_id: str, *, thread_id: Optional[str] = None, parent_id: Optional[str] = None) -> list[str]:
     """Ordered, de-duplicated ``channel_overrides`` lookup keys (matches ``resolve_channel_prompt``:
-    exact id first, then parent — Discord threads inherit parent overrides)."""
-    return list(dict.fromkeys(str(key) for key in (chat_id, thread_id, parent_id) if key))
+    a ``chat_id:thread_id`` composite first — Telegram forum topics need a key scoped by both chat
+    and topic, e.g. ``-100123:188`` — then exact id, then parent (Discord threads inherit parent
+    overrides))."""
+    composite_key = f"{chat_id}:{thread_id}" if chat_id and thread_id else None
+    return list(dict.fromkeys(str(key) for key in (composite_key, chat_id, thread_id, parent_id) if key))
 
 
 def _get_channel_override(
     config: GatewayConfig, platform: Platform, chat_id: str, *, thread_id: Optional[str] = None,
     parent_id: Optional[str] = None) -> Optional[ChannelOverride]:
-    """Per-channel override via chat_id, then thread_id, then parent_id; None if absent."""
+    """Per-channel override via chat_id:thread_id composite, then chat_id, thread_id, parent_id; None if absent."""
     platforms = getattr(config, "platforms", None)
     if not platforms:
         return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2956,12 +2956,14 @@ def _channel_override_lookup_keys(
 ) -> list[str]:
     """Ordered, de-duplicated keys for ``channel_overrides`` lookup.
 
-    Matches ``resolve_channel_prompt`` semantics: exact thread/channel id first,
-    then parent channel/forum id (Discord threads inherit parent overrides).
+    Telegram forum topics need a stable key scoped by both chat and topic,
+    e.g. ``-100123:188``. After that, preserve the existing lookup order:
+    chat/channel id, thread id, then parent id.
     """
     keys: list[str] = []
     seen: set[str] = set()
-    for key in (chat_id, thread_id, parent_id):
+    composite_key = f"{chat_id}:{thread_id}" if chat_id and thread_id else None
+    for key in (composite_key, chat_id, thread_id, parent_id):
         if not key:
             continue
         sk = str(key)
@@ -2982,8 +2984,8 @@ def _get_channel_override(
 ) -> Optional[ChannelOverride]:
     """Return per-channel override for this platform/chat_id, or None.
 
-    Looks up ``channel_overrides`` by ``chat_id``, then ``thread_id``, then
-    ``parent_id`` (forum threads / child channels inherit the parent entry).
+    Looks up ``channel_overrides`` by ``chat_id:thread_id`` first, then
+    ``chat_id``, ``thread_id``, and ``parent_id``.
     """
     platforms = getattr(config, "platforms", None)
     if not platforms:
@@ -7793,9 +7795,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> dict | None:
         """Resolve reasoning effort for a session, honoring session overrides.
 
-        Priority: session-scoped ``/reasoning --session`` override >
-        per-model override (``agent.reasoning_overrides``) > global
-        ``agent.reasoning_effort``. ``model`` should be the session's
+        Priority: session-scoped ``/reasoning --session`` override > channel
+        override > per-model override (``agent.reasoning_overrides``) >
+        global ``agent.reasoning_effort``. ``model`` should be the session's
         *effective* model (session ``/model`` override included) so
         per-model overrides track what the session actually runs — when
         empty, the config's ``model.default`` is used.
@@ -7811,6 +7813,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _r_state = self._peek_session_state(resolved_session_key)
             if _r_state is not None and _r_state.conversation.reasoning_override is not None:
                 return _r_state.conversation.reasoning_override
+        config = getattr(self, "config", None)
+        if config and source is not None:
+            try:
+                override = _get_channel_override(
+                    config,
+                    source.platform,
+                    str(source.chat_id) if source.chat_id else "",
+                    thread_id=(
+                        str(source.thread_id)
+                        if getattr(source, "thread_id", None)
+                        else None
+                    ),
+                    parent_id=(
+                        str(source.parent_chat_id)
+                        if getattr(source, "parent_chat_id", None)
+                        else None
+                    ),
+                )
+                channel_effort = getattr(override, "reasoning_effort", None)
+                if channel_effort is not None:
+                    from hermes_constants import parse_reasoning_effort
+
+                    parsed = parse_reasoning_effort(channel_effort)
+                    if parsed is not None:
+                        return parsed
+                    if str(channel_effort).strip():
+                        logger.warning(
+                            "Unknown channel reasoning_effort '%s', using global default",
+                            channel_effort,
+                        )
+            except Exception:
+                logger.debug("Failed to resolve channel reasoning override", exc_info=True)
         return self._load_reasoning_config(model)
 
     def _set_session_reasoning_override(

--- a/gateway/run_config_loaders.py
+++ b/gateway/run_config_loaders.py
@@ -173,7 +173,8 @@ class GatewayConfigLoadersMixin:
         self, *, source: Optional[SessionSource] = None, session_key: Optional[str] = None,
         model: str = "",
     ) -> dict | None:
-        """Session ``/reasoning --session`` > per-model ``agent.reasoning_overrides`` > global.
+        """Session ``/reasoning --session`` > channel override > per-model
+        ``agent.reasoning_overrides`` > global.
 
         ``model`` must be the session's *effective* model (session ``/model`` override included);
         empty uses ``model.default``.
@@ -183,6 +184,28 @@ class GatewayConfigLoadersMixin:
             _r_state = self._peek_session_state(resolved_session_key)
             if _r_state is not None and _r_state.conversation.reasoning_override is not None:
                 return _r_state.conversation.reasoning_override
+        if source is not None:
+            try:
+                override = self._channel_override(
+                    source.platform,
+                    str(source.chat_id) if source.chat_id else "",
+                    str(source.thread_id) if getattr(source, "thread_id", None) else None,
+                    str(source.parent_chat_id) if getattr(source, "parent_chat_id", None) else None,
+                )
+                channel_effort = getattr(override, "reasoning_effort", None)
+                if channel_effort is not None:
+                    from hermes_constants import parse_reasoning_effort
+
+                    parsed = parse_reasoning_effort(channel_effort)
+                    if parsed is not None:
+                        return parsed
+                    if str(channel_effort).strip():
+                        logger.warning(
+                            "Unknown channel reasoning_effort '%s', using global default",
+                            channel_effort,
+                        )
+            except Exception:
+                logger.debug("Failed to resolve channel reasoning override", exc_info=True)
         return self._load_reasoning_config(model)
 
     def _set_session_reasoning_override(self, session_key: str, reasoning_config: Optional[dict]) -> None:

--- a/gateway/scoped_reasoning.py
+++ b/gateway/scoped_reasoning.py
@@ -1,0 +1,97 @@
+"""Preserve explicit gateway reasoning overrides across runtime route changes.
+
+Channel- and session-scoped reasoning are more specific than per-model/global
+configuration. Provider fallback and same-turn model switching both call the
+shared ``resolve_reasoning_config`` chokepoint, so a scoped value must survive
+those re-resolutions for the rest of the turn.
+
+This module keeps the scope marker on the reasoning-config object itself. That
+avoids a second mutable flag on cached agents: when the gateway refreshes an
+agent for an unscoped turn it assigns a normal ``dict`` again, automatically
+restoring the existing per-model fallback behaviour.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import hermes_constants
+
+from .session_state import ConversationState
+
+
+class ScopedReasoningConfig(dict):
+    """Reasoning config that originated from a gateway session/channel scope."""
+
+
+_INSTALLED = False
+_ORIGINAL_PARSE_REASONING_EFFORT = hermes_constants.parse_reasoning_effort
+_ORIGINAL_RESOLVE_REASONING_CONFIG = hermes_constants.resolve_reasoning_config
+_ORIGINAL_CONVERSATION_SETATTR = ConversationState.__setattr__
+
+
+def _parse_reasoning_effort(effort: Any) -> dict | None:
+    """Mark channel-level parses while leaving global/model parses untouched."""
+    result = _ORIGINAL_PARSE_REASONING_EFFORT(effort)
+    if result is None:
+        return None
+
+    frame = inspect.currentframe()
+    try:
+        caller = frame.f_back if frame is not None else None
+        if (
+            caller is not None
+            and caller.f_code.co_name == "_resolve_session_reasoning_config"
+            and caller.f_globals.get("__name__") == "gateway.run_config_loaders"
+        ):
+            return ScopedReasoningConfig(result)
+    finally:
+        del frame
+
+    return result
+
+
+def _resolve_reasoning_config(cfg: dict | None, model: str = "") -> dict | None:
+    """Keep a scoped value when runtime code re-resolves for another route.
+
+    The two route-changing call sites (provider fallback and same-turn model
+    switching) call the shared resolver with their ``agent`` argument in local
+    scope. If that agent currently carries a scoped config, returning it here
+    preserves the documented session/channel > per-model > global precedence.
+    Unscoped agents fall straight through to the original resolver.
+    """
+    frame = inspect.currentframe()
+    try:
+        caller = frame.f_back if frame is not None else None
+        agent = caller.f_locals.get("agent") if caller is not None else None
+        current = getattr(agent, "reasoning_config", None)
+        if isinstance(current, ScopedReasoningConfig):
+            return current
+    finally:
+        del frame
+
+    return _ORIGINAL_RESOLVE_REASONING_CONFIG(cfg, model)
+
+
+def _conversation_state_setattr(self: ConversationState, name: str, value: Any) -> None:
+    """Mark explicit ``/reasoning`` session overrides at their storage boundary."""
+    if (
+        name == "reasoning_override"
+        and isinstance(value, dict)
+        and not isinstance(value, ScopedReasoningConfig)
+    ):
+        value = ScopedReasoningConfig(value)
+    _ORIGINAL_CONVERSATION_SETATTR(self, name, value)
+
+
+def install_scoped_reasoning_runtime() -> None:
+    """Install the gateway-only scope marker plumbing once per process."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+
+    hermes_constants.parse_reasoning_effort = _parse_reasoning_effort
+    hermes_constants.resolve_reasoning_config = _resolve_reasoning_config
+    ConversationState.__setattr__ = _conversation_state_setattr
+    _INSTALLED = True

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -68,6 +68,27 @@ class TestGetChannelOverride:
         assert result is not None
         assert result.model == "topic-model"
 
+    def test_telegram_topic_key_overrides_chat_default(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "-100123": ChannelOverride(model="chat-model"),
+                        "-100123:188": ChannelOverride(model="topic-model"),
+                    },
+                ),
+            },
+        )
+        result = _get_channel_override(
+            config,
+            Platform.TELEGRAM,
+            "-100123",
+            thread_id="188",
+        )
+        assert result is not None
+        assert result.model == "topic-model"
+
 
 class TestResolveModelForChannel:
     def test_uses_channel_override_when_present(self):
@@ -153,4 +174,160 @@ class TestResolveSessionAgentRuntimePriority:
         assert model == "channel/model"
         assert runtime["provider"] == "openrouter"
 
+    def test_telegram_topic_override_beats_chat_default(self):
+        runner = object.__new__(GatewayRunner)
+        runner._session_model_overrides = {}
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "-100123": ChannelOverride(
+                            model="chat-model",
+                            provider="chat-provider",
+                        ),
+                        "-100123:188": ChannelOverride(
+                            model="topic-model",
+                            provider="topic-provider",
+                        ),
+                    },
+                ),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100123",
+            chat_type="forum",
+            thread_id="188",
+            user_id="u1",
+        )
+        with patch("gateway.run._resolve_gateway_model", return_value="global/model"), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={
+                 "provider": "global-provider",
+                 "api_key": "global-key",
+             }), \
+             patch(
+                 "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+                 return_value={
+                     "provider": "topic-provider",
+                     "api_key": "topic-key",
+                 },
+             ):
+            model, runtime = runner._resolve_session_agent_runtime(
+                source=source,
+                user_config={"model": {"default": "global/model"}},
+            )
+        assert model == "topic-model"
+        assert runtime["provider"] == "topic-provider"
+        assert runtime["api_key"] == "topic-key"
+
+
+class TestResolveSessionReasoningPriority:
+    """Reasoning priority: session -> channel -> per-model -> global."""
+
+    def test_channel_reasoning_effort_beats_global(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "-100123:188": ChannelOverride(reasoning_effort="high"),
+                    },
+                ),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100123",
+            chat_type="forum",
+            thread_id="188",
+            user_id="u1",
+        )
+        with patch.object(
+            GatewayRunner,
+            "_load_reasoning_config",
+            staticmethod(lambda _model="": {"enabled": True, "effort": "low"}),
+        ):
+            reasoning = runner._resolve_session_reasoning_config(source=source)
+        assert reasoning == {"enabled": True, "effort": "high"}
+
+    def test_channel_reasoning_effort_beats_per_model_override(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "-100123:188": ChannelOverride(reasoning_effort="high"),
+                    },
+                ),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100123",
+            chat_type="forum",
+            thread_id="188",
+            user_id="u1",
+        )
+        with patch.object(
+            GatewayRunner,
+            "_load_reasoning_config",
+            staticmethod(lambda _model="": {"enabled": True, "effort": "xhigh"}),
+        ):
+            reasoning = runner._resolve_session_reasoning_config(
+                source=source,
+                model="openai/gpt-5",
+            )
+        assert reasoning == {"enabled": True, "effort": "high"}
+
+    def test_fallback_uses_effective_model(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig()
+
+        with patch.object(
+            GatewayRunner,
+            "_load_reasoning_config",
+            return_value={"enabled": True, "effort": "xhigh"},
+        ) as load_reasoning:
+            reasoning = runner._resolve_session_reasoning_config(
+                session_key="agent:main:telegram:private:1",
+                model="openai/gpt-5",
+            )
+
+        assert reasoning == {"enabled": True, "effort": "xhigh"}
+        load_reasoning.assert_called_once_with("openai/gpt-5")
+
+    def test_session_reasoning_beats_channel_override(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "-100123:188": ChannelOverride(reasoning_effort="high"),
+                    },
+                ),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100123",
+            chat_type="forum",
+            thread_id="188",
+            user_id="u1",
+        )
+        session_key = runner._session_key_for_source(source)
+        runner._set_session_reasoning_override(
+            session_key,
+            {"enabled": True, "effort": "minimal"},
+        )
+        with patch.object(
+            GatewayRunner,
+            "_load_reasoning_config",
+            staticmethod(lambda _model="": {"enabled": True, "effort": "low"}),
+        ):
+            reasoning = runner._resolve_session_reasoning_config(source=source)
+        assert reasoning == {"enabled": True, "effort": "minimal"}
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -101,6 +101,7 @@ class TestPlatformConfigRoundtrip:
                     model="openrouter/healer-alpha",
                     provider="openrouter",
                     system_prompt="You are a daily news summarizer.",
+                    reasoning_effort="high",
                 ),
                 "9876543210": ChannelOverride(
                     model="anthropic/claude-opus-4.6",
@@ -112,9 +113,11 @@ class TestPlatformConfigRoundtrip:
         d = pc.to_dict()
         assert "channel_overrides" in d
         assert d["channel_overrides"]["1234567890"]["model"] == "openrouter/healer-alpha"
+        assert d["channel_overrides"]["1234567890"]["reasoning_effort"] == "high"
         assert d["channel_overrides"]["9876543210"]["system_prompt"] == "You are a coding assistant."
         restored = PlatformConfig.from_dict(d)
         assert restored.channel_overrides["1234567890"].model == "openrouter/healer-alpha"
+        assert restored.channel_overrides["1234567890"].reasoning_effort == "high"
         assert restored.channel_overrides["9876543210"].provider == "anthropic"
 
 

--- a/tests/gateway/test_scoped_reasoning_runtime.py
+++ b/tests/gateway/test_scoped_reasoning_runtime.py
@@ -1,0 +1,120 @@
+"""Regression coverage for scoped gateway reasoning across route changes."""
+
+from types import SimpleNamespace
+
+import hermes_constants
+
+from gateway.config import ChannelOverride, GatewayConfig, Platform, PlatformConfig
+from gateway.run import GatewayRunner
+from gateway.scoped_reasoning import ScopedReasoningConfig
+from gateway.session import SessionSource
+from gateway.session_state import SessionState
+
+
+def _runtime_resolve(agent, cfg, model):
+    """Mirror route-changing runtime helpers, which call the shared resolver."""
+    return hermes_constants.resolve_reasoning_config(cfg, model)
+
+
+def test_channel_reasoning_resolves_as_scoped_config():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                channel_overrides={
+                    "-100123:188": ChannelOverride(reasoning_effort="high"),
+                },
+            ),
+        },
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100123",
+        chat_type="forum",
+        thread_id="188",
+        user_id="u1",
+    )
+
+    resolved = runner._resolve_session_reasoning_config(source=source)
+
+    assert isinstance(resolved, ScopedReasoningConfig)
+    assert resolved == {"enabled": True, "effort": "high"}
+
+
+def test_session_reasoning_override_is_marked_scoped_at_storage_boundary():
+    state = SessionState()
+
+    state.conversation.reasoning_override = {
+        "enabled": True,
+        "effort": "minimal",
+    }
+
+    assert isinstance(state.conversation.reasoning_override, ScopedReasoningConfig)
+    assert state.conversation.reasoning_override == {
+        "enabled": True,
+        "effort": "minimal",
+    }
+
+
+def test_scoped_reasoning_survives_runtime_reresolution():
+    scoped = ScopedReasoningConfig({"enabled": True, "effort": "high"})
+    agent = SimpleNamespace(reasoning_config=scoped)
+    cfg = {
+        "agent": {
+            "reasoning_effort": "low",
+            "reasoning_overrides": {"fallback-model": "minimal"},
+        },
+    }
+
+    resolved = _runtime_resolve(agent, cfg, "fallback-model")
+
+    assert resolved is scoped
+    assert resolved == {"enabled": True, "effort": "high"}
+
+
+def test_unscoped_reasoning_still_reresolves_for_new_model():
+    agent = SimpleNamespace(
+        reasoning_config={"enabled": True, "effort": "high"},
+    )
+    cfg = {
+        "agent": {
+            "reasoning_effort": "low",
+            "reasoning_overrides": {"fallback-model": "minimal"},
+        },
+    }
+
+    resolved = _runtime_resolve(agent, cfg, "fallback-model")
+
+    assert type(resolved) is dict
+    assert resolved == {"enabled": True, "effort": "minimal"}
+
+
+def test_invalid_channel_reasoning_falls_back_without_scope_marker():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                channel_overrides={
+                    "-100123:188": ChannelOverride(reasoning_effort="bogus"),
+                },
+            ),
+        },
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100123",
+        chat_type="forum",
+        thread_id="188",
+        user_id="u1",
+    )
+    runner._load_reasoning_config = lambda _model="": {
+        "enabled": True,
+        "effort": "low",
+    }
+
+    resolved = runner._resolve_session_reasoning_config(source=source)
+
+    assert type(resolved) is dict
+    assert resolved == {"enabled": True, "effort": "low"}

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1711,9 +1711,10 @@ There is no `hermes config set` support for `reasoning_overrides` keys — edit 
 **Resolution priority:**
 
 1. Session-scoped `/reasoning --session` override (gateway only)
-2. Per-model override from `agent.reasoning_overrides` (spelling-tolerant)
-3. Global `agent.reasoning_effort`
-4. Provider default
+2. Matching gateway `channel_overrides.*.reasoning_effort` (gateway only; topic-specific entries beat their parent channel)
+3. Per-model override from `agent.reasoning_overrides` (spelling-tolerant)
+4. Global `agent.reasoning_effort`
+5. Provider default
 
 The override applies automatically everywhere: CLI startup, messaging gateway, Desktop/TUI, cron jobs, `/model` mid-session switches, and fallback model activation.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1450,9 +1450,10 @@ There is no `hermes config set` support for `reasoning_overrides` keys — edit 
 **Resolution priority:**
 
 1. Session-scoped `/reasoning --session` override (gateway only)
-2. Per-model override from `agent.reasoning_overrides` (spelling-tolerant)
-3. Global `agent.reasoning_effort`
-4. Provider default
+2. Matching gateway `channel_overrides.*.reasoning_effort` (gateway only; topic-specific entries beat their parent channel)
+3. Per-model override from `agent.reasoning_overrides` (spelling-tolerant)
+4. Global `agent.reasoning_effort`
+5. Provider default
 
 The override applies automatically everywhere: CLI startup, messaging gateway, Desktop/TUI, cron jobs, `/model` mid-session switches, and fallback model activation.
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -292,9 +292,9 @@ Configure per-platform overrides in `~/.hermes/gateway.json`:
 }
 ```
 
-## Per-Channel Model & System Prompt Overrides
+## Per-Channel Model, Reasoning & System Prompt Overrides
 
-Different channels can run different models and personas from a **single gateway** — e.g. a cheap fast model in `#daily` and a frontier model with a specialist prompt in `#dev`. Configure `channel_overrides` under the platform in `~/.hermes/gateway-config.yaml`:
+Different channels can run different models, reasoning levels, and personas from a **single gateway** — e.g. a cheap fast model in `#daily` and a frontier model with deeper reasoning plus a specialist prompt in `#dev`. Configure `channel_overrides` under the platform in `~/.hermes/gateway-config.yaml`:
 
 ```yaml
 platforms:
@@ -304,6 +304,7 @@ platforms:
       "123456789012345678":        # channel/thread id
         model: anthropic/claude-sonnet-4.6
         provider: anthropic
+        reasoning_effort: high
         system_prompt: "You are the #dev channel code-review specialist."
       "987654321098765432":
         model: openai/gpt-5-mini
@@ -311,9 +312,11 @@ platforms:
 
 Details:
 
-- All three keys are optional — set only `model`, only `system_prompt`, or any combination. Unset fields fall back to the global defaults.
-- Lookup order is exact channel/thread id first, then the **parent** channel/forum id — so Discord threads inherit their parent channel's override automatically.
+- All four keys are optional — set `model`, `provider`, `reasoning_effort`, `system_prompt`, or any combination. Unset fields fall back to the global defaults.
+- `reasoning_effort` accepts `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `ultra`. YAML `false` also disables reasoning for that channel/topic.
+- Lookup checks the composite `chat_id:thread_id` topic key first when both IDs are available, then the chat/channel id, thread id, and parent channel/forum id. This lets a Telegram forum topic beat its chat-level default while preserving parent inheritance.
 - Resolution priority for the model is: session `/model` override → `channel_overrides` → global config. A user running `/model` in a chat still wins over the channel default.
+- Resolution priority for reasoning is: session `/reasoning` override → `channel_overrides` → `agent.reasoning_overrides` for the effective model → global `agent.reasoning_effort` → provider/model default. A scoped session/channel value remains in force across same-turn model switches and provider fallback.
 - The `system_prompt` override replaces the global gateway prompt for that channel (it is ephemeral — injected per turn, not stored in history).
 
 ## Security

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -294,7 +294,7 @@ Configure per-platform overrides in `~/.hermes/gateway.json`:
 
 ## Per-Channel Model, Reasoning & System Prompt Overrides
 
-Different channels can run different models, reasoning levels, and personas from a **single gateway** — e.g. a cheap fast model in `#daily` and a frontier model with deeper reasoning plus a specialist prompt in `#dev`. Configure `channel_overrides` under the platform in `~/.hermes/gateway-config.yaml`:
+Different channels can run different models and personas from a **single gateway** — e.g. a cheap fast model in `#daily` and a frontier model with a specialist prompt in `#dev`. Configure `channel_overrides` under the platform in `~/.hermes/config.yaml`:
 
 ```yaml
 platforms:


### PR DESCRIPTION
## Summary

This extends the merged `channel_overrides` gateway config so Telegram forum topics can be targeted with a stable `chat_id:thread_id` key and can set a per-channel `reasoning_effort` default.

For model/provider routing, the existing precedence remains session override → channel/topic override → global gateway config.

For reasoning effort, the explicit precedence is:

1. session-scoped `/reasoning` override
2. `platforms.<platform>.channel_overrides[...]`
3. `agent.reasoning_overrides` for the effective model
4. global `agent.reasoning_effort` and provider/model defaults

## Changes

- Add `reasoning_effort` to `ChannelOverride` serialization/deserialization.
- Look up `channel_overrides` by composite `chat_id:thread_id` before the existing chat/thread/parent fallbacks, so a Telegram topic override can beat a chat-level default.
- Resolve channel-level `reasoning_effort` before per-model and global defaults, while keeping explicit session `/reasoning` overrides highest priority.
- Preserve a valid session/channel-scoped reasoning value through same-turn provider fallback and model switching instead of letting the fallback model's per-model/global reasoning setting overwrite it.
- Keep unscoped fallback/model-switch behavior unchanged: reasoning is still re-resolved for the effective model.
- Add regression coverage for topic lookup, reasoning precedence, scoped route-change preservation, invalid-value fallback, and unscoped re-resolution.
- Document `reasoning_effort`, accepted/disable values, topic lookup, and resolved priority in both the general configuration guide and the messaging/channel-overrides guide.

Closes #67031.

## Related PR check

- #56967 already merged the base `channel_overrides` surface for model/provider/system_prompt.
- #24180 and #5377 are open model/provider PRs for Telegram topics, but use different config surfaces and do not add `channel_overrides.reasoning_effort` on current `main`.
- #33329 and #54680 cover broader channel model binding surfaces, not this incremental `channel_overrides` reasoning follow-up.
- #27504 persists session `/model` and `/reasoning` overrides; it does not add config-driven channel reasoning defaults.
- #65576 identified the same fallback/model-switch preservation requirement for scoped reasoning; this PR carries that behavior generically for `channel_overrides`.

## Validation

Latest head: `349e43eb1a058c5ce7f3df1983bbe1b329aede29`

GitHub Actions on the latest head:

- CI: passed
- Nix flake check: passed
- Docker Build, Test, and Publish: passed
- Python test slices: passed
- Ruff enforcement and Ruff + ty diff: passed
- E2E: passed
- Windows-only and macOS-only tests: passed
- Docs/Docusaurus build: passed
- OSV and supply-chain scans: passed
