### PR TITLE
fix(model-switch): merge configured custom_providers.models

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2057,10 +2057,14 @@ def list_authenticated_providers(
                         headers=_extra_headers_from_config(ep_cfg) or None,
                     )
                     if live_models:
-                        # Merge: keep configured models, add live models that aren't already present
-                        existing_slugs = {m.get("slug", m.get("id", "")) for m in models_list}
+                        # Merge: keep configured models, add live models that aren't already present.
+                        # fetch_api_models returns list[str]; models_list may contain dicts or strings.
+                        existing_slugs = {
+                            m if isinstance(m, str) else m.get("slug", m.get("id", ""))
+                            for m in models_list
+                        }
                         for lm in live_models:
-                            lm_slug = lm.get("slug", lm.get("id", ""))
+                            lm_slug = lm if isinstance(lm, str) else lm.get("slug", lm.get("id", ""))
                             if lm_slug and lm_slug not in existing_slugs:
                                 models_list.append(lm)
                                 existing_slugs.add(lm_slug)
@@ -2334,10 +2338,14 @@ def list_authenticated_providers(
                         headers=grp.get("extra_headers") or None,
                     )
                     if live_models:
-                        # Merge: keep configured models, add live models that aren't already present
-                        existing_slugs = {m.get("slug", m.get("id", "")) for m in grp["models"]}
+                        # Merge: keep configured models, add live models that aren't already present.
+                        # fetch_api_models returns list[str]; grp["models"] may contain dicts or strings.
+                        existing_slugs = {
+                            m if isinstance(m, str) else m.get("slug", m.get("id", ""))
+                            for m in grp["models"]
+                        }
                         for lm in live_models:
-                            lm_slug = lm.get("slug", lm.get("id", ""))
+                            lm_slug = lm if isinstance(lm, str) else lm.get("slug", lm.get("id", ""))
                             if lm_slug and lm_slug not in existing_slugs:
                                 grp["models"].append(lm)
                                 existing_slugs.add(lm_slug)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2057,7 +2057,13 @@ def list_authenticated_providers(
                         headers=_extra_headers_from_config(ep_cfg) or None,
                     )
                     if live_models:
-                        models_list = live_models
+                        # Merge: keep configured models, add live models that aren't already present
+                        existing_slugs = {m.get("slug", m.get("id", "")) for m in models_list}
+                        for lm in live_models:
+                            lm_slug = lm.get("slug", lm.get("id", ""))
+                            if lm_slug and lm_slug not in existing_slugs:
+                                models_list.append(lm)
+                                existing_slugs.add(lm_slug)
                 except Exception:
                     pass
 
@@ -2328,8 +2334,14 @@ def list_authenticated_providers(
                         headers=grp.get("extra_headers") or None,
                     )
                     if live_models:
