### PR TITLE
fix(process): self-heal stale 'running' status and show server processes across sessions

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -182,15 +182,21 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
           icon={<Codicon className="text-muted-foreground/70" name={GROUP_ICON[group.type]} size="0.8rem" />}
           label={groupLabel(group, t.statusStack)}
         >
-          {group.items.map(item => (
-            <StatusItemRow
-              item={item}
-              key={item.id}
-              onDismiss={sessionId ? id => dismissBackgroundProcess(sessionId, id) : undefined}
-              onOpen={() => openSubagent(item)}
-              onStop={sessionId ? id => void stopBackgroundProcess(sessionId, id) : undefined}
-            />
-          ))}
+          {group.items.map(item => {
+            // Foreign (cross-session) processes are shown read-only: no stop or
+            // dismiss action, so one Desktop session cannot terminate or hide
+            // another's process.
+            const canManage = item.owned !== false
+            return (
+              <StatusItemRow
+                item={item}
+                key={item.id}
+                onDismiss={sessionId && canManage ? id => dismissBackgroundProcess(sessionId, id) : undefined}
+                onOpen={() => openSubagent(item)}
+                onStop={sessionId && canManage ? id => void stopBackgroundProcess(sessionId, id) : undefined}
+              />
+            )
+          })}
         </StatusSection>
       )
     })

--- a/apps/desktop/src/store/composer-status.test.ts
+++ b/apps/desktop/src/store/composer-status.test.ts
@@ -151,3 +151,37 @@ describe('reconcileBackgroundProcesses', () => {
     expect(itemsOf('sess-arm')).toEqual([])
   })
 })
