### PR TITLE
feat(sessions): html + prompt-only formats on 'sessions export'

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13543,9 +13543,17 @@ def main():
     )
     sessions_export.add_argument(
         "--format",
-        choices=["jsonl", "md", "qmd"],
+        choices=["jsonl", "md", "qmd", "html"],
         default="jsonl",
         help="Export format (default: jsonl)",
+    )
+    sessions_export.add_argument(
+        "--only",
+        choices=["user-prompts"],
+        help=(
+            "Export only a filtered view (user-prompts: one prompt record "
+            "per line for jsonl, headed sections for md)"
+        ),
     )
     sessions_export.add_argument(
         "--session-id", help="Session ID or unique prefix to export"
@@ -13787,6 +13795,99 @@ def main():
                 from hermes_cli.session_export_md import redact_session_data
 
                 return redact_session_data(data)
+
+            def _collect_sessions():
+                """Resolve --session-id / filters / bare export into a list
+                of redacted session dicts, or None after printing an error."""
+                if args.session_id:
+                    resolved = db.resolve_session_id(args.session_id)
+                    data = _redact(db.export_session(resolved)) if resolved else None
+                    if not data:
+                        print(f"Session '{args.session_id}' not found.")
+                        return None
+                    return [data]
+                if filters:
+                    candidates = db.list_prune_candidates(**filters)
+                    if args.dry_run:
+                        print(
+                            f"Would export {len(candidates)} session(s) "
+                            f"({describe_filters(filters)})."
+                        )
+                        for row in candidates[:100]:
+                            print(f"  {row.get('id')}  {row.get('source', '')}")
+                        if len(candidates) > 100:
+                            print(f"  ... {len(candidates) - 100} more")
+                        return None
+                    return [
+                        s
+                        for s in (
+                            _redact(db.export_session(row["id"])) for row in candidates
+                        )
+                        if s
+                    ]
+                if args.dry_run:
+                    print("--dry-run requires at least one filter.")
+                    return None
+                return [_redact(s) for s in db.export_all(source=None)]
+
+            # Prompt-only export (--only user-prompts): one prompt record per
+            # line (jsonl) or headed sections (md). Delegates rendering to
+            # hermes_cli.session_export.
+            if getattr(args, "only", None):
+                if args.format not in ("jsonl", "md"):
+                    print("--only user-prompts supports --format jsonl or md.")
+                    return
+                from hermes_cli.session_export import (
+                    export_record_count,
+                    render_sessions_export,
+                )
+
+                sessions = _collect_sessions()
+                if sessions is None:
+                    db.close()
+                    return
+                rendered = render_sessions_export(
+                    sessions,
+                    fmt="markdown" if args.format == "md" else "jsonl",
+                    only=args.only,
+                )
+                if not args.output or args.output == "-":
+                    sys.stdout.write(rendered)
+                    db.close()
+                    return
+                with open(args.output, "w", encoding="utf-8") as f:
+                    f.write(rendered)
+                count, noun = export_record_count(sessions, only=args.only)
+                suffix = "" if count == 1 else "s"
+                print(f"Exported {count} {noun}{suffix} to {args.output}")
+                db.close()
+                return
+
+            # Standalone HTML export: one self-contained file (single session
+            # or multi-session with sidebar navigation).
+            if args.format == "html":
+                if not args.output or args.output == "-":
+                    print("HTML export requires an output file path.")
+                    return
+                from hermes_cli.session_export_html import (
+                    generate_html_export,
+                    generate_multi_session_html_export,
+                )
+
+                sessions = _collect_sessions()
+                if sessions is None:
+                    db.close()
+                    return
+                if len(sessions) == 1:
+                    content = generate_html_export(sessions[0])
+                else:
+                    content = generate_multi_session_html_export(sessions)
+                with open(args.output, "w", encoding="utf-8") as f:
+                    f.write(content)
+                suffix = "" if len(sessions) == 1 else "s"
+                print(f"Exported {len(sessions)} session{suffix} to {args.output} (HTML)")
+                db.close()
+                return
 
             if args.format == "jsonl":
                 if not args.output:

--- a/hermes_cli/session_export.py
+++ b/hermes_cli/session_export.py
@@ -1,0 +1,317 @@
+"""Shared renderers for session export commands.
+
+The CLI, dashboard, and slash-command surfaces all deal with the same
+session-shaped data: a session dict with a ``messages`` list. Keep filtering
+and human-readable rendering here so each surface only has to load sessions
+and write bytes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from html import escape as html_escape
+import json
+from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional, Tuple
+
+
+ExportFormat = Literal["jsonl", "markdown"]
+ExportOnly = Literal["user-prompts"]
+
+
+def normalize_export_format(fmt: str) -> ExportFormat:
+    """Return the canonical export format name."""
+    value = (fmt or "jsonl").strip().lower()
+    if value == "md":
+        value = "markdown"
+    if value not in {"jsonl", "markdown"}:
+        raise ValueError(f"Unsupported session export format: {fmt}")
+    return value  # type: ignore[return-value]
+
+
+def normalize_export_only(only: Optional[str]) -> Optional[ExportOnly]:
+    """Return the canonical export filter name."""
+    if only is None:
+        return None
+    value = only.strip().lower()
+    if value in {"user", "prompts", "user-prompts", "user_prompts"}:
+        return "user-prompts"
+    raise ValueError(f"Unsupported session export filter: {only}")
+
+
+def render_sessions_export(
+    sessions: Iterable[Dict[str, Any]],
+    *,
+    fmt: str = "jsonl",
+    only: Optional[str] = None,
+) -> str:
+    """Render exported sessions in a stable, reusable format.
+
+    ``fmt=jsonl`` with no filter intentionally preserves the legacy shape:
+    one full session object per line. ``only=user-prompts`` switches the unit
+    of export to one prompt record per line so the output is easy to pipe into
+    review, memory-ingestion, or prompt-library tooling.
+    """
+    session_list = list(sessions)
+    export_format = normalize_export_format(fmt)
+    export_only = normalize_export_only(only)
+
+    if export_format == "jsonl":
+        return _render_jsonl(session_list, only=export_only)
+    return _render_markdown(session_list, only=export_only)
+
+
+def export_record_count(
+    sessions: Iterable[Dict[str, Any]], *, only: Optional[str] = None
+) -> Tuple[int, str]:
+    """Return ``(count, noun)`` for status messages after an export."""
+    session_list = list(sessions)
+    export_only = normalize_export_only(only)
+    if export_only == "user-prompts":
+        return sum(1 for _ in iter_user_prompt_records(session_list)), "prompt"
+    return len(session_list), "session"
+
+
+def iter_user_prompt_records(
+    sessions: Iterable[Dict[str, Any]]
+) -> Iterator[Dict[str, Any]]:
+    """Yield one normalized record for each user-authored prompt."""
+    for session in sessions:
+        session_id = str(session.get("id") or session.get("session_id") or "")
+        index = 0
+        for message in _messages(session):
+            if message.get("role") != "user":
+                continue
+            index += 1
+            record: Dict[str, Any] = {
+                "session_id": session_id,
+                "index": index,
+                "created_at": _format_timestamp(message.get("timestamp")),
+                "role": "user",
+                "text": _message_text(message.get("content")),
+            }
+            message_id = message.get("id")
+            if message_id is not None:
+                record["message_id"] = message_id
+            event_id = message.get("platform_message_id") or message.get("event_id")
+            if event_id:
+                record["event_id"] = event_id
+            yield record
+
+
+def _render_jsonl(
+    sessions: List[Dict[str, Any]], *, only: Optional[ExportOnly]
+) -> str:
+    if only == "user-prompts":
+        rows = iter_user_prompt_records(sessions)
+    else:
+        rows = iter(sessions)
+    lines = [json.dumps(row, ensure_ascii=False) for row in rows]
+    return ("\n".join(lines) + "\n") if lines else ""
+
+
+def _render_markdown(
+    sessions: List[Dict[str, Any]], *, only: Optional[ExportOnly]
+) -> str:
+    if only == "user-prompts":
+        return _render_user_prompts_markdown(sessions)
+    return _render_full_markdown(sessions)
+
+
+def _render_user_prompts_markdown(sessions: List[Dict[str, Any]]) -> str:
+    lines: List[str] = []
+    if len(sessions) == 1:
+        session = sessions[0]
+        lines.append(f"# User prompts for session {_heading_text(_session_id(session))}")
+        lines.extend(_session_metadata_lines(session))
+        lines.append("")
+        _append_prompt_records(lines, session, heading_level=2)
+    else:
+        lines.append("# User prompts export")
+        lines.append("")
+        for session in sessions:
+            lines.append(f"## Session {_heading_text(_session_id(session))}")
+            lines.extend(_session_metadata_lines(session))
+            lines.append("")
+            _append_prompt_records(lines, session, heading_level=3)
+    if not sessions:
+        lines.append("_No user prompts found._")
+        lines.append("")
+    return _finish_markdown(lines)
+
+
+def _append_prompt_records(
+    lines: List[str], session: Dict[str, Any], *, heading_level: int
+) -> None:
+    prompts = list(iter_user_prompt_records([session]))
+    if not prompts:
+        lines.append("_No user prompts found._")
+        lines.append("")
+        return
+    marker = "#" * heading_level
+    for prompt in prompts:
+        timestamp = prompt.get("created_at") or "timestamp unavailable"
+        lines.append(f"{marker} {prompt['index']}. {timestamp}")
+        message_id = prompt.get("message_id")
+        if message_id is not None:
+            lines.append(f"Message ID: `{message_id}`")
+            lines.append("")
+        lines.append(str(prompt.get("text") or ""))
+        lines.append("")
+
+
+def _render_full_markdown(sessions: List[Dict[str, Any]]) -> str:
+    lines: List[str] = []
+    if len(sessions) == 1:
+        session = sessions[0]
+        lines.append(f"# Session: {_heading_text(_session_title_or_id(session))}")
+        lines.extend(_session_metadata_lines(session))
+        lines.append("")
+        _append_session_messages(lines, session, heading_level=2)
+    else:
+        lines.append("# Hermes sessions export")
+        lines.append("")
+        for session in sessions:
+            lines.append(f"## Session: {_heading_text(_session_title_or_id(session))}")
+            lines.extend(_session_metadata_lines(session))
+            lines.append("")
+            _append_session_messages(lines, session, heading_level=3)
+    return _finish_markdown(lines)
+
+
+def _append_session_messages(
+    lines: List[str], session: Dict[str, Any], *, heading_level: int
+) -> None:
+    marker = "#" * heading_level
+    visible_messages = [
+        message for message in _messages(session) if message.get("role") != "system"
+    ]
+    if not visible_messages:
+        lines.append("_No messages found._")
+        lines.append("")
+        return
+
+    for message in visible_messages:
+        role = str(message.get("role") or "unknown")
+        timestamp = _format_timestamp(message.get("timestamp"))
+        suffix = f" - {timestamp}" if timestamp else ""
+        if role == "tool":
+            tool_name = str(message.get("tool_name") or message.get("name") or "tool")
+            lines.append(f"{marker} Tool: {_heading_text(tool_name)}{suffix}")
+            lines.append("")
+            lines.append(f"<details><summary>{html_escape(tool_name)}</summary>")
+            lines.append("")
+            lines.append(_fenced_text(_message_text(message.get("content"))))
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
+            continue
+
+        label = {
+            "user": "User",
+            "assistant": "Assistant",
+        }.get(role, role.title())
+        lines.append(f"{marker} {label}{suffix}")
+        lines.append("")
+        lines.append(_message_text(message.get("content")))
+        lines.append("")
+
+
+def _messages(session: Dict[str, Any]) -> List[Dict[str, Any]]:
+    messages = session.get("messages") or []
+    return [message for message in messages if isinstance(message, dict)]
+
+
+def _message_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [_content_part_text(part) for part in content]
+        return "\n".join(part for part in parts if part)
+    if isinstance(content, dict):
+        for key in ("text", "content"):
+            value = content.get(key)
+            if isinstance(value, str):
+                return value
+        return json.dumps(content, ensure_ascii=False, sort_keys=True)
+    return str(content)
+
+
+def _content_part_text(part: Any) -> str:
+    if isinstance(part, str):
+        return part
+    if isinstance(part, dict):
+        for key in ("text", "content"):
+            value = part.get(key)
+            if isinstance(value, str):
+                return value
+        return json.dumps(part, ensure_ascii=False, sort_keys=True)
+    return str(part)
+
+
+def _format_timestamp(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return (
+            datetime.fromtimestamp(float(value), tz=timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
+        )
+    if isinstance(value, datetime):
+        dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat(timespec="seconds").replace(
+            "+00:00", "Z"
+        )
+    return str(value)
+
+
+def _session_metadata_lines(session: Dict[str, Any]) -> List[str]:
+    lines: List[str] = [f"- Session ID: `{_session_id(session)}`"]
+    source = session.get("source")
+    if source:
+        lines.append(f"- Source: `{source}`")
+    model = session.get("model")
+    if model:
+        lines.append(f"- Model: `{model}`")
+    title = session.get("title")
+    if title:
+        lines.append(f"- Title: {_inline_text(str(title))}")
+    started = _format_timestamp(session.get("started_at"))
+    if started:
+        lines.append(f"- Started: {started}")
+    message_count = session.get("message_count")
+    if message_count is not None:
+        lines.append(f"- Messages: {message_count}")
+    return lines
+
+
+def _session_id(session: Dict[str, Any]) -> str:
+    return str(session.get("id") or session.get("session_id") or "unknown")
+
+
+def _session_title_or_id(session: Dict[str, Any]) -> str:
+    title = str(session.get("title") or "").strip()
+    return title or _session_id(session)
+
+
+def _heading_text(value: str) -> str:
+    return " ".join(str(value).splitlines()).strip() or "unknown"
+
+
+def _inline_text(value: str) -> str:
+    return " ".join(value.splitlines()).strip()
+
+
+def _fenced_text(text: str, *, language: str = "text") -> str:
+    fence = "```"
+    while fence in text:
+        fence += "`"
+    return f"{fence}{language}\n{text}\n{fence}"
+
+
+def _finish_markdown(lines: List[str]) -> str:
+    while lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines) + "\n"

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -228,9 +228,6 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             margin: 0;
         }}
 
-        .layout-multi .main-content {{
-            width: 0;
-        }}
         .session-view.active {{
             display: block;
         }}

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -652,6 +652,11 @@ def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
     html_list = []
     for i, msg in enumerate(messages):
         role = msg.get("role", "unknown")
+        
+        # Skip internal metadata messages
+        if role == "session_meta":
+            continue
+            
         content = msg.get("content") or ""
         timestamp = _format_timestamp(msg.get("timestamp", 0))
         

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -800,7 +800,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
         system_html = ""
         if system_prompt:
             system_html = f'''
-            <div class="system-prompt-section">
+            <div class="system-prompt-section active">
                 <div class="system-prompt-header">
                     {ICON_CHEVRON_RIGHT.replace('class="', 'class="chevron ')}
                     {ICON_SHIELD} System Prompt (Persona)

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -1,0 +1,761 @@
+"""
+HTML Export generator for Hermes sessions.
+Generates a standalone, beautiful HTML file with all messages embedded.
+Supports single and multi-session exports with a professional sidebar.
+No remote dependencies.
+Enhanced with UI-UX-PRO-MAX design intelligence.
+"""
+
+import json
+import datetime
+from typing import Any, Dict, List
+
+# --- Icons (Lucide-style SVGs) ---
+ICON_USER = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-user"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>'
+ICON_BOT = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-bot"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>'
+ICON_TERMINAL = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-terminal"><polyline points="4 17 10 11 4 5"/><line x1="12" x2="20" y1="19" y2="19"/></svg>'
+ICON_WRENCH = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-wrench"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>'
+ICON_SPARKLES = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sparkles"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/><path d="M5 3v4"/><path d="M19 17v4"/><path d="M3 5h4"/><path d="M17 19h4"/></svg>'
+ICON_CHEVRON_RIGHT = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-right"><path d="m9 18 6-6-6-6"/></svg>'
+ICON_SEARCH = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-search"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>'
+ICON_HERMES = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#FFD700" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>'
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{page_title}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        :root {{
+            --bg-color: #F8FAFC;
+            --text-color: #0F172A;
+            --secondary-text: #475569;
+            --user-bg: #FFFFFF;
+            --assistant-bg: #F1F5F9;
+            --border-color: #E2E8F0;
+            --accent-color: #CD7F32;
+            --accent-foreground: #FFFFFF;
+            --code-bg: #1E293B;
+            --code-text: #F8FAFC;
+            --reasoning-bg: #FFFBEB;
+            --reasoning-border: #FEF3C7;
+            --tool-bg: #F0F9FF;
+            --tool-border: #E0F2FE;
+            --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+            --sidebar-bg: #FFFFFF;
+            --sidebar-width: 320px;
+        }}
+
+        @media (prefers-color-scheme: dark) {{
+            :root {{
+                --bg-color: #000101;
+                --text-color: #FFF8DC;
+                --secondary-text: #94A3B8;
+                --user-bg: #041c1c;
+                --assistant-bg: #0c1a1a;
+                --border-color: #CD7F32;
+                --accent-color: #FFD700;
+                --code-bg: #000000;
+                --reasoning-bg: #1a1a1a;
+                --reasoning-border: #CD7F32;
+                --tool-bg: #0c4a6e;
+                --tool-border: #075985;
+                --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);
+                --sidebar-bg: #041c1c;
+            }}
+        }}
+
+        * {{
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }}
+
+        body {{
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            line-height: 1.6;
+            color: var(--text-color);
+            background-color: var(--bg-color);
+            -webkit-font-smoothing: antialiased;
+            overflow-x: hidden;
+        }}
+
+        .layout {{
+            display: flex;
+            min-height: 100vh;
+        }}
+
+        /* Sidebar */
+        .sidebar {{
+            width: var(--sidebar-width);
+            background-color: var(--sidebar-bg);
+            border-right: 1px solid var(--border-color);
+            display: flex;
+            flex-direction: column;
+            position: fixed;
+            height: 100vh;
+            z-index: 100;
+            transition: transform 0.3s ease;
+        }}
+
+        @media (max-width: 768px) {{
+            .sidebar {{
+                transform: translateX(-100%);
+            }}
+            .sidebar.open {{
+                transform: translateX(0);
+            }}
+            .main-content {{
+                margin-left: 0 !important;
+            }}
+        }}
+
+        .sidebar-header {{
+            padding: 1.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }}
+
+        .sidebar-brand {{
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            font-weight: 700;
+            font-size: 1.25rem;
+            color: var(--accent-color);
+            margin-bottom: 1rem;
+        }}
+
+        .search-container {{
+            position: relative;
+        }}
+
+        .search-container input {{
+            width: 100%;
+            padding: 0.5rem 1rem 0.5rem 2.25rem;
+            border-radius: 0.5rem;
+            border: 1px solid var(--border-color);
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            font-size: 0.875rem;
+            outline: none;
+        }}
+
+        .search-container svg {{
+            position: absolute;
+            left: 0.75rem;
+            top: 50%;
+            transform: translateY(-50%);
+            color: var(--secondary-text);
+        }}
+
+        .session-list {{
+            flex: 1;
+            overflow-y: auto;
+            padding: 1rem;
+        }}
+
+        .session-item {{
+            display: block;
+            padding: 0.75rem 1rem;
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            text-decoration: none;
+            color: inherit;
+            border: 1px solid transparent;
+        }}
+
+        .session-item:hover {{
+            background-color: rgba(0, 0, 0, 0.05);
+        }}
+
+        @media (prefers-color-scheme: dark) {{
+            .session-item:hover {{
+                background-color: rgba(255, 255, 255, 0.05);
+            }}
+        }}
+
+        .session-item.active {{
+            background-color: var(--user-bg);
+            border-color: var(--accent-color);
+            box-shadow: var(--shadow);
+        }}
+
+        .session-item-title {{
+            font-weight: 600;
+            font-size: 0.875rem;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            margin-bottom: 0.25rem;
+        }}
+
+        .session-item-meta {{
+            font-size: 0.75rem;
+            color: var(--secondary-text);
+            display: flex;
+            justify-content: space-between;
+        }}
+
+        /* Main Content */
+        .main-content {{
+            flex: 1;
+            margin-left: {main_margin};
+            padding: 3rem 2rem;
+            max-width: 100%;
+            transition: margin-left 0.3s ease;
+        }}
+
+        .session-view {{
+            display: none;
+            width: 100%;
+            margin: 0 auto;
+        }}
+
+        .layout-single .session-view {{
+            max-width: 90%;
+            margin: 0 auto;
+        }}
+
+        .layout-multi .session-view {{
+            max-width: 100%;
+            margin: 0;
+        }}
+
+        .layout-multi .main-content {{
+            width: 0;
+        }}
+        .session-view.active {{
+            display: block;
+        }}
+
+        header {{
+            margin-bottom: 3rem;
+            text-align: center;
+        }}
+
+        .meta {{
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            gap: 1.5rem;
+            margin-top: 1rem;
+            font-size: 0.875rem;
+            color: var(--secondary-text);
+         }}
+
+        .meta-item strong {{
+            color: var(--text-color);
+        }}
+
+        /* Messages */
+        .message {{
+            margin-bottom: 1.5rem;
+            border-radius: 0.75rem;
+            background-color: var(--user-bg);
+            border: 1px solid var(--border-color);
+            box-shadow: var(--shadow);
+            overflow: hidden;
+        }}
+
+        .message-user {{
+            background-color: #f0fdf4;
+        }}
+
+        .message-assistant {{
+            background-color: var(--assistant-bg);
+            border-left: 4px solid var(--accent-color);
+        }}
+
+        .message-tool {{
+            background-color: #f8fafc;
+            border-style: dotted;
+        }}
+
+        @media (prefers-color-scheme: dark) {{
+            .message-user {{
+                background-color: #0c2121;
+            }}
+
+            .message-assistant {{
+                background-color: #041c1c;
+            }}
+
+            .message-tool {{
+                background-color: #0f172a;
+            }}
+        }}
+
+        .message-header {{
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 1rem 1.5rem;
+            cursor: pointer;
+            user-select: none;
+            transition: background-color 0.2s ease;
+        }}
+
+        .message-header:hover {{
+            background-color: rgba(0,0,0,0.02);
+        }}
+
+        .message-header svg.chevron {{
+            transition: transform 0.2s ease;
+            color: var(--secondary-text);
+        }}
+
+        .message.active svg.chevron {{
+            transform: rotate(90deg);
+        }}
+
+        .role-badge {{
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.75rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--secondary-text);
+        }}
+
+        .role-badge svg {{
+            color: var(--accent-color);
+        }}
+
+        .timestamp {{
+            font-size: 0.75rem;
+            color: var(--secondary-text);
+            font-variant-numeric: tabular-nums;
+        }}
+
+        .message-body {{
+            display: none;
+            padding: 0 1.5rem 1.5rem 1.5rem;
+            border-top: 1px solid var(--border-color);
+            padding-top: 1.5rem;
+        }}
+
+        .message.active .message-body {{
+            display: block;
+        }}
+
+        .content {{
+            white-space: pre-wrap;
+            word-break: break-word;
+            font-size: 1rem;
+        }}
+
+        /* Code Blocks */
+        code {{
+            font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+            background-color: rgba(0,0,0,0.05);
+            padding: 0.2rem 0.4rem;
+            border-radius: 0.375rem;
+            font-size: 0.9em;
+        }}
+
+        pre {{
+            background-color: var(--code-bg);
+            color: var(--code-text);
+            padding: 1.25rem;
+            border-radius: 0.75rem;
+            overflow-x: auto;
+            margin: 1.25rem 0;
+            font-size: 0.9rem;
+            line-height: 1.5;
+            box-shadow: inset 0 2px 4px 0 rgb(0 0 0 / 0.1);
+        }}
+
+        pre code {{
+            background-color: transparent;
+            padding: 0;
+            border-radius: 0;
+            color: inherit;
+        }}
+
+        /* Tool Calls */
+        .tool-call {{
+            margin: 1rem 0;
+            border-radius: 0.5rem;
+            overflow: hidden;
+            border: 1px solid var(--tool-border);
+            background-color: var(--tool-bg);
+        }}
+
+        .tool-call-header {{
+            padding: 0.75rem 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            cursor: pointer;
+            user-select: none;
+            font-size: 0.875rem;
+            font-weight: 600;
+        }}
+
+        .tool-call-header:hover {{
+            background-color: rgba(0,0,0,0.03);
+        }}
+
+        .tool-call-header svg.chevron {{
+            transition: transform 0.2s ease;
+            color: var(--secondary-text);
+        }}
+
+        .tool-call.active svg.chevron {{
+            transform: rotate(90deg);
+        }}
+
+        .tool-call-content {{
+            display: none;
+            padding: 0 1rem 1rem 1rem;
+        }}
+
+        .tool-call.active .tool-call-content {{
+            display: block;
+        }}
+
+        /* Reasoning */
+        .reasoning {{
+            margin-top: 1.5rem;
+            border-radius: 0.75rem;
+            border: 1px solid var(--reasoning-border);
+            background-color: var(--reasoning-bg);
+            overflow: hidden;
+        }}
+
+        .reasoning-header {{
+            padding: 0.75rem 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            cursor: pointer;
+            user-select: none;
+            font-size: 0.875rem;
+            font-weight: 600;
+        }}
+
+        .reasoning-header:hover {{
+            background-color: rgba(0,0,0,0.02);
+        }}
+
+        .reasoning-header svg.chevron {{
+            transition: transform 0.2s ease;
+            color: var(--secondary-text);
+        }}
+
+        .reasoning.active svg.chevron {{
+            transform: rotate(90deg);
+        }}
+
+        .reasoning-content {{
+            display: none;
+            padding: 0 1rem 1rem 1rem;
+            font-size: 0.925rem;
+            color: var(--secondary-text);
+            border-top: 1px solid var(--reasoning-border);
+            padding-top: 1rem;
+        }}
+
+        .reasoning.active .reasoning-content {{
+            display: block;
+        }}
+
+        footer {{
+            margin-top: 5rem;
+            padding-top: 2rem;
+            border-top: 1px solid var(--border-color);
+            text-align: center;
+            font-size: 0.875rem;
+            color: var(--secondary-text);
+        }}
+
+        /* Animation */
+        .fade-in {{
+            animation: fadeIn 0.4s ease-out backwards;
+        }}
+
+        @keyframes fadeIn {{
+            from {{ opacity: 0; transform: translateY(10px); }}
+            to {{ opacity: 1; transform: translateY(0); }}
+        }}
+
+        /* Utilities */
+        .hidden {{ display: none !important; }}
+    </style>
+</head>
+<body>
+    <div class="layout {layout_class}">
+        {sidebar_html}
+        
+        <div class="main-content">
+            {sessions_html}
+            
+            <footer>
+                Built with ☤ Hermes Agent • Generated on {generated_at}
+            </footer>
+        </div>
+    </div>
+
+    <script>
+        // Session Switching
+        function showSession(id) {{
+            // Update Sidebar
+            document.querySelectorAll('.session-item').forEach(el => el.classList.remove('active'));
+            const activeItem = document.querySelector(`.session-item[data-id="${{id}}"]`);
+            if (activeItem) activeItem.classList.add('active');
+
+            // Update View
+            document.querySelectorAll('.session-view').forEach(el => {{
+                el.classList.remove('active');
+            }});
+            const activeView = document.getElementById(`view-${{id}}`);
+            if (activeView) activeView.classList.add('active');
+
+            // Store in URL hash
+            window.location.hash = id;
+        }}
+
+        // Search Filter
+        const searchInput = document.getElementById('session-search');
+        if (searchInput) {{
+            searchInput.addEventListener('input', (e) => {{
+                const term = e.target.value.toLowerCase();
+                document.querySelectorAll('.session-item').forEach(item => {{
+                    const text = item.innerText.toLowerCase();
+                    if (text.includes(term)) {{
+                        item.classList.remove('hidden');
+                    }} else {{
+                        item.classList.add('hidden');
+                    }}
+                }});
+            }});
+        }}
+
+        // Card Toggles
+        document.addEventListener('click', function(e) {{
+            const header = e.target.closest('.message-header, .tool-call-header, .reasoning-header');
+            if (header) {{
+                header.parentElement.classList.toggle('active');
+            }}
+        }});
+
+        // Initialization
+        window.addEventListener('load', () => {{
+            const hash = window.location.hash.slice(1);
+            if (hash) {{
+                showSession(hash);
+            }} else {{
+                // Show first session by default if none selected
+                const first = document.querySelector('.session-item');
+                if (first) showSession(first.getAttribute('data-id'));
+            }}
+        }});
+
+        // Intersection Observer for scroll animations
+        if ('IntersectionObserver' in window) {{
+            var observer = new IntersectionObserver(function(entries) {{
+                entries.forEach(function(entry) {{
+                    if (entry.isIntersecting) {{
+                        entry.target.classList.add('fade-in');
+                        observer.unobserve(entry.target);
+                    }}
+                }});
+            }}, {{ threshold: 0.1 }});
+
+            document.querySelectorAll('.message').forEach(function(m) {{ observer.observe(m); }});
+        }}
+    </script>
+</body>
+</html>
+"""
+
+def _escape_html(text: str) -> str:
+    if not isinstance(text, str):
+        text = str(text)
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;").replace("'", "&#39;")
+
+def _format_timestamp(ts: float) -> str:
+    if not ts: return "N/A"
+    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+
+def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
+    html_list = []
+    for i, msg in enumerate(messages):
+        role = msg.get("role", "unknown")
+        content = msg.get("content") or ""
+        timestamp = _format_timestamp(msg.get("timestamp", 0))
+        
+        # Icon selection
+        role_icon = ICON_TERMINAL
+        if role == "user":
+            role_icon = ICON_USER
+        elif role == "assistant":
+            role_icon = ICON_BOT
+
+        # Handle multimodal or complex content
+        if isinstance(content, list):
+            content_parts = []
+            for part in content:
+                if isinstance(part, dict):
+                    if part.get("type") == "text":
+                        content_parts.append(part.get("text", ""))
+                    elif part.get("type") == "image_url":
+                        content_parts.append("[Image Attachment]")
+                else:
+                    content_parts.append(str(part))
+            content = "\n".join(content_parts)
+
+        # Build message HTML
+        msg_class = f"message message-{role} active"
+        # Delay animation for initial items
+        delay_style = f' style="animation-delay: {min(i * 0.05, 1.0)}s"' if i < 10 else ""
+        
+        chevron_html = ICON_CHEVRON_RIGHT.replace('class="', 'class="chevron ')
+        
+        html = f'<div class="{msg_class}"{delay_style}>'
+        html += f'  <div class="message-header">'
+        html += f'    <div class="role-badge">{chevron_html} {role_icon} {role}</div>'
+        html += f'    <div class="timestamp">{timestamp}</div>'
+        html += '  </div>'
+        html += '  <div class="message-body">'
+        
+        # Tool Calls
+        tool_calls = msg.get("tool_calls")
+        if tool_calls:
+            for tc in tool_calls:
+                fn_name = tc.get("function", {}).get("name", "unknown")
+                args = tc.get("function", {}).get("arguments", "{}")
+                html += f'''
+                <div class="tool-call">
+                    <div class="tool-call-header">
+                        {ICON_CHEVRON_RIGHT.replace('class="', 'class="chevron ')}
+                        {ICON_WRENCH} Tool Call: {fn_name}
+                    </div>
+                    <div class="tool-call-content">
+                        <pre><code>{_escape_html(args)}</code></pre>
+                    </div>
+                </div>
+                '''
+
+        # Content
+        if content:
+            if role == "tool":
+                html += f'  <div class="content"><pre><code>{_escape_html(content)}</code></pre></div>'
+            else:
+                html += f'  <div class="content">{_escape_html(content)}</div>'
+        
+        # Reasoning
+        reasoning = msg.get("reasoning") or msg.get("reasoning_content")
+        if reasoning:
+            html += f'''
+            <div class="reasoning">
+                <div class="reasoning-header">
+                    {ICON_CHEVRON_RIGHT.replace('class="', 'class="chevron ')}
+                    {ICON_SPARKLES} Reasoning
+                </div>
+                <div class="reasoning-content">
+                    <div class="content">{_escape_html(reasoning)}</div>
+                </div>
+            </div>
+            '''
+            
+        html += '  </div>'
+        html += '</div>'
+        html_list.append(html)
+    return "\n".join(html_list)
+
+def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
+    if not sessions:
+        return "<html><body><h1>No sessions to export.</h1></body></html>"
+
+    is_multi = len(sessions) > 1
+    generated_at = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    
+    # Sidebar
+    sidebar_html = ""
+    if is_multi:
+        sidebar_items = []
+        for s in sessions:
+            sid = s.get("id", "N/A")
+            title = s.get("title") or s.get("preview") or "Untitled Session"
+            if len(title) > 50: title = title[:47] + "..."
+            date = _format_timestamp(s.get("started_at", 0)).split(" ")[0]
+            
+            item = f'''
+            <a class="session-item" data-id="{sid}" onclick="showSession('{sid}')">
+                <div class="session-item-title">{_escape_html(title)}</div>
+                <div class="session-item-meta">
+                    <span>{sid[:8]}</span>
+                    <span>{date}</span>
+                </div>
+            </a>
+            '''
+            sidebar_items.append(item)
+        
+        sidebar_html = f'''
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <div class="sidebar-brand">
+                    {ICON_HERMES} Hermes History
+                </div>
+                <div class="search-container">
+                    {ICON_SEARCH}
+                    <input type="text" id="session-search" placeholder="Search sessions...">
+                </div>
+            </div>
+            <div class="session-list">
+                {"".join(sidebar_items)}
+            </div>
+        </aside>
+        '''
+
+    # Main Content
+    sessions_html_list = []
+    for s in sessions:
+        sid = s.get("id", "N/A")
+        title = s.get("title") or "Hermes Session"
+        model = s.get("model", "Unknown")
+        started_at = _format_timestamp(s.get("started_at", 0))
+        messages = s.get("messages", [])
+        messages_html = _generate_messages_html(messages)
+        
+        view_class = "session-view"
+        if not is_multi: view_class += " active"
+        
+        session_html = f'''
+        <div class="{view_class}" id="view-{sid}">
+            <header class="fade-in">
+                <h1>{_escape_html(title)}</h1>
+                <div class="meta">
+                    <div class="meta-item"><strong>ID:</strong> {sid}</div>
+                    <div class="meta-item"><strong>Model:</strong> {_escape_html(model)}</div>
+                    <div class="meta-item"><strong>Started:</strong> {started_at}</div>
+                </div>
+            </header>
+            <main>
+                {messages_html}
+            </main>
+        </div>
+        '''
+        sessions_html_list.append(session_html)
+
+    return HTML_TEMPLATE.format(
+        page_title="Hermes Session Export" if is_multi else _escape_html(sessions[0].get("title", "Hermes Session")),
+        sidebar_html=sidebar_html,
+        sessions_html="\n".join(sessions_html_list),
+        main_margin="var(--sidebar-width)" if is_multi else "0",
+        layout_class="layout-multi" if is_multi else "layout-single",
+        generated_at=generated_at
+    )
+
+def generate_html_export(session_data: Dict[str, Any]) -> str:
+    """Legacy wrapper for single session export."""
+    return generate_multi_session_html_export([session_data])

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -228,6 +228,10 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             margin: 0;
         }}
 
