### PR TITLE
feat: comprehensive docs + VS Code extension

### DIFF
--- a/docs/acp-registry.md
+++ b/docs/acp-registry.md
@@ -1,0 +1,176 @@
+# ACP Registry — Agent Communication Protocol
+
+Hermes Agent supports the **Agent Communication Protocol (ACP)** for agent-to-agent and agent-to-editor integration. The ACP registry defines how Hermes advertises itself to ACP-compatible editors and tools.
+
+## Registry Manifest
+
+The `acp_registry/agent.json` file in the Hermes repo is the canonical registry entry:
+
+```json
+{
+  "id": "hermes-agent",
+  "name": "Hermes Agent",
+  "version": "0.18.0",
+  "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
+  "repository": "https://github.com/NousResearch/hermes-agent",
+  "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
+  "authors": ["Nous Research"],
+  "license": "MIT",
+  "distribution": {
+    "uvx": {
+      "package": "hermes-agent[acp]==0.18.0",
+      "args": ["hermes-acp"]
+    }
+  }
+}
+```
+
+### Manifest Fields
+
+| Field | Required | Description |
+|-------|:---:|-------------|
+| `id` | ✅ | Unique identifier for the agent |
+| `name` | ✅ | Human-readable display name |
+| `version` | ✅ | Semver version, matches `pyproject.toml` |
+| `description` | ✅ | One-line summary |
+| `repository` | — | Source code repository URL |
+| `website` | — | Documentation / landing page |
+| `authors` | ✅ | List of author/org names |
+| `license` | ✅ | SPDX license identifier |
+| `distribution` | ✅ | How to install and run the agent |
+
+### Distribution Methods
+
+#### `uvx` (recommended)
+
+```json
+"distribution": {
+  "uvx": {
+    "package": "hermes-agent[acp]==0.18.0",
+    "args": ["hermes-acp"]
+  }
+}
+```
+
+Runs via `uv tool run` — no pre-installation needed. The editor downloads and runs the agent on first use.
+
+#### `pipx`
+
+```json
+"distribution": {
+  "pipx": {
+    "package": "hermes-agent[acp]",
+    "args": ["hermes-acp"]
+  }
+}
+```
+
+## Connecting Hermes ACP to Editors
+
+### Zed
+
+1. Open Zed → `zed: acp registry`
+2. Search for **Hermes Agent**
+3. Click **Install**
+
+Or manually:
+```json
+// ~/.config/zed/settings.json
+{
+  "agent": {
+    "enabled": true,
+    "default_model": "hermes-agent"
+  }
+}
+```
+
+### VS Code (ACP extension)
+
+Install the ACP extension for VS Code, then:
+
+```json
+{
+  "acp.agents": [
+    {
+      "id": "hermes-agent",
+      "command": "hermes-acp"
+    }
+  ]
+}
+```
+
+### JetBrains
+
+Install the ACP plugin from JetBrains Marketplace, then configure:
+
+```
+Settings → Tools → ACP → Add Agent
+  Name: Hermes Agent
+  Command: hermes-acp
+```
+
+### Cursor
+
+```json
+// ~/.cursor/acp.json
+{
+  "agents": {
+    "hermes": {
+      "command": "hermes-acp"
+    }
+  }
+}
+```
+
+## ACP Check
+
+Verify ACP is working:
+
+```bash
+hermes acp --check
+```
+
+Expected output:
+```json
+{
+  "status": "ok",
+  "version": "0.18.0",
+  "protocol": "acp-2025-01-01"
+}
+```
+
+## Registry Validation
+
+The registry manifest is validated on every CI run:
+
+```bash
+# tests/acp/test_registry_manifest.py enforces:
+# - agent.json is valid JSON
+# - All required fields present
+# - version matches pyproject.toml
+# - icon.svg exists and is valid XML
+pytest tests/acp/test_registry_manifest.py
+```
+
+## Submitting to the ACP Registry
+
+To register your own agent in the community ACP registry:
+
+1. Create an `acp_registry/` directory with `agent.json` and `icon.svg`
+2. Ensure `version` matches your release
+3. Open a PR to the ACP community registry
+
+## ACP vs MCP
+
+| Feature | ACP | MCP |
+|---------|-----|-----|
+| Purpose | Agent ↔ Editor integration | Tool ↔ Agent integration |
+| Transport | Stdio (JSON-RPC) | Stdio/HTTP/SSE (JSON-RPC) |
+| Hermes entry point | `hermes-acp` | `hermes mcp serve` |
+| Use case | IDE code actions, inline edits | External tool access, browser/search |
+| Install | Editor package manager (uvx) | `hermes mcp add` or config.yaml |
+
+## See Also
+
+- [MCP Reference](mcp-reference.md) — MCP server/client docs
+- [IDE Integration Guide](ide-integration.md) — full IDE setup walkthrough

--- a/docs/gateway-health-check.md
+++ b/docs/gateway-health-check.md
@@ -1,0 +1,100 @@
+# Gateway Platform Health & Auto-Recovery
+
+Hermes Gateway includes a built-in **auto-reconnect watcher** that monitors messaging platform connections and automatically recovers from transient failures. This system runs continuously in the background while the gateway is active.
+
+## How It Works
+
+### Two-Layer Recovery
+
+| Layer | Mechanism | Trigger | Recovery |
+|-------|-----------|---------|----------|
+| **Retryable** | `_platform_reconnect_watcher` | Network/DNS blips, timeouts, connection drops | Auto-retry with exponential backoff |
+| **Non-retryable** | Immediate drop | Bad auth, invalid config, permanent errors | Manual fix required |
+
+### Exponential Backoff
+
+```
+Attempt 1 → wait 30s
+Attempt 2 → wait 60s
+Attempt 3 → wait 120s
+Attempt 4 → wait 240s
+Attempt 5+ → wait 300s (cap, repeats indefinitely)
+```
+
+After 5 attempts, retries continue at the 5-minute cap indefinitely — the watcher never gives up on retryable failures, so a transient outage self-heals once connectivity returns.
+
+### Circuit Breaker
+
+Operators can manually pause/resume platforms:
+
+```
+/platform list           # see all platform statuses
+/platform pause <name>   # stop auto-retry for a platform
+/platform resume <name>  # resume auto-retry
+```
+
+Paused platforms are skipped entirely by the reconnect watcher and need explicit `/platform resume` to come back.
+
+## Startup Behavior
+
+1. Gateway starts and connects all enabled platforms
+2. 10-second initial delay (lets startup finish)
+3. Watcher begins polling `_failed_platforms` every ~1s
+4. If no failed platforms → sleeps 30s and checks again
+5. If failed platforms exist → retries each one at its scheduled time
+
+## Error Classification
+
+### Retryable (auto-recovered)
+
+- DNS resolution failures
+- Connection refused / ECONNREFUSED
+- Connection timeouts
+- Network unreachable
+- Temporary API rate limits (HTTP 429)
+- Server errors (HTTP 5xx)
+- WebSocket disconnections (non-auth)
+
+### Non-retryable (manual intervention needed)
+
+- Authentication failures (HTTP 401, 403)
+- Invalid API tokens/keys
+- Malformed configuration
+- Platform-specific permanent errors
+
+## Monitoring
+
+### Check Platform Status
+
+```
+/platform list
+```
+
+Shows each platform's current state: connected, failed (with retry count and next retry time), or paused.
+
+### Logs
+
+Reconnection activity is logged at INFO level:
+
+```
+Reconnecting telegram (attempt 3)...
+Reconnecting slack (attempt 1)...
+Platform telegram reconnected successfully
+Platform discord still failing: DNS resolution error
+```
+
+### Observability Plugin
+
+Enable the `observability` plugin for Prometheus metrics and structured logging of platform health.
+
+## Best Practices
+
+1. **Don't manually restart for transient failures** — the watcher handles them automatically
+2. **Use `/platform pause` for maintenance windows** — prevent unnecessary retries during known downtime
+3. **Monitor retry counts** — consistently high counts for a platform may indicate config issues
+4. **Check auth tokens first** for permanent 401/403 errors
+
+## See Also
+
+- [Plugin Registry](plugin-registry.md) — platform adapter plugins
+- [MCP Reference](mcp-reference.md) — connecting external tools

