### PR TITLE
Propagate dashboard auth identity to TUI agents

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -59,6 +59,20 @@ from utils import base_url_host_matches, is_truthy_value
 logger = logging.getLogger("run_agent")
 
 
+def _dashboard_env_identity() -> dict[str, str]:
+    """Read non-secret dashboard user identity bridged into child processes."""
+    if os.environ.get("HERMES_SESSION_SOURCE", "").strip() != "dashboard":
+        return {}
+    user_id = os.environ.get("HERMES_SESSION_USER_ID", "").strip()
+    if not user_id or user_id == "server-internal":
+        return {}
+    identity = {"user_id": user_id}
+    user_name = os.environ.get("HERMES_SESSION_USER_NAME", "").strip()
+    if user_name and user_name != user_id:
+        identity["user_name"] = user_name
+    return identity
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.OpenAI`` / ``run_agent.cleanup_vm`` / ... and have those
@@ -391,11 +405,14 @@ def init_agent(
     agent.verbose_logging = verbose_logging
     agent.quiet_mode = quiet_mode
     agent.tool_progress_mode = tool_progress_mode
+    dashboard_identity = _dashboard_env_identity()
+    effective_user_id = user_id or dashboard_identity.get("user_id")
+    effective_user_name = user_name or dashboard_identity.get("user_name")
     agent.ephemeral_system_prompt = ephemeral_system_prompt
     agent.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
-    agent._user_id = user_id  # Platform user identifier (gateway sessions)
+    agent._user_id = effective_user_id  # Platform user identifier (gateway sessions)
     agent._user_id_alt = user_id_alt  # Optional stable alternate platform identifier
-    agent._user_name = user_name
+    agent._user_name = effective_user_name
     agent._chat_id = chat_id
     agent._chat_name = chat_name
     agent._chat_type = chat_type

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -370,6 +370,8 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             session_id=agent.session_id,
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
+            user_id=getattr(agent, "_user_id", None) or "",
+            user_name=getattr(agent, "_user_name", None) or "",
         )
     except Exception as exc:
         logger.warning("on_session_start hook failed: %s", exc)

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -624,7 +624,11 @@ async def api_auth_ws_ticket(request: Request):
     # don't load the ticket store.
     from hermes_cli.dashboard_auth.ws_tickets import TTL_SECONDS, mint_ticket
 
-    ticket = mint_ticket(user_id=sess.user_id, provider=sess.provider)
+    ticket = mint_ticket(
+        user_id=sess.user_id,
+        provider=sess.provider,
+        display_name=sess.display_name,
+    )
     audit_log(
         AuditEvent.WS_TICKET_MINTED,
         provider=sess.provider,

--- a/hermes_cli/dashboard_auth/ws_tickets.py
+++ b/hermes_cli/dashboard_auth/ws_tickets.py
@@ -59,7 +59,7 @@ class TicketInvalid(Exception):
     """Ticket missing, expired, or already consumed."""
 
 
-def mint_ticket(*, user_id: str, provider: str) -> str:
+def mint_ticket(*, user_id: str, provider: str, display_name: str = "") -> str:
     """Generate a one-shot ticket bound to this user identity.
 
     The returned token is base64url, 43 bytes of entropy (32-byte random
@@ -72,6 +72,9 @@ def mint_ticket(*, user_id: str, provider: str) -> str:
         "provider": provider,
         "minted_at": int(time.time()),
     }
+    display = str(display_name or "").strip()
+    if display and display != user_id:
+        info["display_name"] = display
     with _lock:
         _tickets[ticket] = (int(time.time()) + TTL_SECONDS, info)
         _gc_expired_locked()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12691,8 +12691,8 @@ def _ws_auth_mode() -> str:
     return "loopback"
 
 
-def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
-    """Validate WS-upgrade auth; return ``(reason, credential)``.
+def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str, Dict[str, Any]]:
+    """Validate WS-upgrade auth; return ``(reason, credential, identity)``.
 
     ``reason`` is None when the credential is accepted, else a short
     machine-parseable token explaining the rejection (``no_credential``,
@@ -12700,6 +12700,9 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     ``credential`` names which credential type was presented (``ticket``,
     ``internal``, ``token``, or ``none``) so the accepted path can log *how*
     a peer authed, not just that it did.
+    ``identity`` carries non-secret dashboard-auth principal metadata when
+    a browser ticket authenticated the connection. It is empty for legacy
+    tokens, rejected credentials, and server-internal credentials.
 
     Loopback / ``--insecure``: legacy ``?token=<_SESSION_TOKEN>`` query
     parameter, constant-time compared.
@@ -12741,7 +12744,7 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
         if internal:
             try:
                 consume_internal_credential(internal)
-                return None, "internal"
+                return None, "internal", {}
             except TicketInvalid as exc:
                 audit_log(
                     AuditEvent.WS_TICKET_REJECTED,
@@ -12749,15 +12752,22 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                     ip=(ws.client.host if ws.client else ""),
                     path=ws.url.path,
                 )
-                return "internal_invalid", "internal"
+                return "internal_invalid", "internal", {}
 
         ticket = ws.query_params.get("ticket", "")
         if not ticket:
-            return "no_credential", "none"
+            return "no_credential", "none", {}
 
         try:
-            consume_ticket(ticket)
-            return None, "ticket"
+            info = consume_ticket(ticket)
+            identity = {
+                key: value
+                for key, value in dict(info or {}).items()
+                if key in {"user_id", "provider", "user_name", "display_name"} and value
+            }
+            if identity.get("display_name") == identity.get("user_id"):
+                identity.pop("display_name", None)
+            return None, "ticket", identity
         except TicketInvalid as exc:
             audit_log(
                 AuditEvent.WS_TICKET_REJECTED,
@@ -12765,14 +12775,14 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
                 ip=(ws.client.host if ws.client else ""),
                 path=ws.url.path,
             )
-            return "ticket_invalid", "ticket"
+            return "ticket_invalid", "ticket", {}
 
     token = ws.query_params.get("token", "")
     if not token:
-        return "no_credential", "none"
+        return "no_credential", "none", {}
     if hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
-        return None, "token"
-    return "token_mismatch", "token"
+        return None, "token", {}
+    return "token_mismatch", "token", {}
 
 
 def _ws_auth_ok(ws: "WebSocket") -> bool:
@@ -12792,6 +12802,7 @@ def _resolve_chat_argv(
     sidecar_url: Optional[str] = None,
     profile: Optional[str] = None,
     active_session_file: Optional[str] = None,
+    dashboard_identity: Optional[Dict[str, Any]] = None,
 ) -> tuple[list[str], Optional[str], Optional[dict]]:
     """Resolve the argv + cwd + env for the chat PTY.
 
