### PR TITLE
fix(moa): thread custom_providers into aggregator context-length resolution

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1931,7 +1931,8 @@ def get_model_context_length(
             from hermes_cli.moa_config import resolve_moa_preset
             from hermes_cli.runtime_provider import resolve_runtime_provider
 
-            preset = resolve_moa_preset(load_config().get("moa") or {}, model)
+            _moa_cfg = load_config()
+            preset = resolve_moa_preset(_moa_cfg.get("moa") or {}, model)
             agg = preset.get("aggregator") or {}
             agg_provider = str(agg.get("provider") or "").strip()
             agg_model = str(agg.get("model") or "").strip()
@@ -1942,6 +1943,7 @@ def get_model_context_length(
                     base_url=rt.get("base_url", "") or "",
                     api_key=rt.get("api_key", "") or "",
                     provider=agg_provider,
+                    custom_providers=_moa_cfg.get("custom_providers"),
                 )
         except Exception:
             logger.debug("MoA aggregator context-length resolution failed", exc_info=True)


### PR DESCRIPTION
## Problem

When a MoA preset uses a custom provider's model as the aggregator, `get_model_context_length()` resolves the aggregator's real provider+model and recurses to find the acting context window. However, the recursive call **did not pass `custom_providers`**, so the per-model `context_length` override defined under `custom_providers[].models.<model>.context_length` was never consulted (step 0b).

This caused MoA to fall through to the hardcoded catalog match (e.g. `glm` → 202,752) instead of the user-configured value (e.g. 1,048,000), making MoA appear to have a much smaller context window than the aggregator model actually supports.

## Reproduction

1. Configure a MoA preset with an aggregator on a custom provider:
   ```yaml
   custom_providers:
     - name: my-provider
       base_url: https://api.example.com/v3
       models:
         my-model:
           context_length: 1048000
   moa:
     presets:
       default:
         aggregator:
           provider: custom:my-provider
           model: my-model
   ```
2. Launch a MoA-backed session and observe the reported context length.
3. **Before fix:** context = 202,752 (hardcoded `glm` catalog match)
4. **After fix:** context = 1,048,000 (from `custom_providers` override)

Agent log before fix:
   `INFO agent.model_metadata: Using hardcoded context length 202,752 for model 'glm-latest' (custom endpoint, catalog match on 'glm')`

Agent log after fix:
   (no catalog fallback line — step 0b returns the configured 1,048,000)

## Fix

Capture the `load_config()` result and pass `custom_providers` through the recursive call so `get_custom_provider_context_length()` in step 0b can match the aggregator's `base_url` against the user's `custom_providers` and return the correct override.

## Test plan

- [x] Syntax check passes (`py_compile`)
- [x] E2E verification: `get_model_context_length(model='default', provider='moa')` returns 1,048,000 with a config that defines `context_length: 1048000` under `custom_providers[].models.glm-latest`
- [x] Diff is minimal: 3 lines changed, 1 file

## Notes

- This follows the pattern already used in step 0b (`custom_providers per-model override`) — the MoA branch simply wasn't threading the parameter through.
- The `_moa_cfg` variable avoids calling `load_config()` twice.