### PR TITLE
feat: expand native GitHub workflow toolset

### DIFF
--- a/hermes_feature_build_log.md
+++ b/hermes_feature_build_log.md
@@ -23,16 +23,25 @@
 - [x] A10 Commit Track A
 
 ### Track B — github native toolset
-- [ ] B1 Confirm branch strategy for Track B
-- [ ] B2 Implement tools/github_tools.py
-- [ ] B3 Add GitHub auth/helper layer
-- [ ] B4 Add first GitHub wrapper tools
-- [ ] B5 Wire into toolsets.py as opt-in github toolset
-- [ ] B6 Add tests in tests/tools/test_github_tools.py
-- [ ] B7 Run focused tests
+- [x] B1 Confirm branch strategy for Track B
+- [x] B2 Implement tools/github_tools.py
+- [x] B3 Add GitHub auth/helper layer
+- [x] B4 Add first GitHub wrapper tools
+- [x] B5 Wire into toolsets.py as opt-in github toolset
+- [x] B6 Add tests in tests/tools/test_github_tools.py
+- [x] B7 Run focused tests
 - [ ] B8 Run combined tests
 - [ ] B9 Review diff for cleanliness
 - [ ] B10 Commit Track B
+
+### Track C — github_add_issue_comment
+- [x] C1 Check branch, status, and files
+- [x] C2 Implement github_add_issue_comment_tool
+- [x] C3 Register tool schema/handler/toolset
+- [x] C4 Add mocked tests in tests/tools/test_github_tools.py
+- [x] C5 Verify compilation and run regression suite
+- [x] C6 Review diff for cleanliness
+- [x] C7 Commit and log Track C
 
 ### Final
 - [ ] F1 Final implementation summary
@@ -89,5 +98,61 @@
 - **Status:** Completed
 - **Details:** Committed the Track A implementation, tests, toolset configuration, and build log updates to the branch `feat/http-request-tool`.
 - **Commit Message:** `feat: add http_request API tool`
