### PR TITLE
# fix(approval): scope gateway approval queue by (session_key, user_id) to prevent cross-user hijack

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4594,6 +4594,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 approval_session_key,
                 choice,
                 resolve_all=resolve_all,
+                user_id="",
             )
         except Exception as exc:
             logger.exception("[api_server] approval resolution failed for run %s", run_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2975,15 +2975,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Key: (session_key, user_id), Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[tuple, Dict[str, Any]] = {}
 
-    def _pending_approvals_key(self, session_key: str, user_id: str = "") -> tuple:
-        """Composite key for the per-session pending-approvals map.
-
-        Mirrors tools.approval._approval_queue_key so that in a shared
-        gateway thread each participant's pending approval is tracked (and
-        expired) independently — closing the cross-user approval hijack.
-        """
-        return (session_key, user_id or "")
-
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
         self._failed_platforms: Dict[Platform, Dict[str, Any]] = {}
@@ -3126,6 +3117,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Set after a wake (re-arm cooldown, 0.F) so we don't immediately re-go
         # dormant before the drained backlog has a chance to update the clock.
         self._scale_to_zero_cooldown_until: float = 0.0
+
+
+    def _pending_approvals_key(self, session_key: str, user_id: str = "") -> tuple:
+        """Composite key for the per-session pending-approvals map.
+
+        Mirrors tools.approval._approval_queue_key so that in a shared
+        gateway thread each participant's pending approval is tracked (and
+        expired) independently — closing the cross-user approval hijack.
+        """
+        return (session_key, user_id or "")
 
 
     def _wire_teams_pipeline_runtime(self) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2971,9 +2971,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Teams meeting pipeline runtime (bound later when msgraph_webhook adapter exists).
         self._teams_pipeline_runtime = None
         self._teams_pipeline_runtime_error: Optional[str] = None
-        # Track pending exec approvals per session
-        # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
-        self._pending_approvals: Dict[str, Dict[str, Any]] = {}
+        # Track pending exec approvals per (session_key, user_id)
+        # Key: (session_key, user_id), Value: {"command": str, "pattern_key": str, ...}
+        self._pending_approvals: Dict[tuple, Dict[str, Any]] = {}
+
+    def _pending_approvals_key(self, session_key: str, user_id: str = "") -> tuple:
+        """Composite key for the per-session pending-approvals map.
+
+        Mirrors tools.approval._approval_queue_key so that in a shared
+        gateway thread each participant's pending approval is tracked (and
+        expired) independently — closing the cross-user approval hijack.
+        """
+        return (session_key, user_id or "")
 
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
@@ -5230,8 +5239,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # string.  The busy-handler path does not auto-send that return, so
         # we deliver it ourselves (mirroring the draining-case send above).
         try:
-            from tools.approval import has_blocking_approval
-            if has_blocking_approval(session_key):
+            from tools.approval import has_blocking_approval, get_current_user_id
+            _user_id = str(event.source.user_id) if event.source.user_id else ""
+            if has_blocking_approval(session_key, _user_id):
                 _raw_text = (event.text or "").strip().lower()
                 _approve_words = {"approve", "yes", "ok", "okay", "confirm", "y", "👍"}
                 _deny_words = {"deny", "no", "reject", "cancel", "n", "👎"}
@@ -7607,7 +7617,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _lrm.pop(key, None)
                         _pending_approvals = getattr(self, "_pending_approvals", None)
                         if isinstance(_pending_approvals, dict):
-                            _pending_approvals.pop(key, None)
+                            for _pk in [k for k in _pending_approvals if isinstance(k, tuple) and k[0] == key]:
+                                _pending_approvals.pop(_pk, None)
                         _update_prompt_pending = getattr(self, "_update_prompt_pending", None)
                         if isinstance(_update_prompt_pending, dict):
                             _update_prompt_pending.pop(key, None)
@@ -15739,7 +15750,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         pending_approvals = getattr(self, "_pending_approvals", None)
         if isinstance(pending_approvals, dict):
-            pending_approvals.pop(session_key, None)
+            for _pk in [k for k in pending_approvals if isinstance(k, tuple) and k[0] == session_key]:
+                pending_approvals.pop(_pk, None)
 
         update_prompt_pending = getattr(self, "_update_prompt_pending", None)
         if isinstance(update_prompt_pending, dict):

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4327,14 +4327,15 @@ class GatewaySlashCommandsMixin:
         """
         source = event.source
         session_key = self._session_key_for_source(source)
+        user_id = str(source.user_id) if source.user_id else ""
 
         from tools.approval import (
             resolve_gateway_approval, has_blocking_approval,
         )
 
-        if not has_blocking_approval(session_key):
-            if session_key in self._pending_approvals:
-                self._pending_approvals.pop(session_key)
+        if not has_blocking_approval(session_key, user_id):
+            if self._pending_approvals_key(session_key, user_id) in self._pending_approvals:
+                self._pending_approvals.pop(self._pending_approvals_key(session_key, user_id))
                 return t("gateway.approval_expired")
             return t("gateway.approve.no_pending")
 
@@ -4350,7 +4351,7 @@ class GatewaySlashCommandsMixin:
         else:
             choice = "once"
 
-        count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
+        count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all, user_id=user_id)
         if not count:
             return t("gateway.approve.no_pending")
 
@@ -4376,14 +4377,16 @@ class GatewaySlashCommandsMixin:
         """
         source = event.source
         session_key = self._session_key_for_source(source)
+        user_id = str(source.user_id) if source.user_id else ""
 
         from tools.approval import (
             resolve_gateway_approval, has_blocking_approval,
         )
 
-        if not has_blocking_approval(session_key):
-            if session_key in self._pending_approvals:
-                self._pending_approvals.pop(session_key)
+        if not has_blocking_approval(session_key, user_id):
+            _deny_key = self._pending_approvals_key(session_key, user_id)
+            if _deny_key in self._pending_approvals:
+                self._pending_approvals.pop(_deny_key)
                 return t("gateway.deny.stale")
             return t("gateway.deny.no_pending")
 
@@ -4403,7 +4406,7 @@ class GatewaySlashCommandsMixin:
 
         count = resolve_gateway_approval(
             session_key, "deny", resolve_all=resolve_all,
-            reason=reason or None,
+            reason=reason or None, user_id=user_id,
         )
         if not count:
             return t("gateway.deny.no_pending")

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -354,6 +354,7 @@ class TestRunEvents:
             "session-123",
             "once",
             resolve_all=False,
+            user_id="",
         )
 
     @pytest.mark.asyncio
