### PR TITLE
fix(tools): use os.replace for atomic RPC write on Windows

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -445,7 +445,7 @@ def _call(tool_name, args):
             "seq": seq,
             "token": os.environ.get("HERMES_RPC_TOKEN", ""),
         }, f)
-    os.rename(tmp, req_file)
+    os.replace(tmp, req_file)
 
     # Wait for response with adaptive polling
     deadline = time.monotonic() + 300  # 5-minute timeout per tool call


### PR DESCRIPTION
## Summary

Replace `os.rename` with `os.replace` in `tools/code_execution_tool.py` for the atomic RPC request file write.

## Problem

`os.rename(tmp, req_file)` fails on Windows with `WinError 183` ("Cannot create a file when that file already exists") when the destination file is already present. This can occur after a restart or if the server hasn't cleaned up a previous request file with the same sequence number. The tool call crashes instead of proceeding normally.

The same atomic-write pattern in 4+ other files (`bitwarden.py`, `mcp_oauth.py`, `write_approval.py`, `anthropic_adapter.py`) already uses `os.replace`, which atomically replaces on both POSIX and Windows.

## Fix

One-line change: `os.rename` → `os.replace`. No behavioral change on POSIX (both atomically rename), but fixes the Windows crash path.

## Testing
- Syntax check passed (py_compile)
- Behavior verified