-- **Commit Hash:** `467f71023bde8d7ee2d01b1fe98b630304795ff9`
+- **Commit Hash:** `59102b9e2a2ceb7074c8289f25e11b9be5b54779`
+
+## Step B1: Confirm branch strategy for Track B
+- **Status:** Completed
+- **Details:** Switched to branch `feat/github-toolset` based on the clean amended Track A commit `59102b9e2a2ceb7074c8289f25e11b9be5b54779`. Verified that the working tree is clean.
+
+## Step B2: Implement tools/github_tools.py
+- **Status:** Completed
+- **Details:** Created [github_tools.py](file:///c:/Users/ralle/projects/Hermes/tools/github_tools.py) with the base module skeleton and API request helper on top of the secure `http_request` foundation. Defined default base URL, token env var configs, `_get_github_token` resolver, `check_github_requirements` checklist check, and the `github_api_request` helper function which passes target REST paths and standard headers to `http_request_tool`.
+
+## Step B3: Add GitHub auth/helper layer
+- **Status:** Completed
+- **Details:** Expanded [github_tools.py](file:///c:/Users/ralle/projects/Hermes/tools/github_tools.py) to implement robust auth, request-shaping, repository parsing, and error normalization. Added `parse_owner_repo` to resolve repository URLs/paths into `(owner, repo)` tuples, and `get_github_error_message` to extract detailed user-facing descriptions from status codes or standard GitHub API error payloads.
+
+## Step B4: Add first GitHub wrapper tools
+- **Status:** Completed
+- **Details:** Added and self-registered four read-only core GitHub wrapper tools in [github_tools.py](file:///c:/Users/ralle/projects/Hermes/tools/github_tools.py): `github_get_issue`, `github_list_issues` (which excludes PRs), `github_get_pull_request`, and `github_list_pull_requests`. Each tool is configured to parse inputs via `parse_owner_repo`, query the API via `github_api_request`, and filter/format payloads to return only relevant metadata (redacting token/header noise). Registered under the `github` toolset with requirement checks mapping to `check_github_requirements`.
+
+## Step B5: Wire into toolsets.py as opt-in github toolset
+- **Status:** Completed
+- **Details:** Modified [toolsets.py](file:///c:/Users/ralle/projects/Hermes/toolsets.py) to define the opt-in `"github"` toolset in `TOOLSETS`. Listed the four wrapper tools under `"tools"`. This exposes the GitHub capabilities dynamically in sessions where the `github` toolset is requested, while keeping them isolated from core/default toolsets.
+
+## Step B6: Add tests in tests/tools/test_github_tools.py
+- **Status:** Completed
+- **Details:** Created [test_github_tools.py](file:///c:/Users/ralle/projects/Hermes/tests/tools/test_github_tools.py) implementing a mocked test suite covering: check requirements gating (token lookup), owner/repo string and URL parsing including trailing `.git` sanitation, error parsing from response JSON/text, all four core tool success paths, invalid inputs, non-200 and failed requests, and specific issue-vs-PR filtering (PRs correctly omitted in `github_list_issues`).
+
+## Step B7: Run focused tests
+- **Status:** Completed
+- **Details:** Executed the focused pytest suite using `uv run --extra dev pytest tests/tools/test_github_tools.py -v --tb=short`. All 10 test cases passed cleanly.
+
+## Step C1: Check Branch, Status, and Files
+- **Status:** Completed
+- **Details:** Checked git status, active branch (`feat/github-toolset`), and read the relevant implementation files `tools/github_tools.py`, `tests/tools/test_github_tools.py`, and `toolsets.py`.
+
+## Step C2: Implement github_add_issue_comment_tool
+- **Status:** Completed
+- **Details:** Added `github_add_issue_comment_tool` to `tools/github_tools.py`, implementing a safe POST request to `/repos/{owner}/{repo}/issues/{issue_number}/comments` via `github_api_request` and returning id, html_url, body, created_at, updated_at, and author (from user.login).
+
+## Step C3: Register Tool Schema/Handler/Toolset
+- **Status:** Completed
+- **Details:** Registered the schema `GITHUB_ADD_ISSUE_COMMENT_SCHEMA`, handler `_handle_github_add_issue_comment`, and connected it in the registry under the `"github"` toolset in `tools/github_tools.py`. Added it to the static `"github"` toolset definition in `toolsets.py`.
+
+## Step C4: Add Mocked Tests in tests/tools/test_github_tools.py
+- **Status:** Completed
+- **Details:** Added four deterministic mocked unit tests: `test_github_add_issue_comment_success`, `test_github_add_issue_comment_invalid_repo`, `test_github_add_issue_comment_non_200_response`, and `test_github_add_issue_comment_failed_http_request`.
+
+## Step C5: Verify Compilation and Run Regression Suite
+- **Status:** Completed
+- **Details:** Ran `python -m py_compile` to verify syntax check. Executed focused tests (14 passed) and combined regression suite (240 passed in 15.37s).
+
+## Step C6: Review Diff for Cleanliness
+- **Status:** Completed
+- **Details:** Verified `git diff` for minimal changes, lack of debug artifacts, and adherence to styling.
+
+## Step C7: Commit and Log Track C
+- **Status:** Completed
+- **Details:** Committed the changes with message `feat: add github_add_issue_comment tool`. Commit hash: `c7621d48385afb1a2feb690248ce646024a5f08e`.
 

--- a/hermes_feature_build_log.md
+++ b/hermes_feature_build_log.md
@@ -156,3 +156,47 @@
 - **Status:** Completed
 - **Details:** Committed the changes with message `feat: add github_add_issue_comment tool`. Commit hash: `c7621d48385afb1a2feb690248ce646024a5f08e`.
 
+## Step D1: Inspect Branch, GitHub Module, Tests, and Toolset Wiring
+- **Status:** Completed
+- **Details:** Re-checked repo state on `main`, confirmed the native GitHub implementation lived in `tools/github_tools.py`, reviewed `tests/tools/test_github_tools.py`, and verified the opt-in `github` toolset wiring in `toolsets.py` before expanding scope.
+
+## Step D2: Save Repo-Local Expansion Plan
+- **Status:** Completed
+- **Details:** Wrote the workflow expansion plan to `C:\Users\ralle\projects\Hermes\.hermes\plans\2026-07-07_103747-github-workflow-expansion.md`, documenting architecture, implementation order, verification commands, and exit criteria.
+
+## Step D3: Add github_create_issue
+- **Status:** Completed
+- **Details:** Added `github_create_issue_tool` with compact response shaping, schema/handler/registry wiring, and inclusion in the `github` toolset. The tool POSTs to `/repos/{owner}/{repo}/issues` and supports `title`, optional `body`, `labels`, and `assignees`.
+
+## Step D4: Add github_add_pull_request_review_comment
+- **Status:** Completed
+- **Details:** Added `github_add_pull_request_review_comment_tool` for inline PR feedback via `/repos/{owner}/{repo}/pulls/{pull_number}/comments`, supporting `body`, `commit_id`, `path`, `line`, and optional `side`, with compact returned metadata for agents.
+
+## Step D5: Add github_list_workflow_runs
+- **Status:** Completed
+- **Details:** Added `github_list_workflow_runs_tool` for GitHub Actions inspection via `/repos/{owner}/{repo}/actions/runs`, including optional `status` filtering and compact workflow-run summaries.
+
+## Step D6: Add github_get_workflow_run
+- **Status:** Completed
+- **Details:** Added `github_get_workflow_run_tool` for detailed GitHub Actions run inspection via `/repos/{owner}/{repo}/actions/runs/{run_id}` returning branch, SHA, status, conclusion, timestamps, and run attempt.
+
+## Step D7: Add github_rerun_workflow
+- **Status:** Completed
+- **Details:** Added `github_rerun_workflow_tool` for Actions reruns via `/repos/{owner}/{repo}/actions/runs/{run_id}/rerun`, returning an acknowledgement payload with `accepted`, `repository`, and `run_id` when the API accepts the rerun.
+
+## Step D8: Add Mocked Tests for New Workflow Tools
+- **Status:** Completed
+- **Details:** Extended `tests/tools/test_github_tools.py` with deterministic mocked coverage for create-issue success/failure cases, PR review comment success/failure cases, workflow-run listing and detail shaping, and workflow rerun success/error handling.
+
+## Step D9: Run Focused GitHub Verification
+- **Status:** Completed
+- **Details:** Ran `python -m py_compile tools/github_tools.py tests/tools/test_github_tools.py toolsets.py` successfully, then ran `uv run --extra dev pytest tests/tools/test_github_tools.py -v --tb=short`. Result: **26 passed**.
+
+## Step D10: Run Combined Regression Suite
+- **Status:** Completed
+- **Details:** Ran `uv run --extra dev pytest tests/tools/test_http_request_tool.py tests/tools/test_github_tools.py tests/tools/test_url_safety.py tests/tools/test_web_tools_config.py tests/tools/test_tool_search.py -v --tb=short`. Result: **252 passed**, **8 warnings**, **0 failures**.
+
+## Step D11: Review Diff for Cleanliness
+- **Status:** Completed
+- **Details:** Reviewed `git diff` and confirmed the change set is limited to `tools/github_tools.py`, `tests/tools/test_github_tools.py`, and `toolsets.py`, plus the saved plan file. No debug code or unrelated file edits were introduced.
+

--- a/hermes_feature_build_log.md
+++ b/hermes_feature_build_log.md
@@ -198,5 +198,5 @@
 
 ## Step D11: Review Diff for Cleanliness
 - **Status:** Completed
-- **Details:** Reviewed `git diff` and confirmed the change set is limited to `tools/github_tools.py`, `tests/tools/test_github_tools.py`, and `toolsets.py`, plus the saved plan file. No debug code or unrelated file edits were introduced.
+- **Details:** Reviewed `git diff` and confirmed the intentional change set covered `tools/github_tools.py`, `tests/tools/test_github_tools.py`, `toolsets.py`, `hermes_feature_build_log.md`, and the saved plan file. No debug code or unrelated file edits were introduced.
 

--- a/hermes_feature_build_log.md
+++ b/hermes_feature_build_log.md
@@ -1,0 +1,93 @@
+# Hermes Feature Build Log
+
+- **Date/Time:** 2026-07-06T14:49:00-07:00
+- **Machine Name:** Laptop 1
+- **Repo Path:** c:\Users\ralle\projects\Hermes
+- **Current Branch:** main
+- **Objective:** Build two Hermes features in order:
+  1. A new core API tool named `http_request`
+  2. A native `github` toolset built on top of that HTTP foundation
+
+## Master Checklist
+
+### Track A — http_request core tool
+- [x] A1 Check repo state
+- [x] A2 Create feature branch
+- [x] A3 Inspect reference files and patterns
+- [x] A4 Implement tools/http_request.py
+- [x] A5 Wire into toolsets.py as opt-in api toolset
+- [x] A6 Add tests in tests/tools/test_http_request_tool.py
+- [x] A7 Run focused tests
+- [x] A8 Run nearby regression tests
+- [x] A9 Review diff for cleanliness
+- [x] A10 Commit Track A
+
+### Track B — github native toolset
+- [ ] B1 Confirm branch strategy for Track B
+- [ ] B2 Implement tools/github_tools.py
+- [ ] B3 Add GitHub auth/helper layer
+- [ ] B4 Add first GitHub wrapper tools
+- [ ] B5 Wire into toolsets.py as opt-in github toolset
+- [ ] B6 Add tests in tests/tools/test_github_tools.py
+- [ ] B7 Run focused tests
+- [ ] B8 Run combined tests
+- [ ] B9 Review diff for cleanliness
+- [ ] B10 Commit Track B
+
+### Final
+- [ ] F1 Final implementation summary
+- [ ] F2 Suggested PR titles
+- [ ] F3 Suggested PR descriptions
+- [ ] F4 Manual review checklist for me
+
+---
+
+## Step A1: Check Repo State
+- **Status:** Completed
+- **Details:** Cloned `C:\Users\ralle\AppData\Local\hermes\hermes-agent` to `c:\Users\ralle\projects\Hermes`. Repo is clean. Current branch is `main`.
+
+## Step A2: Create Feature Branch
+- **Status:** Completed
+- **Details:** Created and checked out a new feature branch `feat/http-request-tool` from `main`. No pre-existing branch with this name was found.
+
+## Step A3: Inspect Reference Files and Patterns
+- **Status:** Completed
+- **Details:**
+  - **Tool Registration**: Registered at module level via `registry.register()` from [registry.py](file:///c:/Users/ralle/projects/Hermes/tools/registry.py) with name, toolset, schema, handler, check_fn, requires_env, is_async, description, emoji, and max_result_size_chars.
+  - **check_fn usage**: Passed during registration to check tool dependencies or environmental requirements dynamically. Cache-protected for 30s in registry. Returns `False` or raises exceptions (caught as `False`) if unavailable.
+  - **JSON Responses**: Tool handlers must return a serialized JSON string. Helper functions `tool_result` and `tool_error` in [registry.py](file:///c:/Users/ralle/projects/Hermes/tools/registry.py) minimize boilerplate.
+  - **Toolset Definitions**: Structured in [toolsets.py](file:///c:/Users/ralle/projects/Hermes/toolsets.py) using the static `TOOLSETS` dict and composed via `resolve_toolset(name)`.
+  - **SSRF / URL Safety**: Handled by `is_safe_url` / `async_is_safe_url` in [url_safety.py](file:///c:/Users/ralle/projects/Hermes/tools/url_safety.py). Restricts requests to public HTTP/HTTPS destinations, blocking private, CGNAT, link-local, loopback IP ranges, and cloud metadata sentinels (e.g. `169.254.169.254`, `metadata.google.internal`). Can be bypassed globally via `security.allow_private_urls: true` in config (except for cloud metadata sentinels which are always blocked). Redirect-based bypass is mitigated by re-validating the target of each redirect using `httpx` event hooks.
+  - **Nearby Test Patterns**: Standard pytest files inside [tests/tools/](file:///c:/Users/ralle/projects/Hermes/tests/tools/). Example tests like `test_x_search_tool.py` patch outgoing requests using `monkeypatch` to mock backend endpoints, verifying payloads, status codes, timeouts, and error handling.
+  - **Requests vs Httpx**: Standard sync tools (e.g., `x_search_tool.py`) use `requests` while async tools (e.g. `vision_tools.py`) and tools requiring redirect hooks use `httpx`. Given the redirect security requirement to protect against redirect SSRF bypass, using `httpx` with `_ssrf_redirect_guard` is preferred.
+
+## Step A4: Implement tools/http_request.py
+- **Status:** Completed
+- **Details:** Created [http_request.py](file:///c:/Users/ralle/projects/Hermes/tools/http_request.py) containing the `http_request` core tool. Implemented method validation, safe URL resolution using `is_safe_url` and `normalize_url_for_request`, event-hook based redirect validation, headers / query / json_body / form_body support, timeout handling, content-type verification, bearer auth with secret redaction, and response body size truncation. Registered under the `api` toolset via module-level self-registration.
+
+## Step A5: Wire http_request into toolsets.py as opt-in api toolset
+- **Status:** Completed
+- **Details:** Modified [toolsets.py](file:///c:/Users/ralle/projects/Hermes/toolsets.py) to define the new `api` toolset. Grouped the `http_request` tool within it, with the description "Direct structured HTTP API access". The tool is kept opt-in (not added to `_HERMES_CORE_TOOLS`) as requested, ensuring maximum safety and clear architectural isolation.
+
+## Step A6: Add tests in tests/tools/test_http_request_tool.py
+- **Status:** Completed
+- **Details:** Created [test_http_request_tool.py](file:///c:/Users/ralle/projects/Hermes/tests/tools/test_http_request_tool.py) containing comprehensive deterministic pytest coverage. The suite validates invalid methods, localhost/private blocking, cloud metadata blocking, public URLs (mocked), JSON parsing, POST body payloads, custom header inclusion, query string parsing, environment token auth + credential redaction in responses/URLs, timeout handling, connection errors, truncation behavior, and non-200 responses.
+
+## Step A7: Run focused tests for http_request
+- **Status:** Completed
+- **Details:** Executed the focused pytest suite using `uv run --extra dev pytest tests/tools/test_http_request_tool.py -v --tb=short`. All 13 test cases passed cleanly.
+
+## Step A8: Run nearby regression tests
+- **Status:** Completed
+- **Details:** Executed nearby regression tests in `tests/tools/test_url_safety.py`, `tests/tools/test_web_tools_config.py`, and `tests/tools/test_tool_search.py` using `uv run --extra dev pytest tests/tools/test_url_safety.py tests/tools/test_web_tools_config.py tests/tools/test_tool_search.py -v --tb=short`. All 213 test cases passed successfully.
+
+## Step A9: Review diff for cleanliness
+- **Status:** Completed
+- **Details:** Ran `git status` and `git diff` to inspect modifications. Verified that `toolsets.py` contains only the minimal 6-line insertion for the `api` toolset, and the untracked files `tools/http_request.py` and `tests/tools/test_http_request_tool.py` conform strictly to Python styling guidelines and contain no stray debug statements, unused imports, or credential leakage vectors.
+
+## Step A10: Commit Track A
+- **Status:** Completed
+- **Details:** Committed the Track A implementation, tests, toolset configuration, and build log updates to the branch `feat/http-request-tool`.
+- **Commit Message:** `feat: add http_request API tool`
+- **Commit Hash:** `467f71023bde8d7ee2d01b1fe98b630304795ff9`
+

--- a/tests/tools/test_github_tools.py
+++ b/tests/tools/test_github_tools.py
@@ -14,6 +14,11 @@ from tools.github_tools import (
     github_get_pull_request_tool,
     github_list_pull_requests_tool,
     github_add_issue_comment_tool,
+    github_create_issue_tool,
+    github_add_pull_request_review_comment_tool,
+    github_list_workflow_runs_tool,
+    github_get_workflow_run_tool,
+    github_rerun_workflow_tool,
 )
 
 
@@ -324,3 +329,326 @@ def test_github_add_issue_comment_failed_http_request(mock_api_req):
     
     assert "error" in res
     assert "Connection timed out" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_create_issue_success(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": True,
+        "status": 201,
+        "json": {
+            "number": 73,
+            "title": "Add workflow retries",
+            "state": "open",
+            "html_url": "https://github.com/octocat/hello-world/issues/73",
+            "body": "Please add retries to CI.",
+            "labels": [{"name": "enhancement"}, {"name": "ci"}],
+            "assignees": [{"login": "alice"}, {"login": "bob"}],
+            "extra_ignored_field": "noise",
+        },
+    })
+
+    res_str = github_create_issue_tool(
+        "octocat/hello-world",
+        "Add workflow retries",
+        body="Please add retries to CI.",
+        labels=["enhancement", "ci"],
+        assignees=["alice", "bob"],
+    )
+    data = json.loads(res_str)
+
+    assert "error" not in data
+    assert data["number"] == 73
+    assert data["title"] == "Add workflow retries"
+    assert data["state"] == "open"
+    assert data["html_url"] == "https://github.com/octocat/hello-world/issues/73"
+    assert data["body"] == "Please add retries to CI."
+    assert data["labels"] == ["enhancement", "ci"]
+    assert data["assignees"] == ["alice", "bob"]
+    assert "extra_ignored_field" not in data
+
+    mock_api_req.assert_called_once_with(
+        "POST",
+        "/repos/octocat/hello-world/issues",
+        json_body={
+            "title": "Add workflow retries",
+            "body": "Please add retries to CI.",
+            "labels": ["enhancement", "ci"],
+            "assignees": ["alice", "bob"],
+        },
+    )
+
+
+def test_github_create_issue_invalid_repo():
+    res_str = github_create_issue_tool("invalidrepo", "hello")
+    res = json.loads(res_str)
+    assert "error" in res
+    assert "Invalid repository identifier" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_create_issue_non_200_response(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": False,
+        "status": 422,
+        "json": {"message": "Validation Failed"},
+    })
+
+    res_str = github_create_issue_tool("owner/repo", "hello")
+    res = json.loads(res_str)
+
+    assert "error" in res
+    assert "GitHub API error (422): Validation Failed" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_create_issue_failed_http_request(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": False,
+        "error": "Connection timed out",
+        "error_type": "ConnectTimeout",
+    })
+
+    res_str = github_create_issue_tool("owner/repo", "hello")
+    res = json.loads(res_str)
+
+    assert "error" in res
+    assert "Connection timed out" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_add_pull_request_review_comment_success(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": True,
+        "status": 201,
+        "json": {
+            "id": 555,
+            "html_url": "https://github.com/octocat/hello-world/pull/12#discussion_r555",
+            "body": "Please rename this variable.",
+            "path": "tools/github_tools.py",
+            "line": 137,
+            "side": "RIGHT",
+            "created_at": "2026-07-07T10:00:00Z",
+            "user": {"login": "octocat"},
+            "extra_ignored_field": "noise",
+        },
+    })
+
+    res_str = github_add_pull_request_review_comment_tool(
+        "octocat/hello-world",
+        12,
+        body="Please rename this variable.",
+        commit_id="abc123",
+        path="tools/github_tools.py",
+        line=137,
+        side="RIGHT",
+    )
+    data = json.loads(res_str)
+
+    assert "error" not in data
+    assert data["id"] == 555
+    assert data["html_url"] == "https://github.com/octocat/hello-world/pull/12#discussion_r555"
+    assert data["body"] == "Please rename this variable."
+    assert data["path"] == "tools/github_tools.py"
+    assert data["line"] == 137
+    assert data["side"] == "RIGHT"
+    assert data["author"] == "octocat"
+    assert data["created_at"] == "2026-07-07T10:00:00Z"
+    assert "extra_ignored_field" not in data
+
+    mock_api_req.assert_called_once_with(
+        "POST",
+        "/repos/octocat/hello-world/pulls/12/comments",
+        json_body={
+            "body": "Please rename this variable.",
+            "commit_id": "abc123",
+            "path": "tools/github_tools.py",
+            "line": 137,
+            "side": "RIGHT",
+        },
+    )
+
+
+def test_github_add_pull_request_review_comment_invalid_repo():
+    res_str = github_add_pull_request_review_comment_tool(
+        "invalidrepo",
+        12,
+        body="hello",
+        commit_id="abc123",
+        path="tools/github_tools.py",
+        line=137,
+    )
+    res = json.loads(res_str)
+    assert "error" in res
+    assert "Invalid repository identifier" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_add_pull_request_review_comment_non_200_response(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": False,
+        "status": 422,
+        "json": {"message": "Validation Failed"},
+    })
+
+    res_str = github_add_pull_request_review_comment_tool(
+        "owner/repo",
+        12,
+        body="hello",
+        commit_id="abc123",
+        path="tools/github_tools.py",
+        line=137,
+    )
+    res = json.loads(res_str)
+
+    assert "error" in res
+    assert "GitHub API error (422): Validation Failed" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_add_pull_request_review_comment_failed_http_request(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": False,
+        "error": "Connection timed out",
+        "error_type": "ConnectTimeout",
+    })
+
+    res_str = github_add_pull_request_review_comment_tool(
+        "owner/repo",
+        12,
+        body="hello",
+        commit_id="abc123",
+        path="tools/github_tools.py",
+        line=137,
+    )
+    res = json.loads(res_str)
+
+    assert "error" in res
+    assert "Connection timed out" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_list_workflow_runs_success(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": True,
+        "status": 200,
+        "json": {
+            "workflow_runs": [
+                {
+                    "id": 1001,
+                    "name": "CI",
+                    "display_title": "Run tests",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "event": "push",
+                    "head_branch": "main",
+                    "html_url": "https://github.com/octocat/hello-world/actions/runs/1001",
+                    "created_at": "2026-07-07T10:30:00Z",
+                }
+            ]
+        },
+    })
+
+    res_str = github_list_workflow_runs_tool("octocat/hello-world", per_page=10, status="completed")
+    data = json.loads(res_str)
+
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["id"] == 1001
+    assert data[0]["name"] == "CI"
+    assert data[0]["display_title"] == "Run tests"
+    assert data[0]["status"] == "completed"
+    assert data[0]["conclusion"] == "success"
+    assert data[0]["event"] == "push"
+    assert data[0]["head_branch"] == "main"
+
+    mock_api_req.assert_called_once_with(
+        "GET",
+        "/repos/octocat/hello-world/actions/runs",
+        query={"per_page": 10, "status": "completed"},
+    )
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_get_workflow_run_success(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": True,
+        "status": 200,
+        "json": {
+            "id": 1001,
+            "name": "CI",
+            "display_title": "Run tests",
+            "status": "completed",
+            "conclusion": "failure",
+            "event": "pull_request",
+            "head_branch": "feature/github-tools",
+            "head_sha": "deadbeef",
+            "html_url": "https://github.com/octocat/hello-world/actions/runs/1001",
+            "created_at": "2026-07-07T10:30:00Z",
+            "updated_at": "2026-07-07T10:35:00Z",
+            "run_attempt": 2,
+        },
+    })
+
+    res_str = github_get_workflow_run_tool("octocat/hello-world", 1001)
+    data = json.loads(res_str)
+
+    assert data["id"] == 1001
+    assert data["name"] == "CI"
+    assert data["display_title"] == "Run tests"
+    assert data["status"] == "completed"
+    assert data["conclusion"] == "failure"
+    assert data["head_branch"] == "feature/github-tools"
+    assert data["head_sha"] == "deadbeef"
+    assert data["run_attempt"] == 2
+
+    mock_api_req.assert_called_once_with(
+        "GET",
+        "/repos/octocat/hello-world/actions/runs/1001",
+    )
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_rerun_workflow_success(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": True,
+        "status": 201,
+        "json": None,
+    })
+
+    res_str = github_rerun_workflow_tool("octocat/hello-world", 1001)
+    data = json.loads(res_str)
+
+    assert data["accepted"] is True
+    assert data["run_id"] == 1001
+    assert data["repository"] == "octocat/hello-world"
+
+    mock_api_req.assert_called_once_with(
+        "POST",
+        "/repos/octocat/hello-world/actions/runs/1001/rerun",
+    )
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_workflow_tools_failures(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": False,
+        "status": 404,
+        "json": {"message": "Not Found"},
+    })
+
+    list_res = json.loads(github_list_workflow_runs_tool("owner/repo"))
+    get_res = json.loads(github_get_workflow_run_tool("owner/repo", 1001))
+    rerun_res = json.loads(github_rerun_workflow_tool("owner/repo", 1001))
+
+    assert "GitHub API error (404): Not Found" in list_res["error"]
+    assert "GitHub API error (404): Not Found" in get_res["error"]
+    assert "GitHub API error (404): Not Found" in rerun_res["error"]

--- a/tests/tools/test_github_tools.py
+++ b/tests/tools/test_github_tools.py
@@ -1,0 +1,326 @@
+"""Tests for the GitHub native tools and helper layer."""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+from tools.github_tools import (
+    _get_github_token,
+    check_github_requirements,
+    parse_owner_repo,
+    get_github_error_message,
+    github_get_issue_tool,
+    github_list_issues_tool,
+    github_get_pull_request_tool,
+    github_list_pull_requests_tool,
+    github_add_issue_comment_tool,
+)
+
+
+def test_check_github_requirements():
+    # 1. Gating
+    with patch("tools.github_tools._get_github_token", return_value=""):
+        assert check_github_requirements() is False
+
+    with patch("tools.github_tools._get_github_token", return_value="token123"):
+        assert check_github_requirements() is True
+
+
+def test_parse_owner_repo():
+    # 2. Repository parsing
+    # Standard format
+    assert parse_owner_repo("octocat/hello-world") == ("octocat", "hello-world")
+    assert parse_owner_repo(" octocat/hello-world  ") == ("octocat", "hello-world")
+    
+    # Trailing .git
+    assert parse_owner_repo("octocat/hello-world.git") == ("octocat", "hello-world")
+
+    # URL formats
+    assert parse_owner_repo("https://github.com/octocat/hello-world") == ("octocat", "hello-world")
+    assert parse_owner_repo("http://github.com/octocat/hello-world.git") == ("octocat", "hello-world")
+    assert parse_owner_repo("github.com/octocat/hello-world") == ("octocat", "hello-world")
+
+    # Invalid formats
+    with pytest.raises(ValueError, match="Repository identifier cannot be empty"):
+        parse_owner_repo("")
+
+    with pytest.raises(ValueError, match="Invalid repository identifier"):
+        parse_owner_repo("invalid-format")
+
+    with pytest.raises(ValueError, match="Invalid repository identifier"):
+        parse_owner_repo("too/many/slashes/here")
+
+
+def test_get_github_error_message():
+    # 3. GitHub error extraction
+    # JSON error payload from GitHub
+    api_result_with_msg = {
+        "success": True,
+        "ok": False,
+        "status": 404,
+        "json": {"message": "Not Found"},
+    }
+    assert get_github_error_message(api_result_with_msg) == "GitHub API error (404): Not Found"
+
+    # Fallback to text preview
+    api_result_text = {
+        "success": True,
+        "ok": False,
+        "status": 500,
+        "text_preview": "Internal server error details",
+    }
+    assert get_github_error_message(api_result_text) == "GitHub API error (500): Internal server error details"
+
+    # Execution failure
+    api_failed = {
+        "success": False,
+        "error": "Connection timed out",
+    }
+    assert get_github_error_message(api_failed) == "Connection timed out"
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_get_issue_success(mock_api_req):
+    # 4. github_get_issue success case and 7. Output shaping
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": True,
+        "status": 200,
+        "json": {
+            "number": 42,
+            "title": "Fix memory leak",
+            "state": "open",
+            "user": {"login": "octocat"},
+            "assignees": [{"login": "alice"}],
+            "labels": [{"name": "bug"}],
+            "html_url": "https://github.com/octocat/hello-world/issues/42",
+            "body": "Detailed description of bug",
+            "extra_noise": "should be filtered out",
+        }
+    })
+
+    res_str = github_get_issue_tool("octocat/hello-world", 42)
+    data = json.loads(res_str)
+    
+    assert "error" not in data
+    assert data["number"] == 42
+    assert data["title"] == "Fix memory leak"
+    assert data["state"] == "open"
+    assert data["author"] == "octocat"
+    assert data["assignees"] == ["alice"]
+    assert data["labels"] == ["bug"]
+    assert data["html_url"] == "https://github.com/octocat/hello-world/issues/42"
+    assert data["body"] == "Detailed description of bug"
+    assert "extra_noise" not in data
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_list_issues_filtering_and_shaping(mock_api_req):
+    # 4. github_list_issues success
+    # 6. Issue-vs-PR filtering (PRs filtered out)
+    # 7. Output shaping (summary details)
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": True,
+        "status": 200,
+        "json": [
+            {
+                "number": 1,
+                "title": "Bug report",
+                "state": "open",
+                "user": {"login": "user1"},
+                "html_url": "https://github.com/owner/repo/issues/1",
+            },
+            {
+                "number": 2,
+                "title": "Feature branch PR",
+                "state": "open",
+                "user": {"login": "user2"},
+                "html_url": "https://github.com/owner/repo/pull/2",
+                "pull_request": {"url": "https://api.github.com/repos/owner/repo/pulls/2"},
+            }
+        ]
+    })
+
+    res_str = github_list_issues_tool("owner/repo", "open")
+    issues = json.loads(res_str)
+    
+    assert isinstance(issues, list)
+    assert len(issues) == 1
+    assert issues[0]["number"] == 1
+    assert issues[0]["title"] == "Bug report"
+    assert "pull_request" not in issues[0]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_get_pull_request_success(mock_api_req):
+    # 4. github_get_pull_request success case
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": True,
+        "status": 200,
+        "json": {
+            "number": 101,
+            "title": "Add feature",
+            "state": "closed",
+            "user": {"login": "developer"},
+            "draft": False,
+            "merged": True,
+            "base": {"ref": "main", "sha": "basesha123"},
+            "head": {"ref": "feat-branch", "sha": "headsha456"},
+            "html_url": "https://github.com/owner/repo/pull/101",
+            "body": "PR description",
+        }
+    })
+
+    res_str = github_get_pull_request_tool("owner/repo", 101)
+    data = json.loads(res_str)
+    
+    assert "error" not in data
+    assert data["number"] == 101
+    assert data["merged"] is True
+    assert data["base"]["ref"] == "main"
+    assert data["head"]["ref"] == "feat-branch"
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_list_pull_requests_success(mock_api_req):
+    # 4. github_list_pull_requests success case
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": True,
+        "status": 200,
+        "json": [
+            {
+                "number": 5,
+                "title": "Fix typos",
+                "state": "open",
+                "user": {"login": "editor"},
+                "html_url": "https://github.com/owner/repo/pull/5",
+                "draft": True,
+            }
+        ]
+    })
+
+    res_str = github_list_pull_requests_tool("owner/repo")
+    prs = json.loads(res_str)
+    
+    assert isinstance(prs, list)
+    assert len(prs) == 1
+    assert prs[0]["number"] == 5
+    assert prs[0]["draft"] is True
+
+
+def test_wrapper_tool_invalid_repo_input():
+    # 5. Wrapper tool failure cases - invalid repo
+    res_str = github_get_issue_tool("invalidrepo", 1)
+    res = json.loads(res_str)
+    assert "error" in res
+    assert "Invalid repository identifier" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_wrapper_tool_non_200_response(mock_api_req):
+    # 5. Wrapper tool failure cases - non-200
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": False,
+        "status": 404,
+        "json": {"message": "Not Found"},
+    })
+
+    res_str = github_get_issue_tool("owner/repo", 999)
+    res = json.loads(res_str)
+    
+    assert "error" in res
+    assert "GitHub API error (404): Not Found" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_wrapper_tool_failed_http_request(mock_api_req):
+    # 5. Wrapper tool failure cases - HTTP failed
+    mock_api_req.return_value = json.dumps({
+        "success": False,
+        "error": "SSL verification failed",
+        "error_type": "SSLError",
+    })
+
+    res_str = github_list_issues_tool("owner/repo")
+    res = json.loads(res_str)
+    
+    assert "error" in res
+    assert "SSL verification failed" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_add_issue_comment_success(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": True,
+        "status": 201,
+        "json": {
+            "id": 123456,
+            "html_url": "https://github.com/octocat/hello-world/issues/42#issuecomment-123456",
+            "body": "This is a comment body",
+            "created_at": "2026-07-07T09:00:00Z",
+            "updated_at": "2026-07-07T09:00:00Z",
+            "user": {"login": "octocat"},
+            "extra_ignored_field": "noise"
+        }
+    })
+
+    res_str = github_add_issue_comment_tool("octocat/hello-world", 42, "This is a comment body")
+    data = json.loads(res_str)
+
+    assert "error" not in data
+    assert data["id"] == 123456
+    assert data["html_url"] == "https://github.com/octocat/hello-world/issues/42#issuecomment-123456"
+    assert data["body"] == "This is a comment body"
+    assert data["created_at"] == "2026-07-07T09:00:00Z"
+    assert data["updated_at"] == "2026-07-07T09:00:00Z"
+    assert data["author"] == "octocat"
+    assert "extra_ignored_field" not in data
+
+    mock_api_req.assert_called_once_with(
+        "POST",
+        "/repos/octocat/hello-world/issues/42/comments",
+        json_body={"body": "This is a comment body"}
+    )
+
+
+def test_github_add_issue_comment_invalid_repo():
+    res_str = github_add_issue_comment_tool("invalidrepo", 42, "hello")
+    res = json.loads(res_str)
+    assert "error" in res
+    assert "Invalid repository identifier" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_add_issue_comment_non_200_response(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": True,
+        "ok": False,
+        "status": 422,
+        "json": {"message": "Validation Failed"},
+    })
+
+    res_str = github_add_issue_comment_tool("owner/repo", 42, "hello")
+    res = json.loads(res_str)
+    
+    assert "error" in res
+    assert "GitHub API error (422): Validation Failed" in res["error"]
+
+
+@patch("tools.github_tools.github_api_request")
+def test_github_add_issue_comment_failed_http_request(mock_api_req):
+    mock_api_req.return_value = json.dumps({
+        "success": False,
+        "error": "Connection timed out",
+        "error_type": "ConnectTimeout",
+    })
+
+    res_str = github_add_issue_comment_tool("owner/repo", 42, "hello")
+    res = json.loads(res_str)
+    
+    assert "error" in res
+    assert "Connection timed out" in res["error"]

