### PR TITLE
feat(slack): add ignore_other_user_mentions option

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2468,6 +2468,10 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
+        # Ignore a channel/thread message addressed to another user (first token
+        # @mentions someone other than the bot) unless the bot is also mentioned.
+        # Opt-in; default off keeps existing behaviour. Env: SLACK_IGNORE_OTHER_USER_MENTIONS.
+        "ignore_other_user_mentions": False,
         "channel_prompts": {},         # Per-channel ephemeral system prompts
     },
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3321,6 +3321,9 @@ class SlackAdapter(BasePlatformAdapter):
                 thread_ts = None
 
         # In channels, respond if:
+        #   (unless ignore_other_user_mentions is on and the message opens by
+        #    @mentioning another user without also mentioning the bot — then
+        #    stay silent regardless of the rules below)
         #   0. Channel is in free_response_channels, OR require_mention is
         #      disabled — always process regardless of mention.
         #   1. The bot is @mentioned in this message, OR
@@ -3342,6 +3345,22 @@ class SlackAdapter(BasePlatformAdapter):
             if allowed_channels and channel_id not in allowed_channels:
                 logger.debug(
                     "[Slack] Ignoring message in non-allowed channel: %s", channel_id
+                )
+                return
+
+            # A message that opens by @mentioning another user is directed at
+            # that person. Stay silent unless we are also mentioned — this
+            # overrides free-response and mentioned-thread auto-follow so the
+            # bot does not butt in on chatter aimed at someone else.
+            self_uids = {u for u in (bot_uid, self._bot_user_id) if u}
+            if (
+                self._slack_ignore_other_user_mentions()
+                and not is_mentioned
+                and self._slack_message_addressed_to_other_user(routing_text, self_uids)
+            ):
+                logger.debug(
+                    "[Slack] Ignoring message addressed to another user in channel %s",
+                    channel_id,
                 )
                 return
 
@@ -4763,6 +4782,45 @@ class SlackAdapter(BasePlatformAdapter):
             "on",
         }
 
+    def _slack_ignore_other_user_mentions(self) -> bool:
+        """When true, ignore channel/thread messages addressed to another user.
+
+        A message whose first token @-mentions someone other than this bot is
+        treated as directed at that person; the bot stays silent unless it is
+        also mentioned. Defaults to False (opt-in) so existing behaviour is
+        unchanged until enabled. Mirrors Discord's ``ignore_other_user_mentions``
+        (PR #33501), adapted to Slack's thread model: the trigger is a *leading*
+        mention ("addressed to"), so a message that merely references another
+        user mid-sentence still reaches the bot.
+        """
+        configured = self.config.extra.get("ignore_other_user_mentions")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("SLACK_IGNORE_OTHER_USER_MENTIONS", "false").lower() in {
+            "true",
+            "1",
+            "yes",
+            "on",
+        }
+
+    def _slack_message_addressed_to_other_user(self, text: str, self_uids: set) -> bool:
+        """Return True when ``text`` opens by @-mentioning a non-bot user.
+
+        Slack renders a user mention as ``<@U123>`` (or ``<@U123|name>``). A
+        message whose first token is such a mention is addressed to that user.
+        Returns False when the leading mention is the bot itself (``self_uids``),
+        when there is no leading user mention, or for channel/broadcast tokens
+        (``<!here>``, ``<#C…>``) which address the room rather than a person.
+        """
+        if not text:
+            return False
+        match = re.match(r"\s*<@([^>|\s]+)(?:\|[^>]*)?>", text)
+        if not match:
+            return False
+        return match.group(1) not in self_uids
+
     def _slack_free_response_channels(self) -> set:
         """Return channel IDs where no @mention is required."""
         raw = self.config.extra.get("free_response_channels")
@@ -5076,6 +5134,10 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
     if "strict_mention" in slack_cfg and not os.getenv("SLACK_STRICT_MENTION"):
         os.environ["SLACK_STRICT_MENTION"] = str(slack_cfg["strict_mention"]).lower()
+    if "ignore_other_user_mentions" in slack_cfg and not os.getenv("SLACK_IGNORE_OTHER_USER_MENTIONS"):
+        os.environ["SLACK_IGNORE_OTHER_USER_MENTIONS"] = str(
+            slack_cfg["ignore_other_user_mentions"]
+        ).lower()
     if "allow_bots" in slack_cfg and not os.getenv("SLACK_ALLOW_BOTS"):
         os.environ["SLACK_ALLOW_BOTS"] = str(slack_cfg["allow_bots"]).lower()
     frc = slack_cfg.get("free_response_channels")
