### PR TITLE
fix: evaluate cron_mode deny before session approval in approval gate

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2053,10 +2053,6 @@ def _run_approval_gate(
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
         return {"approved": True, "message": None}
 
-    session_key = get_current_session_key()
-    if is_approved(session_key, pattern_key):
-        return {"approved": True, "message": None}
-
     if approval_callback is None:
         try:
             from tools.terminal_tool import _get_approval_callback
@@ -2068,7 +2064,9 @@ def _run_approval_gate(
     is_gateway = _is_gateway_approval_context()
 
     if not is_cli and not is_gateway:
-        # Cron sessions: respect cron_mode config
+        # Cron sessions: respect cron_mode config (evaluated BEFORE
+        # is_approved so an "Always" tap in an interactive session
+        # doesn't create a standing grant for cron jobs).
         if env_var_enabled("HERMES_CRON_SESSION"):
             if _get_cron_approval_mode() == "deny":
                 return {
@@ -2103,6 +2101,14 @@ def _run_approval_gate(
             "HERMES_GATEWAY_SESSION to require approval.",
             autoapprove_log_prefix, pattern_key, description,
         )
+        return {"approved": True, "message": None}
+
+    # Permanent allowlist / session approval (evaluated AFTER the
+    # non-interactive / cron branches above so an "Always" tap in an
+    # interactive session can't silently override cron_mode: deny or
+    # fail_closed_when_no_human).
+    session_key = get_current_session_key()
+    if is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
     if is_gateway or env_var_enabled("HERMES_EXEC_ASK"):


### PR DESCRIPTION
Move the `is_approved()` session-approval check after the
cron/non-interactive branches in `_run_approval_gate()`.

## Problem
A single "Always" tap on a pattern-class key in an interactive
session (Telegram/Discord) created a standing grant that silently
overrode `approvals.cron_mode: deny`, letting dangerous commands
through in unattended cron jobs.

The `is_approved()` check ran BEFORE the cron/non-interactive
branches, so a cron session with a permanent approval from a
previous interactive session would bypass the deny entirely.

`check_execute_code_guard` already orders these checks correctly;
this fix brings `_run_approval_gate` into alignment.

## Fix
Reorder the gate: evaluate cron/non-interactive branches first,
then check `is_approved()` only for interactive CLI and gateway
contexts. Session approvals from "Always" taps now only apply
where a human is actually present.

## Files changed
- tools/approval.py: +11/-5 lines (reorder is_approved check)

Closes #60505