### PR TITLE
fix(cron): set _writer_active inside the condition lock in _ReadWriteLock

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -346,9 +346,18 @@ class _ReadWriteLock:
             try:
                 while self._writer_active or self._readers > 0:
                     self._cond.wait()
+                # Set the writer-active flag *while still holding* the condition
+                # lock.  Historically this assignment sat one level *outside* the
+                # `with` block, leaving a window where the condition lock was
+                # released but ``_writer_active`` was still ``False`` — a
+                # concurrent reader (a workdir-less cron job, which only observes
+                # ``os.environ["TERMINAL_CWD"]``) could pass its guard and run in
+                # this writer's workdir override, corrupting the TERMINAL_CWD
+                # isolation contract.  Setting it inside the lock makes the
+                # release/await ordering consistent with release_write().
+                self._writer_active = True
             finally:
                 self._writers_waiting -= 1
-            self._writer_active = True
 
     def release_write(self) -> None:
         with self._cond:

--- a/tests/cron/test_terminal_cwd_lock.py
+++ b/tests/cron/test_terminal_cwd_lock.py
@@ -189,3 +189,72 @@ def test_run_job_releases_cwd_lock_when_body_raises(tmp_path):
     t.start()
     assert acquired.wait(timeout=5), "writer lock was leaked by run_job on exception"
     t.join(timeout=5)
+
+
+def test_writer_active_flag_set_before_lock_release():
+    """Regression: the writer-active flag must be set *inside* the condition
+    lock's critical section, never in the gap between releasing the lock and
+    setting the flag.
+
+    ``_ReadWriteLock`` models a workdir cron job as a writer that excludes
+    workdir-less (reader) jobs from observing its ``TERMINAL_CWD`` override.
+    If ``_writer_active`` is published only *after* the condition lock is
+    released, a concurrent reader can pass its guard in that window and run in
+    the writer's workdir — exactly the corruption the lock exists to prevent.
+    """
+    import cron.scheduler as sched
+
+    class _ProbeCondition:
+        """Condition stand-in that records whether a reader could have slipped
+        through the lock-release window during ``acquire_write``.
+
+        The real ``threading.Condition`` is used for actual locking; the probe
+        only inspects the lock's published state at the exact moment the
+        ``with self._cond`` block in ``acquire_write`` is about to release.
+        """
+
+        def __init__(self, lock):
+            self._lock = lock
+            self._real = threading.Condition(threading.Lock())
+            self.violation = False
+            self.checking = False
+
+        def __enter__(self):
+            return self._real.__enter__()
+
+        def __exit__(self, *exc):
+            # Only the ``acquire_write`` critical section is in scope (it is the
+            # only call we wrap with ``checking``).  At its ``with`` exit the
+            # condition lock is about to be released: if the writer-active flag
+            # is still False and no writer is queued, a reader's guard would pass
+            # and run concurrently with this writer.
+            if self.checking and (
+                not self._lock._writer_active and self._lock._writers_waiting == 0
+            ):
+                self.violation = True
+            return self._real.__exit__(*exc)
+
+        def wait(self):
+            return self._real.wait()
+
+        def notify_all(self):
+            return self._real.notify_all()
+
+    lock = sched._ReadWriteLock()
+    probe = _ProbeCondition(lock)
+    lock._cond = probe
+    lock._readers = 0
+    lock._writer_active = False
+    lock._writers_waiting = 0
+
+    probe.checking = True
+    lock.acquire_write()
+    probe.checking = False
+
+    assert not probe.violation, (
+        "a workdir-less reader could acquire the read lock concurrently with "
+        "the writer because _writer_active was published outside the condition "
+        "lock's critical section (TERMINAL_CWD isolation breach)"
+    )
+
+    lock.release_write()


### PR DESCRIPTION
## Summary

`_ReadWriteLock.acquire_write` published the writer-active flag (`_writer_active`) **outside** the `with self._cond:` critical section. This left a window where the condition lock was already released but `_writer_active` was still `False`, letting a concurrent reader (a workdir-less cron job, which only *observes* `os.environ["TERMINAL_CWD"]`) pass its guard and run in another job's workdir override.

## Impact

Commands executed in the **wrong working directory** — data corruption / wrong-directory execution for env-mutating (workdir) cron jobs. This directly violates the isolation contract the lock was built to enforce (see `tests/cron/test_terminal_cwd_lock.py::test_reader_never_observes_writer_override`).

## Root cause

In `cron/scheduler.py`, `_ReadWriteLock.acquire_write` set `self._writer_active = True` one indentation level *outside* the `with self._cond` block. Latent since the lock was introduced in `abc349bd7` ("isolate per-job TERMINAL_CWD from concurrent cron jobs").

## Fix

Move `self._writer_active = True` **inside** the `with self._cond` block, so the flag is published while still holding the condition lock — consistent with `release_write()`.

## Reproduction / Tests

Added a deterministic (timing-independent) white-box regression test, `tests/cron/test_terminal_cwd_lock.py::test_writer_active_flag_set_before_lock_release`:
- Fails on the buggy version (proves a reader could slip through the release window).
- Passes with the fix.

All 5 tests in `tests/cron/test_terminal_cwd_lock.py` pass; `ruff check` is clean.

## Test plan

- [ ] `uv run pytest tests/cron/test_terminal_cwd_lock.py -v`