### PR TITLE
fix: use routed context for adaptive model compression

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -40,6 +40,30 @@ from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 
+_OMNIROUTE_CTX_BUCKET_FAMILIES: tuple[
+    tuple[tuple[tuple[str, int], ...], str | None], ...
+] = (
+    (
+        (
+            ("combo/coding-weighted-128k", 128_000),
+            ("combo/coding-weighted-200k", 200_000),
+            ("combo/coding-weighted-262k", 262_144),
+            ("combo/coding-weighted-400k", 400_000),
+            ("combo/coding-weighted-1m", 1_000_000),
+        ),
+        "combo/coding-weighted-wide",
+    ),
+    (
+        (
+            ("combo/coding-extended-ranked-128k", 128_000),
+            ("combo/coding-extended-ranked-200k", 200_000),
+            ("combo/coding-extended-ranked-400k", 400_000),
+            ("combo/coding-extended-ranked-1m", 1_000_000),
+        ),
+        None,
+    ),
+)
+
 # When the fallback chain is fully exhausted on a non-rate-limit failure
 # (e.g. every provider returns a non-retryable client error like HTTP 400),
 # arm a short cooldown so the NEXT turn's restore_primary_runtime stays gated
@@ -171,6 +195,103 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _select_omniroute_buckets(requested_model: str) -> tuple[tuple[str, int], ...] | None:
+    for buckets, entrypoint in _OMNIROUTE_CTX_BUCKET_FAMILIES:
+        if requested_model == entrypoint:
+            return buckets
+        for idx, (model_id, _ctx) in enumerate(buckets):
+            if requested_model == model_id:
+                return buckets[: idx + 1]
+    return None
+
+
+def _requested_output_tokens(api_kwargs: dict) -> int:
+    requested_output = 0
+    for key in ("max_completion_tokens", "max_output_tokens", "max_tokens"):
+        raw = api_kwargs.get(key)
+        try:
+            requested_output = max(requested_output, int(raw or 0))
+        except (TypeError, ValueError):
+            continue
+    return requested_output
+
+
+def resolve_omniroute_context_bucket(
+    requested_model: str,
+    est_input_tokens: int,
+    requested_output: int = 0,
+) -> tuple[str | None, int | None, int | None]:
+    """Return the request-scoped OmniRoute bucket model/context, if applicable."""
+    requested_model = str(requested_model or "").strip()
+    selected_buckets = _select_omniroute_buckets(requested_model)
+    if selected_buckets is None:
+        return None, None, None
+
+    est_in_tokens = max(int(est_input_tokens or 0), 0)
+    requested_output = max(int(requested_output or 0), 0)
+    # ponytail: same reserve for routing and compression; split if providers need per-family tuning.
+    reserve = max(8_192, requested_output, int(est_in_tokens * 0.10))
+    effective_total = est_in_tokens + reserve + 4_096
+
+    for candidate_model, ctx_limit in selected_buckets:
+        if effective_total <= ctx_limit:
+            return candidate_model, ctx_limit, effective_total
+    return selected_buckets[-1][0], selected_buckets[-1][1], effective_total
+
+
+def omniroute_effective_context_for_tokens(
+    requested_model: str,
+    est_input_tokens: int,
+    requested_output: int = 0,
+) -> int | None:
+    _model, context_length, _total = resolve_omniroute_context_bucket(
+        requested_model, est_input_tokens, requested_output,
+    )
+    return context_length
+
+
+def _set_omniroute_effective_context(agent, model: str | None, context_length: int | None) -> None:
+    """Expose the routed OmniRoute bucket to UI/status code without mutating agent.model."""
+    if agent is None:
+        return
+    try:
+        setattr(agent, "_omniroute_effective_model", model)
+        setattr(agent, "_omniroute_effective_context_length", context_length)
+    except Exception:
+        pass
+
+
+def _maybe_route_omniroute_context_bucket_model(agent, api_kwargs: dict) -> dict:
+    """Downshift OmniRoute coding bucket combos to the smallest safe context tier."""
+    if not isinstance(api_kwargs, dict):
+        return api_kwargs
+
+    requested_model = str(api_kwargs.get("model") or "").strip()
+    chosen_model, chosen_context_length, effective_total = resolve_omniroute_context_bucket(
+        requested_model,
+        estimate_request_context_tokens(api_kwargs),
+        _requested_output_tokens(api_kwargs),
+    )
+    if chosen_context_length is None:
+        _set_omniroute_effective_context(agent, None, None)
+        return api_kwargs
+
+    if chosen_model == requested_model:
+        _set_omniroute_effective_context(agent, requested_model, chosen_context_length)
+        return api_kwargs
+
+    routed = dict(api_kwargs)
+    routed["model"] = chosen_model
+    _set_omniroute_effective_context(agent, chosen_model, chosen_context_length)
+    logger.info(
+        "Auto-routed OmniRoute context bucket %s -> %s (estimated total ~%s tokens)",
+        requested_model,
+        chosen_model,
+        f"{int(effective_total or 0):,}",
+    )
+    return routed
+
+
 def interruptible_api_call(agent, api_kwargs: dict):
     """
     Run the API call in a background thread so the main conversation loop
@@ -185,6 +306,8 @@ def interruptible_api_call(agent, api_kwargs: dict):
     the main retry loop can try again with backoff / credential rotation /
     provider fallback.
     """
