### PR TITLE
fix(cli): load prefill_messages_file in hermes_cli backend

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -15,6 +15,7 @@ loaded) so this module never imports ``cli`` at import time -> no import cycle.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, List
@@ -37,7 +38,7 @@ class CLIAgentSetupMixin:
         from cli import _hermes_home, logger
         from hermes_cli.config import cfg_get
 
-        file_path = sys.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
+        file_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
         if not file_path:
             cfg = hermes_cli.config.load_config()
             file_path = str(cfg.get("prefill_messages_file", "") or "")

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -36,11 +36,11 @@ class CLIAgentSetupMixin:
         Relative paths are resolved from ~/.hermes/.
         """
         from cli import _hermes_home, logger
-        from hermes_cli.config import cfg_get
+        from hermes_cli.config import cfg_get, load_config
 
         file_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
         if not file_path:
-            cfg = hermes_cli.config.load_config()
+            cfg = load_config()
             file_path = str(cfg.get("prefill_messages_file", "") or "")
             if not file_path:
                 file_path = str(cfg_get(cfg, "agent", "prefill_messages_file", default="") or "")

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -14,13 +14,55 @@ loaded) so this module never imports ``cli`` at import time -> no import cycle.
 
 from __future__ import annotations
 
+import json
 import sys
+from pathlib import Path
+from typing import Any, Dict, List
 
 from rich.markup import escape as _escape
 
 
 class CLIAgentSetupMixin:
     """Agent construction + session-resume display methods for ``HermesCLI``."""
+
+    @staticmethod
+    def _load_prefill_messages() -> List[Dict[str, Any]]:
+        """Load ephemeral prefill messages from config or env var.
+
+        Checks HERMES_PREFILL_MESSAGES_FILE env var first, then falls back to
+        the top-level prefill_messages_file key in ~/.hermes/config.yaml.
+        agent.prefill_messages_file is accepted as a legacy fallback.
+        Relative paths are resolved from ~/.hermes/.
+        """
+        from cli import _hermes_home, logger
+        from hermes_cli.config import cfg_get
+
+        file_path = sys.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
+        if not file_path:
+            cfg = hermes_cli.config.load_config()
+            file_path = str(cfg.get("prefill_messages_file", "") or "")
+            if not file_path:
+                file_path = str(cfg_get(cfg, "agent", "prefill_messages_file", default="") or "")
+        if not file_path:
+            return []
+
+        path = Path(file_path).expanduser()
+        if not path.is_absolute():
+            path = _hermes_home / path
+        if not path.exists():
+            logger.warning("Prefill messages file not found: %s", path)
+            return []
+
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, list):
+                logger.warning("Prefill messages file must contain a JSON array: %s", path)
+                return []
+            return data
+        except Exception as e:
+            logger.warning("Failed to load prefill messages from %s: %s", path, e)
+            return []
 
     def _ensure_runtime_credentials(self) -> bool:
         """
@@ -233,6 +275,9 @@ class CLIAgentSetupMixin:
 
         if not self._ensure_runtime_credentials():
             return False
+
+        # Load prefill messages from config or env var
+        self.prefill_messages = self._load_prefill_messages()
 
         from hermes_cli.mcp_startup import wait_for_mcp_discovery
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop App (hermes_cli backend) ignoring the `prefill_messages_file` config option. The prefill functionality worked correctly in the TUI (cli.py) and messaging gateway (gateway/run.py), but was silently ignored in the new hermes_cli backend used by the Desktop App.

Root cause: During the god-file Phase 4 refactor (commit 094aa85c3), the `_load_prefill_messages()` function was left behind in cli.py and not ported to hermes_cli/cli_agent_setup_mixin.py. The `_init_agent()` method passes `prefill_messages=self.prefill_messages` to the agent, but `self.prefill_messages` was never assigned from the config file.

This change ports the `_load_prefill_messages()` static method from gateway/run.py into `CLIAgentSetupMixin` and calls it during agent construction, matching the existing TUI and gateway behavior.

## Related Issue

Fixes #60456

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- hermes_cli/cli_agent_setup_mixin.py: Added `_load_prefill_messages()` static method (ported from gateway/run.py)
- hermes_cli/cli_agent_setup_mixin.py: Call `self.prefill_messages = self._load_prefill_messages()` in `_init_agent()` before agent construction

## How to Test

1. Set `prefill_messages_file: prefill-test.json` in config.yaml
2. Create `~/.hermes/prefill-test.json` with valid JSON content
3. Open a new session in the Desktop App
4. Observed result: The prefill message is injected into the conversation as the first assistant message
5. Previously, the prefill was silently ignored with a warning

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [ ] I've updated relevant documentation — or N/A
- [ ] I've updated cli-config.yaml.example — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md — or N/A
- [x] I've considered cross-platform impact — or N/A
- [ ] I've updated tool descriptions/schemas — or N/A
