### PR TITLE
fix(compression): dedup duplicate tool_call_ids to prevent HTTP 400 on strict providers

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2249,6 +2249,33 @@ This compaction should PRIORITISE preserving all information related to the focu
             if not self.quiet_mode:
                 logger.info("Compression sanitizer: removed %d orphaned tool result(s)", len(orphaned_results))
 
+        # 1b. Dedup duplicate tool_call_ids — keep only the last occurrence.
+        # After compression or SMR summarisation, a single tool_call_id can
+        # appear in multiple tool messages (e.g. the original result survives
+        # in the tail while the summary re-inserts a back-reference).  Strict
+        # providers (DeepSeek) reject this with HTTP 400 "Duplicate value for
+        # 'tool_call_id'" (#58327).
+        seen_call_ids: set = set()
+        deduped_count = 0
+        deduped = []
+        for m in reversed(messages):
+            if m.get("role") == "tool":
+                cid = m.get("tool_call_id")
+                if cid and cid in seen_call_ids:
+                    deduped_count += 1
+                    continue
+                if cid:
+                    seen_call_ids.add(cid)
+            deduped.append(m)
+        if deduped_count:
+            messages = list(reversed(deduped))
+            if not self.quiet_mode:
+                logger.info(
+                    "Compression sanitizer: removed %d duplicate tool result(s) "
+                    "(same tool_call_id)",
+                    deduped_count,
+                )
+
         # 2. Strip orphaned tool_calls from assistant messages whose results
         #    were dropped.  Stripping is preferred over inserting stub results
         #    because stubs can be dropped by downstream repair_message_sequence

--- a/tests/agent/test_context_compressor_tool_dedup.py
+++ b/tests/agent/test_context_compressor_tool_dedup.py
@@ -1,0 +1,93 @@
+"""Tests for duplicate tool_call_id sanitization in compression (#58327)."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from agent.context_compressor import CompactionContext
+
+
+class TestSanitizeDuplicateToolCallIds:
+    """Compression sanitizer must dedup duplicate tool_call_ids.
+
+    After compression/SMR, a single tool_call_id can appear in multiple
+    tool messages (original result survives in the tail while the summary
+    re-inserts a back-reference).  Strict providers reject HTTP 400
+    "Duplicate value for 'tool_call_id'" (#58327).
+    """
+
+    @pytest.fixture
+    def ctx(self):
+        cc = CompactionContext.__new__(CompactionContext)
+        cc.quiet_mode = False
+        return cc
+
+    def test_removes_duplicate_tool_call_ids_keeps_last(self, ctx):
+        messages = [
+            {"role": "user", "content": "run ls"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "call_1", "function": {"name": "terminal", "arguments": "ls"}},
+                {"id": "call_2", "function": {"name": "terminal", "arguments": "pwd"}},
+            ]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "file1 file2"},
+            {"role": "tool", "tool_call_id": "call_2", "content": "/home"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "file1 file2"},  # duplicate
+        ]
+        result = ctx._sanitize_tool_pairs(messages)
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        call_ids = [m.get("tool_call_id") for m in tool_msgs]
+        # call_2 should be preserved, call_1 should appear exactly once
+        assert call_ids.count("call_1") == 1
+        assert call_ids.count("call_2") == 1
+        assert len(tool_msgs) == 2
+
+    def test_removes_multiple_duplicates(self, ctx):
+        messages = [
+            {"role": "user", "content": "read file"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "call_1", "function": {"name": "read_file", "arguments": "x.py"}},
+            ]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "content v1"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "content v2"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "content v3"},
+        ]
+        result = ctx._sanitize_tool_pairs(messages)
+        tool_msgs = [m for m in result if m.get("role") == "tool"]
+        # Only the last occurrence survives
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["content"] == "content v3"
+        assert tool_msgs[0]["tool_call_id"] == "call_1"
+
+    def test_no_duplicates_no_change(self, ctx):
+        messages = [
+            {"role": "user", "content": "run ls"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "call_1", "function": {"name": "terminal", "arguments": "ls"}},
+            ]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "output"},
+        ]
+        result = ctx._sanitize_tool_pairs(messages)
+        assert len(result) == 3
+
+    def test_duplicates_with_orphans_both_handled(self, ctx):
+        """Dedup AND orphan removal should work together."""
+        messages = [
+            {"role": "user", "content": "run ls"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "call_1", "function": {"name": "terminal", "arguments": "ls"}},
+            ]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "output"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "output"},    # duplicate
+            {"role": "tool", "tool_call_id": "call_orphan", "content": "orphan"}, # orphan
+        ]
+        result = ctx._sanitize_tool_pairs(messages)
+        tool_ids = [m.get("tool_call_id") for m in result if m.get("role") == "tool"]
+        assert tool_ids == ["call_1"]
+
+    def test_non_tool_messages_preserved(self, ctx):
+        messages = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        result = ctx._sanitize_tool_pairs(messages)
+        assert result == messages

--- a/tests/agent/test_context_compressor_tool_dedup.py
+++ b/tests/agent/test_context_compressor_tool_dedup.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import MagicMock
 
-from agent.context_compressor import CompactionContext
+from agent.context_compressor import ContextCompressor
 
 
 class TestSanitizeDuplicateToolCallIds:
@@ -17,7 +17,7 @@ class TestSanitizeDuplicateToolCallIds:
 
     @pytest.fixture
     def ctx(self):
-        cc = CompactionContext.__new__(CompactionContext)
+        cc = ContextCompressor.__new__(ContextCompressor)
         cc.quiet_mode = False
         return cc
 


### PR DESCRIPTION
## What does this PR do?

Fixes a context compression bug where duplicate `tool_call_id` values survive into the post-compression message list, causing strict providers (DeepSeek) to reject the API call with HTTP 400 and abort the session.

## Related Issue

Fixes #58327

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/context_compressor.py`: Add dedup pass to `_sanitize_tool_pairs()` that removes duplicate tool results sharing the same `tool_call_id`, keeping only the last occurrence
- `tests/agent/test_context_compressor_tool_dedup.py`: 6 tests covering duplicates, no-op, dedup+orphan interaction

## How to Test

1. Run a long session with many tool calls on DeepSeek
2. Trigger context compression
3. Verify session continues normally instead of aborting with HTTP 400