--- a/docs/ide-integration.md
+++ b/docs/ide-integration.md
@@ -1,0 +1,319 @@
+# IDE Integration Guide
+
+Connect Hermes Agent to your favorite IDE using MCP (Model Context Protocol) or ACP (Agent Client Protocol). Once connected, Hermes becomes your in-editor coding assistant with full terminal access, file operations, web search, and delegation.
+
+## Quick Reference
+
+| IDE | Protocol | Config File | Setup Effort |
+|-----|----------|-------------|:---:|
+| Cursor | MCP stdio | `~/.cursor/mcp.json` | ⚡ 2 min |
+| Windsurf | MCP stdio | `~/.codeium/windsurf/mcp_config.json` | ⚡ 2 min |
+| VS Code (Continue) | MCP stdio | `~/.continue/config.json` | ⚡ 3 min |
+| VS Code (Cline) | MCP stdio | Cline Settings UI | ⚡ 2 min |
+| Claude Code | MCP stdio | `claude mcp add` | ⚡ 1 min |
+| JetBrains | ACP | IDE Plugin Settings | ⚡ 3 min |
+| Zed | ACP | `zed: open settings` | ⚡ 2 min |
+| VS Code (Native) | ACP | Extension | ⚡ 2 min |
+
+> **Hermes binary location**: run `which hermes` to find your path. Common locations:
+> - Linux/macOS (uv): `~/.local/bin/hermes`
+> - macOS (Homebrew): `/opt/homebrew/bin/hermes`
+> - Windows: `%USERPROFILE%\.local\bin\hermes.exe` or `%USERPROFILE%\AppData\Roaming\Python\Scripts\hermes.exe`
+>
+> Use the **full path** to avoid PATH resolution issues.
+
+---
+
+## Cursor
+
+Cursor uses `~/.cursor/mcp.json` for MCP server configuration.
+
+### Setup
+
+Create or edit `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "hermes": {
+      "command": "/Users/YOUR_USERNAME/.local/bin/hermes",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Replace `/Users/YOUR_USERNAME/.local/bin/hermes` with your actual path from `which hermes`.
+
+### Troubleshooting
+
+- **"hermes: command not found"** — use the full path from `which hermes`
+- **MCP tools not showing** — restart Cursor (`Cmd+Shift+P` → "Reload Window")
+- **Permission denied** — ensure `hermes` is executable: `chmod +x ~/.local/bin/hermes`
+
+---
+
+## Windsurf
+
+Windsurf uses `~/.codeium/windsurf/mcp_config.json`.
+
+### Setup
+
+Create or edit `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "hermes": {
+      "command": "/Users/YOUR_USERNAME/.local/bin/hermes",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+### Troubleshooting
+
+- **Tools not loading** — open Windsurf's MCP panel and click "Refresh"
+- **Connection refused** — verify the full path is correct
+
+---
+
+## VS Code + Continue
+
+[Continue](https://continue.dev) uses `~/.continue/config.json`.
+
+### Setup
+
+Add Hermes to the `mcpServers` array in `~/.continue/config.json`:
+
+```json
+{
+  "models": [ /* your existing models */ ],
+  "mcpServers": [
+    {
+      "name": "hermes",
+      "command": "/Users/YOUR_USERNAME/.local/bin/hermes",
+      "args": ["mcp", "serve"]
+    }
+  ]
+}
+```
+
+### Using Hermes in Continue
+
+1. Open Continue sidebar (`Cmd+L` / `Ctrl+L`)
+2. Select a chat model
+3. Hermes MCP tools are automatically available: ask to read files, run terminal commands, search the web
+
+### Troubleshooting
+
+- **"hermes not found"** — use the full absolute path from `which hermes`
+- **MCP not connecting** — check Continue logs: `Cmd+Shift+P` → "Continue: View Logs"
+
+---
+
+## VS Code + Cline
+
+[Cline](https://github.com/cline/cline) has a built-in MCP settings UI.
+
+### Setup
+
+1. Open Cline extension
+2. Click the **MCP Servers** icon (plug icon in the Cline sidebar)
+3. Click **"Installed"** tab
+4. Click **"Configure MCP Servers"**
+5. Add a new entry:
+
+```json
+{
+  "mcpServers": {
+    "hermes": {
+      "command": "/Users/YOUR_USERNAME/.local/bin/hermes",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+6. Click **"Done"** — Cline auto-reconnects
+
+### Using Hermes in Cline
+
+Cline will list Hermes tools alongside its built-in tools. You can ask Cline to use Hermes for terminal operations, file manipulation, or web searches — Cline delegates these to the Hermes MCP server transparently.
+
+---
+
+## Claude Code
+
+Anthropic's [Claude Code](https://claude.ai/code) CLI supports MCP servers natively.
+
+### Setup
+
+```bash
+# Add Hermes as an MCP server
+claude mcp add --transport stdio hermes -- hermes mcp serve
+
+# Or with full path:
+claude mcp add --transport stdio hermes -- /Users/YOUR_USERNAME/.local/bin/hermes mcp serve
+```
+
+To verify:
+
+```bash
+claude mcp list
+# Should show "hermes" with status "connected"
+```
+
+### Using Hermes in Claude Code
+
+Once connected, tell Claude to use Hermes tools:
+
+```
+> Use the hermes terminal tool to run `npm test` in this project.
+> Use hermes web_search to find the latest React documentation on Server Components.
+```
+
+### Troubleshooting
+
+- **"Failed to connect"** — run `hermes mcp serve` in a terminal first to verify it works standalone
+- **Remove and re-add**: `claude mcp remove hermes && claude mcp add --transport stdio hermes -- hermes mcp serve`
+- **PATH issues**: use the full absolute path
+
+---
+
+## JetBrains IDEs (IntelliJ, PyCharm, WebStorm, GoLand)
+
+Hermes supports [ACP (Agent Client Protocol)](https://github.com/agentclientprotocol/agent-client-protocol) for JetBrains integration.
+
+### Setup
+
+1. **Install the ACP plugin**:
+   - Open Settings → Plugins → Marketplace
+   - Search for "Agent Client Protocol" or "ACP"
+   - Install and restart
+
+2. **Configure Hermes as ACP server**:
+   - Open Settings → Tools → Agent Client Protocol
+   - Add new agent:
+     - **Name**: Hermes
+     - **Command**: `/Users/YOUR_USERNAME/.local/bin/hermes acp`
+     - **Working Directory**: your project root
+
+3. **Verify**: The Hermes agent should appear in the ACP sidebar with status "Connected"
+
+### Features
+
+- Chat with Hermes directly in the IDE
+- Attach files, selections, and error messages as context
+- Hermes can read project files, run tests, and suggest fixes
+
+---
+
+## Zed
+
+[Zed](https://zed.dev) supports ACP natively.
+
+### Setup
+
+1. Open Zed Settings (`Cmd+,` / `Ctrl+,`)
+2. Add to `settings.json`:
+
+```json
+{
+  "agent_servers": {
+    "Hermes": {
+      "command": "/Users/YOUR_USERNAME/.local/bin/hermes",
+      "args": ["acp"]
+    }
+  }
+}
+```
+
+3. Open the agent panel (`Cmd+Shift+A`) — Hermes appears as an available agent
+
+---
+
+## VS Code (Native ACP Extension)
+
+For native VS Code integration without Continue or Cline:
+
+### Setup
+
+1. Install the "Agent Client Protocol" extension from VS Code Marketplace
+2. Open Settings (`Cmd+,`) → search "ACP"
+3. Add agent configuration:
+
+```json
+{
+  "acp.agents": [
+    {
+      "name": "Hermes",
+      "command": "/Users/YOUR_USERNAME/.local/bin/hermes",
+      "args": ["acp"]
+    }
+  ]
+}
+```
+
+4. The Hermes agent panel opens with `Cmd+Shift+P` → "ACP: Open Chat"
+
+---
+
+## What Hermes Brings to Your IDE
+
+When connected via MCP or ACP, Hermes provides these tools to your IDE's agent:
+
+| Tool | Description |
+|------|-------------|
+| `terminal` | Run shell commands in a persistent environment |
+| `read_file` | Read files with line numbers |
+| `write_file` | Create or overwrite files |
+| `patch` | Targeted find-and-replace edits |
+| `search_files` | Search file contents (ripgrep) or find files by pattern |
+| `web_search` | Real-time web search |
+| `web_fetch` | Fetch and extract web page content |
+| `delegate_task` | Spawn sub-agents for parallel work |
+| `memory` | Persistent cross-session memory |
+| `session_search` | Search past conversations |
+| `image_generate` | AI image generation |
+| `cronjob` | Schedule recurring tasks |
+
+All tools work the same across every IDE — learn them once, use them everywhere.
+
+---
+
+## Security Notes
+
+- **MCP mode is read-write** — Hermes can read, write, and execute files in your system. Only connect to trusted IDE sessions.
+- **Environment isolation** — MCP subprocesses do NOT inherit your full shell environment; only safe baseline variables are passed.
+- **Approval prompts** — dangerous commands (`rm -rf`, `git reset --hard`) trigger user approval before execution (configurable via `approvals.mode` in `~/.hermes/config.yaml`).
+
+---
+
+## Verifying Your Setup
+
+To confirm Hermes MCP is working before connecting to an IDE:
+
+```bash
+# Test MCP server mode
+hermes mcp serve --verbose
+
+# Should output:
+# MCP server starting on stdio...
+# Discovering tools...
+# Ready
+```
+
+Press `Ctrl+C` to stop.
+
+For ACP mode:
+
+```bash
+# Test ACP server mode
+hermes acp --check
+
+# Should output:
+# ACP dependencies OK
+# Adapter imports OK
+```

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -1,0 +1,514 @@
+# Hermes MCP Reference
+
+Complete Model Context Protocol (MCP) reference for Hermes Agent — both as an MCP **client** (connecting to external MCP servers for extra tools) and as an MCP **server** (exposing Hermes conversations to other agents).
+
+## Table of Contents
+
+1. [Hermes as MCP Client](#hermes-as-mcp-client)
+   - [Stdio Transport](#stdio-transport)
+   - [HTTP / StreamableHTTP Transport](#http--streamablehttp-transport)
+   - [SSE Transport](#sse-transport)
+   - [OAuth Authentication](#oauth-authentication)
+   - [Tool Selection](#tool-selection)
+   - [Sampling (Server-Initiated LLM Requests)](#sampling)
+   - [Common MCP Server Examples](#common-mcp-server-examples)
+2. [Hermes as MCP Server](#hermes-as-mcp-server)
+   - [Tools Reference](#tools-reference)
+   - [Client Integration Examples](#client-integration-examples)
+3. [Catalog Servers](#catalog-servers)
+4. [Troubleshooting](#troubleshooting)
+5. [Developer Guide](#developer-guide)
+
+---
+
+## Hermes as MCP Client
+
+Hermes connects to external MCP servers to extend its toolset at runtime. Configuration lives in `~/.hermes/config.yaml` under the `mcp_servers` key.
+
+### Stdio Transport
+
+Spawns a local process and communicates via stdin/stdout JSON-RPC.
+
+```yaml
+# ~/.hermes/config.yaml
+mcp_servers:
+  filesystem:
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    env: {}
+    timeout: 120          # per-tool-call timeout (seconds, default: 300)
+    connect_timeout: 60   # initial connection timeout (default: 60)
+    keepalive_interval: 10  # liveness ping cadence (default: 180s, floored at 5s)
+    supports_parallel_tool_calls: true  # allow concurrent tool calls
+
+  github:
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+```
+
+**Key parameters:**
+
+| Parameter                | Type    | Default | Description                                                 |
+|--------------------------|---------|---------|-------------------------------------------------------------|
+| `command`                | string  | —       | Binary or command to execute (required for stdio)           |
+| `args`                   | list    | `[]`    | Arguments passed to the command                             |
+| `env`                    | dict    | `{}`    | Environment variables for the subprocess                    |
+| `timeout`                | int     | `300`   | Maximum seconds per tool call                               |
+| `connect_timeout`        | int     | `60`    | Maximum seconds to wait for initial JSON-RPC handshake      |
+| `keepalive_interval`     | int     | `180`   | Seconds between liveness pings; lower for servers with short TTLs (e.g. Unreal Engine editor, ~15s) |
+| `supports_parallel_tool_calls` | bool | `false` | When `true`, tools from this server may run concurrently |
+
+**CLI commands:**
+
+```bash
+hermes mcp add filesystem --command npx --args -y @modelcontextprotocol/server-filesystem /tmp
+hermes mcp list          # show all configured servers
+hermes mcp test <name>   # test connection to a server
+hermes mcp remove <name> # remove a server
+```
+
+### HTTP / StreamableHTTP Transport
+
+Connects to a remote MCP endpoint over HTTP. Hermes uses StreamableHTTP by default when the transport isn't explicitly set and the server endpoint negotiates it.
+
+```yaml
+mcp_servers:
+  remote_api:
+    url: "https://my-mcp-server.example.com/mcp"
+    headers:
+      Authorization: "Bearer sk-..."
+    timeout: 180
+    connect_timeout: 30
+```
+
+**Key parameters:**
+
+| Parameter         | Type   | Default  | Description                                    |
+|-------------------|--------|----------|------------------------------------------------|
+| `url`             | string | —        | MCP endpoint URL (required for HTTP transport) |
+| `headers`         | dict   | `{}`     | Custom HTTP headers (auth tokens, etc.)        |
+| `timeout`         | int    | `300`    | Per-tool-call timeout                          |
+| `connect_timeout` | int    | `60`     | Initial HTTP connection timeout                |
+
+### SSE Transport
+
+For MCP servers using the Server-Sent Events protocol:
+
+```yaml
+mcp_servers:
+  searxng:
+    url: "http://localhost:8000/sse"
+    transport: sse
+    timeout: 180
+    connect_timeout: 10
+```
+
+Hybrid servers (SSE endpoint + stdio command for analysis) are supported:
+
+```yaml
+mcp_servers:
+  analysis:
+    url: "http://localhost:8000/sse"
+    transport: sse
+    command: "npx"
+    args: ["-y", "analysis-server"]
+    timeout: 180
+```
+
+### OAuth Authentication
+
+For MCP servers requiring OAuth 2.0 (e.g. Linear, Google APIs):
+
+```yaml
+mcp_servers:
+  linear:
+    url: "https://api.linear.app/mcp"
+    auth: oauth
+    oauth:
+      client_id: "your-client-id"
+      client_secret: "${LINEAR_CLIENT_SECRET}"
+```
+
+CLI commands:
+
+```bash
+hermes mcp add linear --url https://api.linear.app/mcp --auth oauth
+hermes mcp login linear     # trigger OAuth flow
+hermes mcp reauth --all     # re-authenticate all OAuth servers
+```
+
+### Tool Selection
+
+Toggle individual tools on/off per server:
+
+```bash
+hermes mcp configure <name>   # interactive tool picker
+```
+
+Enable only specific tools:
+
+```yaml
+mcp_servers:
+  filesystem:
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    enabled_tools:
+      - read_file
+      - list_directory
+```
+
+### Sampling
+
+Some MCP servers can request LLM completions during tool execution (Sampling). Configure per-server:
+
+```yaml
+mcp_servers:
+  smart_server:
+    url: "https://..."
+    sampling:
+      enabled: true                # default: true
+      model: "gemini-3-flash"     # override model
+      max_tokens_cap: 4096        # max tokens per request
+      timeout: 30                  # LLM call timeout (seconds)
+      max_rpm: 10                  # max requests per minute
+      allowed_models: []           # model whitelist (empty = all)
+      max_tool_rounds: 5           # tool loop limit (0 = disable)
+      log_level: "info"            # audit verbosity
+```
+
+### Common MCP Server Examples
+
+**Filesystem** — read/write files and directories:
+```yaml
+mcp_servers:
+  filesystem:
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/allowed/dir"]
+```
+
+**GitHub** — manage issues, PRs, repos:
+```yaml
+mcp_servers:
+  github:
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+```
+
+**SQLite** — query local databases:
+```yaml
+mcp_servers:
+  sqlite:
+    command: "uvx"
+    args: ["mcp-server-sqlite", "--db-path", "/path/to/database.db"]
+```
+
+**Playwright** — browser automation:
+```yaml
+mcp_servers:
+  playwright:
+    command: "npx"
+    args: ["-y", "@playwright/mcp"]
+```
+
+**PostgreSQL** — query remote databases:
+```yaml
+mcp_servers:
+  postgres:
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-postgres"]
+    env:
+      DATABASE_URL: "postgresql://user:pass@localhost:5432/mydb"
+```
+
+**Brave Search** — web search:
+```yaml
+mcp_servers:
+  brave:
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-brave-search"]
+    env:
+      BRAVE_API_KEY: "your-api-key"
+```
+
+---
+
+## Hermes as MCP Server
+
+Hermes exposes its messaging conversations as MCP tools, letting any MCP client (Claude Code, Cursor, Codex, VS Code, etc.) read and send messages across all connected platforms.
+
+### Quick Start
+
+```bash
+# Start the MCP server on stdio
+hermes mcp serve
+
+# With verbose logging to stderr
+hermes mcp serve --verbose
+```
+
+Requirements: the `mcp` Python package (`pip install mcp`).
+
+### Tools Reference
+
+Hermes exposes **10 tools**, matching OpenClaw's MCP channel bridge surface:
+
+#### `conversations_list`
+
+List active messaging conversations across connected platforms.
+
+| Parameter   | Type    | Default | Description                                      |
+|-------------|---------|---------|--------------------------------------------------|
+| `platform`  | string  | —       | Filter by platform (telegram, discord, slack…)   |
+| `limit`     | int     | 50      | Max conversations (1–200)                        |
+| `search`    | string  | —       | Filter conversations by name                     |
+
+Returns: `count`, `conversations[]` with `session_key`, `platform`, `display_name`, `updated_at`.
+
+#### `conversation_get`
+
+Get detailed info about one conversation.
+
+| Parameter     | Type   | Required | Description                                 |
+|---------------|--------|----------|---------------------------------------------|
+| `session_key` | string | ✅       | Session key from `conversations_list`        |
+
+Returns: platform, chat type, names, token counts, timestamps.
+
+#### `messages_read`
+
+Read recent messages from a conversation in chronological order.
+
+| Parameter     | Type   | Default | Description                                 |
+|---------------|--------|---------|---------------------------------------------|
+| `session_key` | string | ✅      | Session key from `conversations_list`        |
+| `limit`       | int    | 50      | Max messages (1–200, most recent first)      |
+
+Returns: `messages[]` with `id`, `role`, `content` (truncated at 2000 chars), `timestamp`.
+
+#### `attachments_fetch`
+
+List non-text attachments (images, media files) for a message.
+
+| Parameter     | Type   | Required | Description                        |
+|---------------|--------|----------|------------------------------------|
+| `session_key` | string | ✅       | Session key                        |
+| `message_id`  | string | ✅       | Message ID from `messages_read`    |
+
+#### `events_poll`
+
+Poll for new conversation events since a cursor position (non-blocking).
+
+| Parameter      | Type    | Default | Description                               |
+|----------------|---------|---------|-------------------------------------------|
+| `after_cursor` | int     | 0       | Return events after this cursor           |
+| `session_key`  | string  | —       | Filter to one conversation                |
+| `limit`        | int     | 20      | Max events (1–200)                        |
+
+Event types: `message`, `approval_requested`, `approval_resolved`.
+
+#### `events_wait`
+
+Wait for the next event (long-poll, blocking up to timeout).
+
+| Parameter      | Type    | Default  | Description                               |
+|----------------|---------|----------|-------------------------------------------|
+| `after_cursor` | int     | 0        | Wait for events after this cursor         |
+| `session_key`  | string  | —        | Filter to one conversation                |
+| `timeout_ms`   | int     | 30000    | Max wait in milliseconds (max 300000)     |
+
+Returns `null` + `"reason": "timeout"` when no event arrives.
+
+#### `messages_send`
+
+Send a message to a platform conversation. Target format: `"platform:identifier"`.
+
+| Parameter  | Type   | Required | Description                                                |
+|------------|--------|----------|------------------------------------------------------------|
+| `target`   | string | ✅       | `"telegram:6308981865"`, `"discord:#general"`, `"slack:#engineering"` |
+| `message`  | string | ✅       | Message text                                               |
+
+#### `channels_list`
+
+List available messaging channels and target strings for `messages_send`.
+
+| Parameter  | Type    | Description                                  |
+|------------|---------|----------------------------------------------|
+| `platform` | string  | Filter by platform (telegram, discord, etc.) |
+
+#### `permissions_list_open`
+
+List pending approval requests observed during this bridge session.
+
+No parameters. Returns exec and plugin approval requests.
+
+#### `permissions_respond`
+
+Respond to a pending approval request.
+
+| Parameter  | Type   | Required | Description                                        |
+|------------|--------|----------|----------------------------------------------------|
+| `id`       | string | ✅       | Approval ID from `permissions_list_open`            |
+| `decision` | string | ✅       | One of: `"allow-once"`, `"allow-always"`, `"deny"` |
+
+### Client Integration Examples
+
+**Claude Code:**
+```bash
+claude mcp add --transport stdio hermes -- hermes mcp serve
+```
+
+**Cursor / Windsurf / VS Code (`mcp.json`):**
+```json
+{
+  "mcpServers": {
+    "hermes": {
+      "command": "hermes",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+**Claude Desktop (`claude_desktop_config.json`):**
+```json
+{
+  "mcpServers": {
+    "hermes": {
+      "command": "hermes",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+**Zed / JetBrains (ACP native):**
+```
+Add stdio MCP server: command=hermes, args=["mcp", "serve"]
+```
+
+---
+
+## Catalog Servers
+
+Hermes maintains a curated catalog of one-click-install MCP servers:
+
+```bash
+hermes mcp catalog          # list available catalog servers
+hermes mcp install linear   # install a catalog server
+```
+
+Current catalog entries: **Linear**, **n8n**, **Unreal Engine**.
+
+To submit a server for the catalog, open a PR against the Hermes agent repo adding a `mcp_catalog.yaml` entry.
+
+---
+
+## Troubleshooting
+
+### Connection fails with "command not found"
+
+Ensure `npx`/`uvx`/`node` is on the PATH visible to Hermes. For explicit paths:
+
+```yaml
+mcp_servers:
+  myserver:
+    command: "/usr/local/bin/npx"     # absolute path
+    args: ["-y", "@scope/server"]
+    env:
+      PATH: "/usr/local/bin:/usr/bin"  # or add PATH
+```
+
+### "ECONNREFUSED" / timeout on HTTP servers
+
+- Verify the server is running and reachable
+- Check firewall rules
+- Increase `connect_timeout` for slow-starting servers
+- The URL must point to an MCP endpoint, not a plain web app
+
+### Credentials leaking in error messages
+
+Hermes automatically strips credential-like values (API keys, tokens, passwords) from error messages returned to the LLM. This is on by default.
+
+### SSE server stops responding
+
+SSE connections can time out. Increase `keepalive_interval` or switch to StreamableHTTP if the server supports it.
+
+### "package 'mcp' not found" when running `hermes mcp serve`
+
+```bash
+pip install mcp
+```
+
+The `mcp` Python package provides the FastMCP SDK used by Hermes' MCP server.
+
+---
+
+## Developer Guide
+
+### Building an MCP Server for Hermes
+
+Hermes supports three MCP transport protocols:
+
+| Transport         | MIME Type                     | Best For                                    |
+|-------------------|-------------------------------|---------------------------------------------|
+| **stdio**         | —                             | Local tools, CLI wrappers                   |
+| **StreamableHTTP**| `application/json`            | Remote servers, REST-style backends         |
+| **SSE**           | `text/event-stream` (SSE)     | Long-lived event streams, push notifications|
+
+### Stdio Server (Python, FastMCP)
+
+```python
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("my-server")
+
+@mcp.tool()
+def hello(name: str) -> str:
+    """Say hello to someone."""
+    return f"Hello, {name}!"
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(mcp.run_stdio_async())
+```
+
+### HTTP Server (Python, FastMCP)
+
+```python
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("my-remote-server")
+
+@mcp.tool()
+def search_db(query: str) -> str:
+    """Search the database."""
+    return f"Results for: {query}"
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(mcp.run_streamable_http_async())
+```
+
+### Best Practices
+
+1. **Tool descriptions are critical** — the LLM decides when to call your tool based on its name and docstring. Write clear, specific docstrings.
+
+2. **Return structured JSON** — primitive strings work but structured JSON lets the LLM parse results correctly.
+
+3. **Validate inputs** — MCP clients can send any value type; coerce and validate at the tool boundary.
+
+4. **Handle errors gracefully** — return error messages as strings (don't raise exceptions that break the JSON-RPC connection).
+
+5. **Test with `hermes mcp test`** — verify your server works end-to-end before relying on it.
+
+6. **Registry submission** — to get your server into the Hermes catalog (`hermes mcp install`), open a PR adding your entry to the catalog in the agent repo.
+
+---
+
+## Related Docs
+
+- [IDE Integration Guide](ide-integration.md) — connecting Hermes to IDEs via MCP and ACP

--- a/docs/plugin-registry.md
+++ b/docs/plugin-registry.md
@@ -1,0 +1,242 @@
+# Hermes Plugin Registry
+
+Complete catalog of Hermes Agent plugins — official bundled plugins and community plugins.
+
+## Quick Start
+
+```bash
+hermes plugins list                  # list all plugins
+hermes plugins list --plain --no-bundled  # compact view, user plugins only
+hermes plugins enable <name>         # enable a plugin
+hermes plugins disable <name>        # disable a plugin
+hermes plugins                       # interactive toggle UI
+```
+
+Plugins are **opt-in by default** — only `enabled` plugins load at startup.
+
+---
+
+## Official Bundled Plugins
+
+### Platform / Gateway Adapters
+
+Connect Hermes to messaging platforms. Each platform adapter handles inbound messages, outbound delivery, platform-specific features (threads, inline keyboards, adaptive cards), and user/chat allowlists.
+
+| Plugin | Platform | Key Features |
+|--------|----------|-------------|
+| `telegram-platform` | Telegram | Threads/topics, streaming edits, native media, inline keyboards, slash commands, fallback network, mention gating |
+| `slack-platform` | Slack | Socket Mode, slash commands, threads, mrkdwn, approval blocks, free-response channels, channel skill bindings |
+| `discord-platform` | Discord | Gateway intents, slash commands, threads, embeds, roles, voice channel join |
+| `whatsapp-platform` | WhatsApp | Local Node.js bridge (WA Web), DM/group policies, mention gating, free-response |
+| `signal-platform` | Signal | signal-cli bridge, end-to-end encrypted |
+| `sms-platform` | SMS (Twilio) | REST API + inbound webhook, plain text delivery |
+| `teams-platform` | Microsoft Teams | Bot Framework, Adaptive Card approval prompts, personal/group/channel chats |
+| `wecom-platform` | WeCom / 企业微信 | Smart Robot (WebSocket) + self-built callback (HTTP + AES), dual mode |
+| `simplex-platform` | SimpleX Chat | Decentralized, no persistent user IDs, via local simplex-chat daemon |
+| `matrix-platform` | Matrix | Federation, E2E encryption, room management |
+| `imessage-platform` | iMessage | Native macOS bridge via AppleScript/Messages app |
+| `photon-platform` | Photon Spectrum | iMessage via gRPC sidecar, managed Spectrum platform |
+| `raft-platform` | Raft | Workspace agent via wake-channel bridge |
+
+### Web Search Providers
+
+| Plugin | Backend | API Key Required | Free Tier | Notes |
+|--------|---------|:---:|:---:|-------|
+| `web-ddgs` | DuckDuckGo | No | ✅ Unlimited | Privacy-respecting, no key |
+| `web-searxng` | SearXNG | No (self-hosted) | ✅ Self-hosted | Requires `SEARXNG_URL` |
+| `web-brave-free` | Brave Search | Yes | ✅ 2k/mo | `BRAVE_SEARCH_API_KEY` |
+| `web-firecrawl` | Firecrawl | Yes* | — | Direct API or Nous gateway |
+| `web-tavily` | Tavily | Yes | — | Search + extract + crawl |
+| `web-exa` | Exa | Yes | — | Semantic search + content |
+| `web-parallel` | Parallel.ai | Yes | — | Objective-tuned results |
+| `web-xai` | xAI Grok | Yes* | — | OAuth or `XAI_API_KEY` |
+
+### Browser Automation
+
+| Plugin | Backend | Key Required | Notes |
+|--------|---------|:---:|-------|
+| `browser-browser-use` | Browser Use Cloud | Yes | `BROWSER_USE_API_KEY` or Nous subscription |
+| `browser-browserbase` | Browserbase | Yes | `BROWSERBASE_API_KEY` + project, stealth/proxy |
+| `browser-firecrawl` | Firecrawl Browser | Yes | `FIRECRAWL_API_KEY`, distinct from web plugin |
+
+### Image Generation
+
+| Plugin | Backend | Models |
+|--------|---------|--------|
+| `image_gen/fal` | FAL.ai | flux-2-klein, flux-2-pro, nano-banana, gpt-image-1.5 |
+
+### Video Generation
+
+| Plugin | Backend | Models |
+|--------|---------|--------|
+| `video_gen/fal` | FAL.ai | Veo 3.1, Kling, Pixverse (text-to-video, image-to-video) |
+| `video_gen/xai` | xAI Grok | text-to-video, image-to-video, reference-to-video, video editing, video extension |
+
+### Dashboard Authentication
+
+| Plugin | Auth Method | Best For |
+|--------|-------------|----------|
+| `dashboard_auth/basic` | Username/password | Self-hosted, simple `scrypt` hashing, stateless HMAC tokens |
+| `dashboard_auth/drain` | Shared bearer secret | Gateway drain-control endpoint, constant-time compare |
+| `dashboard_auth/nous` | OAuth 2.0 + PKCE (Nous Portal) | Hosted agents, Nous subscription |
+| `dashboard_auth/self-hosted` | OpenID Connect (generic) | Authentik, Keycloak, Zitadel, Authelia, Auth0, Okta, Google |
+
+### Cron Providers
+
+| Plugin | Backend | Use Case |
+|--------|---------|----------|
+| `cron_providers/chronos` | Nous NAS | Scale-to-zero hosted agents — wakes agent at fire time |
+
+### Music & Audio
+
+| Plugin | Tools | Auth |
+|--------|-------|------|
+| `spotify` | 7 tools: playback, devices, queue, search, playlists, albums, library | OAuth PKCE via `hermes auth spotify` |
+
+### Security
+
+| Plugin | Function |
+|--------|----------|
+| `security-guidance` | Appends warnings to file-write results for dangerous patterns (pickle, eval, os.system…). 25 rules forked from Anthropic's claude-plugins-off. Non-blocking — file is written, warning rides back to model. |
+
+### Memory
+
+| Plugin | Function |
+|--------|----------|
+| `memory/*` | Memory layer plugins — identity, workflow, project context persistence |
+
+### Observability
+
+| Plugin | Function |
+|--------|----------|
+| `observability/*` | Telemetry, tracing, and monitoring plugins |
+
+### Utilities
+
+| Plugin | Function |
+|--------|----------|
+| `disk-cleanup` | Auto-track and clean ephemeral files (test scripts, temp outputs, cron logs). Runs via plugin hooks — no agent action required. |
+| `google_meet` | Join Google Meet, transcribe live captions, realtime audio (OpenAI Realtime + BlackHole). v3: remote node host mode. |
+| `teams_pipeline` | Teams meeting pipeline — Graph-backed transcript-first meeting summaries |
+| `context_engine/*` | Context management — compaction, summarization, and token budget control |
+| `kanban` | Project kanban board integration |
+| `hermes-achievements` | Gamification / achievement tracking |
+| `model-providers/*` | Additional model provider adapters |
+
+---
+
+## Community Plugins
+
+Community plugins are installed to `~/.hermes/plugins/`:
+
+```bash
+# Install a community plugin
+hermes plugins install <name>     # install from registry
+hermes plugins install <repo-url> # install from git
+```
+
+### Installing from npm
+
+Some community skills ship as npm packages:
+
+```bash
+npx skillful install <skill-name>    # install a skill package
+npx -y @scope/skill-name             # run directly
+```
+
+### Writing a Plugin
+
+Plugins live in `~/.hermes/plugins/<name>/` and require:
+
+```
+my-plugin/
+├── plugin.yaml    # metadata: name, version, description, plugin_type, requires
+├── __init__.py    # Plugin class implementing the appropriate ABC
+└── provider.py    # (optional) tool/service provider
+```
+
+#### `plugin.yaml` structure
+
+```yaml
+name: my-plugin
+version: 1.0.0
+description: What this plugin does
+plugin_type: tool_provider       # tool_provider | platform_adapter | auth_provider | hook
+requires:
+  python: ">=3.10"
+  env:
+    - MY_API_KEY
+  packages:
+    - requests>=2.28
+tools:                           # (tool_provider only)
+  - name: my_tool
+    description: Tool description for the LLM
+  - name: another_tool
+    description: Another tool
+```
+
+#### Plugin Types
+
+| Type | Interface | When to Use |
+|------|-----------|-------------|
+| `tool_provider` | Register tools into the agent's toolset | Adding new capabilities (search, APIs, integrations) |
+| `platform_adapter` | Inbound/outbound message relay | Connecting a messaging platform |
+| `auth_provider` | Authentication flow for dashboard | Custom login methods |
+| `hook` | Lifecycle hooks (startup, session_init, pre_tool, post_tool, shutdown) | Cross-cutting concerns (logging, security, cleanup) |
+
+#### Hook Lifecycle
+
+Plugins hook into Hermes lifecycle events:
+
+| Hook | Fires | Use Case |
+|------|-------|----------|
+| `on_startup` | Gateway/TUI starts | Init connections, load config |
+| `on_session_init` | New conversation starts | Inject context, set up per-session state |
+| `pre_tool` | Before tool execution | Validation, rate limiting, logging |
+| `post_tool` | After tool execution | Post-processing, security checks, cleanup |
+| `on_shutdown` | Gateway/TUI stops | Graceful disconnection, flush state |
+
+---
+
+## Enabling/Disabling
+
+```bash
+hermes plugins enable telegram-platform    # enable
+hermes plugins disable web-brave-free      # disable
+hermes plugins                             # interactive TUI
+```
+
+Configuration in `~/.hermes/config.yaml`:
+
+```yaml
+plugins:
+  enabled:
+    - telegram-platform
+    - discord-platform
+    - web-ddgs
+  disabled:
+    - web-firecrawl
+```
+
+---
+
+## Plugin Permissions
+
+Plugins run in-process with agent-level access. Enable only plugins you trust. The `security-guidance` plugin provides an additional safety net — it scans file writes for dangerous patterns and warns the model.
+
+For platform adapters, configure per-user and per-chat allowlists to restrict who can interact with your agent:
+
+```yaml
+platforms:
+  telegram:
+    allow_users: ["123456789"]    # only these Telegram user IDs
+    allow_chats: ["-1001234567"]  # only these groups/channels
+```
+
+---
+
+## See Also
+
+- [MCP Reference](mcp-reference.md) — connecting Hermes to MCP servers for additional tools
+- [IDE Integration Guide](ide-integration.md) — connecting Hermes to IDEs
+- [Skills Hub](https://github.com/nousresearch/hermes-agent/tree/main/hermes_cli/skills_hub.py) — community skills registry

--- a/extensions/vscode/.vscodeignore
+++ b/extensions/vscode/.vscodeignore
@@ -1,0 +1,6 @@
+node_modules/
+src/
+.gitignore
+tsconfig.json
+*.ts
+!out/**

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,0 +1,168 @@
+{
+  "name": "hermes-agent",
+  "displayName": "Hermes Agent",
+  "description": "Hermes Agent — self-improving AI agent integrated directly into VS Code via MCP",
+  "version": "1.0.0",
+  "publisher": "nousresearch",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/NousResearch/hermes-agent"
+  },
+  "icon": "icon.png",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Chat",
+    "Machine Learning",
+    "Other"
+  ],
+  "keywords": [
+    "ai",
+    "agent",
+    "hermes",
+    "mcp",
+    "chat",
+    "coding assistant"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "hermes.showChat",
+        "title": "Hermes: Show Chat",
+        "icon": "$(comment-discussion)"
+      },
+      {
+        "command": "hermes.explainCode",
+        "title": "Hermes: Explain This Code"
+      },
+      {
+        "command": "hermes.fixCode",
+        "title": "Hermes: Fix This Code"
+      },
+      {
+        "command": "hermes.reviewCode",
+        "title": "Hermes: Review This Code"
+      },
+      {
+        "command": "hermes.customTask",
+        "title": "Hermes: Custom Task..."
+      },
+      {
+        "command": "hermes.sendSelection",
+        "title": "Hermes: Send Selection to Chat"
+      },
+      {
+        "command": "hermes.stopAgent",
+        "title": "Hermes: Stop Agent"
+      },
+      {
+        "command": "hermes.clearChat",
+        "title": "Hermes: Clear Chat History"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "hermes.explainCode",
+          "group": "hermes",
+          "when": "editorHasSelection"
+        },
+        {
+          "command": "hermes.fixCode",
+          "group": "hermes",
+          "when": "editorHasSelection"
+        },
+        {
+          "command": "hermes.reviewCode",
+          "group": "hermes",
+          "when": "editorHasSelection"
+        },
+        {
+          "command": "hermes.customTask",
+          "group": "hermes",
+          "when": "editorHasSelection"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "hermes.clearChat",
+          "group": "navigation",
+          "when": "view == hermes.chatView"
+        },
+        {
+          "command": "hermes.stopAgent",
+          "group": "navigation",
+          "when": "view == hermes.chatView"
+        }
+      ]
+    },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "hermes-sidebar",
+          "title": "Hermes Agent",
+          "icon": "$(robot)"
+        }
+      ]
+    },
+    "views": {
+      "hermes-sidebar": [
+        {
+          "id": "hermes.chatView",
+          "name": "Chat",
+          "type": "webview"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "Hermes Agent",
+      "properties": {
+        "hermes.mcpCommand": {
+          "type": "string",
+          "default": "hermes",
+          "description": "Command to launch Hermes MCP server (e.g. 'hermes' or full path)"
+        },
+        "hermes.mcpArgs": {
+          "type": "array",
+          "default": ["mcp", "serve"],
+          "description": "Arguments passed to the Hermes MCP server command"
+        },
+        "hermes.autoConnect": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically connect to Hermes MCP server on startup"
+        },
+        "hermes.maxHistory": {
+          "type": "number",
+          "default": 50,
+          "description": "Maximum number of messages to keep in chat history"
+        },
+        "hermes.model": {
+          "type": "string",
+          "default": "",
+          "description": "Model to use (leave empty to use Hermes' default)"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "package": "vsce package",
+    "lint": "eslint src --ext ts"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.85.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.0",
+    "eslint": "^8.0.0",
+    "@vscode/vsce": "^2.22.0"
+  }
+}

--- a/extensions/vscode/src/chatPanel.ts
+++ b/extensions/vscode/src/chatPanel.ts
@@ -1,0 +1,531 @@
+/**
+ * Hermes Chat Panel — WebView-based sidebar chat UI.
+ *
+ * Provides:
+ * - Message history with user/assistant/error styling
+ * - Typing indicator
+ * - Status bar integration
+ * - Clear/reset functionality
+ */
+
+import * as vscode from 'vscode';
+
+interface ChatMessage {
+    role: 'user' | 'assistant' | 'error' | 'system';
+    content: string;
+    timestamp: number;
+    id: string;
+}
+
+type ChatStatus = 'idle' | 'thinking' | 'error' | 'disconnected';
+
+export class ChatPanel implements vscode.WebviewViewProvider {
+    public static readonly viewType = 'hermes.chatView';
+    private _view?: vscode.WebviewView;
+    private _extensionUri: vscode.Uri;
+    private _outputChannel: vscode.OutputChannel;
+    private _messages: ChatMessage[] = [];
+    private _status: ChatStatus = 'disconnected';
+    private _statusBarItem: vscode.StatusBarItem;
+    private _messageIdCounter = 0;
+
+    constructor(extensionUri: vscode.Uri, outputChannel: vscode.OutputChannel) {
+        this._extensionUri = extensionUri;
+        this._outputChannel = outputChannel;
+
+        this._statusBarItem = vscode.window.createStatusBarItem(
+            vscode.StatusBarAlignment.Right,
+            100
+        );
+        this._statusBarItem.command = 'hermes.showChat';
+        this.updateStatusBar();
+
+        vscode.window.registerWebviewViewProvider(ChatPanel.viewType, this, {
+            webviewOptions: { retainContextWhenHidden: true },
+        });
+    }
+
+    public resolveWebviewView(
+        webviewView: vscode.WebviewView,
+    ): void {
+        this._view = webviewView;
+
+        webviewView.webview.options = {
+            enableScripts: true,
+            localResourceRoots: [this._extensionUri],
+        };
+
+        webviewView.webview.html = this._getHtml();
+
+        webviewView.webview.onDidReceiveMessage((data) => {
+            switch (data.type) {
+                case 'sendMessage':
+                    vscode.commands.executeCommand('hermes.customTask');
+                    break;
+                case 'ready':
+                    this._outputChannel.appendLine('Chat panel webview ready.');
+                    break;
+            }
+        });
+
+        webviewView.onDidChangeVisibility(() => {
+            if (webviewView.visible) {
+                this.updateStatusBar();
+            }
+        });
+    }
+
+    reveal(): void {
+        if (this._view) {
+            this._view.show(true);
+        }
+    }
+
+    addUserMessage(content: string): void {
+        this._addMessage({ role: 'user', content });
+    }
+
+    addAssistantMessage(content: string): void {
+        this._addMessage({ role: 'assistant', content });
+    }
+
+    addErrorMessage(content: string): void {
+        this._addMessage({ role: 'error', content });
+    }
+
+    setStatus(status: ChatStatus): void {
+        this._status = status;
+        this.updateStatusBar();
+        this._postToWebview({ type: 'setStatus', status });
+    }
+
+    clear(): void {
+        this._messages = [];
+        this._postToWebview({ type: 'clear' });
+    }
+
+    private _addMessage(msg: Omit<ChatMessage, 'timestamp' | 'id'>): void {
+        const full: ChatMessage = {
+            ...msg,
+            id: `msg-${++this._messageIdCounter}`,
+            timestamp: Date.now(),
+        };
+
+        // Enforce max history
+        const maxHistory = vscode.workspace.getConfiguration('hermes').get<number>('maxHistory', 50);
+        while (this._messages.length >= maxHistory) {
+            this._messages.shift();
+        }
+        this._messages.push(full);
+
+        this._postToWebview({
+            type: 'addMessage',
+            message: full,
+        });
+    }
+
+    private _postToWebview(message: unknown): void {
+        this._view?.webview?.postMessage(message);
+    }
+
+    private updateStatusBar(): void {
+        const icons: Record<ChatStatus, string> = {
+            idle: '$(pass)',
+            thinking: '$(sync~spin)',
+            error: '$(error)',
+            disconnected: '$(debug-disconnect)',
+        };
+
+        const labels: Record<ChatStatus, string> = {
+            idle: 'Hermes: Ready',
+            thinking: 'Hermes: Thinking...',
+            error: 'Hermes: Error',
+            disconnected: 'Hermes: Disconnected',
+        };
+
+        this._statusBarItem.text = `${icons[this._status]} ${labels[this._status]}`;
+        this._statusBarItem.tooltip = `Hermes Agent — ${labels[this._status]}`;
+
+        if (this._status === 'error') {
+            this._statusBarItem.backgroundColor = new vscode.ThemeColor(
+                'statusBarItem.errorBackground'
+            );
+        } else {
+            this._statusBarItem.backgroundColor = undefined;
+        }
+
+        this._statusBarItem.show();
+    }
+
+    private _getHtml(): string {
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';">
+    <title>Hermes Chat</title>
+    <style>
+        :root {
+            --bg: var(--vscode-sideBar-background, #1e1e2e);
+            --fg: var(--vscode-sideBar-foreground, #cdd6f4);
+            --border: var(--vscode-sideBar-border, #313244);
+            --user-bg: var(--vscode-textBlockQuote-background, #45475a);
+            --asst-bg: transparent;
+            --error-bg: #f38ba820;
+            --error-fg: #f38ba8;
+            --accent: var(--vscode-focusBorder, #89b4fa);
+            --input-bg: var(--vscode-input-background, #313244);
+            --input-fg: var(--vscode-input-foreground, #cdd6f4);
+            --radius: 8px;
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: var(--vscode-font-family, -apple-system, sans-serif);
+            font-size: 13px;
+            background: var(--bg);
+            color: var(--fg);
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+            overflow: hidden;
+        }
+
+        #header {
+            padding: 10px 12px;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-weight: 600;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            flex-shrink: 0;
+        }
+
+        #status-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #a6adc8;
+            flex-shrink: 0;
+        }
+        #status-dot.thinking { background: #f9e2af; animation: pulse 1s infinite; }
+        #status-dot.idle { background: #a6e3a1; }
+        #status-dot.error { background: #f38ba8; }
+        #status-dot.disconnected { background: #6c7086; }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.4; }
+        }
+
+        #messages {
+            flex: 1;
+            overflow-y: auto;
+            padding: 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .msg {
+            padding: 10px 12px;
+            border-radius: var(--radius);
+            line-height: 1.5;
+            word-break: break-word;
+            white-space: pre-wrap;
+            font-size: 13px;
+        }
+
+        .msg.user {
+            background: var(--user-bg);
+            align-self: flex-end;
+            max-width: 92%;
+        }
+
+        .msg.assistant {
+            background: var(--asst-bg);
+            border-left: 3px solid var(--accent);
+            padding-left: 10px;
+        }
+
+        .msg.error {
+            background: var(--error-bg);
+            color: var(--error-fg);
+            border-left: 3px solid var(--error-fg);
+            font-style: italic;
+        }
+
+        .msg.system {
+            text-align: center;
+            color: #6c7086;
+            font-size: 11px;
+            padding: 4px;
+        }
+
+        .msg .role-label {
+            font-size: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            opacity: 0.6;
+            margin-bottom: 4px;
+            display: block;
+        }
+
+        #typing-indicator {
+            display: none;
+            padding: 8px 12px;
+            gap: 4px;
+            align-items: center;
+        }
+        #typing-indicator.active { display: flex; }
+        #typing-indicator span {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: #a6adc8;
+            animation: bounce 1.4s infinite;
+        }
+        #typing-indicator span:nth-child(2) { animation-delay: 0.2s; }
+        #typing-indicator span:nth-child(3) { animation-delay: 0.4s; }
+
+        @keyframes bounce {
+            0%, 80%, 100% { transform: scale(0); }
+            40% { transform: scale(1); }
+        }
+
+        #input-area {
+            padding: 10px 12px;
+            border-top: 1px solid var(--border);
+            display: flex;
+            gap: 8px;
+            flex-shrink: 0;
+        }
+
+        #input-area input {
+            flex: 1;
+            background: var(--input-bg);
+            color: var(--input-fg);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            padding: 8px 12px;
+            font-size: 13px;
+            outline: none;
+        }
+        #input-area input:focus {
+            border-color: var(--accent);
+        }
+
+        #input-area button {
+            background: var(--accent);
+            color: var(--bg);
+            border: none;
+            border-radius: var(--radius);
+            padding: 8px 14px;
+            font-size: 13px;
+            cursor: pointer;
+            font-weight: 600;
+        }
+        #input-area button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .empty-state {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            color: #6c7086;
+            text-align: center;
+            padding: 20px;
+        }
+        .empty-state .icon { font-size: 36px; }
+        .empty-state .title { font-size: 14px; font-weight: 600; }
+        .empty-state .hint { font-size: 12px; }
+
+        code {
+            font-family: var(--vscode-editor-font-family, monospace);
+            font-size: 12px;
+            background: var(--user-bg);
+            padding: 1px 4px;
+            border-radius: 4px;
+        }
+
+        pre {
+            background: var(--input-bg);
+            padding: 10px;
+            border-radius: var(--radius);
+            overflow-x: auto;
+            margin: 6px 0;
+        }
+    </style>
+</head>
+<body>
+    <div id="header">
+        <div id="status-dot" class="disconnected"></div>
+        <span>Hermes Agent</span>
+    </div>
+
+    <div id="messages">
+        <div class="empty-state" id="empty-state">
+            <div class="icon">🤖</div>
+            <div class="title">Hermes Agent</div>
+            <div class="hint">Select code and right-click for Explain, Fix, or Review.<br>Or type a message below to chat.</div>
+        </div>
+        <div id="typing-indicator">
+            <span></span><span></span><span></span>
+        </div>
+    </div>
+
+    <div id="input-area">
+        <input type="text" id="message-input" placeholder="Ask Hermes something..."
+               autofocus>
+        <button id="send-btn" disabled>Send</button>
+    </div>
+
+    <script>
+        const vscode = acquireVsCodeApi();
+        const messagesEl = document.getElementById('messages');
+        const emptyState = document.getElementById('empty-state');
+        const typingIndicator = document.getElementById('typing-indicator');
+        const statusDot = document.getElementById('status-dot');
+        const input = document.getElementById('message-input');
+        const sendBtn = document.getElementById('send-btn');
+        let currentStatus = 'disconnected';
+
+        // ── Handle messages from extension ─────────────────────
+        window.addEventListener('message', event => {
+            const msg = event.data;
+            switch (msg.type) {
+                case 'addMessage':
+                    emptyState.style.display = 'none';
+                    addMessageToDom(msg.message);
+                    scrollToBottom();
+                    break;
+                case 'setStatus':
+                    setStatus(msg.status);
+                    break;
+                case 'clear':
+                    const allMsgs = messagesEl.querySelectorAll('.msg');
+                    allMsgs.forEach(m => m.remove());
+                    emptyState.style.display = 'flex';
+                    break;
+            }
+        });
+
+        function addMessageToDom(msg) {
+            const div = document.createElement('div');
+            div.className = 'msg ' + msg.role;
+            div.id = msg.id;
+
+            const label = document.createElement('span');
+            label.className = 'role-label';
+            const labels = { user: 'You', assistant: 'Hermes', error: 'Error', system: '' };
+            label.textContent = labels[msg.role] || '';
+            div.appendChild(label);
+
+            const content = document.createElement('div');
+            content.innerHTML = formatContent(msg.content);
+            div.appendChild(content);
+
+            // Insert before typing indicator
+            messagesEl.insertBefore(div, typingIndicator);
+        }
+
+        function formatContent(text) {
+            // Escape HTML
+            let escaped = text
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+
+            // Code blocks (```code```)
+            escaped = escaped.replace(/\x60\x60\x60([\\s\\S]*?)\x60\x60\x60/g,
+                (_, code) => '<pre><code>' + code + '</code></pre>');
+
+            // Inline code (`code`)
+            escaped = escaped.replace(/\x60([^\x60]+)\x60/g,
+                (_, code) => '<code>' + code + '</code>');
+
+            // Bold (**text**)
+            escaped = escaped.replace(/\\*\\*([^*]+)\\*\\*/g, '<strong>$1</strong>');
+
+            // Line breaks
+            escaped = escaped.replace(/\\n/g, '<br>');
+
+            return escaped;
+        }
+
+        function setStatus(status) {
+            currentStatus = status;
+            statusDot.className = status;
+
+            if (status === 'thinking') {
+                typingIndicator.classList.add('active');
+                sendBtn.disabled = true;
+            } else {
+                typingIndicator.classList.remove('active');
+                sendBtn.disabled = false;
+            }
+
+            input.disabled = (status === 'thinking');
+        }
+
+        function scrollToBottom() {
+            messagesEl.scrollTop = messagesEl.scrollHeight;
+        }
+
+        // ── Input handling ─────────────────────────────────────
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && !e.shiftKey && input.value.trim()) {
+                e.preventDefault();
+                sendMessage();
+            }
+        });
+
+        input.addEventListener('input', () => {
+            sendBtn.disabled = !input.value.trim() || currentStatus === 'thinking';
+        });
+
+        sendBtn.addEventListener('click', () => {
+            if (input.value.trim()) {
+                sendMessage();
+            }
+        });
+
+        function sendMessage() {
+            const text = input.value.trim();
+            if (!text) return;
+
+            // Add locally for instant feedback
+            addMessageToDom({
+                role: 'user',
+                content: text,
+                id: 'local-' + Date.now(),
+                timestamp: Date.now(),
+            });
+            emptyState.style.display = 'none';
+            scrollToBottom();
+
+            // Send to extension
+            vscode.postMessage({ type: 'sendMessage', text });
+            input.value = '';
+            sendBtn.disabled = true;
+        }
+
+        // Signal ready
+        vscode.postMessage({ type: 'ready' });
+    </script>
+</body>
+</html>`;
+    }
+}

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,0 +1,145 @@
+/**
+ * Hermes Agent VS Code Extension — Main Entry Point
+ *
+ * Activates on startup, registers commands, creates the chat sidebar,
+ * and manages the MCP client lifecycle.
+ */
+
+import * as vscode from 'vscode';
+import { HermesMCPClient } from './mcpClient';
+import { ChatPanel } from './chatPanel';
+
+let client: HermesMCPClient;
+let chatPanel: ChatPanel | undefined;
+
+export function activate(context: vscode.ExtensionContext) {
+    const config = vscode.workspace.getConfiguration('hermes');
+    const outputChannel = vscode.window.createOutputChannel('Hermes Agent', { log: true });
+    outputChannel.appendLine('Hermes Agent extension activating...');
+
+    // ── MCP Client ─────────────────────────────────────────────
+    client = new HermesMCPClient({
+        command: config.get<string>('mcpCommand', 'hermes'),
+        args: config.get<string[]>('mcpArgs', ['mcp', 'serve']),
+        outputChannel,
+        autoConnect: config.get<boolean>('autoConnect', true),
+    });
+
+    // ── Chat Panel ─────────────────────────────────────────────
+    chatPanel = new ChatPanel(context.extensionUri, outputChannel);
+
+    // ── Register Commands ──────────────────────────────────────
+    context.subscriptions.push(
+        vscode.commands.registerCommand('hermes.showChat', () => {
+            chatPanel?.reveal();
+        }),
+
+        vscode.commands.registerCommand('hermes.explainCode', async () => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) { return; }
+            const selection = editor.document.getText(editor.selection);
+            const language = editor.document.languageId;
+            const fileName = editor.document.fileName.split('/').pop() || '';
+            await sendTask(`Explain the following ${language} code from ${fileName}:\n\`\`\`${language}\n${selection}\n\`\`\``);
+        }),
+
+        vscode.commands.registerCommand('hermes.fixCode', async () => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) { return; }
+            const selection = editor.document.getText(editor.selection);
+            const language = editor.document.languageId;
+            await sendTask(`Fix any bugs or issues in this ${language} code. Return the corrected code:\n\`\`\`${language}\n${selection}\n\`\`\``);
+        }),
+
+        vscode.commands.registerCommand('hermes.reviewCode', async () => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) { return; }
+            const selection = editor.document.getText(editor.selection);
+            const language = editor.document.languageId;
+            await sendTask(`Review this ${language} code for bugs, security issues, and improvement opportunities:\n\`\`\`${language}\n${selection}\n\`\`\``);
+        }),
+
+        vscode.commands.registerCommand('hermes.customTask', async () => {
+            const editor = vscode.window.activeTextEditor;
+            const task = await vscode.window.showInputBox({
+                prompt: 'What would you like Hermes to do?',
+                placeHolder: 'e.g. Add error handling to this function...',
+            });
+            if (!task) { return; }
+            if (editor && !editor.selection.isEmpty) {
+                const selection = editor.document.getText(editor.selection);
+                const language = editor.document.languageId;
+                await sendTask(`${task}\n\nContext:\n\`\`\`${language}\n${selection}\n\`\`\``);
+            } else {
+                await sendTask(task);
+            }
+        }),
+
+        vscode.commands.registerCommand('hermes.sendSelection', async () => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) { return; }
+            const selection = editor.document.getText(editor.selection);
+            if (selection) {
+                chatPanel?.addUserMessage(selection);
+                await client.sendMessage(selection);
+            }
+        }),
+
+        vscode.commands.registerCommand('hermes.stopAgent', () => {
+            client.cancelCurrent();
+            chatPanel?.setStatus('idle');
+            vscode.window.showInformationMessage('Hermes: stopped current task.');
+        }),
+
+        vscode.commands.registerCommand('hermes.clearChat', () => {
+            chatPanel?.clear();
+        }),
+    );
+
+    // ── Model selection via config change ──────────────────────
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration('hermes.model')) {
+                const model = vscode.workspace.getConfiguration('hermes').get<string>('model', '');
+                outputChannel.appendLine(`Model changed to: ${model || 'default'}`);
+            }
+        }),
+    );
+
+    // ── Auto-connect ───────────────────────────────────────────
+    if (config.get<boolean>('autoConnect', true)) {
+        client.connect().catch(err => {
+            outputChannel.appendLine(`Auto-connect failed: ${err.message}`);
+        });
+    }
+
+    outputChannel.appendLine('Hermes Agent extension activated.');
+}
+
+export function deactivate() {
+    client?.disconnect();
+}
+
+async function sendTask(prompt: string): Promise<void> {
+    if (!client.isConnected()) {
+        const connect = await vscode.window.showInformationMessage(
+            'Hermes is not connected. Connect now?',
+            'Connect', 'Cancel'
+        );
+        if (connect !== 'Connect') { return; }
+        await client.connect();
+    }
+
+    chatPanel?.reveal();
+    chatPanel?.addUserMessage(prompt);
+    chatPanel?.setStatus('thinking');
+
+    try {
+        const response = await client.sendMessage(prompt);
+        chatPanel?.addAssistantMessage(response);
+        chatPanel?.setStatus('idle');
+    } catch (err: any) {
+        chatPanel?.addErrorMessage(err.message || 'Unknown error');
+        chatPanel?.setStatus('error');
+    }
+}

