### PR TITLE
fix: resolve stale import-time HERMES_HOME paths across all call sites

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -652,6 +652,17 @@ _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
 _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 
+
+def _auth_json_path() -> Path:
+    """Return the active profile's auth.json path at call time.
+
+    Long-lived multi-profile runtimes (Dashboard/TUI/Desktop backend, cron)
+    import this module once and later bind different profiles.  Resolving
+    at call time ensures the live profile-scoped HERMES_HOME is always
+    respected (#40677).
+    """
+    return get_hermes_home() / "auth.json"
+
 # Codex OAuth endpoint used when a caller explicitly requests
 # provider="openai-codex".  There is deliberately no hardcoded default
 # model: the set of models OpenAI accepts on this endpoint for
@@ -1490,9 +1501,10 @@ def _read_nous_auth() -> Optional[dict]:
         }
 
     try:
-        if not _AUTH_JSON_PATH.is_file():
+        auth_path = _auth_json_path()
+        if not auth_path.is_file():
             return None
-        data = json.loads(_AUTH_JSON_PATH.read_text())
+        data = json.loads(auth_path.read_text())
         if data.get("active_provider") != "nous":
             return None
         provider = data.get("providers", {}).get("nous", {})

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+_skill_commands_skills_dir: Optional[Path] = None  # profile-scoped invalidation (#40677)
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -323,19 +324,19 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
-    global _skill_commands, _skill_commands_platform
+    global _skill_commands, _skill_commands_platform, _skill_commands_skills_dir
     _skill_commands_platform = _resolve_skill_commands_platform()
     _skill_commands = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
+        from tools.skills_tool import _skills_dir, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+        skills_root = _skills_dir()
+        _skill_commands_skills_dir = skills_root
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
-
-        # Scan local dir first, then external dirs
         dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        if skills_root.exists():
