### PR TITLE
fix(desktop): detect VNC sessions in detectRemoteDisplay to disable GPU

### DIFF
--- a/apps/desktop/electron/backend-ready.test.ts
+++ b/apps/desktop/electron/backend-ready.test.ts
@@ -139,6 +139,28 @@ test('a late announcement after timeout does not throw (listeners torn down)', a
 })
 
 // ---------------------------------------------------------------------------
+// contract: waitForDashboardPort attaches listeners synchronously
+// ---------------------------------------------------------------------------
+
+test('waitForDashboardPort attaches its stdout listener synchronously (no deferred setup gap)', async () => {
+  // The fix in main.ts (d7ada599f) relies on the fact that
+  // waitForDashboardPortAnnouncement attaches its stdout listener during the
+  // constructor call, BEFORE any subsequent code runs. If the function were
+  // refactored to defer listener attachment (e.g. via setTimeout(fn, 0) or
+  // a microtask) the wiring fix would be ineffective — the READY line could
+  // arrive in the async gap. This test confirms the listener is live and
+  // ready to capture data the instant waitForDashboardPort returns.
+  const child = makeFakeChild()
+  // 1. Attach the port listener (synchronous — returns immediately).
+  const p = waitForDashboardPort(child, 1000)
+  // 2. Emit the READY line in the same synchronous turn.
+  child.stdout.emit('data', 'HERMES_BACKEND_READY port=3000\n')
+  // 3. The port promise must resolve immediately — no deferred setup or
+  //    microtask gap — because the listener was attached in step 1.
+  assert.equal(await p, 3000)
+})
+
+// ---------------------------------------------------------------------------
 // ready-file port announcement
 // ---------------------------------------------------------------------------
 

--- a/apps/desktop/electron/bootstrap-platform.test.ts
+++ b/apps/desktop/electron/bootstrap-platform.test.ts
@@ -64,6 +64,30 @@ test('detectRemoteDisplay flags forwarded X11 displays but not local ones', () =
   assert.equal(detectRemoteDisplay({ env: { DISPLAY: ':1' }, platform: 'linux' }), null)
 })
 
+test('detectRemoteDisplay flags VNC sessions on Linux via VNCDESKTOP', () => {
+  // DISPLAY=:1 alone is local, but with VNCDESKTOP set it's a VNC session.
+  // NOTE: the existing assertion above (DISPLAY=:1 → null) must remain — it
+  // proves that a VNC-free local display is not mistaken for remote.
+  assert.match(
+    String(detectRemoteDisplay({ env: { DISPLAY: ':1', VNCDESKTOP: 'tiger' }, platform: 'linux' })),
+    /^vnc \(VNCDESKTOP=tiger\)/
+  )
+  assert.match(
+    String(detectRemoteDisplay({ env: { DISPLAY: ':2', VNCDESKTOP: 'TurboVNC' }, platform: 'linux' })),
+    /^vnc/
+  )
+  // Empty VNCDESKTOP is falsy — the source uses if (env.VNCDESKTOP) so empty
+  // string does NOT trigger detection. This is the intended behaviour.
+  assert.equal(
+    detectRemoteDisplay({ env: { DISPLAY: ':1', VNCDESKTOP: '' }, platform: 'linux' }),
+    null,
+    'empty-string VNCDESKTOP should not trigger detection'
+  )
+  // VNCDESKTOP is only checked on Linux; non-Linux platforms ignore it.
+  assert.equal(detectRemoteDisplay({ env: { VNCDESKTOP: 'tiger' }, platform: 'darwin' }), null)
+  assert.equal(detectRemoteDisplay({ env: { VNCDESKTOP: 'tiger' }, platform: 'win32' }), null)
+})
+
 test('detectRemoteDisplay flags RDP sessions', () => {
   assert.match(String(detectRemoteDisplay({ env: { SESSIONNAME: 'RDP-Tcp#7' }, platform: 'win32' })), /^rdp/)
 })

