### PR TITLE
fix(mcp): clear stale oauth state on auth changes

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -775,17 +775,9 @@ def install_entry(entry: CatalogEntry, *, enable: bool = True) -> None:
 def uninstall_entry(name: str, *, purge_install_dir: bool = True) -> bool:
     """Remove a catalog-installed MCP from config and (optionally) wipe its
     clone directory. Returns True if anything was removed."""
-    cfg = load_config()
-    servers = cfg.get("mcp_servers") or {}
-    removed = False
-    if name in servers:
-        del servers[name]
-        if not servers:
-            cfg.pop("mcp_servers", None)
-        else:
-            cfg["mcp_servers"] = servers
-        save_config(cfg)
-        removed = True
+    from hermes_cli.mcp_config import _remove_mcp_server
+
+    removed = _remove_mcp_server(name)
 
     if purge_install_dir:
         clone = _install_root() / name

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -85,6 +85,36 @@ def _get_mcp_servers(config: Optional[dict] = None) -> Dict[str, dict]:
     return servers
 
 
+def _is_oauth_mcp_server(cfg: Any) -> bool:
+    return isinstance(cfg, dict) and cfg.get("auth") == "oauth" and bool(cfg.get("url"))
+
+
+def _mcp_oauth_endpoint(cfg: Any) -> str:
+    if not isinstance(cfg, dict):
+        return ""
+    return str(cfg.get("url") or "")
+
+
+def _cleanup_mcp_oauth_state_if_needed(
+    name: str,
+    old_config: Any,
+    new_config: Any,
+) -> None:
+    """Drop cached OAuth state when a server no longer uses that OAuth endpoint."""
+    if not _is_oauth_mcp_server(old_config):
+        return
+    if _is_oauth_mcp_server(new_config) and (
+        _mcp_oauth_endpoint(old_config) == _mcp_oauth_endpoint(new_config)
+    ):
+        return
+    try:
+        from tools.mcp_oauth_manager import get_manager
+
+        get_manager().remove(name)
+    except Exception:
+        logger.debug("MCP OAuth cleanup skipped for %s", name, exc_info=True)
+
+
 def _save_mcp_server(name: str, server_config: dict) -> bool:
     """Add or update a server entry in config.yaml.
 
@@ -99,8 +129,11 @@ def _save_mcp_server(name: str, server_config: dict) -> bool:
         _warning(f"Server '{name}' was NOT saved due to suspicious configuration.")
         return False
     config = load_config()
-    config.setdefault("mcp_servers", {})[name] = server_config
+    servers = config.setdefault("mcp_servers", {})
+    old_config = servers.get(name)
+    servers[name] = server_config
     save_config(config)
+    _cleanup_mcp_oauth_state_if_needed(name, old_config, server_config)
     return True
 
 
@@ -110,10 +143,12 @@ def _remove_mcp_server(name: str) -> bool:
     servers = config.get("mcp_servers", {})
     if name not in servers:
         return False
+    old_config = servers.get(name)
     del servers[name]
     if not servers:
         config.pop("mcp_servers", None)
     save_config(config)
+    _cleanup_mcp_oauth_state_if_needed(name, old_config, None)
     return True
 
 
@@ -142,11 +177,14 @@ def _replace_mcp_servers(servers: Dict[str, dict]) -> Tuple[bool, List[str]]:
         return False, issues
 
     config = load_config()
+    old_servers = _get_mcp_servers(config)
     if servers:
         config["mcp_servers"] = dict(servers)
     else:
         config.pop("mcp_servers", None)
     save_config(config)
+    for name, old_cfg in old_servers.items():
+        _cleanup_mcp_oauth_state_if_needed(name, old_cfg, servers.get(name))
     return True, []
 
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -671,16 +671,6 @@ def cmd_mcp_remove(args):
     _remove_mcp_server(name)
     _success(f"Removed '{name}' from config")
 
-    # Clean up OAuth tokens if they exist — route through MCPOAuthManager so
-    # any provider instance cached in the current process (e.g. from an
-    # earlier `hermes mcp test` in the same session) is evicted too.
-    try:
-        from tools.mcp_oauth_manager import get_manager
-        get_manager().remove(name)
-        _success("Cleaned up OAuth tokens")
-    except Exception:
-        pass
-
 
 # ─── hermes mcp list ──────────────────────────────────────────────────────────
 

--- a/hermes_cli/mcp_picker.py
+++ b/hermes_cli/mcp_picker.py
@@ -148,12 +148,10 @@ def _remove_custom(name: str) -> None:
         return
     if not prompt_yes_no(f"Remove '{name}' from mcp_servers?", default=False):
         return
-    del servers[name]
-    if not servers:
-        cfg.pop("mcp_servers", None)
-    else:
-        cfg["mcp_servers"] = servers
-    save_config(cfg)
+
+    from hermes_cli.mcp_config import _remove_mcp_server
+
+    _remove_mcp_server(name)
     print(color(f"  ✓ Removed '{name}'", Colors.GREEN))
 
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -102,6 +102,17 @@ def _entry(name: str):
     return e
 
 
+def _seed_oauth_cache(hermes_home: Path, name: str) -> Path:
+    from tools.mcp_oauth_manager import reset_manager_for_tests
+
+    reset_manager_for_tests()
+    token_dir = hermes_home / "mcp-tokens"
+    token_dir.mkdir(exist_ok=True)
+    for suffix in (".json", ".client.json", ".meta.json"):
+        (token_dir / f"{name}{suffix}").write_text("{}")
+    return token_dir
+
+
 
 # ---------------------------------------------------------------------------
 # Manifest parsing
@@ -375,6 +386,30 @@ class TestUninstall:
 
         assert uninstall_entry("nonexistent") is False
 
+    def test_uninstall_cleans_oauth_state(
+        self,
+        catalog_dir,
+        _isolate_hermes_home,
+    ):
+        _write_manifest(
+            catalog_dir,
+            "demo",
+            _basic_manifest(
+                transport={
+                    "type": "http",
+                    "url": "https://mcp.example.com/mcp",
+                },
+                auth={"type": "oauth"},
+            ),
+        )
+        from hermes_cli.mcp_catalog import install_entry, uninstall_entry
+
+        install_entry(_entry("demo"), enable=True)
+        token_dir = _seed_oauth_cache(_isolate_hermes_home, "demo")
+
+        assert uninstall_entry("demo") is True
+        assert not any(token_dir.iterdir())
+
 
 # ---------------------------------------------------------------------------
 # Picker (non-TTY paths only — interactive curses is integration-tested)
@@ -397,6 +432,30 @@ class TestPicker:
         out = capsys.readouterr().out
         assert "demo" in out
         assert "available" in out
+
+    def test_remove_custom_cleans_oauth_state(
+        self,
+        _isolate_hermes_home,
+        monkeypatch,
+    ):
+        from hermes_cli.config import load_config
+        from hermes_cli.mcp_config import _save_mcp_server
+        from hermes_cli.mcp_picker import _remove_custom
+
+        _save_mcp_server(
+            "oauth-custom",
+            {"url": "https://mcp.example.com/mcp", "auth": "oauth"},
+        )
+        token_dir = _seed_oauth_cache(_isolate_hermes_home, "oauth-custom")
+        monkeypatch.setattr(
+            "hermes_cli.mcp_picker.prompt_yes_no",
+            lambda *args, **kwargs: True,
+        )
+
+        _remove_custom("oauth-custom")
+
+        assert "oauth-custom" not in load_config().get("mcp_servers", {})
+        assert not any(token_dir.iterdir())
 
     def test_install_by_name_unknown(self, catalog_dir, capsys):
         from hermes_cli.mcp_picker import install_by_name

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -174,6 +174,60 @@ class TestMcpRemove:
         cmd_mcp_remove(_make_args(name="oauth-srv"))
         assert not token_file.exists()
 
+    def test_save_switch_from_oauth_to_headers_cleans_oauth_state(self, tmp_path):
+        """Changing auth away from OAuth must drop stale token/client cache."""
+        from hermes_cli.mcp_config import _save_mcp_server
+
+        _save_mcp_server(
+            "cloudflare",
+            {"url": "https://mcp.cloudflare.com/mcp", "auth": "oauth"},
+        )
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        for suffix in (".json", ".client.json", ".meta.json"):
+            (token_dir / f"cloudflare{suffix}").write_text("{}")
+
+        _save_mcp_server(
+            "cloudflare",
+            {
+                "url": "https://mcp.cloudflare.com/mcp",
+                "headers": {"Authorization": "Bearer ${MCP_CLOUDFLARE_API_KEY}"},
+            },
+        )
+
+        assert not any(token_dir.iterdir())
+
+    def test_replace_switch_from_oauth_to_headers_cleans_oauth_state(self, tmp_path):
+        """Dashboard/editor whole-map saves must also evict stale OAuth cache."""
+        _seed_config(
+            tmp_path,
+            {
+                "cloudflare": {
+                    "url": "https://mcp.cloudflare.com/mcp",
+                    "auth": "oauth",
+                }
+            },
+        )
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        for suffix in (".json", ".client.json", ".meta.json"):
+            (token_dir / f"cloudflare{suffix}").write_text("{}")
+
+        from hermes_cli.mcp_config import _replace_mcp_servers
+
+        ok, issues = _replace_mcp_servers(
+            {
+                "cloudflare": {
+                    "url": "https://mcp.cloudflare.com/mcp",
+                    "headers": {"Authorization": "Bearer ${MCP_CLOUDFLARE_API_KEY}"},
+                }
+            }
+        )
+
+        assert ok is True
+        assert issues == []
+        assert not any(token_dir.iterdir())
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_add


### PR DESCRIPTION
## Summary

- Clear persisted and in-process MCP OAuth state when a server changes away from its previous OAuth endpoint.
- Route CLI, dashboard/editor, picker custom removal, and catalog uninstall through the same cleanup-owning config helpers.
- Add regression coverage for auth transitions and both picker/catalog removal paths.

## Root Cause

Several MCP config mutation paths updated `mcp_servers` directly without calling `MCPOAuthManager.remove()`. Persisted token/client/metadata files and an in-process provider could therefore survive a removal or auth transition and be reused if that server later returned to OAuth or changed endpoints.

The current config remains authoritative: cached files alone do not activate OAuth after `auth: oauth` is removed. This change keeps cache lifecycle aligned with config lifecycle instead of treating stale cache files as the auth selector.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_catalog.py tests/tools/test_mcp_oauth_manager.py -- -q` (117 passed)
- `python3 -m py_compile hermes_cli/mcp_config.py hermes_cli/mcp_picker.py hermes_cli/mcp_catalog.py tests/hermes_cli/test_mcp_catalog.py`
- `git diff --check`

Refs #60313