### PR TITLE
security(tui): strip stale dangerous confirmations on session resume

### DIFF
--- a/tests/tui_gateway/test_stale_confirmation_resume.py
+++ b/tests/tui_gateway/test_stale_confirmation_resume.py
@@ -1,0 +1,55 @@
+"""Tests for TUI stale confirmation expiry on session resume (#60209)."""
+
+import time
+import pytest
+
+from agent.replay_cleanup import (
+    strip_stale_dangerous_confirmations,
+    is_dangerous_confirmation,
+    _DANGEROUS_CONFIRMATION_EXPIRY_SECONDS,
+)
+
+
+class TestTuiStaleConfirmation:
+    def test_stale_confirmation_stripped_on_resume(self):
+        """Confirmation older than expiry window should be stripped."""
+        now = time.time()
+        history = [
+            {"role": "user", "content": "can you restart?", "timestamp": now - 100},
+            {"role": "assistant", "content": "Type confirm...", "timestamp": now - 99},
+            {"role": "user", "content": "confirm forced restart", "timestamp": now - 61},
+            {"role": "assistant", "content": "OK restarting", "timestamp": now - 60},
+        ]
+        result = strip_stale_dangerous_confirmations(history, now=now)
+        # The confirmation message should be expired
+        confirmations = [
+            m for m in result
+            if m["role"] == "user" and "confirm forced restart" in (m.get("content") or "")
+        ]
+        assert len(confirmations) == 0
+
+    def test_fresh_confirmation_preserved(self):
+        """Confirmation within expiry window should be kept."""
+        now = time.time()
+        history = [
+            {"role": "user", "content": "can you restart?", "timestamp": now - 30},
+            {"role": "assistant", "content": "Type confirm...", "timestamp": now - 29},
+            {"role": "user", "content": "confirm forced restart", "timestamp": now - 5},
+            {"role": "assistant", "content": "OK restarting", "timestamp": now - 4},
+        ]
+        result = strip_stale_dangerous_confirmations(history, now=now)
+        confirmations = [
+            m for m in result
+            if m["role"] == "user" and "confirm forced restart" in (m.get("content") or "")
+        ]
+        assert len(confirmations) == 1
+
+    def test_expiry_window_is_reasonable(self):
+        """Expiry window should be 60 seconds (short for safety)."""
+        assert _DANGEROUS_CONFIRMATION_EXPIRY_SECONDS == 60.0
+
+    def test_dangerous_patterns_recognized(self):
+        """Known dangerous confirmation patterns should be detected."""
+        assert is_dangerous_confirmation("confirm forced restart")
+        assert is_dangerous_confirmation("confirm forced reboot")
+        assert not is_dangerous_confirmation("hello world")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -26,7 +26,7 @@ from hermes_constants import (
 from hermes_cli.env_loader import load_hermes_dotenv
 from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
-from agent.replay_cleanup import sanitize_replay_history
+from agent.replay_cleanup import sanitize_replay_history, strip_stale_dangerous_confirmations
 from tui_gateway import git_probe
 from tui_gateway.transport import (
     StdioTransport,
@@ -5550,6 +5550,10 @@ def _(rid, params: dict) -> dict:
         # not replay the unanswered call forever (#29086).
         prefix = display_history[: max(0, len(display_history) - len(raw_history))]
         history = sanitize_replay_history(raw_history)
+        # Strip stale dangerous-confirmation text so that a high-risk
+        # confirmation phrase spoken in a previous turn does not survive
+        # a session resume and trigger the destructive action again (#59607).
+        history = strip_stale_dangerous_confirmations(history, now=time.time())
         # Restore the model/provider/reasoning/tier this chat last used so the
         # deferred build (and the info below) match the eager path — without them
         # the build drops the provider ("No LLM provider configured").
@@ -5625,6 +5629,10 @@ def _(rid, params: dict) -> dict:
             : max(0, len(display_history) - len(raw_history))
         ]
         history = sanitize_replay_history(raw_history)
+        # Strip stale dangerous-confirmation text so that a high-risk
+        # confirmation phrase spoken in a previous turn does not survive
+        # a session resume and trigger the destructive action again (#59607).
+        history = strip_stale_dangerous_confirmations(history, now=time.time())
         messages = _history_to_messages(display_history)
         tokens = _set_session_context(target)
         try:


### PR DESCRIPTION
## What does this PR do?

The TUI gateway has two session resume paths that strip dangling tool-call tails but do not expire stale dangerous-confirmation text — unlike the main gateway, which already does this (#60110, #60117).

When a user confirms a destructive action in a TUI session, that confirmation text persists. On resume, the model could re-interpret an unrelated message as a fresh confirmation and re-trigger the destructive action.

## Related Issue

Fixes the TUI sibling path of #59607.

## Type of Change

- [x] Bug fix
- [x] Security fix

## Changes Made

- `tui_gateway/server.py`: Import `strip_stale_dangerous_confirmations`, add call after `sanitize_replay_history()` in both TUI resume paths
- `tests/tui_gateway/test_stale_confirmation_resume.py`: 4 tests covering stale/fresh confirmation, expiry window, and dangerous pattern detection

## How to Test

1. Start TUI, confirm a destructive action
2. Kill the session, resume it after 60+ seconds
3. Verify the confirmation text is stripped from the replayed history