--- a/extensions/vscode/src/mcpClient.ts
+++ b/extensions/vscode/src/mcpClient.ts
@@ -1,0 +1,241 @@
+/**
+ * Hermes MCP Client — communicates with `hermes mcp serve` over stdio JSON-RPC.
+ *
+ * Handles:
+ * - Process spawn and lifecycle
+ * - JSON-RPC 2.0 request/response
+ * - Automatic reconnection with exponential backoff
+ * - Tool discovery (conversation list, message send)
+ */
+
+import { ChildProcess, spawn } from 'child_process';
+import { createInterface, Interface } from 'readline';
+import * as vscode from 'vscode';
+
+interface MCPClientConfig {
+    command: string;
+    args: string[];
+    outputChannel: vscode.OutputChannel;
+    autoConnect: boolean;
+}
+
+interface JSONRPCRequest {
+    jsonrpc: '2.0';
+    id: number;
+    method: string;
+    params: Record<string, unknown>;
+}
+
+interface JSONRPCResponse {
+    jsonrpc: '2.0';
+    id: number;
+    result?: unknown;
+    error?: { code: number; message: string; data?: unknown };
+}
+
+type PendingCall = {
+    resolve: (value: string) => void;
+    reject: (error: Error) => void;
+    timer: NodeJS.Timeout;
+};
+
+export class HermesMCPClient {
+    private config: MCPClientConfig;
+    private process: ChildProcess | null = null;
+    private rl: Interface | null = null;
+    private nextId = 1;
+    private pending = new Map<number, PendingCall>();
+    private _connected = false;
+    private reconnectAttempts = 0;
+    private reconnectTimer: NodeJS.Timeout | null = null;
+    private readonly MAX_RECONNECT_DELAY = 30_000;
+
+    constructor(config: MCPClientConfig) {
+        this.config = config;
+    }
+
+    isConnected(): boolean {
+        return this._connected && this.process !== null && !this.process.killed;
+    }
+
+    async connect(): Promise<void> {
+        if (this.isConnected()) { return; }
+
+        this.config.outputChannel.appendLine(
+            `Starting Hermes MCP: ${this.config.command} ${this.config.args.join(' ')}`
+        );
+
+        return new Promise((resolve, reject) => {
+            this.process = spawn(this.config.command, this.config.args, {
+                stdio: ['pipe', 'pipe', 'pipe'],
+                env: { ...process.env },
+            });
+
+            let initialized = false;
+
+            this.process.on('error', (err) => {
+                this.config.outputChannel.appendLine(`Process error: ${err.message}`);
+                if (!initialized) { reject(err); }
+            });
+
+            this.process.on('exit', (code, signal) => {
+                this.config.outputChannel.appendLine(
+                    `Hermes process exited (code=${code}, signal=${signal})`
+                );
+                this._connected = false;
+                if (!initialized) {
+                    reject(new Error(`Process exited with code ${code}`));
+                }
+                this.scheduleReconnect();
+            });
+
+            if (this.process.stderr) {
+                // Hermes logs to stderr in MCP serve mode
+                const stderrRl = createInterface({ input: this.process.stderr });
+                stderrRl.on('line', (line) => {
+                    this.config.outputChannel.appendLine(`[hermes] ${line}`);
+                });
+            }
+
+            if (this.process.stdout) {
+                this.rl = createInterface({ input: this.process.stdout });
+                this.rl.on('line', (line) => {
+                    try {
+                        const msg = JSON.parse(line) as JSONRPCResponse;
+                        if (msg.id !== undefined && this.pending.has(msg.id)) {
+                            const pending = this.pending.get(msg.id)!;
+                            clearTimeout(pending.timer);
+                            this.pending.delete(msg.id);
+                            if (msg.error) {
+                                pending.reject(new Error(msg.error.message));
+                            } else {
+                                pending.resolve(
+                                    typeof msg.result === 'string'
+                                        ? msg.result
+                                        : JSON.stringify(msg.result)
+                                );
+                            }
+                        }
+                    } catch {
+                        // Non-JSON line (e.g. initialization messages)
+                    }
+                });
+            }
+
+            // Give the process a moment to start
+            setTimeout(() => {
+                if (!initialized && this.process && !this.process.killed) {
+                    initialized = true;
+                    this._connected = true;
+                    this.reconnectAttempts = 0;
+                    this.config.outputChannel.appendLine('Hermes MCP connected.');
+                    resolve();
+                }
+            }, 1000);
+        });
+    }
+
+    disconnect(): void {
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+        if (this.process && !this.process.killed) {
+            this.process.kill();
+        }
+        this._connected = false;
+        this.config.outputChannel.appendLine('Hermes MCP disconnected.');
+    }
+
+    private scheduleReconnect(): void {
+        if (!this.config.autoConnect) { return; }
+
+        const delay = Math.min(
+            1000 * Math.pow(2, this.reconnectAttempts),
+            this.MAX_RECONNECT_DELAY
+        );
+        this.reconnectAttempts++;
+
+        this.config.outputChannel.appendLine(
+            `Reconnecting in ${delay / 1000}s (attempt ${this.reconnectAttempts})...`
+        );
+
+        this.reconnectTimer = setTimeout(async () => {
+            try {
+                await this.connect();
+                this.config.outputChannel.appendLine('Reconnected successfully.');
+            } catch {
+                this.config.outputChannel.appendLine('Reconnect failed, will retry...');
+                this.scheduleReconnect();
+            }
+        }, delay);
+    }
+
+    async sendMessage(message: string, sessionKey?: string): Promise<string> {
+        if (!this.isConnected()) {
+            throw new Error('Not connected to Hermes MCP server');
+        }
+
+        // Use the MCP messages_send tool
+        const result = await this.callTool(
+            sessionKey ? 'messages_send' : 'conversations_list',
+            sessionKey
+                ? { target: sessionKey, message }
+                : { limit: 10 }
+        );
+
+        // If we got conversation list, send to the first/recent conversation
+        if (!sessionKey) {
+            try {
+                const list = JSON.parse(result);
+                if (list.conversations && list.conversations.length > 0) {
+                    const target = list.conversations[0].session_key;
+                    return this.callTool('messages_send', { target, message });
+                }
+            } catch {
+                // Fall through
+            }
+        }
+
+        return result;
+    }
+
+    private callTool(method: string, params: Record<string, unknown>): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const id = this.nextId++;
+            const request: JSONRPCRequest = {
+                jsonrpc: '2.0',
+                id,
+                method: `tools/call`,
+                params: {
+                    name: method,
+                    arguments: params,
+                },
+            };
+
+            const timer = setTimeout(() => {
+                this.pending.delete(id);
+                reject(new Error(`MCP call timed out: ${method}`));
+            }, 60_000); // 60 second timeout
+
+            this.pending.set(id, { resolve, reject, timer });
+
+            if (this.process?.stdin) {
+                this.process.stdin.write(JSON.stringify(request) + '\n');
+            } else {
+                clearTimeout(timer);
+                this.pending.delete(id);
+                reject(new Error('Process stdin not available'));
+            }
+        });
+    }
+
+    cancelCurrent(): void {
+        // Clear all pending calls
+        for (const [id, pending] of this.pending) {
+            clearTimeout(pending.timer);
+            pending.reject(new Error('Cancelled by user'));
+        }
+        this.pending.clear();
+    }
+}

