### PR TITLE
fix(qqbot): add return_exceptions=True to asyncio.gather in chunked upload

### DIFF
--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -599,4 +599,9 @@ async def _run_with_concurrency(
         async with sem:
             await thunk()
 
-    await asyncio.gather(*(_wrap(t) for t in tasks))
+    results = await asyncio.gather(
+        *(_wrap(t) for t in tasks), return_exceptions=True
+    )
+    for r in results:
+        if isinstance(r, Exception):
+            raise r


### PR DESCRIPTION
## Summary

Add  to  in  to prevent cascading cancellation when one part upload fails.

## Problem

In , the  helper uses  without . When uploading a large file via QQ Bot chunked upload, each part is uploaded concurrently. If one part fails after exhausting all retries (raising ),  immediately propagates the exception and cancels all other in-flight coroutines.

This means:
- Other parts that were successfully uploading get cancelled mid-flight
- The upload is left in a partially-complete state with no graceful error reporting
- The caller sees an unhandled exception rather than a controlled failure

## Fix

Added  to the  call, then iterates results to raise the first exception found. This preserves the original failure semantics (exception is still raised to the caller) while ensuring all in-flight coroutines complete their current operation rather than being abruptly cancelled.

## Testing
- Syntax check passed (py_compile)
- Behavior verified: exception propagation preserved, no cascading cancellation