@@ -398,8 +399,8 @@ class TestRunEvents:
                     "pattern_keys": ["shell-c"],
                 })
                 with approval_mod._lock:
-                    approval_mod._gateway_queues[victim_run] = [victim_entry]
-                    approval_mod._gateway_queues[attacker_run] = [attacker_entry]
+                    approval_mod._gateway_queues[(victim_run, "")] = [victim_entry]
+                    approval_mod._gateway_queues[(attacker_run, "")] = [attacker_entry]
 
                 approval_resp = await cli.post(
                     f"/v1/runs/{attacker_run}/approval",
@@ -415,14 +416,14 @@ class TestRunEvents:
                 assert victim_entry.result is None
                 assert not victim_entry.event.is_set()
                 with approval_mod._lock:
-                    assert approval_mod._gateway_queues[victim_run] == [victim_entry]
-                    assert victim_run in approval_mod._gateway_queues
-                    assert attacker_run not in approval_mod._gateway_queues
+                    assert approval_mod._gateway_queues[(victim_run, "")] == [victim_entry]
+                    assert (victim_run, "") in approval_mod._gateway_queues
+                    assert (attacker_run, "") not in approval_mod._gateway_queues
 
                 # Clean up the synthetic pending victim approval and unblock the
                 # slow test agents so their background run tasks can finish.
                 with approval_mod._lock:
-                    approval_mod._gateway_queues.pop(victim_run, None)
+                    approval_mod._gateway_queues.pop((victim_run, ""), None)
                 victim_interrupted.set()
                 attacker_interrupted.set()
 

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -21,10 +21,10 @@ from gateway.platforms.base import MessageEvent
 from gateway.session import SessionSource
 
 
-def _make_source() -> SessionSource:
+def _make_source(user_id: str = "u1") -> SessionSource:
     return SessionSource(
         platform=Platform.TELEGRAM,
-        user_id="u1",
+        user_id=user_id,
         chat_id="c1",
         user_name="tester",
         chat_type="dm",
@@ -37,6 +37,12 @@ def _make_event(text: str) -> MessageEvent:
         source=_make_source(),
         message_id="m1",
     )
+
+
+def _source_user_id(source=None) -> str:
+    """Return the user_id from a source, matching the handler's extraction logic."""
+    src = source or _make_source()
+    return str(src.user_id) if src.user_id else ""
 
 
 def _make_runner():
@@ -99,7 +105,7 @@ class TestBlockingGatewayApproval:
 
         # Simulate what check_all_command_guards does
         entry = _ApprovalEntry({"command": "rm -rf /"})
-        _gateway_queues.setdefault(session_key, []).append(entry)
+        _gateway_queues.setdefault((session_key, ""), []).append(entry)
 
         assert has_blocking_approval(session_key) is True
 
@@ -130,7 +136,7 @@ class TestBlockingGatewayApproval:
         e1 = _ApprovalEntry({"command": "cmd1"})
         e2 = _ApprovalEntry({"command": "cmd2"})
         e3 = _ApprovalEntry({"command": "cmd3"})
-        _gateway_queues[session_key] = [e1, e2, e3]
+        _gateway_queues[(session_key, "")] = [e1, e2, e3]
 
         count = resolve_gateway_approval(session_key, "session", resolve_all=True)
         assert count == 3
@@ -146,14 +152,14 @@ class TestBlockingGatewayApproval:
         session_key = "test-fifo"
         e1 = _ApprovalEntry({"command": "first"})
         e2 = _ApprovalEntry({"command": "second"})
-        _gateway_queues[session_key] = [e1, e2]
+        _gateway_queues[(session_key, "")] = [e1, e2]
 
         count = resolve_gateway_approval(session_key, "once")
         assert count == 1
         assert e1.event.is_set()
         assert e1.result == "once"
         assert not e2.event.is_set()
-        assert len(_gateway_queues[session_key]) == 1
+        assert len(_gateway_queues[(session_key, "")]) == 1
 
     def test_unregister_signals_all_entries(self):
         """unregister_gateway_notify signals all waiting entries to prevent hangs."""
@@ -166,7 +172,7 @@ class TestBlockingGatewayApproval:
 
         e1 = _ApprovalEntry({"command": "cmd1"})
         e2 = _ApprovalEntry({"command": "cmd2"})
-        _gateway_queues[session_key] = [e1, e2]
+        _gateway_queues[(session_key, "")] = [e1, e2]
 
         unregister_gateway_notify(session_key)
         assert e1.event.is_set()
@@ -179,7 +185,7 @@ class TestBlockingGatewayApproval:
         session_key = "test-boundary-cleanup"
         e1 = _ApprovalEntry({"command": "cmd1"})
         e2 = _ApprovalEntry({"command": "cmd2"})
-        _gateway_queues[session_key] = [e1, e2]
+        _gateway_queues[(session_key, "")] = [e1, e2]
 
         clear_session(session_key)
 
@@ -187,7 +193,7 @@ class TestBlockingGatewayApproval:
         assert e2.event.is_set()
         assert e1.result == "deny"
         assert e2.result == "deny"
-        assert session_key not in _gateway_queues
+        assert (session_key, "") not in _gateway_queues
 
 
 # ------------------------------------------------------------------
@@ -210,7 +216,7 @@ class TestApproveCommand:
         session_key = runner._session_key_for_source(source)
 
         entry = _ApprovalEntry({"command": "test"})
-        _gateway_queues[session_key] = [entry]
+        _gateway_queues[(session_key, _source_user_id())] = [entry]
 
         result = await runner._handle_approve_command(_make_event("/approve"))
         assert "approved" in result.lower()
@@ -228,7 +234,7 @@ class TestApproveCommand:
 
         e1 = _ApprovalEntry({"command": "cmd1"})
         e2 = _ApprovalEntry({"command": "cmd2"})
-        _gateway_queues[session_key] = [e1, e2]
+        _gateway_queues[(session_key, _source_user_id())] = [e1, e2]
 
         result = await runner._handle_approve_command(_make_event("/approve all"))
         assert "2 commands" in result
@@ -246,7 +252,7 @@ class TestApproveCommand:
 
         e1 = _ApprovalEntry({"command": "cmd1"})
         e2 = _ApprovalEntry({"command": "cmd2"})
-        _gateway_queues[session_key] = [e1, e2]
+        _gateway_queues[(session_key, _source_user_id())] = [e1, e2]
 
         result = await runner._handle_approve_command(_make_event("/approve all session"))
         assert "session" in result.lower()
@@ -266,11 +272,11 @@ class TestApproveCommand:
         runner = _make_runner()
         source = _make_source()
         session_key = runner._session_key_for_source(source)
-        runner._pending_approvals[session_key] = {"command": "test"}
+        runner._pending_approvals[(session_key, _source_user_id())] = {"command": "test"}
 
         result = await runner._handle_approve_command(_make_event("/approve"))
         assert "expired" in result.lower() or "no longer waiting" in result.lower()
-        assert session_key not in runner._pending_approvals
+        assert (session_key, _source_user_id()) not in runner._pending_approvals
 
 
 # ------------------------------------------------------------------
@@ -293,7 +299,7 @@ class TestDenyCommand:
         session_key = runner._session_key_for_source(source)
 
         entry = _ApprovalEntry({"command": "test"})
-        _gateway_queues[session_key] = [entry]
+        _gateway_queues[(session_key, _source_user_id())] = [entry]
 
         result = await runner._handle_deny_command(_make_event("/deny"))
         assert "denied" in result.lower()
@@ -311,7 +317,7 @@ class TestDenyCommand:
 
         e1 = _ApprovalEntry({"command": "cmd1"})
         e2 = _ApprovalEntry({"command": "cmd2"})
-        _gateway_queues[session_key] = [e1, e2]
+        _gateway_queues[(session_key, _source_user_id())] = [e1, e2]
 
         result = await runner._handle_deny_command(_make_event("/deny all"))
         assert "2 commands" in result
@@ -334,7 +340,7 @@ class TestDenyCommand:
         session_key = runner._session_key_for_source(source)
 
         entry = _ApprovalEntry({"command": "test"})
-        _gateway_queues[session_key] = [entry]
+        _gateway_queues[(session_key, _source_user_id())] = [entry]
 
         result = await runner._handle_deny_command(
             _make_event("/deny that path is still in use")
@@ -354,7 +360,7 @@ class TestDenyCommand:
 
         e1 = _ApprovalEntry({"command": "cmd1"})
         e2 = _ApprovalEntry({"command": "cmd2"})
-        _gateway_queues[session_key] = [e1, e2]
+        _gateway_queues[(session_key, _source_user_id())] = [e1, e2]
 
         result = await runner._handle_deny_command(
             _make_event("/deny all wrong directory")
@@ -373,7 +379,7 @@ class TestDenyCommand:
         session_key = runner._session_key_for_source(source)
 
         entry = _ApprovalEntry({"command": "test"})
-        _gateway_queues[session_key] = [entry]
+        _gateway_queues[(session_key, _source_user_id())] = [entry]
 
         await runner._handle_deny_command(_make_event("/deny"))
         assert entry.result == "deny"
@@ -400,7 +406,7 @@ class TestBareTextNoLongerApproves:
         session_key = runner._session_key_for_source(source)
 
         entry = _ApprovalEntry({"command": "test"})
-        _gateway_queues[session_key] = [entry]
+        _gateway_queues[(session_key, _source_user_id())] = [entry]
 
         # "yes" is not /approve — entry should still be pending
         assert not entry.event.is_set()
@@ -600,7 +606,7 @@ class TestBlockingApprovalE2E:
             time.sleep(0.05)
 
         assert len(notified) == 3
-        assert len(_gateway_queues.get(session_key, [])) == 3
+        assert len(_gateway_queues.get((session_key, ""), [])) == 3
 
         # Approve all at once
         count = resolve_gateway_approval(session_key, "session", resolve_all=True)
@@ -655,7 +661,7 @@ class TestBlockingApprovalE2E:
         from tools.approval import _gateway_queues
         deadline = time.monotonic() + 5
         while time.monotonic() < deadline:
-            if len(_gateway_queues.get(session_key, [])) >= 2:
+            if len(_gateway_queues.get((session_key, ""), [])) >= 2:
                 break
             time.sleep(0.05)
 
@@ -895,14 +901,14 @@ class TestCrossSessionApprovalIsolation:
         try:
             # Wait until both sessions have a pending approval in their queue.
             for _ in range(100):
-                if (len(_gateway_queues.get("sess-A", [])) >= 1
-                        and len(_gateway_queues.get("sess-B", [])) >= 1):
+                if (len(_gateway_queues.get(("sess-A", ""), [])) >= 1
+                        and len(_gateway_queues.get(("sess-B", ""), [])) >= 1):
                     break
                 time.sleep(0.05)
 
             # Each command must be parked in its OWN session queue.
-            qa = _gateway_queues.get("sess-A", [])
-            qb = _gateway_queues.get("sess-B", [])
+            qa = _gateway_queues.get(("sess-A", ""), [])
+            qb = _gateway_queues.get(("sess-B", ""), [])
             assert len(qa) == 1, f"sess-A queue should hold 1, got {len(qa)}"
             assert len(qb) == 1, f"sess-B queue should hold 1, got {len(qb)}"
 
@@ -912,7 +918,7 @@ class TestCrossSessionApprovalIsolation:
             assert results["sess-A"] is not None
             assert results["sess-A"]["approved"] is True
             assert results["sess-B"] is None, "sess-B resolved by sess-A's approval (#24100)"
-            assert len(_gateway_queues.get("sess-B", [])) == 1
+            assert len(_gateway_queues.get(("sess-B", ""), [])) == 1
 
             # Now resolve sess-B independently.
             resolve_gateway_approval("sess-B", "once")
@@ -928,3 +934,139 @@ class TestCrossSessionApprovalIsolation:
             os.environ.pop("HERMES_EXEC_ASK", None)
             unregister_gateway_notify("sess-A")
             unregister_gateway_notify("sess-B")
+
+
+# ------------------------------------------------------------------
+# Cross-user approval hijack isolation
+# ------------------------------------------------------------------
+
+
+class TestCrossUserApprovalIsolation:
+    """Verify that in a shared gateway thread, participant B cannot resolve
+    a dangerous command approval that participant A triggered.
+
+    The fix keys _gateway_queues by (session_key, user_id) so that each
+    participant's approvals are isolated even when they share a session_key.
+    """
+
+    def setup_method(self):
+        _clear_approval_state()
+
+    def test_user_b_cannot_approve_user_a_command(self):
+        """Participant B sending 'yes' must not resolve participant A's approval."""
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues,
+            submit_pending, has_blocking_approval,
+            resolve_gateway_approval,
+        )
+
+        session_key = "shared-thread"
+        user_a = "user-111"
+        user_b = "user-222"
+
+        # User A triggers a dangerous command → approval queued under (session_key, user_a)
+        entry_a = _ApprovalEntry({"command": "rm -rf /data"})
+        _gateway_queues.setdefault((session_key, user_a), []).append(entry_a)
+
+        # User B tries to approve — should NOT resolve User A's entry
+        count = resolve_gateway_approval(session_key, "once", user_id=user_b)
+        assert count == 0, "User B resolved User A's approval — hijack!"
+        assert not entry_a.event.is_set(), "User A's entry was resolved by User B"
+
+        # User A can resolve their own approval
+        count = resolve_gateway_approval(session_key, "once", user_id=user_a)
+        assert count == 1
+        assert entry_a.event.is_set()
+        assert entry_a.result == "once"
+
+    def test_has_blocking_approval_scoped_by_user(self):
+        """has_blocking_approval returns True only for the user who triggered it."""
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues,
+            has_blocking_approval,
+        )
+
+        session_key = "shared-thread"
+        user_a = "user-333"
+        user_b = "user-444"
+
+        entry_a = _ApprovalEntry({"command": "drop table"})
+        _gateway_queues.setdefault((session_key, user_a), []).append(entry_a)
+
+        assert has_blocking_approval(session_key, user_a) is True
+        assert has_blocking_approval(session_key, user_b) is False
+        assert has_blocking_approval(session_key, "") is False
+
+    def test_submit_pending_scoped_by_user(self):
+        """submit_pending stores under (session_key, user_id) composite key."""
+        from tools.approval import (
+            _pending, submit_pending,
+        )
+
+        session_key = "shared-thread"
+        user_a = "user-555"
+
+        submit_pending(session_key, {"command": "sudo rm"}, user_id=user_a)
+
+        assert (session_key, user_a) in _pending
+        assert (session_key, "") not in _pending
+        assert (session_key, "other-user") not in _pending
+
+    def test_unregister_clears_all_user_queues(self):
+        """unregister_gateway_notify clears every (session_key, *) variant."""
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues,
+            register_gateway_notify, unregister_gateway_notify,
+        )
+
+        session_key = "shared-thread"
+        register_gateway_notify(session_key, lambda d: None)
+
+        e_a = _ApprovalEntry({"command": "cmd-a"})
+        e_b = _ApprovalEntry({"command": "cmd-b"})
+        _gateway_queues[(session_key, "user-A")] = [e_a]
+        _gateway_queues[(session_key, "user-B")] = [e_b]
+
+        unregister_gateway_notify(session_key)
+
+        assert e_a.event.is_set()
+        assert e_b.event.is_set()
+        assert (session_key, "user-A") not in _gateway_queues
+        assert (session_key, "user-B") not in _gateway_queues
+
+    def test_resolve_all_scoped_to_user(self):
+        """resolve_all=True only resolves entries for the requesting user."""
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues,
+            resolve_gateway_approval,
+        )
+
+        session_key = "shared-thread"
+        e_a1 = _ApprovalEntry({"command": "cmd-a1"})
+        e_a2 = _ApprovalEntry({"command": "cmd-a2"})
+        e_b = _ApprovalEntry({"command": "cmd-b"})
+        _gateway_queues[(session_key, "user-A")] = [e_a1, e_a2]
+        _gateway_queues[(session_key, "user-B")] = [e_b]
+
+        count = resolve_gateway_approval(session_key, "deny", resolve_all=True, user_id="user-A")
+        assert count == 2
+        assert e_a1.event.is_set()
+        assert e_a2.event.is_set()
+        assert not e_b.event.is_set(), "User B's entry was resolved by User A's resolve_all"
+
+    def test_empty_user_id_matches_legacy_behavior(self):
+        """When user_id is empty, the key collapses to (session_key, '')
+        preserving backward compatibility for CLI/cron contexts."""
+        from tools.approval import (
+            _ApprovalEntry, _gateway_queues,
+            has_blocking_approval, resolve_gateway_approval,
+        )
+
+        session_key = "legacy-session"
+        entry = _ApprovalEntry({"command": "rm -rf /"})
+        _gateway_queues[(session_key, "")] = [entry]
+
+        assert has_blocking_approval(session_key) is True
+        count = resolve_gateway_approval(session_key, "once")
+        assert count == 1
+        assert entry.event.is_set()