--- a/apps/desktop/electron/bootstrap-platform.ts
+++ b/apps/desktop/electron/bootstrap-platform.ts
@@ -92,6 +92,11 @@ function detectRemoteDisplay(options: { env?: NodeJS.ProcessEnv; platform?: Node
     if (display.includes(':') && display.split(':')[0]) {
       return `x11-forwarding (DISPLAY=${display})`
     }
+
+    // TigerVNC / TurboVNC sessions use CPU-only llvmpipe rendering; Chromium's
+    // GPU compositor fails with ContextResult::kTransientFailure on the command
+    // buffer because there's no hardware GPU to accelerate with.
+    if (env.VNCDESKTOP) return `vnc (VNCDESKTOP=${env.VNCDESKTOP})`
   }
 
   if (platform === 'win32') {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6846,14 +6846,27 @@ async function startHermes() {
       })
     )
 
-    hermesProcess.stdout.on('data', rememberLog)
-    hermesProcess.stderr.on('data', rememberLog)
     let backendReady = false
     let rejectBackendStart = null
 
     const backendStartFailed = new Promise((_resolve, reject) => {
       rejectBackendStart = reject
     })
+
+    // Set up the port-announcement listener BEFORE rememberLog so we never
+    // miss the HERMES_BACKEND_READY line in the gap between the two listeners.
+    const portPromise = (async () => {
+      const p = await Promise.race([
+        waitForDashboardPortAnnouncement(hermesProcess, { readyFile }),
+        backendStartFailed
+      ])
+      if (readyFile) {
+        fs.unlink(readyFile, () => {})
+      }
+      return p
+    })()
+    hermesProcess.stdout.on('data', rememberLog)
+    hermesProcess.stderr.on('data', rememberLog)
 
     hermesProcess.once('error', error => {
       rememberLog(`Hermes backend failed to start: ${error.message}`)
@@ -6899,14 +6912,7 @@ async function startHermes() {
     await advanceBootProgress('backend.port', 'Waiting for Hermes backend to launch', 86)
 
     // Discover the ephemeral port the child bound to
-    const port = await Promise.race([
-      waitForDashboardPortAnnouncement(hermesProcess, { readyFile }),
-      backendStartFailed
-    ])
-
-    if (readyFile) {
-      fs.unlink(readyFile, () => {})
-    }
+    const port = await portPromise
 
     const baseUrl = `http://127.0.0.1:${port}`
     await advanceBootProgress('backend.wait', 'Waiting for Hermes backend to become ready', 90)


### PR DESCRIPTION
## Problem

Running Hermes Desktop through TigerVNC/TurboVNC produces a blank window. Chromium's GPU compositor fails with `ContextResult::kTransientFailure: Failed to send GpuControl.CreateCommandBuffer` because VNC uses CPU-only llvmpipe rendering — there's no hardware GPU to accelerate through the wire.

The existing `detectRemoteDisplay()` function catches SSH X11-forwarded displays (host-prefixed `DISPLAY`, e.g. `localhost:10.0`) but not VNC sessions (`DISPLAY=:1` with `VNCDESKTOP` set).

## Fixes

### 1. VNC GPU detection (`31d411c54`)
Add a check for the `VNCDESKTOP` environment variable (set by TigerVNC/TurboVNC) so the app auto-disables GPU hardware acceleration in VNC contexts.

### 2. Port-announcement race fix (`d7ada599f`)
The port-announcement listener (`waitForDashboardPortAnnouncement`) was registered after `rememberLog`, creating a race condition where the `HERMES_BACKEND_READY` line could arrive in the gap between the two listener registrations and be missed. Moves the port listener to before `rememberLog` so it's always the first listener attached to the backend process stdout/stderr.

## Testing

Before: GPU error on launch in VNC, blank window.
After: `remote display detected (vnc (VNCDESKTOP=...)); disabling GPU hardware acceleration to prevent flicker` — window renders correctly. Backend-ready signal is reliably captured.

## Related

The desktop-file workaround (`HERMES_DESKTOP_DISABLE_GPU=1`) can be removed once this ships.