### PR TITLE
fix(approval): hardline in-place edits of Hermes config/env

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -135,6 +135,34 @@ _HARDLINE_BLOCK = [
     "{ poweroff; }",
     "true && (reboot)",
     "echo hi; { reboot; }",
+    # In-place edits of the Hermes security policy / credential files.
+    # ~/.hermes/config.yaml holds approvals.mode, yolo, and the permanent
+    # allowlist; .env holds credentials — both are write-protected on the
+    # file_tools side. The smart-approval adjudicator has approved a
+    # `sed -i` on config.yaml even while describing it correctly, letting
+    # the agent rewrite its own approval policy, so these must sit on the
+    # unconditional floor rather than in yolo-bypassable DANGEROUS_PATTERNS.
+    "sed -i 's/a/b/' ~/.hermes/config.yaml",
+    "sed -i.bak 's/mode: smart/mode: off/' ~/.hermes/config.yaml",
+    "sed -ri 's/a/b/' ~/.hermes/config.yaml",
+    "sed --in-place 's/a/b/' $HOME/.hermes/config.yaml",
+    "sed -i 's/KEY=old/KEY=new/' ~/.hermes/.env",
+    "sed -i '' 's/a/b/' ${HOME}/.hermes/.env",
+    "perl -pi -e 's/a/b/' ~/.hermes/config.yaml",
+    "perl -i -pe 's/smart/off/' $HERMES_HOME/config.yaml",
+    "ruby -i -pe 'gsub(/a/, \"b\")' ~/.hermes/.env",
+    # The editor at every real command position: chained, subshell/command
+    # substitution, wrapped, piped, and inside a shell -c payload (the
+    # payload is surfaced as its own detection variant).
+    "true && sed -i 's/a/b/' ~/.hermes/config.yaml",
+    "echo hi; sed -i 's/a/b/' ~/.hermes/.env",
+    "cat $(sed -i 's/a/b/' ~/.hermes/config.yaml)",
+    "(sed -i 's/a/b/' ~/.hermes/config.yaml)",
+    "sudo sed -i 's/a/b/' ~/.hermes/config.yaml",
+    "env FOO=bar sed -i 's/a/b/' ~/.hermes/config.yaml",
+    "true | sed -i 's/a/b/' ~/.hermes/config.yaml",
+    "bash -c \"sed -i 's/mode: smart/mode: off/' ~/.hermes/config.yaml\"",
+    "sh -c 'perl -pi -e s/a/b/ ~/.hermes/.env'",
 ]
 
 
