### PR TITLE
fix(vision): stream image downloads so the size cap bounds memory

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -167,6 +167,106 @@ class TestImageToBase64DataUrl:
 
 
 # ---------------------------------------------------------------------------
+# _download_image — streaming size cap
+# ---------------------------------------------------------------------------
+
+
+class _FakeImageResponse:
+    def __init__(self, *, chunks, headers=None, url="https://example.com/pic.png"):
+        self._chunks = chunks
+        self.headers = headers or {}
+        self.url = url
+        self.is_redirect = False
+        self.next_request = None
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_bytes(self, chunk_size=None):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeImageStream:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *args):
+        return None
+
+
+class _FakeImageClient:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    def stream(self, *args, **kwargs):
+        return _FakeImageStream(self._response)
+
+
+class TestDownloadImageStreaming:
+    def _install_client(self, monkeypatch, response):
+        monkeypatch.setattr("tools.vision_tools.check_website_access", lambda url: None)
+        monkeypatch.setattr(
+            "tools.vision_tools.httpx.AsyncClient",
+            lambda *args, **kwargs: _FakeImageClient(response),
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_content_length(self, tmp_path, monkeypatch):
+        from tools.vision_tools import _download_image
+
+        monkeypatch.setattr("tools.vision_tools._VISION_MAX_DOWNLOAD_BYTES", 8)
+        self._install_client(
+            monkeypatch,
+            _FakeImageResponse(chunks=[b"ok"], headers={"content-length": "9"}),
+        )
+        with pytest.raises(ValueError, match="too large"):
+            await _download_image("https://example.com/pic.png", tmp_path / "pic.png",
+                                  max_retries=1)
+
+    @pytest.mark.asyncio
+    async def test_aborts_oversized_body_without_content_length(
+        self, tmp_path, monkeypatch
+    ):
+        """Chunked responses without Content-Length must still hit the cap."""
+        from tools.vision_tools import _download_image
+
+        monkeypatch.setattr("tools.vision_tools._VISION_MAX_DOWNLOAD_BYTES", 8)
+        self._install_client(
+            monkeypatch,
+            _FakeImageResponse(chunks=[b"xxxx", b"xxxx", b"xxxx"]),  # 12 > 8
+        )
+        destination = tmp_path / "pic.png"
+        with pytest.raises(ValueError, match="too large"):
+            await _download_image("https://example.com/pic.png", destination,
+                                  max_retries=1)
+        assert not destination.exists()  # no truncated file left behind
+
+    @pytest.mark.asyncio
+    async def test_downloads_within_cap(self, tmp_path, monkeypatch):
+        from tools.vision_tools import _download_image
+
+        self._install_client(
+            monkeypatch,
+            _FakeImageResponse(chunks=[b"png-", b"data"]),
+        )
+        destination = tmp_path / "pic.png"
+        result = await _download_image("https://example.com/pic.png", destination,
+                                       max_retries=1)
+        assert result == destination
+        assert destination.read_bytes() == b"png-data"
+
+
+# ---------------------------------------------------------------------------
 # _handle_vision_analyze — type signature & behavior
 # ---------------------------------------------------------------------------
 
@@ -289,7 +389,7 @@ class TestErrorLoggingExcInfo:
             mock_client = AsyncMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(side_effect=ConnectionError("network down"))
+            mock_client.stream = MagicMock(side_effect=ConnectionError("network down"))
             mock_client_cls.return_value = mock_client
 
             dest = tmp_path / "image.jpg"
@@ -505,7 +605,10 @@ class TestVisionSafetyGuards:
             mock_client = AsyncMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=FakeResponse())
+            stream_cm = AsyncMock()
+            stream_cm.__aenter__ = AsyncMock(return_value=FakeResponse())
+            stream_cm.__aexit__ = AsyncMock(return_value=False)
+            mock_client.stream = MagicMock(return_value=stream_cm)
             mock_client_cls.return_value = mock_client
 
             await _download_image("https://allowed.test/cat.png", tmp_path / "cat.png", max_retries=1)
@@ -1025,7 +1128,10 @@ class TestDownloadRetryClassification:
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.get = AsyncMock(return_value=mock_response)
+        stream_cm = AsyncMock()
+        stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        stream_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_client.stream = MagicMock(return_value=stream_cm)
         return mock_client
 
     def test_is_retryable_classification(self):
@@ -1060,7 +1166,7 @@ class TestDownloadRetryClassification:
                 "https://example.com/missing.jpg", tmp_path / "x.jpg", max_retries=3
             )
         # Exactly one attempt, zero backoff sleeps.
-        assert mock_client.get.await_count == 1
+        assert mock_client.stream.call_count == 1
         mock_sleep.assert_not_called()
 
     @pytest.mark.asyncio
@@ -1080,7 +1186,7 @@ class TestDownloadRetryClassification:
                 "https://example.com/flaky.jpg", tmp_path / "y.jpg", max_retries=3
             )
         # All three attempts used, two backoff sleeps between them.
