### PR TITLE
fix(skills): don't silently drop skills with a null or non-string name

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -380,7 +380,13 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     # (kanban/docker/s6). Offer-time only; explicit load bypasses.
                     if not skill_matches_environment(frontmatter):
                         continue
-                    name = frontmatter.get('name', skill_md.parent.name)
+                    # A bare "name:" (YAML null) or numeric name must not
+                    # raise later (.lower() on a non-string is swallowed by
+                    # the per-skill handler below and the skill vanishes).
+                    raw_name = frontmatter.get('name')
+                    name = (str(raw_name) if raw_name is not None else '').strip()
+                    if not name:
+                        name = skill_md.parent.name
                     if name in seen_names:
                         continue
                     # Respect user's disabled skills config

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -58,6 +58,42 @@ class TestScanSkillCommands:
         assert "/my-skill" in result
         assert result["/my-skill"]["name"] == "my-skill"
 
+    def test_null_name_falls_back_to_dir_name(self, tmp_path):
+        """A bare ``name:`` key (YAML null) must not drop the slash command."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = tmp_path / "null-name"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname:\ndescription: has a null name\n---\n\nBody.\n"
+            )
+            result = scan_skill_commands()
+        assert "/null-name" in result
+        assert result["/null-name"]["name"] == "null-name"
+
+    def test_numeric_name_coerced(self, tmp_path):
+        """A numeric ``name: 123`` must not drop the slash command."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = tmp_path / "numeric-name"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: 123\ndescription: numeric name\n---\n\nBody.\n"
+            )
+            result = scan_skill_commands()
+        assert "/123" in result
+        assert result["/123"]["name"] == "123"
+
+    def test_zero_name_kept_as_string(self, tmp_path):
+        """``name: 0`` is falsy but real — it must become "0", not the dir name."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = tmp_path / "zero-name"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: 0\ndescription: zero name\n---\n\nBody.\n"
+            )
+            result = scan_skill_commands()
+        assert "/0" in result
+        assert result["/0"]["name"] == "0"
+
     def test_empty_dir(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             result = scan_skill_commands()

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -255,6 +255,30 @@ class TestFindAllSkills:
             skills = _find_all_skills()
         assert len(skills[0]["description"]) <= MAX_DESCRIPTION_LENGTH
 
+    def test_null_name_falls_back_to_dir_name(self, tmp_path):
+        """A bare ``name:`` key (YAML null) must not drop the skill."""
+        skill_dir = tmp_path / "null-name"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname:\ndescription: has a null name\n---\n\nBody.\n"
+        )
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skills = _find_all_skills()
+        assert len(skills) == 1
+        assert skills[0]["name"] == "null-name"
+
+    def test_non_string_name_coerced(self, tmp_path):
+        """A numeric ``name: 123`` must not drop the skill."""
+        skill_dir = tmp_path / "numeric-name"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: 123\ndescription: numeric name\n---\n\nBody.\n"
+        )
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skills = _find_all_skills()
+        assert len(skills) == 1
+        assert skills[0]["name"] == "123"
+
     def test_skips_git_directories(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "real-skill")

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -279,6 +279,18 @@ class TestFindAllSkills:
         assert len(skills) == 1
         assert skills[0]["name"] == "123"
 
+    def test_zero_name_kept_as_string(self, tmp_path):
+        """``name: 0`` is falsy but real — it must become "0", not the dir name."""
+        skill_dir = tmp_path / "zero-name"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: 0\ndescription: zero name\n---\n\nBody.\n"
+        )
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skills = _find_all_skills()
+        assert len(skills) == 1
+        assert skills[0]["name"] == "0"
+
     def test_skips_git_directories(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "real-skill")

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -643,7 +643,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 if not skill_matches_environment(frontmatter):
                     continue
 
-                name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
+                name = str(frontmatter.get("name") or skill_dir.name)[:MAX_NAME_LENGTH]
                 if name in seen_names:
                     continue
                 if name in disabled:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -643,7 +643,11 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 if not skill_matches_environment(frontmatter):
                     continue
 
-                name = str(frontmatter.get("name") or skill_dir.name)[:MAX_NAME_LENGTH]
+                # Fall back to the directory name only for a missing/null/blank
+                # name; falsy-but-real values like ``name: 0`` keep "0".
+                raw_name = frontmatter.get("name")
+                name = (str(raw_name) if raw_name is not None else "").strip()
+                name = (name or skill_dir.name)[:MAX_NAME_LENGTH]
                 if name in seen_names:
                     continue
                 if name in disabled:


### PR DESCRIPTION
## Problem

`_find_all_skills()` (`tools/skills_tool.py`) runs

```python
name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
```

directly on the parsed YAML value. A bare `name:` key parses as `None` and `name: 123` parses as an `int`, so the slice raises `TypeError`. The broad `except Exception` in the scan loop swallows it, and the skill **silently disappears from `skills_list()`** — while `skill_view()` still loads the same skill fine (it uses the tolerant lookup), which makes the failure very confusing to debug.

## Fix

Coerce through `str()` with a fallback to the directory name:

```python
name = str(frontmatter.get("name") or skill_dir.name)[:MAX_NAME_LENGTH]
```

This matches the tolerant pattern already used in `agent/skill_utils.py` (`frontmatter.get("name") or skill_file.parent.name` followed by `str(...)`).

## Repro

```python
from agent.skill_utils import parse_frontmatter
fm, _ = parse_frontmatter("---\nname:\ndescription: d\n---\nbody")
fm.get("name", "dirname")[:64]   # TypeError: 'NoneType' object is not subscriptable
```

## Tests

Added two regression tests to `TestFindAllSkills`:
- `name:` (YAML null) → skill listed under its directory name
- `name: 123` → skill listed as `"123"`

`python -m pytest tests/tools/test_skills_tool.py` — 89 passed (the 2 `TestSkillViewCollisionDetection` failures are pre-existing on clean `main` in this Windows environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)