### PR TITLE
fix(gateway): reset weixin rate-limit cooldown on next attempt instead of permanent block (#60116)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1752,8 +1752,14 @@ class WeixinAdapter(BasePlatformAdapter):
         last_error: Optional[Exception] = None
         retried_without_token = False
         for attempt in range(self._send_chunk_retries + 1):
-            if self._rate_limit_cooldown_remaining() > 0:
-                raise self._rate_limit_error()
+            remaining = self._rate_limit_cooldown_remaining()
+            if remaining > 0:
+                logger.info(
+                    "[%s] rate-limit cooldown active; waiting %.1fs before retry",
+                    self.name, remaining,
+                )
+                await asyncio.sleep(remaining)
+                # Cooldown expired — continue to the API call below
             try:
                 resp = await _send_message(
                     self._send_session,


### PR DESCRIPTION
Resets weixin rate-limit cooldown on next attempt instead of permanent block. Changes the early-exit `raise` to `await asyncio.sleep(remaining)` so sends wait for cooldown to expire then retry. Closes #60116