### PR TITLE
fix(qqbot): resolve credentials under the active profile secret scope

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import os
 from typing import Optional
 
-from gateway.config import Platform
+from gateway.config import Platform, _getenv
 from gateway.session import SessionSource
 from gateway.whatsapp_identity import (
     expand_whatsapp_aliases as _expand_whatsapp_auth_aliases,
@@ -456,7 +456,7 @@ class GatewayAuthorizationMixin:
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
             if chat_allowlist_env:
-                raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
+                raw_chat_allowlist = _getenv(chat_allowlist_env, "").strip()
                 if raw_chat_allowlist:
                     allowed_group_ids = {
                         cid.strip()
@@ -498,7 +498,7 @@ class GatewayAuthorizationMixin:
         }
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
-            if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+            if allow_bots_var and _getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
                 return True
 
         if not user_id:
@@ -567,7 +567,7 @@ class GatewayAuthorizationMixin:
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
-        if platform_allow_all_var and _auth_env(platform_allow_all_var).lower() in {"true", "1", "yes"}:
+        if platform_allow_all_var and _getenv(platform_allow_all_var, "").lower() in {"true", "1", "yes"}:
             return True
 
         # Adapter-verified role auth: the Discord adapter already confirmed the
@@ -598,12 +598,12 @@ class GatewayAuthorizationMixin:
             return True
 
         # Check platform-specific and global allowlists
-        platform_allowlist = _auth_env(platform_env_map.get(source.platform, ""))
+        platform_allowlist = _getenv(platform_env_map.get(source.platform, ""), "").strip()
         group_user_allowlist = ""
         group_chat_allowlist = ""
         if source.chat_type in {"group", "forum"}:
-            group_user_allowlist = _auth_env(platform_group_user_env_map.get(source.platform, ""))
-            group_chat_allowlist = _auth_env(platform_group_chat_env_map.get(source.platform, ""))
+            group_user_allowlist = _getenv(platform_group_user_env_map.get(source.platform, ""), "").strip()
+            group_chat_allowlist = _getenv(platform_group_chat_env_map.get(source.platform, ""), "").strip()
         global_allowlist = _auth_env("GATEWAY_ALLOWED_USERS")
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
@@ -876,10 +876,10 @@ class GatewayAuthorizationMixin:
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
-            if os.getenv(platform_env_map.get(platform, ""), "").strip():
+            if _getenv(platform_env_map.get(platform, ""), "").strip():
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):
-                if os.getenv(env_key, "").strip():
+                if _getenv(env_key, "").strip():
                     return "ignore"
 
         if os.getenv("GATEWAY_ALLOWED_USERS", "").strip():

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -147,6 +147,29 @@ def _coerce_list(value: Any) -> List[str]:
     return _coerce_list_impl(value)
 
 
+def _resolve_qq_secret(name: str, default: str = "") -> str:
+    """Resolve a per-profile ``QQ_*`` setting honoring the active secret scope.
+
+    When a profile secret scope is installed — every secondary multiplex
+    profile is constructed and handled inside ``_profile_runtime_scope``
+    (``gateway/run.py``), as is each per-turn inbound message — read from it so
+    profiles never see each other's ``os.environ`` values. This is the
+    cross-profile credential collision fixed for the WeChat adapter in #59662.
+
+    The primary/active profile is constructed without a scope and legitimately
+    owns ``os.environ``, so fall back to it there instead of failing closed: a
+    bare ``get_secret`` would raise ``UnscopedSecretError`` on the active
+    profile's ``__init__`` and break its startup. Mirrors the scope-aware
+    ``gateway.config._getenv`` reader.
+    """
+    from agent.secret_scope import current_secret_scope, get_secret
+
+    if current_secret_scope() is not None:
+        val = get_secret(name, default)
+        return val if val is not None else default
+    return os.getenv(name, default)
+
+
 # ---------------------------------------------------------------------------
 # QQAdapter
 # ---------------------------------------------------------------------------
@@ -202,9 +225,11 @@ class QQAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.QQBOT)
 
         extra = config.extra or {}
-        self._app_id = str(extra.get("app_id") or os.getenv("QQ_APP_ID", "")).strip()
+        self._app_id = str(
+            extra.get("app_id") or _resolve_qq_secret("QQ_APP_ID", "")
+        ).strip()
         self._client_secret = str(
-            extra.get("client_secret") or os.getenv("QQ_CLIENT_SECRET", "")
+            extra.get("client_secret") or _resolve_qq_secret("QQ_CLIENT_SECRET", "")
         ).strip()
         self._markdown_support = bool(extra.get("markdown_support", True))
 
