### PR TITLE
feat(approval): use sequential pending write ids

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -9,8 +9,9 @@ subcommand dispatch.
 
 import json
 import os
-import tempfile
 import shutil
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -229,12 +230,92 @@ def test_pending_store_roundtrip(hermes_home):
     from tools import write_approval as wa
     rec = wa.stage_write("memory", {"action": "add", "target": "user", "content": "x"},
                          summary="add x", origin="foreground")
+    assert rec["id"] == "1"
     assert wa.pending_count("memory") == 1
     got = wa.get_pending("memory", rec["id"])
     assert got["payload"]["content"] == "x"
     assert wa.discard_pending("memory", rec["id"]) is True
     assert wa.pending_count("memory") == 0
     assert wa.get_pending("memory", rec["id"]) is None
+
+
+def test_pending_store_assigns_sequential_ids(hermes_home):
+    from tools import write_approval as wa
+    first = wa.stage_write("memory", {"action": "add", "target": "user", "content": "a"},
+                           summary="a", origin="foreground")
+    second = wa.stage_write("memory", {"action": "add", "target": "user", "content": "b"},
+                            summary="b", origin="foreground")
+
+    assert first["id"] == "1"
+    assert second["id"] == "2"
+    assert [r["id"] for r in wa.list_pending("memory")] == ["1", "2"]
+
+
+def test_pending_store_uses_highest_remaining_numeric_id(hermes_home):
+    from tools import write_approval as wa
+    first = wa.stage_write("memory", {"action": "add", "target": "user", "content": "a"},
+                           summary="a", origin="foreground")
+    second = wa.stage_write("memory", {"action": "add", "target": "user", "content": "b"},
+                            summary="b", origin="foreground")
+
+    assert wa.discard_pending("memory", first["id"]) is True
+    third = wa.stage_write("memory", {"action": "add", "target": "user", "content": "c"},
+                           summary="c", origin="foreground")
+
+    assert second["id"] == "2"
+    assert third["id"] == "3"
+
+
+def test_pending_store_rescans_after_raced_id_create(hermes_home, monkeypatch):
+    from tools import write_approval as wa
+
+    real_write = wa._write_pending_record
+    attempts = []
+
+    def _race_once(path, contents):
+        attempts.append(path.name)
+        if len(attempts) == 1:
+            path.write_text('{"id": "1", "created_at": 1}', encoding="utf-8")
+            (path.parent / "2.json").write_text('{"id": "2", "created_at": 2}', encoding="utf-8")
+            raise FileExistsError(path)
+        real_write(path, contents)
+
+    monkeypatch.setattr(wa, "_write_pending_record", _race_once)
+    rec = wa.stage_write("memory", {"action": "add", "target": "user", "content": "x"},
+                         summary="x", origin="foreground")
+
+    assert attempts == ["1.json", "3.json"]
+    assert rec["id"] == "3"
+    assert wa.get_pending("memory", "1")["id"] == "1"
+    assert wa.get_pending("memory", "2")["id"] == "2"
+    assert wa.get_pending("memory", "3")["payload"]["content"] == "x"
+
+
+def test_pending_store_serialization_failure_leaves_no_record(hermes_home):
+    from tools import write_approval as wa
+    rec = wa.stage_write("memory", {"action": object()},
+                         summary="x", origin="foreground")
+
+    assert rec["id"] == "1"
+    assert wa.pending_count("memory") == 0
+    pending_dir = Path(hermes_home) / "pending" / "memory"
+    assert list(pending_dir.glob("*.json")) == []
+
+
+def test_pending_store_ignores_legacy_nonnumeric_ids(hermes_home):
+    from tools import write_approval as wa
+    pending_dir = Path(hermes_home) / "pending" / "memory"
+    pending_dir.mkdir(parents=True)
+    (pending_dir / "7.json").write_text('{"id": "7", "created_at": 1}', encoding="utf-8")
+    (pending_dir / "7b787650.json").write_text(
+        '{"id": "7b787650", "created_at": 2}',
+        encoding="utf-8",
+    )
+
+    rec = wa.stage_write("memory", {"action": "add", "target": "user", "content": "x"},
+                         summary="x", origin="foreground")
+
+    assert rec["id"] == "8"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -44,9 +44,7 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
-import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -111,6 +109,56 @@ def _pending_dir(subsystem: str) -> Path:
     return get_hermes_home() / "pending" / subsystem
 
 
