### PR TITLE
fix(doctor): suppress warnings for default-off/opt-in toolsets

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -132,8 +132,29 @@ def _doctor_tool_availability_detail(toolset: str) -> str:
     return ""
 
 
+def _is_default_off_toolset(item: dict) -> bool:
+    """Return True for opt-in toolsets that are intentionally unavailable.
+
+    ``doctor`` should not warn about every bundled-but-disabled integration.
+    Toolsets such as Home Assistant, Spotify, MoA, video generation, Discord
+    admin tools, and X search are shipped with Hermes but are default-off
+    until the user explicitly configures credentials or enables them via
+    ``hermes tools``. Surfacing them as per-toolset warnings makes a clean
+    install look dirty, even though the final missing-API-key summary is
+    already scoped to CLI-enabled toolsets by
+    :func:`_missing_api_key_toolsets_for_summary`.
+    """
+    name = item.get("name")
+    try:
+        from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
+
+        return name in _DEFAULT_OFF_TOOLSETS
+    except Exception:
+        return False
+
+
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
-    """Adjust runtime-gated tool availability for doctor diagnostics."""
+    """Adjust runtime-gated / opt-in tool availability for doctor diagnostics."""
     updated_available = list(available)
     updated_unavailable = []
     for item in unavailable:
@@ -145,6 +166,12 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
         if name == "honcho" and _honcho_is_configured_for_doctor():
             if "honcho" not in updated_available:
                 updated_available.append("honcho")
+            continue
+        if _is_default_off_toolset(item):
+            # Default-off integrations are healthy when absent. If the user
+            # explicitly enables one and it is still unavailable, the runtime
+            # tool gating path will keep its schemas out; doctor should stay
+            # focused on actionable setup issues, not every optional backend.
             continue
         updated_unavailable.append(item)
     return updated_available, updated_unavailable

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -132,7 +132,7 @@ def _doctor_tool_availability_detail(toolset: str) -> str:
     return ""
 
 
-def _is_default_off_toolset(item: dict) -> bool:
+def _is_default_off_toolset(item: dict, enabled_toolsets: set[str] | None) -> bool:
     """Return True for opt-in toolsets that are intentionally unavailable.
 
     ``doctor`` should not warn about every bundled-but-disabled integration.
@@ -143,12 +143,27 @@ def _is_default_off_toolset(item: dict) -> bool:
     install look dirty, even though the final missing-API-key summary is
     already scoped to CLI-enabled toolsets by
     :func:`_missing_api_key_toolsets_for_summary`.
+
+    Only suppresses when the toolset is confirmed absent from the resolved
+    CLI-enabled set. A user who explicitly enabled a default-off toolset via
+    ``hermes tools`` (it's still in ``_DEFAULT_OFF_TOOLSETS`` by name, but no
+    longer actually default *for them*) has opted into wanting missing
+    credentials surfaced -- silently hiding that warning would make doctor
+    lie about why the toolset isn't working. When ``enabled_toolsets`` is
+    None (config resolution failed), retains the warning rather than
+    guessing -- failing toward showing more information, not less.
     """
     name = item.get("name")
     try:
         from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
 
-        return name in _DEFAULT_OFF_TOOLSETS
+        if name not in _DEFAULT_OFF_TOOLSETS:
+            return False
+        if enabled_toolsets is None:
+            # Resolver failed -- can't confirm this is still an unopted-in
+            # default, so don't suppress.
+            return False
+        return name not in enabled_toolsets
     except Exception:
         return False
 
@@ -157,6 +172,7 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
     """Adjust runtime-gated / opt-in tool availability for doctor diagnostics."""
     updated_available = list(available)
     updated_unavailable = []
+    enabled_toolsets = _enabled_cli_toolsets_for_doctor()
     for item in unavailable:
         name = item.get("name")
         if _is_kanban_worker_env_gate(item):
@@ -167,11 +183,12 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
             if "honcho" not in updated_available:
                 updated_available.append("honcho")
             continue
-        if _is_default_off_toolset(item):
-            # Default-off integrations are healthy when absent. If the user
-            # explicitly enables one and it is still unavailable, the runtime
-            # tool gating path will keep its schemas out; doctor should stay
-            # focused on actionable setup issues, not every optional backend.
+        if _is_default_off_toolset(item, enabled_toolsets):
+            # Default-off integrations the user never opted into are healthy
+            # when absent. If the user explicitly enabled one (it's in
+            # enabled_toolsets) and it's still unavailable, the check above
+            # already returns False for it, so it falls through to the
+            # normal warning path below instead of being suppressed.
             continue
         updated_unavailable.append(item)
     return updated_available, updated_unavailable

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -348,7 +348,9 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
                 )
             )
     return rows
