### PR TITLE
feat(claude): add parity support for Codex-style extended thinking features (#59856)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2635,17 +2635,29 @@ def build_anthropic_kwargs(
     #
     # On 4.7+ the `thinking.display` field defaults to "omitted", which
     # silently hides reasoning text that Hermes surfaces in its CLI. We
-    # request "summarized" so the reasoning blocks stay populated — matching
+    # default to "summarized" so the reasoning blocks stay populated — matching
     # 4.6 behavior and preserving the activity-feed UX during long tool runs.
+    # Users can set reasoning_config.display = "omitted" for latency-sensitive
+    # workflows (faster TTFB as the server skips streaming thinking tokens).
+    # This mirrors Codex's ``reasoning.summary`` control — both APIs expose a
+    # display/summary toggle for cross-provider parity.
     _is_kimi_coding = _is_kimi_family_endpoint(base_url, model)
     if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()
             budget = THINKING_BUDGET.get(effort, 8000)
+            # Resolve thinking display mode. Accepts "summarized" (default) or
+            # "omitted" (faster TTFB — server skips streaming thinking tokens
+            # and returns only the signature). Configurable via
+            # reasoning_config.display for parity with Codex's
+            # ``reasoning.summary`` control.
+            _display = str(reasoning_config.get("display", "summarized")).strip().lower()
+            if _display not in ("summarized", "omitted"):
+                _display = "summarized"
             if _supports_adaptive_thinking(model):
                 kwargs["thinking"] = {
                     "type": "adaptive",
-                    "display": "summarized",
+                    "display": _display,
                 }
                 adaptive_effort = ADAPTIVE_EFFORT_MAP.get(effort, "medium")
                 # Downgrade xhigh→max on models that don't list xhigh as a

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1704,6 +1704,67 @@ class TestBuildAnthropicKwargs:
         )
         assert kwargs["max_tokens"] == 64_000
 
+    # ── thinking.display parity (Codex reasoning.summary) ──────────────
+
+    def test_reasoning_config_default_display_is_summarized(self):
+        """Default display='summarized' — backward compatible with existing
+        behavior. reasoning_config without an explicit display field keeps
+        reasoning text populated in the response stream."""
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[{"role": "user", "content": "think"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kwargs["thinking"]["type"] == "adaptive"
+        assert kwargs["thinking"]["display"] == "summarized"
+
+    def test_reasoning_config_display_omitted_is_passed_through(self):
+        """display='omitted' is passed through to the Anthropic API for
+        latency-sensitive workflows. The server skips streaming thinking
+        tokens and returns only the signature, improving TTFB. Mirrors
+        Codex's reasoning.summary control for cross-provider parity."""
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[{"role": "user", "content": "think fast"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={
+                "enabled": True, "effort": "high", "display": "omitted",
+            },
+        )
+        assert kwargs["thinking"]["type"] == "adaptive"
+        assert kwargs["thinking"]["display"] == "omitted"
+
+    def test_reasoning_config_invalid_display_falls_back_to_summarized(self):
+        """An unrecognised display value must not reach the API — fall back
+        to 'summarized' so a stale or malformed config doesn't cause a
+        request failure."""
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[{"role": "user", "content": "think"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={
+                "enabled": True, "effort": "medium", "display": "invalid-value",
+            },
+        )
+        assert kwargs["thinking"]["display"] == "summarized"
+
+    def test_reasoning_config_display_case_insensitive(self):
+        """display value is normalised to lowercase."""
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[{"role": "user", "content": "think"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={
+                "enabled": True, "effort": "medium", "display": "OMITTED",
+            },
+        )
+        assert kwargs["thinking"]["display"] == "omitted"
+
 
 # ---------------------------------------------------------------------------
 # Model output limit lookup


### PR DESCRIPTION
Add Claude Codex-style extended thinking parity. Makes thinking.display configurable via reasoning_config (summarized/omitted) for faster TTFB. Closes #59856