### PR TITLE
fix(aux): forward max_tokens to all providers instead of dropping it (#60388)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6211,38 +6211,23 @@ def _build_call_kwargs(
         kwargs["temperature"] = temperature
 
     if max_tokens is not None:
-        # We do NOT cap output by default. Most chat-completions providers treat
-        # an omitted max_tokens as "use the model's max output", which is what we
-        # want for auxiliary tasks (compression summaries, titles, vision, etc.) —
-        # an explicit cap only risks truncating a summary or 400-ing on providers
-        # that reject the parameter outright (e.g. GitHub Copilot / newer OpenAI
-        # GPT-5 models require max_completion_tokens, not max_tokens; ZAI vision
-        # models reject it entirely with error 1210). Omitting it sidesteps all of
-        # those wire-format quirks at once.
+        # Forward an explicit max_tokens to ALL providers so the user's
+        # configured caps (reference_max_tokens, per-slot max_tokens,
+        # title_max_tokens, etc.) are respected everywhere (#60388).
+        # Previously we only sent it to Anthropic-compat and NVIDIA NIM
+        # endpoints, silently dropping it for everyone else — meaning MoA
+        # reference_max_tokens and auxiliary max_tokens settings in
+        # config.yaml had no effect on OpenRouter, Copilot, Nous, custom
+        # endpoints, etc.
         #
-        # The one exception is the Anthropic Messages wire (MiniMax and any
-        # ``/anthropic`` endpoint reached through the OpenAI SDK wrapper), where
-        # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
-        # there.
-        #
-        # NVIDIA NIM (integrate.api.nvidia.com and local NIM endpoints) is a
-        # second exception: some models—notably minimaxai/minimax-m3—return HTTP
-        # 200 with an empty choices[] payload when max_tokens is omitted. The main
-        # NVIDIA chat path already sends an output cap via the provider profile;
-        # preserve it on the auxiliary path too.
-        _effective_base = base_url or (
-            _current_custom_base_url() if provider == "custom" else ""
-        )
-        _provider_norm = str(provider or "").strip().lower()
-        _is_nvidia_nim = (
-            _provider_norm in {"nvidia", "nvidia-nim", "nim", "build-nvidia", "nemotron"}
-            or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
-        )
-        if (
-            _is_anthropic_compat_endpoint(provider, _effective_base)
-            or _is_nvidia_nim
-        ):
-            kwargs["max_tokens"] = max_tokens
+        # The old omits-by-default design avoided a few provider-specific
+        # quirks (ZAI vision models reject max_tokens with error 1210;
+        # GitHub Copilot / newer GPT-5 models need max_completion_tokens
+        # instead), but those are edge cases that produce a 400/fallback
+        # rather than silent omission — a failing reference is visible
+        # whereas a silently ignored cap is invisible. Provider-specific
+        # parameter mapping belongs in the provider adapter, not here.
+        kwargs["max_tokens"] = max_tokens
 
     if tools:
         # Defensive dedup: providers like Google Vertex, Azure, and Bedrock

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -276,13 +276,14 @@ class TestResolveTaskProviderModel:
 
 
 class TestBuildCallKwargsMaxTokens:
-    """_build_call_kwargs should not cap output by default (#34530).
+    """_build_call_kwargs forwards max_tokens to ALL providers when set.
 
-    Most chat-completions providers treat an omitted max_tokens as "use the
-    model max", which is what we want for auxiliary tasks. An explicit cap only
-    risks truncation or a wire-format 400 (GitHub Copilot / GPT-5 reject
-    max_tokens; ZAI vision rejects it entirely). The Anthropic Messages wire is
-    the one exception — max_tokens is a mandatory field there.
+    When the user configures reference_max_tokens, per-slot max_tokens, or
+    title_max_tokens etc., the value should be included in the API request
+    regardless of provider so the configured cap is actually enforced
+    (#60388).  Provider-specific edge cases (e.g. ZAI vision rejecting
+    max_tokens) are handled at a higher level in the provider adapter or
+    appear as a visible 400/fallback rather than silent omission.
     """
 
     @pytest.mark.parametrize(
@@ -297,7 +298,7 @@ class TestBuildCallKwargsMaxTokens:
             ("zai", "glm-4v-flash", "https://open.bigmodel.cn/api/paas/v4"),
         ],
     )
-    def test_omits_max_tokens_for_openai_compatible(self, provider, model, base_url):
+    def test_includes_max_tokens_for_all_providers(self, provider, model, base_url):
         from agent.auxiliary_client import _build_call_kwargs
 
         kwargs = _build_call_kwargs(
@@ -307,8 +308,7 @@ class TestBuildCallKwargsMaxTokens:
             max_tokens=1234,
             base_url=base_url,
         )
-        assert "max_tokens" not in kwargs
-        assert "max_completion_tokens" not in kwargs
+        assert kwargs.get("max_tokens") == 1234
 
     @pytest.mark.parametrize(
         "provider,model,base_url",


### PR DESCRIPTION
## Problem

`_build_call_kwargs` in `auxiliary_client.py` only forwarded `max_tokens` to the API request for Anthropic-compat and NVIDIA NIM endpoints. For all other providers (OpenRouter, Copilot, Nous, custom endpoints, ZAI, etc.), the value was silently dropped — meaning:

1. **MoA `reference_max_tokens`** preset setting had no effect on most providers
2. **Per-slot `max_tokens`** on reference models was stripped  
3. **Auxiliary task `max_tokens`** (title generation, compression, etc.) was silently ignored

The result was unbounded output from reference models and auxiliary calls regardless of the cap configured in `config.yaml`.

## Fix

Always include `max_tokens` in the request kwargs when explicitly provided by the caller, regardless of provider. Provider-specific edge cases (ZAI vision models rejecting `max_tokens` with error 1210; GitHub Copilot / newer GPT-5 models needing `max_completion_tokens`) produce a visible HTTP 400 and fallback rather than silent omission — a failing reference is visible to the user, whereas a silently ignored cap is invisible and misleading.

The existing special cases (Anthropic Messages wire requiring `max_tokens`) continue to work because we now always send it — they were already covered.

**Changes:**
- `agent/auxiliary_client.py`: Replace the provider-filtered `max_tokens` forwarding with an unconditional forward
- `tests/agent/test_auxiliary_client.py`: Update the `test_omits_max_tokens_for_openai_compatible` test to `test_includes_max_tokens_for_all_providers`

Fixes #60388