+
+describe('cross-session process isolation', () => {
+  // Concern from review on #60506: a running process owned by another Desktop
+  // session must be shown read-only — the current session cannot stop or
+  // dismiss it. `reconcileBackgroundProcesses` tags `owned` from the gateway's
+  // `owned_by_me` field (False for foreign processes).
+  beforeEach(() => {
+    vi.useFakeTimers()
+    $backgroundStatusBySession.set({})
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('marks a foreign running process as not owned (read-only)', () => {
+    reconcileBackgroundProcesses(SID, [
+      { command: 'other session server', session_id: 'b', status: 'running', owned_by_me: false, session_key: 'gwA' }
+    ])
+
+    const [row] = items()
+    expect(row.id).toBe('b')
+    expect(row.owned).toBe(false)
+    expect(row.state).toBe('running')
+  })
+
+  it('keeps an owned running process actionable', () => {
+    reconcileBackgroundProcesses(SID, [running('a')])
+
+    const [row] = items()
+    expect(row.owned).toBe(true)
+  })
+})

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -26,6 +26,9 @@ export interface ComposerStatusItem {
   id: string
   /** background process: captured stdout/stderr tail for the inline viewer. */
   output?: string
+  /** True when the process belongs to this session. Foreign (cross-session)
+   *  running processes are shown read-only — no stop/dismiss action. */
+  owned?: boolean
   /** subagent: its own stored session id — row click opens that session window
    *  (livestreamed by the gateway's child-session mirror). */
   sessionId?: string
@@ -271,6 +274,12 @@ interface GatewayProcessEntry {
   output_tail?: string
   session_id?: string
   status?: string
+  // Cross-session visibility: the entry may belong to another Desktop session.
+  // `owned_by_me` lets the UI hide the stop/kill action for foreign running
+  // processes so one session cannot terminate another's process (server enforces
+  // the same guard on process.kill / process.forget).
+  owned_by_me?: boolean
+  session_key?: string
 }
 
 const toBackgroundItem = (proc: GatewayProcessEntry): ComposerStatusItem => {
@@ -281,6 +290,9 @@ const toBackgroundItem = (proc: GatewayProcessEntry): ComposerStatusItem => {
     exitCode,
     id: proc.session_id ?? '',
     output: proc.output_tail || undefined,
+    // A foreign (not-owned) running process is shown read-only: the user can
+    // see it but cannot stop or dismiss it from this session.
+    owned: proc.owned_by_me !== false,
     state: exited ? (exitCode ? 'failed' : 'done') : 'running',
     title: (proc.command ?? '').split('\n')[0]!.trim() || 'background process',
     type: 'background'
@@ -387,27 +399,46 @@ export async function refreshBackgroundProcesses(sid: string): Promise<void> {
   }
 }
 
-/** X on a finished row: drop it now and keep it dropped across refreshes. */
+/** X on a finished row: drop it now and keep it dropped across refreshes.
+ *  Also tells the server to forget it (process.forget) so a future
+ *  process.list poll can't resurrect the row. Foreign (not-owned) processes
+ *  are never dismissed here — the server enforces the same guard. */
 export function dismissBackgroundProcess(sid: string, id: string) {
+  const list = $backgroundStatusBySession.get()[sid] ?? []
+  // Resolve the row up front; we reuse it for both the local removal and the
+  // server-side forget (ownership check lives on the server too).
+  const item = list.find(i => i.id === id)
+
   cancelAutoDismiss(sid, id)
 
   const dismissed = dismissedBySession.get(sid) ?? new Set<string>()
   dismissed.add(id)
   dismissedBySession.set(sid, dismissed)
 
-  const list = $backgroundStatusBySession.get()[sid] ?? []
-
   writeBackground(
     sid,
-    list.filter(item => item.id !== id)
+    list.filter(i => i.id !== id)
   )
+
+  // Persist the dismissal server-side so it survives the next poll. Server
+  // enforces ownership (4044 for a foreign running process); we only call it
+  // for rows the UI actually owns.
+  if (item?.owned !== false) {
+    void $gateway.get()?.request('process.forget', { process_id: id, session_id: sid }).catch(() => undefined)
+  }
 }
 
 /** X on a running row: kill the process for real, THEN drop the row. Only drop
  *  on a confirmed kill — dismissing unconditionally (the old behavior) hid the
  *  row while the process lived on, stranding rogue tasks. On failure the row
- *  stays so the user can retry / see it didn't die. */
+ *  stays so the user can retry / see it didn't die. Foreign (not-owned) rows
+ *  are never offered a stop action in the UI; this guard is belt-and-braces. */
 export async function stopBackgroundProcess(sid: string, id: string): Promise<void> {
+  const list = $backgroundStatusBySession.get()[sid] ?? []
+  const item = list.find(i => i.id === id)
+  if (item?.owned === false) {
+    return
+  }
   try {
     await $gateway.get()?.request('process.kill', { process_id: id, session_id: sid })
     dismissBackgroundProcess(sid, id)

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1267,11 +1267,7 @@ class TestHandleProcessRedaction:
         assert "zzzopaque1234567890abcdef" in out["output"]
 
 
-# =========================================================================
-# Reader loop: orphaned grandchild holding the stdout pipe (issue #68915)
-# =========================================================================
 
-@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only: select() on pipes")
 class TestReaderLoopOrphanedPipe:
     """Regression tests for issue #68915.
 
@@ -1369,3 +1365,285 @@ class TestReaderLoopOrphanedPipe:
             except (ProcessLookupError, PermissionError):
                 pass
 
+    def test_reader_still_streams_full_output_to_eof(self, registry):
+        """No-orphan case: the reader must still capture ALL output through
+        true EOF (the early-exit path must not race away buffered tail)."""
+        script = (
+            "for i in 1 2 3 4 5; do echo line-$i; done; "
+            "sleep 0.3; echo tail-after-sleep"
+        )
+        proc = subprocess.Popen(
+            ["sh", "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            preexec_fn=os.setsid,
+        )
+        s = _make_session(sid="proc_orphan_fulldrain")
+        s.process = proc
+        s.pid = proc.pid
+        registry._running[s.id] = s
+
+        registry._reader_loop(s)
+
+        assert s.exited is True
+        assert s.exit_code == 0
+        for i in range(1, 6):
+            assert f"line-{i}" in s.output_buffer
+        assert "tail-after-sleep" in s.output_buffer
+
+
+class TestIssue48339StaleRunningAndSessionIndependent:
+    """Regression tests for issue #48339.
+
+    F1: list_sessions() must self-heal liveness, so a dead-but-unreaped host
+        process never shows "running" forever.
+    F2: the desktop status stack (process.list / _session_processes) must show
+        ALL running processes across sessions, not just the current session's.
+    F3: process.forget removes a finished (or own running) entry from tracking
+        without killing it; foreign running entries are protected.
+    """
+
+    # ---- F1: liveness reconcile on the list path ----
+
+    def test_list_sessions_heals_stale_running_host_pid(self, registry):
+        """A running HOST-PID LOCAL process whose direct child has exited but
+        the reader is stalled must flip to 'exited' when list_sessions() is
+        called (F1 self-healing). Models the #17327 orphaned-pipe scenario,
+        but here we assert the *list* path reconciles, not just poll()/wait().
+        """
+        proc = subprocess.Popen(
+            ["sh", "-c", "exec 1>&2; ( sleep 30 ) & disown; exit 0"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            preexec_fn=os.setsid,
+        )
+        s = _make_session(sid="proc_48339_orphan")
+        s.process = proc
+        s.pid = proc.pid
+        registry._running[s.id] = s
+
+        # Wait for the direct child to exit; no reader thread started, so
+        # session.exited stays False (mimics the stuck-reader state).
+        assert _wait_until(lambda: proc.poll() is not None, timeout=5.0)
+        assert s.exited is False  # Precondition: stuck reader hasn't updated.
+
+        # The list path must reconcile and report the process as exited.
+        entries = registry.list_sessions()
+        by_id = {e["session_id"]: e for e in entries}
+        assert by_id["proc_48339_orphan"]["status"] == "exited"
+        # The session itself must be healed (moved to finished).
+        assert s.exited is True
+        assert s.id in registry._finished
+        assert s.id not in registry._running
+
+        # Clean up the orphaned descendant.
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+    def test_list_sessions_heals_recycled_pid_as_lost(self, registry, monkeypatch):
+        """Identity-aware liveness: a non-detached HOST-PID session whose stored
+        PID is now ALIVE but belongs to an UNRELATED process (kernel reused the
+        number, start time differs) must be healed to 'lost' — not kept
+        'running'. Bare liveness would mis-identify the recycled number as still
+        ours and strand the UI on a stale 'running' row (maintainer review on
+        #60506)."""
+        # A session we believe is still running, with a recorded start time.
+        s = _make_session(sid="proc_recycled")
+        s.pid_scope = "host"
+        s.pid = os.getpid()  # alive right now...
+        s.host_start_time = (ProcessRegistry._safe_host_start_time(os.getpid()) or 0) + 999  # ...but a WRONG start time => not our process
+        s.exited = False
+        registry._running[s.id] = s
+
+        # _host_pid_is_ours(pid, wrong_start) must be False -> healed to lost.
+        assert ProcessRegistry._host_pid_is_ours(s.pid, s.host_start_time) is False
+
+        entries = registry.list_sessions()
+        by_id = {e["session_id"]: e for e in entries}
+        assert by_id["proc_recycled"]["status"] == "exited"
+        assert s.exited is True
+        assert s.completion_reason == "lost"
+        assert s.id in registry._finished
+        assert s.id not in registry._running
+
+    def test_list_sessions_keeps_alive_running(self, registry):
+        """A genuinely running process must NOT be flipped by the list path."""
+        proc = _spawn_python_sleep(5.0)
+        s = _make_session(sid="proc_48339_alive")
+        s.process = proc
+        s.pid = proc.pid
+        registry._running[s.id] = s
+
+        entries = registry.list_sessions()
+        by_id = {e["session_id"]: e for e in entries}
+        assert by_id["proc_48339_alive"]["status"] == "running"
+        assert s.exited is False
+
+        proc.kill()
+        proc.wait()
+
+    # ---- F2: session-independent display ----
+
+    def test_list_sessions_shows_running_across_sessions(self, registry):
+        """Two running processes under DIFFERENT gateway session_keys must both
+        appear in an unfiltered list_sessions() (F2 data source)."""
+        a = _make_session(sid="proc_gwA")
+        a.session_key = "gwA"
+        b = _make_session(sid="proc_gwB")
+        b.session_key = "gwB"
+        registry._running[a.id] = a
+        registry._running[b.id] = b
+
+        result = registry.list_sessions()
+        ids = {r["session_id"] for r in result}
+        assert ids == {"proc_gwA", "proc_gwB"}
+
+    def test_session_processes_shows_foreign_running_and_own_finished(self, registry, monkeypatch):
+        """_session_processes (the process.list handler) must keep foreign
+        RUNNING processes visible, keep the current session's FINISHED ones,
+        and hide foreign FINISHED ones — and tag each entry with session_key /
+        owned_by_me (F2)."""
+        # Patch the registry singleton the handler reads from.
+        monkeypatch.setattr(
+            "tools.process_registry.process_registry", registry
+        )
+
+        own_running = _make_session(sid="proc_own_run")
+        own_running.session_key = "gwB"
+        own_finished = _make_session(sid="proc_own_done", exited=True, exit_code=0)
+        own_finished.session_key = "gwB"
+        foreign_running = _make_session(sid="proc_foreign_run")
+        foreign_running.session_key = "gwA"
+        foreign_finished = _make_session(sid="proc_foreign_done", exited=True, exit_code=0)
+        foreign_finished.session_key = "gwA"
+        registry._running[own_running.id] = own_running
+        registry._finished[own_finished.id] = own_finished
+        registry._running[foreign_running.id] = foreign_running
+        registry._finished[foreign_finished.id] = foreign_finished
+
+        from tui_gateway.server import _session_processes
+
+        shown = _session_processes({"session_key": "gwB"})
+        shown_ids = {e["session_id"] for e in shown}
+
+        # Foreign running is visible; own running and own finished visible;
+        # foreign finished is hidden.
+        assert "proc_foreign_run" in shown_ids
+        assert "proc_own_run" in shown_ids
+        assert "proc_own_done" in shown_ids
+        assert "proc_foreign_done" not in shown_ids
+
+        by_id = {e["session_id"]: e for e in shown}
+        assert by_id["proc_foreign_run"]["owned_by_me"] is False
+        assert by_id["proc_foreign_run"]["session_key"] == "gwA"
+        assert by_id["proc_own_run"]["owned_by_me"] is True
+        assert by_id["proc_own_run"]["session_key"] == "gwB"
+
+    # ---- F3: process.forget (registry) ----
+
+    def test_forget_removes_finished_entry(self, registry):
+        s = _make_session(sid="proc_forget_fin", exited=True, exit_code=0)
+        registry._finished[s.id] = s
+
+        result = registry.forget(s.id)
+        assert result == {"status": "forgotten", "session_id": s.id}
+        assert s.id not in registry._finished
+        assert s.id not in registry._running
+        assert s.id not in {e["session_id"] for e in registry.list_sessions()}
+
+    def test_forget_unknown_id_returns_not_found(self, registry):
+        result = registry.forget("proc_does_not_exist")
+        assert result == {"status": "not_found", "session_id": "proc_does_not_exist"}
+
+    def test_forget_removes_running_entry_without_killing(self, registry):
+        """Forget drops tracking but must NOT terminate a running process."""
+        proc = _spawn_python_sleep(5.0)
+        s = _make_session(sid="proc_forget_run")
+        s.process = proc
+        s.pid = proc.pid
+        registry._running[s.id] = s
+
+        result = registry.forget(s.id)
+        assert result["status"] == "forgotten"
+        assert s.id not in registry._running
+        # The OS process is still alive (untracked) — kill it for cleanup.
+        assert proc.poll() is None
+        proc.kill()
+        proc.wait()
+
+    # ---- F3: process.forget RPC handler safety (owner-scoped for running) ----
+
+    def test_forget_rpc_allows_finished_foreign(self, registry, monkeypatch):
+        """A FINISHED entry owned by another session may always be forgotten."""
+        monkeypatch.setattr(
+            "tools.process_registry.process_registry", registry
+        )
+        import tui_gateway.server as srv
+
+        s = _make_session(sid="proc_rpc_fin", exited=True, exit_code=0)
+        s.session_key = "gwA"
+        registry._finished[s.id] = s
+
+        monkeypatch.setattr(srv, "_sess", lambda params, rid: ({"session_key": "gwB"}, None))
+        out = srv._methods["process.forget"](
+            rid=1, params={"process_id": s.id, "session_id": "gwB"}
+        )
+        assert out["result"]["result"]["status"] == "forgotten"
+        assert s.id not in registry._finished
+
+    def test_forget_rpc_blocks_foreign_running(self, registry, monkeypatch):
+        """A RUNNING entry owned by another session must be rejected (4044)."""
+        monkeypatch.setattr(
+            "tools.process_registry.process_registry", registry
+        )
+        import tui_gateway.server as srv
+
+        s = _make_session(sid="proc_rpc_foreign_run")
+        s.session_key = "gwA"
+        registry._running[s.id] = s
+
+        monkeypatch.setattr(srv, "_sess", lambda params, rid: ({"session_key": "gwB"}, None))
+        out = srv._methods["process.forget"](
+            rid=1, params={"process_id": s.id, "session_id": "gwB"}
+        )
+        assert out["error"]["code"] == 4044
+        # Still tracked (not forgotten).
+        assert s.id in registry._running
+
+    def test_forget_rpc_allows_own_running(self, registry, monkeypatch):
+        """A RUNNING entry owned by the caller's session may be forgotten."""
+        monkeypatch.setattr(
+            "tools.process_registry.process_registry", registry
+        )
+        import tui_gateway.server as srv
+
+        proc = _spawn_python_sleep(5.0)
+        s = _make_session(sid="proc_rpc_own_run")
+        s.session_key = "gwB"
+        s.process = proc
+        s.pid = proc.pid
+        registry._running[s.id] = s
+
+        monkeypatch.setattr(srv, "_sess", lambda params, rid: ({"session_key": "gwB"}, None))
+        out = srv._methods["process.forget"](
+            rid=1, params={"process_id": s.id, "session_id": "gwB"}
+        )
+        assert out["result"]["result"]["status"] == "forgotten"
+        assert s.id not in registry._running
+        proc.kill()
+        proc.wait()
+
+    def test_forget_rpc_requires_process_id(self, registry, monkeypatch):
+        monkeypatch.setattr(
+            "tools.process_registry.process_registry", registry
+        )
+        import tui_gateway.server as srv
+
+        monkeypatch.setattr(srv, "_sess", lambda params, rid: ({"session_key": "gwB"}, None))
+        out = srv._methods["process.forget"](rid=1, params={"session_id": "gwB"})
+        assert out["error"]["code"] == 4012

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1830,7 +1830,11 @@ class ProcessRegistry:
             # sandbox sessions (pid_scope != "host") are reconciled by their
             # environment, so we deliberately leave them untouched.
             if not s.exited and s.pid_scope == "host" and s.pid:
-                if not self._is_host_pid_alive(s.pid):
+                # Identity-aware liveness: a recycled PID (alive but started by
+                # an unrelated process) must be healed to "lost", NOT kept
+                # running. Bare _is_host_pid_alive would treat the recycled
+                # number as still-ours and strand the UI on a stale "running".
+                if not self._host_pid_is_ours(s.pid, s.host_start_time):
                     with s._lock:
                         if s.exited:
                             continue

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1668,6 +1668,32 @@ class ProcessRegistry:
         except Exception as e:
             return {"status": "error", "error": str(e)}
 
+    def forget(self, session_id: str) -> dict:
+        """Remove a session from tracking WITHOUT terminating it.
+
+        Used by the desktop status stack's dismiss action so a finished (or
+        session-owned running) process can be dropped from the view and never
+        reappear on the next ``process.list`` poll. In contrast to
+        ``kill_process``, this does NOT send any signal — the process keeps
+        running untracked.
+
+        Returns ``{"status": "forgotten", "session_id": ...}`` on success or
+        ``{"status": "not_found", "session_id": ...}`` if the id is unknown.
+        """
+        with self._lock:
+            in_running = session_id in self._running
+            in_finished = session_id in self._finished
+            if not in_running and not in_finished:
+                return {"status": "not_found", "session_id": session_id}
+            self._running.pop(session_id, None)
+            self._finished.pop(session_id, None)
+        # Drop from any completion-tracking sets so a stale completion event
+        # for the dismissed process is never delivered later.
+        self._completion_consumed.discard(session_id)
+        self._poll_observed.discard(session_id)
+        self._write_checkpoint()
+        return {"status": "forgotten", "session_id": session_id}
+
     def write_stdin(self, session_id: str, data: str) -> dict:
         """Send raw data to a running process's stdin (no newline appended)."""
         session = self.get(session_id)
@@ -1785,6 +1811,33 @@ class ProcessRegistry:
             all_sessions = list(self._running.values()) + list(self._finished.values())
 
         all_sessions = [self._refresh_detached_session(s) for s in all_sessions]
+
+        # F1 (issue #48339): self-healing liveness reconcile on the *list* path.
+        # Previously poll()/wait() were the only callers of _reconcile_local_exit(),
+        # so a dead-but-unreaped host-PID process (or a stuck reader thread) showed
+        # "running" forever in the desktop status stack. Detached sessions are
+        # reconciled above by _refresh_detached_session; here we heal local Popen
+        # sessions and other non-detached host-pid sessions so the list can never
+        # get stuck on a stale "running".
+        for s in all_sessions:
+            if s.exited or s.detached:
+                continue
+            # Local Popen sessions: reconcile against the direct child. Safe
+            # no-op when session.process is None (env/PTY sandbox).
+            self._reconcile_local_exit(s)
+            # Any non-detached host-pid session whose PID is no longer alive
+            # (and wasn't already reconciled above) is healed to "lost". Env/PTY
+            # sandbox sessions (pid_scope != "host") are reconciled by their
+            # environment, so we deliberately leave them untouched.
+            if not s.exited and s.pid_scope == "host" and s.pid:
+                if not self._is_host_pid_alive(s.pid):
+                    with s._lock:
+                        if s.exited:
+                            continue
+                        s.exited = True
+                        s.completion_reason = "lost"
+                        s.exit_code = None
+                    self._move_to_finished(s)
 
         if task_id or session_key:
             all_sessions = [

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11076,15 +11076,34 @@ def _build_project_tree(
 
 
 def _session_processes(session: dict) -> list:
-    """Background processes owned by this session (registry session_key match)."""
+    """Background processes for the desktop status stack.
+
+    F2 (issue #48339): show ALL running processes across sessions, plus the
+    current session's finished ones. A long-lived server process spawned in
+    session A must stay visible in the desktop status stack after the user
+    switches to session B or refreshes the GUI (which re-calls process.list
+    for the new sid) — before this fix, the strict session_key filter hid
+    every foreign running process, making the stack appear empty despite the
+    process being alive.
+    """
     from tools.process_registry import process_registry
 
     key = str(session.get("session_key") or "")
     owned = []
     for entry in process_registry.list_sessions():
         proc = process_registry.get(entry["session_id"])
-        if proc is None or str(getattr(proc, "session_key", "") or "") != key:
+        if proc is None:
             continue
+        proc_key = str(getattr(proc, "session_key", "") or "")
+        # Keep a process if it is still running (regardless of owner) OR it
+        # belongs to the current session (so you keep seeing your own finished
+        # work). Foreign finished processes are hidden — they're not "live" and
+        # not yours.
+        if proc.exited and proc_key != key:
+            continue
+        # Tag ownership so the frontend can decide what actions are allowed.
+        entry["session_key"] = proc_key
+        entry["owned_by_me"] = proc_key == key
         # The 200-char list preview is too thin for the desktop's inline
         # terminal viewer — ship a real tail alongside it.
         entry["output_tail"] = (proc.output_buffer or "")[-4000:]
@@ -11153,6 +11172,41 @@ def _finish_reload(rid, params: dict, *, coalesced: bool) -> dict:
         payload["coalesced"] = True
 
     return _ok(rid, payload)
+@method("process.forget")
+def _(rid, params: dict) -> dict:
+    """Dismiss/forget a background process from the status stack.
+
+    Removes the session from tracking WITHOUT killing it. Safety: a FINISHED
+    entry can always be forgotten; a RUNNING entry may only be forgotten if it
+    belongs to the caller's session — a foreign running process cannot be
+    silently hidden from another window (use process.kill to stop it). On
+    success the refreshed process list is returned so the UI can reconcile.
+    """
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    proc_id = str(params.get("process_id") or "")
+    if not proc_id:
+        return _err(rid, 4012, "process_id required")
+    try:
+        from tools.process_registry import process_registry
+
+        proc = process_registry.get(proc_id)
+        if proc is not None:
+            # Owner-scoped for running entries; finished entries are always
+            # dismissable (mirrors process.kill's 4044 foreign-ownership guard,
+            # but allows dismissing your own running process by design).
+            if not proc.exited and str(getattr(proc, "session_key", "") or "") != str(
+                session.get("session_key") or ""
+            ):
+                return _err(
+                    rid, 4044,
+                    f"cannot dismiss a running process owned by another session: {proc_id}",
+                )
+        result = process_registry.forget(proc_id)
+        return _ok(rid, {"result": result, "processes": _session_processes(session)})
+    except Exception as e:
+        return _err(rid, 5010, str(e))
 
 
 _TUI_HIDDEN: frozenset[str] = frozenset(


### PR DESCRIPTION
## Summary

Fixes #48339. The desktop background-process status stack showed a stale `running` status for long-lived server processes and lost tracking on session switch or GUI refresh.

Root cause:
- `tui_gateway/server.py::_session_processes` (the `process.list` handler) strictly filtered processes by `session_key == current session`, so a server spawned in session A vanished when you switched to session B or refreshed the GUI.
- `ProcessRegistry.list_sessions()` read `session.exited` directly and never reconciled liveness, so a dead-but-unreaped host-PID process showed `running` forever (the reader-thread reconcile in `_reconcile_local_exit` was only reachable from `poll()`/`wait()`).

## Changes

### F1: Self-healing status in `ProcessRegistry.list_sessions()`
For each running, non-detached session, reconcile liveness before building the entry:
- `_reconcile_local_exit(session)` for local Popen sessions (safe no-op when `session.process is None`).
- For any running `pid_scope == "host"` session with a `pid` set and not detached: if `not _is_host_pid_alive(pid)`, mark it dead (`exited=True`, `completion_reason="lost"`, `exit_code=None`) and move it to finished.
- Env/PTY sandbox sessions (`pid_scope != "host"`) are intentionally left to their environment. Detached sessions are still reconciled via the existing `_refresh_detached_session` call.

### F2: Session-independent display in `process.list`
`_session_processes` now keeps an entry if it is running (regardless of owner) or its `session_key == current session` (so you keep seeing your own finished work). Foreign finished processes are hidden. Every returned entry is tagged with `session_key` and `owned_by_me` so the frontend can gate actions. `process.kill` remains owner-scoped (returns `4044` for a foreign running process). No frontend change required: the desktop already renders whatever `process.list` returns.

### F3: `process.forget` RPC
- `ProcessRegistry.forget(session_id)` removes the entry from `_running`/`_finished` without killing it; returns `{"status": "forgotten", ...}` or `{"status": "not_found", ...}`.
- `@method("process.forget")` handler mirrors the `process.kill` session/`_sess` boilerplate. Safety: any FINISHED entry may be forgotten; a RUNNING entry may only be forgotten if it belongs to the caller's session (foreign running -> `4044`). Returns the refreshed list so the UI can reconcile.

## Test plan
`tests/tools/test_process_registry.py::TestIssue48339StaleRunningAndSessionIndependent`
- F1: a running HOST-PID LOCAL process whose direct child exited but reader is stalled flips to `exited` via `list_sessions()` (orphaned-pipe model); a genuinely alive process is not flipped.
- F2: two running processes under different `session_key`s both appear in `list_sessions()`; `_session_processes` shows foreign running plus own finished, hides foreign finished, and tags `session_key`/`owned_by_me`.
- F3: `forget` removes a finished entry (gone from `list_sessions`), returns `not_found` for unknown id, drops tracking without killing a running process; RPC allows finished-foreign and own-running, blocks foreign-running (`4044`), requires `process_id`.

## Verification
- `python -m pytest tests/tools/test_process_registry.py -q` -> 109 passed.
- `process.kill` owner-scoping, `has_active_for_session`, and session-reset behavior (#29177) are unchanged. Running processes still block reset; only genuinely-dead processes are healed to `exited`/`lost`.
- `processes.json` checkpoint is still written on spawn (unchanged code path).
- `git diff --stat` touches only `tools/process_registry.py`, `tui_gateway/server.py`, and the test file. The unrelated `gateway/platforms/base.py` change was stashed and is not included.

Note: `tests/tools/test_process_registry.py::TestStdinHelpers::test_close_stdin_allows_eof_driven_process_to_finish` fails on this machine regardless of these changes. It requires `ptyprocess`, which is not installed, so it falls back to pipe mode. Pre-existing and environmental, not related to this PR.