@@ -2202,13 +2227,13 @@ class QQAdapter(BasePlatformAdapter):
                     }
 
         # 2. QQ-specific env vars (set by `hermes setup gateway` / `hermes gateway`)
-        qq_stt_key = os.getenv("QQ_STT_API_KEY", "")
+        qq_stt_key = _resolve_qq_secret("QQ_STT_API_KEY", "")
         if qq_stt_key:
-            base_url = os.getenv(
+            base_url = _resolve_qq_secret(
                 "QQ_STT_BASE_URL",
                 "https://open.bigmodel.cn/api/coding/paas/v4",
             )
-            model = os.getenv("QQ_STT_MODEL", "glm-asr")
+            model = _resolve_qq_secret("QQ_STT_MODEL", "glm-asr")
             return {
                 "base_url": base_url.rstrip("/"),
                 "api_key": qq_stt_key,
@@ -3170,7 +3195,7 @@ class QQAdapter(BasePlatformAdapter):
     def _open_dm_opted_in(self) -> bool:
         if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("QQ_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return _resolve_qq_secret("QQ_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 
     def _is_dm_allowed(self, user_id: str) -> bool:
         if self._dm_policy == "disabled":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2204,6 +2204,7 @@ from gateway.config import (
     _BUILTIN_PLATFORM_VALUES,
     GatewayConfig,
     PlatformConfig,
+    _getenv,
     load_gateway_config,
 )
 from gateway.session import (
@@ -2293,11 +2294,11 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
         extra = getattr(platform_config, "extra", None) or {}
         dm_policy = str(
             extra.get("dm_policy")
-            or (os.getenv(dm_env, "pairing") if dm_env else "pairing")
+            or (_getenv(dm_env, "pairing") if dm_env else "pairing")
         ).strip().lower()
         group_policy = str(
             extra.get("group_policy")
-            or (os.getenv(group_env, "pairing") if group_env else "pairing")
+            or (_getenv(group_env, "pairing") if group_env else "pairing")
         ).strip().lower()
         if dm_policy != "open" and group_policy != "open":
             continue
@@ -2306,7 +2307,7 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
         ).lower() in {"true", "1", "yes"}
         platform_opted_in = gateway_allow_all or (
             allow_all_env
-            and os.getenv(allow_all_env, "").lower() in {"true", "1", "yes"}
+            and _getenv(allow_all_env, "").lower() in {"true", "1", "yes"}
         )
         if platform_opted_in:
             continue

--- a/tests/gateway/test_qqbot_credential_isolation.py
+++ b/tests/gateway/test_qqbot_credential_isolation.py
@@ -1,0 +1,102 @@
+"""Credential isolation for the QQ (qqbot) gateway adapter.
+
+Covers the multiplex credential-collision class (same class as the
+WeChat/weixin adapter tracked in #59662): the QQ adapter resolves its ``QQ_*``
+settings through the active profile secret scope rather than raw ``os.getenv``,
+so a secondary profile whose secret lives in its own ``.env`` (installed as an
+isolated scope, not into ``os.environ``) does not fall back to the
+default/primary profile's value.
+
+Also guards the primary/active profile: it is constructed without a scope and
+legitimately owns ``os.environ``, so the resolver must fall back to
+``os.environ`` there (not fail closed) even when multiplexing is active —
+otherwise the active profile's adapter would raise ``UnscopedSecretError`` on
+construction and fail to start.
+"""
+import pytest
+
+from agent import secret_scope as ss
+from gateway.config import PlatformConfig
+from gateway.platforms.qqbot.adapter import QQAdapter
+
+
+@pytest.fixture(autouse=True)
+def _reset_multiplex():
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+def _make_adapter(extra=None):
+    return QQAdapter(PlatformConfig(enabled=True, extra=extra or {}))
+
+
+class TestQQCredentialScope:
+    def test_credentials_read_scope_not_environ(self, monkeypatch):
+        # os.environ holds another profile's values; the scoped values must win.
+        monkeypatch.setenv("QQ_APP_ID", "global-app")
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "global-secret")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope(
+            {"QQ_APP_ID": "profileA-app", "QQ_CLIENT_SECRET": "profileA-secret"}
+        )
+        try:
+            adapter = _make_adapter()
+        finally:
+            ss.reset_secret_scope(tok)
+        assert adapter._app_id == "profileA-app"
+        assert adapter._client_secret == "profileA-secret"
+
+    def test_two_profiles_isolated(self):
+        ss.set_multiplex_active(True)
+        tok_a = ss.set_secret_scope({"QQ_CLIENT_SECRET": "secret-A"})
+        try:
+            a = _make_adapter()
+        finally:
+            ss.reset_secret_scope(tok_a)
+        tok_b = ss.set_secret_scope({"QQ_CLIENT_SECRET": "secret-B"})
+        try:
+            b = _make_adapter()
+        finally:
+            ss.reset_secret_scope(tok_b)
+        assert a._client_secret == "secret-A"
+        assert b._client_secret == "secret-B"
+
+    def test_single_profile_still_reads_environ(self, monkeypatch):
+        # No scope + multiplex inactive (default single-profile deployment):
+        # legacy os.environ behavior is preserved — no regression.
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "legacy-secret")
+        adapter = _make_adapter()
+        assert adapter._client_secret == "legacy-secret"
+
+    def test_active_profile_no_scope_reads_environ_without_raising(self, monkeypatch):
+        # The primary/active profile is built with NO scope while multiplexing
+        # is active. A bare get_secret() would fail closed (UnscopedSecretError)
+        # and break its startup; the resolver must fall back to os.environ.
+        monkeypatch.setenv("QQ_APP_ID", "primary-app")
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "primary-secret")
+        ss.set_multiplex_active(True)
+        assert ss.current_secret_scope() is None  # no scope installed
+        adapter = _make_adapter()  # must not raise
+        assert adapter._app_id == "primary-app"
+        assert adapter._client_secret == "primary-secret"
+
+    def test_explicit_config_extra_takes_precedence(self, monkeypatch):
+        # An explicit value in config.extra still wins over env/scope.
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "env-secret")
+        adapter = _make_adapter(extra={"client_secret": "explicit"})
+        assert adapter._client_secret == "explicit"
+
+
+class TestQQSttConfigScope:
+    def test_stt_api_key_reads_scope(self, monkeypatch):
+        monkeypatch.setenv("QQ_STT_API_KEY", "global-stt-key")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"QQ_STT_API_KEY": "profileA-stt-key"})
+        try:
+            adapter = _make_adapter()
+            stt = adapter._resolve_stt_config()
+        finally:
+            ss.reset_secret_scope(tok)
+        assert stt is not None
+        assert stt["api_key"] == "profileA-stt-key"

