### PR TITLE
fix(reasoning): add deepseek-v4-flash and deepseek-v4-pro to reasoning timeout floor

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -66,9 +66,13 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     ("nemotron-3-ultra", 600),
     ("nemotron-3-super", 600),
     ("nemotron-3-nano",  300),
-    # DeepSeek — R1 reasoning model on hosted NIM / DeepSeek direct.
+    # DeepSeek — R1 and V4 reasoning models on hosted NIM / DeepSeek direct.
+    # V4 series emits reasoning_content in a separate delta field before
+    # final content, requiring the same extended stale timeout floor.
     ("deepseek-r1", 600),
     ("deepseek-reasoner", 600),
+    ("deepseek-v4-flash", 600),
+    ("deepseek-v4-pro", 600),
     # Qwen — QwQ reasoning + Qwen3 thinking variants.  QwQ-32B
     # preview is the stable slug; ``qwen3`` covers the family of
     # thinking-mode Qwen3 models (qwen3-235b-a22b, qwen3-32b, etc.)
@@ -189,6 +193,10 @@ def get_reasoning_stale_timeout_floor(model: object) -> Optional[float]:
     >>> get_reasoning_stale_timeout_floor("openai/o3-mini")
     300.0
     >>> get_reasoning_stale_timeout_floor("deepseek/deepseek-r1")
+    600.0
+    >>> get_reasoning_stale_timeout_floor("deepseek/deepseek-v4-flash")
+    600.0
+    >>> get_reasoning_stale_timeout_floor("deepseek/deepseek-v4-pro")
     600.0
     >>> get_reasoning_stale_timeout_floor("qwen/qwen3-235b-a22b-thinking")
     180.0

--- a/tests/agent/test_reasoning_timeouts.py
+++ b/tests/agent/test_reasoning_timeouts.py
@@ -1,0 +1,46 @@
+"""Test get_reasoning_stale_timeout_floor for DeepSeek V4 reasoning models."""
+
+from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+
+def test_deepseek_v4_reasoning_models_have_timeout_floor():
+    """DeepSeek V4 reasoning models should have 600s timeout floor.
+
+    DeepSeek V4 models (deepseek-v4-flash, deepseek-v4-pro) emit
+    reasoning_content in a separate delta field before final content,
+    requiring the same extended stale timeout floor as R1.
+    See #60338.
+    """
+    # Direct model names (no aggregator prefix)
+    assert get_reasoning_stale_timeout_floor("deepseek-v4-flash") == 600.0
+    assert get_reasoning_stale_timeout_floor("deepseek-v4-pro") == 600.0
+
+    # With aggregator prefixes (common usage)
+    assert get_reasoning_stale_timeout_floor("deepseek/deepseek-v4-flash") == 600.0
+    assert get_reasoning_stale_timeout_floor("deepseek/deepseek-v4-pro") == 600.0
+
+    # With custom provider prefixes
+    assert get_reasoning_stale_timeout_floor("opencode/deepseek-v4-flash") == 600.0
+    assert get_reasoning_stale_timeout_floor("custom/deepseek-v4-pro") == 600.0
+
+
+def test_deepseek_v4_timeout_floor_matches_r1():
+    """V4 models should have the same floor as R1 (600s)."""
+    v4_flash_floor = get_reasoning_stale_timeout_floor("deepseek-v4-flash")
+    v4_pro_floor = get_reasoning_stale_timeout_floor("deepseek-v4-pro")
+    r1_floor = get_reasoning_stale_timeout_floor("deepseek-r1")
+    reasoner_floor = get_reasoning_stale_timeout_floor("deepseek-reasoner")
+
+    assert v4_flash_floor == v4_pro_floor == r1_floor == reasoner_floor == 600.0
+
+
+def test_deepseek_v4_does_not_match_non_reasoning_deepseek():
+    """Non-reasoning deepseek variants should not match V4 patterns."""
+    # deepseek-chat is not a reasoning model and should not match
+    # the deepseek-v4 patterns (requires start-of-slug anchor).
+    assert get_reasoning_stale_timeout_floor("deepseek-chat") is None
+    assert get_reasoning_stale_timeout_floor("deepseek/deepseek-chat") is None
+
+    # But V4 patterns should still match V4 models even with non-V4 prefixes
+    assert get_reasoning_stale_timeout_floor("some-deepseek-v4-flash") is None  # wrong prefix
+    assert get_reasoning_stale_timeout_floor("deepseek-v4-flash-model") == 600.0  # suffix OK


### PR DESCRIPTION
## What does this PR do?

Adds `deepseek-v4-flash` and `deepseek-v4-pro` to the reasoning-model stale timeout floor (600 seconds).

DeepSeek V4 models emit `reasoning_content` in a separate delta field before final content, requiring the same extended stale timeout floor as R1. Without this floor, streams on providers like opencode-go hang for 30–50 seconds with `APITimeoutError`, while direct calls to the same endpoint succeed in ~3 seconds.

## Related Issue

Fixes #60338

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/reasoning_timeouts.py`: Added `"deepseek-v4-flash"` and `"deepseek-v4-pro"` entries with 600s timeout floor
- `tests/agent/test_reasoning_timeouts.py`: Added regression tests to verify V4 models match the timeout floor and don't over-match non-reasoning variants

## How to Test

1. Run the new test suite:
   ```bash
   python -m pytest tests/agent/test_reasoning_timeouts.py -v
   ```
   Observed result: All 3 tests pass.

2. Verify the function returns the correct floor for V4 models:
   ```python
   from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
   assert get_reasoning_stale_timeout_floor("deepseek-v4-flash") == 600.0
   assert get_reasoning_stale_timeout_floor("deepseek-v4-pro") == 600.0
   ```
   Observed result: Both assertions pass.

3. Verify V4 models don't match non-reasoning variants:
   ```python
   assert get_reasoning_stale_timeout_floor("deepseek-chat") is None
   assert get_reasoning_stale_timeout_floor("some-deepseek-v4-flash") is None
   ```
   Observed result: Both assertions pass (start-of-slug anchor works correctly).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A