### PR TITLE
fix: block write_file/patch from bypassing skills.write_approval gate

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -686,6 +686,32 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+    # When skills.write_approval is enabled, block write_file/patch from directly
+    # writing to ~/.hermes/skills/ so the approval gate cannot be bypassed.
+    # The agent must use skill_manage() instead, which correctly stages writes
+    # and returns a pending_id for user approval.
+    try:
+        from tools import write_approval as _wa
+        if _wa.write_approval_enabled(_wa.SKILLS):
+            _skills_prefix = os.path.join(
+                os.path.normpath(_expand_tilde("~/.hermes")),
+                "skills",
+            )
+            _skills_prefix_resolved = os.path.realpath(_skills_prefix)
+            if (
+                resolved.startswith(_skills_prefix_resolved + os.sep)
+                or resolved == _skills_prefix_resolved
+                or normalized.startswith(_skills_prefix + os.sep)
+                or normalized == _skills_prefix
+            ):
+                return (
+                    f"Refusing to write to skills directory: {filepath}\n"
+                    "skills.write_approval is enabled. "
+                    "Use skill_manage(action=...) to create, edit, patch, or "
+                    "delete skills instead of write_file or patch."
+                )
+    except Exception:
+        pass  # Fail open on import error — let the write proceed
     return None
 
 


### PR DESCRIPTION
## Problem

When `skills.write_approval` is enabled in config, the `skill_manage` tool correctly stages writes and returns a `pending_id` for user approval. However, `write_file` and `patch` tools write directly to paths under `~/.hermes/skills/` without going through the approval gate, allowing the gate to be silently bypassed.

## Root Cause

`_check_sensitive_path()` in `tools/file_tools.py` blocks writes to `config.yaml` and system paths (`/etc/`, `/boot/`, etc.) but did not check whether the target path falls under the skills directory. The cross-profile guard (`_check_cross_profile_path`) only checks for OTHER profiles' skills/plugins/cron/memories, not the current profile's.

## Fix

Added a skills-path detection block in `_check_sensitive_path()` that, when `skills.write_approval` is enabled, checks whether the target path falls under `~/.hermes/skills/`. If so, it returns an error message directing the agent to use `skill_manage()` instead of `write_file`/`patch`. This mirrors the existing config.yaml protection pattern and ensures skill writes always go through the write_approval gate.

The check validates against both the resolved (via `_resolve_path_for_task`) and normalized (via `_expand_tilde`) forms of the path, handling both `~/.hermes/skills/...` and absolute resolved paths. It fails open on import errors so gate module issues don't block legitimate writes.

## Testing

- Verified the fix compiles: `python3 -m py_compile tools/file_tools.py` passes
- The lint check (auto-run by the patch tool) confirms valid syntax
- The function is called by both `write_file_tool` (line 1649) and `patch_tool` (line 1777) as their first security guard

Closes #60440