--- a/tests/gateway/test_qqbot_credential_isolation.py
+++ b/tests/gateway/test_qqbot_credential_isolation.py
@@ -100,3 +100,26 @@ class TestQQSttConfigScope:
             ss.reset_secret_scope(tok)
         assert stt is not None
         assert stt["api_key"] == "profileA-stt-key"
+
+    def test_all_stt_values_read_scope(self, monkeypatch):
+        # Every QQ_STT_* value must come from the scope, not os.environ.
+        monkeypatch.setenv("QQ_STT_API_KEY", "global-stt-key")
+        monkeypatch.setenv("QQ_STT_BASE_URL", "https://global.example/v1")
+        monkeypatch.setenv("QQ_STT_MODEL", "global-asr")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope(
+            {
+                "QQ_STT_API_KEY": "profileA-stt-key",
+                "QQ_STT_BASE_URL": "https://scoped.example/v1",
+                "QQ_STT_MODEL": "scoped-asr",
+            }
+        )
+        try:
+            adapter = _make_adapter()
+            stt = adapter._resolve_stt_config()
+        finally:
+            ss.reset_secret_scope(tok)
+        assert stt is not None
+        assert stt["api_key"] == "profileA-stt-key"
+        assert stt["base_url"] == "https://scoped.example/v1"
+        assert stt["model"] == "scoped-asr"

--- a/tests/gateway/test_qqbot_scope_paths.py
+++ b/tests/gateway/test_qqbot_scope_paths.py
@@ -117,6 +117,37 @@ class TestAuthzAllowAllScope:
         assert runner._is_user_authorized(_qq_dm_source(profile=None)) is True
 
 