+    api_kwargs = _maybe_route_omniroute_context_bucket_model(agent, api_kwargs)
+
     result = {"response": None, "error": None}
     request_client_holder = {"client": None, "owner_tid": None}
     request_client_lock = threading.Lock()
@@ -1780,6 +1903,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     """
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted before streaming API call")
+
+    api_kwargs = _maybe_route_omniroute_context_bucket_model(agent, api_kwargs)
 
     if agent.api_mode == "codex_responses":
         # Codex streams internally via _run_codex_stream. The main dispatch

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -987,6 +987,13 @@ class ContextCompressor(ContextEngine):
                               effective_window - 1))
         return floored
 
+    def threshold_for_context(self, context_length: int | None) -> int:
+        if not context_length:
+            return self.threshold_tokens
+        return self._compute_threshold_tokens(
+            int(context_length), self.threshold_percent, self.max_tokens,
+        )
+
     def __init__(
         self,
         model: str,
@@ -1170,7 +1177,7 @@ class ContextCompressor(ContextEngine):
         self.last_rough_tokens_when_real_prompt_fit = max(baseline, rough_tokens)
         return True
 
-    def should_compress(self, prompt_tokens: int = None) -> bool:
+    def should_compress(self, prompt_tokens: int = None, *, context_length: int | None = None) -> bool:
         """Check if context exceeds the compression threshold.
 
         Includes anti-thrashing protection: if the last two compressions
