### PR TITLE
security(discord): bound image/animation/attachment HTTP response reads

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2506,7 +2506,9 @@ class DiscordAdapter(BasePlatformAdapter):
                                         self.name, resp.status, image_url[:80],
                                     )
                                     continue
-                                data = await resp.read()
+                                data = await _read_response_bytes_bounded(
+                                    resp, _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES
+                                )
                                 ct = resp.headers.get("content-type", "image/png")
                                 ext = "png"
                                 if "jpeg" in ct or "jpg" in ct:
@@ -3594,7 +3596,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     if resp.status != 200:
                         raise Exception(f"Failed to download image: HTTP {resp.status}")
 
-                    image_data = await resp.read()
+                    image_data = await _read_response_bytes_bounded(
+                        resp, _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES
+                    )
 
                     # Determine filename from URL or content type
                     content_type = resp.headers.get("content-type", "image/png")
@@ -3673,7 +3677,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     if resp.status != 200:
                         raise Exception(f"Failed to download animation: HTTP {resp.status}")
 
-                    animation_data = await resp.read()
+                    animation_data = await _read_response_bytes_bounded(
+                        resp, _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES
+                    )
 
                     import io
                     file = discord.File(io.BytesIO(animation_data), filename="animation.gif")
@@ -5988,7 +5994,9 @@ class DiscordAdapter(BasePlatformAdapter):
             ) as resp:
                 if resp.status != 200:
                     raise Exception(f"HTTP {resp.status}")
-                return await resp.read()
+                return await _read_response_bytes_bounded(
+                    resp, _DISCORD_ATTACHMENT_DOWNLOAD_MAX_BYTES
+                )
 
     async def _handle_message(self, message: DiscordMessage, role_authorized: bool = False) -> None:
         """Handle incoming Discord messages."""
@@ -7633,10 +7641,23 @@ if DISCORD_AVAILABLE:
 _DISCORD_CHANNEL_TYPE_PROBE_CACHE: Dict[str, bool] = {}
 _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES = 1 * 1024 * 1024
 _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES = 8 * 1024
+_DISCORD_IMAGE_DOWNLOAD_MAX_BYTES = 50 * 1024 * 1024  # generous limit for images/animations
+_DISCORD_ATTACHMENT_DOWNLOAD_MAX_BYTES = 100 * 1024 * 1024  # generous for file attachments
 
 
 def _remember_channel_is_forum(chat_id: str, is_forum: bool) -> None:
     _DISCORD_CHANNEL_TYPE_PROBE_CACHE[str(chat_id)] = bool(is_forum)
+
+
+async def _read_response_bytes_bounded(resp: Any, limit_bytes: int) -> bytes:
+    """Read at most *limit_bytes* from an aiohttp response, raising on overflow."""
+    data = await resp.content.read(limit_bytes + 1)
+    if len(data) > limit_bytes:
+        resp.close()
+        raise ValueError(
+            f"Response body exceeded {limit_bytes} bytes ({len(data)} bytes read)"
+        )
+    return data
 
 
 def _probe_is_forum_cached(chat_id: str) -> Optional[bool]:

--- a/tests/gateway/test_discord_attachment_download.py
+++ b/tests/gateway/test_discord_attachment_download.py
@@ -286,6 +286,8 @@ class TestCacheDiscordDocument:
         resp = AsyncMock()
         resp.status = 200
         resp.read = AsyncMock(return_value=_PDF_BYTES)
+        resp.content = MagicMock()
+        resp.content.read = AsyncMock(return_value=_PDF_BYTES)
         resp.__aenter__ = AsyncMock(return_value=resp)
         resp.__aexit__ = AsyncMock(return_value=False)
 

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -142,6 +142,8 @@ def _mock_aiohttp_download(raw_bytes: bytes):
     resp = AsyncMock()
     resp.status = 200
     resp.read = AsyncMock(return_value=raw_bytes)
+    resp.content = MagicMock()
+    resp.content.read = AsyncMock(return_value=raw_bytes)
     resp.__aenter__ = AsyncMock(return_value=resp)
     resp.__aexit__ = AsyncMock(return_value=False)
 
@@ -344,6 +346,8 @@ class TestIncomingDocumentHandling:
                     resp = AsyncMock()
                     resp.status = 200
                     resp.read = AsyncMock(return_value=data)
+                    resp.content = MagicMock()
+                    resp.content.read = AsyncMock(return_value=data)
                     resp.__aenter__ = AsyncMock(return_value=resp)
                     resp.__aexit__ = AsyncMock(return_value=False)
                     return resp