+class TestAuthzAllowlistScope:
+    """Pins the per-platform user-allowlist read (not just the allow-all flag).
+
+    Distinct from the allow-all tests: here QQ_ALLOW_ALL_USERS is absent, so
+    authorization depends entirely on the scoped QQ_ALLOWED_USERS matching the
+    sender — reverting that read to raw os.getenv would default-deny.
+    """
+
+    def test_scoped_user_allowlist_authorizes(self, monkeypatch):
+        monkeypatch.setenv("QQ_ALLOWED_USERS", "")  # global env has no allowlist
+        runner = _make_qq_runner()
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"QQ_ALLOWED_USERS": "user-1,user-2"})
+        try:
+            assert runner._is_user_authorized(_qq_dm_source()) is True
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_scoped_user_allowlist_excludes_non_member(self, monkeypatch):
+        monkeypatch.setenv("QQ_ALLOWED_USERS", "user-1")  # primary env admits user-1
+        runner = _make_qq_runner()
+        ss.set_multiplex_active(True)
+        # Secondary scope lists only user-9 → user-1 must NOT inherit the
+        # primary's environ allowlist.
+        tok = ss.set_secret_scope({"QQ_ALLOWED_USERS": "user-9"})
+        try:
+            assert runner._is_user_authorized(_qq_dm_source()) is False
+        finally:
+            ss.reset_secret_scope(tok)
+
+
 class TestStartupValidatorScope:
     @staticmethod
     def _open_dm_config():

