### PR TITLE
docs(gateway): sharpen the cached-agent bypass comment (#59607)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18240,11 +18240,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "conversation context (possible FTS write corruption)",
                         session_key, len(agent_history), len(_selected),
                     )
-                    # The live in-memory history bypassed the replay-cleanup
-                    # pass inside _build_gateway_agent_history — re-apply the
-                    # stale-confirmation expiry (#59607) so a dangerous
-                    # confirmation can't slip through this path either.
-                    # Idempotent; messages without timestamps are untouched.
+                    # The live in-memory history bypassed the
+                    # _build_gateway_agent_history cleanup pipeline above —
+                    # re-apply the stale-confirmation expiry (#59607) so a
+                    # dangerous confirmation can't slip through this path
+                    # either. Idempotent; messages without timestamps are
+                    # untouched.
                     agent_history = _strip_stale_dangerous_confirmations(
                         _selected, now=time.time()
                     )


### PR DESCRIPTION
## Summary
Comment-precision follow-up from the #60117 review: the cached-agent live-history path bypasses the whole `_build_gateway_agent_history` cleanup pipeline, not just the replay-cleanup pass — the comment now says so. No code change.

This commit was pushed to #60117's branch but the merge landed on the prior SHA first (same push/merge race as #60110).

## Changes
- `gateway/run.py`: comment wording only (+6/-5)

Refs #59607. Follow-up to #60117.