### PR TITLE
fix(insights): update session model+billing route on fallback activation

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1352,6 +1352,29 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             agent._transport_cache.clear()
         agent._fallback_activated = True
 
+        # Update the session's billing route so insights/cost tracking
+        # attributes subsequent API calls to the fallback model, not the
+        # stale primary model.  Without this, COALESCE in
+        # update_token_counts keeps the primary's model/provider and
+        # all fallback cost is mis-attributed.  See #60431 discussion.
+        if getattr(agent, "_session_db", None) and getattr(agent, "session_id", None):
+            try:
+                agent._session_db.update_session_model(
+                    agent.session_id, fb_model,
+                )
+                agent._session_db.update_session_billing_route(
+                    agent.session_id,
+                    provider=fb_provider,
+                    base_url=fb_base_url,
+                    billing_mode=fb_api_mode,
+                )
+            except Exception:
+                logger.debug(
+                    "Could not update billing route for fallback to %s/%s",
+                    fb_provider, fb_model,
+                    exc_info=True,
+                )
+
         # Rebind the credential pool to the fallback provider when the provider
         # changes.  Keeping the primary pool attached would make downstream
         # recovery (rate_limit / billing / auth) mutate the wrong credential


### PR DESCRIPTION
## Problem

When a model fallback fires (e.g. primary model fails, falls back to a different model), the session DB's `model` and `billing_provider` columns stay at the primary model's values. This is because `update_token_counts` uses `COALESCE(model, ?)` which only fills NULL — it never overwrites an existing value.

Result: all API costs incurred during fallback are attributed to the **nominal session model** in the insights dashboard, not the model that actually generated the tokens. For example, if a session starts with `claude-sonnet-5` (copilot) and falls back to `gpt-5.5` (copilot), all the gpt-5.5 cost shows up under "claude-sonnet-5" in insights.

## Root Cause

`try_activate_fallback()` in `agent/chat_completion_helpers.py` mutates `agent.model` and `agent.provider` in-place (line 1347-1348), but does **not** call `update_session_model()` or `update_session_billing_route()` — those functions are only called from `switch_model_in_place()` (explicit `/model` command), not from the automatic fallback path.

Meanwhile `update_token_counts()` uses `COALESCE` for model/provider, so the fallback values are silently dropped on every subsequent API call.

## Fix

Call `update_session_model()` and `update_session_billing_route()` immediately after the fallback model/provider are set on the agent, mirroring the existing pattern in `switch_model_in_place()` (line 2047-2061).

The dollar amounts were already correct (per-call cost estimation uses `agent.model` which is the fallback) — only the grouping/attribution was wrong.

## Testing

- 218 copilot-related tests pass (1 pre-existing failure in `test_copilot_acp_client` unrelated to this change)
- Verified the code path matches the existing `switch_model_in_place` pattern