### PR TITLE
fix(gateway): suppress lifecycle pings during restart loops

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4151,6 +4151,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
         return max_restarts, window_seconds
 
+    def _restart_loop_home_channel_notifications_suppressed(self) -> bool:
+        """Return True when lifecycle home-channel broadcasts should be muted.
+
+        The restart-loop guard was originally scoped to auto-resume only: once
+        it tripped, the gateway stopped replaying the restart-interrupted turn
+        but every supervisor-driven SIGTERM could still notify the configured
+        home channel. Reuse the same persisted breaker state here so a detected
+        respawn loop cannot keep sending operator lifecycle pings indefinitely.
+        """
+        try:
+            from gateway import restart_loop_guard as _rlg
+
+            max_restarts, window_seconds = self._restart_loop_guard_config()
+            return _rlg.is_restart_loop_tripped(max_restarts, window_seconds)
+        except Exception as exc:  # noqa: BLE001 — notification suppression must fail open
+            logger.debug("restart-loop notification suppression check skipped: %s", exc)
+            return False
+
     def _scale_to_zero_should_arm(self) -> bool:
         """Whether to start the idle watcher (D1/D11/§3.4(1))."""
         from gateway.relay import relay_wake_url
@@ -5729,6 +5747,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Never let the suppression check block the shutdown broadcast —
             # fail toward the louder, more-visible behaviour.
             logger.debug("drain_notification_suppressed check failed: %s", e)
+
+        if self._restart_loop_home_channel_notifications_suppressed():
+            logger.info(
+                "Home-channel shutdown broadcast suppressed by restart-loop breaker"
+            )
+            return
 
         # Snapshot adapters up front: adapter.send() can hit a fatal error
         # path that pops the adapter from self.adapters (see _handle_fatal

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -604,3 +604,36 @@ async def test_drain_without_suppress_flag_still_broadcasts_home_channel(tmp_pat
     # Both targets notified (today's behaviour preserved).
     assert "999" in sent_chat_ids
     assert "home-42" in sent_chat_ids
+
+
+@pytest.mark.asyncio
+async def test_restart_loop_breaker_suppresses_home_channel_shutdown_only(
+    tmp_path, monkeypatch
+):
+    """A tripped respawn-loop breaker mutes home-channel lifecycle spam.
+
+    Active-session interruption notices still deliver because they are tied to
+    a concrete in-flight task; only the generic home-channel broadcast is
+    suppressed once the persisted restart-loop guard has tripped.
+    """
+    from gateway.config import HomeChannel, Platform
+    import gateway.restart_loop_guard as rlg
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner._running_agents["agent:main:telegram:dm:999"] = MagicMock()
+
+    for _ in range(rlg.DEFAULT_MAX_RESTARTS):
+        rlg.record_restart_interrupted_boot(rlg.DEFAULT_WINDOW_SECONDS)
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    sent_chat_ids = {chat_id for chat_id, _content, _meta in adapter.sent_calls}
+    assert "999" in sent_chat_ids
+    assert "home-42" not in sent_chat_ids


### PR DESCRIPTION
## Problem

The restart-loop breaker already detects repeated restart-interrupted gateway boots and stops auto-resume, but shutdown home-channel broadcasts did not consult that breaker. In a supervisor respawn loop, the gateway could keep sending "Gateway shutting down" lifecycle messages to a configured home channel even after the breaker tripped.

Fixes #60438.

## Root Cause

`GatewayRunner._schedule_auto_resume_pending_sessions()` records and checks the persisted restart-loop guard state, while `_notify_active_sessions_of_shutdown()` only checked the drain marker and per-platform `gateway_restart_notification` flag before broadcasting to home channels. The two shutdown protections were disconnected.

## Fix

- Added a small GatewayRunner helper that reads the existing restart-loop guard state with the configured threshold/window.
- Suppressed only the generic home-channel shutdown broadcast when the breaker is tripped.
- Preserved active-session interruption notices, so users with a concrete in-flight task still get the resume hint.
- Added regression coverage for the exact split: active chat notified, home channel muted.

## Tests

- `scripts/run_tests.sh tests/gateway/test_restart_drain.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py -q`
- `scripts/run_tests.sh tests/gateway/test_restart_drain.py tests/hermes_cli/test_gateway_restart_loop.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check gateway/run.py tests/gateway/test_restart_drain.py`
- `git diff --check`