-        assert mock_client.get.await_count == 3
+        assert mock_client.stream.call_count == 3
         assert mock_sleep.await_count == 2
 
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -317,34 +317,51 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
                 follow_redirects=True,
                 event_hooks={"response": [_ssrf_redirect_guard]},
             ) as client:
-                response = await client.get(
+                # Stream instead of buffering: client.get() reads the whole
+                # body into memory BEFORE the size check runs, so a chunked
+                # response without Content-Length (or with a lying one) could
+                # balloon RAM far past the cap. Streaming enforces the limit
+                # per-chunk and aborts early.
+                async with client.stream(
+                    "GET",
                     image_url,
                     headers={
                         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
                         "Accept": "image/*,*/*;q=0.8",
                     },
-                )
-                response.raise_for_status()
+                ) as response:
+                    response.raise_for_status()
 
-                # Reject overly large images early via Content-Length header.
-                cl = response.headers.get("content-length")
-                if cl and int(cl) > _VISION_MAX_DOWNLOAD_BYTES:
-                    raise ValueError(
-                        f"Image too large ({int(cl)} bytes, max {_VISION_MAX_DOWNLOAD_BYTES})"
-                    )
+                    # Reject overly large images early via Content-Length header.
+                    cl = response.headers.get("content-length")
+                    if cl and int(cl) > _VISION_MAX_DOWNLOAD_BYTES:
+                        raise ValueError(
+                            f"Image too large ({int(cl)} bytes, max {_VISION_MAX_DOWNLOAD_BYTES})"
+                        )
 
-                final_url = str(response.url)
-                blocked = check_website_access(final_url)
-                if blocked:
-                    raise PermissionError(blocked["message"])
-                
-                # Save the image content (double-check actual size)
-                body = response.content
-                if len(body) > _VISION_MAX_DOWNLOAD_BYTES:
-                    raise ValueError(
-                        f"Image too large ({len(body)} bytes, max {_VISION_MAX_DOWNLOAD_BYTES})"
-                    )
-                destination.write_bytes(body)
+                    final_url = str(response.url)
+                    blocked = check_website_access(final_url)
+                    if blocked:
+                        raise PermissionError(blocked["message"])
+
+                    # Save the image content, enforcing the cap on actual bytes
+                    received = 0
+                    try:
+                        with destination.open("wb") as fh:
+                            async for chunk in response.aiter_bytes(chunk_size=64 * 1024):
+                                received += len(chunk)
+                                if received > _VISION_MAX_DOWNLOAD_BYTES:
+                                    raise ValueError(
+                                        f"Image too large (>{_VISION_MAX_DOWNLOAD_BYTES} bytes)"
+                                    )
+                                fh.write(chunk)
+                    except BaseException:
+                        # Don't leave a truncated file behind for the caller.
+                        try:
+                            destination.unlink()
+                        except OSError:
+                            pass
+                        raise
             
             return destination
         except Exception as e:


### PR DESCRIPTION
## Problem

`_download_image()` in `tools/vision_tools.py` fetches with `client.get()`, which **buffers the entire response body into memory before any size check runs**:

```python
response = await client.get(image_url, ...)   # whole body already in RAM here
...
cl = response.headers.get("content-length")   # absent on chunked responses
...
body = response.content
if len(body) > _VISION_MAX_DOWNLOAD_BYTES:    # too late — already buffered
```

The Content-Length pre-check doesn't help when the response is chunked (no header) or the header lies. A hostile or misbehaving image URL can balloon the agent's RAM far past `_VISION_MAX_DOWNLOAD_BYTES` (50 MB) — the cap only ever rejected the payload *after* paying its full memory cost.

The video sibling `_download_video` has the identical pattern and is being fixed in #55028 — this PR covers the image path the same way.

## Fix

Switch to `client.stream()` and enforce the cap per 64 KB chunk, aborting the transfer as soon as the running total exceeds the limit. The partial file is removed on failure so callers never see a truncated image. The SSRF redirect guard (`event_hooks`), final-URL policy check, Content-Length fast-reject, and error-class-aware retry logic are all unchanged.

## Repro

Local HTTP server streaming a 100 MB chunked response (no Content-Length) with the cap monkeypatched to 1 MB:

- before: the whole body is buffered, then rejected;
- after: `ValueError` raised at the cap — the client closed the connection after ~6 MB of the 100 MB the server tried to send, and no partial file is left behind. A normal small download still works.

## Tests

- New `TestDownloadImageStreaming`: oversized Content-Length rejected; chunked over-cap body aborted with no truncated file left; within-cap download succeeds.
- Updated the four existing `_download_image` mocks from `client.get` to `client.stream` (retry classification, redirect policy block, exc_info logging) — assertions unchanged.

`python -m pytest tests/tools/test_vision_tools.py` — 88 passed. `tests/test_model_tools_async_bridge.py` + `tests/gateway/test_bluebubbles.py` — 72 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)