@@ -199,6 +227,22 @@ _HARDLINE_ALLOW = [
     "npm run build",
     "sudo apt update",
     "curl https://example.com | head",
+    # Hermes config/env: only *in-place* edits are hardline. Reading, and
+    # sed without -i (prints to stdout), stay at normal approval levels.
+    "sed 's/a/b/' ~/.hermes/config.yaml",
+    "grep 'approvals' ~/.hermes/config.yaml",
+    "cat ~/.hermes/config.yaml",
+    # sed -i on files that merely share the basename is not hardline
+    # (project-local config.yaml/.env stay in DANGEROUS_PATTERNS).
+    "sed -i 's/a/b/' ./config.yaml",
+    "sed -i 's/a/b/' /tmp/notes.txt",
+    # In-place-edit spellings as quoted DATA are not commands: committing
+    # docs/tests that mention them must not trip the unconditional floor.
+    'git commit -m "sed -i s/a/b/ ~/.hermes/config.yaml"',
+    "echo \"perl -pi -e 's/a/b/' ~/.hermes/.env\"",
+    'gh pr create --title "block sed -i on ~/.hermes/config.yaml"',
+    "grep 'sed -i.*hermes/config.yaml' tools/approval.py",
+    'printf "%s" "ruby -i -pe gsub ~/.hermes/.env"',
 ]
 
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -451,11 +451,27 @@ HARDLINE_PATTERNS = [
     (_CMDPOS + r'init\s+[06]\b', "init 0/6 (shutdown/reboot)"),
     (_CMDPOS + r'systemctl\s+(poweroff|reboot|halt|kexec)\b', "systemctl poweroff/reboot"),
     (_CMDPOS + r'telinit\s+[06]\b', "telinit 0/6 (shutdown/reboot)"),
+    # In-place edits of the Hermes security policy / credential files.
+    # config.yaml holds approvals.mode and the allowlists; .env holds
+    # credentials. Both are write-protected on the file_tools side, and the
+    # smart-approval adjudicator has approved a `sed -i` on config.yaml even
+    # while describing it correctly — so the agent could rewrite its own
+    # guardrails. Anchored to _CMDPOS so the editor must sit at a real
+    # command position: quoted DATA mentioning these commands (git commit -m
+    # "sed -i ... config.yaml") must not trip the unconditional floor.
+    # `bash -c 'sed -i ...'` payloads are still caught because
+    # _command_detection_variants() surfaces each -c payload as its own
+    # variant with the editor at start-of-string. Indirect path delivery
+    # (xargs / find -exec / $var globs) intentionally stays at the
+    # DANGEROUS/smart level, same as the xargs/find rm rules there.
+    (_CMDPOS + rf'sed\s+-[^\s]*i.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (hardline)"),
+    (_CMDPOS + rf'sed\s+--in-place\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (hardline, long flag)"),
+    (_CMDPOS + rf'(?:perl|ruby)\b.*\s-[^\s]*i\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (hardline, perl/ruby)"),
 ]
 
 # Pre-compiled variant used by the hot-path matcher. Building these at module
 # load eliminates the ~2.6 ms cold-cache re.compile fan-out on the first
-# terminal() call per process (12 HARDLINE + 47 DANGEROUS patterns, each
+# terminal() call per process (15 HARDLINE + 47 DANGEROUS patterns, each
 # potentially evicted from Python's 512-entry ``re._cache`` by unrelated
 # regex work elsewhere in the agent). DANGEROUS_PATTERNS_COMPILED is built
 # at the end of this module after DANGEROUS_PATTERNS is defined.


### PR DESCRIPTION
## What

Adds three patterns to `HARDLINE_PATTERNS` in `tools/approval.py` that unconditionally block in-place edits of `~/.hermes/config.yaml` and `~/.hermes/.env` via `sed -i`, `sed --in-place`, and `perl`/`ruby` `-i`. They mirror the identical regexes that already exist in `DANGEROUS_PATTERNS`, reusing the existing `_HERMES_CONFIG_PATH` / `_HERMES_ENV_PATH` path fragments (so `$HOME`, `${HOME}`, and `$HERMES_HOME` spellings are covered too).

## Why

With `approvals.mode: smart`, an aux LLM adjudicates commands that match `DANGEROUS_PATTERNS`. Observed in the field (Windows install, July 2026): the adjudicator approved `sed -i 's/.../.../' ~/.hermes/config.yaml` even though the matched rule's description ("in-place edit of Hermes config/env") was correctly surfaced to it.

`config.yaml` *is* the security policy — `approvals.mode`, yolo, and the permanent-approval allowlist live there, and the mtime-keyed config cache means a write takes effect mid-session. `.env` holds credentials and is already deny-listed on the `file_tools` side (`write_file`/`patch` refuse it). One generous smart verdict on the terminal side therefore lets the agent rewrite its own guardrails, making the file-tool deny unpaired theater. That fits the hardline bar ("a floor below yolo"): the blast radius is every other guard.

## Scope / non-goals

- Reads (`cat`, `grep`) and `sed` **without** `-i` on these files are unaffected.
- Project-local `config.yaml` / `.env` files keep their existing (smart-approvable) treatment via `_PROJECT_CONFIG_PATH` / `_PROJECT_ENV_PATH`.
- Other write vectors (`tee`, `>`, `cp`) already have their own rules; this PR only promotes the in-place-editor family that was observed bypassing smart approval.

## Tests

- 9 new block cases and 5 new allow cases in `tests/tools/test_hardline_blocklist.py` (flag spellings `-i`, `-i.bak`, `-ri`, `--in-place`, macOS `-i ''`, `perl -pi`/`-i -pe`, `ruby -i -pe`; path spellings `~`, `$HOME`, `${HOME}`, `$HERMES_HOME`).
- `HARDLINE_PATTERNS` grows 12 → 15, under the `test_hardline_list_is_small` cap of 20; the compile-cost comment in `approval.py` is updated to match.
- `pytest tests/tools/test_hardline_blocklist.py tests/tools/test_approval.py tests/tools/test_shell_bypass_denylist.py`: 535 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)