### PR TITLE
fix(delegate): include explicit timeout metadata in subagent results

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2004,8 +2004,11 @@ def _run_single_child(
                     _err = (
                         f"Subagent timed out after {child_timeout}s with "
                         f"{child_api_calls} API call(s) completed — likely "
-                        f"stuck on a slow API call or unresponsive network request."
+                        f"stuck on a slow API call, tool call, or unresponsive "
+                        f"network request."
                     )
+                    if diagnostic_path:
+                        _err += f" Diagnostic: {diagnostic_path}"
             else:
                 _err = str(_timeout_exc)
 
@@ -2017,6 +2020,13 @@ def _run_single_child(
                 "exit_reason": "timeout" if is_timeout else "error",
                 "api_calls": child_api_calls,
                 "duration_seconds": duration,
+                "timeout_seconds": child_timeout if is_timeout else None,
+                "timed_out_after_seconds": duration if is_timeout else None,
+                "timeout_phase": (
+                    "before_first_llm_call" if is_timeout and child_api_calls == 0
+                    else "after_llm_calls" if is_timeout
+                    else None
+                ),
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
             }


### PR DESCRIPTION
## Summary

When a subagent times out, the result dict now includes explicit metadata fields so parent agents (and users) can distinguish *why* the timeout happened:

- `timeout_seconds`: the configured timeout value
- `timed_out_after_seconds`: actual wall-clock duration before timeout
- `timeout_phase`: `"before_first_llm_call"` (0 API calls) or `"after_llm_calls"` (N>0)

Also attaches the `diagnostic_path` to the N>0 API-call timeout error message, matching the existing zero-API-call path.

## Before
```json
{
  "status": "timeout",
  "error": "Subagent timed out after 300s with 3 API call(s) completed — likely stuck on a slow API call or unresponsive network request.",
  "api_calls": 3,
  "duration_seconds": 300.0
}
```

## After
```json
{
  "status": "timeout",
  "error": "Subagent timed out after 300s with 3 API call(s) completed — likely stuck on a slow API call, tool call, or unresponsive network request. Diagnostic: /tmp/...",
  "api_calls": 3,
  "duration_seconds": 300.0,
  "timeout_seconds": 300,
  "timed_out_after_seconds": 300.0,
  "timeout_phase": "after_llm_calls"
}
```

## Backward Compatibility

All new fields are additive. Existing code that reads `status`, `error`, `api_calls`, `duration_seconds` continues to work unchanged.

Addresses parts of #51690 (visibility) and #17308 (N-API-call timeout diagnostics).