### PR TITLE
feat(skills): support diff all for modified bundled skills

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1196,18 +1196,14 @@ def do_list_modified(console: Optional[Console] = None,
     for entry in modified:
         c.print(f"  [yellow]~[/] {entry['name']}")
     c.print()
-    c.print("[dim]See changes:   hermes skills diff <name>[/]")
+    c.print("[dim]See all changes: hermes skills diff all[/]")
+    c.print("[dim]See one skill:   hermes skills diff <name>[/]")
     c.print("[dim]Resume updates: hermes skills reset <name>          (keep your copy, re-baseline)[/]")
     c.print("[dim]Revert to stock: hermes skills reset <name> --restore[/]\n")
 
 
-def do_diff(name: str, console: Optional[Console] = None) -> None:
-    """Show how the user's copy of a bundled skill differs from the stock version."""
-    from tools.skills_sync import diff_bundled_skill
-
-    c = console or _console
-    result = diff_bundled_skill(name)
-
+def _print_bundled_skill_diff_result(result: dict, c: Console,
+                                     *, show_reset_hint: bool = True) -> None:
     if not result["ok"]:
         c.print(f"[bold red]Error:[/] {result['message']}\n")
         return
@@ -1237,7 +1233,42 @@ def do_diff(name: str, console: Optional[Console] = None) -> None:
         else:  # binary
             c.print(f"[yellow]~ {entry['path']}:[/] binary file differs")
     c.print()
-    c.print(f"[dim]Revert with: hermes skills reset {name} --restore[/]\n")
+    if show_reset_hint:
+        c.print(f"[dim]Revert with: hermes skills reset {result['name']} --restore[/]\n")
+
+
+def do_diff_all(console: Optional[Console] = None) -> None:
+    """Show diffs for all user-modified bundled skills."""
+    from tools.skills_sync import diff_bundled_skill_paths, list_user_modified_bundled_skills
+
+    c = console or _console
+    modified = list_user_modified_bundled_skills()
+    if not modified:
+        c.print("[dim]No user-modified bundled skills — everything tracks upstream.[/]\n")
+        return
+
+    c.print(f"\n[bold]{len(modified)} user-modified bundled skill diff(s)[/]\n")
+    for index, entry in enumerate(modified):
+        name = entry["name"]
+        if index:
+            c.print("[dim]" + ("-" * 72) + "[/]\n")
+        c.print(f"[bold cyan]# {name}[/]")
+        result = diff_bundled_skill_paths(name, entry["dest"], entry["bundled_src"])
+        _print_bundled_skill_diff_result(result, c, show_reset_hint=False)
+    c.print("[dim]Revert one skill with: hermes skills reset <name> --restore[/]\n")
+
+
+def do_diff(name: str, console: Optional[Console] = None) -> None:
+    """Show how the user's copy of a bundled skill differs from the stock version."""
+    from tools.skills_sync import diff_bundled_skill
+
+    c = console or _console
+    if name.lower() == "all":
+        do_diff_all(console=c)
+        return
+
+    result = diff_bundled_skill(name)
+    _print_bundled_skill_diff_result(result, c)
 
 
 def do_opt_out(remove: bool = False,

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -187,7 +187,8 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         description=(
             "Show the bundled skills whose local copy differs from the version last "
             "synced, i.e. the ones `hermes update` reports as user-modified and skips. "
-            "Use `hermes skills diff <name>` to see changes and `hermes skills reset "
+            "Use `hermes skills diff all` to see all changes, `hermes skills diff <name>` "
+            "for one skill, and `hermes skills reset "
             "<name>` to resume updates."
         ),
     )
@@ -199,15 +200,15 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
 
     skills_diff = skills_subparsers.add_parser(
         "diff",
-        help="Show how your copy of a bundled skill differs from the stock version",
+        help="Show how your copy of one or all bundled skills differs from the stock version",
         description=(
             "Print a unified diff between your local copy of a bundled skill and the "
-            "current bundled (stock) version, so you can confirm what changed before "
-            "running `hermes skills reset`."
+            "current bundled (stock) version. Pass `all` to show every user-modified "
+            "bundled skill in one output before running `hermes skills reset`."
         ),
     )
     skills_diff.add_argument(
-        "name", help="Skill name to diff (e.g. google-workspace)"
+        "name", help="Skill name to diff, or 'all' for every modified bundled skill"
     )
 
     skills_opt_out = skills_subparsers.add_parser(

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,7 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import do_check, do_diff, do_install, do_list, do_update, handle_skills_slash
 
 
 class _DummyLockFile:
@@ -96,6 +96,36 @@ def _capture_update(monkeypatch, results) -> tuple[str, list[tuple[str, str, boo
 
     do_update(console=console)
     return sink.getvalue(), installs
+
+
+def _capture_diff(name: str) -> str:
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_diff(name, console=console)
+    return sink.getvalue()
+
+
+def _diff_result(name: str, line: str) -> dict:
+    return {
+        "ok": True,
+        "name": name,
+        "found": True,
+        "modified": True,
+        "message": f"Changes for '{name}'",
+        "diffs": [
+            {
+                "path": "SKILL.md",
+                "status": "modified",
+                "diff": (
+                    "--- SKILL.md\n"
+                    "+++ SKILL.md\n"
+                    "@@ -1 +1 @@\n"
+                    "-old\n"
+                    f"+{line}\n"
+                ),
+            }
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +277,76 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
 
     assert installs == [("skills-sh/example/repo/hub-skill", "category", True)]
     assert "Updated 1 skill" in output
+
+
+def test_do_diff_all_reports_no_modified_bundled_skills(monkeypatch):
+    import tools.skills_sync as skills_sync
+
+    monkeypatch.setattr(skills_sync, "list_user_modified_bundled_skills", lambda: [])
+
+    output = _capture_diff("all")
+
+    assert "No user-modified bundled skills" in output
+
+
+def test_do_diff_all_prints_each_modified_bundled_skill(monkeypatch):
+    import tools.skills_sync as skills_sync
+
+    diffed = []
+
+    monkeypatch.setattr(
+        skills_sync,
+        "list_user_modified_bundled_skills",
+        lambda: [
+            {"name": "alpha", "dest": "alpha-dest", "bundled_src": "alpha-src"},
+            {"name": "beta", "dest": "beta-dest", "bundled_src": "beta-src"},
+        ],
+    )
+    monkeypatch.setattr(
+        skills_sync,
+        "diff_bundled_skill",
+        lambda name: pytest.fail("bulk diff should reuse listed skill paths"),
+    )
+
+    def _fake_diff_paths(name, dest, bundled_src):
+        diffed.append((name, dest, bundled_src))
+        return _diff_result(name, f"{name} local edit")
+
+    monkeypatch.setattr(skills_sync, "diff_bundled_skill_paths", _fake_diff_paths)
+
+    output = _capture_diff("all")
+
+    assert diffed == [
+        ("alpha", "alpha-dest", "alpha-src"),
+        ("beta", "beta-dest", "beta-src"),
+    ]
+    assert "2 user-modified bundled skill diff(s)" in output
+    assert "# alpha" in output
+    assert "+alpha local edit" in output
+    assert "# beta" in output
+    assert "+beta local edit" in output
+    assert "Revert one skill with: hermes skills reset <name> --restore" in output
+
+
+def test_do_diff_named_skill_uses_single_skill_diff(monkeypatch):
+    import tools.skills_sync as skills_sync
+
+    monkeypatch.setattr(
+        skills_sync,
+        "list_user_modified_bundled_skills",
+        lambda: pytest.fail("single-skill diff should not list all modified skills"),
+    )
+    monkeypatch.setattr(
+        skills_sync,
+        "diff_bundled_skill",
+        lambda name: _diff_result(name, "named local edit"),
+    )
+
+    output = _capture_diff("alpha")
+
+    assert "Changes for 'alpha'" in output
+    assert "+named local edit" in output
+    assert "Revert with: hermes skills reset alpha --restore" in output
 
 
 def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():
@@ -780,4 +880,3 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["source"] == "browse-sh"
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
-

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -936,11 +936,12 @@ def _read_for_diff(path: Path) -> Tuple[Optional[bytes], Optional[str]]:
         return data, None
 
 
-def diff_bundled_skill(name: str) -> dict:
-    """Diff a user's copy of a bundled skill against the current stock version.
+def diff_bundled_skill_paths(name: str, dest: Path, bundled_src: Path) -> dict:
+    """Diff a local bundled skill path against a specific stock skill path.
 
-    Lets a user see exactly what diverged before deciding whether to keep their
-    edits or ``hermes skills reset`` back to upstream.
+    ``list_user_modified_bundled_skills`` already resolves ``dest`` and
+    ``bundled_src``. This path-based helper lets callers diff those entries
+    without re-discovering the bundled skills catalog for every skill.
 
     Returns a dict:
         ``ok`` (bool), ``name`` (str), ``found`` (bool — bundled source exists),
@@ -951,10 +952,7 @@ def diff_bundled_skill(name: str) -> dict:
     """
     import difflib
 
-    bundled_dir = _get_bundled_dir()
-    bundled_by_name = dict(_discover_bundled_skills(bundled_dir))
-    bundled_src = bundled_by_name.get(name)
-    if bundled_src is None:
+    if not bundled_src.exists():
         return {
             "ok": False,
             "name": name,
@@ -966,7 +964,7 @@ def diff_bundled_skill(name: str) -> dict:
                 f"diff against). Hub-installed skills use `hermes skills inspect`."
             ),
         }
-    dest = _compute_relative_dest(bundled_src, bundled_dir)
+
     if not dest.exists():
         return {
             "ok": False,
@@ -1033,6 +1031,31 @@ def diff_bundled_skill(name: str) -> dict:
             else f"'{name}' differs from the stock version in {len(diffs)} file(s)."
         ),
     }
+
+
+def diff_bundled_skill(name: str) -> dict:
+    """Diff a user's copy of a bundled skill against the current stock version.
+
+    Lets a user see exactly what diverged before deciding whether to keep their
+    edits or ``hermes skills reset`` back to upstream.
+    """
+    bundled_dir = _get_bundled_dir()
+    bundled_by_name = dict(_discover_bundled_skills(bundled_dir))
+    bundled_src = bundled_by_name.get(name)
+    if bundled_src is None:
+        return {
+            "ok": False,
+            "name": name,
+            "found": False,
+            "modified": False,
+            "diffs": [],
+            "message": (
+                f"'{name}' is not a tracked bundled skill (no stock version to "
+                f"diff against). Hub-installed skills use `hermes skills inspect`."
+            ),
+        }
+    dest = _compute_relative_dest(bundled_src, bundled_dir)
+    return diff_bundled_skill_paths(name, dest, bundled_src)
 
 
 def set_bundled_skills_opt_out(enabled: bool) -> dict:


### PR DESCRIPTION
## What does this PR do?

Adds CLI support for `hermes skills diff all`, which prints diffs for every user-modified bundled skill in one command.

This is intentionally limited to the CLI command path. `/skills diff all` is left out of scope because `/skills diff <id>` is currently used by the pending skill-write approval flow.

## Related Issue

Addresses the CLI portion of #60445.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added `hermes skills diff all` handling in the skills CLI path.
- Reused resolved bundled-skill paths for bulk diffs to avoid rediscovering the bundled skill catalog per modified skill.
- Updated `hermes skills diff --help` text for the `all` argument.
- Added focused tests for empty, multi-skill, and single-skill diff behavior.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_skills_hub.py tests/tools/test_skills_list_modified_diff.py -q`
2. `uv run --extra dev ruff check hermes_cli/skills_hub.py hermes_cli/subcommands/skills.py tools/skills_sync.py tests/hermes_cli/test_skills_hub.py tests/tools/test_skills_list_modified_diff.py`
3. `uv run --extra dev python scripts/check-windows-footguns.py hermes_cli/skills_hub.py hermes_cli/subcommands/skills.py tools/skills_sync.py tests/hermes_cli/test_skills_hub.py`
4. `uv run --extra dev python -m hermes_cli.main skills diff --help`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A
