### PR TITLE
fix(web): lazy-install ddgs backend

### DIFF
--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -28,6 +28,33 @@ logger = logging.getLogger(__name__)
 _SEARCH_TIMEOUT_SECS = 30
 
 
+def _ensure_ddgs_package_importable() -> bool:
+    """Return True once ``ddgs`` is importable, lazy-installing if allowed."""
+    try:
+        import ddgs  # noqa: F401
+
+        return True
+    except ImportError:
+        pass
+
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+
+        _lazy_ensure("search.ddgs", prompt=False)
+    except ImportError:
+        pass
+    except Exception as exc:  # noqa: BLE001 — lazy_deps carries the install hint
+        logger.debug("DDGS lazy install unavailable: %s", exc)
+        return False
+
+    try:
+        import ddgs  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def _run_ddgs_search(query: str, safe_limit: int) -> list[dict[str, Any]]:
     """Run the blocking ddgs query and return normalized hits.
 
@@ -78,12 +105,7 @@ class DDGSWebSearchProvider(WebSearchProvider):
         NOT perform network I/O — runs at tool-registration time and on every
         ``hermes tools`` paint.
         """
-        try:
-            import ddgs  # noqa: F401
-
-            return True
-        except ImportError:
-            return False
+        return _ensure_ddgs_package_importable()
 
     def supports_search(self) -> bool:
         return True