--- a/tests/tools/test_github_tools.py
+++ b/tests/tools/test_github_tools.py
@@ -574,6 +574,13 @@ def test_github_list_workflow_runs_success(mock_api_req):
     )
 
 
+def test_github_list_workflow_runs_invalid_repo():
+    res_str = github_list_workflow_runs_tool("invalidrepo")
+    res = json.loads(res_str)
+    assert "error" in res
+    assert "Invalid repository identifier" in res["error"]
+
+
 @patch("tools.github_tools.github_api_request")
 def test_github_get_workflow_run_success(mock_api_req):
     mock_api_req.return_value = json.dumps({
@@ -614,6 +621,13 @@ def test_github_get_workflow_run_success(mock_api_req):
     )
 
 
+def test_github_get_workflow_run_invalid_repo():
+    res_str = github_get_workflow_run_tool("invalidrepo", 1001)
+    res = json.loads(res_str)
+    assert "error" in res
+    assert "Invalid repository identifier" in res["error"]
+
+
 @patch("tools.github_tools.github_api_request")
 def test_github_rerun_workflow_success(mock_api_req):
     mock_api_req.return_value = json.dumps({
@@ -634,6 +648,13 @@ def test_github_rerun_workflow_success(mock_api_req):
         "POST",
         "/repos/octocat/hello-world/actions/runs/1001/rerun",
     )
+
+
+def test_github_rerun_workflow_invalid_repo():
+    res_str = github_rerun_workflow_tool("invalidrepo", 1001)
+    res = json.loads(res_str)
+    assert "error" in res
+    assert "Invalid repository identifier" in res["error"]
 
 
 @patch("tools.github_tools.github_api_request")

--- a/tests/tools/test_http_request_tool.py
+++ b/tests/tools/test_http_request_tool.py
@@ -1,0 +1,249 @@
+"""Tests for the http_request tool."""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+import httpx
+
+from tools.http_request import http_request_tool, redact_url_secrets, redact_sensitive_headers
+
+
+def test_invalid_method():
+    # 1. invalid method rejected
+    res_str = http_request_tool(method="INVALID", url="https://example.com")
+    res = json.loads(res_str)
+    assert res["success"] is False
+    assert "Unsupported HTTP method" in res["error"]
+    assert res["error_type"] == "ValueError"
+
+
+def test_private_url_blocked():
+    # 2. localhost/private URL blocked
+    # is_safe_url will reject 127.0.0.1
+    res_str = http_request_tool(method="GET", url="http://127.0.0.1")
+    res = json.loads(res_str)
+    assert res["success"] is False
+    assert "URL is not safe to access" in res["error"]
+    assert res["error_type"] == "PermissionError"
+
+
+def test_metadata_ip_blocked():
+    # 3. metadata IP blocked
+    # 169.254.169.254 is link-local and blocked by is_safe_url
+    res_str = http_request_tool(method="GET", url="http://169.254.169.254/latest/meta-data")
+    res = json.loads(res_str)
+    assert res["success"] is False
+    assert "URL is not safe to access" in res["error"]
+    assert res["error_type"] == "PermissionError"
+
+
+@patch("tools.http_request.is_safe_url", return_value=True)
+def test_public_url_allowed_and_get_json(mock_safe):
+    # 4. public URL allowed when safety check indicates safe
+    # 5. GET JSON response parsed correctly
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.is_success = True
+    mock_response.headers = {"content-type": "application/json; charset=utf-8"}
+    mock_response.text = '{"status": "ok", "items": [1, 2]}'
+    mock_response.json.return_value = {"status": "ok", "items": [1, 2]}
+    
+    with patch("httpx.Client.request", return_value=mock_response) as mock_request:
+        res_str = http_request_tool(method="GET", url="https://api.github.com/users/test")
+        res = json.loads(res_str)
+        
+        assert res["success"] is True
+        assert res["status"] == 200
+        assert res["ok"] is True
+        assert "application/json" in res["content_type"]
+        assert res["json"] == {"status": "ok", "items": [1, 2]}
+        assert res["truncated"] is False
+        
+        mock_request.assert_called_once()
+        args, kwargs = mock_request.call_args
+        assert kwargs["method"] == "GET"
+        assert kwargs["url"] == "https://api.github.com/users/test"
+
+
+@patch("tools.http_request.is_safe_url", return_value=True)
+def test_post_json_body(mock_safe):
+    # 6. POST JSON body sent correctly
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.is_success = True
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.text = '{"id": 123}'
+    mock_response.json.return_value = {"id": 123}
+    
+    with patch("httpx.Client.request", return_value=mock_response) as mock_request:
+        payload = {"title": "new issue", "body": "description"}
+        res_str = http_request_tool(
+            method="POST",
+            url="https://api.github.com/repos/test/issues",
+            json_body=payload
+        )
+        res = json.loads(res_str)
+        
+        assert res["success"] is True
+        assert res["status"] == 201
+        
+        mock_request.assert_called_once()
+        args, kwargs = mock_request.call_args
+        assert kwargs["method"] == "POST"
+        assert kwargs["json"] == payload
+        assert kwargs["data"] is None
+
+
+@patch("tools.http_request.is_safe_url", return_value=True)
+def test_query_params_and_custom_headers(mock_safe):
+    # 7. query params handled correctly
+    # 8. custom headers handled correctly
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.is_success = True
+    mock_response.headers = {"content-type": "text/html"}
+    mock_response.text = "<html>Hello</html>"
+    
+    headers = {"X-Custom-Header": "value1", "Authorization": "Bearer supersecret"}
+    query = {"page": "1", "q": "test"}
+    
+    with patch("httpx.Client.request", return_value=mock_response) as mock_request:
+        res_str = http_request_tool(
+            method="GET",
+            url="https://example.com/search",
+            headers=headers,
+            query=query
+        )
+        res = json.loads(res_str)
+        
+        assert res["success"] is True
+        
+        mock_request.assert_called_once()
+        args, kwargs = mock_request.call_args
+        assert kwargs["params"] == query
+        # Request headers should have Authorization
+        assert kwargs["headers"]["Authorization"] == "Bearer supersecret"
+        
+        # Output url and headers must be redacted
+        assert res["url"] == "https://example.com/search"
+        assert res["headers"].get("Authorization") is None  # response headers didn't have it
+
+
+@patch("tools.http_request.is_safe_url", return_value=True)
+@patch("tools.http_request._get_env_value", return_value="env-secret-token")
+def test_bearer_token_auth_from_env(mock_get_env, mock_safe):
+    # 9. bearer token auth from env handled correctly
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.is_success = True
+    mock_response.headers = {"content-type": "application/json", "Authorization": "Bearer env-secret-token"}
+    mock_response.text = '{"data": "auth_ok"}'
+    mock_response.json.return_value = {"data": "auth_ok"}
+    
+    with patch("httpx.Client.request", return_value=mock_response) as mock_request:
+        res_str = http_request_tool(
+            method="GET",
+            url="https://api.github.com/user",
+            auth_mode="bearer_env",
+            auth_token_env="MY_GITHUB_TOKEN"
+        )
+        res = json.loads(res_str)
+        
+        assert res["success"] is True
+        mock_get_env.assert_called_once_with("MY_GITHUB_TOKEN")
+        
+        # Verify Authorization header was sent with the env value
+        mock_request.assert_called_once()
+        args, kwargs = mock_request.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer env-secret-token"
+        
+        # Response headers had Authorization (mocked), verify it is redacted in output
+        assert res["headers"]["Authorization"] == "[REDACTED]"
+
+
+@patch("tools.http_request.is_safe_url", return_value=True)
+def test_timeout_error(mock_safe):
+    # 10. timeout returns structured error
+    with patch("httpx.Client.request", side_effect=httpx.TimeoutException("Request timed out")):
+        res_str = http_request_tool(method="GET", url="https://example.com", timeout_seconds=5)
+        res = json.loads(res_str)
+        assert res["success"] is False
+        assert "Request timed out" in res["error"]
+        assert res["error_type"] == "TimeoutException"
+
+
+@patch("tools.http_request.is_safe_url", return_value=True)
+def test_connection_error(mock_safe):
+    # 11. connection error returns structured error
+    with patch("httpx.Client.request", side_effect=httpx.ConnectError("Connection refused")):
+        res_str = http_request_tool(method="GET", url="https://example.com")
+        res = json.loads(res_str)
+        assert res["success"] is False
+        assert "Connection refused" in res["error"]
+        assert res["error_type"] == "ConnectError"
+
+
+@patch("tools.http_request.is_safe_url", return_value=True)
+@patch("tools.http_request.registry.get_max_result_size", return_value=15)
+def test_response_truncation(mock_max_size, mock_safe):
+    # 12. large text response is truncated or previewed safely
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.is_success = True
+    mock_response.headers = {"content-type": "text/plain"}
+    # Length of "abcdefghijklmnopqrstuvwxyz" is 26, which is > 15
+    mock_response.text = "abcdefghijklmnopqrstuvwxyz"
+    
+    with patch("httpx.Client.request", return_value=mock_response):
+        res_str = http_request_tool(method="GET", url="https://example.com/large")
+        res = json.loads(res_str)
+        
+        assert res["success"] is True
+        assert res["truncated"] is True
+        # It should slice at 15 and add the truncated note
+        assert res["text_preview"].startswith("abcdefghijklmno")
+        assert "[TRUNCATED]" in res["text_preview"]
+        # Since it is truncated, json should be None
+        assert res["json"] is None
+
+
+@patch("tools.http_request.is_safe_url", return_value=True)
+def test_non_200_response(mock_safe):
+    # 13. non-200 response still returns structured result cleanly
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.is_success = False
+    mock_response.headers = {"content-type": "text/plain"}
+    mock_response.text = "Not Found"
+    
+    with patch("httpx.Client.request", return_value=mock_response):
+        res_str = http_request_tool(method="GET", url="https://example.com/missing")
+        res = json.loads(res_str)
+        
+        assert res["success"] is True
+        assert res["status"] == 404
+        assert res["ok"] is False
+        assert res["text_preview"] == "Not Found"
+
+
+def test_redact_url_secrets():
+    # Test that secret query parameters are redacted
+    url_with_secret = "https://example.com/api?api_key=secret123&q=query&token=abc"
+    redacted = redact_url_secrets(url_with_secret)
+    assert "api_key=%5BREDACTED%5D" in redacted
+    assert "token=%5BREDACTED%5D" in redacted
+    assert "q=query" in redacted
+
+
+def test_redact_sensitive_headers():
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer 123",
+        "x-api-key": "secret",
+        "Accept": "*/*"
+    }
+    redacted = redact_sensitive_headers(headers)
+    assert redacted["Content-Type"] == "application/json"
+    assert redacted["Authorization"] == "[REDACTED]"
+    assert redacted["x-api-key"] == "[REDACTED]"
+    assert redacted["Accept"] == "*/*"

--- a/tools/github_tools.py
+++ b/tools/github_tools.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""Native GitHub tools package built on the secure `http_request` foundation.
+
+Provides helper methods, error shaping, and core GitHub integrations.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+from tools.http_request import http_request_tool
+from tools.registry import registry, tool_result, tool_error
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_GITHUB_API_BASE = "https://api.github.com"
+GITHUB_TOKEN_ENV_VAR = "GITHUB_TOKEN"
+
+
+def _get_github_token() -> str:
+    """Helper to resolve GitHub token from environment.
+    
+    Checks GITHUB_TOKEN from Hermes configuration or environment.
+    """
+    try:
+        from hermes_cli.config import get_env_value
+        val = get_env_value(GITHUB_TOKEN_ENV_VAR)
+    except Exception:
+        val = None
+    if val is None:
+        val = os.getenv(GITHUB_TOKEN_ENV_VAR, "")
+    return (val or "").strip()
+
+
+def check_github_requirements() -> bool:
+    """Check if GitHub tool prerequisites are met (i.e., token is available)."""
+    return bool(_get_github_token())
+
+
+def parse_owner_repo(repo_str: str) -> Tuple[str, str]:
+    """Parse owner and repository name from a string (owner/repo or GitHub URL).
+    
+    Raises ValueError if the format is invalid.
+    """
+    clean_str = repo_str.strip()
+    if not clean_str:
+        raise ValueError("Repository identifier cannot be empty")
+
+    # 1. Handle GitHub URLs
+    if "github.com" in clean_str.lower():
+        try:
+            # Add scheme if missing so urlparse works correctly
+            url_to_parse = clean_str
+            if not re.match(r"^[a-z]+://", clean_str.lower()):
+                url_to_parse = "https://" + clean_str
+            
+            parsed = urlparse(url_to_parse)
+            path_parts = [p for p in parsed.path.split("/") if p]
+            if len(path_parts) >= 2:
+                # Extract owner and repo (ignoring trailing .git if present)
+                owner = path_parts[0]
+                repo = path_parts[1]
+                if repo.lower().endswith(".git"):
+                    repo = repo[:-4]
+                return owner, repo
+        except Exception as exc:
+            raise ValueError(f"Failed to parse URL '{repo_str}': {exc}")
+
+    # 2. Handle standard owner/repo format
+    parts = [p.strip() for p in clean_str.split("/") if p.strip()]
+    if len(parts) == 2:
+        owner, repo = parts
+        if repo.lower().endswith(".git"):
+            repo = repo[:-4]
+        return owner, repo
+
+    raise ValueError(
+        f"Invalid repository identifier: '{repo_str}'. "
+        "Must be in 'owner/repo' format or a valid GitHub URL."
+    )
+
+
+def github_api_request(
+    method: str,
+    path: str,
+    query: Optional[Dict[str, Any]] = None,
+    json_body: Optional[Any] = None,
+    headers: Optional[Dict[str, str]] = None,
+) -> str:
+    """Execute a request against the GitHub REST API using the http_request_tool foundation.
+    
+    Includes standard GitHub headers and bearer token authorization.
+    """
+    # 1. Construct URL
+    base_url = DEFAULT_GITHUB_API_BASE.rstrip("/")
+    clean_path = path.lstrip("/")
+    url = f"{base_url}/{clean_path}"
+
+    # 2. Setup standard GitHub headers
+    req_headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if headers:
+        req_headers.update(headers)
+
+    # 3. Delegate to secure http_request_tool
+    return http_request_tool(
+        method=method,
+        url=url,
+        headers=req_headers,
+        query=query,
+        json_body=json_body,
+        auth_mode="bearer_env",
+        auth_token_env=GITHUB_TOKEN_ENV_VAR,
+    )
+
+
+def get_github_error_message(result: Dict[str, Any]) -> str:
+    """Extract a user-friendly error message from a GitHub tool result dictionary.
+    
+    Assumes result is the parsed dictionary output from github_api_request.
+    """
+    if not result.get("success"):
+        return result.get("error", "Unknown tool execution failure")
+    
+    if not result.get("ok"):
+        status = result.get("status")
+        # Try to parse GitHub error message
+        json_data = result.get("json")
+        if isinstance(json_data, dict) and "message" in json_data:
+            return f"GitHub API error ({status}): {json_data['message']}"
+        
+        # Fallback to text preview
+        preview = result.get("text_preview", "").strip()
+        if preview:
+            # If the response itself is short, show it
+            if len(preview) < 200:
+                return f"GitHub API error ({status}): {preview}"
+            return f"GitHub API error ({status}): {preview[:200]}..."
+        
+        return f"GitHub API error ({status})"
+    
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Tool Implementations
+# ---------------------------------------------------------------------------
+
+def github_get_issue_tool(repository: str, issue_number: int) -> str:
+    """Retrieve detailed information about a specific issue in a GitHub repository."""
+    try:
+        owner, repo = parse_owner_repo(repository)
+        path = f"/repos/{owner}/{repo}/issues/{issue_number}"
+        res_str = github_api_request("GET", path)
+        res_data = json.loads(res_str)
+        
+        if not res_data.get("success"):
+            return res_str
+        if not res_data.get("ok"):
+            return tool_error(get_github_error_message(res_data), status=res_data.get("status"))
+            
+        issue = res_data.get("json")
+        if not isinstance(issue, dict):
+            return tool_error("Invalid response payload from GitHub API")
+            
+        formatted = {
+            "number": issue.get("number"),
+            "title": issue.get("title"),
+            "state": issue.get("state"),
+            "author": issue.get("user", {}).get("login") if isinstance(issue.get("user"), dict) else None,
+            "assignees": [a.get("login") for a in issue.get("assignees") or [] if isinstance(a, dict)],
+            "labels": [l.get("name") for l in issue.get("labels") or [] if isinstance(l, dict)],
+            "html_url": issue.get("html_url"),
+            "body": issue.get("body"),
+        }
+        return tool_result(formatted)
+    except Exception as e:
+        logger.exception("github_get_issue_tool failed")
+        return tool_error(str(e))
+
+
+def github_list_issues_tool(repository: str, state: str = "open", per_page: int = 30) -> str:
+    """List issues in a GitHub repository (excludes pull requests)."""
+    try:
+        owner, repo = parse_owner_repo(repository)
+        path = f"/repos/{owner}/{repo}/issues"
+        query = {"state": state, "per_page": per_page}
+        res_str = github_api_request("GET", path, query=query)
+        res_data = json.loads(res_str)
+        
+        if not res_data.get("success"):
+            return res_str
+        if not res_data.get("ok"):
+            return tool_error(get_github_error_message(res_data), status=res_data.get("status"))
+            
+        issues = res_data.get("json")
+        if not isinstance(issues, list):
+            return tool_error("Invalid response payload from GitHub API")
+            
+        formatted = []
+        for issue in issues:
+            if not isinstance(issue, dict):
+                continue
+            # GitHub's issues endpoint returns PRs too; filter them out
+            if "pull_request" in issue:
+                continue
+            formatted.append({
+                "number": issue.get("number"),
+                "title": issue.get("title"),
+                "state": issue.get("state"),
+                "author": issue.get("user", {}).get("login") if isinstance(issue.get("user"), dict) else None,
+                "html_url": issue.get("html_url"),
+            })
+        return tool_result(formatted)
+    except Exception as e:
+        logger.exception("github_list_issues_tool failed")
+        return tool_error(str(e))
+
+
+def github_get_pull_request_tool(repository: str, pull_number: int) -> str:
+    """Retrieve detailed information about a specific pull request in a GitHub repository."""
+    try:
+        owner, repo = parse_owner_repo(repository)
+        path = f"/repos/{owner}/{repo}/pulls/{pull_number}"
+        res_str = github_api_request("GET", path)
+        res_data = json.loads(res_str)
+        
+        if not res_data.get("success"):
+            return res_str
+        if not res_data.get("ok"):
+            return tool_error(get_github_error_message(res_data), status=res_data.get("status"))
+            
+        pr = res_data.get("json")
+        if not isinstance(pr, dict):
+            return tool_error("Invalid response payload from GitHub API")
+            
+        formatted = {
+            "number": pr.get("number"),
+            "title": pr.get("title"),
+            "state": pr.get("state"),
+            "author": pr.get("user", {}).get("login") if isinstance(pr.get("user"), dict) else None,
+            "draft": pr.get("draft", False),
+            "merged": pr.get("merged", False),
+            "base": {
+                "ref": pr.get("base", {}).get("ref") if isinstance(pr.get("base"), dict) else None,
+                "sha": pr.get("base", {}).get("sha") if isinstance(pr.get("base"), dict) else None,
+            },
+            "head": {
+                "ref": pr.get("head", {}).get("ref") if isinstance(pr.get("head"), dict) else None,
+                "sha": pr.get("head", {}).get("sha") if isinstance(pr.get("head"), dict) else None,
+            },
+            "html_url": pr.get("html_url"),
+            "body": pr.get("body"),
+        }
+        return tool_result(formatted)
+    except Exception as e:
+        logger.exception("github_get_pull_request_tool failed")
+        return tool_error(str(e))
+
+
+def github_list_pull_requests_tool(repository: str, state: str = "open", per_page: int = 30) -> str:
+    """List pull requests in a GitHub repository."""
+    try:
+        owner, repo = parse_owner_repo(repository)
+        path = f"/repos/{owner}/{repo}/pulls"
+        query = {"state": state, "per_page": per_page}
+        res_str = github_api_request("GET", path, query=query)
+        res_data = json.loads(res_str)
+        
+        if not res_data.get("success"):
+            return res_str
+        if not res_data.get("ok"):
+            return tool_error(get_github_error_message(res_data), status=res_data.get("status"))
+            
+        pulls = res_data.get("json")
+        if not isinstance(pulls, list):
+            return tool_error("Invalid response payload from GitHub API")
+            
+        formatted = []
+        for pr in pulls:
+            if not isinstance(pr, dict):
+                continue
+            formatted.append({
+                "number": pr.get("number"),
+                "title": pr.get("title"),
+                "state": pr.get("state"),
+                "author": pr.get("user", {}).get("login") if isinstance(pr.get("user"), dict) else None,
+                "html_url": pr.get("html_url"),
+                "draft": pr.get("draft", False),
+            })
+        return tool_result(formatted)
+    except Exception as e:
+        logger.exception("github_list_pull_requests_tool failed")
+        return tool_error(str(e))
+
+
+def github_add_issue_comment_tool(repository: str, issue_number: int, body: str) -> str:
+    """Add a comment to an issue in a GitHub repository."""
+    try:
+        owner, repo = parse_owner_repo(repository)
+        path = f"/repos/{owner}/{repo}/issues/{issue_number}/comments"
+        json_payload = {"body": body}
+        res_str = github_api_request("POST", path, json_body=json_payload)
+        res_data = json.loads(res_str)
+        
+        if not res_data.get("success"):
+            return res_str
+        if not res_data.get("ok"):
+            return tool_error(get_github_error_message(res_data), status=res_data.get("status"))
+            
+        comment = res_data.get("json")
+        if not isinstance(comment, dict):
+            return tool_error("Invalid response payload from GitHub API")
+            
+        formatted = {
+            "id": comment.get("id"),
+            "html_url": comment.get("html_url"),
+            "body": comment.get("body"),
+            "created_at": comment.get("created_at"),
+            "updated_at": comment.get("updated_at"),
+            "author": comment.get("user", {}).get("login") if isinstance(comment.get("user"), dict) else None,
+        }
+        return tool_result(formatted)
+    except Exception as e:
+        logger.exception("github_add_issue_comment_tool failed")
+        return tool_error(str(e))
+
+
+# -----------------------------------------------------------------------------------------------------------
+# Schemas & Handlers for Registry
+# ---------------------------------------------------------------------------
+
+GITHUB_GET_ISSUE_SCHEMA = {
+    "name": "github_get_issue",
+    "description": "Retrieve detailed information about a specific issue in a GitHub repository.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repository": {
+                "type": "string",
+                "description": "Repository identifier, either in 'owner/repo' format or as a full GitHub URL.",
+            },
+            "issue_number": {
+                "type": "integer",
+                "description": "The issue number to retrieve.",
+            },
+        },
+        "required": ["repository", "issue_number"],
+    },
+}
+
+GITHUB_LIST_ISSUES_SCHEMA = {
+    "name": "github_list_issues",
+    "description": "List issues in a GitHub repository.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repository": {
+                "type": "string",
+                "description": "Repository identifier, either in 'owner/repo' format or as a full GitHub URL.",
+            },
+            "state": {
+                "type": "string",
+                "description": "Filter by issue state.",
+                "enum": ["open", "closed", "all"],
+                "default": "open",
+            },
+            "per_page": {
+                "type": "integer",
+                "description": "Number of items to retrieve per page (max 100, default 30).",
+                "default": 30,
+            },
+        },
+        "required": ["repository"],
+    },
+}
+
+GITHUB_GET_PULL_REQUEST_SCHEMA = {
+    "name": "github_get_pull_request",
+    "description": "Retrieve detailed information about a specific pull request in a GitHub repository.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repository": {
+                "type": "string",
+                "description": "Repository identifier, either in 'owner/repo' format or as a full GitHub URL.",
+            },
+            "pull_number": {
+                "type": "integer",
+                "description": "The pull request number to retrieve.",
+            },
+        },
+        "required": ["repository", "pull_number"],
+    },
+}
+
+GITHUB_LIST_PULL_REQUESTS_SCHEMA = {
+    "name": "github_list_pull_requests",
+    "description": "List pull requests in a GitHub repository.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repository": {
+                "type": "string",
+                "description": "Repository identifier, either in 'owner/repo' format or as a full GitHub URL.",
+            },
+            "state": {
+                "type": "string",
+                "description": "Filter by pull request state.",
+                "enum": ["open", "closed", "all"],
+                "default": "open",
+            },
+            "per_page": {
+                "type": "integer",
+                "description": "Number of items to retrieve per page (max 100, default 30).",
+                "default": 30,
+            },
+        },
+        "required": ["repository"],
+    },
+}
+
+GITHUB_ADD_ISSUE_COMMENT_SCHEMA = {
+    "name": "github_add_issue_comment",
+    "description": "Add a comment to an issue in a GitHub repository.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repository": {
+                "type": "string",
+                "description": "Repository identifier, either in 'owner/repo' format or as a full GitHub URL.",
+            },
+            "issue_number": {
+                "type": "integer",
+                "description": "The issue number to add the comment to.",
+            },
+            "body": {
+                "type": "string",
+                "description": "The comment text body (Markdown supported).",
+            },
+        },
+        "required": ["repository", "issue_number", "body"],
+    },
+}
+
+
+def _handle_github_get_issue(args: dict, **kwargs) -> str:
+    return github_get_issue_tool(
+        repository=args.get("repository", ""),
+        issue_number=int(args.get("issue_number")),
+    )
+
+
+def _handle_github_list_issues(args: dict, **kwargs) -> str:
+    return github_list_issues_tool(
+        repository=args.get("repository", ""),
+        state=args.get("state", "open"),
+        per_page=int(args.get("per_page", 30)),
+    )
+
+
+def _handle_github_get_pull_request(args: dict, **kwargs) -> str:
+    return github_get_pull_request_tool(
+        repository=args.get("repository", ""),
+        pull_number=int(args.get("pull_number")),
+    )
+
+
+def _handle_github_list_pull_requests(args: dict, **kwargs) -> str:
+    return github_list_pull_requests_tool(
+        repository=args.get("repository", ""),
+        state=args.get("state", "open"),
+        per_page=int(args.get("per_page", 30)),
+    )
+
+
+def _handle_github_add_issue_comment(args: dict, **kwargs) -> str:
+    return github_add_issue_comment_tool(
+        repository=args.get("repository", ""),
+        issue_number=int(args.get("issue_number")),
+        body=args.get("body", ""),
+    )
+
+
+# Register tools under the "github" toolset
+registry.register(
+    name="github_get_issue",
+    toolset="github",
+    schema=GITHUB_GET_ISSUE_SCHEMA,
+    handler=_handle_github_get_issue,
+    check_fn=check_github_requirements,
+    requires_env=[GITHUB_TOKEN_ENV_VAR],
+    emoji="🐙",
+)
+
+registry.register(
+    name="github_list_issues",
+    toolset="github",
+    schema=GITHUB_LIST_ISSUES_SCHEMA,
+    handler=_handle_github_list_issues,
+    check_fn=check_github_requirements,
+    requires_env=[GITHUB_TOKEN_ENV_VAR],
+    emoji="🐙",
+)
+
+registry.register(
+    name="github_get_pull_request",
+    toolset="github",
+    schema=GITHUB_GET_PULL_REQUEST_SCHEMA,
+    handler=_handle_github_get_pull_request,
+    check_fn=check_github_requirements,
+    requires_env=[GITHUB_TOKEN_ENV_VAR],
+    emoji="🐙",
+)
+
+registry.register(
+    name="github_list_pull_requests",
+    toolset="github",
+    schema=GITHUB_LIST_PULL_REQUESTS_SCHEMA,
+    handler=_handle_github_list_pull_requests,
+    check_fn=check_github_requirements,
+    requires_env=[GITHUB_TOKEN_ENV_VAR],
+    emoji="🐙",
+)
+
+registry.register(
+    name="github_add_issue_comment",
+    toolset="github",
+    schema=GITHUB_ADD_ISSUE_COMMENT_SCHEMA,
+    handler=_handle_github_add_issue_comment,
+    check_fn=check_github_requirements,
+    requires_env=[GITHUB_TOKEN_ENV_VAR],
+    emoji="🐙",
+)