--- a/tests/gateway/test_qqbot_scope_paths.py
+++ b/tests/gateway/test_qqbot_scope_paths.py
@@ -1,0 +1,227 @@
+"""End-to-end profile-scope coverage for the QQ (qqbot) authorization,
+startup-validation, and direct-send paths.
+
+Complements ``test_qqbot_credential_isolation.py`` (adapter-level resolver):
+the adapter intake fix alone is not enough because three other paths read the
+same per-profile ``QQ_*`` values independently:
+
+- gateway authorization (``AuthorizationMixin._is_user_authorized``) reads
+  ``QQ_ALLOW_ALL_USERS`` when deciding whether to honor an allow-all opt-in;
+- secondary-profile startup validation
+  (``gateway.run._own_policy_open_startup_violation``) reads the platform
+  opt-in while running inside ``_profile_runtime_scope``;
+- the ``send_message`` tool's direct REST path (``_send_qqbot``) falls back to
+  ``QQ_APP_ID`` / ``QQ_CLIENT_SECRET``.
+
+Each must resolve through the active profile secret scope (scope wins over
+``os.environ``; a profile that did NOT opt in must not inherit the primary
+profile's environ opt-in) while unscoped single-profile deployments keep the
+legacy ``os.environ`` behavior.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent import secret_scope as ss
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _reset_scope_state(monkeypatch):
+    for key in (
+        "QQ_ALLOW_ALL_USERS",
+        "QQ_ALLOWED_USERS",
+        "QQ_GROUP_ALLOWED_USERS",
+        "QQ_APP_ID",
+        "QQ_CLIENT_SECRET",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+def _make_qq_runner():
+    """Minimal runner whose authz path reaches the QQ env checks."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+
+    default_adapter = SimpleNamespace(
+        send=AsyncMock(),
+        enforces_own_access_policy=True,
+        _dm_policy="allowlist",
+        _group_policy="pairing",
+    )
+    secondary_adapter = SimpleNamespace(
+        send=AsyncMock(),
+        enforces_own_access_policy=True,
+        _dm_policy="open",
+        _group_policy="open",
+    )
+    runner.adapters = {Platform.QQBOT: default_adapter}
+    runner._profile_adapters = {"coder": {Platform.QQBOT: secondary_adapter}}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    return runner
+
+
+def _qq_dm_source(profile="coder"):
+    return SessionSource(
+        platform=Platform.QQBOT,
+        user_id="user-1",
+        chat_id="dm-chat",
+        user_name="user-1",
+        chat_type="dm",
+        profile=profile,
+    )
+
+
+class TestAuthzAllowAllScope:
+    def test_scoped_allow_all_honored(self):
+        # The secondary profile opted in via its own .env (scope); os.environ
+        # has no opt-in. Authorization must honor the scoped value.
+        runner = _make_qq_runner()
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"QQ_ALLOW_ALL_USERS": "true"})
+        try:
+            assert runner._is_user_authorized(_qq_dm_source()) is True
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_scope_does_not_inherit_environ_opt_in(self, monkeypatch):
+        # The PRIMARY profile opted in via os.environ; the secondary profile's
+        # scope has no opt-in. The secondary must NOT inherit the primary's
+        # allow-all (this is the cross-profile leak the fix closes).
+        monkeypatch.setenv("QQ_ALLOW_ALL_USERS", "true")
+        runner = _make_qq_runner()
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})
+        try:
+            assert runner._is_user_authorized(_qq_dm_source()) is False
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_single_profile_environ_unchanged(self, monkeypatch):
+        # Multiplex inactive, no scope: legacy os.environ behavior preserved.
+        monkeypatch.setenv("QQ_ALLOW_ALL_USERS", "true")
+        runner = _make_qq_runner()
+        assert runner._is_user_authorized(_qq_dm_source(profile=None)) is True
+
+
+class TestStartupValidatorScope:
+    @staticmethod
+    def _open_dm_config():
+        return GatewayConfig(
+            platforms={
+                Platform.QQBOT: PlatformConfig(
+                    enabled=True, extra={"dm_policy": "open"}
+                )
+            }
+        )
+
+    def test_scoped_opt_in_clears_violation(self):
+        # Mirrors _start_one_profile_adapters: the validator runs inside the
+        # profile scope, so the profile's own opt-in must clear the violation.
+        from gateway.run import _own_policy_open_startup_violation
+
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"QQ_ALLOW_ALL_USERS": "true"})
+        try:
+            assert _own_policy_open_startup_violation(self._open_dm_config()) is None
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_scope_does_not_inherit_environ_opt_in(self, monkeypatch):
+        # Primary's environ opt-in must not silently bless a secondary
+        # profile whose own scope never opted in.
+        from gateway.run import _own_policy_open_startup_violation
+
+        monkeypatch.setenv("QQ_ALLOW_ALL_USERS", "true")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})
+        try:
+            violation = _own_policy_open_startup_violation(self._open_dm_config())
+        finally:
+            ss.reset_secret_scope(tok)
+        assert violation is not None
+        assert "qqbot" in violation
+
+    def test_unscoped_environ_unchanged(self, monkeypatch):
+        # Single-profile startup (no scope installed) keeps reading environ.
+        from gateway.run import _own_policy_open_startup_violation
+
+        monkeypatch.setenv("QQ_ALLOW_ALL_USERS", "true")
+        assert _own_policy_open_startup_violation(self._open_dm_config()) is None
+
+
+class TestDirectSendScope:
+    @staticmethod
+    def _fake_httpx(captured):
+        class _Resp:
+            status_code = 500
+
+            @staticmethod
+            def json():
+                return {}
+
+        class _AsyncClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def post(self, url, **kwargs):
+                captured.append(kwargs.get("json") or {})
+                return _Resp()
+
+        module = types.ModuleType("httpx")
+        module.AsyncClient = _AsyncClient
+        return module
+
+    @pytest.mark.asyncio
+    async def test_scoped_credentials_win_over_environ(self, monkeypatch):
+        from tools.send_message_tool import _send_qqbot
+
+        captured = []
+        monkeypatch.setitem(sys.modules, "httpx", self._fake_httpx(captured))
+        monkeypatch.setenv("QQ_APP_ID", "global-app")
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "global-secret")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope(
+            {"QQ_APP_ID": "profileA-app", "QQ_CLIENT_SECRET": "profileA-secret"}
+        )
+        try:
+            await _send_qqbot(
+                PlatformConfig(enabled=True, extra={}), "chat-1", "hi"
+            )
+        finally:
+            ss.reset_secret_scope(tok)
+        assert captured, "token request never issued"
+        assert captured[0]["appId"] == "profileA-app"
+        assert captured[0]["clientSecret"] == "profileA-secret"
+
+    @pytest.mark.asyncio
+    async def test_unscoped_falls_back_to_environ(self, monkeypatch):
+        from tools.send_message_tool import _send_qqbot
+
+        captured = []
+        monkeypatch.setitem(sys.modules, "httpx", self._fake_httpx(captured))
+        monkeypatch.setenv("QQ_APP_ID", "env-app")
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "env-secret")
+        await _send_qqbot(PlatformConfig(enabled=True, extra={}), "chat-1", "hi")
+        assert captured, "token request never issued"
+        assert captured[0]["appId"] == "env-app"
+        assert captured[0]["clientSecret"] == "env-secret"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2006,10 +2006,15 @@ async def _send_qqbot(pconfig, chat_id, message):
     except ImportError:
         return _error("QQBot direct send requires httpx. Run: pip install httpx")
 
+    # Resolve credential fallbacks through the profile secret scope (with the
+    # plain-environ fallback for unscoped single-profile runs) so a multiplex
+    # profile's direct send never borrows another profile's QQ credentials.
+    from gateway.config import _getenv
+
     extra = pconfig.extra or {}