@@ -98,12 +120,13 @@ class DDGSWebSearchProvider(WebSearchProvider):
         wall-clock timeout (``_SEARCH_TIMEOUT_SECS``) so a hung search cannot
         block the shared agent loop indefinitely (#36776).
         """
-        try:
-            import ddgs  # type: ignore  # noqa: F401 — availability probe
-        except ImportError:
+        if not _ensure_ddgs_package_importable():
             return {
                 "success": False,
-                "error": "ddgs package is not installed — run `pip install ddgs`",
+                "error": (
+                    "ddgs package is not installed and lazy installation could not make "
+                    "it available — run `pip install ddgs==9.14.4`"
+                ),
             }
 
         # DDGS().text yields at most `max_results` items; we cap defensively

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452
 exa = ["exa-py==2.10.2"]
 firecrawl = ["firecrawl-py==4.17.0"]
 parallel-web = ["parallel-web==0.4.2"]
+ddgs = ["ddgs==9.14.4"]
 # Image generation backends
 fal = ["fal-client==0.13.1"]
 # Edge TTS — default TTS provider but still optional (users can pick

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -66,7 +66,7 @@ def test_lazy_installable_extras_excluded_from_all():
     # this list AND verify [all] doesn't contain it.
     lazy_covered_extras = {
         "anthropic", "bedrock",
-        "exa", "firecrawl", "parallel-web",
+        "ddgs", "exa", "firecrawl", "parallel-web",
         "fal",
         "edge-tts", "tts-premium",
         "voice",  # faster-whisper / sounddevice / numpy

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -68,6 +68,12 @@ class TestDDGSProviderIsConfigured:
     def test_not_configured_when_package_missing(self, monkeypatch):
         monkeypatch.delitem(sys.modules, "ddgs", raising=False)
         monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
+        from tools import lazy_deps
+
+        unavailable = lazy_deps.FeatureUnavailable(
+            "search.ddgs", ("ddgs==9.14.4",), "blocked for test"
+        )
+        monkeypatch.setattr(lazy_deps, "ensure", lambda *_a, **_kw: (_ for _ in ()).throw(unavailable))
         # Block the import so ``import ddgs`` raises ImportError even if the package is actually installed
         import builtins
         orig_import = builtins.__import__
@@ -80,6 +86,31 @@ class TestDDGSProviderIsConfigured:
         monkeypatch.setattr(builtins, "__import__", blocked_import)
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
         assert DDGSWebSearchProvider().is_available() is False
+
+    def test_configured_after_lazy_install(self, monkeypatch):
+        monkeypatch.delitem(sys.modules, "ddgs", raising=False)
+        monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
+        from tools import lazy_deps
+
+        calls = []
+        orig_import = __import__
+
+        def fake_ensure(feature, prompt=True):
+            calls.append((feature, prompt))
+            _install_fake_ddgs(monkeypatch)
+
+        def blocked_first_import(name, *args, **kwargs):
+            if name == "ddgs" and not calls:
+                raise ImportError("missing until lazy install")
+            return orig_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(lazy_deps, "ensure", fake_ensure)
+        monkeypatch.setattr("builtins.__import__", blocked_first_import)
+
+        from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
+        assert DDGSWebSearchProvider().is_available() is True
+        assert calls == [("search.ddgs", False)]
 
     def test_provider_name(self):
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
@@ -134,6 +165,12 @@ class TestDDGSProviderSearch:
     def test_missing_package_returns_failure(self, monkeypatch):
         monkeypatch.delitem(sys.modules, "ddgs", raising=False)
         monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
+        from tools import lazy_deps
+
+        unavailable = lazy_deps.FeatureUnavailable(
+            "search.ddgs", ("ddgs==9.14.4",), "blocked for test"
+        )
+        monkeypatch.setattr(lazy_deps, "ensure", lambda *_a, **_kw: (_ for _ in ()).throw(unavailable))
         import builtins
         orig_import = builtins.__import__
 
@@ -148,6 +185,7 @@ class TestDDGSProviderSearch:
         result = DDGSWebSearchProvider().search("q", limit=5)
         assert result["success"] is False
         assert "ddgs" in result["error"].lower()
+        assert "9.14.4" in result["error"]
 
     def test_runtime_error_returns_failure(self, monkeypatch):
         _install_fake_ddgs(monkeypatch, text_raises=RuntimeError("rate limited 202"))
@@ -230,6 +268,13 @@ class TestDDGSBackendWiring:
         from tools import web_tools
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
         assert web_tools._is_backend_available("ddgs") is False
+
+    def test_web_tools_ddgs_probe_uses_lazy_install_chokepoint(self, monkeypatch):
+        from plugins.web.ddgs import provider
+        from tools import web_tools
+
+        monkeypatch.setattr(provider, "_ensure_ddgs_package_importable", lambda: True)
+        assert web_tools._ddgs_package_importable() is True
 
     def test_configured_backend_accepted(self, monkeypatch):
         from tools import web_tools

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -110,6 +110,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "provider.azure_identity": ("azure-identity==1.25.3",),
 
     # ─── Web search backends ───────────────────────────────────────────────
+    "search.ddgs": ("ddgs==9.14.4",),
     "search.exa": ("exa-py==2.10.2",),
     "search.firecrawl": ("firecrawl-py==4.17.0",),
     "search.parallel": ("parallel-web==0.4.2",),

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -342,9 +342,10 @@ def _ddgs_package_importable() -> bool:
     (and tests can monkeypatch a single symbol).
     """
     try:
-        import ddgs  # noqa: F401
-        return True
-    except ImportError:
+        from plugins.web.ddgs.provider import _ensure_ddgs_package_importable
+
+        return _ensure_ddgs_package_importable()
+    except Exception:
         return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`web.backend: ddgs` is the default no-key web search backend, but the `ddgs` package was not in the lazy dependency allowlist. In sealed-venv Docker deployments, a fresh container cannot install it into the durable lazy target, so `check_web_api_key()` reports the default backend unavailable and `web_search` never lights up.

Fixes #60425.

## Root Cause

Both `plugins/web/ddgs/provider.py` and `tools/web_tools._ddgs_package_importable()` only performed a bare `import ddgs`. Unlike Exa, Firecrawl, and Parallel, the ddgs backend had no `LAZY_DEPS` entry or runtime `ensure()` chokepoint.

## Fix

- Added `search.ddgs` to `tools/lazy_deps.py` and the matching `ddgs` extra in `pyproject.toml`.
- Routed ddgs availability/search probes through a shared lazy-install chokepoint.
- Kept `tools/web_tools` and the provider on the same availability path so tool registration and direct provider calls agree.
- Added regression coverage for lazy-install activation and metadata pin consistency.

## Tests

- `scripts/run_tests.sh tests/tools/test_web_providers_ddgs.py -q`
- `scripts/run_tests.sh tests/test_project_metadata.py -q`
- `scripts/run_tests.sh tests/tools/test_web_providers_ddgs.py tests/test_project_metadata.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check plugins/web/ddgs/provider.py tools/web_tools.py tools/lazy_deps.py tests/tools/test_web_providers_ddgs.py tests/test_project_metadata.py`
- `git diff --check`
