### PR TITLE
fix(auxiliary): add xAI OAuth route to auth refresh provider resolver

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3466,7 +3466,7 @@ def _auth_refresh_provider_for_route(
     Auto-routed auxiliary calls keep ``resolved_provider == "auto"`` even
     after _get_cached_client() selects a concrete backend. Infer the backend
     from the selected client's base URL so auth refresh works for auto →
-    Copilot/Codex/Anthropic/Nous routes too. (#20832)
+    Copilot/Codex/Anthropic/Nous/xAI routes too. (#20832)
     """
     normalized = _normalize_aux_provider(resolved_provider)
     if normalized and normalized != "auto":
@@ -3479,6 +3479,10 @@ def _auth_refresh_provider_for_route(
         return "anthropic"
     if base_url_host_matches(client_base_url, "inference-api.nousresearch.com"):
         return "nous"
+    if base_url_host_matches(client_base_url, "api.x.ai") or base_url_host_matches(
+        client_base_url, "x.ai"
+    ):
+        return "xai-oauth"
     return normalized
 
 

--- a/tests/agent/test_auxiliary_xai_auth_route.py
+++ b/tests/agent/test_auxiliary_xai_auth_route.py
@@ -1,0 +1,27 @@
+"""Tests for xAI OAuth auth refresh route mapping (#60264)."""
+
+import pytest
+
+
+class TestAuthRefreshXaiRoute:
+    def test_xai_oauth_route_mapped(self):
+        """api.x.ai and x.ai should map to xai-oauth."""
+        from agent.auxiliary_client import _auth_refresh_provider_for_route
+
+        assert _auth_refresh_provider_for_route("auto", "https://api.x.ai/v1") == "xai-oauth"
+        assert _auth_refresh_provider_for_route("auto", "https://x.ai/v1") == "xai-oauth"
+
+    def test_existing_routes_unchanged(self):
+        """Existing provider mappings should still work."""
+        from agent.auxiliary_client import _auth_refresh_provider_for_route
+
+        assert _auth_refresh_provider_for_route("auto", "https://api.githubcopilot.com") == "copilot"
+        assert _auth_refresh_provider_for_route("auto", "https://chatgpt.com/backend-api/codex") == "openai-codex"
+        assert _auth_refresh_provider_for_route("auto", "https://api.anthropic.com") == "anthropic"
+
+    def test_explicit_provider_passthrough(self):
+        """Explicit (non-auto) providers should pass through unchanged."""
+        from agent.auxiliary_client import _auth_refresh_provider_for_route
+
+        assert _auth_refresh_provider_for_route("openai", "https://api.openai.com") == "openai"
+        assert _auth_refresh_provider_for_route("nous", "https://any.url") == "nous"


### PR DESCRIPTION
## What does this PR do?

`_auth_refresh_provider_for_route()` maps auto-routed base URLs to providers (#59837) but missed xAI OAuth. The sibling `_resolve_provider_from_client()` already maps `api.x.ai`. This adds the same mapping so auto-routed xAI calls can refresh their short-lived OAuth token.

## Related Issue

Fixes sibling path of #59837 (#20832).

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/auxiliary_client.py`: Add xAI OAuth mapping to `_auth_refresh_provider_for_route()`
- `tests/agent/test_auxiliary_xai_auth_route.py`: Route mapping + passthrough tests

## How to Test

1. Configure xAI OAuth as an auxiliary provider
2. Trigger an auto-routed auxiliary call through xAI
3. Verify expired tokens are refreshed instead of failing