@@ -5125,9 +5187,9 @@ def register(ctx) -> None:
         # and the static _PLATFORMS["slack"] dict in hermes_cli/gateway.py.
         setup_fn=interactive_setup,
         # YAML→env config bridge — owns the translation of config.yaml slack:
-        # keys (require_mention, strict_mention, allow_bots,
-        # free_response_channels, reactions, allowed_channels) into SLACK_*
-        # env vars that the adapter reads via os.getenv(). Replaces the
+        # keys (require_mention, strict_mention, ignore_other_user_mentions,
+        # allow_bots, free_response_channels, reactions, allowed_channels) into
+        # SLACK_* env vars that the adapter reads via os.getenv(). Replaces the
         # hardcoded block in gateway/config.py. Hook contract: #24849.
         apply_yaml_config_fn=_apply_yaml_config,
         # Auth env vars for _is_user_authorized() integration

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3356,6 +3356,7 @@ class SlackAdapter(BasePlatformAdapter):
             if (
                 self._slack_ignore_other_user_mentions()
                 and not is_mentioned
+                and not self._slack_message_mentions_self(routing_text, self_uids)
                 and self._slack_message_addressed_to_other_user(routing_text, self_uids)
             ):
                 logger.debug(
@@ -4820,6 +4821,21 @@ class SlackAdapter(BasePlatformAdapter):
         if not match:
             return False
         return match.group(1) not in self_uids
+
+    def _slack_message_mentions_self(self, text: str, self_uids: set) -> bool:
+        """Return True when ``text`` @-mentions this bot anywhere in the message.
+
+        Matches both mention markups — ``<@U123>`` and the pipe form
+        ``<@U123|name>`` — so the ignore_other_user_mentions gate treats a
+        pipe-form bot mention as "also mentioned" even though the exact-markup
+        ``is_mentioned`` check only recognises ``<@U123>``.
+        """
+        if not text:
+            return False
+        return any(
+            re.search(rf"<@{re.escape(uid)}(?:\|[^>]*)?>", text)
+            for uid in self_uids
+        )
 
     def _slack_free_response_channels(self) -> set:
         """Return channel IDs where no @mention is required."""

--- a/tests/gateway/test_slack_ignore_other_user_mentions.py
+++ b/tests/gateway/test_slack_ignore_other_user_mentions.py
@@ -160,6 +160,35 @@ def test_addressed_channel_and_broadcast_tokens_are_not_users():
 
 
 # ---------------------------------------------------------------------------
+# _slack_message_mentions_self()
+# ---------------------------------------------------------------------------
+
+def _mentions_self(text):
+    return _make_adapter()._slack_message_mentions_self(text, SELF_UIDS)
+
+
+def test_mentions_self_plain_form():
+    assert _mentions_self(f"hello <@{BOT_USER_ID}>") is True
+
+
+def test_mentions_self_pipe_form():
+    assert _mentions_self(f"hello <@{BOT_USER_ID}|hermes>") is True
+
+
+def test_mentions_self_other_user_only():
+    assert _mentions_self(f"hello <@{OTHER_USER_ID}|rasha>") is False
+
+
+def test_mentions_self_id_prefix_is_not_a_match():
+    # <@U_BOT_123X> is a different user whose ID merely starts with ours.
+    assert _mentions_self(f"hello <@{BOT_USER_ID}X>") is False
+
+
+def test_mentions_self_empty():
+    assert _mentions_self("") is False
+
+
+# ---------------------------------------------------------------------------
 # Integration: real _handle_slack_message
 # ---------------------------------------------------------------------------
 
@@ -240,6 +269,24 @@ async def test_free_response_replies_when_bot_also_mentioned(adapter):
     await _run(
         adapter,
         _event(f"<@{OTHER_USER_ID}> and <@{BOT_USER_ID}> please compare", ts="1700000000.000003"),
+    )
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_free_response_replies_when_bot_mentioned_in_pipe_form(adapter):
+    """A pipe-form bot mention (``<@U123|name>``) counts as "also mentioned"
+    even though the exact-markup ``is_mentioned`` check misses it."""
+    adapter.config.extra["free_response_channels"] = CHANNEL_ID
+    adapter.config.extra["ignore_other_user_mentions"] = True
+
+    await _run(
+        adapter,
+        _event(
+            f"<@{OTHER_USER_ID}|rasha> and <@{BOT_USER_ID}|hermes> please compare",
+            ts="1700000000.000004",
+        ),
     )
 
     adapter.handle_message.assert_awaited_once()

--- a/tests/gateway/test_slack_ignore_other_user_mentions.py
+++ b/tests/gateway/test_slack_ignore_other_user_mentions.py
@@ -1,0 +1,320 @@
+"""Tests for the Slack ``ignore_other_user_mentions`` option.
+
+When enabled, the bot stays silent on a channel/thread message that opens by
+@-mentioning someone other than itself (a message *addressed to* another user),
+unless the bot is also mentioned. This is Slack parity for the Discord option
+of the same name (PR #33501), adapted to Slack's thread model: the trigger is a
+*leading* mention, so a message that merely references another user mid-sentence
+(e.g. "loop in @rasha") still reaches the bot.
+
+Helper-level tests exercise the real config/parse methods directly; the
+integration tests drive the real ``SlackAdapter._handle_slack_message`` so the
+gate is verified end-to-end rather than against a re-implementation.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Mock slack-bolt if not installed (same pattern as test_slack_mention.py)
+# ---------------------------------------------------------------------------
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        ("slack_bolt.adapter.socket_mode.async_handler", slack_bolt.adapter.socket_mode.async_handler),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+
+BOT_USER_ID = "U_BOT_123"
+OTHER_USER_ID = "U_OTHER_456"
+CHANNEL_ID = "C0AQWDLHY9M"
+
+
+def _make_adapter(**extra):
+    adapter = object.__new__(SlackAdapter)
+    adapter.platform = Platform.SLACK
+    adapter.config = PlatformConfig(enabled=True, extra=dict(extra))
+    adapter._bot_user_id = BOT_USER_ID
+    adapter._team_bot_user_ids = {}
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# _slack_ignore_other_user_mentions()
+# ---------------------------------------------------------------------------
+
+def test_ignore_other_user_mentions_defaults_off(monkeypatch):
+    monkeypatch.delenv("SLACK_IGNORE_OTHER_USER_MENTIONS", raising=False)
+    adapter = _make_adapter()
+    assert adapter._slack_ignore_other_user_mentions() is False
+
+
+def test_ignore_other_user_mentions_extra_true():
+    adapter = _make_adapter(ignore_other_user_mentions=True)
+    assert adapter._slack_ignore_other_user_mentions() is True
+
+
+def test_ignore_other_user_mentions_extra_false():
+    adapter = _make_adapter(ignore_other_user_mentions=False)
+    assert adapter._slack_ignore_other_user_mentions() is False
+
+
+def test_ignore_other_user_mentions_extra_string_forms():
+    assert _make_adapter(ignore_other_user_mentions="on")._slack_ignore_other_user_mentions() is True
+    assert _make_adapter(ignore_other_user_mentions="true")._slack_ignore_other_user_mentions() is True
+    assert _make_adapter(ignore_other_user_mentions="off")._slack_ignore_other_user_mentions() is False
+
+
+def test_ignore_other_user_mentions_env_fallback(monkeypatch):
+    monkeypatch.setenv("SLACK_IGNORE_OTHER_USER_MENTIONS", "true")
+    adapter = _make_adapter()
+    assert adapter._slack_ignore_other_user_mentions() is True
+
+
+def test_ignore_other_user_mentions_extra_overrides_env(monkeypatch):
+    monkeypatch.setenv("SLACK_IGNORE_OTHER_USER_MENTIONS", "true")
+    adapter = _make_adapter(ignore_other_user_mentions=False)
+    assert adapter._slack_ignore_other_user_mentions() is False
+
+
+# ---------------------------------------------------------------------------
+# _slack_message_addressed_to_other_user()
+# ---------------------------------------------------------------------------
+
+SELF_UIDS = {BOT_USER_ID}
+
+
+def _addressed(text):
+    return _make_adapter()._slack_message_addressed_to_other_user(text, SELF_UIDS)
+
+
+def test_addressed_leading_other_user_mention():
+    assert _addressed(f"<@{OTHER_USER_ID}> check this out") is True
+
+
+def test_addressed_leading_bot_mention_is_not_other():
+    assert _addressed(f"<@{BOT_USER_ID}> hello") is False
+
+
+def test_addressed_pipe_form_other_user():
+    assert _addressed(f"<@{OTHER_USER_ID}|rasha> check this out") is True
+
+
+def test_addressed_pipe_form_bot_is_not_other():
+    assert _addressed(f"<@{BOT_USER_ID}|hermes> hello") is False
+
+
+def test_addressed_no_mention():
+    assert _addressed("hello there, thanks for that") is False
+
+
+def test_addressed_mid_text_mention_not_leading():
+    assert _addressed(f"can you loop in <@{OTHER_USER_ID}> on this?") is False
+
+
+def test_addressed_leading_whitespace_then_other_mention():
+    assert _addressed(f"   <@{OTHER_USER_ID}> take a look") is True
+
+
+def test_addressed_empty_and_blank():
+    assert _addressed("") is False
+    assert _addressed("   ") is False
+
+
+def test_addressed_channel_and_broadcast_tokens_are_not_users():
+    # <!here>, <!channel>, and channel refs address the room, not a person.
+    assert _addressed("<!here> standup in 5") is False
+    assert _addressed("<#C0000000000|general> see here") is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: real _handle_slack_message
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def adapter():
+    config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+    a = SlackAdapter(config)
+    a._app = MagicMock()
+    a._app.client = AsyncMock()
+    a._bot_user_id = BOT_USER_ID
+    a._running = True
+    a.handle_message = AsyncMock()
+    return a
+
+
+@pytest.fixture(autouse=True)
+def _redirect_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
+    )
+    # Keep gating driven by config.extra, not ambient env.
+    monkeypatch.delenv("SLACK_IGNORE_OTHER_USER_MENTIONS", raising=False)
+    monkeypatch.delenv("SLACK_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("SLACK_REQUIRE_MENTION", raising=False)
+
+
+def _event(text, ts, thread_ts=None):
+    event = {
+        "channel": CHANNEL_ID,
+        "channel_type": "channel",
+        "user": "U_HUMAN",
+        "text": text,
+        "ts": ts,
+    }
+    if thread_ts is not None:
+        event["thread_ts"] = thread_ts
+    return event
+
+
+async def _run(adapter, event):
+    with patch.object(
+        adapter, "_resolve_user_name", new=AsyncMock(return_value="human")
+    ), patch.object(
+        adapter, "_fetch_thread_context", new=AsyncMock(return_value=None)
+    ), patch.object(
+        adapter, "_fetch_thread_parent_text", new=AsyncMock(return_value="")
+    ), patch.object(
+        adapter, "_has_active_session_for_thread", return_value=False
+    ):
+        await adapter._handle_slack_message(event)
+
+
+@pytest.mark.asyncio
+async def test_free_response_ignores_message_addressed_to_other_user(adapter):
+    adapter.config.extra["free_response_channels"] = CHANNEL_ID
+    adapter.config.extra["ignore_other_user_mentions"] = True
+
+    await _run(adapter, _event(f"<@{OTHER_USER_ID}> this is for you", ts="1700000000.000001"))
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_free_response_can_opt_out_of_ignoring_other_user_mentions(adapter):
+    adapter.config.extra["free_response_channels"] = CHANNEL_ID
+    adapter.config.extra["ignore_other_user_mentions"] = False
+
+    await _run(adapter, _event(f"<@{OTHER_USER_ID}> still ambient chatter", ts="1700000000.000002"))
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_free_response_replies_when_bot_also_mentioned(adapter):
+    adapter.config.extra["free_response_channels"] = CHANNEL_ID
+    adapter.config.extra["ignore_other_user_mentions"] = True
+
+    await _run(
+        adapter,
+        _event(f"<@{OTHER_USER_ID}> and <@{BOT_USER_ID}> please compare", ts="1700000000.000003"),
+    )
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mentioned_thread_ignores_followup_addressed_to_other_user(adapter):
+    """Ben's case: once the bot has been mentioned in a thread it auto-follows,
+    but a follow-up addressed to another human should not wake it."""
+    thread_ts = "1700000000.000010"
+    adapter._mentioned_threads.add(thread_ts)
+    adapter.config.extra["ignore_other_user_mentions"] = True
+
+    await _run(
+        adapter,
+        _event(f"<@{OTHER_USER_ID}> check this out", ts="1700000000.000011", thread_ts=thread_ts),
+    )
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mentioned_thread_still_answers_plain_followup(adapter):
+    """No over-suppression: a plain follow-up (no leading mention) in a
+    mentioned thread is still answered when the option is on."""
+    thread_ts = "1700000000.000020"
+    adapter._mentioned_threads.add(thread_ts)
+    adapter.config.extra["ignore_other_user_mentions"] = True
+
+    await _run(
+        adapter,
+        _event("thanks, that makes sense", ts="1700000000.000021", thread_ts=thread_ts),
+    )
+
+    adapter.handle_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Config bridge: config.yaml slack.ignore_other_user_mentions → extra + env
+# ---------------------------------------------------------------------------
+
+def test_config_bridges_slack_ignore_other_user_mentions(monkeypatch, tmp_path):
+    """config.yaml ``slack.ignore_other_user_mentions`` reaches the runtime env
+    var the adapter reads (same wiring as ``strict_mention`` — via the plugin's
+    apply_yaml_config_fn bridge, not the generic shared-key allowlist)."""
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n  ignore_other_user_mentions: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SLACK_IGNORE_OTHER_USER_MENTIONS", raising=False)
+
+    load_gateway_config()
+
+    import os as _os
+    assert _os.environ["SLACK_IGNORE_OTHER_USER_MENTIONS"] == "true"
+
+
+def test_ignore_other_user_mentions_env_wins_over_yaml(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n  ignore_other_user_mentions: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_IGNORE_OTHER_USER_MENTIONS", "false")
+
+    load_gateway_config()
+
+    import os as _os
+    assert _os.environ["SLACK_IGNORE_OTHER_USER_MENTIONS"] == "false"

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -437,6 +437,15 @@ slack:
   # must @mention the bot before Hermes will respond.
   strict_mention: false
 
+  # Ignore messages addressed to another user: when a channel or thread
+  # message *opens* by @mentioning someone other than the bot (e.g.
+  # "@rasha can you take this?"), stay silent unless the bot is also
+  # mentioned. Only a *leading* mention counts as "addressed to" — a
+  # message that references someone mid-sentence ("loop in @rasha")
+  # still reaches the bot. Overrides free_response_channels and thread
+  # auto-engagement. Opt-in; default off. Env: SLACK_IGNORE_OTHER_USER_MENTIONS.
+  ignore_other_user_mentions: false
+
   # Custom mention patterns that trigger the bot
   # (in addition to the default @mention detection)
   mention_patterns:
@@ -449,6 +458,10 @@ slack:
 
 :::tip When to use `strict_mention`
 Set this to `true` in busy workspaces where Slack's default "the bot remembers this thread" behavior surprises users — for example, a long tech-support thread where the bot helped at the start and you'd rather it stay silent unless explicitly pinged again. DMs and active interactive sessions are unaffected.
+:::
+
+:::tip When to use `ignore_other_user_mentions`
+Set this to `true` when the bot follows busy threads (via thread auto-engagement or `free_response_channels`) and butts in on messages humans address to each other. It is a narrower tool than `strict_mention`: plain follow-ups in an engaged thread still get answers; only messages that open by @mentioning another person are skipped. **1:1 DMs are unaffected**; group DMs (MPIMs) and channels both apply it, matching the shared-surface policy below. Broadcast tokens (`@here`, `@channel`) and channel references address the room, not a person, so they are never skipped.
 :::
 
 :::info


### PR DESCRIPTION
## What does this PR do?

Adds a Slack `ignore_other_user_mentions` option so the bot stays out of
conversations aimed at another person.

Once the bot is @mentioned in a thread, the Slack adapter records that thread
(`_mentioned_threads`) and auto-responds to **every** subsequent message in it
— including ones a human addresses to another human. So in a thread where the
bot is active, someone typing `@rasha check this out` gets an unwanted reply
from the bot. The existing knobs don't fix this cleanly:

- `require_mention: false` / `free_response_channels` — respond to everything.
- `strict_mention: true` — require an @mention on *every* turn, which throws
  away the natural "just reply in the thread" follow-up flow.

`ignore_other_user_mentions` is the missing middle: plain follow-ups still reach
the bot, but a message **addressed to** someone else does not, unless the bot is
also mentioned.

### Behaviour

With `slack.ignore_other_user_mentions: true` (in a channel/thread, not a DM):

| Message | Result |
| --- | --- |
| `@rasha check this out` | **ignored** |
| `thanks, that's clear` (plain follow-up) | replies |
| `@hermes what do you think?` | replies |
| `@rasha and @hermes, compare these` (bot also mentioned) | replies |
| any DM | replies (DMs are never filtered) |

### Semantics note (vs the Discord option)

This mirrors Discord's `ignore_other_user_mentions` (#33501) but adapts the
trigger to Slack's thread model. Discord suppresses on a mention of another
human *anywhere* in the message; here the trigger is a **leading** mention
("addressed to"). In an active thread people routinely reference a teammate
mid-sentence in a request that is genuinely for the bot ("can you compare this
with what @rasha said?") without re-@mentioning the bot — a leading-mention
trigger keeps answering those while still staying silent on `@rasha ...`.

Default is **off** (opt-in), so existing deployments are unchanged until they
enable it. (Discord's proposed default is on; Slack is conservative here to
avoid changing current behaviour — happy to align if maintainers prefer.)

## Related Issue

No existing Slack issue. Related work:

- #33501 — `fix(discord): ignore messages mentioning other users` (the Discord
  precedent this mirrors; naming kept identical for cross-platform consistency).
- #55901 / #49055 — Slack `thread_require_mention` proposals, which take the
  blunter "require @mention on every thread reply" route. This is complementary
  and narrower.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/slack/adapter.py`
  - `_slack_ignore_other_user_mentions()` — reads `config.extra` then
    `SLACK_IGNORE_OTHER_USER_MENTIONS` (default off), matching the sibling
    `strict_mention` accessor.
  - `_slack_message_addressed_to_other_user()` — True when the trimmed text
    opens with a `<@U…>` (or `<@U…|name>`) mention of a non-bot user; False for
    the bot's own leading mention, no leading mention, or room/broadcast tokens
    (`<!here>`, `<#C…>`).
  - Gate in `_handle_slack_message`, placed ahead of the
    free-response / require_mention ladder so it also overrides the
    mentioned-thread auto-follow. Only fires when `not is_mentioned`.
  - `_apply_yaml_config()` bridges `slack.ignore_other_user_mentions` →
    `SLACK_IGNORE_OTHER_USER_MENTIONS` (env wins over YAML), like the other keys.
- `hermes_cli/config.py` — documents the key in the `slack` defaults (off).
- `tests/gateway/test_slack_ignore_other_user_mentions.py` — new.

## How to Test

```
uv run --extra dev python -m pytest tests/gateway/test_slack_ignore_other_user_mentions.py -q -o 'addopts='
```

22 tests: the two config accessors/parsers (config.extra + env precedence,
leading/mid/pipe/broadcast-token cases), the YAML→env bridge, and integration
tests that drive the real `_handle_slack_message` — free-response channel and
a pre-seeded mentioned-thread — asserting the bot stays silent on a message
addressed to another user, still answers plain follow-ups, and answers when it
is also mentioned.

Manual: enable `slack.ignore_other_user_mentions: true`, @mention the bot in a
thread, then post `@someoneelse ...` in that thread — the bot no longer replies;
a plain follow-up still gets a reply.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 24.6)

> Test note: the new test file passes clean (22/22, no warnings), as do the
> targeted `tests/gateway/test_slack*.py` and `test_config.py` runs. The change
> adds **zero** new failures in canonical collection order. `test_slack_channel_session_scope.py`
> has 7 pre-existing failures on `main` (identical count with this change
> stashed) from cross-file test-isolation, and several unrelated
> `tests/gateway/` modules fail to collect without optional web/starlette deps
> installed — both pre-date this PR and are left untouched.

### Documentation & Housekeeping

- [x] Docstrings updated
- [x] `cli-config.yaml.example` — N/A (no Slack config-key section exists there;
  sibling keys like `strict_mention`/`require_mention` aren't documented in it
  either)
- [x] Architecture/workflow docs — N/A
- [x] Cross-platform impact considered — N/A (pure Slack routing logic)
- [x] Tool descriptions/schemas — N/A
