### PR TITLE
fix(desktop): replace cpSync with manual recursive copy for Windows non-ASCII path compatibility

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.cjs
+++ b/apps/desktop/scripts/stage-native-deps.cjs
@@ -249,6 +249,49 @@ function resolveJsClosure(roots) {
 // package is copied whole (minus node_modules/ — the closure is flattened so
 // every dep already has its own top-level entry) into a real node_modules
 // layout, which keeps the deps' own internal require()s working unchanged.
+// Workaround for Node.js 24.x cpSync bug on Windows: recursive cpSync calls
+// cpSyncOverrideFile which tries to unlink the destination first; on paths
+// with non-ASCII characters (e.g. "í" in user folder) the unlink returns
+// "The operation completed successfully" with errno 0 and an empty code,
+// aborting the build. copyFileSync opens dest with O_TRUNC (no unlink), so
+// it sidesteps the bug. Recursive walk + per-file copyFileSync is functionally
+// equivalent to cpSync(recursive:true) for our use case.
+function copyDirSyncSafe(src, dest) {
+  fs.mkdirSync(dest, { recursive: true })
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    if (entry.name === 'node_modules') continue
+    const srcPath = path.join(src, entry.name)
+    const destPath = path.join(dest, entry.name)
+    if (entry.isDirectory()) {
+      copyDirSyncSafe(srcPath, destPath)
+    } else if (entry.isFile()) {
+      try {
+        fs.copyFileSync(srcPath, destPath)
+      } catch (err) {
+        // Retry once after a short delay: Windows Defender / AV scans
+        // can hold a brief handle on newly-written files and cause the
+        // first copy attempt to fail.
+        const delayMs = 250
+        const start = Date.now()
+        let lastErr = err
+        while (Date.now() - start < 5000) {
+          try {
+            fs.copyFileSync(srcPath, destPath)
+            lastErr = null
+            break
+          } catch (e) {
+            lastErr = e
+            const busy = require('node:child_process')
+              .execSync(`powershell -NoProfile -Command "Start-Sleep -Milliseconds ${delayMs}"`,
+                        { stdio: 'ignore' })
+          }
+        }
+        if (lastErr) throw lastErr
+      }
+    }
+  }
+}
+
 function stageJsClosure(roots) {
   const closure = resolveJsClosure(roots)
   rmrf(JS_DEP_STAGE_ROOT)
@@ -259,10 +302,7 @@ function stageJsClosure(roots) {
     ensureDir(path.dirname(dest))
     // Copy the package directory but skip any nested node_modules/ — the
     // closure is flattened, so nested copies would just bloat the bundle.
-    fs.cpSync(fromDir, dest, {
-      recursive: true,
-      filter: src => path.basename(src) !== 'node_modules'
-    })
+    copyDirSyncSafe(fromDir, dest)
     staged += 1
   }
   console.log(

--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -14,6 +14,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
 import {
   chmodSync,
+  copyFileSync,
   cpSync,
   existsSync,
   mkdirSync,
@@ -80,6 +81,26 @@ function copyGlobByExt(srcDir, destDir, extensions) {
 }
 
 /**
+ * Recursive directory copy built on per-file copyFileSync.
+ *
+ * fs.cpSync(..., { recursive: true }) fails on Windows when the *source*
+ * path contains non-ASCII characters (user names like "Pınar"): Node 22
+ * throws EIO/errno 5 and Node 24 fail-fasts with 0xC0000409 inside the
+ * native recursive copy, before any catch handler runs. Per-file
+ * copyFileSync never enters that native path (#60447, #70779).
+ */
+function copyDirByFile(srcDir, destDir) {
+  mkdirSync(destDir, { recursive: true })
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      copyDirByFile(join(srcDir, entry.name), join(destDir, entry.name))
+    } else if (entry.isFile()) {
+      copyFileSync(join(srcDir, entry.name), join(destDir, entry.name))
+    }
+  }
+}
+
+/**
  * Copies the locally-compiled build/Release output (used when no prebuild
  * was available and node-pty was built from source for the host machine).
  *
@@ -96,7 +117,7 @@ function copyBuildRelease(srcDir, destDir) {
   mkdirSync(destDir, { recursive: true })
   for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
-      cpSync(join(srcDir, entry.name), join(destDir, entry.name), { recursive: true })
+      copyDirByFile(join(srcDir, entry.name), join(destDir, entry.name))
       continue
     }
     if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
@@ -261,7 +282,7 @@ export function stageNodePtyInto(srcRoot, destRoot, { platform = process.platfor
     mkdirSync(destPrebuild, { recursive: true })
     for (const entry of readdirSync(prebuildDir, { withFileTypes: true })) {
       if (entry.name === 'conpty' && entry.isDirectory()) {
-        cpSync(join(prebuildDir, 'conpty'), join(destPrebuild, 'conpty'), { recursive: true })
+        copyDirByFile(join(prebuildDir, 'conpty'), join(destPrebuild, 'conpty'))
         continue
       }
       if (entry.isFile() && /\.(node|dll|exe)$/.test(entry.name)) {

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -3,7 +3,7 @@ import fs, { existsSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { test } from 'vitest'
+import { test, vi } from 'vitest'
 
 import {
   installGetWindowsNativeBinding,
@@ -12,6 +12,30 @@ import {
   stageNodePtyInto,
   classifyNativeBinary
 } from '../scripts/stage-native-deps.mjs'
+
+// Recursive fs.cpSync crashes in Node's native copy path when the *source*
+// path contains non-ASCII characters on Windows: Node 22 throws a catchable
+// EIO/errno 5 (#60447, #70779) and Node 24 fail-fasts with 0xC0000409 before
+// any handler runs. Simulate the catchable Node 22 form on every platform so
+// staging is proven to never depend on recursive cpSync. Single-file copies
+// are unaffected on real Windows and delegate to the real implementation.
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    cpSync: (src, dest, options) => {
+      if (options?.recursive) {
+        throw Object.assign(new Error(`EIO: Access is denied. '${src}'`), {
+          errno: 5,
+          code: 'EIO',
+          path: String(src),
+          syscall: 'cp'
+        })
+      }
+      return actual.cpSync(src, dest, options)
+    }
+  }
+})
 
 const { join } = path
 
@@ -356,6 +380,63 @@ test('validation rejects a staged binary with the wrong platform magic', () => {
       () => stageNodePtyInto(srcRoot, destRoot, { platform: 'linux', arch: 'x64' }),
       /platform mismatch/i
     )
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+// ─── non-ASCII source paths (Windows recursive cpSync crash) ───────
+
+test('non-ASCII source path: staging survives recursive cpSync failure and stages directories per-file', () => {
+  const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
+  try {
+    // Mirror the reporter layout: the repo and its dist tree live under a
+    // non-ASCII user directory (C:\Users\Pınar\...).
+    const userDir = join(tmp, 'Pınar')
+    const srcRoot = join(userDir, 'hermes-agent', 'node_modules', 'node-pty')
+    const destRoot = join(userDir, 'hermes-agent', 'apps', 'desktop', 'dist', 'node_modules', 'node-pty')
+    const prebuildDir = join(srcRoot, 'prebuilds', `${process.platform}-${process.arch}`)
+    const buildReleaseDir = join(srcRoot, 'build', 'Release')
+
+    makeFakeNodePty(srcRoot, {
+      prebuildPlatform: process.platform,
+      prebuildArch: process.arch
+    })
+    // conpty/ — the directory whose recursive copy was the reported crash
+    // site (EIO on the conpty prebuild dir).
+    fs.mkdirSync(join(prebuildDir, 'conpty'), { recursive: true })
+    fs.writeFileSync(join(prebuildDir, 'conpty', 'conpty.dll'), 'conpty payload')
+    fs.writeFileSync(join(prebuildDir, 'conpty', 'OpenConsole.exe'), 'console payload')
+    fs.writeFileSync(join(prebuildDir, 'stray.pdb'), 'debug symbols must be skipped')
+    // build/Release with a nested subdirectory — exercises the wholesale
+    // directory branch of copyBuildRelease too.
+    makeFakeNode(join(buildReleaseDir, 'deep', 'nested', 'payload.node'), process.platform)
+    fs.writeFileSync(join(buildReleaseDir, 'README.md'), 'not a native payload')
+
+    const returned = stageNodePtyInto(srcRoot, destRoot, {
+      platform: process.platform,
+      arch: process.arch
+    })
+
+    assert.equal(returned, destRoot)
+    // Single-file copies (delegated cpSync) still work.
+    assert.ok(existsSync(join(destRoot, 'package.json')))
+    assert.ok(existsSync(join(destRoot, 'lib', 'index.js')))
+    // The conpty directory payload landed byte-identical via per-file copies.
+    const stagedPrebuild = join(destRoot, 'prebuilds', `${process.platform}-${process.arch}`)
+    assert.ok(
+      fs.readFileSync(join(stagedPrebuild, 'conpty', 'conpty.dll')).equals(Buffer.from('conpty payload'))
+    )
+    assert.ok(
+      fs.readFileSync(join(stagedPrebuild, 'conpty', 'OpenConsole.exe')).equals(Buffer.from('console payload'))
+    )
+    // Extension filtering is preserved alongside the copy-path change.
+    assert.ok(!existsSync(join(stagedPrebuild, 'stray.pdb')))
+    // Nested build/Release directories are staged through the same rule.
+    const stagedNested = join(destRoot, 'build', 'Release', 'deep', 'nested', 'payload.node')
+    assert.ok(existsSync(stagedNested), 'nested build/Release payload must be staged')
+    assert.equal(classifyNativeBinary(stagedNested), process.platform)
+    assert.ok(!existsSync(join(destRoot, 'build', 'Release', 'README.md')))
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true })
   }


### PR DESCRIPTION
## What does this PR do?

Stages node-pty's native payloads without recursive `fs.cpSync`, which crashes in Node's native copy path when the **source path contains non-ASCII characters** (e.g. `C:\Users\Pınar\...` on Windows). Two symptoms of the same root cause are reported: Node 22 throws a catchable `EIO`/errno 5, and Node 24 fail-fasts with `0xC0000409` inside `fsBinding.cpSyncCopyDir` before any handler runs. Per-file `copyFileSync` never enters that native path, so both the `conpty` prebuild directory and `build/Release` subdirectories are now staged through `copyDirByFile`, a small recursive walk over `copyFileSync`.

This is a re-scope of the original patch onto the current build path: the `.cjs` script it patched was deleted on main; the active call sites are in `apps/desktop/scripts/stage-native-deps.mjs`. The earlier PowerShell-based retry loop is dropped entirely (single-file copies don't hit the bug, so no retry is needed — and the unguarded shell-out was a liability on non-Windows hosts).

## Related Issue

Fixes #60447
Refs #70779 (bundles this EIO family with the 8.3 short-path family; also carries a second reproduction on a Chinese-username system where the same per-file workaround was verified end-to-end, and the Node 24 fail-fast variant)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/scripts/stage-native-deps.mjs`
  - add `copyDirByFile(srcDir, destDir)`: recursive directory copy built on per-file `copyFileSync`, with a comment documenting the Windows non-ASCII source-path crash (`EIO` on Node 22, `0xC0000409` on Node 24)
  - `copyBuildRelease`: wholesale directory entries now go through `copyDirByFile` instead of `cpSync(..., { recursive: true })`
  - `stageNodePtyInto`: the `conpty` prebuild directory (the reported crash site) now goes through `copyDirByFile`
  - all single-file `cpSync` calls are unchanged (they never enter the native recursive path)
- `apps/desktop/scripts/stage-native-deps.test.mjs`
  - `vi.mock('node:fs')` simulates the Node 22 `EIO`/errno 5 for any `recursive: true` `cpSync` (delegating everything else to the real module), so every platform exercises the failure mode
  - new regression test stages a fake node-pty tree under a non-ASCII user directory (`.../Pınar/hermes-agent/...`) with a `conpty/` payload, nested `build/Release` subdirectory, and filter-bait files (`.pdb`, `README.md`); staging must complete with byte-identical payloads and filtering preserved — it fails on main and passes with this fix

## How to Test

1. `cd apps/desktop && npx vitest run --project electron scripts/stage-native-deps.test.mjs`
2. Observed result: 31 passed (31) with the fix; reverting only `stage-native-deps.mjs` to main makes the new `non-ASCII source path` test fail with the simulated `EIO: Access is denied` from the conpty directory copy, matching the original report's stack (`stageNodePtyInto` → `cpSync` of `node-pty/prebuilds/win32-x64/conpty`).
3. On a real Windows host with a non-ASCII user profile (`C:\Users\Pınar`), `npm run build` in `apps/desktop` previously failed in `stage-native-deps`; #70779 reports the same per-file workaround verified end-to-end on a Chinese-username system.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (JS-only change; full vitest suite for the touched file passes — 31/31)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon) + verified against the Windows reproductions in #60447/#70779

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (helper docstring documents the failure mode)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (the change exists specifically for Windows non-ASCII paths; per-file copies are behavior-identical elsewhere)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