-    appid = extra.get("app_id") or os.getenv("QQ_APP_ID", "")
+    appid = extra.get("app_id") or _getenv("QQ_APP_ID", "")
     secret = (pconfig.token or extra.get("client_secret")
-              or os.getenv("QQ_CLIENT_SECRET", ""))
+              or _getenv("QQ_CLIENT_SECRET", ""))
     if not appid or not secret:
         return _error("QQBot: QQ_APP_ID / QQ_CLIENT_SECRET not configured.")
 


### PR DESCRIPTION
## What does this PR do?

The QQ (`qqbot`) gateway adapter read its per-profile settings — `QQ_APP_ID`, `QQ_CLIENT_SECRET`, the `QQ_STT_*` speech-to-text config, and the `QQ_ALLOW_ALL_USERS` policy flag — through raw `os.getenv`. That bypasses the active profile secret scope, so in multiplex mode a secondary profile whose secret lives in its own `.env` (loaded as an isolated scope, not into `os.environ`) silently falls back to the default/primary profile's value — the same cross-profile credential collision fixed for the WeChat/`weixin` adapter in #59662.

This routes those reads through a small scope-aware resolver, `_resolve_qq_secret`:

- **A profile secret scope is installed** (every secondary multiplex profile is constructed and handled inside `_profile_runtime_scope`, as is each per-turn inbound message) → read from the scope via `get_secret`, so profiles never see each other's `os.environ` values.
- **No scope installed** → fall back to `os.environ`. This fallback is deliberate: the primary/active profile is constructed **without** a scope (`gateway/run.py`) while multiplexing is active, so a bare `get_secret` would raise `UnscopedSecretError` and break the active profile's startup. The resolver mirrors the existing scope-aware `gateway.config._getenv`.

Because secondary profiles are always scoped during construction and runtime (contextvars propagate to their asyncio tasks), they never reach the `os.environ` fallback — no leak. Single-profile deployments are unaffected (multiplex inactive → `os.environ`, exactly as before).

`GATEWAY_ALLOW_ALL_USERS` and the network proxy vars are intentionally left as raw `os.getenv` — they are deployment-global settings, not per-profile secrets.

## Related Issue

Same class as #59662 (the WeChat/`weixin` adapter). No qqbot-specific issue exists yet.

## Type of Change

- [x] Security fix

## Changes Made

- `gateway/platforms/qqbot/adapter.py`: add `_resolve_qq_secret` (scope-aware, with `os.environ` fallback for the unscoped active profile) and route all per-profile `QQ_*` reads through it. Returns `str`, so the STT `base_url`/`model` are no longer `Optional`-typed.
- `tests/gateway/test_qqbot_credential_isolation.py`: new regression tests — scope-wins-over-environ, two-profile isolation, single-profile fallback, explicit-config precedence, STT key scoping, and **active-profile-no-scope construction** (proves the fail-closed case does not raise).

## How to Test

Run: `pytest tests/gateway/test_qqbot_credential_isolation.py -q`

## Checklist

- [x] Conventional Commit message
- [x] Only changes related to this fix
- [x] Tests pass locally
- [x] Added tests for the change


## Review follow-up (hermes-sweeper)

Commit `7875c0a20` extends the same scoped resolution to the three flagged paths:

- **Gateway authorization** (`gateway/authz_mixin.py`): the per-platform allow-all flag, per-platform/group allowlists, and allow-bots reads now go through the scope-aware `gateway.config._getenv`. The deployment-global `GATEWAY_ALLOW_ALL_USERS` / `GATEWAY_ALLOWED_USERS` reads intentionally remain raw `os.getenv`. Because these checks are platform-generic, the fix applies to every own-policy platform (not just QQ); with no scope installed `_getenv` is byte-identical to `os.getenv`, so single-profile deployments are unaffected.
- **Startup validation** (`gateway/run.py::_own_policy_open_startup_violation`): the per-platform dm/group policy and allow-all opt-in resolve via `_getenv`; the secondary-profile caller already runs inside `_profile_runtime_scope`, so each profile's own opt-in is honored.
- **Direct send** (`tools/send_message_tool.py::_send_qqbot`): the `QQ_APP_ID` / `QQ_CLIENT_SECRET` fallbacks now honor the active profile scope.

New end-to-end tests in `tests/gateway/test_qqbot_scope_paths.py` cover all three paths (scoped value wins over environ, a profile without its own opt-in does not inherit the primary's environ opt-in, unscoped single-profile behavior unchanged), and the STT suite now asserts `QQ_STT_BASE_URL` / `QQ_STT_MODEL` scoping alongside the API key. All five scoped-behavior tests fail on the previous head and pass on this one.
