### PR TITLE
fix(display): honor explicit tool success results

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1251,6 +1251,8 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
 
     # Structured error in JSON result (any tool that surfaces {"error": ...}).
     if isinstance(data, dict):
+        if data.get("success") is True:
+            return False, ""
         err = data.get("error") or data.get("message")
         if err and (data.get("success") is False or "error" in data):
             return True, f" [{_trim_error(str(err))}]"
@@ -1459,5 +1461,4 @@ def get_cute_tool_message(
 # =========================================================================
 # Honcho session line (one-liner with clickable OSC 8 hyperlink)
 # =========================================================================
-
 

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -6,14 +6,15 @@ from unittest.mock import MagicMock
 
 import agent.display as display_module
 from agent.display import (
+    _detect_tool_failure,
+    _render_inline_unified_diff,
+    _summarize_rendered_diff_sections,
     build_tool_preview,
     capture_local_edit_snapshot,
     extract_edit_diff,
     get_cute_tool_message,
     redact_tool_args_for_display,
     set_tool_preview_max_len,
-    _render_inline_unified_diff,
-    _summarize_rendered_diff_sections,
     render_edit_diff_with_delta,
 )
 
@@ -492,3 +493,19 @@ class TestBuildToolLabel:
         for tool_name in _TOOL_VERBS:
             label = build_tool_label(tool_name, {"query": "x", "path": "x", "url": "x"})
             assert label, f"{tool_name} produced empty label"
+
+
+class TestDetectToolFailure:
+    def test_success_true_wins_over_nested_error_text(self):
+        result = (
+            '{"success": true, "data": {"kind": "standalone", '
+            '"notes": "contains the word error in ordinary data"}}'
+        )
+
+        assert _detect_tool_failure("dsl_songbook_save", result) == (False, "")
+
+    def test_success_false_is_failure(self):
+        assert _detect_tool_failure("dsl_songbook_save", '{"success": false, "error": "nope"}') == (
+            True,
+            " [nope]",
+        )


### PR DESCRIPTION
## Summary
- treat JSON tool results with `success: true` as successful before applying substring heuristics
- keep `success: false` and explicit `error` payloads marked as tool failures
- add regression coverage for plugin-style success envelopes that contain error text in data

## Tests
- `uv run pytest tests/agent/test_display.py -q`