--- a/tools/github_tools.py
+++ b/tools/github_tools.py
@@ -333,6 +333,211 @@ def github_add_issue_comment_tool(repository: str, issue_number: int, body: str)
         return tool_error(str(e))
 
 
+def github_create_issue_tool(
+    repository: str,
+    title: str,
+    body: str = "",
+    labels: Optional[List[str]] = None,
+    assignees: Optional[List[str]] = None,
+) -> str:
+    """Create a new issue in a GitHub repository."""
+    try:
+        owner, repo = parse_owner_repo(repository)
+        path = f"/repos/{owner}/{repo}/issues"
+        json_payload: Dict[str, Any] = {"title": title}
+        if body:
+            json_payload["body"] = body
+        if labels:
+            json_payload["labels"] = labels
+        if assignees:
+            json_payload["assignees"] = assignees
+
+        res_str = github_api_request("POST", path, json_body=json_payload)
+        res_data = json.loads(res_str)
+
+        if not res_data.get("success"):
+            return res_str
+        if not res_data.get("ok"):
+            return tool_error(get_github_error_message(res_data), status=res_data.get("status"))
+
+        issue = res_data.get("json")
+        if not isinstance(issue, dict):
+            return tool_error("Invalid response payload from GitHub API")
+
+        formatted = {
+            "number": issue.get("number"),
+            "title": issue.get("title"),
+            "state": issue.get("state"),
+            "html_url": issue.get("html_url"),
+            "body": issue.get("body"),
+            "labels": [label.get("name") for label in issue.get("labels") or [] if isinstance(label, dict)],
+            "assignees": [assignee.get("login") for assignee in issue.get("assignees") or [] if isinstance(assignee, dict)],
+        }
+        return tool_result(formatted)
+    except Exception as e:
+        logger.exception("github_create_issue_tool failed")
+        return tool_error(str(e))
+
+
+def github_add_pull_request_review_comment_tool(
+    repository: str,
+    pull_number: int,
+    body: str,
+    commit_id: str,
+    path: str,
+    line: int,
+    side: str = "RIGHT",
+) -> str:
+    """Add an inline review comment to a pull request in a GitHub repository."""
+    try:
+        owner, repo = parse_owner_repo(repository)
+        api_path = f"/repos/{owner}/{repo}/pulls/{pull_number}/comments"
+        json_payload: Dict[str, Any] = {
+            "body": body,
+            "commit_id": commit_id,
+            "path": path,
+            "line": line,
+        }
+        if side:
+            json_payload["side"] = side
+
+        res_str = github_api_request("POST", api_path, json_body=json_payload)
+        res_data = json.loads(res_str)
+
+        if not res_data.get("success"):
+            return res_str
+        if not res_data.get("ok"):
+            return tool_error(get_github_error_message(res_data), status=res_data.get("status"))
+
+        comment = res_data.get("json")
+        if not isinstance(comment, dict):
+            return tool_error("Invalid response payload from GitHub API")
+
+        formatted = {
+            "id": comment.get("id"),
+            "html_url": comment.get("html_url"),
+            "body": comment.get("body"),
+            "path": comment.get("path"),
+            "line": comment.get("line"),
+            "side": comment.get("side"),
+            "author": comment.get("user", {}).get("login") if isinstance(comment.get("user"), dict) else None,
+            "created_at": comment.get("created_at"),
+        }
+        return tool_result(formatted)
+    except Exception as e:
+        logger.exception("github_add_pull_request_review_comment_tool failed")
+        return tool_error(str(e))
+
+
+def github_list_workflow_runs_tool(
+    repository: str,
+    per_page: int = 30,
+    status: Optional[str] = None,
+) -> str:
+    """List GitHub Actions workflow runs for a repository."""
+    try:
+        owner, repo = parse_owner_repo(repository)
+        api_path = f"/repos/{owner}/{repo}/actions/runs"
+        query: Dict[str, Any] = {"per_page": per_page}
+        if status:
+            query["status"] = status
+
+        res_str = github_api_request("GET", api_path, query=query)
+        res_data = json.loads(res_str)
+
+        if not res_data.get("success"):
+            return res_str
+        if not res_data.get("ok"):
+            return tool_error(get_github_error_message(res_data), status=res_data.get("status"))
+
+        payload = res_data.get("json")
+        if not isinstance(payload, dict):
+            return tool_error("Invalid response payload from GitHub API")
+        runs = payload.get("workflow_runs")
+        if not isinstance(runs, list):
+            return tool_error("Invalid response payload from GitHub API")
+
+        formatted = []
+        for run in runs:
+            if not isinstance(run, dict):
+                continue
+            formatted.append({
+                "id": run.get("id"),
+                "name": run.get("name"),
+                "display_title": run.get("display_title"),
+                "status": run.get("status"),
+                "conclusion": run.get("conclusion"),
+                "event": run.get("event"),
+                "head_branch": run.get("head_branch"),
+                "html_url": run.get("html_url"),
+                "created_at": run.get("created_at"),
+            })
+        return tool_result(formatted)
+    except Exception as e:
+        logger.exception("github_list_workflow_runs_tool failed")
+        return tool_error(str(e))
+
+
+def github_get_workflow_run_tool(repository: str, run_id: int) -> str:
+    """Get detailed information for a GitHub Actions workflow run."""
+    try:
+        owner, repo = parse_owner_repo(repository)
+        api_path = f"/repos/{owner}/{repo}/actions/runs/{run_id}"
+        res_str = github_api_request("GET", api_path)
+        res_data = json.loads(res_str)
+
+        if not res_data.get("success"):
+            return res_str
+        if not res_data.get("ok"):
+            return tool_error(get_github_error_message(res_data), status=res_data.get("status"))
+
+        run = res_data.get("json")
+        if not isinstance(run, dict):
+            return tool_error("Invalid response payload from GitHub API")
+
+        formatted = {
+            "id": run.get("id"),
+            "name": run.get("name"),
+            "display_title": run.get("display_title"),
+            "status": run.get("status"),
+            "conclusion": run.get("conclusion"),
+            "event": run.get("event"),
+            "head_branch": run.get("head_branch"),
+            "head_sha": run.get("head_sha"),
+            "html_url": run.get("html_url"),
+            "created_at": run.get("created_at"),
+            "updated_at": run.get("updated_at"),
+            "run_attempt": run.get("run_attempt"),
+        }
+        return tool_result(formatted)
+    except Exception as e:
+        logger.exception("github_get_workflow_run_tool failed")
+        return tool_error(str(e))
+
+
+def github_rerun_workflow_tool(repository: str, run_id: int) -> str:
+    """Trigger a rerun for a GitHub Actions workflow run."""
+    try:
+        owner, repo = parse_owner_repo(repository)
+        api_path = f"/repos/{owner}/{repo}/actions/runs/{run_id}/rerun"
+        res_str = github_api_request("POST", api_path)
+        res_data = json.loads(res_str)
+
+        if not res_data.get("success"):
+            return res_str
+        if not res_data.get("ok"):
+            return tool_error(get_github_error_message(res_data), status=res_data.get("status"))
+
+        return tool_result({
+            "accepted": True,
+            "repository": f"{owner}/{repo}",
+            "run_id": run_id,
+        })
+    except Exception as e:
+        logger.exception("github_rerun_workflow_tool failed")
+        return tool_error(str(e))
+
+
 # -----------------------------------------------------------------------------------------------------------
 # Schemas & Handlers for Registry
 # ---------------------------------------------------------------------------