--- a/extensions/vscode/tsconfig.json
+++ b/extensions/vscode/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and a VS Code extension to Hermes Agent.

### Phase 5a: MCP Tools Reference (`docs/mcp-reference.md`, 514 lines)
- Complete MCP client/server reference with YAML config examples
- Stdio/HTTP/SSE transport documentation with parameter tables
- OAuth authentication, tool selection, sampling configuration
- Full 10-tool MCP server bridge surface (`conversations_list`, `messages_read`, `messages_send`, `events_poll`, `events_wait`, etc.)
- Common MCP server examples (Filesystem, GitHub, SQLite, Playwright, Brave Search)
- Troubleshooting guide and developer guide for building MCP servers

### Phase 5b: Plugin Registry (`docs/plugin-registry.md`)
- Full catalog of 49+ bundled plugins across 19 categories
- Platform adapters (Telegram, Slack, Discord, WhatsApp, WeCom, SimpleX, etc.)
- Web search providers (8 backends), browser automation (3 backends)
- Image/video generation, dashboard auth, cron, music, security
- Community plugin installation guide and `plugin.yaml` manifest format
- Plugin hook lifecycle reference

### Phase 5c: Gateway Health Check (`docs/gateway-health-check.md`)
- Auto-reconnect watcher with exponential backoff (30s→300s cap)
- Error classification (retryable vs non-retryable)
- Circuit breaker via `/platform pause/resume`

### Phase 5d: ACP Registry (`docs/acp-registry.md`)
- `agent.json` manifest specification
- Distribution methods (uvx/pipx)
- Editor connection guides (Zed, VS Code, JetBrains, Cursor)
- ACP vs MCP comparison

### Phase 6: VS Code Extension (`extensions/vscode/`, 1104 lines TypeScript)
- **`package.json`**: 8 commands, right-click context menu, sidebar WebView, 5 config settings
- **`src/extension.ts`**: Activation, command dispatch, Explain/Fix/Review/Custom Task code actions
- **`src/mcpClient.ts`**: JSON-RPC 2.0 stdio MCP client with exponential backoff auto-reconnect
- **`src/chatPanel.ts`**: WebView chat UI with message history, typing indicator, status bar, Catppuccin theme
- Ready to build: `npm install && npx tsc && npx vsce package`

### Files Changed
- 11 files, 2461 insertions
- 4 new docs + 1 new extensions/vscode project