@@ -12827,6 +12838,10 @@ def _resolve_chat_argv(
     ``HERMES_TUI_GATEWAY_URL`` attach is SKIPPED for scoped chats: the
     dashboard's in-memory gateway runs under the dashboard's own profile,
     so a profile-scoped chat must spawn its own gateway subprocess.
+
+    `dashboard_identity` (when set by a dashboard-auth browser ticket) is
+    forwarded via the existing ``HERMES_SESSION_USER_*`` env bridge so the
+    TUI gateway can pass the authenticated user id to ``AIAgent``.
     """
     from hermes_cli.main import PROJECT_ROOT, _make_tui_argv
 
@@ -12852,6 +12867,22 @@ def _resolve_chat_argv(
     env.setdefault("HERMES_TUI_DISABLE_MOUSE", "1")
     env.setdefault("HERMES_TUI_INLINE", "1")
     env["HERMES_TUI_DASHBOARD"] = "1"
+
+    dashboard_user_id = str((dashboard_identity or {}).get("user_id") or "").strip()
+    if dashboard_user_id:
+        env["HERMES_SESSION_PLATFORM"] = "tui"
+        env["HERMES_SESSION_SOURCE"] = "dashboard"
+        env["HERMES_SESSION_USER_ID"] = dashboard_user_id
+        dashboard_user_name = str(
+            (dashboard_identity or {}).get("user_name")
+            or (dashboard_identity or {}).get("display_name")
+            or ""
+        ).strip()
+        if dashboard_user_name and dashboard_user_name != dashboard_user_id:
+            env["HERMES_SESSION_USER_NAME"] = dashboard_user_name
+        dashboard_provider = str((dashboard_identity or {}).get("provider") or "").strip()
+        if dashboard_provider:
+            env["HERMES_DASHBOARD_AUTH_PROVIDER"] = dashboard_provider
 
     if profile_dir is not None:
         env["HERMES_HOME"] = str(profile_dir)
@@ -12955,6 +12986,7 @@ async def _resolve_chat_argv_async(
     sidecar_url: Optional[str] = None,
     profile: Optional[str] = None,
     active_session_file: Optional[str] = None,
+    dashboard_identity: Optional[Dict[str, Any]] = None,
 ) -> tuple[list[str], Optional[str], Optional[dict]]:
     """Resolve chat argv without blocking the dashboard event loop.
 
@@ -12973,6 +13005,8 @@ async def _resolve_chat_argv_async(
     }
     if active_session_file is not None:
         kwargs["active_session_file"] = active_session_file
+    if dashboard_identity is not None:
+        kwargs["dashboard_identity"] = dashboard_identity
 
     async with _get_chat_argv_lock(app):
         return await asyncio.to_thread(
@@ -13312,7 +13346,7 @@ async def console_ws(ws: WebSocket) -> None:
         await ws.close(code=4404, reason="embedded chat disabled")
         return
 
-    auth_reason, cred = _ws_auth_reason(ws)
+    auth_reason, cred, _dashboard_identity = _ws_auth_reason(ws)
     mode = _ws_auth_mode()
     if auth_reason is not None:
         _log.warning(
@@ -13674,7 +13708,7 @@ async def pty_ws(ws: WebSocket) -> None:
     #     browser banner agree on the cause:
     #       4401 bad credential   4403 host/origin mismatch
     #       4408 peer not allowed  4404 chat disabled
-    auth_reason, cred = _ws_auth_reason(ws)
+    auth_reason, cred, dashboard_identity = _ws_auth_reason(ws)
     mode = _ws_auth_mode()
     if auth_reason is not None:
         _log.warning(
@@ -13739,6 +13773,8 @@ async def pty_ws(ws: WebSocket) -> None:
     }
     if active_session_file is not None:
         resolve_kwargs["active_session_file"] = str(active_session_file)
+    if dashboard_identity:
+        resolve_kwargs["dashboard_identity"] = dashboard_identity
 
     try:
         argv, cwd, env = await _resolve_chat_argv_async(**resolve_kwargs)
@@ -13864,7 +13900,8 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
-    if not _ws_auth_ok(ws):
+    auth_reason, _cred, dashboard_identity = _ws_auth_reason(ws)
+    if auth_reason is not None:
         await ws.close(code=4401)
         return
 
@@ -13874,7 +13911,7 @@ async def gateway_ws(ws: WebSocket) -> None:
 
     from tui_gateway.ws import handle_ws
 
-    await handle_ws(ws)
+    await handle_ws(ws, dashboard_identity=dashboard_identity)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_agent_init_dashboard_identity.py
+++ b/tests/agent/test_agent_init_dashboard_identity.py
@@ -1,0 +1,28 @@
+from agent import agent_init
+
+
+def test_dashboard_env_identity_requires_dashboard_source(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "alice")
+    monkeypatch.setenv("HERMES_SESSION_USER_NAME", "Alice Example")
+    monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
+
+    assert agent_init._dashboard_env_identity() == {}
+
+
+def test_dashboard_env_identity_reads_non_secret_user_fields(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "dashboard")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "alice")
+    monkeypatch.setenv("HERMES_SESSION_USER_NAME", "Alice Example")
+
+    assert agent_init._dashboard_env_identity() == {
+        "user_id": "alice",
+        "user_name": "Alice Example",
+    }
+
+
+def test_dashboard_env_identity_does_not_use_user_id_as_name(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "dashboard")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "alice")
+    monkeypatch.setenv("HERMES_SESSION_USER_NAME", "alice")
+
+    assert agent_init._dashboard_env_identity() == {"user_id": "alice"}

--- a/tests/agent/test_conversation_loop_identity.py
+++ b/tests/agent/test_conversation_loop_identity.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+from agent import conversation_loop
+
+
+def test_on_session_start_hook_receives_agent_identity(monkeypatch):
+    captured = {}
+
+    def fake_invoke_hook(event, **kwargs):
+        captured["event"] = event
+        captured["kwargs"] = kwargs
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+    monkeypatch.setattr(
+        "agent.credits_tracker.seed_credits_at_session_start",
+        lambda _agent: None,
+    )
+    agent = SimpleNamespace(
+        _session_db=None,
+        _user_id="alice",
+        _user_name="Alice Example",
+        model="gpt-5.5",
+        platform="tui",
+        provider="openai-codex",
+        session_id="session-1",
+        _build_system_prompt=lambda system_message=None: "system prompt",
+    )
+
+    conversation_loop._restore_or_build_system_prompt(
+        agent,
+        system_message=None,
+        conversation_history=[],
+    )
+
+    assert captured["event"] == "on_session_start"
+    assert captured["kwargs"]["session_id"] == "session-1"
+    assert captured["kwargs"]["platform"] == "tui"
+    assert captured["kwargs"]["user_id"] == "alice"
+    assert captured["kwargs"]["user_name"] == "Alice Example"

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -24,6 +24,7 @@ from hermes_cli.dashboard_auth import clear_providers, register_provider
 from hermes_cli.dashboard_auth.ws_tickets import (
     _reset_for_tests,
     consume_internal_credential,
+    consume_ticket,
     internal_ws_credential,
     mint_ticket,
 )
@@ -120,6 +121,9 @@ class TestWsTicketEndpoint:
         assert isinstance(body["ticket"], str)
         assert len(body["ticket"]) >= 32
         assert body["ttl_seconds"] == 30
+        info = consume_ticket(body["ticket"])
+        assert info["user_id"] == "stub-user-1"
+        assert info["display_name"] == "Stub User"
 
     def test_unauthenticated_returns_401_or_redirect(self, gated_app):
         r = gated_app.post("/api/auth/ws-ticket", follow_redirects=False)
@@ -228,6 +232,49 @@ class TestWsAuthOkGated:
         ticket = mint_ticket(user_id="u1", provider="stub")
         ws = _fake_ws(query={"ticket": ticket})
         assert web_server._ws_auth_ok(ws) is True
+
+    def test_valid_ticket_identity_is_returned(self, gated_app):
+        ticket = mint_ticket(user_id="u1", provider="stub", display_name="User One")
+        ws = _fake_ws(query={"ticket": ticket})
+
+        reason, credential, identity = web_server._ws_auth_reason(ws)
+
+        assert reason is None
+        assert credential == "ticket"
+        assert identity == {
+            "user_id": "u1",
+            "provider": "stub",
+            "display_name": "User One",
+        }
+
+    def test_ticket_identity_does_not_use_user_id_as_display_name(self, gated_app):
+        ticket = mint_ticket(user_id="u1", provider="stub", display_name="u1")
+        ws = _fake_ws(query={"ticket": ticket})
+
+        reason, credential, identity = web_server._ws_auth_reason(ws)
+
+        assert reason is None
+        assert credential == "ticket"
+        assert identity == {"user_id": "u1", "provider": "stub"}
+
+    def test_legacy_token_has_no_dashboard_identity(self, loopback_app):
+        ws = _fake_ws(query={"token": web_server._SESSION_TOKEN})
+
+        reason, credential, identity = web_server._ws_auth_reason(ws)
+
+        assert reason is None
+        assert credential == "token"
+        assert identity == {}
+
+    def test_internal_credential_has_no_browser_identity(self, gated_app):
+        cred = internal_ws_credential()
+        ws = _fake_ws(query={"internal": cred})
+
+        reason, credential, identity = web_server._ws_auth_reason(ws)
+
+        assert reason is None
+        assert credential == "internal"
+        assert identity == {}
 
     def test_consumed_ticket_rejected(self, gated_app):
         ticket = mint_ticket(user_id="u1", provider="stub")

--- a/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_tickets.py
@@ -41,6 +41,22 @@ class TestMintAndConsume:
         assert info["provider"] == "nous"
         assert "minted_at" in info
 
+    def test_round_trip_includes_display_name(self):
+        ticket = mint_ticket(
+            user_id="u1",
+            provider="nous",
+            display_name="User One",
+        )
+        info = consume_ticket(ticket)
+        assert info["user_id"] == "u1"
+        assert info["display_name"] == "User One"
+
+    def test_display_name_does_not_duplicate_user_id(self):
+        ticket = mint_ticket(user_id="u1", provider="nous", display_name="u1")
+        info = consume_ticket(ticket)
+        assert info["user_id"] == "u1"
+        assert "display_name" not in info
+
     def test_ticket_has_minimum_length(self):
         # ``secrets.token_urlsafe(32)`` produces ~43 chars; enforce a floor
         # so a future refactor can't accidentally shrink the entropy.

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5919,6 +5919,43 @@ class TestPtyWebSocket:
         assert env["HERMES_TUI_INLINE"] == "1"
         assert env["HERMES_TUI_DISABLE_MOUSE"] == "1"
 
+    def test_resolve_chat_argv_forwards_dashboard_identity(self, monkeypatch):
+        import hermes_cli.main as main_mod
+
+        monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
+        monkeypatch.setattr(
+            main_mod,
+            "_make_tui_argv",
+            lambda project_root, tui_dev=False: (["node", "dist/entry.js"], "/tmp/ui-tui"),
+        )
+
+        _argv, _cwd, env = self.ws_module._resolve_chat_argv(
+            dashboard_identity={"user_id": "alice", "display_name": "Alice Example"}
+        )
+
+        assert env["HERMES_SESSION_PLATFORM"] == "tui"
+        assert env["HERMES_SESSION_SOURCE"] == "dashboard"
+        assert env["HERMES_SESSION_USER_ID"] == "alice"
+        assert env["HERMES_SESSION_USER_NAME"] == "Alice Example"
+
+    def test_resolve_chat_argv_leaves_identity_unset_without_ticket(self, monkeypatch):
+        import hermes_cli.main as main_mod
+
+        monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
+        monkeypatch.setattr(
+            main_mod,
+            "_make_tui_argv",
+            lambda project_root, tui_dev=False: (["node", "dist/entry.js"], "/tmp/ui-tui"),
+        )
+
+        _argv, _cwd, env = self.ws_module._resolve_chat_argv()
+
+        assert "HERMES_SESSION_USER_ID" not in env
+        assert "HERMES_SESSION_USER_NAME" not in env
+        assert "HERMES_SESSION_SOURCE" not in env
+
     def test_resolve_chat_argv_applies_terminal_backend_config(
         self, monkeypatch, _isolate_hermes_home
     ):
@@ -6045,6 +6082,83 @@ class TestPtyWebSocket:
                 pass
 
         assert captured["resume"] == "sess-99"
+
+    def test_pty_ws_passes_ticket_identity_to_resolver(self, monkeypatch):
+        from hermes_cli.dashboard_auth.ws_tickets import mint_ticket
+
+        captured: dict = {}
+        monkeypatch.setattr(self.ws_module.app.state, "auth_required", True, raising=False)
+        monkeypatch.setattr(
+            self.ws_module.app.state, "bound_host", "example.test", raising=False
+        )
+        monkeypatch.setattr(self.ws_module.app.state, "bound_port", 443, raising=False)
+
+        async def fake_resolve_async(
+            resume=None,
+            sidecar_url=None,
+            profile=None,
+            active_session_file=None,
+            dashboard_identity=None,
+        ):
+            captured["dashboard_identity"] = dashboard_identity
+            return (["/bin/sh", "-c", "printf ticket-identity-ok"], None, None)
+
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv_async", fake_resolve_async)
+        ticket = mint_ticket(
+            user_id="alice",
+            provider="stub",
+            display_name="Alice Example",
+        )
+
+        with self.client.websocket_connect(
+            f"/api/pty?ticket={ticket}",
+            headers={"host": "example.test", "origin": "https://example.test"},
+        ) as conn:
+            try:
+                conn.receive_bytes()
+            except Exception:
+                pass
+
+        assert captured["dashboard_identity"] == {
+            "user_id": "alice",
+            "provider": "stub",
+            "display_name": "Alice Example",
+        }
+
+    def test_gateway_ws_passes_ticket_identity_to_tui_ws(self, monkeypatch):
+        from hermes_cli.dashboard_auth.ws_tickets import mint_ticket
+        from tui_gateway import ws as tui_ws
+
+        captured: dict = {}
+        monkeypatch.setattr(self.ws_module.app.state, "auth_required", True, raising=False)
+        monkeypatch.setattr(
+            self.ws_module.app.state, "bound_host", "example.test", raising=False
+        )
+        monkeypatch.setattr(self.ws_module.app.state, "bound_port", 443, raising=False)
+
+        async def fake_handle(ws, *, dashboard_identity=None):
+            captured["dashboard_identity"] = dashboard_identity
+            await ws.accept()
+            await ws.close()
+
+        monkeypatch.setattr(tui_ws, "handle_ws", fake_handle)
+        ticket = mint_ticket(
+            user_id="alice",
+            provider="stub",
+            display_name="Alice Example",
+        )
+
+        with self.client.websocket_connect(
+            f"/api/ws?ticket={ticket}",
+            headers={"host": "example.test", "origin": "https://example.test"},
+        ):
+            pass
+
+        assert captured["dashboard_identity"] == {
+            "user_id": "alice",
+            "provider": "stub",
+            "display_name": "Alice Example",
+        }
 
     def _assert_pty_propagates(self, monkeypatch, raising_resolver, *, profile=None, expect_detail=None):
         """Drive /api/pty with a resolver that raises, and assert the error

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -88,6 +88,78 @@ def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
         server._sessions.pop(sid, None)
 
 
+def test_session_context_uses_dashboard_identity_env(monkeypatch, tmp_path):
+    from gateway.session_context import get_session_env
+
+    session_key = "dashboard-key"
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "dashboard")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "alice")
+    monkeypatch.setenv("HERMES_SESSION_USER_NAME", "Alice Example")
+    server._sessions["dashboard-sid"] = {
+        "session_key": session_key,
+        "cwd": str(tmp_path),
+        "source": "tui",
+    }
+
+    try:
+        tokens = server._set_session_context(session_key)
+        try:
+            assert get_session_env("HERMES_SESSION_USER_ID") == "alice"
+            assert get_session_env("HERMES_SESSION_USER_NAME") == "Alice Example"
+        finally:
+            server._clear_session_context(tokens)
+    finally:
+        server._sessions.pop("dashboard-sid", None)
+
+
+def test_session_context_uses_stored_dashboard_identity(monkeypatch, tmp_path):
+    from gateway.session_context import get_session_env
+
+    session_key = "dashboard-key"
+    server._sessions["dashboard-sid"] = {
+        "session_key": session_key,
+        "cwd": str(tmp_path),
+        "source": "tui",
+        "dashboard_identity": {
+            "user_id": "alice",
+            "display_name": "Alice Example",
+            "provider": "stub",
+        },
+    }
+
+    try:
+        tokens = server._set_session_context(session_key)
+        try:
+            assert get_session_env("HERMES_SESSION_USER_ID") == "alice"
+            assert get_session_env("HERMES_SESSION_USER_NAME") == "Alice Example"
+        finally:
+            server._clear_session_context(tokens)
+    finally:
+        server._sessions.pop("dashboard-sid", None)
+
+
+def test_dispatch_binds_dashboard_identity_for_session_create(monkeypatch):
+    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+    server._sessions.clear()
+    try:
+        resp = server.dispatch(
+            {"id": "1", "method": "session.create", "params": {"cols": 80}},
+            dashboard_identity={
+                "user_id": "alice",
+                "display_name": "Alice Example",
+                "provider": "stub",
+            },
+        )
+        sid = resp["result"]["session_id"]
+        assert server._sessions[sid]["dashboard_identity"] == {
+            "user_id": "alice",
+            "user_name": "Alice Example",
+            "provider": "stub",
+        }
+    finally:
+        server._sessions.clear()
+
+
 def test_handoff_fail_marks_only_inflight_rows(monkeypatch):
     class DbContext:
         def __init__(self, db):
@@ -1719,6 +1791,79 @@ def test_make_agent_passes_configured_fallback_chain(monkeypatch):
     assert captured["platform"] == "tui"
 
 
+def test_make_agent_passes_dashboard_identity(monkeypatch):
+    captured = {}
+
+    def fake_agent(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(model=kwargs.get("model"))
+
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "dashboard")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "alice")
+    monkeypatch.setenv("HERMES_SESSION_USER_NAME", "Alice Example")
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_TUI_PROVIDER", raising=False)
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"model": {"default": "gpt-5.5", "provider": "openai-codex"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, target_model=None: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "token",
+            "api_mode": "codex_responses",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr("run_agent.AIAgent", fake_agent)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    server._make_agent("sid", "session-key")
+
+    assert captured["user_id"] == "alice"
+    assert captured["user_name"] == "Alice Example"
+
+
+def test_slash_worker_receives_dashboard_identity_env(monkeypatch):
+    captured = {}
+
+    class FakeProc:
+        stdin = None
+        stdout = None
+        stderr = None
+
+        def poll(self):
+            return None
+
+    def fake_popen(*args, **kwargs):
+        captured["env"] = kwargs["env"]
+        return FakeProc()
+
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+
+    server._SlashWorker(
+        "session-key",
+        "gpt-5.5",
+        dashboard_identity={
+            "user_id": "alice",
+            "display_name": "Alice Example",
+            "provider": "stub",
+        },
+    )
+
+    env = captured["env"]
+    assert env["HERMES_SESSION_PLATFORM"] == "tui"
+    assert env["HERMES_SESSION_SOURCE"] == "dashboard"
+    assert env["HERMES_SESSION_USER_ID"] == "alice"
+    assert env["HERMES_SESSION_USER_NAME"] == "Alice Example"
+    assert env["HERMES_DASHBOARD_AUTH_PROVIDER"] == "stub"
+
+
 def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
     chain = [
         {"provider": "openrouter", "model": "openai/gpt-5.5"},
@@ -1736,6 +1881,23 @@ def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
     kwargs = server._background_agent_kwargs(agent, "task-id")
 
     assert kwargs["fallback_model"] == chain
+
+
+def test_background_agent_kwargs_preserves_dashboard_identity(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="gpt-5.5",
+        provider="openai-codex",
+        _user_id="alice",
+        _user_name="Alice Example",
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 25})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    kwargs = server._background_agent_kwargs(agent, "task-id")
+
+    assert kwargs["user_id"] == "alice"
+    assert kwargs["user_name"] == "Alice Example"
 
 
 def test_background_agent_kwargs_preserves_empty_fallback_chain(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -275,7 +275,13 @@ _detached_ws_transport = _DropTransport()
 class _SlashWorker:
     """Persistent HermesCLI subprocess for slash commands."""
 
-    def __init__(self, session_key: str, model: str, profile_home: str | None = None):
+    def __init__(
+        self,
+        session_key: str,
+        model: str,
+        profile_home: str | None = None,
+        dashboard_identity: dict | None = None,
+    ):
         self._lock = threading.Lock()
         self._seq = 0
         self.stderr_tail: list[str] = []
@@ -297,6 +303,7 @@ class _SlashWorker:
         # slash_worker runs the Hermes agent → needs provider credentials.
         # Tier-1 secrets (gateway/GitHub/infra) are still stripped (#29157).
         env = hermes_subprocess_env(inherit_credentials=True)
+        _apply_dashboard_identity_env(env, dashboard_identity)
         if profile_home:
             # Global-remote / multi-profile sessions: the worker must resolve
             # config/skills/state against the session's profile home, not the
@@ -1164,7 +1171,12 @@ def handle_request(req: dict) -> dict | None:
     return fn(rid, params)
 
 
-def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
+def dispatch(
+    req: dict,
+    transport: Optional[Transport] = None,
+    *,
+    dashboard_identity: dict | None = None,
+) -> dict | None:
     """Route inbound RPCs — long handlers to the pool, everything else inline.
 
     Returns a response dict when handled inline. Returns None when the
@@ -1178,6 +1190,9 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
     """
     t = transport or _stdio_transport
     token = bind_transport(t)
+    identity_token = _dashboard_identity_context.set(
+        _normalize_dashboard_identity(dashboard_identity)
+    )
     try:
         normalized = _normalize_request(req)
         if isinstance(normalized, dict):
@@ -1202,6 +1217,7 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
 
         return None
     finally:
+        _dashboard_identity_context.reset(identity_token)
         reset_transport(token)
 
 
@@ -1310,6 +1326,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     key,
                     getattr(agent, "model", _resolve_model()),
                     profile_home=current.get("profile_home"),
+                    dashboard_identity=current.get("dashboard_identity"),
                 )
                 _attach_worker(sid, current, worker)
             except Exception:
@@ -1558,6 +1575,76 @@ def _session_source(session: dict | None) -> str:
         if source:
             return source
     return "tui"
+
+
+_dashboard_identity_context: contextvars.ContextVar[dict[str, str]] = contextvars.ContextVar(
+    "dashboard_identity",
+    default={},
+)
+
+
+def _normalize_dashboard_identity(identity: dict | None) -> dict[str, str]:
+    if not isinstance(identity, dict):
+        return {}
+    result: dict[str, str] = {}
+    user_id = str(identity.get("user_id") or "").strip()
+    if user_id and user_id != "server-internal":
+        result["user_id"] = user_id
+    user_name = str(
+        identity.get("user_name") or identity.get("display_name") or ""
+    ).strip()
+    if user_name and user_name != user_id:
+        result["user_name"] = user_name
+    provider = str(identity.get("provider") or "").strip()
+    if provider:
+        result["provider"] = provider
+    return result
+
+
+def _current_dashboard_identity(identity: dict | None = None) -> dict[str, str]:
+    normalized = _normalize_dashboard_identity(identity)
+    if normalized.get("user_id"):
+        return normalized
+
+    context_identity = _normalize_dashboard_identity(_dashboard_identity_context.get({}))
+    if context_identity.get("user_id"):
+        return context_identity
+
+    try:
+        from gateway.session_context import get_session_env
+
+        if get_session_env("HERMES_SESSION_SOURCE") == "dashboard":
+            session_identity = _normalize_dashboard_identity({
+                "user_id": get_session_env("HERMES_SESSION_USER_ID"),
+                "user_name": get_session_env("HERMES_SESSION_USER_NAME"),
+                "provider": get_session_env("HERMES_DASHBOARD_AUTH_PROVIDER"),
+            })
+            if session_identity.get("user_id"):
+                return session_identity
+    except Exception:
+        pass
+
+    if os.environ.get("HERMES_SESSION_SOURCE", "").strip() != "dashboard":
+        return {}
+    return _normalize_dashboard_identity({
+        "user_id": os.environ.get("HERMES_SESSION_USER_ID", ""),
+        "user_name": os.environ.get("HERMES_SESSION_USER_NAME", ""),
+        "provider": os.environ.get("HERMES_DASHBOARD_AUTH_PROVIDER", ""),
+    })
+
+
+def _apply_dashboard_identity_env(env: dict[str, str], identity: dict | None = None) -> None:
+    ident = _current_dashboard_identity(identity)
+    user_id = ident.get("user_id", "")
+    if not user_id:
+        return
+    env["HERMES_SESSION_PLATFORM"] = "tui"
+    env["HERMES_SESSION_SOURCE"] = "dashboard"
+    env["HERMES_SESSION_USER_ID"] = user_id
+    if ident.get("user_name"):
+        env["HERMES_SESSION_USER_NAME"] = ident["user_name"]
+    if ident.get("provider"):
+        env["HERMES_DASHBOARD_AUTH_PROVIDER"] = ident["provider"]
 
 
 def _register_session_cwd(session: dict | None) -> None:
@@ -1892,7 +1979,11 @@ def _cwd_for_session_key(session_key: str) -> str:
     return ""
 
 
-def _set_session_context(session_key: str, cwd: str | None = None) -> list:
+def _set_session_context(
+    session_key: str,
+    cwd: str | None = None,
+    dashboard_identity: dict | None = None,
+) -> list:
     try:
         from gateway.session_context import set_session_vars
 
@@ -1906,8 +1997,18 @@ def _set_session_context(session_key: str, cwd: str | None = None) -> list:
             for sess in list(_sessions.values()):
                 if sess.get("session_key") == session_key:
                     source = _session_source(sess)
+                    if dashboard_identity is None:
+                        dashboard_identity = sess.get("dashboard_identity")
                     break
-        return set_session_vars(session_key=session_key, source=source, cwd=resolved)
+        identity = _current_dashboard_identity(dashboard_identity)
+        return set_session_vars(
+            platform="tui",
+            session_key=session_key,
+            source=source,
+            cwd=resolved,
+            user_id=identity.get("user_id", ""),
+            user_name=identity.get("user_name", ""),
+        )
     except Exception:
         return []
 
@@ -2640,6 +2741,7 @@ def _restart_slash_worker(sid: str, session: dict):
             session["session_key"],
             getattr(session.get("agent"), "model", _resolve_model()),
             profile_home=session.get("profile_home"),
+            dashboard_identity=session.get("dashboard_identity"),
         )
     except Exception:
         session["slash_worker"] = None
@@ -4015,6 +4117,8 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "service_tier": getattr(agent, "service_tier", None) or _load_service_tier(),
         "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "platform": "tui",
+        "user_id": getattr(agent, "_user_id", None) or None,
+        "user_name": getattr(agent, "_user_name", None) or None,
         "session_db": _get_db(),
         "fallback_model": _agent_fallback_model(agent),
     }
@@ -4419,6 +4523,7 @@ def _make_agent(
             "target_model": model or None,
         })
     _pr = _load_provider_routing()
+    identity = _current_dashboard_identity()
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 90),
@@ -4456,6 +4561,8 @@ def _make_agent(
         provider_require_parameters=_pr.get("require_parameters", False),
         provider_data_collection=_pr.get("data_collection"),
         platform="tui",
+        user_id=identity.get("user_id") or None,
+        user_name=identity.get("user_name") or None,
         session_id=session_id or key,
         session_db=session_db if session_db is not None else _get_db(),
         ephemeral_system_prompt=system_prompt or None,
@@ -4530,6 +4637,7 @@ def _init_session(
                 key,
                 getattr(agent, "model", _resolve_model()),
                 profile_home=_sessions[sid].get("profile_home"),
+                dashboard_identity=_sessions[sid].get("dashboard_identity"),
             ),
         )
     except Exception:
@@ -5018,6 +5126,7 @@ def _(rid, params: dict) -> dict:
     # and each turn re-bind HERMES_HOME. None/own profile → launch (unchanged).
     profile = (params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
+    dashboard_identity = _current_dashboard_identity(params.get("dashboard_identity"))
 
     # The desktop composer owns its model/effort/fast as plain UI state and ships
     # it on every session.create. Honor each as a PER-SESSION override (built into
@@ -5065,6 +5174,7 @@ def _(rid, params: dict) -> dict:
             "history_version": 0,
             "image_counter": 0,
             "cwd": resolved_cwd,
+            "dashboard_identity": dashboard_identity,
             "inflight_turn": None,
             "last_active": now,
             "model_override": session_model_override,
@@ -12727,6 +12837,7 @@ def _(rid, params: dict) -> dict:
                 session["session_key"],
                 getattr(session.get("agent"), "model", _resolve_model()),
                 profile_home=session.get("profile_home"),
+                dashboard_identity=session.get("dashboard_identity"),
             )
             _attach_worker(params.get("session_id", ""), session, worker)
         except Exception as e:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -280,7 +280,7 @@ def _disable_nagle(ws: Any) -> None:
         _log.debug("ws TCP_NODELAY skip: %s", exc)
 
 
-async def handle_ws(ws: Any) -> None:
+async def handle_ws(ws: Any, *, dashboard_identity: dict | None = None) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``."""
     peer = _ws_peer_label(ws)
     transport: WSTransport | None = None
@@ -385,7 +385,12 @@ async def handle_ws(ws: Any) -> None:
             req_id = req.get("id") if isinstance(req, dict) else None
             req_method = req.get("method") if isinstance(req, dict) else None
             try:
-                resp = await asyncio.to_thread(server.dispatch, req, transport)
+                resp = await asyncio.to_thread(
+                    server.dispatch,
+                    req,
+                    transport,
+                    dashboard_identity=dashboard_identity,
+                )
             except Exception:
                 dispatch_crashes += 1
                 _log.exception(


### PR DESCRIPTION
## Summary

Fixes #35408.

Dashboard auth already mints WebSocket tickets that contain the authenticated dashboard principal, but the dashboard chat paths discarded that identity before it reached the TUI agent runtime. As a result, dashboard-authenticated chat sessions could reach `AIAgent` without `user_id`, so user-scoped memory, session hooks, background/slash-worker agents, and audit-style integrations could not reliably distinguish authenticated dashboard users.

This PR preserves that identity through both dashboard chat paths:

- WS tickets now carry a minimal, non-secret identity payload: `user_id`, `provider`, and optional `display_name`.
- `_ws_auth_reason()` returns that allowlisted identity for browser ticket authentication.
- `/api/pty` passes browser identity into the spawned TUI child via the existing `HERMES_SESSION_USER_*` convention.
- `/api/ws` passes browser identity into `tui_gateway.ws.handle_ws()`, then into `tui_gateway.server.dispatch()`.
- `tui_gateway` binds the identity to the created session, session context, `AIAgent(user_id=..., user_name=...)`, and TUI slash-worker subprocess env.
- Child agent processes read the dashboard env bridge in `agent_init` when `HERMES_SESSION_SOURCE=dashboard`.
- Background TUI agents inherit the parent agent identity.
- `on_session_start` hooks receive `user_id` and `user_name`, matching the agent session identity.

## Compatibility

- Loopback and `--insecure` token-based WebSocket auth continue to authenticate as before and do not set dashboard identity.
- Gated server-internal WebSocket credentials continue to work for server-spawned child connections and intentionally do not become a browser user identity.
- The change is provider-agnostic: password, OAuth/OIDC, and other dashboard auth providers work through the existing `Session.user_id` / `Session.display_name` -> WS ticket path.
- `display_name` is treated as optional display metadata. If a provider's display name duplicates `user_id`, it is not forwarded as a human name.
- The child-process env fallback is source-gated by `HERMES_SESSION_SOURCE=dashboard`, so ordinary CLI/cron/API flows do not inherit dashboard identity accidentally.

## Tests

- `uv run --extra dev python -m pytest tests/hermes_cli/test_dashboard_auth_ws_tickets.py tests/hermes_cli/test_dashboard_auth_ws_auth.py tests/hermes_cli/test_web_server.py::TestPtyWebSocket tests/test_tui_gateway_ws.py tests/test_tui_gateway_server.py::test_session_context_uses_dashboard_identity_env tests/test_tui_gateway_server.py::test_session_context_uses_stored_dashboard_identity tests/test_tui_gateway_server.py::test_dispatch_binds_dashboard_identity_for_session_create tests/test_tui_gateway_server.py::test_make_agent_passes_dashboard_identity tests/test_tui_gateway_server.py::test_slash_worker_receives_dashboard_identity_env tests/test_tui_gateway_server.py::test_background_agent_kwargs_preserves_dashboard_identity tests/agent/test_agent_init_dashboard_identity.py tests/agent/test_conversation_loop_identity.py -q`
- `uv run --extra dev ruff check hermes_cli/dashboard_auth/ws_tickets.py hermes_cli/dashboard_auth/routes.py hermes_cli/web_server.py tui_gateway/ws.py tui_gateway/server.py agent/agent_init.py agent/conversation_loop.py tests/hermes_cli/test_dashboard_auth_ws_tickets.py tests/hermes_cli/test_dashboard_auth_ws_auth.py tests/hermes_cli/test_web_server.py tests/test_tui_gateway_server.py tests/agent/test_agent_init_dashboard_identity.py tests/agent/test_conversation_loop_identity.py`
- `uv run --extra dev python -m py_compile hermes_cli/dashboard_auth/ws_tickets.py hermes_cli/dashboard_auth/routes.py hermes_cli/web_server.py tui_gateway/ws.py tui_gateway/server.py agent/agent_init.py agent/conversation_loop.py tests/hermes_cli/test_dashboard_auth_ws_tickets.py tests/hermes_cli/test_dashboard_auth_ws_auth.py tests/hermes_cli/test_web_server.py tests/test_tui_gateway_server.py tests/agent/test_agent_init_dashboard_identity.py tests/agent/test_conversation_loop_identity.py`
