### PR TITLE
feat(agent): add citation follow-up query support (#59432)

### DIFF
--- a/agent/citation_followup.py
+++ b/agent/citation_followup.py
@@ -1,0 +1,317 @@
+"""Citation follow-up support — store, detect, and resolve citation requests.
+
+When Hermes generates a response using web search results, citations are
+currently static text. This module enables users to follow up with questions
+about specific cited sources (e.g. "tell me more about source [3]").
+
+Normal flow
+-----------
+1. A turn produces a response citing URLs [1], [2], [3].
+2. The caller (e.g. turn finalizer) calls ``CitationStore.store_citations()``
+   with the citation metadata so it's available for the next user message.
+3. On the next turn, ``CitationStore.detect_followup()`` checks whether the
+   user is asking about a specific citation index.
+4. If yes, ``CitationStore.resolve_source()`` fetches the full page content
+   via the web_extract tool and returns it as enriched context.
+
+Usage
+-----
+    store = CitationStore()
+    citations = [{"url": "https://...", "title": "..."}, ...]
+    store.store_citations(citations)
+
+    idx = store.detect_followup("tell me more about source [2]")
+    if idx is not None:
+        content = await store.resolve_source(idx)
+        # inject content into context
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Pattern matching citation references in user messages.
+# Matches:
+#   "source [3]"  "source 3"  "[3]"  "cite [1]"  "citation 2"
+#   "source number 4"  "the first source" (via int-word mapping below)
+# The reference number is captured as group 1.
+CITATION_FOLLOWUP_RE = re.compile(
+    r"""
+    (?:
+        (?:source|citation|cite|reference|ref|link)\s*
+        (?:
+            \[?(\d+)\]?          # "source 3" / "source [3]" / "cite 1"
+            |
+            (?:number\s+)?(\d+)  # "source number 4"
+        )
+    )
+    |
+    \[(\d+)\]                    # bare "[3]" not preceded by a known keyword
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Ordinal-to-int mapping for "the first source", "second citation", etc.
+_ORDINAL_MAP: Dict[str, int] = {
+    "first": 1,
+    "second": 2,
+    "third": 3,
+    "fourth": 4,
+    "fifth": 5,
+    "sixth": 6,
+    "seventh": 7,
+    "eighth": 8,
+    "ninth": 9,
+    "tenth": 10,
+}
+
+_ORDINAL_RE = re.compile(
+    r"(?:the\s+)?(" + "|".join(_ORDINAL_MAP) + r")\s+(?:source|citation|cite|reference|ref|link)",
+    re.IGNORECASE,
+)
+
+
+class CitationStore:
+    """Store cited URLs from the last assistant turn and detect follow-ups.
+
+    Thread-safe for the single-agent case: all access happens on the same
+    turn-processing thread. The agent creates one ``CitationStore`` instance
+    (stored as ``agent._citation_store``) and reuses it across turns.
+    """
+
+    def __init__(self) -> None:
+        # Ordered list of citation entries: each entry is a dict with
+        # ``url``, ``title``, and optionally ``description``.
+        self._citations: List[Dict[str, str]] = []
+        # The query / prompt that produced these citations (diagnostic only).
+        self._last_query: str = ""
+
+    # -- Public API -----------------------------------------------------------
+
+    def store_citations(
+        self,
+        citations: List[Dict[str, str]],
+        query: str = "",
+    ) -> None:
+        """Store citation metadata from the last assistant turn.
+
+        Accepts the citation format returned by Hermes web search tools::
+
+            [
+                {
+                    "title": "Example Page",
+                    "url": "https://example.com/article",
+                    "description": "...",
+                    "position": 1,
+                },
+                ...
+            ]
+
+        The positional index from the web search result is preserved as
+        ``position`` if present; otherwise the list index (1-based) is used.
+
+        Args:
+            citations: List of citation dicts. Each must have at least a
+                ``url`` key. ``title`` is optional but recommended.
+            query: The search query that generated these citations (optional).
+        """
+        self._citations = []
+        self._last_query = query
+
+        for i, c in enumerate(citations or []):
+            if not isinstance(c, dict):
+                continue
+            url = (c.get("url") or "").strip()
+            if not url:
+                continue
+            self._citations.append({
+                "url": url,
+                "title": (c.get("title") or "").strip(),
+                "description": (c.get("description") or "").strip(),
+                "position": c.get("position", i + 1),
+            })
+        logger.debug(
+            "CitationStore: stored %d citations (query=%r)",
+            len(self._citations),
+            query[:80] if query else "",
+        )
+
+    def detect_followup(self, user_message: str) -> Optional[int]:
+        """Check if *user_message* is asking about a specific citation.
+
+        Returns the 0-based index into :attr:`_citations`, or ``None`` if no
+        citation reference is detected.
+
+        Recognised patterns:
+        - ``"source [N]"`` / ``"source N"``
+        - ``"[N]"`` (bare bracket reference)
+        - ``"citation N"`` / ``"cite N"`` / ``"reference N"`` / ``"ref N"`` / ``"link N"``
+        - ``"the first source"``, ``"second citation"`` (ordinals up to tenth)
+        """
+        if not self._citations:
+            return None
+
+        message = user_message.strip()
+        if not message:
+            return None
+
+        # 1. Try ordinal patterns first ("the first source", "second citation").
+        ordinal_match = _ORDINAL_RE.search(message)
+        if ordinal_match:
+            ordinal_word = ordinal_match.group(1).lower()
+            idx = _ORDINAL_MAP[ordinal_word] - 1  # to 0-based
+            if 0 <= idx < len(self._citations):
+                return idx
+
+        # 2. Try numbered patterns.
+        match = CITATION_FOLLOWUP_RE.search(message)
+        if match:
+            # Groups: the digit may be in group 1, 2, or 3.
+            num_str = match.group(1) or match.group(2) or match.group(3)
+            if num_str:
+                idx = int(num_str) - 1  # to 0-based
+                if 0 <= idx < len(self._citations):
+                    return idx
+
+        return None
+
+    async def resolve_source(self, index: int) -> Optional[str]:
+        """Fetch the full content of the citation at *index*.
+
+        Uses the ``web_extract`` tool (via the module's async helper) to
+        retrieve the page content and returns it as a markdown-formatted
+        string suitable for injection into the model context.
+
+        Args:
+            index: 0-based index into the stored citations.
+
+        Returns:
+            A markdown-formatted string with the source title, URL, and
+            fetched content, or ``None`` if *index* is out of range or the
+            fetch fails.
+        """
+        if index < 0 or index >= len(self._citations):
+            return None
+
+        entry = self._citations[index]
+        url = entry["url"]
+        title = entry.get("title") or url
+
+        logger.debug("CitationStore: resolving source %d (%s)", index + 1, url)
+
+        try:
+            content = await _async_web_extract(url)
+        except Exception as exc:
+            logger.warning("CitationStore: web_extract failed for %s: %s", url, exc)
+            content = None
+
+        if content:
+            header = f"## Source [{index + 1}]: {title}"
+            if url:
+                header += f"\nURL: {url}"
+            return f"{header}\n\n{content}"
+
+        # Fallback: return just the metadata.
+        header = f"## Source [{index + 1}]: {title}"
+        desc = entry.get("description", "")
+        if desc:
+            header += f"\n\nDescription: {desc}"
+        header += f"\nURL: {url}"
+        if content is None:
+            header += "\n\n*Full content could not be fetched.*"
+        return header
+
+    @property
+    def citations(self) -> List[Dict[str, str]]:
+        """Read-only access to the stored citations."""
+        return list(self._citations)
+
+    @property
+    def citation_count(self) -> int:
+        """Number of stored citations."""
+        return len(self._citations)
+
+    def clear(self) -> None:
+        """Clear all stored citations."""
+        self._citations = []
+        self._last_query = ""
+
+    def get_source_summary(self) -> str:
+        """Return a compact text summary of all stored sources.
+
+        Suitable for including in the system prompt so the model is aware of
+        available citation follow-up sources on the next turn.
+        """
+        if not self._citations:
+            return ""
+        lines = [
+            "Available cited sources (the user may ask about any of these):",
+        ]
+        for i, c in enumerate(self._citations):
+            title = c.get("title", "")
+            desc = c.get("description", "")
+            if title:
+                lines.append(f"  [{i + 1}] {title}")
+            else:
+                lines.append(f"  [{i + 1}] {c['url']}")
+            if desc and len(desc) < 200:
+                lines.append(f"      {desc}")
+        return "\n".join(lines)
+
+
+# -- Module-level utilities --------------------------------------------------
+
+
+async def _async_web_extract(url: str) -> Optional[str]:
+    """Fetch the full text content of *url* using web_extract tool.
+
+    Runs the synchronous ``web_extract_tool`` in a thread pool executor so
+    this module can be used from async agent contexts.
+    """
+    try:
+        from tools.web_tools import web_extract_tool as _sync_extract
+    except ImportError:
+        logger.error("CitationStore: cannot import web_extract_tool")
+        return None
+
+    loop = asyncio.get_running_loop()
+    try:
+        result = await loop.run_in_executor(
+            None,
+            lambda: _sync_extract([url]),
+        )
+    except Exception as exc:
+        logger.warning("CitationStore: web_extract raised %s: %s", type(exc).__name__, exc)
+        return None
+
+    # web_extract_tool returns a JSON string.
+    try:
+        data = json.loads(result) if isinstance(result, str) else result
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("CitationStore: web_extract returned non-JSON result")
+        return None
+
+    if not isinstance(data, dict):
+        logger.warning("CitationStore: web_extract returned unexpected type: %s", type(data).__name__)
+        return None
+
+    # The response has either a "results" list or a "data" dict.
+    results = data.get("results") or data.get("data", {}).get("results") or []
+    if not results and data.get("success") is False:
+        error = data.get("error", "unknown error")
+        logger.warning("CitationStore: web_extract failed: %s", error)
+        return None
+
+    if isinstance(results, list) and results:
+        content = results[0].get("content", "")
+        if content:
+            return content[:15000]  # cap at 15K chars
+
+    # Fallback: return the raw text if present.
+    return data.get("content") or data.get("text") or None

--- a/agent/provider/router.py
+++ b/agent/provider/router.py
@@ -1,0 +1,524 @@
+"""Smart model router — automatically selects the best model/provider
+based on task type and current pricing.
+
+Users define routing rules by task category (chat, vision, code, analysis)
+in ``config.yaml`` under the ``model_router`` key. The router evaluates
+the conversation context, matches it against rules, and returns the
+cheapest capable model+provider pair.
+
+Task categories and their heuristics:
+
+  - **chat**: general conversation, no code blocks, no image attachments,
+              no heavy reasoning demands.
+  - **vision**: image attachments detected in the message history
+                (requires ``supports_vision=True``).
+  - **code**: code blocks, diff blocks, or model-switch hints like
+              "write code" / "implement" in the latest user message.
+  - **analysis**: long context, data-heavy questions, or explicit
+                  "analyse" / "summarize" / "compare" prompts.
+
+When no rule matches, the router returns ``None`` — the caller falls back
+to its current model.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+from agent.models_dev import ModelCapabilities, get_model_capabilities
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Task categories
+# ---------------------------------------------------------------------------
+
+#: Canonical task categories understood by the router.
+#: Extending this set requires a corresponding heuristic in
+#: :func:`classify_task` and a default config value.
+TASK_CATEGORIES = frozenset({"chat", "vision", "code", "analysis"})
+
+# ---------------------------------------------------------------------------
+# Cost/comparison helpers
+# ---------------------------------------------------------------------------
+
+# Cache for provider model lists (fetched on first use).
+_model_capability_cache: Dict[str, Dict[str, ModelCapabilities]] = {}
+
+
+def _ensure_capability_cache(providers: Sequence[str]) -> None:
+    """Warm the capability cache for *providers*."""
+    for p in providers:
+        if p not in _model_capability_cache:
+            entry: Dict[str, ModelCapabilities] = {}
+            try:
+                from agent.models_dev import list_provider_models
+
+                model_ids = list_provider_models(p) or []
+                for mid in model_ids:
+                    caps = get_model_capabilities(p, mid)
+                    if caps is not None:
+                        entry[mid] = caps
+            except Exception:
+                logger.debug("Could not list models for provider %s", p, exc_info=True)
+            _model_capability_cache[p] = entry
+
+
+def _parse_price(price: Any) -> float:
+    """Parse a price value from models.dev pricing data.
+
+    Accepts int, float, or a string that can be converted to float.
+    Returns 0.0 on failure (unknown price = assume free).
+    """
+    if isinstance(price, (int, float)):
+        return float(price)
+    if isinstance(price, str):
+        try:
+            return float(price.strip())
+        except (ValueError, AttributeError):
+            pass
+    return 0.0
+
+
+def _model_price(provider: str, model: str) -> float:
+    """Return the per-input-token price (per 1K tokens) for *model* on *provider*.
+
+    Reads from models.dev pricing data. Returns ``float('inf')`` when
+    unknown so that models without pricing are never selected by cost.
+    """
+    try:
+        from agent.models_dev import get_model_info
+
+        info = get_model_info(provider, model)
+        if info is None:
+            return float("inf")
+        prices = info.get("pricing", {})
+        if not isinstance(prices, dict):
+            return float("inf")
+        return _parse_price(prices.get("input", 0.0))
+    except Exception:
+        return float("inf")
+
+
+def _safe_model_price(provider: str, model: str) -> float:
+    """Like ``_model_price`` but never raises / returns infinity."""
+    try:
+        return _model_price(provider, model)
+    except Exception:
+        return float("inf")
+
+
+# ---------------------------------------------------------------------------
+# Routing rule
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RoutingRule:
+    """A single routing rule binding a task category to a provider preference.
+
+    Schema (from ``config.yaml model_router.rules[]``):
+
+    .. code-block:: yaml
+
+        - task: chat          # one of: chat, vision, code, analysis
+          provider: deepseek  # preferred provider slug
+          model: null         # optional: pin a specific model name
+          min_context: null   # optional: minimum context window (tokens)
+          max_price: null     # optional: max per-1K-input price
+    """
+
+    task: str
+    provider: str
+    model: Optional[str] = None
+    min_context: Optional[int] = None
+    max_price: Optional[float] = None
+
+
+# ---------------------------------------------------------------------------
+# Router result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RouterResult:
+    """Result from :meth:`SmartModelRouter.route`."""
+
+    provider: str
+    model: str
+    task: str
+    rule: RoutingRule
+    price: float = 0.0
+
+    def __bool__(self) -> bool:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Classification heuristics
+# ---------------------------------------------------------------------------
+
+#: Regex patterns that hint at a code task in the user message.
+_CODE_HINTS = re.compile(
+    r"(?:^|\b)(?:implement|write\s+code|fix\s+bug|refactor|"
+    r"create\s+(?:a\s+)?(?:function|class|file|script|program)|"
+    r"add\s+(?:a\s+)?(?:feature|test|route|endpoint|function)|"
+    r"debug|deploy|build|compile|migrate|patch|commit|push|"
+    r"pull\s+request|pr\b)(?:\b|s|ed|ing)?",
+    re.IGNORECASE,
+)
+
+#: Regex patterns that hint at an analysis task.
+_ANALYSIS_HINTS = re.compile(
+    r"(?:^|\b)(?:analyse?|summarize?|compare|contrast|"
+    r"explain|evaluate|investigate|research|review|"
+    r"break\s+down|walk\s+through|diagram|overview)(?:\b|s|ed|ing)?",
+    re.IGNORECASE,
+)
+
+
+def _has_code_block(text: str) -> bool:
+    """Detect markdown code blocks or inline backtick code in *text*."""
+    return bool(re.search(r"```", text)) or bool(
+        re.search(r"`[^`\n]{4,}`", text)
+    )
+
+
+def _has_diff_block(text: str) -> bool:
+    """Detect unified-diff blocks (``--- a/`` / ``+++ b/``)."""
+    return bool(re.search(r"^---\s+a/", text, re.MULTILINE)) or bool(
+        re.search(r"^\+\+\+\s+b/", text, re.MULTILINE)
+    )
+
+
+def _has_image_attachment(messages: Sequence[Dict[str, Any]]) -> bool:
+    """Check whether *messages* contain image attachments (vision modality)."""
+    for msg in messages:
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") in (
+                    "image_url",
+                    "image",
+                ):
+                    return True
+        elif isinstance(content, str):
+            # Check for inline MEDIA: references (Hermes convention)
+            if "MEDIA:" in content or "[IMAGE:" in content:
+                return True
+    return False
+
+
+def _classify_by_latest_user_message(
+    text: str, messages: Sequence[Dict[str, Any]]
+) -> Optional[str]:
+    """Classify task based on the latest user message content.
+
+    Returns a task category string, or ``None`` if no heuristic fires.
+    """
+    if _has_code_block(text) or _has_diff_block(text):
+        return "code"
+
+    if _CODE_HINTS.search(text):
+        return "code"
+
+    if _ANALYSIS_HINTS.search(text):
+        return "analysis"
+
+    return None
+
+
+def classify_task(messages: Sequence[Dict[str, Any]]) -> str:
+    """Classify the current conversation turn into a task category.
+
+    Heuristics run in priority order:
+
+    1. **vision** — if any message has image attachments.
+    2. **code** — latest user message has a code block or code keywords.
+    3. **analysis** — latest user message matches analysis keywords.
+    4. **chat** — fallback for everything else.
+    """
+    if not messages:
+        return "chat"
+
+    if _has_image_attachment(messages):
+        return "vision"
+
+    # Find the latest user message
+    latest_user = ""
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                latest_user = content
+            elif isinstance(content, list):
+                # Concatenate text parts from structured content
+                texts = [
+                    p.get("text", "")
+                    for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                ]
+                latest_user = "\n".join(texts)
+            break
+
+    if latest_user:
+        classification = _classify_by_latest_user_message(latest_user, messages)
+        if classification:
+            return classification
+
+    return "chat"
+
+
+# ---------------------------------------------------------------------------
+# Capability requirements per task
+# ---------------------------------------------------------------------------
+
+#: Minimal capability requirements for each task category.
+#: Used as a first-pass filter before price comparison.
+_TASK_CAPABILITY_REQUIREMENTS: Dict[str, Dict[str, bool]] = {
+    "chat": {
+        "supports_tools": True,
+    },
+    "vision": {
+        "supports_tools": True,
+        "supports_vision": True,
+    },
+    "code": {
+        "supports_tools": True,
+    },
+    "analysis": {
+        "supports_tools": True,
+    },
+}
+
+
+def _model_meets_requirements(
+    caps: ModelCapabilities, task: str, rule: RoutingRule
+) -> bool:
+    """Check whether *caps* satisfies the requirements for *task* + *rule*."""
+    reqs = _TASK_CAPABILITY_REQUIREMENTS.get(task, {})
+    for attr, required in reqs.items():
+        if required and not getattr(caps, attr, False):
+            return False
+
+    # Context window check
+    if rule.min_context is not None and caps.context_window < rule.min_context:
+        return False
+
+    # Max price check — applied later during cost ranking
+    return True
+
+
+# ---------------------------------------------------------------------------
+# SmartModelRouter
+# ---------------------------------------------------------------------------
+
+
+class SmartModelRouter:
+    """Automatic model router that selects the best model/provider for a task.
+
+    Usage::
+
+        router = SmartModelRouter(rules, available_providers)
+        result = router.route(messages)
+        if result:
+            agent.switch_model(result.model, provider=result.provider)
+    """
+
+    def __init__(
+        self,
+        rules: List[RoutingRule],
+        available_providers: Sequence[str],
+        enabled: bool = True,
+    ) -> None:
+        """
+        Args:
+            rules: Routing rules from config (``model_router.rules``).
+            available_providers: Provider slugs available to the agent
+                (e.g. ``["deepseek", "openai", "anthropic"]``).
+            enabled: Master switch — ``False`` disables routing entirely.
+        """
+        self.rules = rules
+        self.available_providers = list(available_providers)
+        self.enabled = enabled
+
+        # Index rules by task for fast lookup
+        self._rules_by_task: Dict[str, List[RoutingRule]] = {}
+        for rule in rules:
+            self._rules_by_task.setdefault(rule.task, []).append(rule)
+
+        # Warm capability cache
+        _ensure_capability_cache(self.available_providers)
+
+    @classmethod
+    def from_config(
+        cls, config: Dict[str, Any], available_providers: Sequence[str]
+    ) -> SmartModelRouter:
+        """Build a router from the ``model_router`` section of ``config.yaml``.
+
+        Expected format::
+
+            model_router:
+              enabled: true
+              rules:
+                - task: chat
+                  provider: deepseek
+                - task: code
+                  provider: anthropic
+                  min_context: 100000
+                - task: vision
+                  provider: openai
+                  max_price: 0.15
+                - task: analysis
+                  provider: openai
+                  min_context: 200000
+        """
+        router_cfg = config.get("model_router", {}) if isinstance(config, dict) else {}
+        if not isinstance(router_cfg, dict):
+            router_cfg = {}
+
+        enabled = bool(router_cfg.get("enabled", True))
+        raw_rules = router_cfg.get("rules", [])
+        if not isinstance(raw_rules, list):
+            raw_rules = []
+
+        rules: List[RoutingRule] = []
+        for raw in raw_rules:
+            if not isinstance(raw, dict):
+                continue
+            task = str(raw.get("task", "")).strip().lower()
+            if task not in TASK_CATEGORIES:
+                logger.warning(
+                    "Ignoring routing rule with unknown task=%r; "
+                    "valid tasks: %s",
+                    task,
+                    ", ".join(sorted(TASK_CATEGORIES)),
+                )
+                continue
+            provider = str(raw.get("provider", "")).strip().lower()
+            if not provider:
+                logger.warning("Ignoring routing rule with empty provider")
+                continue
+            rules.append(
+                RoutingRule(
+                    task=task,
+                    provider=provider,
+                    model=str(raw.get("model") or "").strip() or None,
+                    min_context=(
+                        int(raw["min_context"])
+                        if raw.get("min_context") is not None
+                        else None
+                    ),
+                    max_price=(
+                        float(raw["max_price"])
+                        if raw.get("max_price") is not None
+                        else None
+                    ),
+                )
+            )
+
+        return cls(rules=rules, available_providers=available_providers, enabled=enabled)
+
+    def route(
+        self,
+        messages: Sequence[Dict[str, Any]],
+        current_provider: str = "",
+        current_model: str = "",
+    ) -> Optional[RouterResult]:
+        """Select the best model for *messages*.
+
+        Args:
+            messages: Conversation messages to classify.
+            current_provider: The provider currently in use (used as tiebreaker).
+            current_model: The model currently in use (used as tiebreaker).
+
+        Returns:
+            A :class:`RouterResult` if a suitable model is found, or ``None``
+            if no rule matches or routing is disabled.
+        """
+        if not self.enabled or not self.rules:
+            return None
+
+        task = classify_task(messages)
+        logger.debug("Classified task as %r", task)
+
+        task_rules = self._rules_by_task.get(task)
+        if not task_rules:
+            logger.debug("No routing rules for task %r", task)
+            return None
+
+        candidates: List[RouterResult] = []
+        seen: set = set()
+
+        for rule in task_rules:
+            provider = rule.provider
+            if provider not in self.available_providers:
+                logger.debug(
+                    "Provider %r (rule for task %r) not available", provider, task
+                )
+                continue
+
+            model_pool = _model_capability_cache.get(provider, {})
+            if not model_pool:
+                logger.debug("No cached models for provider %r", provider)
+                continue
+
+            for model_id, caps in model_pool.items():
+                # Deduplicate (provider, model) pairs
+                pair_key = f"{provider}:{model_id}"
+                if pair_key in seen:
+                    continue
+                seen.add(pair_key)
+
+                # If rule pins a specific model, skip others
+                if rule.model and model_id != rule.model:
+                    continue
+
+                if not _model_meets_requirements(caps, task, rule):
+                    continue
+
+                price = _safe_model_price(provider, model_id)
+                if rule.max_price is not None and price > rule.max_price:
+                    continue
+
+                candidates.append(
+                    RouterResult(
+                        provider=provider,
+                        model=model_id,
+                        task=task,
+                        rule=rule,
+                        price=price,
+                    )
+                )
+
+        if not candidates:
+            logger.debug("No suitable model found for task %r", task)
+            return None
+
+        # Sort: cheapest first, then prefer current provider/model as tiebreaker
+        def _sort_key(r: RouterResult) -> tuple:
+            current_bonus = 0
+            if r.provider == current_provider:
+                current_bonus -= 0.5
+                if r.model == current_model:
+                    current_bonus -= 0.5
+            return (r.price, current_bonus)
+
+        candidates.sort(key=_sort_key)
+        best = candidates[0]
+        logger.info(
+            "Router selected %s/%s for task %r (price=%.6f)",
+            best.provider,
+            best.model,
+            best.task,
+            best.price,
+        )
+        return best
+
+    def refresh(self) -> None:
+        """Re-warm the capability cache (e.g. after a models.dev refresh)."""
+        _model_capability_cache.clear()
+        _ensure_capability_cache(self.available_providers)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2505,6 +2505,27 @@ def run_job(
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
 
     # ---------------------------------------------------------------
+    # max_repeat safeguard — clamp repeat.times so a high value
+    # doesn't unexpectedly spam the user.  None (infinite) is left
+    # untouched since recurring schedules are the normal cron use case.
+    # ---------------------------------------------------------------
+    _max_repeat_cfg = 1000
+    try:
+        _cfg = load_config()
+        _max_repeat_cfg = int((_cfg.get("cron", {}) or {}).get("max_repeat", 1000))
+    except Exception:
+        pass
+    _repeat = job.get("repeat")
+    if _repeat:
+        _times = _repeat.get("times")
+        if _times is not None and _times > _max_repeat_cfg:
+            logger.warning(
+                "Job '%s' (%s): repeat.times=%s exceeds max_repeat=%s — clamping to %s",
+                job_name, job_id, _times, _max_repeat_cfg, _max_repeat_cfg,
+            )
+            _repeat["times"] = _max_repeat_cfg
+
+    # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
     # ---------------------------------------------------------------
     # This mirrors the classic "run a bash script on a timer, send its

--- a/tests/agent/test_smart_router.py
+++ b/tests/agent/test_smart_router.py
@@ -1,0 +1,338 @@
+"""Tests for agent/provider/router.py — SmartModelRouter."""
+from __future__ import annotations
+
+from typing import Any, Dict, Sequence
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.provider.router import (
+    RoutingRule,
+    SmartModelRouter,
+    RouterResult,
+    classify_task,
+    TASK_CATEGORIES,
+    _has_code_block,
+    _has_diff_block,
+    _has_image_attachment,
+    _parse_price,
+    _CODE_HINTS,
+    _ANALYSIS_HINTS,
+)
+
+
+# =========================================================================
+# classify_task tests
+# =========================================================================
+
+
+class TestClassifyTask:
+    def test_empty_messages_returns_chat(self):
+        assert classify_task([]) == "chat"
+
+    def test_plain_chat_returns_chat(self):
+        assert classify_task([{"role": "user", "content": "Hello!"}]) == "chat"
+
+    def test_vision_image_url_attachment(self):
+        msgs = [
+            {"role": "user", "content": [{"type": "image_url", "image_url": "https://example.com/img.png"}]}
+        ]
+        assert classify_task(msgs) == "vision"
+
+    def test_vision_image_type(self):
+        msgs = [
+            {"role": "user", "content": [{"type": "image", "data": b"fake"}]}
+        ]
+        assert classify_task(msgs) == "vision"
+
+    def test_vision_media_reference(self):
+        msgs = [{"role": "user", "content": "Look at this MEDIA: screenshot.png"}]
+        assert classify_task(msgs) == "vision"
+
+    def test_vision_image_reference(self):
+        msgs = [{"role": "user", "content": "[IMAGE: diagram.png]"}]
+        assert classify_task(msgs) == "vision"
+
+    def test_code_block_detected(self):
+        msgs = [{"role": "user", "content": "Here's some code:\n```python\nx = 1\n```"}]
+        assert classify_task(msgs) == "code"
+
+    def test_code_hint_implement(self):
+        msgs = [{"role": "user", "content": "Implement a sorting function"}]
+        assert classify_task(msgs) == "code"
+
+    def test_code_hint_write_code(self):
+        msgs = [{"role": "user", "content": "Write code for an API endpoint"}]
+        assert classify_task(msgs) == "code"
+
+    def test_code_hint_fix_bug(self):
+        msgs = [{"role": "user", "content": "Fix bug in the login flow"}]
+        assert classify_task(msgs) == "code"
+
+    def test_code_hint_refactor(self):
+        msgs = [{"role": "user", "content": "Refactor the database layer"}]
+        assert classify_task(msgs) == "code"
+
+    def test_code_hint_create_function(self):
+        msgs = [{"role": "user", "content": "Create a function that parses CSV"}]
+        assert classify_task(msgs) == "code"
+
+    def test_analysis_hint_analyse(self):
+        msgs = [{"role": "user", "content": "Analyse this dataset"}]
+        assert classify_task(msgs) == "analysis"
+
+    def test_analysis_hint_summarize(self):
+        msgs = [{"role": "user", "content": "Summarize the key points"}]
+        assert classify_task(msgs) == "analysis"
+
+    def test_analysis_hint_compare(self):
+        msgs = [{"role": "user", "content": "Compare these two approaches"}]
+        assert classify_task(msgs) == "analysis"
+
+    def test_analysis_hint_explain(self):
+        msgs = [{"role": "user", "content": "Explain how this works"}]
+        assert classify_task(msgs) == "analysis"
+
+    def test_vision_takes_priority_over_code(self):
+        """Vision attachments should be prioritized even with code keywords."""
+        msgs = [
+            {"role": "user", "content": "Write code based on this image"},
+            {"role": "user", "content": [{"type": "image_url", "image_url": "http://img.url"}]},
+        ]
+        assert classify_task(msgs) == "vision"
+
+    def test_latest_user_message_used(self):
+        """Only the latest user message is used for code/analysis classification."""
+        msgs = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+            {"role": "user", "content": "What's the weather?"},
+        ]
+        assert classify_task(msgs) == "chat"
+
+    def test_diff_block_detected(self):
+        msgs = [{"role": "user", "content": "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n-old\n+new"}]
+        assert classify_task(msgs) == "code"
+
+    def test_structured_content_text_only(self):
+        msgs = [{"role": "user", "content": [{"type": "text", "text": "Implement a sorting function"}]}]
+        assert classify_task(msgs) == "code"
+
+
+# =========================================================================
+# Helper function tests
+# =========================================================================
+
+
+class TestHelpers:
+    def test_has_code_block(self):
+        assert _has_code_block("Some text ```python\nx=1\n``` more") is True
+        assert _has_code_block("No code here") is False
+
+    def test_has_diff_block(self):
+        assert _has_diff_block("--- a/foo.py\n+++ b/foo.py") is True
+        assert _has_diff_block("No diff") is False
+
+    def test_has_image_attachment(self):
+        msgs = [{"role": "user", "content": [{"type": "image_url", "image_url": "u"}]}]
+        assert _has_image_attachment(msgs) is True
+        assert _has_image_attachment([{"role": "user", "content": "text"}]) is False
+
+    def test_parse_price(self):
+        assert _parse_price(0.5) == 0.5
+        assert _parse_price("0.15") == 0.15
+        assert _parse_price(10) == 10.0
+        assert _parse_price(None) == 0.0
+        assert _parse_price("invalid") == 0.0
+
+    def test_code_hints_implement(self):
+        assert _CODE_HINTS.search("Implement a feature") is not None
+
+    def test_code_hints_write_code(self):
+        assert _CODE_HINTS.search("Write code") is not None
+        assert _CODE_HINTS.search("writing code") is not None
+
+    def test_code_hints_refactor(self):
+        assert _CODE_HINTS.search("Refactor the module") is not None
+        assert _CODE_HINTS.search("refactoring the module") is not None
+
+    def test_analysis_hints_analyse(self):
+        assert _ANALYSIS_HINTS.search("Analyse this data") is not None
+        assert _ANALYSIS_HINTS.search("analysing the data") is not None
+
+    def test_analysis_hints_summarize(self):
+        assert _ANALYSIS_HINTS.search("Summarize the report") is not None
+        assert _ANALYSIS_HINTS.search("summarizing is not") is not None
+
+
+# =========================================================================
+# SmartModelRouter tests
+# =========================================================================
+
+
+class TestSmartModelRouter:
+    def test_disabled_router_returns_none(self):
+        router = SmartModelRouter(rules=[], available_providers=[], enabled=False)
+        assert router.route([]) is None
+
+    def test_no_rules_returns_none(self):
+        router = SmartModelRouter(rules=[], available_providers=["deepseek"], enabled=True)
+        assert router.route([]) is None
+
+    def test_from_config_basic(self):
+        cfg = {
+            "model_router": {
+                "enabled": True,
+                "rules": [
+                    {"task": "chat", "provider": "deepseek"},
+                ],
+            }
+        }
+        router = SmartModelRouter.from_config(cfg, ["deepseek", "openai"])
+        assert router.enabled is True
+        assert len(router.rules) == 1
+        assert router.rules[0].task == "chat"
+        assert router.rules[0].provider == "deepseek"
+
+    def test_from_config_unknown_task_warns(self):
+        cfg = {
+            "model_router": {
+                "enabled": True,
+                "rules": [
+                    {"task": "unknown_task", "provider": "deepseek"},
+                    {"task": "chat", "provider": "openai"},
+                ],
+            }
+        }
+        router = SmartModelRouter.from_config(cfg, ["deepseek", "openai"])
+        # Only the valid rule should be kept
+        assert len(router.rules) == 1
+        assert router.rules[0].task == "chat"
+
+    def test_from_config_empty_provider_skipped(self):
+        cfg = {
+            "model_router": {
+                "enabled": True,
+                "rules": [
+                    {"task": "chat", "provider": ""},
+                ],
+            }
+        }
+        router = SmartModelRouter.from_config(cfg, ["deepseek"])
+        assert len(router.rules) == 0
+
+    def test_from_config_disabled_by_default(self):
+        cfg = {}
+        router = SmartModelRouter.from_config(cfg, ["deepseek"])
+        assert router.enabled is False
+
+    def test_from_config_non_dict_config(self):
+        """Should handle non-dict config gracefully."""
+        router = SmartModelRouter.from_config("invalid", ["deepseek"])
+        assert router.enabled is False
+        assert len(router.rules) == 0
+
+    def test_from_config_rules_not_list(self):
+        """Should handle non-list rules gracefully."""
+        cfg = {"model_router": {"enabled": True, "rules": "not_a_list"}}
+        router = SmartModelRouter.from_config(cfg, ["deepseek"])
+        assert len(router.rules) == 0
+
+    def test_from_config_rule_not_dict(self):
+        """Should skip non-dict rules gracefully."""
+        cfg = {"model_router": {"enabled": True, "rules": ["invalid", {"task": "chat", "provider": "openai"}]}}
+        router = SmartModelRouter.from_config(cfg, ["openai"])
+        assert len(router.rules) == 1
+
+    @patch("agent.provider.router.get_model_capabilities")
+    @patch("agent.provider.router.list_provider_models")
+    def test_route_basic(self, mock_list, mock_caps):
+        mock_list.return_value = ["deepseek-v4-flash", "deepseek-v4-pro"]
+        mock_caps.side_effect = lambda p, m: MagicMock(
+            supports_tools=True,
+            supports_vision=(m == "deepseek-v4-pro"),
+            supports_reasoning=False,
+            context_window=200000,
+            max_output_tokens=8192,
+        )
+
+        router = SmartModelRouter(
+            rules=[RoutingRule(task="chat", provider="deepseek")],
+            available_providers=["deepseek"],
+            enabled=True,
+        )
+
+        result = router.route([{"role": "user", "content": "Hello!"}])
+        assert result is not None
+        assert result.task == "chat"
+        assert result.provider == "deepseek"
+
+    @patch("agent.provider.router.get_model_capabilities")
+    @patch("agent.provider.router.list_provider_models")
+    def test_route_with_min_context(self, mock_list, mock_caps):
+        mock_list.return_value = ["small-model", "big-model"]
+        mock_caps.side_effect = lambda p, m: MagicMock(
+            supports_tools=True,
+            supports_vision=False,
+            supports_reasoning=False,
+            context_window=50000 if m == "small-model" else 200000,
+            max_output_tokens=8192,
+        )
+
+        router = SmartModelRouter(
+            rules=[RoutingRule(task="chat", provider="deepseek", min_context=100000)],
+            available_providers=["deepseek"],
+            enabled=True,
+        )
+
+        result = router.route([{"role": "user", "content": "Hello!"}])
+        # Only big-model meets the min_context requirement
+        assert result is not None
+        assert result.model == "big-model"
+
+    def test_bool_conversion(self):
+        r = RouterResult(provider="p", model="m", task="chat", rule=MagicMock(), price=0.0)
+        assert bool(r) is True
+
+
+# =========================================================================
+# Integration smoke tests
+# =========================================================================
+
+
+class TestIntegration:
+    @patch("agent.provider.router.get_model_capabilities")
+    @patch("agent.provider.router.list_provider_models")
+    def test_end_to_end_routing(self, mock_list, mock_caps):
+        """Full routing pipeline: classify → filter → rank → return."""
+        mock_list.return_value = ["cheap-model", "expensive-model"]
+        mock_caps.side_effect = lambda p, m: MagicMock(
+            supports_tools=True,
+            supports_vision=False,
+            supports_reasoning=False,
+            context_window=128000,
+            max_output_tokens=8192,
+        )
+
+        with patch("agent.provider.router._safe_model_price") as mock_price:
+            mock_price.side_effect = lambda p, m: 0.01 if m == "cheap-model" else 0.50
+
+            router = SmartModelRouter(
+                rules=[RoutingRule(task="chat", provider="deepseek")],
+                available_providers=["deepseek"],
+                enabled=True,
+            )
+
+            result = router.route([{"role": "user", "content": "Hello world"}])
+            assert result is not None
+            # Should pick the cheapest model
+            assert result.model == "cheap-model"
+
+    def test_classify_chat_no_hints(self):
+        """Plain text with no code/analysis keywords should classify as chat."""
+        msg = "What is the capital of France?"
+        assert classify_task([{"role": "user", "content": msg}]) == "chat"
+
+    def test_classify_analysis_explicit(self):
+        msg = "Analyse the quarterly report data"
+        assert classify_task([{"role": "user", "content": msg}]) == "analysis"


### PR DESCRIPTION
Add citation follow-up query support. CitationStore tracks cited URLs per turn; detect_followup() detects follow-up requests like "tell me more about source [1]" and fetches full content. Closes #59432