### PR TITLE
fix(tui_gateway): yield event loop between frames in _safe_send_many

### DIFF
--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -231,10 +231,20 @@ class WSTransport:
             )
 
     async def _safe_send_many(self, lines: list[str]) -> None:
-        """Send a batch of pre-serialized frames in order on the loop thread."""
+        """Send a batch of pre-serialized frames in order on the loop thread.
+
+        ``await asyncio.sleep(0)`` between frames cooperatively yields the event
+        loop after each send.  Without it, a large batch (e.g. ``session.resume``
+        replaying hundreds of history frames) can monopolise the loop long enough
+        for the uvicorn ws keepalive ping to time out and disconnect the client
+        that just reconnected.  The yield has no measurable effect on throughput
+        for normal streaming batches (which are small), but prevents the loop
+        stall on bulk-replay paths.  See #50005 / #53773.
+        """
         try:
             for line in lines:
                 await self._ws.send_text(line)
+                await asyncio.sleep(0)  # yield to event loop between frames
         except Exception as exc:
             self._closed = True
             _log.warning(


### PR DESCRIPTION
## What does this PR do?

Adds `await asyncio.sleep(0)` between frames in `_safe_send_many` to cooperatively yield the event loop during bulk-send operations.

This fixes a specific stall scenario — `session.resume` bulk history replay — that is **not covered by PR #51841** (token coalescing + loopback ping tuning).

### Root cause

When a Desktop client reconnects after a brief disconnect, the server replays the full session history via `session.resume`. For long sessions (700+ messages), this calls `_safe_send_many` with a large batch of pre-serialised frames. The current tight `for` loop:

```python
for line in lines:
    await self._ws.send_text(line)
```

`ws.send_text()` is a coroutine, but it only yields when the underlying socket buffer is full. On a fast local/VPN link the buffer rarely fills, so the entire batch runs to completion without ever returning control to the event loop. On a 700-message resume, this held the loop for **~40–60 seconds**.

During that window, uvicorn's ws keepalive ping (`ws_ping_interval=20s`, `ws_ping_timeout=20s`) runs on the same starved loop — the pong deadline fires and the client that just reconnected is **immediately disconnected again**.

### Why this is distinct from #51841

| Fix | What it covers | What it misses |
|-----|---------------|----------------|
| #51841 QW-1 (loopback ping 30s/60s) | Recoverable GIL stalls during agent turns | Bulk replay batches that exceed 60s |
| #51841 CF-2 (token coalescing) | High-frequency streaming delta frames | `session.resume` history frames (not streaming events) |
| **This PR** | `_safe_send_many` bulk-replay path | — |

The three fixes are complementary. CF-2 reduces the batch sizes that reach `_safe_send_many` during streaming, but `session.resume` sends historical frames directly — the coalesce path is not involved.

### Fix

```python
for line in lines:
    await self._ws.send_text(line)
    await asyncio.sleep(0)  # yield to event loop between frames
```

One line. Cooperatively yields the loop after each frame so the ping coroutine (and other waiters) can be serviced between sends. Zero effect on throughput for normal streaming batches (which are small).

## Related Issue

Fixes #50005
Fixes #53773

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/ws.py`: add `await asyncio.sleep(0)` in `_safe_send_many` for-loop; expand docstring to document the bulk-replay stall scenario

## How to Test

1. Create a long session (500+ messages) in Hermes Desktop
2. Close Desktop App, wait ~10s, reopen and reconnect
3. **Before fix**: observe `ws write slow (loop stalled >10.0s)` warnings for 40–60s, then `WebSocketDisconnect`; "reasoning not ready" persists
4. **After fix**: reconnect completes in <5s, no stall warnings, agent is immediately ready

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (1 file, 1 line of logic)
- [x] I've tested on my platform: Ubuntu 24.04, Hermes v0.18.0, Tailscale WireGuard

### Documentation & Housekeeping

- [x] Docstring updated to document the bulk-replay stall scenario — or N/A
- [x] No config keys added/changed — N/A
- [x] No architecture changes — N/A
- [x] Cross-platform: `asyncio.sleep(0)` is stdlib, no platform-specific behaviour — N/A

## Screenshots / Logs

**Before fix** (700-message session resume, Tailscale link):
```
WARNING tui_gateway.ws: ws write slow (loop stalled >10.0s) peer=100.x.x.x:xxxxx — frame left in flight
WARNING tui_gateway.ws: ws write slow (loop stalled >10.0s) peer=100.x.x.x:xxxxx — frame left in flight
... (×5, spanning ~50s)
WARNING tui_gateway.ws: ws send failed peer=100.x.x.x:xxxxx error_type=WebSocketDisconnect error=
INFO    tui_gateway.ws: ws closed peer=100.x.x.x:xxxxx reason=send_failed_after_response messages=772
```

**After fix**: reconnect completes in <5s, zero stall warnings.