### PR TITLE
fix(cli): port _load_prefill_messages to hermes_cli for Desktop App support (#60456)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -330,6 +330,18 @@ class CLIAgentSetupMixin:
                 pass
         
         try:
+            # Ensure prefill messages are loaded (may not be set by Desktop app
+            # or other consumers that use CLIAgentSetupMixin directly).
+            if getattr(self, "prefill_messages", None) is None:
+                from cli import CLI_CONFIG
+                from hermes_cli.prefill import (
+                    load_prefill_messages,
+                    resolve_prefill_messages_file,
+                )
+
+                self.prefill_messages = load_prefill_messages(
+                    resolve_prefill_messages_file(CLI_CONFIG)
+                )
             runtime = runtime_override or {
                 "api_key": self.api_key,
                 "base_url": self.base_url,

--- a/hermes_cli/prefill.py
+++ b/hermes_cli/prefill.py
@@ -1,0 +1,72 @@
+"""
+Prefill messages: ephemeral few-shot priming for every API call.
+
+Ported out of ``cli.py`` (``_load_prefill_messages`` and
+``_resolve_prefill_messages_file``) so the Desktop app and any other
+``hermes_cli`` consumer can load prefill messages without depending on
+``cli.py`` module-level globals.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+
+def load_prefill_messages(file_path: str) -> List[Dict[str, Any]]:
+    """Load ephemeral prefill messages from a JSON file.
+
+    The file should contain a JSON array of ``{role, content}`` dicts, e.g.::
+
+        [{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "Hello!"}]
+
+    Relative paths are resolved from ``~/.hermes/``.
+
+    Returns an empty list if the path is empty or the file doesn't exist.
+    """
+    if not file_path:
+        return []
+    path = Path(file_path).expanduser()
+    if not path.is_absolute():
+        path = get_hermes_home() / path
+    if not path.exists():
+        logger.warning("Prefill messages file not found: %s", path)
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, list):
+            logger.warning("Prefill messages file must contain a JSON array: %s", path)
+            return []
+        return data
+    except Exception as e:
+        logger.warning("Failed to load prefill messages from %s: %s", path, e)
+        return []
+
+
+def resolve_prefill_messages_file(config: Dict[str, Any]) -> str:
+    """Resolve the prefill-file path from env var / config.
+
+    Checks ``HERMES_PREFILL_MESSAGES_FILE`` env var first, then the top-level
+    ``prefill_messages_file`` config key, and finally the legacy
+    ``agent.prefill_messages_file`` key.
+
+    Returns the resolved path string (possibly empty).
+    """
+    env_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "").strip()
+    if env_path:
+        return env_path
+    top_level = str(config.get("prefill_messages_file", "") or "").strip()
+    if top_level:
+        return top_level
+    agent_cfg = config.get("agent", {})
+    if isinstance(agent_cfg, dict):
+        return str(agent_cfg.get("prefill_messages_file", "") or "").strip()
+    return ""


### PR DESCRIPTION
Port _load_prefill_messages() from cli.py to hermes_cli/prefill.py so the Desktop App (which uses CLIAgentSetupMixin) loads prefill messages from config. Fixes regression from Phase 4 god-file refactor. Closes #60456