+            dirs_to_scan.append(skills_root)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:
@@ -393,10 +394,19 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     Rescans when the active platform scope changes (e.g. a gateway
     process serving Telegram and Discord concurrently) so each platform
     sees its own ``skills.platform_disabled`` view (#14536).
+    Also rescans when the active profile's skills directory changes
+    (e.g. a Dashboard/TUI/Desktop backend serving multiple profiles
+    from one long-lived process — #40677).
     """
+    try:
+        from tools.skills_tool import _skills_dir
+        current_skills_dir = _skills_dir()
+    except Exception:
+        current_skills_dir = None
     if (
         not _skill_commands
         or _skill_commands_platform != _resolve_skill_commands_platform()
+        or _skill_commands_skills_dir != current_skills_dir
     ):
         scan_skill_commands()
     return _skill_commands

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -528,11 +528,14 @@ def normalize_skill_lookup_name(identifier: str) -> str:
     # (not via get_skills_dir()): callers and tests patch
     # ``tools.skills_tool.SKILLS_DIR`` and skill_view() itself resolves
     # against that module attribute, so normalization must agree with the
-    # exact root skill_view() will enforce.  Import deferred to avoid a
+    # exact root skill_view() will enforce.  Use _skills_dir() (not the
+    # module-level SKILLS_DIR) so the live profile-scoped HERMES_HOME is
+    # always respected in long-lived multi-profile runtimes (#40677).
+    # Import deferred to avoid a
     # module cycle (tools.skills_tool imports agent.skill_utils).
     try:
         from tools import skills_tool as _skills_tool
-        primary_root = Path(_skills_tool.SKILLS_DIR)
+        primary_root = Path(_skills_tool._skills_dir())
     except Exception:
         primary_root = get_skills_dir()
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11507,18 +11507,15 @@ def _profile_scope(profile: Optional[str]):
     1. ``load_config``/``save_config`` resolve ``get_hermes_home()`` at call
        time — the context-local override from ``set_hermes_home_override``
        reaches them (same pattern as ``_write_profile_model``).
-    2. ``tools.skills_tool`` and ``tools.skill_manager_tool`` bind
-       ``SKILLS_DIR`` at import time, so the override CANNOT reach them.
-       Like ``_call_cron_for_profile`` does for cron's module globals,
-       temporarily retarget both under a lock and restore them
-       immediately after.
+    2. ``tools.skills_tool`` and ``tools.skill_manager_tool`` resolve
+       ``SKILLS_DIR`` at call time via ``_skills_dir()`` (#60180), so the
+       ``set_hermes_home_override`` above is sufficient — no module-global
+       patching is needed.  The lock serializes concurrent skills-list
+       calls that may compete for the override.
 
     ``profile`` of None/""/"current" means "the dashboard's own profile" —
-    config resolution is untouched, but the skill-module globals are still
-    retargeted to the *current* ``get_hermes_home()`` so writes land in the
-    live home even when the import-time binding is stale (e.g. the process
-    imported the modules before a HERMES_HOME override, or under test
-    isolation).
+    config resolution is untouched; skills resolution uses the current
+    ``get_hermes_home()`` via ``_skills_dir()`` (#60180).
     """
     requested = (profile or "").strip()
 
@@ -11527,8 +11524,6 @@ def _profile_scope(profile: Optional[str]):
         set_hermes_home_override,
         reset_hermes_home_override,
     )
-    from tools import skills_tool as _skills_tool
-    from tools import skill_manager_tool as _skill_mgr
 
     token = None
     if not requested or requested.lower() == "current":
@@ -11538,21 +11533,9 @@ def _profile_scope(profile: Optional[str]):
         token = set_hermes_home_override(str(profile_dir))
 
     with _SKILLS_PROFILE_LOCK:
-        old_home = _skills_tool.HERMES_HOME
-        old_skills_dir = _skills_tool.SKILLS_DIR
-        old_mgr_home = _skill_mgr.HERMES_HOME
-        old_mgr_skills_dir = _skill_mgr.SKILLS_DIR
-        _skills_tool.HERMES_HOME = profile_dir
-        _skills_tool.SKILLS_DIR = profile_dir / "skills"
-        _skill_mgr.HERMES_HOME = profile_dir
-        _skill_mgr.SKILLS_DIR = profile_dir / "skills"
         try:
             yield profile_dir if token is not None else None
         finally:
-            _skills_tool.HERMES_HOME = old_home
-            _skills_tool.SKILLS_DIR = old_skills_dir
-            _skill_mgr.HERMES_HOME = old_mgr_home
-            _skill_mgr.SKILLS_DIR = old_mgr_skills_dir
             if token is not None:
                 reset_hermes_home_override(token)
 
@@ -11562,13 +11545,10 @@ def _config_profile_scope(profile: Optional[str]):
     """Await-safe, config-only profile scope for handlers that ``await``.
 
     Unlike ``_profile_scope`` this touches ONLY the context-local
-    ``set_hermes_home_override`` contextvar — it does NOT swap the
-    process-global ``skills_tool``/``skill_manager`` module attributes.
-    Those globals are shared across all event-loop tasks, so holding them
-    across an ``await`` lets a concurrent skills request restore THIS
-    request's profile dir on its ``finally`` (cross-contamination). The
-    contextvar override is task-local and survives an ``await`` cleanly,
-    which is all endpoints that resolve ``get_hermes_home()`` at call time
+    ``set_hermes_home_override`` contextvar — it does NOT swap
+    process-global module attributes.  Since ``_skills_dir()`` resolves
+    at call time (#60180), the contextvar override alone is sufficient
+    for all endpoints that resolve ``get_hermes_home()`` at call time.
     (config, env, gateway status) actually need.
 
     None/""/"current" means the dashboard's own profile — no override.

--- a/tests/agent/test_auxiliary_auth_json_path.py
+++ b/tests/agent/test_auxiliary_auth_json_path.py
@@ -23,15 +23,17 @@ class TestAuthJsonPath:
         assert str(profile_a) in str(path_a)
         assert path_a.name == "auth.json"
 
-        # Switch profile
-        monkeypatch.setattr(
-            "agent.auxiliary_client.get_hermes_home",
-            lambda: profile_b,
-        )
+        # Switch profile — reload and then re-apply monkeypatch
+        # (reload re-executes the import from hermes_cli.config, overwriting
+        # the module-level name set by monkeypatch)
         import importlib
         import agent.auxiliary_client as aux_mod
 
         importlib.reload(aux_mod)
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_hermes_home",
+            lambda: profile_b,
+        )
         path_b = aux_mod._auth_json_path()
         assert str(profile_b) in str(path_b)
         assert path_a != path_b

--- a/tests/agent/test_auxiliary_auth_json_path.py
+++ b/tests/agent/test_auxiliary_auth_json_path.py
@@ -1,0 +1,44 @@
+"""Tests for profile-aware path resolution in auxiliary client (#60241)."""
+
+import pytest
+from pathlib import Path
+
+
+class TestAuthJsonPath:
+    def test_resolves_at_call_time(self, monkeypatch, tmp_path):
+        """_auth_json_path() should use the live HERMES_HOME, not import-time."""
+        profile_a = tmp_path / "profile_a"
+        profile_b = tmp_path / "profile_b"
+        profile_a.mkdir()
+        profile_b.mkdir()
+
+        # Monkeypatch get_hermes_home BEFORE importing the module
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_hermes_home",
+            lambda: profile_a,
+        )
+        from agent.auxiliary_client import _auth_json_path
+
+        path_a = _auth_json_path()
+        assert str(profile_a) in str(path_a)
+        assert path_a.name == "auth.json"
+
+        # Switch profile
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_hermes_home",
+            lambda: profile_b,
+        )
+        import importlib
+        import agent.auxiliary_client as aux_mod
+
+        importlib.reload(aux_mod)
+        path_b = aux_mod._auth_json_path()
+        assert str(profile_b) in str(path_b)
+        assert path_a != path_b
+
+    def test_legacy_constant_preserved(self):
+        """The module-level _AUTH_JSON_PATH constant still exists for compatibility."""
+        from agent.auxiliary_client import _AUTH_JSON_PATH
+
+        assert isinstance(_AUTH_JSON_PATH, Path)
+        assert _AUTH_JSON_PATH.name == "auth.json"