-def _is_default_off_toolset(item: dict) -> bool:
+
+
+def _is_default_off_toolset(item: dict, enabled_toolsets: set[str] | None) -> bool:
     """Return True for opt-in toolsets that are intentionally unavailable.
 
     ``doctor`` should not warn about every bundled-but-disabled integration.
@@ -359,12 +361,27 @@ def _is_default_off_toolset(item: dict) -> bool:
     install look dirty, even though the final missing-API-key summary is
     already scoped to CLI-enabled toolsets by
     :func:`_missing_api_key_toolsets_for_summary`.
+
+    Only suppresses when the toolset is confirmed absent from the resolved
+    CLI-enabled set. A user who explicitly enabled a default-off toolset via
+    ``hermes tools`` (it's still in ``_DEFAULT_OFF_TOOLSETS`` by name, but no
+    longer actually default *for them*) has opted into wanting missing
+    credentials surfaced -- silently hiding that warning would make doctor
+    lie about why the toolset isn't working. When ``enabled_toolsets`` is
+    None (config resolution failed), retains the warning rather than
+    guessing -- failing toward showing more information, not less.
     """
     name = item.get("name")
     try:
         from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
 
-        return name in _DEFAULT_OFF_TOOLSETS
+        if name not in _DEFAULT_OFF_TOOLSETS:
+            return False
+        if enabled_toolsets is None:
+            # Resolver failed -- can't confirm this is still an unopted-in
+            # default, so don't suppress.
+            return False
+        return name not in enabled_toolsets
     except Exception:
         return False
 
@@ -373,6 +390,7 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
     """Adjust runtime-gated / opt-in tool availability for doctor diagnostics."""
     updated_available = list(available)
     updated_unavailable = []
+    enabled_toolsets = _enabled_cli_toolsets_for_doctor()
     for item in unavailable:
         name = item.get("name")
         if _is_kanban_worker_env_gate(item):
@@ -383,11 +401,12 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
             if "honcho" not in updated_available:
                 updated_available.append("honcho")
             continue
-        if _is_default_off_toolset(item):
-            # Default-off integrations are healthy when absent. If the user
-            # explicitly enables one and it is still unavailable, the runtime
-            # tool gating path will keep its schemas out; doctor should stay
-            # focused on actionable setup issues, not every optional backend.
+        if _is_default_off_toolset(item, enabled_toolsets):
+            # Default-off integrations the user never opted into are healthy
+            # when absent. If the user explicitly enabled one (it's in
+            # enabled_toolsets) and it's still unavailable, the check above
+            # already returns False for it, so it falls through to the
+            # normal warning path below instead of being suppressed.
             continue
         updated_unavailable.append(item)
     return updated_available, updated_unavailable

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -348,9 +348,29 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
                 )
             )
     return rows
+def _is_default_off_toolset(item: dict) -> bool:
+    """Return True for opt-in toolsets that are intentionally unavailable.
+
+    ``doctor`` should not warn about every bundled-but-disabled integration.
+    Toolsets such as Home Assistant, Spotify, MoA, video generation, Discord
+    admin tools, and X search are shipped with Hermes but are default-off
+    until the user explicitly configures credentials or enables them via
+    ``hermes tools``. Surfacing them as per-toolset warnings makes a clean
+    install look dirty, even though the final missing-API-key summary is
+    already scoped to CLI-enabled toolsets by
+    :func:`_missing_api_key_toolsets_for_summary`.
+    """
+    name = item.get("name")
+    try:
+        from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
+
+        return name in _DEFAULT_OFF_TOOLSETS
+    except Exception:
+        return False
+
 
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
-    """Adjust runtime-gated tool availability for doctor diagnostics."""
+    """Adjust runtime-gated / opt-in tool availability for doctor diagnostics."""
     updated_available = list(available)
     updated_unavailable = []
     for item in unavailable:
@@ -362,6 +382,12 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
         if name == "honcho" and _honcho_is_configured_for_doctor():
             if "honcho" not in updated_available:
                 updated_available.append("honcho")
+            continue
+        if _is_default_off_toolset(item):
+            # Default-off integrations are healthy when absent. If the user
+            # explicitly enables one and it is still unavailable, the runtime
+            # tool gating path will keep its schemas out; doctor should stay
+            # focused on actionable setup issues, not every optional backend.
             continue
         updated_unavailable.append(item)
     return updated_available, updated_unavailable

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -191,6 +191,57 @@ class TestDoctorToolAvailabilityOverrides:
 
         assert doctor._doctor_tool_availability_detail("kanban") == "(runtime-gated; loaded only for dispatcher-spawned workers)"
 