@@ -450,6 +655,143 @@ GITHUB_ADD_ISSUE_COMMENT_SCHEMA = {
     },
 }
 
+GITHUB_CREATE_ISSUE_SCHEMA = {
+    "name": "github_create_issue",
+    "description": "Create a new issue in a GitHub repository.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repository": {
+                "type": "string",
+                "description": "Repository identifier, either in 'owner/repo' format or as a full GitHub URL.",
+            },
+            "title": {
+                "type": "string",
+                "description": "Title for the new issue.",
+            },
+            "body": {
+                "type": "string",
+                "description": "Issue body in Markdown.",
+                "default": "",
+            },
+            "labels": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional label names to apply.",
+            },
+            "assignees": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional GitHub usernames to assign.",
+            },
+        },
+        "required": ["repository", "title"],
+    },
+}
+
+GITHUB_ADD_PULL_REQUEST_REVIEW_COMMENT_SCHEMA = {
+    "name": "github_add_pull_request_review_comment",
+    "description": "Add an inline review comment to a pull request in a GitHub repository.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repository": {
+                "type": "string",
+                "description": "Repository identifier, either in 'owner/repo' format or as a full GitHub URL.",
+            },
+            "pull_number": {
+                "type": "integer",
+                "description": "Pull request number to comment on.",
+            },
+            "body": {
+                "type": "string",
+                "description": "Review comment body in Markdown.",
+            },
+            "commit_id": {
+                "type": "string",
+                "description": "Commit SHA the inline comment should attach to.",
+            },
+            "path": {
+                "type": "string",
+                "description": "Repository-relative file path for the inline comment.",
+            },
+            "line": {
+                "type": "integer",
+                "description": "Line number on the diff to attach the comment to.",
+            },
+            "side": {
+                "type": "string",
+                "description": "Diff side for the comment.",
+                "enum": ["LEFT", "RIGHT"],
+                "default": "RIGHT",
+            },
+        },
+        "required": ["repository", "pull_number", "body", "commit_id", "path", "line"],
+    },
+}
+
+GITHUB_LIST_WORKFLOW_RUNS_SCHEMA = {
+    "name": "github_list_workflow_runs",
+    "description": "List GitHub Actions workflow runs for a repository.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repository": {
+                "type": "string",
+                "description": "Repository identifier, either in 'owner/repo' format or as a full GitHub URL.",
+            },
+            "per_page": {
+                "type": "integer",
+                "description": "Number of workflow runs to return (max 100, default 30).",
+                "default": 30,
+            },
+            "status": {
+                "type": "string",
+                "description": "Optional workflow run status/conclusion filter.",
+            },
+        },
+        "required": ["repository"],
+    },
+}
+
+GITHUB_GET_WORKFLOW_RUN_SCHEMA = {
+    "name": "github_get_workflow_run",
+    "description": "Get detailed information for a GitHub Actions workflow run.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repository": {
+                "type": "string",
+                "description": "Repository identifier, either in 'owner/repo' format or as a full GitHub URL.",
+            },
+            "run_id": {
+                "type": "integer",
+                "description": "Workflow run ID.",
+            },
+        },
+        "required": ["repository", "run_id"],
+    },
+}
+
+GITHUB_RERUN_WORKFLOW_SCHEMA = {
+    "name": "github_rerun_workflow",
+    "description": "Trigger a rerun for a GitHub Actions workflow run.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repository": {
+                "type": "string",
+                "description": "Repository identifier, either in 'owner/repo' format or as a full GitHub URL.",
+            },
+            "run_id": {
+                "type": "integer",
+                "description": "Workflow run ID to rerun.",
+            },
+        },
+        "required": ["repository", "run_id"],
+    },
+}
+
 
 def _handle_github_get_issue(args: dict, **kwargs) -> str:
     return github_get_issue_tool(
@@ -486,6 +828,50 @@ def _handle_github_add_issue_comment(args: dict, **kwargs) -> str:
         repository=args.get("repository", ""),
         issue_number=int(args.get("issue_number")),
         body=args.get("body", ""),
+    )
+
+
+def _handle_github_create_issue(args: dict, **kwargs) -> str:
+    return github_create_issue_tool(
+        repository=args.get("repository", ""),
+        title=args.get("title", ""),
+        body=args.get("body", ""),
+        labels=args.get("labels"),
+        assignees=args.get("assignees"),
+    )
+
+
+def _handle_github_add_pull_request_review_comment(args: dict, **kwargs) -> str:
+    return github_add_pull_request_review_comment_tool(
+        repository=args.get("repository", ""),
+        pull_number=int(args.get("pull_number")),
+        body=args.get("body", ""),
+        commit_id=args.get("commit_id", ""),
+        path=args.get("path", ""),
+        line=int(args.get("line")),
+        side=args.get("side", "RIGHT"),
+    )
+
+
+def _handle_github_list_workflow_runs(args: dict, **kwargs) -> str:
+    return github_list_workflow_runs_tool(
+        repository=args.get("repository", ""),
+        per_page=int(args.get("per_page", 30)),
+        status=args.get("status"),
+    )
+
+
+def _handle_github_get_workflow_run(args: dict, **kwargs) -> str:
+    return github_get_workflow_run_tool(
+        repository=args.get("repository", ""),
+        run_id=int(args.get("run_id")),
+    )
+
+
+def _handle_github_rerun_workflow(args: dict, **kwargs) -> str:
+    return github_rerun_workflow_tool(
+        repository=args.get("repository", ""),
+        run_id=int(args.get("run_id")),
     )
 
 