-                        grp["models"] = live_models
-                        grp["total_models"] = len(live_models)
+                        # Merge: keep configured models, add live models that aren't already present
+                        existing_slugs = {m.get("slug", m.get("id", "")) for m in grp["models"]}
+                        for lm in live_models:
+                            lm_slug = lm.get("slug", lm.get("id", ""))
+                            if lm_slug and lm_slug not in existing_slugs:
+                                grp["models"].append(lm)
+                                existing_slugs.add(lm_slug)
+                        grp["total_models"] = len(grp["models"])
                 except Exception:
                     pass
             results.append({

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -108,7 +108,7 @@ def test_list_authenticated_providers_can_probe_only_current_custom_provider(mon
     offline = next(p for p in providers if p["slug"] == "custom:offline-proxy")
     assert calls == ["http://active.local/v1"]
     assert active["is_current"] is True
-    assert active["models"] == ["active-a", "active-b"]
+    assert active["models"] == ["configured-active", "active-a", "active-b"]
     assert offline["models"] == ["configured-offline"]
 
 

--- a/tests/test_custom_providers_model_merge.py
+++ b/tests/test_custom_providers_model_merge.py
@@ -20,7 +20,7 @@ def test_configured_models_merged_with_live_models():
     ]
     
     # Patch fetch_api_models in hermes_cli.model_switch (where it's imported locally)
-    with patch('hermes_cli.model_switch.fetch_api_models', return_value=live_models):
+    with patch('hermes_cli.models.fetch_api_models', return_value=live_models):
         providers = list_authenticated_providers(
             custom_providers=[
                 {
@@ -61,7 +61,7 @@ def test_configured_models_preserved_when_live_discovery_fails():
     ]
     
     # Mock fetch_api_models to raise an exception
-    with patch('hermes_cli.model_switch.fetch_api_models', side_effect=Exception("Network error")):
+    with patch('hermes_cli.models.fetch_api_models', side_effect=Exception("Network error")):
         providers = list_authenticated_providers(
             custom_providers=[
                 {
@@ -100,7 +100,7 @@ def test_no_duplicates_when_live_returns_same_model():
         {"slug": "only-live", "name": "Only Live"}
     ]
     
-    with patch('hermes_cli.model_switch.fetch_api_models', return_value=live_models):
+    with patch('hermes_cli.models.fetch_api_models', return_value=live_models):
         providers = list_authenticated_providers(
             custom_providers=[
                 {

--- a/tests/test_custom_providers_model_merge.py
+++ b/tests/test_custom_providers_model_merge.py
@@ -11,28 +11,25 @@ def test_configured_models_merged_with_live_models():
     from hermes_cli.model_switch import list_authenticated_providers
     
     configured_models = [
-        {"slug": "configured-model-1", "name": "Configured Model 1"},
-        {"slug": "configured-model-2", "name": "Configured Model 2"}
+        {"id": "configured-model-1", "name": "Configured Model 1"},
+        {"id": "configured-model-2", "name": "Configured Model 2"}
     ]
-    live_models = [
-        {"slug": "live-model-1", "name": "Live Model 1"},
-        {"slug": "live-model-2", "name": "Live Model 2"}
-    ]
+    # fetch_api_models returns list[str] — model slugs
+    live_models = ["live-model-1", "live-model-2"]
     
-    # Patch fetch_api_models in hermes_cli.model_switch (where it's imported locally)
     with patch('hermes_cli.models.fetch_api_models', return_value=live_models):
         providers = list_authenticated_providers(
             custom_providers=[
                 {
                     "name": "Test Provider",
                     "api": "http://localhost:9999/v1",
+                    "api_key": "sk-test",
                     "models": configured_models,
                     "discover_models": True
                 }
             ]
         )
     
-    # Find our test provider
     test_provider = None
     for p in providers:
         if p.get("name") == "Test Provider":
@@ -42,9 +39,9 @@ def test_configured_models_merged_with_live_models():
     assert test_provider is not None, "Test provider not found in results"
     
     result_models = test_provider.get("models", [])
-    result_slugs = {m.get("slug") for m in result_models}
+    # After merge, models_list contains strings (declared_model_ids) + live strings
+    result_slugs = {m if isinstance(m, str) else m.get("slug", m.get("id", "")) for m in result_models}
     
-    # Should contain BOTH configured and live models
     assert "configured-model-1" in result_slugs, "Configured model 1 missing"
     assert "configured-model-2" in result_slugs, "Configured model 2 missing"
     assert "live-model-1" in result_slugs, "Live model 1 missing"
@@ -57,16 +54,16 @@ def test_configured_models_preserved_when_live_discovery_fails():
     from hermes_cli.model_switch import list_authenticated_providers
     
     configured_models = [
-        {"slug": "configured-only", "name": "Configured Only"}
+        {"id": "configured-only", "name": "Configured Only"}
     ]
     
-    # Mock fetch_api_models to raise an exception
     with patch('hermes_cli.models.fetch_api_models', side_effect=Exception("Network error")):
         providers = list_authenticated_providers(
             custom_providers=[
                 {
                     "name": "Test Provider 2",
                     "api": "http://localhost:9998/v1",
+                    "api_key": "sk-test",
                     "models": configured_models,
                     "discover_models": True
                 }
@@ -82,7 +79,8 @@ def test_configured_models_preserved_when_live_discovery_fails():
     assert test_provider is not None
     result_models = test_provider.get("models", [])
     assert len(result_models) == 1, "Configured models should be preserved when discovery fails"
-    assert result_models[0].get("slug") == "configured-only"
+    # _declared_model_ids extracts "id" from dict, so result is string
+    assert result_models[0] == "configured-only"
 
 
 def test_no_duplicates_when_live_returns_same_model():
@@ -92,13 +90,10 @@ def test_no_duplicates_when_live_returns_same_model():
     from hermes_cli.model_switch import list_authenticated_providers
     
     configured_models = [
-        {"slug": "shared-model", "name": "Shared Model"},
-        {"slug": "only-configured", "name": "Only Configured"}
+        {"id": "shared-model", "name": "Shared Model"},
+        {"id": "only-configured", "name": "Only Configured"}
     ]
-    live_models = [
-        {"slug": "shared-model", "name": "Shared Model Live"},
-        {"slug": "only-live", "name": "Only Live"}
-    ]
+    live_models = ["shared-model", "only-live"]
     
     with patch('hermes_cli.models.fetch_api_models', return_value=live_models):
         providers = list_authenticated_providers(
@@ -106,6 +101,7 @@ def test_no_duplicates_when_live_returns_same_model():
                 {
                     "name": "Test Provider 3",
                     "api": "http://localhost:9997/v1",
+                    "api_key": "sk-test",
                     "models": configured_models,
                     "discover_models": True
                 }
@@ -120,7 +116,7 @@ def test_no_duplicates_when_live_returns_same_model():
     
     assert test_provider is not None
     result_models = test_provider.get("models", [])
-    result_slugs = [m.get("slug") for m in result_models]
+    result_slugs = [m if isinstance(m, str) else m.get("slug", m.get("id", "")) for m in result_models]
     
     # shared-model should appear only once
     assert result_slugs.count("shared-model") == 1, "Duplicate model found"

--- a/tests/test_custom_providers_model_merge.py
+++ b/tests/test_custom_providers_model_merge.py
@@ -1,0 +1,127 @@
+"""Test for issue #59560: custom_providers.models list should not be ignored when live /models discovery returns a different list."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+def test_configured_models_merged_with_live_models():
+    """
+    When custom_providers have configured models AND live discovery returns models,
+    the result should MERGE them (not replace configured with live).
+    """
+    from hermes_cli.model_switch import list_authenticated_providers
+    
+    configured_models = [
+        {"slug": "configured-model-1", "name": "Configured Model 1"},
+        {"slug": "configured-model-2", "name": "Configured Model 2"}
+    ]
+    live_models = [
+        {"slug": "live-model-1", "name": "Live Model 1"},
+        {"slug": "live-model-2", "name": "Live Model 2"}
+    ]
+    
+    # Patch fetch_api_models in hermes_cli.model_switch (where it's imported locally)
+    with patch('hermes_cli.model_switch.fetch_api_models', return_value=live_models):
+        providers = list_authenticated_providers(
+            custom_providers=[
+                {
+                    "name": "Test Provider",
+                    "api": "http://localhost:9999/v1",
+                    "models": configured_models,
+                    "discover_models": True
+                }
+            ]
+        )
+    
+    # Find our test provider
+    test_provider = None
+    for p in providers:
+        if p.get("name") == "Test Provider":
+            test_provider = p
+            break
+    
+    assert test_provider is not None, "Test provider not found in results"
+    
+    result_models = test_provider.get("models", [])
+    result_slugs = {m.get("slug") for m in result_models}
+    
+    # Should contain BOTH configured and live models
+    assert "configured-model-1" in result_slugs, "Configured model 1 missing"
+    assert "configured-model-2" in result_slugs, "Configured model 2 missing"
+    assert "live-model-1" in result_slugs, "Live model 1 missing"
+    assert "live-model-2" in result_slugs, "Live model 2 missing"
+    assert len(result_models) == 4, f"Expected 4 merged models, got {len(result_models)}"
+
+
+def test_configured_models_preserved_when_live_discovery_fails():
+    """When live discovery fails, configured models should still be present."""
+    from hermes_cli.model_switch import list_authenticated_providers
+    
+    configured_models = [
+        {"slug": "configured-only", "name": "Configured Only"}
+    ]
+    
+    # Mock fetch_api_models to raise an exception
+    with patch('hermes_cli.model_switch.fetch_api_models', side_effect=Exception("Network error")):
+        providers = list_authenticated_providers(
+            custom_providers=[
+                {
+                    "name": "Test Provider 2",
+                    "api": "http://localhost:9998/v1",
+                    "models": configured_models,
+                    "discover_models": True
+                }
+            ]
+        )
+    
+    test_provider = None
+    for p in providers:
+        if p.get("name") == "Test Provider 2":
+            test_provider = p
+            break
+    
+    assert test_provider is not None
+    result_models = test_provider.get("models", [])
+    assert len(result_models) == 1, "Configured models should be preserved when discovery fails"
+    assert result_models[0].get("slug") == "configured-only"
+
+
+def test_no_duplicates_when_live_returns_same_model():
+    """
+    If a model exists in both configured and live, it should not be duplicated.
+    """
+    from hermes_cli.model_switch import list_authenticated_providers
+    
+    configured_models = [
+        {"slug": "shared-model", "name": "Shared Model"},
+        {"slug": "only-configured", "name": "Only Configured"}
+    ]
+    live_models = [
+        {"slug": "shared-model", "name": "Shared Model Live"},
+        {"slug": "only-live", "name": "Only Live"}
+    ]
+    
+    with patch('hermes_cli.model_switch.fetch_api_models', return_value=live_models):
+        providers = list_authenticated_providers(
+            custom_providers=[
+                {
+                    "name": "Test Provider 3",
+                    "api": "http://localhost:9997/v1",
+                    "models": configured_models,
+                    "discover_models": True
+                }
+            ]
+        )
+    
+    test_provider = None
+    for p in providers:
+        if p.get("name") == "Test Provider 3":
+            test_provider = p
+            break
+    
+    assert test_provider is not None
+    result_models = test_provider.get("models", [])
+    result_slugs = [m.get("slug") for m in result_models]
+    
+    # shared-model should appear only once
+    assert result_slugs.count("shared-model") == 1, "Duplicate model found"
+    assert len(result_models) == 3, f"Expected 3 unique models, got {len(result_models)}: {result_slugs}"


### PR DESCRIPTION
Fixes #59560

## Problem
Custom providers defined in config.yaml's custom_providers section were not being merged into the live provider catalog during model switching. This caused custom models to silently disappear from the picker.

## Fix
Ensures custom_providers.models are merged into the destination provider's model list during swap, preserving user-configured custom endpoints.

## Testing
- Added test suite covering merge behavior
- Verified custom models persist across provider switches