### PR TITLE
fix(whatsapp): carry forward message_id from latest event in text merge paths

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2118,6 +2118,15 @@ def merge_pending_message_event(
         ):
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            # Carry forward message_id and reply_to_message_id from the latest
+            # event so the agent's reply quotes the most recent message.
+            # Same pattern as _queue_text_debounce (base.py ~line 4272).
+            latest_message_id = getattr(event, "message_id", None)
+            if latest_message_id is not None:
+                existing.message_id = str(latest_message_id)
+            latest_anchor = latest_message_id or getattr(event, "reply_to_message_id", None)
+            if latest_anchor is not None and hasattr(existing, "reply_to_message_id"):
+                existing.reply_to_message_id = str(latest_anchor)
             return
 
     pending_messages[session_key] = event

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1299,6 +1299,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
+            # Carry forward message_id and reply_to_message_id from the latest
+            # event so the agent's reply quotes the most recent message.
+            latest_message_id = getattr(event, "message_id", None)
+            if latest_message_id is not None:
+                existing.message_id = str(latest_message_id)
+            latest_anchor = latest_message_id or getattr(event, "reply_to_message_id", None)
+            if latest_anchor is not None and hasattr(existing, "reply_to_message_id"):
+                existing.reply_to_message_id = str(latest_anchor)
 
         prior_task = self._pending_text_batch_tasks.get(key)
         if prior_task and not prior_task.done():


### PR DESCRIPTION
## Summary

When rapid-fire text messages arrive while the agent is busy (or within the Baileys bridge text-batch window), the merged pending event retains the FIRST message's `message_id` and `reply_to_message_id`. The agent's reply quotes the wrong (older) message because `_reply_anchor_for_event()` returns the stale first message's ID.

## Root Cause

Two code paths have the same gap:

1. **`merge_pending_message_event`** in `gateway/platforms/base.py` (line ~2114): when `merge_text=True` and two TEXT events are merged, text is appended but `message_id`/`reply_to_message_id` are never updated from the latest event.

2. **`_enqueue_text_event`** in `plugins/platforms/whatsapp/adapter.py` (line ~1295): the Baileys bridge adapter's own text batching mechanism has the identical gap — it appends text and media but never carries forward the latest event's identity fields.

Compare `_queue_text_debounce` (base.py ~line 4272) which DOES correctly update `message_id` from the latest event — that was the reference implementation for this fix.

## Fix

After appending text from the incoming event in both merge paths, also update `message_id` and `reply_to_message_id` on the existing merged event to reflect the latest inbound message. This ensures `_reply_anchor_for_event()` returns the correct (latest) message ID when the agent processes the merged event.

## Testing

- Verified the fix matches the same pattern used by `_queue_text_debounce`
- Both merge paths (base adapter + Baileys bridge) are fixed

Fixes #59582