@@ -535,6 +921,56 @@ registry.register(
     toolset="github",
     schema=GITHUB_ADD_ISSUE_COMMENT_SCHEMA,
     handler=_handle_github_add_issue_comment,
+    check_fn=check_github_requirements,
+    requires_env=[GITHUB_TOKEN_ENV_VAR],
+    emoji="🐙",
+)
+
+registry.register(
+    name="github_create_issue",
+    toolset="github",
+    schema=GITHUB_CREATE_ISSUE_SCHEMA,
+    handler=_handle_github_create_issue,
+    check_fn=check_github_requirements,
+    requires_env=[GITHUB_TOKEN_ENV_VAR],
+    emoji="🐙",
+)
+
+registry.register(
+    name="github_add_pull_request_review_comment",
+    toolset="github",
+    schema=GITHUB_ADD_PULL_REQUEST_REVIEW_COMMENT_SCHEMA,
+    handler=_handle_github_add_pull_request_review_comment,
+    check_fn=check_github_requirements,
+    requires_env=[GITHUB_TOKEN_ENV_VAR],
+    emoji="🐙",
+)
+
+registry.register(
+    name="github_list_workflow_runs",
+    toolset="github",
+    schema=GITHUB_LIST_WORKFLOW_RUNS_SCHEMA,
+    handler=_handle_github_list_workflow_runs,
+    check_fn=check_github_requirements,
+    requires_env=[GITHUB_TOKEN_ENV_VAR],
+    emoji="🐙",
+)
+
+registry.register(
+    name="github_get_workflow_run",
+    toolset="github",
+    schema=GITHUB_GET_WORKFLOW_RUN_SCHEMA,
+    handler=_handle_github_get_workflow_run,
+    check_fn=check_github_requirements,
+    requires_env=[GITHUB_TOKEN_ENV_VAR],
+    emoji="🐙",
+)
+
+registry.register(
+    name="github_rerun_workflow",
+    toolset="github",
+    schema=GITHUB_RERUN_WORKFLOW_SCHEMA,
+    handler=_handle_github_rerun_workflow,
     check_fn=check_github_requirements,
     requires_env=[GITHUB_TOKEN_ENV_VAR],
     emoji="🐙",

--- a/tools/http_request.py
+++ b/tools/http_request.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""HTTP Request core tool for performing web requests safely.
+
+SSRF protection is enforced via `tools.url_safety.is_safe_url` and
+event-hook redirects are validated to prevent bypasses.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+import httpx
+
+from tools.registry import registry, tool_result, tool_error
+from tools.url_safety import is_safe_url, normalize_url_for_request
+
+logger = logging.getLogger(__name__)
+
+
+def _get_env_value(name: str) -> str:
+    """Resolve environment variable from Hermes config or process env."""
+    try:
+        from hermes_cli.config import get_env_value
+        val = get_env_value(name)
+    except Exception:
+        val = None
+    if val is None:
+        val = os.getenv(name, "")
+    return (val or "").strip()
+
+
+def redact_url_secrets(url: str) -> str:
+    """Redact keys containing key/token/secret/auth from query params."""
+    try:
+        parsed = urlparse(url)
+        if not parsed.query:
+            return url
+        qsl = parse_qsl(parsed.query, keep_blank_values=True)
+        redacted_qsl = []
+        for k, v in qsl:
+            k_lower = k.lower()
+            if any(secret_word in k_lower for secret_word in ("key", "token", "secret", "auth")):
+                redacted_qsl.append((k, "[REDACTED]"))
+            else:
+                redacted_qsl.append((k, v))
+        new_query = urlencode(redacted_qsl)
+        return urlunparse(parsed._replace(query=new_query))
+    except Exception:
+        return url
+
+
+def redact_sensitive_headers(headers: Dict[str, str]) -> Dict[str, str]:
+    """Redact sensitive header values to prevent credential leaks."""
+    if not headers:
+        return {}
+    redacted = {}
+    for k, v in headers.items():
+        k_lower = k.lower()
+        if any(secret_word in k_lower for secret_word in ("auth", "key", "token", "secret", "signature", "cookie", "cert")):
+            redacted[k] = "[REDACTED]"
+        else:
+            redacted[k] = v
+    return redacted
+
+
+def http_request_tool(
+    method: str,
+    url: str,
+    headers: Optional[Dict[str, str]] = None,
+    query: Optional[Dict[str, Any]] = None,
+    json_body: Optional[Any] = None,
+    form_body: Optional[Dict[str, Any]] = None,
+    timeout_seconds: Optional[float] = 30.0,
+    expected_content_type: Optional[str] = None,
+    auth_mode: str = "none",
+    auth_token_env: Optional[str] = None,
+) -> str:
+    """Perform a secure HTTP request with redirection protection and output sanitization."""
+    # Redacted URL placeholder in case we error before full URL parsing
+    redacted_url = redact_url_secrets(url)
+    
+    try:
+        # 1. Method Validation
+        method = str(method).strip().upper()
+        if method not in {"GET", "POST", "PUT", "PATCH", "DELETE"}:
+            raise ValueError(f"Unsupported HTTP method: {method}")
+
+        # 2. URL Normalization & Prep
+        url_to_check = url.strip()
+        url_lower = url_to_check.lower()
+        if not (url_lower.startswith("http://") or url_lower.startswith("https://")):
+            if not re.match(r"^[a-z]+://", url_lower):
+                url_to_check = "https://" + url_to_check
+
+        normalized_url = normalize_url_for_request(url_to_check)
+        redacted_url = redact_url_secrets(normalized_url)
+
+        # 3. Safety/SSRF Checks
+        if not is_safe_url(normalized_url):
+            raise PermissionError(f"URL is not safe to access: {redacted_url}")
+
+        # 4. Auth & Header Prep
+        req_headers = dict(headers) if headers else {}
+        auth_mode = str(auth_mode).strip().lower()
+        if auth_mode not in {"none", "bearer_env"}:
+            raise ValueError(f"Unsupported auth_mode: {auth_mode}")
+
+        if auth_mode == "bearer_env":
+            if not auth_token_env:
+                raise ValueError("auth_token_env must be provided when auth_mode is bearer_env")
+            token = _get_env_value(auth_token_env)
+            if not token:
+                raise ValueError(f"Environment variable '{auth_token_env}' is empty or not set")
+            req_headers["Authorization"] = f"Bearer {token}"
+
+        # 5. Body Validation
+        if json_body is not None and form_body is not None:
+            raise ValueError("Cannot specify both json_body and form_body")
+
+        # 6. Timeout Setup
+        if timeout_seconds is not None:
+            try:
+                timeout = float(timeout_seconds)
+                if timeout <= 0:
+                    raise ValueError("Timeout must be a positive number")
+            except (ValueError, TypeError):
+                raise ValueError(f"Invalid timeout value: {timeout_seconds}")
+        else:
+            timeout = 30.0
+
+        # 7. Redirect safety guard
+        def _ssrf_redirect_guard(response):
+            if response.is_redirect and response.next_request:
+                redirect_url = str(response.next_request.url)
+                if not is_safe_url(redirect_url):
+                    raise ValueError(
+                        f"Blocked redirect to private/internal address: {redact_url_secrets(redirect_url)}"
+                    )
+
+        # 8. Request Execution
+        with httpx.Client(
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        ) as client:
+            response = client.request(
+                method=method,
+                url=normalized_url,
+                headers=req_headers,
+                params=query,
+                json=json_body,
+                data=form_body,
+                timeout=timeout,
+            )
+
+        # 9. Expected Content Type validation
+        content_type = response.headers.get("content-type", "")
+        if expected_content_type:
+            ect = expected_content_type.strip().lower()
+            if ect not in content_type.lower():
+                raise ValueError(
+                    f"Expected content type '{expected_content_type}', but got '{content_type}'"
+                )
+
+        # 10. Truncation and JSON Parsing
+        max_len = registry.get_max_result_size("http_request", 100_000)
+        
+        truncated = False
+        text_preview = response.text
+        if len(text_preview) > max_len:
+            text_preview = text_preview[:max_len] + "\n... [TRUNCATED] ..."
+            truncated = True
+
+        json_data = None
+        if not truncated and "application/json" in content_type.lower():
+            try:
+                json_data = response.json()
+            except Exception:
+                pass
+
+        return tool_result(
+            success=True,
+            tool="http_request",
+            method=method,
+            url=redacted_url,
+            status=response.status_code,
+            ok=response.is_success,
+            content_type=content_type,
+            headers=redact_sensitive_headers(dict(response.headers)),
+            json=json_data,
+            text_preview=text_preview,
+            truncated=truncated,
+        )
+
+    except Exception as e:
+        logger.exception("http_request tool execution failed")
+        return tool_result(
+            success=False,
+            tool="http_request",
+            method=method if 'method' in locals() else str(method),
+            url=redacted_url,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+
+
+HTTP_REQUEST_SCHEMA = {
+    "name": "http_request",
+    "description": (
+        "Perform an HTTP request (GET, POST, PUT, PATCH, DELETE) to a public URL. "
+        "Supports custom headers, query parameters, JSON/form bodies, timeout configuration, "
+        "and bearer token authentication via environment variables."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "method": {
+                "type": "string",
+                "description": "The HTTP method to use (GET, POST, PUT, PATCH, DELETE).",
+                "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+            },
+            "url": {
+                "type": "string",
+                "description": "The target HTTP or HTTPS URL.",
+            },
+            "headers": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string",
+                },
+                "description": "Optional HTTP headers to include in the request.",
+            },
+            "query": {
+                "type": "object",
+                "description": "Optional query parameters to append to the URL.",
+            },
+            "json_body": {
+                "type": "object",
+                "description": "Optional JSON body to send with the request.",
+            },
+            "form_body": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string",
+                },
+                "description": "Optional form body (URL-encoded) to send with the request.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "description": "Optional timeout for the request in seconds. Default is 30.",
+                "default": 30.0,
+            },
+            "expected_content_type": {
+                "type": "string",
+                "description": "Optional expected content-type pattern to check in response headers (e.g., 'application/json').",
+            },
+            "auth_mode": {
+                "type": "string",
+                "description": "Authentication mode. Use 'none' or 'bearer_env'. Default is 'none'.",
+                "enum": ["none", "bearer_env"],
+                "default": "none",
+            },
+            "auth_token_env": {
+                "type": "string",
+                "description": "The environment variable name containing the bearer token (only used if auth_mode is 'bearer_env').",
+            },
+        },
+        "required": ["method", "url"],
+    },
+}
+
+
+def _handle_http_request(args: dict, **kwargs) -> str:
+    return http_request_tool(
+        method=args.get("method", "GET"),
+        url=args.get("url", ""),
+        headers=args.get("headers"),
+        query=args.get("query"),
+        json_body=args.get("json_body"),
+        form_body=args.get("form_body"),
+        timeout_seconds=args.get("timeout_seconds"),
+        expected_content_type=args.get("expected_content_type"),
+        auth_mode=args.get("auth_mode", "none"),
+        auth_token_env=args.get("auth_token_env"),
+    )
+
+
+registry.register(
+    name="http_request",
+    toolset="api",
+    schema=HTTP_REQUEST_SCHEMA,
+    handler=_handle_http_request,
+    emoji="🌐",
+    max_result_size_chars=100_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -106,17 +106,22 @@ TOOLSETS = {
     },
     
     "github": {
-        "description": "Native GitHub operations (get/list issues, pull requests, and comments)",
+        "description": "Native GitHub operations (issues, pull requests, comments, issue creation, PR review comments, and workflow runs)",
         "tools": [
             "github_get_issue",
             "github_list_issues",
             "github_get_pull_request",
             "github_list_pull_requests",
-            "github_add_issue_comment"
+            "github_add_issue_comment",
+            "github_create_issue",
+            "github_add_pull_request_review_comment",
+            "github_list_workflow_runs",
+            "github_get_workflow_run",
+            "github_rerun_workflow"
         ],
         "includes": []
     },
-    
+
     "search": {
         "description": "Web search only (no content extraction/scraping)",
         "tools": ["web_search"],

--- a/toolsets.py
+++ b/toolsets.py
@@ -105,6 +105,18 @@ TOOLSETS = {
         "includes": []
     },
     
+    "github": {
+        "description": "Native GitHub operations (get/list issues, pull requests, and comments)",
+        "tools": [
+            "github_get_issue",
+            "github_list_issues",
+            "github_get_pull_request",
+            "github_list_pull_requests",
+            "github_add_issue_comment"
+        ],
+        "includes": []
+    },
+    
     "search": {
         "description": "Web search only (no content extraction/scraping)",
         "tools": ["web_search"],

--- a/toolsets.py
+++ b/toolsets.py
@@ -99,6 +99,12 @@ TOOLSETS = {
         "includes": []  # No other toolsets included
     },
     
+    "api": {
+        "description": "Direct structured HTTP API access",
+        "tools": ["http_request"],
+        "includes": []
+    },
+    
     "search": {
         "description": "Web search only (no content extraction/scraping)",
         "tools": ["web_search"],


### PR DESCRIPTION
## Summary
- expand the native GitHub toolset beyond read/list/comment operations
- add issue creation, PR review comment, and workflow-run actions
- add follow-up coverage for invalid repository handling and tighten the build-log note

## What changed
- add `github_create_issue`
- add `github_add_pull_request_review_comment`
- add `github_list_workflow_runs`
- add `github_get_workflow_run`
- add `github_rerun_workflow`
- register the new tools and expose them via the `github` toolset
- extend mocked GitHub tool tests for success/error cases and invalid repo coverage

## Verification
- `python -m py_compile tools/github_tools.py tests/tools/test_github_tools.py toolsets.py`
- `uv run --extra dev pytest tests/tools/test_github_tools.py -q`
- combined regression previously passed during feature verification: `252 passed, 8 warnings, 0 failures`
