### PR TITLE
Expose session rewind over HTTP (POST /api/sessions/{id}/rewind)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8201,6 +8201,47 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
         db.close()
 
 
+class SessionRewind(BaseModel):
+    # Rewind point: a message id from GET /api/sessions/{id}/messages. Must be a
+    # 'user' message; it and every later message are soft-deleted (active=0).
+    target_message_id: int
+    # Mutate a session belonging to another profile (opens its state.db). Omit
+    # for the current/default profile.
+    profile: Optional[str] = None
+
+
+@app.post("/api/sessions/{session_id}/rewind")
+async def rewind_session_endpoint(session_id: str, body: SessionRewind):
+    """Rewind a session to an earlier user message, clearing later context.
+
+    Soft-deletes the target user message and every message after it (active=0,
+    kept on disk for audit, hidden from get_messages/search) so subsequent chat
+    turns no longer see the rewound messages. Wraps SessionDB.rewind_to_message
+    — the same mechanic behind the gateway /undo and /rewind commands (#21910) —
+    exposing it over HTTP for API clients (e.g. the desktop chat's "clear
+    context from here" affordance), which previously had no way to reach it.
+
+    Returns ``rewound_count`` (rows newly deactivated), ``target_message`` (the
+    rewind point, content decoded so the client can pre-fill the composer), and
+    ``new_head_id`` (last still-active message id, or null).
+    """
+    db = _open_session_db_for_profile(body.profile)
+    try:
+        sid = db.resolve_session_id(session_id)
+        if not sid:
+            raise HTTPException(status_code=404, detail="Session not found")
+        # Rewind the same resolved session id that GET /messages returns target
+        # ids from, so a target picked off that transcript resolves correctly.
+        sid = db.resolve_resume_session_id(sid)
+        try:
+            result = db.rewind_to_message(sid, body.target_message_id)
+        except ValueError as e:  # unknown id, or target isn't a 'user' message
+            raise HTTPException(status_code=400, detail=str(e))
+        return {"ok": True, **result}
+    finally:
+        db.close()
+
+
 @app.get("/api/sessions/{session_id}/export")
 async def export_session_endpoint(session_id: str, profile: Optional[str] = None):
     """Export a single session (metadata + messages) as JSON."""

--- a/tests/hermes_cli/test_web_server_rewind.py
+++ b/tests/hermes_cli/test_web_server_rewind.py
@@ -1,0 +1,73 @@
+"""HTTP test for POST /api/sessions/{id}/rewind.
+
+Exposes SessionDB.rewind_to_message (the /undo + /rewind mechanic, issue
+#21910) over the desktop-facing gateway API so an API client can clear
+conversation context from a chosen user message onward. The primitive
+previously had no HTTP route.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from hermes_state import SessionDB
+from hermes_cli import web_server
+
+
+@pytest.fixture()
+def seeded_db(tmp_path, monkeypatch):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", source="desktop")
+    ids = []
+    for i in range(1, 4):
+        ids.append(db.append_message("s1", "user", f"q{i}"))
+        ids.append(db.append_message("s1", "assistant", f"a{i}"))
+    # Serve this exact db instance to the endpoint, regardless of profile.
+    monkeypatch.setattr(web_server, "_open_session_db_for_profile", lambda profile: db)
+    return db, ids
+
+
+def test_rewind_to_user_message_clears_later_context(seeded_db):
+    db, ids = seeded_db
+    q2_id = ids[2]  # third seeded row is the 2nd user turn (q2)
+
+    res = asyncio.run(
+        web_server.rewind_session_endpoint(
+            "s1", web_server.SessionRewind(target_message_id=q2_id)
+        )
+    )
+
+    assert res["ok"] is True
+    assert res["rewound_count"] == 4  # q2, a2, q3, a3
+    assert res["target_message"]["content"] == "q2"
+    # Only q1, a1 remain in the active transcript the model sees.
+    active = db.get_messages("s1")
+    assert [m["content"] for m in active] == ["q1", "a1"]
+    # Rewound rows are soft-deleted (kept for audit), not destroyed.
+    assert len(db.get_messages("s1", include_inactive=True)) == 6
+
+
+def test_rewind_rejects_non_user_target(seeded_db):
+    db, ids = seeded_db
+    a1_id = ids[1]  # an assistant message — rewind targets must be 'user'
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            web_server.rewind_session_endpoint(
+                "s1", web_server.SessionRewind(target_message_id=a1_id)
+            )
+        )
+    assert exc.value.status_code == 400
+
+
+def test_rewind_unknown_session_returns_404(seeded_db):
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            web_server.rewind_session_endpoint(
+                "does-not-exist", web_server.SessionRewind(target_message_id=1)
+            )
+        )
+    assert exc.value.status_code == 404


### PR DESCRIPTION
SessionDB.rewind_to_message already implements context rewind — it soft-deletes a chosen user message and every message after it (active=0, kept for audit, hidden from get_messages/search), and backs the gateway /undo and /rewind commands (issue #21910). It had no HTTP route, so API clients (e.g. a desktop chat "clear context from here" action) could not reach it.

Add a POST /api/sessions/{session_id}/rewind endpoint that wraps the primitive, following the conventions of the neighbouring session routes (_open_session_db_for_profile, resolve_session_id, ValueError -> 400, try/finally close). It resolves the resume session id first so a target picked off GET /messages resolves correctly, and returns rewound_count, the decoded target_message, and new_head_id.

Add tests covering a successful rewind (later context cleared, rows soft-deleted not destroyed), a non-user target rejected with 400, and an unknown session returning 404.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->


## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`