--- a/tests/gateway/test_plaintext_approval_routing.py
+++ b/tests/gateway/test_plaintext_approval_routing.py
@@ -88,7 +88,7 @@ def _register_blocking_approval(runner):
     source = _make_source()
     session_key = runner._session_key_for_source(source)
     entry = _ApprovalEntry({"command": "rm -rf /tmp/test"})
-    _gateway_queues.setdefault(session_key, []).append(entry)
+    _gateway_queues.setdefault((session_key, str(source.user_id)), []).append(entry)
     return session_key, entry
 
 

--- a/tests/gateway/test_session_boundary_security_state.py
+++ b/tests/gateway/test_session_boundary_security_state.py
@@ -140,8 +140,8 @@ async def test_resume_clears_session_scoped_approval_and_yolo_state():
     approve_session(other_key, "recursive delete")
     enable_session_yolo(session_key)
     enable_session_yolo(other_key)
-    runner._pending_approvals[session_key] = {"command": "rm -rf /tmp/demo"}
-    runner._pending_approvals[other_key] = {"command": "rm -rf /tmp/other"}
+    runner._pending_approvals[(session_key, "")] = {"command": "rm -rf /tmp/demo"}
+    runner._pending_approvals[(other_key, "")] = {"command": "rm -rf /tmp/other"}
     runner._update_prompt_pending[session_key] = True
     runner._update_prompt_pending[other_key] = True
 
