### PR TITLE
fix: reject invalid JSON/YAML/TOML before write, not after

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1405,6 +1405,26 @@ class ShellFileOperations(FileOperations):
             if mkdir_result.exit_code == 0:
                 dirs_created = True
 
+        # Pre-write in-process syntax gate for JSON, YAML, and TOML.
+        # Run the parse BEFORE _atomic_write so invalid content is
+        # rejected before any bytes hit disk.  Scoped to structured
+        # formats only — Python is excluded because the test suite
+        # writes non-Python text through *.py paths as generic
+        # write-mechanics fixtures.
+        if ext in LINTERS_INPROC and ext != '.py':
+            inproc = LINTERS_INPROC[ext]
+            if inproc is not None:
+                ok, err = inproc(content)
+                if not ok:
+                    return WriteResult(
+                        error=(
+                            f"Syntax error in {path}: {err} — "
+                            f"file was NOT written (content rejected "
+                            f"before reaching disk)."
+                        ),
+                        lint={"status": "error", "output": err},
+                    )
+
         # Write atomically: stream into a temp file in the SAME directory,
         # then ``mv`` it over the target. The rename is atomic on POSIX
         # (and on every backend FS we run on), so a crash / power loss /


### PR DESCRIPTION
Move the in-process syntax check for structured formats ahead of
`_atomic_write()` so syntactically invalid content is rejected
before any bytes hit disk.

## Problem
`write_file()` ran `_atomic_write()` first, then `_check_lint_delta()`
afterward. A parse failure never set the top-level `error` key, so the
tool reported success even when the content it wrote didn't parse.
See #60525.

## Fix
Add a pre-write syntax gate for JSON, YAML, and TOML that runs the
in-process linter BEFORE the atomic write. If the content fails to
parse, the write is rejected with a top-level error and the file is
never touched.

## Scope
JSON, YAML, and TOML only. Python is excluded because the test suite
writes non-Python text through `*.py` paths as generic write-mechanics
fixtures — a naive full-`LINTERS_INPROC` scope would break those tests.

## Validation
```
# Before (clean main): writes invalid JSON to disk, reports success
# After (patched): rejects invalid JSON before write, error returned
```

## Files changed
- tools/file_operations.py: +20 lines (pre-write syntax gate)

Closes #60525