### PR TITLE
fix(cli): run checkout launcher through managed venv

### DIFF
--- a/hermes
+++ b/hermes
@@ -6,6 +6,68 @@ This wrapper should behave like the installed `hermes` command, including
 subcommands such as `gateway`, `cron`, and `doctor`.
 """
 
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _adjacent_venv_python() -> Path | None:
+    """Return the Python interpreter from the checkout-local venv, if present.
+
+    Legacy service units and direct checkout invocations may execute this file
+    with `/usr/bin/env python3`, bypassing the Hermes virtualenv and therefore
+    missing packages installed only in the managed venv.  Prefer the venv that
+    sits next to this launcher, but fall back to the current interpreter for
+    editable/source checkouts that intentionally have no managed venv.
+    """
+
+    root = Path(__file__).resolve().parent
+    candidates: list[Path]
+    if os.name == "nt":
+        candidates = [
+            root / "venv" / "Scripts" / "python.exe",
+            root / ".venv" / "Scripts" / "python.exe",
+        ]
+    else:
+        candidates = [
+            root / "venv" / "bin" / "python",
+            root / ".venv" / "bin" / "python",
+        ]
+
+    current = Path(sys.executable)
+    try:
+        current_resolved = current.resolve()
+    except OSError:
+        current_resolved = current
+
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        try:
+            candidate_resolved = candidate.resolve()
+        except OSError:
+            candidate_resolved = candidate
+        if candidate_resolved == current_resolved:
+            return None
+        return candidate
+    return None
+
+
+def _reexec_with_adjacent_venv() -> None:
+    python = _adjacent_venv_python()
+    if python is None:
+        return
+
+    os.environ.pop("PYTHONPATH", None)
+    os.environ.pop("PYTHONHOME", None)
+    os.environ.setdefault("VIRTUAL_ENV", str(python.parent.parent))
+    os.execv(str(python), [str(python), str(Path(__file__).resolve()), *sys.argv[1:]])
+
+
 if __name__ == "__main__":
+    _reexec_with_adjacent_venv()
     from hermes_cli.main import main
+
     main()

--- a/hermes
+++ b/hermes
@@ -36,20 +36,16 @@ def _adjacent_venv_python() -> Path | None:
             root / ".venv" / "bin" / "python",
         ]
 
-    current = Path(sys.executable)
-    try:
-        current_resolved = current.resolve()
-    except OSError:
-        current_resolved = current
-
     for candidate in candidates:
         if not candidate.exists():
             continue
         try:
-            candidate_resolved = candidate.resolve()
+            candidate_venv = candidate.parent.parent.resolve()
+            current_prefix = Path(sys.prefix).resolve()
         except OSError:
-            candidate_resolved = candidate
-        if candidate_resolved == current_resolved:
+            candidate_venv = candidate.parent.parent
+            current_prefix = Path(sys.prefix)
+        if candidate_venv == current_prefix:
             return None
         return candidate
     return None

--- a/tests/test_checkout_launcher.py
+++ b/tests/test_checkout_launcher.py
@@ -1,0 +1,52 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LAUNCHER = REPO_ROOT / "hermes"
+
+
+def test_checkout_launcher_reexecs_adjacent_venv_python(tmp_path: Path) -> None:
+    """Legacy service units that invoke ./hermes must still enter the venv.
+
+    A systemd unit installed by older Hermes versions could run the checkout's
+    top-level ``hermes`` script directly.  If its shebang resolves to the system
+    Python, gateway-only dependencies from the managed venv are invisible.  The
+    launcher should detect an adjacent venv and exec that interpreter before
+    importing Hermes modules.
+    """
+
+    install_root = tmp_path / "hermes-agent"
+    install_root.mkdir()
+    launcher = install_root / "hermes"
+    launcher.write_text(LAUNCHER.read_text(encoding="utf-8"), encoding="utf-8")
+
+    fake_python = install_root / "venv" / "bin" / "python"
+    fake_python.parent.mkdir(parents=True)
+    marker = tmp_path / "argv.txt"
+    fake_python.write_text(
+        "#!/usr/bin/env sh\n"
+        f"printf '%s\\n' \"$@\" > {marker}\n"
+        "exit 42\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "should-be-cleared"
+    result = subprocess.run(
+        [sys.executable, str(launcher), "gateway", "run"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 42
+    assert marker.read_text(encoding="utf-8").splitlines() == [
+        str(launcher.resolve()),
+        "gateway",
+        "run",
+    ]

--- a/tests/test_checkout_launcher.py
+++ b/tests/test_checkout_launcher.py
@@ -1,14 +1,27 @@
+import json
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "hermes"
 
 
-def test_checkout_launcher_reexecs_adjacent_venv_python(tmp_path: Path) -> None:
+@pytest.fixture
+def install_root() -> Path:
+    with tempfile.TemporaryDirectory(prefix=".launcher-test-", dir=REPO_ROOT) as root:
+        yield Path(root)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="managed uv venvs use symlinks on POSIX")
+def test_checkout_launcher_reexecs_adjacent_venv_python(
+    install_root: Path, tmp_path: Path
+) -> None:
     """Legacy service units that invoke ./hermes must still enter the venv.
 
     A systemd unit installed by older Hermes versions could run the checkout's