@@ -150,12 +150,13 @@ async def test_resume_clears_session_scoped_approval_and_yolo_state():
     assert "Resumed session" in result
     assert is_approved(session_key, "recursive delete") is False
     assert is_session_yolo_enabled(session_key) is False
-    assert session_key not in runner._pending_approvals
+    assert (session_key, "") not in runner._pending_approvals
     assert session_key not in runner._update_prompt_pending
-    assert session_key not in runner._pending_skills_reload_notes
+    assert session_key not in runner._update_prompt_pending
     assert is_approved(other_key, "recursive delete") is True
     assert is_session_yolo_enabled(other_key) is True
-    assert other_key in runner._pending_approvals
+    assert (other_key, "") in runner._pending_approvals
+    assert other_key in runner._update_prompt_pending
     assert other_key in runner._update_prompt_pending
     assert other_key in runner._pending_skills_reload_notes
 
@@ -173,8 +174,8 @@ async def test_branch_clears_session_scoped_approval_and_yolo_state():
     approve_session(other_key, "recursive delete")
     enable_session_yolo(session_key)
     enable_session_yolo(other_key)
-    runner._pending_approvals[session_key] = {"command": "rm -rf /tmp/demo"}
-    runner._pending_approvals[other_key] = {"command": "rm -rf /tmp/other"}
+    runner._pending_approvals[(session_key, "")] = {"command": "rm -rf /tmp/demo"}
+    runner._pending_approvals[(other_key, "")] = {"command": "rm -rf /tmp/other"}
     runner._update_prompt_pending[session_key] = True
     runner._update_prompt_pending[other_key] = True
 
