### PR TITLE
fix(approval): honor /stop cancel over a racing /approve (fail-closed)

### DIFF
--- a/tests/tools/test_approval_interrupt.py
+++ b/tests/tools/test_approval_interrupt.py
@@ -158,3 +158,92 @@ class TestApprovalInterrupt:
         assert not t.is_alive()
         # Timed out (no resolution) because the foreign interrupt was ignored.
         assert result_holder["result"] == {"resolved": False, "choice": None, "reason": None}
+
+    def test_concurrent_approve_cannot_override_interrupt_deny(self, monkeypatch):
+        """A /stop-driven interrupt must resolve a pending approval as "deny",
+        even when a concurrent /approve is being processed on the gateway loop
+        at the same instant.
+
+        Reproduces the race deterministically: the agent thread is parked in
+        ``entry.event.wait()``.  The moment it wakes (the event was signalled
+        by a concurrent ``/approve``), the user's ``/stop`` is also active.
+        The wait loop is driven down the ``event.wait() == True`` branch and
+        must re-check ``is_interrupted()`` there — otherwise it trusts
+        ``entry.result`` (set to "once" by the approve) and a *cancelled*
+        dangerous command executes.
+
+        Without the post-wait interrupt re-check, this returns "once".
+        """
+        from tools import approval as mod
+
+        # Use monkeypatch (auto-restored) rather than a bare module attribute
+        # assignment so this test cannot leak approval-config overrides into
+        # other test files in a single pytest process.
+        monkeypatch.setattr(
+            mod, "_get_approval_config", lambda: {"gateway_timeout": 300}
+        )
+
+        approval_data = {
+            "command": "rm -rf /",
+            "description": "catastrophic recursive delete",
+            "pattern_key": "rm_rf",
+            "pattern_keys": ["rm_rf"],
+        }
+        result_holder = {}
+        notified = threading.Event()
+
+        def _notify_cb(_data):
+            notified.set()
+
+        # is_interrupted() starts False so the worker enters event.wait();
+        # it flips True exactly when the wait returns, simulating /stop
+        # arriving concurrently with the approve's event.set().
+        _interrupted = {"v": False}
+        monkeypatch.setattr(mod, "is_interrupted", lambda: _interrupted["v"])
+
+        def _worker():
+            result_holder["result"] = mod._await_gateway_decision(
+                self.SESSION_KEY, _notify_cb, approval_data
+            )
+
+        t = threading.Thread(target=_worker, daemon=True)
+        t.start()
+        assert notified.wait(timeout=5), "approval was never enqueued/notified"
+
+        # Grab the live entry the worker is blocked on and control its wait:
+        # when the worker calls wait(), a concurrent /approve finalizes "once"
+        # and the user's /stop becomes active, then the event is "signalled".
+        entry = mod._gateway_queues[self.SESSION_KEY][0]
+
+        def _wait(timeout=None):
+            mod.resolve_gateway_approval(self.SESSION_KEY, "once")
+            _interrupted["v"] = True
+            return True
+
+        monkeypatch.setattr(entry.event, "wait", _wait)
+
+        t.join(timeout=10)
+        assert not t.is_alive(), "approval wait did not return after interrupt"
+
+        # The user cancelled via /stop — the outcome must stay "deny", never
+        # be flipped to "once" by the concurrent approve.
+        assert result_holder["result"] == {
+            "resolved": True,
+            "choice": "deny",
+            "reason": None,
+        }, result_holder["result"]
+
+    def test_finalize_entry_is_idempotent(self):
+        """Two concurrent decisions on one entry keep the first outcome."""
+        from tools import approval as mod
+
+        _clear_approval_state()
+        entry = mod._ApprovalEntry({"command": "x"})
+
+        # First decision wins.
+        assert mod._finalize_entry(entry, "deny") is True
+        # A later "once" must be ignored.
+        assert mod._finalize_entry(entry, "once") is False
+        assert entry.result == "deny"
+        assert entry.finalized is True
+

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1418,7 +1418,7 @@ _permanent_approved: set = set()
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason")
+    __slots__ = ("event", "data", "result", "reason", "finalized")
 
     def __init__(self, data: dict):
         self.event = threading.Event()
@@ -1428,6 +1428,14 @@ class _ApprovalEntry:
         # (``/deny <reason>``) so the agent can adapt instead of only
         # hearing "denied". Ported from qwibitai/nanoclaw#2832.
         self.reason: Optional[str] = None