--- a/tests/agent/test_skill_commands_cache_profile_aware.py
+++ b/tests/agent/test_skill_commands_cache_profile_aware.py
@@ -1,0 +1,67 @@
+"""Tests for profile-aware skills slash-command cache invalidation (#60257)."""
+
+import pytest
+
+
+class TestSkillCommandsCacheProfileAware:
+    def test_cache_tracks_skills_dir(self, monkeypatch, tmp_path):
+        """get_skill_commands should track _skill_commands_skills_dir."""
+        profile_a = tmp_path / "profile_a"
+        profile_b = tmp_path / "profile_b"
+        (profile_a / "skills").mkdir(parents=True)
+        (profile_b / "skills").mkdir(parents=True)
+
+        monkeypatch.setattr(
+            "tools.skills_tool._skills_dir",
+            lambda: profile_a / "skills",
+        )
+        monkeypatch.setattr(
+            "tools.skills_tool._find_all_skills",
+            lambda *a, **kw: [],
+        )
+
+        import agent.skill_commands as sc
+
+        # Force a scan
+        sc._skill_commands = {}
+        sc._skill_commands_skills_dir = None
+        sc.get_skill_commands()
+
+        # After scan, _skill_commands_skills_dir should be set
+        assert sc._skill_commands_skills_dir == profile_a / "skills"
+
+        # Switch profile — cache should be invalidated
+        monkeypatch.setattr(
+            "tools.skills_tool._skills_dir",
+            lambda: profile_b / "skills",
+        )
+
+        # Force re-check
+        result = sc.get_skill_commands()
+        assert sc._skill_commands_skills_dir == profile_b / "skills"
+
+    def test_scan_uses_skills_dir_not_module_constant(self, monkeypatch, tmp_path):
+        """scan_skill_commands should use _skills_dir(), not SKILLS_DIR."""
+        profile_dir = tmp_path / "profile"
+        (profile_dir / "skills").mkdir(parents=True)
+
+        monkeypatch.setattr(
+            "tools.skills_tool.SKILLS_DIR",
+            tmp_path / "stale_dir",  # wrong, stale path
+        )
+        monkeypatch.setattr(
+            "tools.skills_tool._skills_dir",
+            lambda: profile_dir / "skills",
+        )
+        monkeypatch.setattr(
+            "tools.skills_tool._find_all_skills",
+            lambda *a, **kw: [],
+        )
+
+        import agent.skill_commands as sc
+        sc._skill_commands = {}
+        sc._skill_commands_skills_dir = None
+        sc.scan_skill_commands()
+
+        # Should use profile_dir (from _skills_dir), not stale_dir (from SKILLS_DIR)
+        assert sc._skill_commands_skills_dir == profile_dir / "skills"

