### PR TITLE
fix(compression): prevent no-progress summarization and add reasoning_content echo-back

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2914,6 +2914,100 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     api_msg.pop("reasoning_content", None)
 
 
+def needs_thinking_reasoning_pad(
+    provider: str = "",
+    model: str = "",
+    base_url: str = "",
+) -> bool:
+    """Return True when the given provider/model/endpoint enforces reasoning_content echo-back.
+
+    DeepSeek V4 thinking, Kimi/Moonshot thinking, and Xiaomi MiMo thinking
+    all require ``reasoning_content`` on every assistant tool-call message;
+    omitting it causes HTTP 400 on replay.
+
+    This is the standalone counterpart of ``AIAgent._needs_thinking_reasoning_pad()``
+    for use in auxiliary paths (context compression, session search) that don't
+    have access to a live AIAgent instance with its cached detection.
+    """
+    provider_lower = (provider or "").lower()
+    model_lower = (model or "").lower()
+    effective_base = base_url or ""
+
+    # DeepSeek
+    if (
+        provider_lower == "deepseek"
+        or "deepseek" in model_lower
+        or base_url_host_matches(effective_base, "api.deepseek.com")
+    ):
+        return True
+
+    # Kimi / Moonshot
+    if provider_lower in {"kimi-coding", "kimi-coding-cn"}:
+        return True
+    if (
+        base_url_host_matches(effective_base, "api.kimi.com")
+        or base_url_host_matches(effective_base, "moonshot.ai")
+        or base_url_host_matches(effective_base, "moonshot.cn")
+    ):
+        return True
+
+    # Xiaomi MiMo
+    if (
+        provider_lower == "xiaomi"
+        or "mimo" in model_lower
+        or base_url_host_matches(effective_base, "api.xiaomimimo.com")
+        or base_url_host_matches(effective_base, "xiaomimimo.com")
+    ):
+        return True
+
+    return False
+
+
+def ensure_reasoning_content_on_messages(
+    messages: list,
+    provider: str = "",
+    model: str = "",
+    base_url: str = "",
+) -> int:
+    """Ensure every assistant tool-call message carries reasoning_content.
+
+    For providers that enforce the echo-back (DeepSeek, Kimi, MiMo), every
+    assistant tool-call message in the list is checked and padded with a
+    single-space ``reasoning_content`` if missing. Non-tool-call assistant
+    messages are also padded, matching the established replay contract in
+    ``copy_reasoning_content_for_api()`` step 4.
+
+    This is the standalone counterpart of ``_ensure_reasoning_content_on_tool_calls()``
+    for use in auxiliary paths that don't have a live AIAgent instance.
+
+    Returns the number of messages that were patched.
+    """
+    if not needs_thinking_reasoning_pad(provider, model, base_url):
+        return 0
+
+    patched = 0
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        existing = msg.get("reasoning_content")
+        if isinstance(existing, str) and existing.strip():
+            continue
+        # Inject a single space — DeepSeek V4 Pro rejects empty string
+        # with HTTP 400. A space satisfies non-empty checks everywhere
+        # without leaking fabricated reasoning. Refs #17341.
+        msg["reasoning_content"] = " "
+        patched += 1
+
+    if patched:
+        logger.info(
+            "Padded reasoning_content on %d assistant message(s) "
+            "(provider=%s model=%s)",
+            patched, provider, model,
+        )
+
+    return patched
+
+
 def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
     """Re-pad (or strip) assistant turns' reasoning_content for the active provider.
 
@@ -3297,6 +3391,8 @@ __all__ = [
     "sanitize_api_messages",
     "looks_like_codex_intermediate_ack",
     "copy_reasoning_content_for_api",
+    "needs_thinking_reasoning_pad",
+    "ensure_reasoning_content_on_messages",
     "cleanup_dead_connections",
     "extract_api_error_context",
     "apply_pending_steer_to_tool_results",

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6623,6 +6623,22 @@ def _build_call_kwargs(
         ):
             kwargs["_reasoning_config"] = dict(reasoning_config)
 
+    # Ensure every assistant tool-call message carries reasoning_content
+    # for providers that enforce the echo-back (DeepSeek, Kimi, MiMo).
+    # Auxiliary tasks (compression, session search, etc.) may receive
+    # conversation history that includes assistant tool-call messages.
+    # The primary loop's message builder already handles this via
+    # copy_reasoning_content_for_api(), but the auxiliary path bypasses
+    # that. Centralized helper from agent_runtime_helpers. Refs #17341.
+    from agent.agent_runtime_helpers import ensure_reasoning_content_on_messages
+
+    ensure_reasoning_content_on_messages(
+        messages,
+        provider=provider,
+        model=model,
+        base_url=base_url or "",
+    )
+
     return kwargs
 
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -32,6 +32,7 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
 )
 from agent.redact import redact_sensitive_text
+from agent.agent_runtime_helpers import ensure_reasoning_content_on_messages
 
 logger = logging.getLogger(__name__)
 
@@ -3155,6 +3156,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             return messages
 
         turns_to_summarize = messages[compress_start:compress_end]
+
         # A persisted handoff summary can sit in the protected head after a
         # resume (commonly immediately after the system prompt). Search from
         # the first non-system message through the compression window so we can
@@ -3204,7 +3206,46 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         # Phase 3: Generate structured summary
         summary_focus_topic = focus_topic or self._derive_auto_focus_topic(messages)
-        summary = self._generate_summary(turns_to_summarize, focus_topic=summary_focus_topic)
+
+        # Pre-LLM feasibility check: if the middle section is too small to
+        # yield meaningful token savings, skip the expensive LLM summarization
+        # call and fall through to the deterministic message-dropping path
+        # (which is cheap and always applicable).  Without this guard a
+        # tool-heavy session where the protected tail already holds most of
+        # the tokens can burn 500+ seconds on a summary call that replaces a
+        # few lightweight messages, leaving the total token count essentially
+        # unchanged.
+        #
+        # Only fires after at least one prior compression cycle, tracked by
+        # ``_ineffective_compression_count``.  The first-ever compress for a
+        # session always attempts the LLM call so error/fallback paths are
+        # exercised before the guard suppresses subsequent retries.
+        #
+        # Skipped when ``force=True`` (manual /compress) so auth/error
+        # handling paths are always exercised on explicit user request.
+        if not force and self._ineffective_compression_count >= 1:
+            middle_tokens = estimate_messages_tokens_rough(turns_to_summarize)
+            summary_is_too_small = middle_tokens < int(self.threshold_tokens * 0.1)
+            if summary_is_too_small:
+                self._ineffective_compression_count += 1
+                self._last_compression_savings_pct = 0.0
+                if not self.quiet_mode:
+                    logger.warning(
+                        "Compression skipped: middle section (%d tokens at indices "
+                        "%d-%d) is less than 10%% of threshold (%d tokens) — "
+                        "skipping LLM summarization, proceeding with message dropping. "
+                        "ineffective_compression_count=%d",
+                        middle_tokens, compress_start, compress_end,
+                        self.threshold_tokens,
+                        self._ineffective_compression_count,
+                    )
+        else:
+            summary_is_too_small = False
+
+        if summary_is_too_small:
+            summary = None  # Skip the LLM call; fall through to message dropping
+        else:
+            summary = self._generate_summary(turns_to_summarize, focus_topic=summary_focus_topic)
 
         # If summary generation failed, behavior splits on
         # ``abort_on_summary_failure`` (config: compression.abort_on_summary_failure):
@@ -3448,5 +3489,18 @@ This compaction should PRIORITISE preserving all information related to the focu
         # future copy site cannot re-leak the marker into the child-session flush.
         _strip_persistence_markers(compressed)
         self._last_compression_made_progress = True
+
+        # Ensure every assistant tool-call message carries reasoning_content
+        # for providers that enforce the echo-back (DeepSeek, Kimi, MiMo).
+        # Compressed messages are persisted to the session DB and may be loaded
+        # by paths outside the main loop's API message building, which already
+        # handles this via copy_reasoning_content_for_api(). Self-healing here
+        # is defense-in-depth. Refs #17341.
+        ensure_reasoning_content_on_messages(
+            compressed,
+            provider=getattr(self, "provider", None),
+            model=getattr(self, "model", None),
+            base_url=getattr(self, "base_url", None),
+        )
 
         return compressed

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -12,6 +12,10 @@ from agent.context_compressor import (
     COMPRESSED_SUMMARY_METADATA_KEY,
     _summarize_tool_result,
 )
+from agent.agent_runtime_helpers import (
+    needs_thinking_reasoning_pad,
+    ensure_reasoning_content_on_messages,
+)
 from hermes_state import SessionDB
 
 
@@ -3483,3 +3487,180 @@ class TestDoubleCompactionSummaryRole:
             "summary of earlier turns" in (m.get("content") or "")
             for m in result
         )
+
+
+class TestPreLlmFeasibilityCheck:
+    """Pre-LLM feasibility check in compress(): skip the LLM summarization call
+    when the middle section is too small to yield meaningful token savings."""
+
+    def test_skips_when_middle_below_10_percent(self, compressor):
+        """compress() should return messages unchanged when the middle section is
+        below 10% of threshold_tokens."""
+        # The fixture compressor has threshold_percent=0.85 on a 100K model,
+        # so threshold_tokens=85K.  10% of that = 8.5K.
+        # Build a transcript where the middle section is a single tiny turn
+        # (~5 tokens) while the tail dominates.
+        #
+        # We cannot rely purely on real token counts because _find_tail_cut_by_tokens
+        # uses estimate_messages_tokens_rough for boundary detection and the estimate
+        # is based on message structure, not content length.  Instead we patch
+        # estimate_messages_tokens_rough to return controlled values.
+
+        # Pre-set the ineffective count to 1 so the pre-LLM check fires
+        # on this first call.  Without at least one prior ineffective cycle
+        # the check is intentionally lenient — the first compress always
+        # fires the LLM call and only subsequent repeats are skipped.
+        compressor._ineffective_compression_count = 1
+
+        msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            # Middle — tiny
+            {"role": "user", "content": "short"},
+            {"role": "assistant", "content": "ok"},
+            # Tail — large enough to be protected
+            {"role": "user", "content": "x" * 500},
+            {"role": "assistant", "content": "y" * 500},
+        ]
+
+        with patch("agent.context_compressor.estimate_messages_tokens_rough") as mock_est:
+            def fake_estimate(msgs_list):
+                if len(msgs_list) <= 2:
+                    return 50
+                return 50_000
+            mock_est.side_effect = fake_estimate
+
+            result = compressor.compress(msgs)
+
+        # compress_start >= compress_end guard should pass (6 messages > 2+3+1),
+        # then _prune_old_tool_results runs, then compress_end is found.
+        # The second estimate_messages_tokens_rough call for the middle section
+        # returns the small value, triggering the pre-LLM skip.
+        assert result is msgs, "Should return the same list when skipping"
+        assert compressor._ineffective_compression_count >= 1
+
+    def test_proceeds_when_middle_exceeds_minimum(self, compressor):
+        """compress() should proceed with summarization when the middle section
+        has enough tokens."""
+        head = [{"role": "user", "content": "hello"}]
+        middle = [{"role": "user", "content": "x" * 5000}, {"role": "assistant", "content": "y" * 3000}]
+        tail = []
+        for i in range(30):
+            tail.append({"role": "user", "content": "x" * 500})
+            tail.append({"role": "assistant", "content": "y" * 200})
+        msgs = head + middle + tail
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message = MagicMock()
+        mock_response.choices[0].message.content = "summary of earlier turns"
+
+        initial_count = compressor._ineffective_compression_count
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            with patch("agent.context_compressor.estimate_messages_tokens_rough") as mock_est:
+                def fake_estimate(msgs_list):
+                    if len(msgs_list) <= 4:
+                        return 100 * len(msgs_list)
+                    return 10_000 * len(msgs_list)
+                mock_est.side_effect = fake_estimate
+
+                result = compressor.compress(msgs)
+
+        assert result is not msgs, "Should return a new list when compression proceeds"
+        assert compressor._ineffective_compression_count == initial_count
+
+    def test_has_content_to_compress_stays_simple(self, compressor):
+        """has_content_to_compress() should only check compress_start < compress_end,
+        not the 10% middle threshold (which belongs in compress())."""
+        with patch.object(compressor, "_align_boundary_forward", return_value=2):
+            with patch.object(compressor, "_find_tail_cut_by_tokens", return_value=10):
+                assert compressor.has_content_to_compress([]) is True
+
+        with patch.object(compressor, "_align_boundary_forward", return_value=10):
+            with patch.object(compressor, "_find_tail_cut_by_tokens", return_value=5):
+                assert compressor.has_content_to_compress([]) is False
+
+
+class TestReasoningContentPadding:
+    """Tests for ensure_reasoning_content_on_messages and needs_thinking_reasoning_pad."""
+
+    def test_deepseek_provider_triggers_padding(self):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "tool_calls": [{"id": "call_1"}], "content": ""},
+        ]
+        patched = ensure_reasoning_content_on_messages(msgs, provider="deepseek")
+        assert patched == 1
+        assert msgs[1].get("reasoning_content") == " "
+
+    def test_deepseek_model_triggers_padding(self):
+        msgs = [
+            {"role": "assistant", "tool_calls": [{"id": "call_1"}], "content": ""},
+        ]
+        patched = ensure_reasoning_content_on_messages(msgs, model="deepseek-v4")
+        assert patched == 1
+
+    def test_kimi_provider_triggers_padding(self):
+        msgs = [
+            {"role": "assistant", "tool_calls": [{"id": "call_1"}], "content": ""},
+        ]
+        patched = ensure_reasoning_content_on_messages(msgs, provider="kimi-coding")
+        assert patched == 1
+        assert msgs[0].get("reasoning_content") == " "
+
+    def test_mimo_model_triggers_padding(self):
+        msgs = [
+            {"role": "assistant", "tool_calls": [{"id": "call_1"}], "content": ""},
+        ]
+        patched = ensure_reasoning_content_on_messages(msgs, model="mimo-1.5")
+        assert patched == 1
+
+    def test_skips_non_tool_call_messages(self):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "plain response"},
+        ]
+        patched = ensure_reasoning_content_on_messages(msgs, provider="deepseek")
+        # These are not tool-call messages but needs_thinking_reasoning_pad is True
+        # so all assistant messages should still get reasoning_content.
+        # The established contract pads ALL assistant turns.
+        assert patched == 1
+        assert msgs[1].get("reasoning_content") == " "
+
+    def test_skips_when_reasoning_content_already_present(self):
+        msgs = [
+            {"role": "assistant", "tool_calls": [{"id": "call_1"}],
+             "reasoning_content": "existing reasoning"},
+        ]
+        patched = ensure_reasoning_content_on_messages(msgs, provider="deepseek")
+        assert patched == 0
+        assert msgs[0]["reasoning_content"] == "existing reasoning"
+
+    def test_strict_provider_skips_padding(self):
+        msgs = [
+            {"role": "assistant", "tool_calls": [{"id": "call_1"}], "content": ""},
+        ]
+        patched = ensure_reasoning_content_on_messages(msgs, provider="openai")
+        assert patched == 0
+
+    def test_needs_thinking_reasoning_pad_deepseek(self):
+        assert needs_thinking_reasoning_pad(provider="deepseek") is True
+        assert needs_thinking_reasoning_pad(model="deepseek-v4") is True
+        assert needs_thinking_reasoning_pad(base_url="https://api.deepseek.com") is True
+
+    def test_needs_thinking_reasoning_pad_kimi(self):
+        assert needs_thinking_reasoning_pad(provider="kimi-coding") is True
+        assert needs_thinking_reasoning_pad(provider="kimi-coding-cn") is True
+        assert needs_thinking_reasoning_pad(base_url="https://api.kimi.com/v1") is True
+        assert needs_thinking_reasoning_pad(base_url="https://moonshot.ai") is True
+
+    def test_needs_thinking_reasoning_pad_mimo(self):
+        assert needs_thinking_reasoning_pad(provider="xiaomi") is True
+        assert needs_thinking_reasoning_pad(model="mimo-1.5") is True
+        assert needs_thinking_reasoning_pad(base_url="https://api.xiaomimimo.com") is True
+
+    def test_needs_thinking_reasoning_pad_false_for_other(self):
+        assert needs_thinking_reasoning_pad(provider="openai") is False
+        assert needs_thinking_reasoning_pad(provider="anthropic") is False
+        assert needs_thinking_reasoning_pad(provider="", model="", base_url="") is False
+


### PR DESCRIPTION
Rebased on upstream `main` (`f8ddf4fd86`) to incorporate independent no-progress
protection that has already landed upstream. This PR now focuses on the two gaps
that remain unaddressed.

---

## 1. Pre-LLM feasibility check in `compress()`

When the middle section is below 10% of `threshold_tokens`, skip the expensive
LLM summarization call and fall through to the deterministic message-dropping
path (which is cheap and always applicable). Without this guard, a tool-heavy
session where the protected tail already holds most of the tokens can burn
500+ seconds on a summary call that replaces a few lightweight messages,
leaving the total token count essentially unchanged.

Tracks `_ineffective_compression_count` for observability in logs.

- Gated behind `_ineffective_compression_count >= 1` so the first-ever compress
  always exercises auth/error/fallback paths before the guard suppresses retries.
- Skipped when `force=True` (manual `/compress`) so user-initiated compression
  is never silently no-op'd.
- Rests **only** in `compress()` — the gateway-facing `has_content_to_compress()`
  remains a simple `compress_start < compress_end` check so the cheap pruning
  path in `gateway/slash_commands.py` is never bypassed.

## 2. `reasoning_content` echo-back for DeepSeek / Kimi / MiMo

Centralized standalone functions `needs_thinking_reasoning_pad()` and
`ensure_reasoning_content_on_messages()` in `agent_runtime_helpers.py`.

Both `auxiliary_client.py` (auxiliary tasks like compression, session search)
and `context_compressor.py` (compressed message rebuild) now use the centralized
helper to ensure every **assistant** message carries `reasoning_content` when
the provider enforces the echo-back — matching the established replay contract
in `copy_reasoning_content_for_api()` which pads ALL assistant turns, not just
tool-call ones.

DeepSeek V4 thinking, Kimi/Moonshot thinking, and Xiaomi MiMo thinking all
require `reasoning_content` on every assistant turn when history is replayed.
Without it, the next API call fails with HTTP 400 ("The reasoning_content in
the thinking mode must be passed back to the API").

Injects a single space character — DeepSeek V4 Pro rejects an empty string with
HTTP 400. A space satisfies non-empty checks everywhere without leaking
fabricated reasoning (refs #17341).

## Changes addressing hermes-sweeper review

- **Removed** per-message token cap (upstream `main` already has no-progress
  protection via `b18490b89`, `32f30d2a4`)
- **Removed** 10% threshold from `has_content_to_compress()` (which would
  bypass cheap pruning in `gateway/slash_commands.py`)
- **Centralized** reasoning normalization contract instead of duplicating it
  in `context_compressor.py`
- **Added** targeted regression coverage: `TestPreLlmFeasibilityCheck` (3 tests)
  and `TestReasoningContentPadding` (11 tests)

## Files changed

| File | Change |
|---|---|
| `agent/agent_runtime_helpers.py` | +90 — `needs_thinking_reasoning_pad()`, `ensure_reasoning_content_on_messages()` standalone functions, exported in `__all__` |
| `agent/auxiliary_client.py` | +16 — calls `ensure_reasoning_content_on_messages()` in `_build_call_kwargs()` |
| `agent/context_compressor.py` | +55 — pre-LLM feasibility check in `compress()`, `ensure_reasoning_content_on_messages()` on compressed output, import from `agent_runtime_helpers` |
| `tests/agent/test_context_compressor.py` | +181 — 14 new tests across two test classes |