--- a/tests/gateway/test_discord_image_download_bounds.py
+++ b/tests/gateway/test_discord_image_download_bounds.py
@@ -5,6 +5,7 @@ resource-limiting pattern to image/animation/attachment downloads
 in the Discord adapter that were left unbounded.
 """
 
+import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -34,7 +35,7 @@ class TestReadResponseBytesBounded:
         resp.content = MagicMock()
         resp.content.read = AsyncMock(return_value=b"x" * 100)
 
-        result = pytest.run_sync(
+        result = asyncio.run(
             _read_response_bytes_bounded(resp, 200)
         )
         assert result == b"x" * 100
@@ -47,7 +48,7 @@ class TestReadResponseBytesBounded:
         resp.close = MagicMock()
 
         with pytest.raises(ValueError, match="exceeded 100 bytes"):
-            pytest.run_sync(
+            asyncio.run(
                 _read_response_bytes_bounded(resp, 100)
             )
         resp.close.assert_called_once()
@@ -57,7 +58,7 @@ class TestReadResponseBytesBounded:
         resp.content = MagicMock()
         resp.content.read = AsyncMock(return_value=b"x" * 100)
 
-        result = pytest.run_sync(
+        result = asyncio.run(
             _read_response_bytes_bounded(resp, 100)
         )
         assert result == b"x" * 100

--- a/tests/gateway/test_discord_image_download_bounds.py
+++ b/tests/gateway/test_discord_image_download_bounds.py
@@ -1,0 +1,73 @@
+"""Tests for bounded HTTP response reads in Discord image/download paths.
+
+Companion to #60122, #60112 (REST body bounding) — extends the same
+resource-limiting pattern to image/animation/attachment downloads
+in the Discord adapter that were left unbounded.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from plugins.platforms.discord.adapter import (
+    _read_response_bytes_bounded,
+    _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES,
+    _DISCORD_ATTACHMENT_DOWNLOAD_MAX_BYTES,
+)
+
+
+class AsyncContextManagerMock:
+    """Mock that supports ``async with``."""
+
+    def __init__(self, return_value):
+        self._return_value = return_value
+
+    async def __aenter__(self):
+        return self._return_value
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class TestReadResponseBytesBounded:
+    def test_reads_within_limit(self):
+        resp = MagicMock()
+        resp.content = MagicMock()
+        resp.content.read = AsyncMock(return_value=b"x" * 100)
+
+        result = pytest.run_sync(
+            _read_response_bytes_bounded(resp, 200)
+        )
+        assert result == b"x" * 100
+        resp.content.read.assert_awaited_once_with(201)
+
+    def test_raises_on_overflow(self):
+        resp = MagicMock()
+        resp.content = MagicMock()
+        resp.content.read = AsyncMock(return_value=b"x" * 101)
+        resp.close = MagicMock()
+
+        with pytest.raises(ValueError, match="exceeded 100 bytes"):
+            pytest.run_sync(
+                _read_response_bytes_bounded(resp, 100)
+            )
+        resp.close.assert_called_once()
+
+    def test_exact_limit_passes(self):
+        resp = MagicMock()
+        resp.content = MagicMock()
+        resp.content.read = AsyncMock(return_value=b"x" * 100)
+
+        result = pytest.run_sync(
+            _read_response_bytes_bounded(resp, 100)
+        )
+        assert result == b"x" * 100
+
+
+class TestImageDownloadLimits:
+    def test_constants_are_reasonable(self):
+        assert _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES == 50 * 1024 * 1024
+        assert _DISCORD_ATTACHMENT_DOWNLOAD_MAX_BYTES == 100 * 1024 * 1024
+
+    def test_image_limit_greater_than_zero(self):
+        assert _DISCORD_IMAGE_DOWNLOAD_MAX_BYTES > 0
+        assert _DISCORD_ATTACHMENT_DOWNLOAD_MAX_BYTES > 0


### PR DESCRIPTION
## What does this PR do?

Extends the Discord resource-bounding pass (#60122, #60112, #60113) to four HTTP response reads for image/animation/attachment downloads that were left unbounded. An attacker or misconfigured CDN could exhaust bot memory via a multi-GB response.

## Related Issue

Fixes sibling paths of #60122, #60112.

## Type of Change

- [x] Bug fix
- [x] Security fix

## Changes Made

- `plugins/platforms/discord/adapter.py`: Add `_read_response_bytes_bounded()`, constants (50MB/100MB), replace 4 unbounded reads
- `tests/gateway/test_discord_image_download_bounds.py`: Unit tests

## How to Test

1. Configure Discord bot with image download enabled
2. Send an image URL pointing to a >50MB file
3. Verify download is rejected with clear error instead of OOM