+    def test_suppresses_warning_for_default_off_toolset_missing_creds(self, monkeypatch):
+        # Home Assistant is opt-in (_DEFAULT_OFF_TOOLSETS) — a clean install
+        # that never configured it should not surface a doctor warning.
+        homeassistant_entry = {
+            "name": "homeassistant",
+            "missing_vars": ["HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"],
+            "tools": ["homeassistant_call_service"],
+        }
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [homeassistant_entry],
+        )
+
+        assert available == []
+        assert unavailable == []
+
+    def test_suppresses_warning_for_each_default_off_toolset(self, monkeypatch):
+        from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
+
+        entries = [
+            {"name": name, "missing_vars": ["SOME_KEY"], "tools": ["some_tool"]}
+            for name in _DEFAULT_OFF_TOOLSETS
+        ]
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides([], entries)
+
+        assert available == []
+        assert unavailable == []
+
+    def test_leaves_normally_enabled_toolset_unavailable_when_missing_creds(self, monkeypatch):
+        # A non-opt-in toolset (e.g. a core web-search provider) missing its
+        # API key must still be reported so the user can fix a real problem.
+        search_entry = {
+            "name": "web_search",
+            "missing_vars": ["SEARCH_API_KEY"],
+            "tools": ["web_search"],
+        }
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [search_entry],
+        )
+
+        assert available == []
+        assert unavailable == [search_entry]
+
+    def test_default_off_toolset_detection_helper(self):
+        assert doctor._is_default_off_toolset({"name": "spotify"}) is True
+        assert doctor._is_default_off_toolset({"name": "web_search"}) is False
+
 
 class TestHonchoDoctorConfigDetection:
     def test_reports_configured_when_enabled_with_api_key(self, monkeypatch):

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -193,7 +193,10 @@ class TestDoctorToolAvailabilityOverrides:
 
     def test_suppresses_warning_for_default_off_toolset_missing_creds(self, monkeypatch):
         # Home Assistant is opt-in (_DEFAULT_OFF_TOOLSETS) — a clean install
-        # that never configured it should not surface a doctor warning.
+        # that never configured/enabled it should not surface a doctor
+        # warning. Resolver returns an enabled set that does NOT include
+        # homeassistant, matching a clean install.
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: set())
         homeassistant_entry = {
             "name": "homeassistant",
             "missing_vars": ["HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"],
@@ -211,6 +214,7 @@ class TestDoctorToolAvailabilityOverrides:
     def test_suppresses_warning_for_each_default_off_toolset(self, monkeypatch):
         from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
 
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: set())
         entries = [
             {"name": name, "missing_vars": ["SOME_KEY"], "tools": ["some_tool"]}
             for name in _DEFAULT_OFF_TOOLSETS
@@ -224,6 +228,7 @@ class TestDoctorToolAvailabilityOverrides:
     def test_leaves_normally_enabled_toolset_unavailable_when_missing_creds(self, monkeypatch):
         # A non-opt-in toolset (e.g. a core web-search provider) missing its
         # API key must still be reported so the user can fix a real problem.
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: set())
         search_entry = {
             "name": "web_search",
             "missing_vars": ["SEARCH_API_KEY"],
@@ -238,9 +243,52 @@ class TestDoctorToolAvailabilityOverrides:
         assert available == []
         assert unavailable == [search_entry]
 
+    def test_does_not_suppress_default_off_toolset_the_user_explicitly_enabled(self, monkeypatch):
+        # Regression for sweeper review on PR #60364: a user who explicitly
+        # enables a default-off toolset via `hermes tools` has opted into
+        # wanting its missing-credential problems surfaced. Suppressing the
+        # warning here would hide a real, actionable setup issue for an
+        # integration the user is actively relying on.
+        monkeypatch.setattr(
+            doctor, "_enabled_cli_toolsets_for_doctor", lambda: {"homeassistant"}
+        )
+        homeassistant_entry = {
+            "name": "homeassistant",
+            "missing_vars": ["HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"],
+            "tools": ["homeassistant_call_service"],
+        }
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [homeassistant_entry],
+        )
+
+        assert available == []
+        assert unavailable == [homeassistant_entry]
+
+    def test_does_not_suppress_when_enabled_resolver_fails(self, monkeypatch):
+        # If config resolution fails (returns None), fail toward showing the
+        # warning rather than guessing the toolset is safely unopted-into.
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: None)
+        homeassistant_entry = {
+            "name": "homeassistant",
+            "missing_vars": ["HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"],
+            "tools": ["homeassistant_call_service"],
+        }
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [homeassistant_entry],
+        )
+
+        assert available == []
+        assert unavailable == [homeassistant_entry]
+
     def test_default_off_toolset_detection_helper(self):