+        # Once an outcome is decided (interrupt-driven deny, timeout-driven
+        # cleanup, or a user /approve//deny), this entry is ``finalized`` and
+        # must not be re-resolved.  Without it, a /stop-driven "deny" and a
+        # concurrent gateway "/approve" race on the shared ``result`` field:
+        # the approve can overwrite the deny after the wait loop has already
+        # broken on the interrupt's event.set(), causing a cancelled dangerous
+        # command to execute.  See _finalize_entry.
+        self.finalized: bool = False
 
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
@@ -1459,6 +1467,31 @@ def unregister_gateway_notify(session_key: str) -> None:
         entry.event.set()
 
 
+def _finalize_entry(entry: "_ApprovalEntry", result: str,
+                    reason: Optional[str] = None) -> bool:
+    """Decide an approval entry exactly once, under the global lock.
+
+    Returns True if this call set the outcome, False if the entry was already
+    finalized by a concurrent path (e.g. an interrupt-driven deny vs. a
+    gateway /approve).  Either way the entry's ``result`` is left at the
+    *first* decision so the agent thread reads a single, stable outcome.
+
+    The wait loop reads ``entry.result`` *after* it has broken out of its
+    poll loop (outside ``_lock``), so without this guarded single-writer the
+    shared field can be clobbered by a racing ``resolve_gateway_approval`` or
+    ``clear_session`` call, flipping a user-issued "deny" into an "approve".
+    """
+    with _lock:
+        if entry.finalized:
+            return False
+        entry.result = result
+        if reason:
+            entry.reason = reason
+        entry.finalized = True
+        entry.event.set()
+    return True
+
+
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
                              reason: Optional[str] = None) -> int:
@@ -1487,12 +1520,15 @@ def resolve_gateway_approval(session_key: str, choice: str,
         if not queue:
             _gateway_queues.pop(session_key, None)
 
+    # A finalized entry (e.g. already denied by a concurrent /stop, or cleared
+    # on session teardown) must keep its existing outcome — a late /approve
+    # must not revive a cancelled command.  _finalize_entry is a no-op for
+    # already-finalized entries, so only genuinely-pending entries count.
+    resolved = 0
     for entry in targets:
-        entry.result = choice
-        if reason:
-            entry.reason = reason
-        entry.event.set()
-    return len(targets)
+        if _finalize_entry(entry, choice, reason=reason):
+            resolved += 1
+    return resolved
 
 
 def has_blocking_approval(session_key: str) -> bool:
@@ -1541,8 +1577,9 @@ def clear_session(session_key: str) -> None:
     for entry in entries:
         # Session-boundary cleanup should cancel any blocked approval waits
         # immediately so the old run can unwind instead of idling until timeout.
-        entry.result = "deny"
-        entry.event.set()
+        # Finalize so a late /approve arriving after teardown cannot flip this
+        # cancellation back into an approval (see _finalize_entry).
+        _finalize_entry(entry, "deny")
 
 
 def is_session_yolo_enabled(session_key: str) -> bool:
@@ -2244,14 +2281,36 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                 "returning deny for session %s",
                 session_key,
             )
-            entry.result = "deny"
-            entry.event.set()
+            # An explicit /stop (or /new) is a cancel: it MUST finalize this
+            # approval as "deny" and win over any concurrent /approve, even one
+            # that already finalized "once" while this worker was parked in
+            # event.wait().  Force the outcome under the lock and ignore the
+            # check-first guard in _finalize_entry, so a racing approve cannot
+            # flip a user-issued cancel into an execution.  The wait loop reads
+            # entry.result below; forcing it here makes that read stable.
+            with _lock:
+                entry.result = "deny"
+                entry.finalized = True
+                entry.event.set()
             resolved = True
             break
         _remaining = _deadline - time.monotonic()
         if _remaining <= 0:
             break
         if entry.event.wait(timeout=min(1.0, _remaining)):
+            # The event was signalled, but it may have been signalled by a
+            # concurrent /approve while the user was also cancelling via /stop.
+            # Honor the cancel: a user-issued interrupt must win over a racing
+            # approval (fail-closed).  Re-checking here is essential because the
+            # interrupt branch below only runs when we *reach* the top of the
+            # loop; if we were woken by an /approve's event.set() we would
+            # otherwise trust entry.result without ever re-checking the cancel.
+            if is_interrupted():
+                with _lock:
+                    entry.result = "deny"
+                    entry.finalized = True
+                resolved = True
+                break
             resolved = True
             break
         if touch_activity_if_due is not None:


### PR DESCRIPTION
## Summary

In the gateway command-approval flow, a pending dangerous-command approval
resolves as soon as `entry.event.wait()` returns `True` and then trusts the
shared `entry.result` field **without re-checking `is_interrupted()`**. When a
user hits `/stop` (cancel) at the same instant an `/approve` is being processed
by the gateway event loop, the approve can overwrite the shared `result` to
`"once"` — so a **cancelled** dangerous command still executes.

## Impact

- **Who:** Every gateway session that uses command approvals (the default
  dangerous-command gate) across all messaging platforms (Telegram, Discord,
  Slack, …).
- **Severity:** A user who cancels a pending `rm -rf` / `sudo` / other blocked
  command via `/stop` can have that command run anyway if an `/approve` is
  raced in at the same moment. This is a confidentiality/integrity violation —
  arbitrary command execution against the user's explicit intent.
- **Trigger:** Requires `/stop` (or `/new`) and `/approve` to be processed
  concurrently on a single pending approval — a narrow but real window during
  normal interactive use.

## Root cause

`tools/approval.py`, `_await_gateway_decision()`:

- The poll loop blocks on `entry.event.wait()`. When the event is signalled
  (by `resolve_gateway_approval`), the loop does `resolved = True; break` and
  reads `entry.result` **outside any lock**, never re-checking
  `is_interrupted()`.
- `resolve_gateway_approval()` mutates the same `entry.result` field
  unconditionally (outside the critical section of `_lock`).
- The interrupt branch set `entry.result = "deny"` but did **not own** the
  outcome — a concurrent approve could clobber it after the loop had already
  broken on the interrupt's `event.set()`.
- `_ApprovalEntry` had no finalization/owner guard (`__slots__` = `event,
  data, result, reason`), so two writers (agent thread + gateway loop) raced
  on a single mutable field with no coherence.

The user's cancel must always win (fail-closed): a `/stop` during a pending
approval is an explicit "do not run this" and must not be flipped into a run.

## Fix

- Add a `finalized: bool` slot to `_ApprovalEntry`.
- Add a single locked writer, `_finalize_entry(entry, result, reason=None)`,
  that is idempotent: the first decision wins; later writers are no-ops. Used
  by `resolve_gateway_approval` and `clear_session` cleanup.
- In the wait loop's event-signalled branch, re-check `is_interrupted()` and,
  when interrupted, force the outcome to `"deny"` under `_lock` (overriding any
  concurrent approve). This makes a user-issued cancel always beat a racing
  approval.
- The interrupt branch also forces `deny` under `_lock` so it cannot be
  overwritten.

Scope of change is limited to `tools/approval.py` (decision state) — no new
tools, no config surface, no behavior change for the normal (non-raced)
approve/deny/timeout paths.

## Reproduction

Deterministic regression test (`tests/tools/test_approval_interrupt.py`):

1. Enqueue a pending approval; the agent thread parks in `entry.event.wait()`.
2. Control the entry's `event.wait` so that, the moment it returns, a concurrent
   `resolve_gateway_approval(session_key, "once")` finalizes and `is_interrupted()`
   flips to `True` (simulating `/stop` arriving together with the approve).
3. The worker is driven down the `event.wait() == True` branch and must resolve
   as `"deny"`.

- **Pre-fix:** returns `{"resolved": True, "choice": "once", ...}` — the cancel
  is silently dropped and the dangerous command would run.
- **Post-fix:** returns `{"resolved": True, "choice": "deny", ...}`.

A second unit test asserts `_finalize_entry` is idempotent (first decision
sticks).

## Tests

- `tests/tools/test_approval_interrupt.py::test_concurrent_approve_cannot_override_interrupt_deny`
- `tests/tools/test_approval_interrupt.py::test_finalize_entry_is_idempotent`

**Mutation-checked:** stashing the source fix makes
`test_concurrent_approve_cannot_override_interrupt_deny` FAIL (pre-fix code
returns `"once"`); restoring the fix makes it PASS. The test therefore proves
the regression, not just freezes current behavior.

Existing interrupt/timeout approval tests continue to pass.