### PR TITLE
fix(copilot): use target_model not config default for api_mode resolution

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -311,13 +311,25 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(
+    model_cfg: Dict[str, Any],
+    api_key: str,
+    *,
+    target_model: Optional[str] = None,
+) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
+    # Prefer the caller's target_model (e.g. from the WebUI dropdown) over
+    # the persisted model.default.  Without this, a session whose config
+    # default is a non-GPT-5 model (e.g. deepseek-v4) but whose active
+    # model is gpt-5.5 would resolve chat_completions instead of
+    # codex_responses, causing HTTP 400 "model not accessible via
+    # /chat/completions endpoint" on every turn.
+    model_name = (target_model or model_cfg.get("default") or "")
+    model_name = str(model_name).strip()
     if not model_name:
         return "chat_completions"
 
@@ -443,7 +455,11 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
         base_url = _nous_inference_base_url_override() or base_url
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_mode = _copilot_runtime_api_mode(
+            model_cfg,
+            getattr(entry, "runtime_api_key", ""),
+            target_model=target_model,
+        )
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
@@ -2000,7 +2016,11 @@ def resolve_runtime_provider(
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+            api_mode = _copilot_runtime_api_mode(
+                model_cfg,
+                creds.get("api_key", ""),
+                target_model=target_model,
+            )
         elif provider == "xai":
             api_mode = "codex_responses"
         else:


### PR DESCRIPTION
## Problem

When selecting GPT-5.5 via Copilot as the primary model from the WebUI dropdown, every API call fails with:

```
HTTP 400: model gpt-5.5 is not accessible via the /chat/completions endpoint
```

GPT-5.x models on Copilot require the `/responses` endpoint (`codex_responses` API mode), but the request is sent to `/chat/completions` instead.

## Root Cause

`_copilot_runtime_api_mode()` in `runtime_provider.py` reads `model_cfg.get("default")` — the persisted config.yaml default model (e.g. `deepseek-ai/DeepSeek-V4-Flash`) — instead of the actual target model (`gpt-5.5`) when deciding which API endpoint to use.

The WebUI correctly passes `target_model` to `resolve_runtime_provider()`, but `_copilot_runtime_api_mode()` does not accept or use it. Since the config default is not a GPT-5 model, `_should_use_copilot_responses_api()` returns `False`, and the API mode resolves to `chat_completions`.

The fallback path (`try_activate_fallback` in `chat_completion_helpers.py`) is unaffected because it uses `_provider_model_requires_responses_api()` with the correct model name — which is why GPT-5.5 works as a fallback but fails as a primary model selected from the WebUI.

## Fix

Pass `target_model` through `_copilot_runtime_api_mode()` at both call sites (pool entry path at line 446 and non-pool path at line 2003) and prefer it over `model_cfg.get("default")` when determining the API mode.

## Reproduction

1. Set config.yaml default model to a non-GPT-5 model (e.g. `deepseek-ai/DeepSeek-V4-Flash` on `custom:wandb`)
2. In the WebUI, select `@copilot:gpt-5.5` from the model dropdown
3. Send a message — HTTP 400 from Copilot
4. Falls back through the chain (claude-sonnet-5 on copilot also fails if not in catalog, then to local MLX which may also fail)

## Testing

- 218 copilot-related tests pass (1 pre-existing failure in `test_copilot_acp_client` unrelated to this change — `HERMES_REAL_HOME` env var issue)
- Simulated the fix: with `target_model="gpt-5.5"` and config default `deepseek-ai/DeepSeek-V4-Flash`, the API mode now correctly resolves to `codex_responses`

> Note: This was authored using the GitHub Copilot commit email per the AGENTS.md fork conventions.