-        assert doctor._is_default_off_toolset({"name": "spotify"}) is True
-        assert doctor._is_default_off_toolset({"name": "web_search"}) is False
+        assert doctor._is_default_off_toolset({"name": "spotify"}, set()) is True
+        assert doctor._is_default_off_toolset({"name": "spotify"}, {"spotify"}) is False
+        assert doctor._is_default_off_toolset({"name": "spotify"}, None) is False
+        assert doctor._is_default_off_toolset({"name": "web_search"}, set()) is False
 
 
 class TestHonchoDoctorConfigDetection:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -228,6 +228,57 @@ class TestDoctorToolAvailabilityOverrides:
 
 
 
+    def test_suppresses_warning_for_default_off_toolset_missing_creds(self, monkeypatch):
+        # Home Assistant is opt-in (_DEFAULT_OFF_TOOLSETS) — a clean install
+        # that never configured it should not surface a doctor warning.
+        homeassistant_entry = {
+            "name": "homeassistant",
+            "missing_vars": ["HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"],
+            "tools": ["homeassistant_call_service"],
+        }
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [homeassistant_entry],
+        )
+
+        assert available == []
+        assert unavailable == []
+
+    def test_suppresses_warning_for_each_default_off_toolset(self, monkeypatch):
+        from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
+
+        entries = [
+            {"name": name, "missing_vars": ["SOME_KEY"], "tools": ["some_tool"]}
+            for name in _DEFAULT_OFF_TOOLSETS
+        ]
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides([], entries)
+
+        assert available == []
+        assert unavailable == []
+
+    def test_leaves_normally_enabled_toolset_unavailable_when_missing_creds(self, monkeypatch):
+        # A non-opt-in toolset (e.g. a core web-search provider) missing its
+        # API key must still be reported so the user can fix a real problem.
+        search_entry = {
+            "name": "web_search",
+            "missing_vars": ["SEARCH_API_KEY"],
+            "tools": ["web_search"],
+        }
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [search_entry],
+        )
+
+        assert available == []
+        assert unavailable == [search_entry]
+
+    def test_default_off_toolset_detection_helper(self):
+        assert doctor._is_default_off_toolset({"name": "spotify"}) is True
+        assert doctor._is_default_off_toolset({"name": "web_search"}) is False
+
 
 class TestHonchoDoctorConfigDetection:
     def test_reports_configured_when_enabled_with_api_key(self, monkeypatch):

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -230,7 +230,10 @@ class TestDoctorToolAvailabilityOverrides:
 
     def test_suppresses_warning_for_default_off_toolset_missing_creds(self, monkeypatch):
         # Home Assistant is opt-in (_DEFAULT_OFF_TOOLSETS) — a clean install