@@ -1178,7 +1185,8 @@ class ContextCompressor(ContextEngine):
         where each pass removes only 1-2 messages.
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
-        if tokens < self.threshold_tokens:
+        threshold_tokens = self.threshold_for_context(context_length)
+        if tokens < threshold_tokens:
             return False
         # Do not trigger compression while the summary LLM is in cooldown.
         # On a 429/transient failure _generate_summary() sets a cooldown and

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -32,6 +32,7 @@ from agent.conversation_compression import conversation_history_after_compressio
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
+from agent.chat_completion_helpers import omniroute_effective_context_for_tokens
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
@@ -998,6 +999,10 @@ def run_conversation(
         # LLM cooldown + anti-thrash guards (#11529). compression_attempts is a
         # hard per-turn backstop shared with the overflow error handlers.
         _compressor = agent.context_compressor
+        _effective_context = omniroute_effective_context_for_tokens(
+            agent.model, request_pressure_tokens, getattr(_compressor, "max_tokens", None) or 0,
+        )
+        _effective_threshold = _compressor.threshold_for_context(_effective_context)
         _defer_preflight = getattr(
             _compressor, "should_defer_preflight_to_real_usage", lambda _t: False
         )
@@ -1010,16 +1015,16 @@ def run_conversation(
             and compression_attempts < 3
             and not _defer_preflight(request_pressure_tokens)
             and not _compression_cooldown
-            and _compressor.should_compress(request_pressure_tokens)
+            and _compressor.should_compress(request_pressure_tokens, context_length=_effective_context)
         ):
             compression_attempts += 1
             logger.info(
                 "Pre-API compression: ~%s request tokens >= %s threshold "
                 "(context=%s, attempt=%s/3)",
                 f"{request_pressure_tokens:,}",
-                f"{int(getattr(_compressor, 'threshold_tokens', 0) or 0):,}",
-                f"{int(getattr(_compressor, 'context_length', 0) or 0):,}"
-                if getattr(_compressor, "context_length", 0) else "unknown",
+                f"{_effective_threshold:,}",
+                f"{int(_effective_context or getattr(_compressor, 'context_length', 0) or 0):,}"
+                if (_effective_context or getattr(_compressor, "context_length", 0)) else "unknown",
                 compression_attempts,
             )
             agent._emit_status(

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -28,6 +28,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from agent.chat_completion_helpers import omniroute_effective_context_for_tokens
 from agent.conversation_compression import conversation_history_after_compression
 from agent.iteration_budget import IterationBudget
 from agent.model_metadata import (
@@ -351,11 +352,21 @@ def build_turn_context(
     # Gate the (expensive) full token estimate behind a cheap pre-check.
     # See ``_should_run_preflight_estimate`` for the OR semantics that fix
     # issue #27405 (a few very large messages slipping past the count gate).
+    _precheck_threshold = agent.context_compressor.threshold_tokens
+    _precheck_context = omniroute_effective_context_for_tokens(
+        agent.model, 0, getattr(agent.context_compressor, "max_tokens", None) or 0,
+    )
+    if _precheck_context:
+        _precheck_threshold = min(
+            _precheck_threshold,
+            agent.context_compressor.threshold_for_context(_precheck_context),
+        )
+
     if agent.compression_enabled and _should_run_preflight_estimate(
         messages,
         agent.context_compressor.protect_first_n,
         agent.context_compressor.protect_last_n,
-        agent.context_compressor.threshold_tokens,
+        _precheck_threshold,
     ):
         _preflight_tokens = estimate_request_tokens_rough(
             messages,
@@ -363,6 +374,10 @@ def build_turn_context(
             tools=agent.tools or None,
         )
         _compressor = agent.context_compressor
+        _effective_context = omniroute_effective_context_for_tokens(
+            agent.model, _preflight_tokens, getattr(_compressor, "max_tokens", None) or 0,
+        )
+        _effective_threshold = _compressor.threshold_for_context(_effective_context)
         _defer_preflight = getattr(
             _compressor,
             "should_defer_preflight_to_real_usage",
@@ -401,7 +416,7 @@ def build_turn_context(
                 "Skipping preflight compression: rough estimate ~%s >= %s, "
                 "but last real provider prompt was %s after compression",
                 f"{_preflight_tokens:,}",
-                f"{_compressor.threshold_tokens:,}",
+                f"{_effective_threshold:,}",
                 f"{_compressor.last_real_prompt_tokens:,}",
             )
         elif _compression_cooldown:
@@ -417,17 +432,17 @@ def build_turn_context(
                 "(mode=%s); Hermes will not start thread compaction here.",
                 getattr(agent, "codex_app_server_auto_compaction", "native"),
             )
-        elif _compressor.should_compress(_preflight_tokens):
+        elif _compressor.should_compress(_preflight_tokens, context_length=_effective_context):
             logger.info(
                 "Preflight compression: ~%s tokens >= %s threshold (model %s, ctx %s)",
                 f"{_preflight_tokens:,}",
-                f"{_compressor.threshold_tokens:,}",
+                f"{_effective_threshold:,}",
                 agent.model,
-                f"{_compressor.context_length:,}",
+                f"{(_effective_context or _compressor.context_length):,}",
             )
             agent._emit_status(
                 f"📦 Preflight compression: ~{_preflight_tokens:,} tokens "
-                f">= {_compressor.threshold_tokens:,} threshold. "
+                f">= {_effective_threshold:,} threshold. "
                 "This may take a moment."
             )
             for _pass in range(3):
@@ -458,7 +473,10 @@ def build_turn_context(
                 agent._last_content_with_tools = None
                 agent._last_content_tools_all_housekeeping = False
                 agent._mute_post_response = False
-                if not _compressor.should_compress(_preflight_tokens):
+                _effective_context = omniroute_effective_context_for_tokens(
+                    agent.model, _preflight_tokens, getattr(_compressor, "max_tokens", None) or 0,
+                )
+                if not _compressor.should_compress(_preflight_tokens, context_length=_effective_context):
                     break
 
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).

--- a/cli.py
+++ b/cli.py
@@ -4629,6 +4629,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             context_length = getattr(compressor, "context_length", 0) or 0
             if context_length < 0:
                 context_length = 0
+            effective_context_length = getattr(agent, "_omniroute_effective_context_length", None)
+            if isinstance(effective_context_length, int) and effective_context_length > 0:
+                context_length = effective_context_length
             snapshot["context_tokens"] = context_tokens
             snapshot["context_length"] = context_length or None
             snapshot["compressions"] = getattr(compressor, "compression_count", 0) or 0

--- a/tests/agent/test_chat_completion_helpers_omniroute_routing.py
+++ b/tests/agent/test_chat_completion_helpers_omniroute_routing.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import _maybe_route_omniroute_context_bucket_model
+
+
+def _payload(model: str, tokens: int, **extra):
+    payload = {
+        "model": model,
+        # estimate_request_context_tokens() uses chars//4 for the `input` shape.
+        "input": "x" * (tokens * 4),
+    }
+    payload.update(extra)
+    return payload
+
+
+def test_omniroute_weighted_wide_downshifts_small_requests_to_128k():
+    agent = SimpleNamespace()
+    routed = _maybe_route_omniroute_context_bucket_model(
+        agent, _payload("combo/coding-weighted-wide", 20_000)
+    )
+    assert routed["model"] == "combo/coding-weighted-128k"
+    assert agent._omniroute_effective_model == "combo/coding-weighted-128k"
+    assert agent._omniroute_effective_context_length == 128_000
+
+
+def test_omniroute_weighted_wide_picks_200k_for_mid_size_requests():
+    routed = _maybe_route_omniroute_context_bucket_model(
+        object(), _payload("combo/coding-weighted-wide", 120_000)
+    )
+    assert routed["model"] == "combo/coding-weighted-200k"
+
+
+def test_omniroute_weighted_wide_picks_262k_between_200k_and_400k():
+    routed = _maybe_route_omniroute_context_bucket_model(
+        object(), _payload("combo/coding-weighted-wide", 220_000)
+    )
+    assert routed["model"] == "combo/coding-weighted-262k"
+
+
+def test_omniroute_weighted_wide_picks_400k_for_large_requests():
+    routed = _maybe_route_omniroute_context_bucket_model(
+        object(), _payload("combo/coding-weighted-wide", 320_000)
+    )
+    assert routed["model"] == "combo/coding-weighted-400k"
+
+
+def test_legacy_ranked_1m_bucket_still_downshifts():
+    routed = _maybe_route_omniroute_context_bucket_model(
+        object(), _payload("combo/coding-extended-ranked-1m", 220_000)
+    )
+    assert routed["model"] == "combo/coding-extended-ranked-400k"
+
+
+def test_omniroute_selected_cap_never_silently_upgrades_above_requested_tier():
+    routed = _maybe_route_omniroute_context_bucket_model(
+        object(), _payload("combo/coding-extended-ranked-400k", 420_000)
+    )
+    assert routed["model"] == "combo/coding-extended-ranked-400k"
+
+
+def test_requested_output_reserve_can_bump_to_next_bucket():
+    routed = _maybe_route_omniroute_context_bucket_model(
+        object(),
+        _payload(
+            "combo/coding-extended-ranked-200k",
+            110_000,
+            max_completion_tokens=40_000,
+        ),
+    )
+    assert routed["model"] == "combo/coding-extended-ranked-200k"
+
+
+def test_non_bucket_models_are_unchanged():
+    agent = SimpleNamespace(_omniroute_effective_context_length=128_000)
+    payload = _payload("combo/coding-extended-gpt55-400k", 20_000)
+    routed = _maybe_route_omniroute_context_bucket_model(agent, payload)
+    assert routed is payload
+    assert agent._omniroute_effective_model is None
+    assert agent._omniroute_effective_context_length is None

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -46,6 +46,18 @@ class TestShouldCompress:
 
 
 
+    def test_request_scoped_context_threshold(self, compressor):
+        compressor.threshold_tokens = 500_000  # session-wide model is large
+        compressor.threshold_percent = 0.85
+        compressor.max_tokens = None
+
+        assert compressor.should_compress(prompt_tokens=100_000) is False
+        assert compressor.should_compress(
+            prompt_tokens=110_000,
+            context_length=128_000,
+        ) is True
+
+
 class TestUpdateFromResponse:
     def test_updates_fields(self, compressor):
         compressor.awaiting_real_usage_after_compression = True

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -30,6 +30,7 @@ def _attach_agent(
     context_tokens: int,
     context_length: int,
     compressions: int = 0,
+    effective_context_length: int | None = None,
 ):
     cli_obj.agent = SimpleNamespace(
         model=cli_obj.model,
@@ -49,6 +50,7 @@ def _attach_agent(
             context_length=context_length,
             compression_count=compressions,
         ),
+        _omniroute_effective_context_length=effective_context_length,
     )
     return cli_obj
 
@@ -137,6 +139,23 @@ class TestCLIStatusBar:
 
         text = cli_obj._build_status_bar_text(width=120)
         assert "$" not in text  # cost is never shown in status bar
+
+    def test_build_status_bar_text_prefers_effective_omniroute_context(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="combo/coding-weighted-wide"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=1_000_000,
+            effective_context_length=128_000,
+        )
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert snapshot["context_length"] == 128_000
+        text = cli_obj._build_status_bar_text(width=120)
+        assert "12.4K/128K" in text
 
     def test_build_status_bar_text_collapses_for_narrow_terminal(self):
         cli_obj = _attach_agent(


### PR DESCRIPTION
## Summary

This fixes compression budgeting for model IDs that are not a single fixed model, but a request-time router/alias that can choose different concrete context windows per request.

The motivating case is an OmniRoute routing combo such as `combo/coding-weighted-wide`. That model ID is configured in Hermes as the active model, but OmniRoute can route an individual request to a concrete sibling bucket such as:

- `combo/coding-weighted-128k`
- `combo/coding-weighted-200k`
- `combo/coding-weighted-262k`
- `combo/coding-weighted-400k`
- `combo/coding-weighted-1m`

Most users who configure one provider API key and one concrete model are unaffected by this. Their model has one stable context length, and the existing compression behavior is unchanged.

## Problem

Hermes currently initializes the context compressor from the configured model's context length. That works for normal fixed-model setups.

It breaks for adaptive/router model IDs:

1. The configured Hermes model can advertise a large/wide context, e.g. a `wide` routing entrypoint.
2. Before the API call, Hermes/OmniRoute routing can select a smaller concrete bucket for the actual request, e.g. `128k`, `200k`, or `262k`.
3. Compression preflight still compares the request against the original configured model's budget, not the routed request's budget.
4. Hermes can therefore skip compression because it thinks the request fits the wide context, then send the request to a smaller routed bucket where it is too close to the limit or over the limit.

In short: routing is request-scoped, but compression budgeting was session/model-scoped.

## What changed

- Add a shared resolver for OmniRoute context-bucket model IDs.
- Use that resolver in the final API routing path.
- Use the same resolver earlier, during compression preflight, so compression decisions are based on the effective routed context window.
- Apply the same request-scoped context budget in the tool-loop pressure check, where a turn can grow after tool outputs are appended.
- Keep `agent.model` unchanged. The configured model remains the user's selected model/router alias.
- Expose the effective routed context to the status bar separately, so the UI can show the concrete context budget without mutating the session model.

## Scope

This is intentionally narrow:

- Fixed single-model provider setups should behave the same as before.
- Non-OmniRoute models return `None` from the resolver and keep existing compression thresholds.
- The patch does not try to introduce a generic provider-routing abstraction.
- The concrete OmniRoute combo names are handled because those are the known router aliases that caused the mismatch.

A more general abstraction could be added later if Hermes supports other request-time model routers, but this patch keeps the fix minimal and avoids changing behavior for common one-model configurations.

## Example

If Hermes is configured with:

```text
model = combo/coding-weighted-wide
```

and the current request is small enough that the router will send it to:

```text
combo/coding-weighted-128k
```

then compression should compare the request against the `128k` budget, not the `wide/1m` budget.

Likewise, if the request is routed to `262k`, compression should use the `262k` threshold.

## Test plan

- `python -m py_compile agent/chat_completion_helpers.py agent/context_compressor.py agent/turn_context.py agent/conversation_loop.py cli.py`
- `pytest -q tests/agent/test_chat_completion_helpers_omniroute_routing.py tests/agent/test_context_compressor.py::TestShouldCompress tests/cli/test_cli_status_bar.py::TestCLIStatusBar::test_build_status_bar_text_prefers_effective_omniroute_context`