+def _numeric_pending_id(value: str) -> Optional[int]:
+    if not value.isdecimal():
+        return None
+    parsed = int(value)
+    return parsed if parsed > 0 else None
+
+
+def _highest_numeric_pending_file_id(d: Path) -> int:
+    highest = 0
+    if d.exists():
+        for p in d.glob("*.json"):
+            parsed = _numeric_pending_id(p.stem)
+            if parsed is not None:
+                highest = max(highest, parsed)
+    return highest
+
+
+def _write_pending_record(path: Path, contents: str) -> None:
+    try:
+        with path.open("x", encoding="utf-8") as f:
+            f.write(contents)
+    except FileExistsError:
+        raise
+    except Exception:
+        try:
+            path.unlink()
+        except Exception:
+            pass
+        raise
+
+
+def _build_pending_record(
+    pid: str,
+    subsystem: str,
+    payload: Dict[str, Any],
+    *,
+    summary: str,
+    origin: str,
+) -> Dict[str, Any]:
+    return {
+        "id": pid,
+        "subsystem": subsystem,
+        "action": payload.get("action", ""),
+        "summary": (summary or "").strip(),
+        "origin": origin or "foreground",
+        "created_at": time.time(),
+        "payload": payload,
+    }
+
+
 def stage_write(subsystem: str, payload: Dict[str, Any],
                 *, summary: str, origin: str) -> Dict[str, Any]:
     """Persist a pending write and return a short record describing it.
@@ -129,23 +177,21 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
     logs and still returns a record (the write is simply lost, which is the
     safe failure for an approval gate — nothing is silently committed).
     """
-    pid = uuid.uuid4().hex[:8]
-    record = {
-        "id": pid,
-        "subsystem": subsystem,
-        "action": payload.get("action", ""),
-        "summary": (summary or "").strip(),
-        "origin": origin or "foreground",
-        "created_at": time.time(),
-        "payload": payload,
-    }
+    record = _build_pending_record("1", subsystem, payload, summary=summary, origin=origin)
     try:
         d = _pending_dir(subsystem)
         d.mkdir(parents=True, exist_ok=True)
-        path = d / f"{pid}.json"
-        tmp = path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
-        os.replace(tmp, path)
+        next_id = _highest_numeric_pending_file_id(d) + 1
+        while True:
+            pid = str(next_id)
+            record = _build_pending_record(pid, subsystem, payload, summary=summary, origin=origin)
+            path = d / f"{pid}.json"
+            body = json.dumps(record, ensure_ascii=False, indent=2) + "\n"
+            try:
+                _write_pending_record(path, body)
+                break
+            except FileExistsError:
+                next_id = max(next_id + 1, _highest_numeric_pending_file_id(d) + 1)
     except Exception as e:  # pragma: no cover - disk failure path
         logger.error("Failed to stage pending %s write: %s", subsystem, e, exc_info=True)
     return record


### PR DESCRIPTION
## What does this PR do?

Adds sequential numeric IDs for pending memory and skill write-approval records, replacing the previous random 8-character UUID fragments.

Pending records now use `1`, `2`, `3`, and so on per subsystem, which makes `/memory approve <id>` and `/skills approve <id>` easier to read and type.

## Related Issue

Fixes #60446.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Replaced random pending write IDs with numeric IDs derived from existing pending record filenames.
- Allocate the next ID as the highest current numeric pending ID plus one.
- Ignore legacy non-numeric pending record IDs for allocation while keeping them readable and approvable.
- Use exclusive final record creation and rescan after collisions so concurrent staging does not overwrite an existing pending record.
- Added regression coverage for sequencing, highest-ID scanning, raced ID creation, legacy IDs, and serialization failures.

## Implementation Note

This intentionally avoids a persistent counter file. IDs are short-lived pending-queue handles, so if the highest pending records are removed, a later pending write may reuse that number.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_write_approval.py -q`
2. `uv run --extra dev ruff check tools/write_approval.py tests/tools/test_write_approval.py`
3. `uv run --extra dev python scripts/check-windows-footguns.py tools/write_approval.py tests/tools/test_write_approval.py`
4. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A

