### PR TITLE
Fix BasicAuth dashboard authentication redirect

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,10 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password-only providers have no OAuth redirect flow.
+    # Let the normal /login page render instead of trying OAuth.
+    if getattr(provider, "supports_password", False):
+        return None
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -195,6 +195,11 @@ async def auth_login(request: Request, provider: str, next: str = ""):
 
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))
+    except NotImplementedError as e:
+        raise HTTPException(
+        status_code=400,
+        detail=str(e),
+        )
     except ProviderError as e:
         audit_log(
             AuditEvent.LOGIN_FAILURE,


### PR DESCRIPTION
Fixes the dashboard login flow when BasicAuthProvider is the only configured provider.

Changes:
- Skip OAuth redirect for password-only providers.
- Return HTTP 400 instead of HTTP 500 when a provider does not implement OAuth login.

This prevents the dashboard from redirecting BasicAuth users into an unsupported OAuth flow.