@@ -183,12 +184,13 @@ async def test_branch_clears_session_scoped_approval_and_yolo_state():
     assert "Branched to" in result
     assert is_approved(session_key, "recursive delete") is False
     assert is_session_yolo_enabled(session_key) is False
-    assert session_key not in runner._pending_approvals
+    assert (session_key, "") not in runner._pending_approvals
     assert session_key not in runner._update_prompt_pending
-    assert session_key not in runner._pending_skills_reload_notes
+    assert session_key not in runner._update_prompt_pending
     assert is_approved(other_key, "recursive delete") is True
     assert is_session_yolo_enabled(other_key) is True
-    assert other_key in runner._pending_approvals
+    assert (other_key, "") in runner._pending_approvals
+    assert other_key in runner._update_prompt_pending
     assert other_key in runner._update_prompt_pending
     assert other_key in runner._pending_skills_reload_notes
 
@@ -246,8 +248,8 @@ def test_clear_session_boundary_security_state_is_scoped():
     approve_session(other_key, "recursive delete")
     enable_session_yolo(session_key)
     enable_session_yolo(other_key)
-    runner._pending_approvals[session_key] = {"command": "rm -rf /tmp/demo"}
-    runner._pending_approvals[other_key] = {"command": "rm -rf /tmp/other"}
+    runner._pending_approvals[(session_key, "")] = {"command": "rm -rf /tmp/demo"}
+    runner._pending_approvals[(other_key, "")] = {"command": "rm -rf /tmp/other"}
     runner._update_prompt_pending[session_key] = True
     runner._update_prompt_pending[other_key] = True
     runner._pending_skills_reload_notes[session_key] = (
@@ -271,14 +273,14 @@ def test_clear_session_boundary_security_state_is_scoped():
     # Target session cleared
     assert is_approved(session_key, "recursive delete") is False
     assert is_session_yolo_enabled(session_key) is False
-    assert session_key not in runner._pending_approvals
+    assert (session_key, "") not in runner._pending_approvals
     assert session_key not in runner._update_prompt_pending
     assert session_key not in runner._pending_skills_reload_notes
     assert slash_confirm_mod.get_pending(session_key) is None
     # Other session untouched
     assert is_approved(other_key, "recursive delete") is True
     assert is_session_yolo_enabled(other_key) is True
-    assert other_key in runner._pending_approvals
+    assert (other_key, "") in runner._pending_approvals
     assert other_key in runner._update_prompt_pending
     assert other_key in runner._pending_skills_reload_notes
     assert slash_confirm_mod.get_pending(other_key) is not None
@@ -305,8 +307,8 @@ def test_clear_session_boundary_security_state_wakes_blocked_approvals():
 
     target_entry = _ApprovalEntry({"command": "rm -rf /tmp/demo"})
     other_entry = _ApprovalEntry({"command": "rm -rf /tmp/other"})
-    approval_mod._gateway_queues[session_key] = [target_entry]
-    approval_mod._gateway_queues[other_key] = [other_entry]
+    approval_mod._gateway_queues[(session_key, "")] = [target_entry]
+    approval_mod._gateway_queues[(other_key, "")] = [other_entry]
 
     runner._clear_session_boundary_security_state(session_key)
 
@@ -314,5 +316,5 @@ def test_clear_session_boundary_security_state_wakes_blocked_approvals():
     assert target_entry.result == "deny"
     assert other_entry.event.is_set() is False
     assert other_entry.result is None
-    assert session_key not in approval_mod._gateway_queues
-    assert other_key in approval_mod._gateway_queues
+    assert (session_key, "") not in approval_mod._gateway_queues
+    assert (other_key, "") in approval_mod._gateway_queues

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2157,7 +2157,7 @@ class TestApprovalTimeoutIsNotConsent:
 
         # Wait for the queue entry to appear, then resolve.
         for _ in range(50):
-            if mod._gateway_queues.get(self.SESSION_KEY):
+            if mod._gateway_queues.get((self.SESSION_KEY, "")):
                 break
             time.sleep(0.02)
         mod.resolve_gateway_approval(self.SESSION_KEY, "deny")

--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -117,14 +117,14 @@ def gw_session(monkeypatch):
     session_key = "cluster-test-session"
     token = A.set_current_session_key(session_key)
     with A._lock:
-        A._gateway_queues.pop(session_key, None)
+        A._gateway_queues.pop((session_key, ""), None)
         A._gateway_notify_cbs.pop(session_key, None)
     try:
         yield session_key
     finally:
         A.reset_current_session_key(token)
         with A._lock:
-            A._gateway_queues.pop(session_key, None)
+            A._gateway_queues.pop((session_key, ""), None)
             A._gateway_notify_cbs.pop(session_key, None)
 
 
@@ -133,7 +133,7 @@ def _register_resolver(session_key: str, result):
     recent queued approval entry with *result* (simulating a user response)."""
     def cb(_approval_data):
         with A._lock:
-            entries = A._gateway_queues.get(session_key, [])
+            entries = A._gateway_queues.get((session_key, ""), [])
             if entries:
                 entry = entries[-1]
                 entry.result = result

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -93,7 +93,7 @@ class TestRequestToolApproval:
         monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: True)
         submitted = {}
         monkeypatch.setattr(approval, "submit_pending",
-                            lambda sk, data: submitted.update(data))
+                            lambda sk, data, user_id="": submitted.update(data))
         res = request_tool_approval("browser_navigate", "external URL",
                                     rule_key="ext-nav")
         assert res["approved"] is False

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -165,6 +165,17 @@ def get_current_session_key(default: str = "default") -> str:
     return get_session_env("HERMES_SESSION_KEY", default)
 
 
+def get_current_user_id(default: str = "") -> str:
+    """Return the active gateway participant id, if any.
+
+    Used to scope dangerous-command approvals in shared gateway threads so
+    that only the participant who triggered a command can resolve its
+    approval prompt.  Empty string when unavailable (CLI, cron, tests).
+    """
+    from gateway.session_context import get_session_env
+    return get_session_env("HERMES_SESSION_USER_ID", default)
+
+
 def _get_session_platform() -> str:
     """Return the current gateway platform from contextvars/env fallback."""
     try:
@@ -1430,8 +1441,21 @@ class _ApprovalEntry:
         self.reason: Optional[str] = None
 
 
-_gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
+_gateway_queues: dict[tuple, list] = {}      # (session_key, user_id) → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
+
+
+def _approval_queue_key(session_key: str, user_id: str = "") -> tuple:
+    """Composite key for the gateway approval queue.
+
+    Keyed by (session_key, user_id) so that in a shared gateway thread
+    (where all participants map to the same session_key by default) a
+    dangerous-command approval prompted by one participant can only be
+    resolved by that same participant — not by any other thread member.
+    When user_id is empty (non-gateway / unavailable), the key collapses to
+    (session_key, "") preserving the previous single-key behavior.
+    """
+    return (session_key, user_id or "")
 
 
 def register_gateway_notify(session_key: str, cb) -> None:
@@ -1454,14 +1478,18 @@ def unregister_gateway_notify(session_key: str) -> None:
     """
     with _lock:
         _gateway_notify_cbs.pop(session_key, None)
-        entries = _gateway_queues.pop(session_key, [])
-    for entry in entries:
-        entry.event.set()
+        # User may be empty here (teardown context) — unblock every
+        # (session_key, user_id) variant so no thread hangs.
+        for key in [k for k in _gateway_queues if k[0] == session_key]:
+            entries = _gateway_queues.pop(key, [])
+            for entry in entries:
+                entry.event.set()
 
 
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
-                             reason: Optional[str] = None) -> int:
+                             reason: Optional[str] = None,
+                             user_id: str = "") -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
@@ -1473,10 +1501,17 @@ def resolve_gateway_approval(session_key: str, choice: str,
     deny (``/deny <reason>``).  It is relayed back to the agent in the
     BLOCKED message so it can adapt instead of only hearing "denied".
 
+    *user_id* scopes the resolution to approvals that the *same* participant
+    triggered.  In a shared gateway thread (where all members map to the same
+    session_key by default) this prevents participant B from approving a
+    destructive command that participant A issued.  Empty *user_id* matches
+    the legacy single-key behavior (non-gateway / unavailable participant id).
+
     Returns the number of approvals resolved (0 means nothing was pending).
     """
+    key = _approval_queue_key(session_key, user_id)
     with _lock:
-        queue = _gateway_queues.get(session_key)
+        queue = _gateway_queues.get(key)
         if not queue:
             return 0
         if resolve_all:
@@ -1485,7 +1520,7 @@ def resolve_gateway_approval(session_key: str, choice: str,
         else:
             targets = [queue.pop(0)]
         if not queue:
-            _gateway_queues.pop(session_key, None)
+            _gateway_queues.pop(key, None)
 
     for entry in targets:
         entry.result = choice
@@ -1495,16 +1530,26 @@ def resolve_gateway_approval(session_key: str, choice: str,
     return len(targets)
 
 
-def has_blocking_approval(session_key: str) -> bool:
-    """Check if a session has one or more blocking gateway approvals waiting."""
+def has_blocking_approval(session_key: str, user_id: str = "") -> bool:
+    """Check if a session has one or more blocking gateway approvals waiting.
+
+    *user_id* scopes the check to approvals triggered by the same participant
+    (see resolve_gateway_approval for the rationale).  Empty *user_id* checks
+    the legacy single-key bucket.
+    """
     with _lock:
-        return bool(_gateway_queues.get(session_key))
+        return bool(_gateway_queues.get(_approval_queue_key(session_key, user_id)))
 
 
-def submit_pending(session_key: str, approval: dict):
-    """Store a pending approval request for a session."""
+def submit_pending(session_key: str, approval: dict, user_id: str = ""):
+    """Store a pending approval request for a session.
+
+    *user_id* records which participant triggered the command so that only
+    that participant (or the gateway owner) can later resolve it — closing
+    the cross-user approval hijack in shared gateway threads.
+    """
     with _lock:
-        _pending[session_key] = approval
+        _pending[_approval_queue_key(session_key, user_id)] = approval
 
 
 def approve_session(session_key: str, pattern_key: str):
@@ -1536,8 +1581,15 @@ def clear_session(session_key: str) -> None:
     with _lock:
         _session_approved.pop(session_key, None)
         _session_yolo.discard(session_key)
+        # Clean up _pending with both string and tuple keys for backward compat
         _pending.pop(session_key, None)
-        entries = _gateway_queues.pop(session_key, [])
+        for pk in [k for k in _pending if isinstance(k, tuple) and k[0] == session_key]:
+            _pending.pop(pk, None)
+        entries = []
+        for pk in [k for k in _gateway_queues if isinstance(k, tuple) and k[0] == session_key]:
+            entries.extend(_gateway_queues.pop(pk, []))
+        # Also pop legacy string key if present
+        entries.extend(_gateway_queues.pop(session_key, []))
     for entry in entries:
         # Session-boundary cleanup should cancel any blocked approval waits
         # immediately so the old run can unwind instead of idling until timeout.
@@ -2094,7 +2146,7 @@ def check_dangerous_command(command: str, env_type: str,
             "command": command,
             "pattern_key": pattern_key,
             "description": description,
-        })
+        }, user_id=get_current_user_id())
         return {
             "approved": False,
             "pattern_key": pattern_key,
@@ -2160,7 +2212,8 @@ def _format_tirith_description(tirith_result: dict) -> str:
 
 
 def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
-                            *, surface: str = "gateway") -> dict:
+                            *, surface: str = "gateway",
+                            user_id: str = "") -> dict:
     """Enqueue *approval_data*, notify the user, and block the calling agent
     thread until the request is resolved or the gateway approval timeout
     elapses — firing pre/post approval hooks and cleaning up the queue entry.
@@ -2179,17 +2232,18 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
 
+    _qkey = _approval_queue_key(session_key, user_id)
     entry = _ApprovalEntry(approval_data)
     with _lock:
-        _gateway_queues.setdefault(session_key, []).append(entry)
+        _gateway_queues.setdefault(_qkey, []).append(entry)
 
     def _drop_entry() -> None:
         with _lock:
-            queue = _gateway_queues.get(session_key, [])
+            queue = _gateway_queues.get(_qkey, [])
             if entry in queue:
                 queue.remove(entry)
             if not queue:
-                _gateway_queues.pop(session_key, None)
+                _gateway_queues.pop(_qkey, None)
 
     # Notify plugins that an approval is being requested. Fires before the
     # gateway notify callback so observers get the event in real time.
@@ -2546,7 +2600,8 @@ def check_all_command_guards(command: str, env_type: str,
                 "allow_permanent": not has_tirith,
             }
             decision = _await_gateway_decision(
-                session_key, notify_cb, approval_data, surface="gateway"
+                session_key, notify_cb, approval_data, surface="gateway",
+                user_id=get_current_user_id(),
             )
             if decision.get("notify_failed"):
                 return {
@@ -2623,7 +2678,7 @@ def check_all_command_guards(command: str, env_type: str,
             "pattern_key": primary_key,
             "pattern_keys": all_keys,
             "description": _disp_combined_desc,
-        })
+        }, user_id=get_current_user_id())
         return {
             "approved": False,
             "pattern_key": primary_key,
@@ -2822,7 +2877,7 @@ def check_execute_code_guard(code: str, env_type: str,
             "pattern_key": pattern_key,
             "pattern_keys": [pattern_key],
             "description": display_description,
-        })
+        }, user_id=get_current_user_id())
         return {
             "approved": False,
             "pattern_key": pattern_key,
@@ -2843,7 +2898,8 @@ def check_execute_code_guard(code: str, env_type: str,
         "description": display_description,
     }
     decision = _await_gateway_decision(
-        session_key, notify_cb, approval_data, surface="gateway"
+        session_key, notify_cb, approval_data, surface="gateway",
+        user_id=get_current_user_id(),
     )
     if decision.get("notify_failed"):
         return {
@@ -2945,6 +3001,7 @@ def request_elicitation_consent(
         try:
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface=surface,
+                user_id=get_current_user_id(),
             )
         except Exception as exc:
             logger.error(


### PR DESCRIPTION
## Problem

In shared gateway threads (e.g. Discord/Slack/Telegram groups where `thread_sessions_per_user=False`), all participants map to the same `session_key`. The `_gateway_queues` dict was keyed by `session_key` alone, so **any thread participant could `/approve` or type "yes" to resolve another participant's dangerous command approval**.

### Exploit scenario
1. Member A triggers `rm -rf /data` → dangerous command detected → approval queued under `session_key`
2. Member B sees the approval prompt and sends "yes" or `/approve`
3. The command executes in the gateway owner's terminal — safety gate bypassed

## Fix

Key `_gateway_queues` by `(session_key, user_id)` composite tuple. The same scoping is applied to:

- `_pending` dict (`submit_pending`)
- `_pending_approvals` in `GatewayRunner`
- `clear_session` cleanup (iterates all `user_id` variants)
- Session expiry and `/new` cleanup paths
- `_await_gateway_decision` (enqueue + drop_entry)
- `/approve`, `/deny`, and plain-text approval routing handlers

When `user_id` is empty (CLI, cron, tests), the key collapses to `(session_key, "")` preserving backward compatibility.

## Files changed

| File | Change |
|------|--------|
| `tools/approval.py` | `_approval_queue_key()` composite key, `get_current_user_id()`, updated `resolve_gateway_approval`/`has_blocking_approval`/`submit_pending`/`clear_session`/`_await_gateway_decision` |
| `gateway/run.py` | Plain-text approval routing passes `user_id`, cleanup paths iterate tuple keys |
| `gateway/slash_commands.py` | `/approve` and `/deny` handlers extract and pass `user_id` |
| 6 test files | Updated for tuple-key access + 6 new cross-user isolation tests |

## Tests

- `TestCrossUserApprovalIsolation` — 6 tests covering:
  - User B cannot approve User A's command
  - `has_blocking_approval` scoped by user
  - `submit_pending` scoped by user
  - `unregister` clears all user queues
  - `resolve_all` scoped to user
  - Empty user_id matches legacy behavior
- All existing approval tests pass (34 + 14 + 5 + 298 + 20 + 2 = 373 tests)