@@ -18,24 +31,55 @@ def test_checkout_launcher_reexecs_adjacent_venv_python(tmp_path: Path) -> None:
     importing Hermes modules.
     """
 
-    install_root = tmp_path / "hermes-agent"
-    install_root.mkdir()
     launcher = install_root / "hermes"
-    launcher.write_text(LAUNCHER.read_text(encoding="utf-8"), encoding="utf-8")
+    os.link(LAUNCHER, launcher)
 
-    fake_python = install_root / "venv" / "bin" / "python"
-    fake_python.parent.mkdir(parents=True)
-    marker = tmp_path / "argv.txt"
-    fake_python.write_text(
-        "#!/usr/bin/env sh\n"
-        f"printf '%s\\n' \"$@\" > {marker}\n"
-        "exit 42\n",
+    venv = install_root / "venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--symlinks", str(venv)],
+        check=True,
+    )
+    venv_python = venv / "bin" / "python"
+    site_packages = Path(
+        subprocess.run(
+            [
+                str(venv_python),
+                "-c",
+                "import sysconfig; print(sysconfig.get_path('purelib'))",
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+    )
+    probe_package = site_packages / "hermes_cli"
+    probe_package.mkdir()
+    (probe_package / "__init__.py").touch()
+    marker = tmp_path / "launcher-result.json"
+    (probe_package / "main.py").write_text(
+        "import json\n"
+        "import os\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "\n"
+        "def main():\n"
+        "    result = {\n"
+        "        'argv': sys.argv,\n"
+        "        'executable': sys.executable,\n"
+        "        'prefix': sys.prefix,\n"
+        "        'pythonpath': os.environ.get('PYTHONPATH'),\n"
+        "        'pythonhome': os.environ.get('PYTHONHOME'),\n"
+        "    }\n"
+        "    Path(os.environ['HERMES_LAUNCHER_TEST_RESULT']).write_text(\n"
+        "        json.dumps(result), encoding='utf-8'\n"
+        "    )\n",
         encoding="utf-8",
     )
-    fake_python.chmod(0o755)
 
     env = os.environ.copy()
+    env["HERMES_LAUNCHER_TEST_RESULT"] = str(marker)
     env["PYTHONPATH"] = "should-be-cleared"
+    env["PYTHONHOME"] = sys.base_prefix
     result = subprocess.run(
         [sys.executable, str(launcher), "gateway", "run"],
         env=env,
@@ -44,9 +88,14 @@ def test_checkout_launcher_reexecs_adjacent_venv_python(tmp_path: Path) -> None:
         check=False,
     )
 
-    assert result.returncode == 42
-    assert marker.read_text(encoding="utf-8").splitlines() == [
+    assert result.returncode == 0, result.stderr
+    recorded = json.loads(marker.read_text(encoding="utf-8"))
+    assert Path(recorded["executable"]).resolve() == Path(sys.executable).resolve()
+    assert Path(recorded["prefix"]).resolve() == venv.resolve()
+    assert recorded["argv"] == [
         str(launcher.resolve()),
         "gateway",
         "run",
     ]
+    assert recorded["pythonpath"] is None
+    assert recorded["pythonhome"] is None


### PR DESCRIPTION
## Summary
- make the checkout-local `./hermes` launcher re-exec the adjacent managed venv Python before importing Hermes modules
- clear inherited Python import env before re-exec, matching the installed shell shim behavior
- add a regression test for legacy service/direct-checkout invocations that hit the launcher with a non-venv Python

## Why
A legacy gateway service or direct checkout invocation can run the top-level `hermes` script via `/usr/bin/env python3`. In headless/systemd environments that interpreter may be the system Python, so gateway dependencies installed only in the managed Hermes venv (for example Telegram/MCP dependencies) are unavailable. The current systemd generator already uses the venv Python directly, but stale units and direct launcher paths still need to be robust.

## Tested platforms
- Fedora Linux 7.0.13-200.fc44.x86_64, Python 3.11.14, managed Hermes install layout under `~/.hermes/hermes-agent`

## Tests
- `scripts/run_tests.sh tests/test_checkout_launcher.py tests/test_install_sh_pythonpath_sanitization.py tests/hermes_cli/test_gateway_service.py` → 188 passed
- `python scripts/check-windows-footguns.py hermes tests/test_checkout_launcher.py` → no Windows footguns found (1 Python file scanned)
- `./hermes --version` → confirmed launcher works through the managed venv
- `python -m pytest tests/ -o 'addopts=' -q` → timed out after 600s in this local environment, with many unrelated failures already appearing before the timeout