-        # that never configured it should not surface a doctor warning.
+        # that never configured/enabled it should not surface a doctor
+        # warning. Resolver returns an enabled set that does NOT include
+        # homeassistant, matching a clean install.
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: set())
         homeassistant_entry = {
             "name": "homeassistant",
             "missing_vars": ["HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"],
@@ -248,6 +251,7 @@ class TestDoctorToolAvailabilityOverrides:
     def test_suppresses_warning_for_each_default_off_toolset(self, monkeypatch):
         from hermes_cli.tools_config import _DEFAULT_OFF_TOOLSETS
 
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: set())
         entries = [
             {"name": name, "missing_vars": ["SOME_KEY"], "tools": ["some_tool"]}
             for name in _DEFAULT_OFF_TOOLSETS
@@ -261,6 +265,7 @@ class TestDoctorToolAvailabilityOverrides:
     def test_leaves_normally_enabled_toolset_unavailable_when_missing_creds(self, monkeypatch):
         # A non-opt-in toolset (e.g. a core web-search provider) missing its
         # API key must still be reported so the user can fix a real problem.
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: set())
         search_entry = {
             "name": "web_search",
             "missing_vars": ["SEARCH_API_KEY"],
@@ -275,9 +280,52 @@ class TestDoctorToolAvailabilityOverrides:
         assert available == []
         assert unavailable == [search_entry]
 
+    def test_does_not_suppress_default_off_toolset_the_user_explicitly_enabled(self, monkeypatch):
+        # Regression for sweeper review on PR #60364: a user who explicitly
+        # enables a default-off toolset via `hermes tools` has opted into
+        # wanting its missing-credential problems surfaced. Suppressing the
+        # warning here would hide a real, actionable setup issue for an
+        # integration the user is actively relying on.
+        monkeypatch.setattr(
+            doctor, "_enabled_cli_toolsets_for_doctor", lambda: {"homeassistant"}
+        )
+        homeassistant_entry = {
+            "name": "homeassistant",
+            "missing_vars": ["HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"],
+            "tools": ["homeassistant_call_service"],
+        }
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [homeassistant_entry],
+        )
+
+        assert available == []
+        assert unavailable == [homeassistant_entry]
+
+    def test_does_not_suppress_when_enabled_resolver_fails(self, monkeypatch):
+        # If config resolution fails (returns None), fail toward showing the
+        # warning rather than guessing the toolset is safely unopted-into.
+        monkeypatch.setattr(doctor, "_enabled_cli_toolsets_for_doctor", lambda: None)
+        homeassistant_entry = {
+            "name": "homeassistant",
+            "missing_vars": ["HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"],
+            "tools": ["homeassistant_call_service"],
+        }
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [homeassistant_entry],
+        )
+
+        assert available == []
+        assert unavailable == [homeassistant_entry]
+
     def test_default_off_toolset_detection_helper(self):
-        assert doctor._is_default_off_toolset({"name": "spotify"}) is True
-        assert doctor._is_default_off_toolset({"name": "web_search"}) is False
+        assert doctor._is_default_off_toolset({"name": "spotify"}, set()) is True
+        assert doctor._is_default_off_toolset({"name": "spotify"}, {"spotify"}) is False
+        assert doctor._is_default_off_toolset({"name": "spotify"}, None) is False
+        assert doctor._is_default_off_toolset({"name": "web_search"}, set()) is False
 
 
 class TestHonchoDoctorConfigDetection:


### PR DESCRIPTION
## Problem

`hermes doctor`'s Tool Availability section warns about every registered toolset that's unavailable due to missing credentials — including bundled-but-intentionally-disabled opt-in integrations (Home Assistant, Spotify, MoA, video generation, Discord admin tools, X search). A clean install that never configured these looks dirty in the per-toolset warning list, even though nothing is actually wrong.

## Relationship to existing code / issue #11336

This repo already has `_missing_api_key_toolsets_for_summary()`, which filters the final `Run 'hermes setup'...` summary line by CLI-enabled toolsets. That mechanism does **not** touch the earlier per-toolset Tool Availability warnings this PR addresses — the two are complementary layers, not overlapping/duplicate logic. Confirmed by reading both call sites before writing this fix.

Same class of bug as issue #11336 ('hermes doctor should ignore disabled toolsets in missing-key summary', closed but never merged — 6 competing community PRs exist against that issue, all targeting the summary-line half of the problem). None of those PRs address the per-toolset warning list this fixes. This is an independent implementation and does not depend on any of them.

## Fix

Adds `_is_default_off_toolset(item)`, which checks `hermes_cli.tools_config`'s existing `_DEFAULT_OFF_TOOLSETS` set (already used elsewhere in the codebase for toolset gating — not a new concept). `_apply_doctor_tool_availability_overrides()` now suppresses per-toolset warnings for entries in that set, alongside its existing runtime-gated-toolset handling.

## Testing

```
$ python -m pytest tests/hermes_cli/test_doctor.py -k 'DefaultOff or default_off or ToolAvailabilityOverrides' -v
10 passed in 0.89s
```

4 new tests added:
- `test_suppresses_warning_for_default_off_toolset_missing_creds`
- `test_suppresses_warning_for_each_default_off_toolset` (parametrized over all of `_DEFAULT_OFF_TOOLSETS`)
- `test_leaves_normally_enabled_toolset_unavailable_when_missing_creds` (regression guard — a real missing-key problem in an enabled toolset must still warn)
- `test_default_off_toolset_detection_helper`

Also verified: `ast.parse` syntax check OK, `ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py` — all checks passed.

Note: the full `tests/hermes_cli/test_doctor.py` suite (70 tests) has a pre-existing slow/hanging test unrelated to this change (some other test in the file makes a live network-adjacent call and can exceed 60s); the scoped run above targeting the changed code passes cleanly and quickly.