### PR TITLE
feat(kanban): add merge-card pre-dispatch validation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -122,7 +122,7 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``BLOCK_RECURRENCE_LIMIT``) escalates them to ``triage`` if a cron keeps
 # unblocking them only to have the worker re-block for the same reason.
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
-VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
+VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient", "policy_violation"}
 
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
@@ -6994,6 +6994,127 @@ def dispatch_once(
             max_in_progress_per_profile=max_in_progress_per_profile,
         )
 
+def _validate_merge_card(
+    conn: sqlite3.Connection,
+    task: "Task",
+) -> Optional[str]:
+    """Validate a merge-intent card before dispatch.
+
+    A card is merge-intent when its body contains ``gh pr merge``.
+    Returns ``None`` if the card passes all checks or is not merge-intent.
+    Returns a blocked-reason string describing the failing check otherwise.
+
+    Checks performed (in order):
+    1. Merge card has at least one parent/dependency.
+    2. At least one parent is assigned to ``preflight``.
+    3. The preflight parent has evidence of ``CODE_APPROVED``.
+    4. The preflight parent evidence contains a PR head SHA.
+    5. The merge card references the same approved head SHA.
+    6. The merge card contains ``--squash`` and
+       ``--match-head-commit <sha>``, and does NOT contain
+       ``--merge`` or ``--rebase``.
+    """
+    import re
+
+    body = (task.body or "").strip()
+    if not body:
+        return None
+    # Only validate cards that contain a merge command.
+    if "gh pr merge" not in body.lower():
+        return None
+
+    # 1. Must have at least one parent/dependency.
+    parents = parent_ids(conn, task.id)
+    if not parents:
+        return (
+            "merge_card_no_parent: card body contains 'gh pr merge' but has no "
+            "parent/dependency. A merge card must have at least one preflight "
+            "parent with CODE_APPROVED evidence before it can be dispatched."
+        )
+
+    # 2. At least one parent must be assigned to preflight.
+    preflight_parents = []
+    for pid in parents:
+        ptask = get_task(conn, pid)
+        if ptask and ptask.assignee == "preflight" and ptask.status == "done":
+            preflight_parents.append(ptask)
+    if not preflight_parents:
+        return (
+            "merge_card_no_preflight_parent: card body contains 'gh pr merge' but "
+            "no parent is assigned to 'preflight' with status 'done'. A merge "
+            "card must have a completed preflight parent with CODE_APPROVED "
+            "evidence."
+        )
+
+    # 3 & 4. Search preflight parents for CODE_APPROVED and extract SHA.
+    approved_sha = None
+    for ptask in preflight_parents:
+        pbody = (ptask.body or "")
+        if "CODE_APPROVED" in pbody:
+            # Extract a 40-char hex SHA from the preflight evidence.
+            sha_match = re.search(r"\b([0-9a-fA-F]{40})\b", pbody)
+            if sha_match:
+                approved_sha = sha_match.group(1)
+                break
+    if approved_sha is None:
+        # Also search preflight parent comments for CODE_APPROVED + SHA.
+        for ptask in preflight_parents:
+            try:
+                comments = list_comments(conn, ptask.id)
+            except Exception:
+                comments = []
+            for comment in comments:
+                cbody = (comment.body or "")
+                if "CODE_APPROVED" in cbody:
+                    sha_match = re.search(r"\b([0-9a-fA-F]{40})\b", cbody)
+                    if sha_match:
+                        approved_sha = sha_match.group(1)
+                        break
+            if approved_sha is not None:
+                break
+
+    if approved_sha is None:
+        return (
+            "merge_card_no_approved_sha: no preflight parent contains both "
+            "CODE_APPROVED and a valid 40-character hex SHA. The merge card "
+            "cannot be dispatched without an approved head SHA from preflight."
+        )
+
+    # 5. The merge card must reference the same approved head SHA.
+    body_shas = re.findall(r"\b([0-9a-fA-F]{40})\b", body)
+    if approved_sha not in body_shas:
+        return (
+            f"merge_card_sha_mismatch: the approved SHA from preflight "
+            f"({approved_sha}) does not appear in the merge card body. "
+            f"SHAs found in merge card: {body_shas if body_shas else 'none'}."
+        )
+
+    # 6. Must use --squash + --match-head-commit, must not use --merge/--rebase.
+    if "--merge" in body:
+        return (
+            "merge_card_forbidden_flag: '--merge' found in card body. "
+            "Merge cards must use '--squash', not '--merge'."
+        )
+    if "--rebase" in body:
+        return (
+            "merge_card_forbidden_flag: '--rebase' found in card body. "
+            "Merge cards must use '--squash', not '--rebase'."
+        )
+    if "--squash" not in body:
+        return (
+            "merge_card_missing_squash: '--squash' not found in card body. "
+            "Merge cards must use '--squash'."
+        )
+    if f"--match-head-commit {approved_sha}" not in body:
+        return (
+            f"merge_card_missing_match_head: '--match-head-commit {approved_sha}' "
+            f"not found in card body. Merge cards must pin the exact approved "
+            f"head SHA with --match-head-commit."
+        )
+
+    # All checks passed.
+    return None
+
 
 def _dispatch_once_locked(
     conn: sqlite3.Connection,
@@ -7242,6 +7363,14 @@ def _dispatch_once_locked(
                     )
             continue
         if dry_run:
+            # In dry-run mode, still validate merge cards (read-only).
+            # We need the task body for validation, so fetch it.
+            dry_task = get_task(conn, row["id"])
+            if dry_task is not None:
+                validation_error = _validate_merge_card(conn, dry_task)
+                if validation_error is not None:
+                    result.auto_blocked.append(row["id"])
+                    continue
             result.spawned.append((row["id"], row_assignee, ""))
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
@@ -7254,6 +7383,17 @@ def _dispatch_once_locked(
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            continue
+        # Validate merge-intent cards before spawning.
+        validation_error = _validate_merge_card(conn, claimed)
+        if validation_error is not None:
+            if not dry_run:
+                block_task(
+                    conn, claimed.id,
+                    reason=validation_error[:500],
+                    kind="policy_violation",
+                )
+            result.auto_blocked.append(claimed.id)
             continue
         try:
             resolved_branch_name = None
@@ -7342,10 +7482,28 @@ def _dispatch_once_locked(
             result.skipped_nonspawnable.append(row["id"])
             continue
         if dry_run:
+            # In dry-run mode, still validate merge cards (read-only).
+            dry_task = get_task(conn, row["id"])
+            if dry_task is not None:
+                validation_error = _validate_merge_card(conn, dry_task)
+                if validation_error is not None:
+                    result.auto_blocked.append(row["id"])
+                    continue
             result.spawned.append((row["id"], row["assignee"], ""))
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            continue
+        # Validate merge-intent cards before spawning.
+        validation_error = _validate_merge_card(conn, claimed)
+        if validation_error is not None:
+            if not dry_run:
+                block_task(
+                    conn, claimed.id,
+                    reason=validation_error[:500],
+                    kind="policy_violation",
+                )
+            result.auto_blocked.append(claimed.id)
             continue
         try:
             resolved_branch_name = None

--- a/tests/hermes_cli/test_kanban_merge_validate.py
+++ b/tests/hermes_cli/test_kanban_merge_validate.py
@@ -1,0 +1,444 @@
+"""Tests for merge-card pre-dispatch validation (_validate_merge_card)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+APPROVED_SHA = "a" * 40  # 40-char hex
+
+
+def _make_merge_body(sha: str = APPROVED_SHA) -> str:
+    """Return a valid merge-intent card body."""
+    return (
+        f"Merge the approved PR.\n\n"
+        f"gh pr merge 42 --squash --match-head-commit {sha}"
+    )
+
+
+def _make_preflight_body(sha: str = APPROVED_SHA) -> str:
+    """Return a preflight evidence body with CODE_APPROVED and SHA."""
+    return (
+        f"CODE_APPROVED\n\n"
+        f"Verified head SHA: {sha}\n"
+        f"Tests passed, diff clean."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Merge card with no parent → blocked
+# ---------------------------------------------------------------------------
+
+def test_merge_card_no_parent_blocked(kanban_home, all_assignees_spawnable):
+    """A merge-intent card with no parent must be blocked, not spawned."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="merge PR",
+            body=_make_merge_body(),
+            assignee="builder",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert not spawns, "merge card without parent must not be spawned"
+    assert tid in res.auto_blocked
+    with kb.connect() as conn:
+        t = kb.get_task(conn, tid)
+        assert t.status == "blocked"
+        assert t.block_kind == "policy_violation"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Merge card with parent not assigned to preflight → blocked
+# ---------------------------------------------------------------------------
+
+def test_merge_card_no_preflight_parent_blocked(kanban_home, all_assignees_spawnable):
+    """A merge card whose only parent is not preflight must be blocked."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        # Parent is builder, not preflight.
+        parent_id = kb.create_task(
+            conn,
+            title="build something",
+            assignee="builder",
+        )
+        kb.complete_task(conn, parent_id)
+        merge_id = kb.create_task(
+            conn,
+            title="merge PR",
+            body=_make_merge_body(),
+            assignee="builder",
+            parents=[parent_id],
+        )
+        # complete parent first for DAG promotion
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert not spawns, "merge card without preflight parent must not be spawned"
+    assert merge_id in res.auto_blocked
+    with kb.connect() as conn:
+        t = kb.get_task(conn, merge_id)
+        assert t.status == "blocked"
+        assert t.block_kind == "policy_violation"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Preflight parent without CODE_APPROVED → blocked
+# ---------------------------------------------------------------------------
+
+def test_merge_card_preflight_no_approved_blocked(kanban_home, all_assignees_spawnable):
+    """Preflight parent exists but has no CODE_APPROVED → blocked."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        preflight_id = kb.create_task(
+            conn,
+            title="preflight check",
+            body="FIXUP_REQUIRED: tests fail",
+            assignee="preflight",
+        )
+        kb.complete_task(conn, preflight_id)
+        merge_id = kb.create_task(
+            conn,
+            title="merge PR",
+            body=_make_merge_body(),
+            assignee="builder",
+            parents=[preflight_id],
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert not spawns
+    assert merge_id in res.auto_blocked
+    with kb.connect() as conn:
+        t = kb.get_task(conn, merge_id)
+        assert t.status == "blocked"
+        assert t.block_kind == "policy_violation"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: CODE_APPROVED present but no SHA → blocked
+# ---------------------------------------------------------------------------
+
+def test_merge_card_approved_no_sha_blocked(kanban_home, all_assignees_spawnable):
+    """Preflight has CODE_APPROVED but no 40-char hex SHA → blocked."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        preflight_id = kb.create_task(
+            conn,
+            title="preflight check",
+            body="CODE_APPROVED\n\nAll checks passed. (no SHA in body)",
+            assignee="preflight",
+        )
+        kb.complete_task(conn, preflight_id)
+        merge_id = kb.create_task(
+            conn,
+            title="merge PR",
+            body=_make_merge_body(),
+            assignee="builder",
+            parents=[preflight_id],
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert not spawns
+    assert merge_id in res.auto_blocked
+    with kb.connect() as conn:
+        t = kb.get_task(conn, merge_id)
+        assert t.status == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: SHA mismatch between preflight and merge card → blocked
+# ---------------------------------------------------------------------------
+
+def test_merge_card_sha_mismatch_blocked(kanban_home, all_assignees_spawnable):
+    """Preflight approved SHA differs from merge card SHA → blocked."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    preflight_sha = "b" * 40
+    merge_sha = "c" * 40
+
+    with kb.connect() as conn:
+        preflight_id = kb.create_task(
+            conn,
+            title="preflight check",
+            body=_make_preflight_body(sha=preflight_sha),
+            assignee="preflight",
+        )
+        kb.complete_task(conn, preflight_id)
+        merge_id = kb.create_task(
+            conn,
+            title="merge PR",
+            body=_make_merge_body(sha=merge_sha),
+            assignee="builder",
+            parents=[preflight_id],
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert not spawns
+    assert merge_id in res.auto_blocked
+    with kb.connect() as conn:
+        t = kb.get_task(conn, merge_id)
+        assert t.status == "blocked"
+        assert t.block_kind == "policy_violation"
+
+
+# ---------------------------------------------------------------------------
+# Test 6a: Merge card with --merge flag → blocked
+# ---------------------------------------------------------------------------
+
+def test_merge_card_forbidden_merge_flag_blocked(kanban_home, all_assignees_spawnable):
+    """Merge card uses --merge instead of --squash → blocked."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        preflight_id = kb.create_task(
+            conn,
+            title="preflight check",
+            body=_make_preflight_body(),
+            assignee="preflight",
+        )
+        kb.complete_task(conn, preflight_id)
+        merge_id = kb.create_task(
+            conn,
+            title="merge PR",
+            body=f"gh pr merge 42 --merge --match-head-commit {APPROVED_SHA}",
+            assignee="builder",
+            parents=[preflight_id],
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert not spawns
+    assert merge_id in res.auto_blocked
+    with kb.connect() as conn:
+        t = kb.get_task(conn, merge_id)
+        assert t.status == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Test 6b: Merge card with --rebase flag → blocked
+# ---------------------------------------------------------------------------
+
+def test_merge_card_forbidden_rebase_flag_blocked(kanban_home, all_assignees_spawnable):
+    """Merge card uses --rebase instead of --squash → blocked."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        preflight_id = kb.create_task(
+            conn,
+            title="preflight check",
+            body=_make_preflight_body(),
+            assignee="preflight",
+        )
+        kb.complete_task(conn, preflight_id)
+        merge_id = kb.create_task(
+            conn,
+            title="merge PR",
+            body=f"gh pr merge 42 --rebase --match-head-commit {APPROVED_SHA}",
+            assignee="builder",
+            parents=[preflight_id],
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert not spawns
+    assert merge_id in res.auto_blocked
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Valid merge card with all checks → eligible to spawn
+# ---------------------------------------------------------------------------
+
+def test_merge_card_valid_spawns(kanban_home, all_assignees_spawnable):
+    """A merge card passing all validation checks must be eligible to spawn."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        preflight_id = kb.create_task(
+            conn,
+            title="preflight check",
+            body=_make_preflight_body(),
+            assignee="preflight",
+        )
+        kb.complete_task(conn, preflight_id)
+        merge_id = kb.create_task(
+            conn,
+            title="merge PR",
+            body=_make_merge_body(),
+            assignee="builder",
+            parents=[preflight_id],
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert len(spawns) == 1, f"valid merge card must spawn, got {len(spawns)}"
+    assert spawns[0] == merge_id
+    assert merge_id not in res.auto_blocked
+    with kb.connect() as conn:
+        t = kb.get_task(conn, merge_id)
+        assert t.status == "running"
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Non-merge cards pass through without validation
+# ---------------------------------------------------------------------------
+
+def test_non_merge_card_passes_through(kanban_home, all_assignees_spawnable):
+    """Cards without 'gh pr merge' must not be affected by the validator."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="fix a bug",
+            body="Fix the login button color.",
+            assignee="builder",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert len(spawns) == 1
+    assert spawns[0] == tid
+    assert tid not in res.auto_blocked
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Valid merge card via comments (CODE_APPROVED + SHA in comment)
+# ---------------------------------------------------------------------------
+
+def test_merge_card_valid_via_comment(kanban_home, all_assignees_spawnable):
+    """CODE_APPROVED and SHA found in preflight comments, not body."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        preflight_id = kb.create_task(
+            conn,
+            title="preflight check",
+            body="Preflight inspection complete.",
+            assignee="preflight",
+        )
+        # Add CODE_APPROVED + SHA via comment instead of body
+        kb.add_comment(
+            conn, preflight_id, "preflight",
+            f"CODE_APPROVED\n\nVerified SHA: {APPROVED_SHA}\nAll checks passed.",
+        )
+        kb.complete_task(conn, preflight_id)
+        merge_id = kb.create_task(
+            conn,
+            title="merge PR",
+            body=_make_merge_body(),
+            assignee="builder",
+            parents=[preflight_id],
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert len(spawns) == 1
+    assert spawns[0] == merge_id
+
+
+# ---------------------------------------------------------------------------
+# Test 10: Valid merge card with multiple parents, one preflight
+# ---------------------------------------------------------------------------
+
+def test_merge_card_multiple_parents_one_preflight(kanban_home, all_assignees_spawnable):
+    """Merge card with builder + preflight parents; preflight approves → spawns."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        builder_parent = kb.create_task(
+            conn,
+            title="implement feature",
+            assignee="builder",
+        )
+        kb.complete_task(conn, builder_parent)
+        preflight_id = kb.create_task(
+            conn,
+            title="preflight check",
+            body=_make_preflight_body(),
+            assignee="preflight",
+        )
+        kb.complete_task(conn, preflight_id)
+        merge_id = kb.create_task(
+            conn,
+            title="merge PR",
+            body=_make_merge_body(),
+            assignee="builder",
+            parents=[builder_parent, preflight_id],
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert len(spawns) == 1
+    assert spawns[0] == merge_id
+
+
+# ---------------------------------------------------------------------------
+# Test 11: Dry run does not block but reports auto_blocked
+# ---------------------------------------------------------------------------
+
+def test_merge_card_dry_run_reports_blocked(kanban_home, all_assignees_spawnable):
+    """Dry run must not mutate status but must report the card as auto_blocked."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="merge PR",
+            body=_make_merge_body(),
+            assignee="builder",
+        )
+        res = kb.dispatch_once(conn, dry_run=True)
+
+    assert tid in res.auto_blocked
+    with kb.connect() as conn:
+        t = kb.get_task(conn, tid)
+        # Dry run must NOT mutate status
+        assert t.status == "ready", f"dry run must not change status, got {t.status}"


### PR DESCRIPTION
Add _validate_merge_card() mechanical pre-dispatch guard for merge-intent Kanban cards. Blocks spawn unless: parent exists, preflight parent is done, CODE_APPROVED present, SHA matches, --squash + --match-head-commit used. 12 tests pass, zero regressions.