### PR TITLE
fix(memory): better error when replace() content already exists verbatim (#60089)

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -418,6 +418,23 @@ class MemoryStore:
                 # If all matches are identical (exact duplicates), operate on the first one
                 unique_texts = {e for _, e in matches}
                 if len(unique_texts) > 1:
+                    # Check if new_content already exists verbatim among the matched
+                    # entries.  If so, a fallback add() would create a duplicate,
+                    # so warn up front and point at batch operations (#60089).
+                    if new_content in unique_texts:
+                        previews = self._previews([e for _, e in matches])
+                        return self._consolidation_failure({
+                            "success": False,
+                            "error": (
+                                f"Multiple entries matched '{old_text}', and the "
+                                f"replacement content already exists as a separate "
+                                f"entry.  Use a more specific 'old_text' to target "
+                                f"the exact entry, or remove the existing duplicate "
+                                f"entry first."
+                            ),
+                            "matches": previews,
+                            "current_entries": entries,
+                        })
                     previews = self._previews([e for _, e in matches])
                     return {
                         "success": False,


### PR DESCRIPTION
When `MemoryStore.replace()` finds multiple entries matching `old_text` and the replacement content already exists verbatim as a separate entry, warn the caller with a specific error message instead of the generic "Multiple entries matched" message. This prevents the model from falling back to `add()` and creating a duplicate.

**Problem:** `MemoryStore.replace()` returns a generic "Multiple entries matched" error when `old_text` matches multiple entries. The model's natural fallback is `add()`, which creates a duplicate of content that already existed — with no signal that the intended text was already stored.

**Fix:** When multiple entries match and `new_content` is already present verbatim, the error message now explicitly calls this out and directs the caller to use a more specific `old_text` or remove the duplicate first.

Fixes #60089