### PR TITLE
feat(discord): support progress message cleanup

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2274,6 +2274,36 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def delete_message(
+        self,
+        chat_id: str,
+        message_id: str,
+    ) -> bool:
+        """Delete a previously sent Discord message.
+
+        Enables ``display.cleanup_progress`` on Discord: the gateway collects
+        tool-progress / status bubble message IDs and deletes them after the
+        final response is delivered.  The base-class default returns ``False``
+        (no-op), which silently disables cleanup on adapters without an
+        override.  Follows the same channel-resolution pattern as
+        ``edit_message``.
+        """
+        if not self._client:
+            return False
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            msg = await channel.fetch_message(int(message_id))
+            await msg.delete()
+            return True
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.warning(
+                "[%s] Failed to delete Discord message %s: %s",
+                self.name, message_id, e,
+            )
+            return False
+
     @staticmethod
     def _is_length_overflow_error(err: Exception) -> bool:
         """True when a Discord edit/send failed because text exceeded 2,000.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3793,6 +3793,36 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def delete_message(
+        self,
+        chat_id: str,
+        message_id: str,
+    ) -> bool:
+        """Delete a previously sent Discord message.
+
+        Enables ``display.cleanup_progress`` on Discord: the gateway collects
+        tool-progress and status message IDs and deletes them after the final
+        response is delivered. The base-class default returns ``False`` for
+        adapters that do not support deletion.
+        """
+        if not self._client:
+            return False
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            msg = await channel.fetch_message(int(message_id))
+            await msg.delete()
+            return True
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.warning(
+                "[%s] Failed to delete Discord message %s: %s",
+                self.name,
+                message_id,
+                e,
+            )
+            return False
+
     @staticmethod
     def _is_length_overflow_error(err: Exception) -> bool:
         """True when a Discord edit/send failed because text exceeded 2,000.

--- a/tests/gateway/test_discord_delete_message.py
+++ b/tests/gateway/test_discord_delete_message.py
@@ -1,0 +1,134 @@
+"""Tests for DiscordAdapter.delete_message.
+
+The gateway's ``display.cleanup_progress`` feature (bf843adf0) deletes
+tool-progress / status bubbles after the final response lands, but only on
+adapters that override ``BasePlatformAdapter.delete_message``.  These tests
+cover the Discord override: successful deletion, the fetch_channel fallback,
+and graceful ``False`` returns on failure (cleanup callers fall back to
+leaving the message in place).
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import sys
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+def _adapter():
+    return DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+
+@pytest.mark.asyncio
+async def test_delete_message_deletes_and_returns_true():
+    adapter = _adapter()
+
+    msg = SimpleNamespace(delete=AsyncMock())
+    channel = SimpleNamespace(fetch_message=AsyncMock(return_value=msg))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    assert await adapter.delete_message("555", "1234") is True
+    channel.fetch_message.assert_awaited_once_with(1234)
+    msg.delete.assert_awaited_once()
+    adapter._client.fetch_channel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_message_falls_back_to_fetch_channel():
+    adapter = _adapter()
+
+    msg = SimpleNamespace(delete=AsyncMock())
+    channel = SimpleNamespace(fetch_message=AsyncMock(return_value=msg))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: None,
+        fetch_channel=AsyncMock(return_value=channel),
+    )
+
+    assert await adapter.delete_message("555", "1234") is True
+    adapter._client.fetch_channel.assert_awaited_once_with(555)
+    msg.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_message_returns_false_when_not_connected():
+    adapter = _adapter()
+    adapter._client = None
+
+    assert await adapter.delete_message("555", "1234") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_message_returns_false_on_api_error():
+    adapter = _adapter()
+
+    # e.g. 404 Unknown Message (already deleted) or 403 Missing Permissions.
+    channel = SimpleNamespace(
+        fetch_message=AsyncMock(
+            side_effect=RuntimeError("404 Not Found (error code: 10008): Unknown Message")
+        ),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    assert await adapter.delete_message("555", "1234") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_message_returns_false_when_delete_raises():
+    adapter = _adapter()
+
+    msg = SimpleNamespace(
+        delete=AsyncMock(
+            side_effect=RuntimeError("403 Forbidden (error code: 50013): Missing Permissions")
+        ),
+    )
+    channel = SimpleNamespace(fetch_message=AsyncMock(return_value=msg))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    assert await adapter.delete_message("555", "1234") is False


### PR DESCRIPTION
## Summary
- implement `DiscordAdapter.delete_message()` on the current plugin-based adapter
- enable the existing `display.cleanup_progress` lifecycle to remove Discord progress/status messages after final delivery
- return the adapter's current boolean deletion contract and fail closed on API errors
- cover direct lookup, `fetch_channel` fallback, disconnected state, fetch failure, and delete failure

## Why
Current `main` already owns the generic post-delivery cleanup lifecycle through `display.cleanup_progress`, but Discord still inherits the base no-op `delete_message()` implementation. As a result, `display.platforms.discord.cleanup_progress: true` cannot actually remove progress messages.

This PR fills only that platform capability gap. It does not add another display setting or duplicate the gateway cleanup lifecycle.

## Tests
- `PYTHONPATH=. python -m pytest -q tests/gateway/test_discord_delete_message.py tests/gateway/test_run_cleanup_progress.py` — 7 passed
- `ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_delete_message.py`
- `git diff --check`

## Compatibility
No default behavior changes. Message deletion is used only when the existing cleanup setting is enabled. Failures return `False` and leave the progress message in place.