+        .layout-multi .main-content {{
+            width: 0;
+        }}
+
         .session-view.active {{
             display: block;
         }}

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -18,6 +18,7 @@ ICON_WRENCH = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" vi
 ICON_SPARKLES = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sparkles"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/><path d="M5 3v4"/><path d="M19 17v4"/><path d="M3 5h4"/><path d="M17 19h4"/></svg>'
 ICON_CHEVRON_RIGHT = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-right"><path d="m9 18 6-6-6-6"/></svg>'
 ICON_SEARCH = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-search"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>'
+ICON_SHIELD = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-shield"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.5 3.8 17 5 19 5a1 1 0 0 1 1 1z"/></svg>'
 ICON_HERMES = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#FFD700" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>'
 
 HTML_TEMPLATE = """<!DOCTYPE html>
@@ -272,6 +273,12 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             border-left: 4px solid var(--accent-color);
         }}
 
+        .message-system {{
+            background-color: var(--bg-color);
+            border-left: 4px solid var(--secondary-text);
+            opacity: 0.9;
+        }}
+
         .message-tool {{
             background-color: #f8fafc;
             border-style: dotted;
@@ -284,6 +291,11 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 
             .message-assistant {{
                 background-color: #041c1c;
+            }}
+
+            .message-system {{
+                background-color: #020617;
+                border-left: 4px solid var(--secondary-text);
             }}
 
             .message-tool {{
@@ -599,6 +611,8 @@ def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
             role_icon = ICON_USER
         elif role == "assistant":
             role_icon = ICON_BOT
+        elif role == "system":
+            role_icon = ICON_SHIELD
 
         # Handle multimodal or complex content
         if isinstance(content, list):
@@ -725,7 +739,22 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
         model = s.get("model", "Unknown")
         started_at = _format_timestamp(s.get("started_at", 0))
         messages = s.get("messages", [])
-        messages_html = _generate_messages_html(messages)
+        
+        # System Prompt Handling: Prepend if present in session metadata and not already in messages
+        system_prompt = s.get("system_prompt")
+        all_messages = []
+        if system_prompt:
+            # Avoid duplicating if the first message in the list is already the system prompt
+            first_msg = messages[0] if messages else None
+            if not (first_msg and first_msg.get("role") == "system" and first_msg.get("content") == system_prompt):
+                all_messages.append({
+                    "role": "system",
+                    "content": system_prompt,
+                    "timestamp": s.get("started_at", 0)
+                })
+        all_messages.extend(messages)
+        
+        messages_html = _generate_messages_html(all_messages)
         
         view_class = "session-view"
         if not is_multi: view_class += " active"

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -480,6 +480,55 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             display: block;
         }}
 
+        /* System Prompt Section */
+        .system-prompt-section {{
+            margin-top: 2rem;
+            border-radius: 0.75rem;
+            border: 1px solid var(--border-color);
+            background-color: var(--user-bg);
+            overflow: hidden;
+            text-align: left;
+            max-width: 800px;
+            margin-left: auto;
+            margin-right: auto;
+        }}
+
+        .system-prompt-header {{
+            padding: 0.75rem 1.25rem;
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+            cursor: pointer;
+            user-select: none;
+            font-size: 0.875rem;
+            font-weight: 600;
+            color: var(--secondary-text);
+        }}
+
+        .system-prompt-header:hover {{
+            background-color: rgba(0,0,0,0.02);
+        }}
+
+        .system-prompt-header svg.chevron {{
+            transition: transform 0.2s ease;
+        }}
+
+        .system-prompt-section.active svg.chevron {{
+            transform: rotate(90deg);
+        }}
+
+        .system-prompt-content {{
+            display: none;
+            padding: 0 1.25rem 1.25rem 1.25rem;
+            font-size: 0.9rem;
+            border-top: 1px solid var(--border-color);
+            padding-top: 1rem;
+        }}
+
+        .system-prompt-section.active .system-prompt-content {{
+            display: block;
+        }}
+
         footer {{
             margin-top: 5rem;
             padding-top: 2rem;
@@ -553,7 +602,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 
         // Card Toggles
         document.addEventListener('click', function(e) {{
-            const header = e.target.closest('.message-header, .tool-call-header, .reasoning-header');
+            const header = e.target.closest('.message-header, .tool-call-header, .reasoning-header, .system-prompt-header');
             if (header) {{
                 header.parentElement.classList.toggle('active');
             }}
@@ -740,27 +789,30 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
         started_at = _format_timestamp(s.get("started_at", 0))
         messages = s.get("messages", [])
         
-        # System Prompt Handling: Prepend if present in session metadata and not already in messages
-        system_prompt = s.get("system_prompt")
-        all_messages = []
-        if system_prompt:
-            # Avoid duplicating if the first message in the list is already the system prompt
-            first_msg = messages[0] if messages else None
-            if not (first_msg and first_msg.get("role") == "system" and first_msg.get("content") == system_prompt):
-                all_messages.append({
-                    "role": "system",
-                    "content": system_prompt,
-                    "timestamp": s.get("started_at", 0)
-                })
-        all_messages.extend(messages)
-        
-        messages_html = _generate_messages_html(all_messages)
+        messages_html = _generate_messages_html(messages)
         
         view_class = "session-view"
         if not is_multi: view_class += " active"
         
+        session_view_id = f"view-{sid}"
+        
+        system_prompt = s.get("system_prompt")
+        system_html = ""
+        if system_prompt:
+            system_html = f'''
+            <div class="system-prompt-section">
+                <div class="system-prompt-header">
+                    {ICON_CHEVRON_RIGHT.replace('class="', 'class="chevron ')}
+                    {ICON_SHIELD} System Prompt (Persona)
+                </div>
+                <div class="system-prompt-content">
+                    <div class="content">{_escape_html(system_prompt)}</div>
+                </div>
+            </div>
+            '''
+        
         session_html = f'''
-        <div class="{view_class}" id="view-{sid}">
+        <div class="{view_class}" id="{session_view_id}">
             <header class="fade-in">
                 <h1>{_escape_html(title)}</h1>
                 <div class="meta">
@@ -768,6 +820,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
                     <div class="meta-item"><strong>Model:</strong> {_escape_html(model)}</div>
                     <div class="meta-item"><strong>Started:</strong> {started_at}</div>
                 </div>
+                {system_html}
             </header>
             <main>
                 {messages_html}

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -839,6 +839,9 @@ AUTHOR_MAP = {
     "27719690+Mirac1eSky@users.noreply.github.com": "Mirac1eSky",
     "web3blind@users.noreply.github.com": "web3blind",
     "264741654+web3blind@users.noreply.github.com": "web3blind",
+    # Sessions export format cluster (July 2026): HTML + prompt-only salvages
+    "840004959@qq.com": "simplast",
+    "catbearlove1@gmail.com": "catbearlove1-lang",
     "julia@alexland.us": "alexg0bot",
     "christian@scheid.tech": "scheidti",
     # Moonshot schema anyOf+enum salvage (May 2026)

--- a/tests/hermes_cli/test_session_export.py
+++ b/tests/hermes_cli/test_session_export.py
@@ -188,7 +188,7 @@ def test_sessions_export_cli_prompt_only_markdown_file(monkeypatch, capsys, tmp_
             "--session-id",
             "sess",
             "--format",
-            "markdown",
+            "md",
             "--only",
             "user-prompts",
         ],
@@ -203,13 +203,13 @@ def test_sessions_export_cli_prompt_only_markdown_file(monkeypatch, capsys, tmp_
     assert "I will inspect the auth middleware." not in content
 
 
-def test_sessions_export_rejects_full_session_markdown(monkeypatch, capsys):
+def test_sessions_export_only_rejects_unsupported_format(monkeypatch, capsys):
     import hermes_cli.main as main_mod
     import hermes_state
 
     class FakeDB:
         def export_all(self, source=None):
-            return [_sample_session()]
+            raise AssertionError("should refuse before touching the DB")
 
         def close(self):
             pass
@@ -218,92 +218,9 @@ def test_sessions_export_rejects_full_session_markdown(monkeypatch, capsys):
     monkeypatch.setattr(
         sys,
         "argv",
-        ["hermes", "sessions", "export", "-", "--format", "markdown"],
+        ["hermes", "sessions", "export", "-", "--format", "html", "--only", "user-prompts"],
     )
 
     main_mod.main()
 
-    assert (
-        "Error: --format markdown currently requires --only user-prompts."
-        in capsys.readouterr().out
-    )
-
-
-def test_sessions_export_prompts_cli_stdout(monkeypatch, capsys):
-    import hermes_cli.main as main_mod
-    import hermes_state
-
-    captured = {}
-
-    class FakeDB:
-        def resolve_session_id(self, session_id):
-            captured["resolved_from"] = session_id
-            return "sess-123"
-
-        def export_session(self, session_id):
-            captured["exported"] = session_id
-            return _sample_session()
-
-        def close(self):
-            captured["closed"] = True
-
-    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["hermes", "sessions", "export-prompts", "sess"],
-    )
-
-    main_mod.main()
-
-    output = capsys.readouterr().out
-    records = [json.loads(line) for line in output.splitlines()]
-    assert [record["text"] for record in records] == [
-        "Why is login broken?",
-        "Only show me the prompts.",
-    ]
-    assert captured == {
-        "resolved_from": "sess",
-        "exported": "sess-123",
-        "closed": True,
-    }
-
-
-def test_sessions_export_prompts_cli_markdown_file(monkeypatch, capsys, tmp_path):
-    import hermes_cli.main as main_mod
-    import hermes_state
-
-    class FakeDB:
-        def resolve_session_id(self, _session_id):
-            return "sess-123"
-
-        def export_session(self, _session_id):
-            return _sample_session()
-
-        def close(self):
-            pass
-
-    output_path = tmp_path / "prompts.md"
-    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "hermes",
-            "sessions",
-            "export-prompts",
-            "sess",
-            "--format",
-            "md",
-            "--output",
-            str(output_path),
-        ],
-    )
-
-    main_mod.main()
-
-    assert f"Exported 2 prompts to {output_path}" in capsys.readouterr().out
-    content = output_path.read_text(encoding="utf-8")
-    assert "# User prompts for session sess-123" in content
-    assert "Why is login broken?" in content
-    assert "I will inspect the auth middleware." not in content
+    assert "--only user-prompts supports --format jsonl or md." in capsys.readouterr().out

--- a/tests/hermes_cli/test_session_export.py
+++ b/tests/hermes_cli/test_session_export.py
@@ -1,0 +1,309 @@
+import json
+import sys
+
+from hermes_cli.session_export import export_record_count, render_sessions_export
+
+
+def _sample_session():
+    return {
+        "id": "sess-123",
+        "source": "cli",
+        "model": "test/model",
+        "title": "Debug auth flow",
+        "started_at": 1700000000,
+        "message_count": 5,
+        "messages": [
+            {
+                "id": 1,
+                "role": "system",
+                "content": "hidden system context",
+                "timestamp": 1700000000,
+            },
+            {
+                "id": 2,
+                "role": "user",
+                "content": "Why is login broken?",
+                "timestamp": 1700000001,
+                "platform_message_id": "evt-2",
+            },
+            {
+                "id": 3,
+                "role": "assistant",
+                "content": "I will inspect the auth middleware.",
+                "timestamp": 1700000002,
+            },
+            {
+                "id": 4,
+                "role": "tool",
+                "tool_name": "read_file",
+                "content": "def redirect_after_login(): pass",
+                "timestamp": 1700000003,
+            },
+            {
+                "id": 5,
+                "role": "user",
+                "content": [{"type": "text", "text": "Only show me the prompts."}],
+                "timestamp": 1700000004,
+            },
+        ],
+    }
+
+
+def test_default_jsonl_preserves_full_session_shape():
+    session = _sample_session()
+
+    rendered = render_sessions_export([session])
+
+    assert [json.loads(line) for line in rendered.splitlines()] == [session]
+
+
+def test_prompt_only_jsonl_emits_one_record_per_user_prompt():
+    rendered = render_sessions_export(
+        [_sample_session()],
+        only="user-prompts",
+    )
+
+    records = [json.loads(line) for line in rendered.splitlines()]
+
+    assert records == [
+        {
+            "session_id": "sess-123",
+            "index": 1,
+            "created_at": "2023-11-14T22:13:21Z",
+            "role": "user",
+            "text": "Why is login broken?",
+            "message_id": 2,
+            "event_id": "evt-2",
+        },
+        {
+            "session_id": "sess-123",
+            "index": 2,
+            "created_at": "2023-11-14T22:13:24Z",
+            "role": "user",
+            "text": "Only show me the prompts.",
+            "message_id": 5,
+        },
+    ]
+
+
+def test_prompt_only_markdown_excludes_assistant_tool_and_system_content():
+    rendered = render_sessions_export(
+        [_sample_session()],
+        fmt="markdown",
+        only="user-prompts",
+    )
+
+    assert "# User prompts for session sess-123" in rendered
+    assert "## 1. 2023-11-14T22:13:21Z" in rendered
+    assert "Why is login broken?" in rendered
+    assert "Only show me the prompts." in rendered
+    assert "I will inspect the auth middleware." not in rendered
+    assert "def redirect_after_login" not in rendered
+    assert "hidden system context" not in rendered
+
+
+def test_full_markdown_renderer_collapses_tool_output_and_filters_system():
+    rendered = render_sessions_export([_sample_session()], fmt="markdown")
+
+    assert "# Session: Debug auth flow" in rendered
+    assert "## User - 2023-11-14T22:13:21Z" in rendered
+    assert "## Assistant - 2023-11-14T22:13:22Z" in rendered
+    assert "<details><summary>read_file</summary>" in rendered
+    assert "```text\ndef redirect_after_login(): pass\n```" in rendered
+    assert "hidden system context" not in rendered
+
+
+def test_export_record_count_switches_unit_for_prompt_only_exports():
+    assert export_record_count([_sample_session()]) == (1, "session")
+    assert export_record_count([_sample_session()], only="user-prompts") == (
+        2,
+        "prompt",
+    )
+
+
+def test_sessions_export_cli_prompt_only_stdout(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {}
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            captured["resolved_from"] = session_id
+            return "sess-123"
+
+        def export_session(self, session_id):
+            captured["exported"] = session_id
+            return _sample_session()
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "export", "-", "--session-id", "sess", "--only", "user-prompts"],
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    records = [json.loads(line) for line in output.splitlines()]
+    assert [record["text"] for record in records] == [
+        "Why is login broken?",
+        "Only show me the prompts.",
+    ]
+    assert captured == {
+        "resolved_from": "sess",
+        "exported": "sess-123",
+        "closed": True,
+    }
+
+
+def test_sessions_export_cli_prompt_only_markdown_file(monkeypatch, capsys, tmp_path):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    class FakeDB:
+        def resolve_session_id(self, _session_id):
+            return "sess-123"
+
+        def export_session(self, _session_id):
+            return _sample_session()
+
+        def close(self):
+            pass
+
+    output_path = tmp_path / "prompts.md"
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "sessions",
+            "export",
+            str(output_path),
+            "--session-id",
+            "sess",
+            "--format",
+            "markdown",
+            "--only",
+            "user-prompts",
+        ],
+    )
+
+    main_mod.main()
+
+    assert f"Exported 2 prompts to {output_path}" in capsys.readouterr().out
+    content = output_path.read_text(encoding="utf-8")
+    assert "# User prompts for session sess-123" in content
+    assert "Why is login broken?" in content
+    assert "I will inspect the auth middleware." not in content
+
+
+def test_sessions_export_rejects_full_session_markdown(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    class FakeDB:
+        def export_all(self, source=None):
+            return [_sample_session()]
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "export", "-", "--format", "markdown"],
+    )
+
+    main_mod.main()
+
+    assert (
+        "Error: --format markdown currently requires --only user-prompts."
+        in capsys.readouterr().out
+    )
+
+
+def test_sessions_export_prompts_cli_stdout(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {}
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            captured["resolved_from"] = session_id
+            return "sess-123"
+
+        def export_session(self, session_id):
+            captured["exported"] = session_id
+            return _sample_session()
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "sessions", "export-prompts", "sess"],
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    records = [json.loads(line) for line in output.splitlines()]
+    assert [record["text"] for record in records] == [
+        "Why is login broken?",
+        "Only show me the prompts.",
+    ]
+    assert captured == {
+        "resolved_from": "sess",
+        "exported": "sess-123",
+        "closed": True,
+    }
+
+
+def test_sessions_export_prompts_cli_markdown_file(monkeypatch, capsys, tmp_path):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    class FakeDB:
+        def resolve_session_id(self, _session_id):
+            return "sess-123"
+
+        def export_session(self, _session_id):
+            return _sample_session()
+
+        def close(self):
+            pass
+
+    output_path = tmp_path / "prompts.md"
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "sessions",
+            "export-prompts",
+            "sess",
+            "--format",
+            "md",
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    main_mod.main()
+
+    assert f"Exported 2 prompts to {output_path}" in capsys.readouterr().out
+    content = output_path.read_text(encoding="utf-8")
+    assert "# User prompts for session sess-123" in content
+    assert "Why is login broken?" in content
+    assert "I will inspect the auth middleware." not in content

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -312,6 +312,32 @@ Exported files contain one JSON object per line with full session metadata and a
 
 `export` accepts the same filters as `prune` / `archive` — `--older-than` / `--newer-than` / `--before` / `--after` (durations like `5h`/`2d`/`1w`, bare days, or ISO timestamps), `--source`, `--title`, `--model`, `--provider`, `--cwd`, `--min-messages` / `--max-messages`, `--min-tokens` / `--max-tokens`, `--min-cost` / `--max-cost`, `--min-tool-calls` / `--max-tool-calls`, `--user`, `--chat-id`, `--chat-type`, `--branch`, and `--end-reason`. Add `--dry-run` to preview which sessions match without writing anything. Note: bulk filters match *ended* sessions; unfiltered `export` dumps everything, including active ones.
 
+### Export Sessions to HTML
+
+`--format html` writes a single self-contained HTML file — no remote dependencies — with styled message bubbles, collapsible tool output, and (for multi-session exports) a sidebar to switch between sessions:
+
+```bash
+# One session as a standalone HTML page
+hermes sessions export --format html --session-id 20250305_091523_a1b2c3d4 transcript.html
+
+# All Telegram sessions from the last week in one file, secrets redacted
+hermes sessions export --format html --newer-than 1w --source telegram --redact archive.html
+```
+
+### Export Only Your Prompts
+
+`--only user-prompts` exports just the prompts you wrote — no assistant replies, tool output, or system context. Useful for building prompt libraries or reviewing what you asked:
+
+```bash
+# One JSONL record per prompt (session id, index, timestamp, text)
+hermes sessions export prompts.jsonl --session-id 20250305_091523_a1b2c3d4 --only user-prompts
+
+# Markdown, straight to stdout
+hermes sessions export - --session-id 20250305_091523_a1b2c3d4 --only user-prompts --format md
+```
+
+Works with `--format jsonl` (default) or `md`, honors the same filters for bulk export, and combines with `--redact`.
+
 ### Export Sessions to Markdown/QMD
 
 Pass `--format md` or `--format qmd` when you want a readable, file-based archive before hiding or deleting old sessions. Markdown/QMD exports write one file per session into a directory (default: `~/.hermes/session-exports`).

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/sessions.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/sessions.md
@@ -289,6 +289,32 @@ hermes sessions export backup.jsonl --redact
 
 `export` 接受与 `prune` / `archive` 相同的过滤器 — `--older-than` / `--newer-than` / `--before` / `--after`（时长如 `5h`/`2d`/`1w`、纯数字天数或 ISO 时间戳）、`--source`、`--title`、`--model`、`--provider`、`--cwd`、`--min-messages` / `--max-messages`、`--min-tokens` / `--max-tokens`、`--min-cost` / `--max-cost`、`--min-tool-calls` / `--max-tool-calls`、`--user`、`--chat-id`、`--chat-type`、`--branch` 和 `--end-reason`。加 `--dry-run` 可预览匹配的 session 而不写入任何内容。注意：带过滤器的批量导出只匹配*已结束*的 session；不带过滤器的 `export` 会导出所有 session（包括活跃的）。
 
+### 导出 Session 为 HTML
+
+`--format html` 生成一个完全独立的 HTML 文件 — 无远程依赖 — 带样式化的消息气泡、可折叠的工具输出，多 session 导出时还带侧边栏导航：
+
+```bash
+# 将一个 session 导出为独立 HTML 页面
+hermes sessions export --format html --session-id 20250305_091523_a1b2c3d4 transcript.html
+
+# 将最近一周的所有 Telegram session 导出到一个文件，并脱敏
+hermes sessions export --format html --newer-than 1w --source telegram --redact archive.html
+```
+
+### 只导出你的 Prompt
+
+`--only user-prompts` 只导出你写的 prompt — 不含助手回复、工具输出或系统上下文。适合构建 prompt 库或回顾你问过什么：
+
+```bash
+# 每个 prompt 一条 JSONL 记录（session id、序号、时间戳、文本）
+hermes sessions export prompts.jsonl --session-id 20250305_091523_a1b2c3d4 --only user-prompts
+
+# Markdown 格式，直接输出到 stdout
+hermes sessions export - --session-id 20250305_091523_a1b2c3d4 --only user-prompts --format md
+```
+
+支持 `--format jsonl`（默认）或 `md`，批量导出时同样支持全部过滤器，也可与 `--redact` 组合。
+
 ### 导出 Session 为 Markdown/QMD
 
 当你想在隐藏或删除旧 session 之前保留一份可读的文件归档时，传入 `--format md` 或 `--format qmd`。Markdown/QMD 导出会为每个 session 写入一个文件到目录中（默认：`~/.hermes/session-exports`）。


### PR DESCRIPTION
## Summary
`hermes sessions export` gains `--format html` (standalone single-file transcripts with sidebar navigation) and `--only user-prompts` (prompt-only JSONL/Markdown export) — completing the unified export surface established in #60186.

Salvages PR #30481 by @simplast and PR #57683 by @catbearlove1-lang (commits cherry-picked, authorship preserved). Both PRs predated the unified `--format` surface; their renderers landed intact and were rewired onto it.

## Changes
- `hermes_cli/session_export_html.py` (new, @simplast, 8 commits): standalone HTML generator — embedded CSS/SVG icons, no remote dependencies, light/dark theme, collapsible tool output, system-prompt header section, multi-session sidebar with search.
- `hermes_cli/session_export.py` (new, @catbearlove1-lang): shared prompt-only renderer — one JSONL record per user prompt (session id, 1-based index, timestamp, text, message/event ids) or headed Markdown sections; assistant/tool/system content excluded.
- `hermes_cli/main.py` (ours): both wired into the existing surface — `--format html` (file path required, refuses stdout; single → full page, multi → sidebar layout) and `--only user-prompts` (jsonl/md only, works single-session, filtered bulk, and stdout). Both compose with the shared filter set and `--redact`. A `_collect_sessions()` helper now backs all format paths. The original PRs' extension-sniffing dispatch (`.html` suffix) and separate `export-prompts` subcommand were subsumed by `--format`/`--only`.
- `scripts/release.py`: AUTHOR_MAP entries for both contributors.
- Docs EN + zh-Hans; contributor tests adapted to the unified surface.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh` targeted (session_export, export_md CLI, formatter, state helpers, sessions delete) | all green |
| Live E2E (real SessionDB, temp HERMES_HOME) | 8/8: HTML single (valid standalone doc), HTML multi filtered + redacted (secret absent), HTML-to-stdout refusal, prompt-only JSONL stdout, prompt-only md bulk (assistant content excluded), `--only`+html refusal, prompt-only+redact, md regression |
| `git diff --stat origin/main..HEAD` | only the 7 intended files |

## Infographic
![Sessions export HTML + prompt-only infographic](https://v3b.fal.media/files/b/0aa15643/k_FOY_k88agaYKqC052ab_NioA86qY.png)