--- a/tests/agent/test_skill_utils_profile_aware.py
+++ b/tests/agent/test_skill_utils_profile_aware.py
@@ -1,0 +1,28 @@
+"""Tests for profile-aware skills dir in skill_utils normalization (#60231)."""
+
+import pytest
+
+
+class TestSkillUtilsProfileAware:
+    def test_normalize_uses_skills_dir_not_module_constant(self, monkeypatch, tmp_path):
+        """normalize_skill_identifier should use _skills_dir(), not SKILLS_DIR."""
+        profile_a = tmp_path / "profile_a"
+        profile_b = tmp_path / "profile_b"
+        (profile_a / "skills").mkdir(parents=True)
+        (profile_b / "skills").mkdir(parents=True)
+
+        # Patch the SKILLS_DIR module attribute to a stale value
+        monkeypatch.setattr(
+            "tools.skills_tool.SKILLS_DIR",
+            profile_a / "skills",
+        )
+        monkeypatch.setattr(
+            "tools.skills_tool._skills_dir",
+            lambda: profile_b / "skills",
+        )
+
+        from agent.skill_utils import normalize_skill_identifier
+
+        result = normalize_skill_identifier("test-skill")
+        # Should use profile_b (from _skills_dir()), not profile_a (stale SKILLS_DIR)
+        assert result is not None

--- a/tests/agent/test_skill_utils_profile_aware.py
+++ b/tests/agent/test_skill_utils_profile_aware.py
@@ -5,7 +5,7 @@ import pytest
 
 class TestSkillUtilsProfileAware:
     def test_normalize_uses_skills_dir_not_module_constant(self, monkeypatch, tmp_path):
-        """normalize_skill_identifier should use _skills_dir(), not SKILLS_DIR."""
+        """normalize_skill_lookup_name should use _skills_dir(), not SKILLS_DIR."""
         profile_a = tmp_path / "profile_a"
         profile_b = tmp_path / "profile_b"
         (profile_a / "skills").mkdir(parents=True)
@@ -21,8 +21,8 @@ class TestSkillUtilsProfileAware:
             lambda: profile_b / "skills",
         )
 
-        from agent.skill_utils import normalize_skill_identifier
+        from agent.skill_utils import normalize_skill_lookup_name
 
-        result = normalize_skill_identifier("test-skill")
+        result = normalize_skill_lookup_name("test-skill")
         # Should use profile_b (from _skills_dir()), not profile_a (stale SKILLS_DIR)
         assert result is not None


### PR DESCRIPTION
## What does this PR do?

#60180 introduced `_skills_dir()` for call-time profile-scoped skills resolution, but four sibling paths still captured `get_hermes_home()` at import time — causing stale-path behavior in long-lived multi-profile runtimes (Dashboard/TUI/Desktop backend, cron).

- **`agent/skill_utils.py`**: `normalize_skill_lookup_name()` uses `_skills_dir()` instead of `SKILLS_DIR`
- **`agent/auxiliary_client.py`**: `_AUTH_JSON_PATH` replaced with call-time `_auth_json_path()`
- **`agent/skill_commands.py`**: Profile-scoped cache invalidation, `_skills_dir()` in scan
- **`hermes_cli/web_server.py`**: Drop redundant module-global patching (14 lines saved)

## Related Issue

Completes the #60180 profile-awareness chain (#40677, #14536).

## Type of Change

- [x] Bug fix
- [x] Refactor

## Changes Made

4 source files + 3 test files covering call-time resolution across the multi-profile runtime surface.

## How to Test

1. Start a multi-profile Dashboard instance
2. Switch profiles — verify skills, auth, and commands resolve from the correct profile
3. Verify the TUI model picker works without stale-path errors