### PR TITLE
fix(agent): surface Codex commentary items as interim messages

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4669,6 +4669,7 @@ class AIAgent:
         visible = "\n\n".join(parts).strip()
         if visible:
             visible = self._strip_think_blocks(visible).strip()
+            visible = redact_sensitive_text(visible)
         return visible
 
     def _emit_interim_assistant_message(self, assistant_msg: Dict[str, Any]) -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4632,6 +4632,45 @@ class AIAgent:
         )
         return bool(streamed) and streamed == visible_content
 
+    def _extract_codex_interim_visible_text(self, assistant_msg: Dict[str, Any]) -> str:
+        """Extract visible Codex Responses commentary text.
+
+        Codex Responses can keep user-facing mid-turn narration as structured
+        ``phase=commentary`` message items while final answer text remains in
+        assistant ``content``.  Non-streaming gateway surfaces need that
+        commentary through the interim assistant callback before tool calls run.
+        ``phase=analysis`` remains hidden because it is provider scratchpad.
+        """
+        items = assistant_msg.get("codex_message_items")
+        if not isinstance(items, list):
+            return ""
+
+        parts: List[str] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") != "message":
+                continue
+            phase = item.get("phase")
+            if not isinstance(phase, str) or phase.strip().lower() != "commentary":
+                continue
+            content_parts = item.get("content")
+            if not isinstance(content_parts, list):
+                continue
+            for part in content_parts:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") != "output_text":
+                    continue
+                text = part.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+
+        visible = "\n\n".join(parts).strip()
+        if visible:
+            visible = self._strip_think_blocks(visible).strip()
+        return visible
+
     def _emit_interim_assistant_message(self, assistant_msg: Dict[str, Any]) -> None:
         """Surface a real mid-turn assistant commentary message to the UI layer."""
         cb = getattr(self, "interim_assistant_callback", None)
@@ -4639,6 +4678,8 @@ class AIAgent:
             return
         content = assistant_msg.get("content")
         visible = self._strip_think_blocks(content or "").strip()
+        if not visible or visible == "(empty)":
+            visible = self._extract_codex_interim_visible_text(assistant_msg)
         if not visible or visible == "(empty)":
             return
         already_streamed = self._interim_content_was_streamed(visible)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1986,6 +1986,35 @@ def test_interim_commentary_uses_codex_commentary_items_when_content_is_empty(mo
     }
 
 
+def test_interim_commentary_redacts_secrets_from_codex_commentary_items(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    observed = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: observed.append(text)
+    )
+    secret = "sk-" + ("A" * 32)
+
+    agent._emit_interim_assistant_message({
+        "role": "assistant",
+        "content": "",
+        "codex_message_items": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "phase": "commentary",
+                "content": [
+                    {"type": "output_text", "text": f"Using credential {secret}."}
+                ],
+            },
+        ],
+    })
+
+    assert len(observed) == 1
+    assert secret not in observed[0]
+    assert "Using credential" in observed[0]
+
+
 def test_stream_delta_strips_leaked_memory_context(monkeypatch):
     agent = _build_agent(monkeypatch)
     observed = []

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1941,6 +1941,51 @@ def test_interim_commentary_preserves_assistant_content(monkeypatch):
     assert "I'll inspect the repo structure first." in observed["text"]
 
 
+def test_interim_commentary_uses_codex_commentary_items_when_content_is_empty(monkeypatch):
+    """Codex Responses stores commentary phase text outside content.
+
+    The gateway still needs that visible mid-turn narration to flow through the
+    interim assistant callback; otherwise Discord with streaming disabled gets
+    no natural progress commentary before tools run. Analysis/final-answer items
+    stay hidden from interim delivery.
+    """
+    agent = _build_agent(monkeypatch)
+    observed = {}
+    agent.interim_assistant_callback = lambda text, *, already_streamed=False: observed.update(
+        {"text": text, "already_streamed": already_streamed}
+    )
+
+    agent._emit_interim_assistant_message({
+        "role": "assistant",
+        "content": "",
+        "codex_message_items": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "phase": "analysis",
+                "content": [{"type": "output_text", "text": "Need inspect files."}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "phase": "commentary",
+                "content": [{"type": "output_text", "text": "I'll inspect the repo first."}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "phase": "final_answer",
+                "content": [{"type": "output_text", "text": "Done."}],
+            },
+        ],
+    })
+
+    assert observed == {
+        "text": "I'll inspect the repo first.",
+        "already_streamed": False,
+    }
+
+
 def test_stream_delta_strips_leaked_memory_context(monkeypatch):
     agent = _build_agent(monkeypatch)
     observed = []


### PR DESCRIPTION
## Summary
- surface Codex Responses `phase="commentary"` message items through the existing interim assistant callback when top-level assistant `content` is empty
- pass extracted structured commentary through the existing secret redactor before it reaches Telegram/Discord or another interim callback
- keep `phase="analysis"` and `phase="final_answer"` hidden from interim delivery
- add regression coverage for non-streaming gateway surfaces that rely on interim assistant messages before tool calls

## Why
Codex Responses can store user-facing mid-turn narration in structured `codex_message_items` instead of top-level assistant `content`. `_emit_interim_assistant_message()` only inspected `content`, so non-streaming gateway surfaces could miss natural progress commentary before tool execution even though the callback path was configured.

This keeps the fix narrow: only explicit `phase="commentary"` output text is surfaced, while provider scratchpad/analysis remains hidden.

## Verification
Fresh branch based on current `origin/main` (`1c473bc6a`):

- `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -k 'interim_commentary or commentary_only or codex_commentary' -q -o 'addopts='` → `6 passed, 80 deselected`
- `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='` → `87 passed`
- `python -m pytest tests/agent/test_redact.py -q -o 'addopts='` → `149 passed`
- `python -m pytest tests/run_agent/test_provider_parity.py -k 'codex or commentary or message_items' -q -o 'addopts='` → `38 passed, 55 deselected`
- `python -m pytest tests/gateway -k 'commentary or interim or progress' -q -o 'addopts='` → `119 passed, 1 skipped, 8800 deselected`
- `python -m compileall -q run_agent.py tests/run_agent/test_run_agent_codex_responses.py gateway/run.py gateway/stream_consumer.py` → exit 0
- `python -m ruff check run_agent.py tests/run_agent/test_run_agent_codex_responses.py` → `All checks passed!` (with existing invalid `# noqa` warning at `run_agent.py:107`)
- `git diff --check` → exit 0

Current-main compatibility check (`origin/main` at `46e87b14f`): both PR commits cherry-picked cleanly into a detached worktree, then:

- Codex Responses run-agent suite: `88 passed`
- redaction suite: `149 passed`
- provider parity selection: `38 passed, 55 deselected`
- gateway commentary/interim/progress selection: `145 passed, 1 skipped, 9040 deselected`
- Ruff, `compileall`, and `git diff --check`: passed
