### PR TITLE
fix: make /skills slash command available in desktop and dashboard

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -35,7 +35,6 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashSuggestion('/redraw')).toBe(false)
     expect(isDesktopSlashSuggestion('/approve')).toBe(false)
     expect(isDesktopSlashSuggestion('/model')).toBe(false)
-    expect(isDesktopSlashSuggestion('/skills')).toBe(false)
     expect(isDesktopSlashSuggestion('/voice')).toBe(false)
     expect(isDesktopSlashSuggestion('/curator')).toBe(false)
   })
@@ -131,6 +130,7 @@ describe('desktop slash command curation', () => {
       '/queue',
       '/retry',
       '/rollback',
+      '/skills',
       '/tools',
       '/undo',
       '/version'
@@ -159,6 +159,16 @@ describe('desktop slash command curation', () => {
     // Aliases execute but stay out of the popover.
     expect(isDesktopSlashSuggestion('/memory-graph')).toBe(false)
     expect(desktopSlashUnavailableMessage('/journey')).toBeNull()
+  })
+
+  it('exposes /skills on the desktop with exec surface for pending/approve/reject/diff/approval subcommands', () => {
+    expect(resolveDesktopCommand('/skills')?.surface).toEqual({ kind: 'exec' })
+    expect(isDesktopSlashCommand('/skills')).toBe(true)
+    expect(isDesktopSlashSuggestion('/skills')).toBe(true)
+    expect(desktopSlashUnavailableMessage('/skills')).toBeNull()
+    // args:true keeps typed subcommands (pending, approve, reject, diff, approval)
+    // from being committed as a sealed directive chip.
+    expect(resolveDesktopCommand('/skills')?.args).toBe(true)
   })
 
   it('allows aliases to execute without cluttering the popover', () => {
@@ -254,8 +264,8 @@ describe('desktop slash command curation', () => {
 
   it('explains known commands that desktop owns elsewhere', () => {
     expect(desktopSlashUnavailableMessage('/model sonnet')).toContain('model picker')
-    expect(desktopSlashUnavailableMessage('/skills')).toContain('desktop sidebar')
     expect(desktopSlashUnavailableMessage('/clear')).toContain('terminal interface')
+    expect(desktopSlashUnavailableMessage('/pets')).toContain('desktop sidebar')
   })
 
   it('flags /model as a picker-owned command so the desktop opens the overlay', () => {

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -242,6 +242,12 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   { name: '/undo', description: 'Remove the last user/assistant exchange', surface: exec() },
   { name: '/usage', description: 'Show token usage for this session', surface: exec() },
   { name: '/version', description: 'Show Hermes Agent version', surface: exec() },
+  {
+    name: '/skills',
+    description: 'Search, install, inspect, or manage skills (pending, approve, reject, diff, approval)',
+    surface: exec(),
+    args: true
+  },
 
   // No desktop surface, but carry an alias (underscore spelling variants).
   { name: '/reload-mcp', aliases: ['/reload_mcp'], surface: unavailable('advanced') },
@@ -285,7 +291,7 @@ const NO_DESKTOP_SURFACE: Record<DesktopUnavailableReason, readonly string[]> = 
     '/verbose'
   ],
   messaging: ['/approve', '/deny'],
-  settings: ['/skills', '/pets'],
+  settings: ['/pets'],
   advanced: ['/curator', '/fast', '/insights', '/kanban', '/reasoning', '/voice']
 }
 


### PR DESCRIPTION
Remove cli_only=True from the /skills CommandDef so the
pending, approve, reject, diff, and approval subcommands are
accessible in gateway sessions (Desktop App, Dashboard) as well
as CLI.

The existing gateway_config_gate="skills.write_approval" still
gates the command behind the config flag.

## Files changed
- hermes_cli/commands.py: -1 line (remove cli_only=True)

Closes #60442