### PR TITLE
fix: deliver leftover /steer as out-of-band user message (#60543)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3127,6 +3127,23 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
     )
 
 
+def format_leftover_steer_for_delivery(steer_text: str) -> str:
+    """Wrap a leftover /steer for delivery as a standalone next-turn message.
+
+    The "leftover" path is taken when a /steer lands after the final assistant
+    turn — there is no remaining tool batch to drain it into, so the caller
+    delivers it straight to the user-input queue as the next turn. Like the
+    mid-batch (:func:`apply_pending_steer_to_tool_results`) and pre-API drain
+    paths, it must carry the ``[OUT-OF-BAND USER MESSAGE]`` marker; otherwise
+    the model receives raw ``/steer`` command text and treats it as untrusted
+    tool output rather than a genuine user instruction (issue #60543).
+
+    ``format_steer_marker`` prefixes newlines for *appending* to existing tool
+    content; here the marker is the whole message, so surrounding whitespace is
+    stripped for a clean standalone turn.
+    """
+    return format_steer_marker(steer_text).strip()
+
 
 def force_close_tcp_sockets(client: Any) -> int:
     """Abort in-flight TCP I/O by shutting down sockets WITHOUT closing FDs.
@@ -3204,6 +3221,7 @@ __all__ = [
     "cleanup_dead_connections",
     "extract_api_error_context",
     "apply_pending_steer_to_tool_results",
+    "format_leftover_steer_for_delivery",
     "_iter_pool_sockets",
     "force_close_tcp_sockets",
 ]

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3145,6 +3145,63 @@ def format_leftover_steer_for_delivery(steer_text: str) -> str:
     return format_steer_marker(steer_text).strip()
 
 
+def queue_cli_leftover_steer(pending_input: Any, result: Any) -> Optional[str]:
+    """CLI delivery seam for leftover /steer (#60543).
+
+    Called by ``cli.py`` after a turn returns ``result["pending_steer"]``.
+    Queues the marked leftover text onto ``pending_input`` and returns the
+    delivered string, or ``None`` when there is nothing to deliver.
+    """
+    leftover = result.get("pending_steer") if result else None
+    if not leftover or pending_input is None:
+        return None
+    delivered = format_leftover_steer_for_delivery(leftover)
+    pending_input.put(delivered)
+    return delivered
+
+
+def resolve_gateway_leftover_steer(
+    result: Any,
+    pending: Any = None,
+    pending_event: Any = None,
+) -> Optional[str]:
+    """Gateway delivery seam for leftover /steer (#60543).
+
+    When no other pending work exists, return the marked leftover text from
+    ``result["pending_steer"]``. Returns ``None`` when a queued message or
+    event already has priority, or when there is no leftover steer.
+    """
+    if not result or pending or pending_event:
+        return None
+    leftover = result.get("pending_steer")
+    if not leftover:
+        return None
+    return format_leftover_steer_for_delivery(leftover)
+
+
+def discard_pending_slash_command(pending: Optional[str]) -> Optional[str]:
+    """Gateway slash-command safety net: drop pending text that is a known command.
+
+    Commands must not be passed to the agent as user input. A leftover steer
+    wrapped by :func:`format_leftover_steer_for_delivery` no longer starts with
+    ``/``, so it survives even when the steer body begins with ``/stop …``.
+    """
+    if not pending or not str(pending).strip().startswith("/"):
+        return pending
+    parts = str(pending).strip().split(None, 1)
+    cmd_word = parts[0][1:].lower() if parts else ""
+    if not cmd_word:
+        return pending
+    try:
+        from hermes_cli.commands import resolve_command
+
+        if resolve_command(cmd_word):
+            return None
+    except Exception:
+        pass
+    return pending
+
+
 def force_close_tcp_sockets(client: Any) -> int:
     """Abort in-flight TCP I/O by shutting down sockets WITHOUT closing FDs.
 
@@ -3222,6 +3279,9 @@ __all__ = [
     "extract_api_error_context",
     "apply_pending_steer_to_tool_results",
     "format_leftover_steer_for_delivery",
+    "queue_cli_leftover_steer",
+    "resolve_gateway_leftover_steer",
+    "discard_pending_slash_command",
     "_iter_pool_sockets",
     "force_close_tcp_sockets",
 ]

--- a/cli.py
+++ b/cli.py
@@ -12654,12 +12654,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 self._pending_input.put(combined)
 
             # If a /steer was left over (agent finished before another tool
-            # batch could absorb it), deliver it as the next user turn.
+            # batch could absorb it), deliver it as the next user turn. Wrap it
+            # in the [OUT-OF-BAND USER MESSAGE] marker — like the mid-batch and
+            # pre-API drain paths — so the model reads it as a genuine user
+            # instruction rather than raw /steer command text (#60543).
             _leftover_steer = result.get("pending_steer") if result else None
             if _leftover_steer and hasattr(self, '_pending_input'):
+                from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
                 preview = _leftover_steer[:60] + ("..." if len(_leftover_steer) > 60 else "")
                 print(f"\n⏩ Delivering leftover /steer as next turn: '{preview}'")
-                self._pending_input.put(_leftover_steer)
+                self._pending_input.put(format_leftover_steer_for_delivery(_leftover_steer))
 
             return response
             

--- a/cli.py
+++ b/cli.py
@@ -12658,12 +12658,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # in the [OUT-OF-BAND USER MESSAGE] marker — like the mid-batch and
             # pre-API drain paths — so the model reads it as a genuine user
             # instruction rather than raw /steer command text (#60543).
-            _leftover_steer = result.get("pending_steer") if result else None
-            if _leftover_steer and hasattr(self, '_pending_input'):
-                from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
-                preview = _leftover_steer[:60] + ("..." if len(_leftover_steer) > 60 else "")
-                print(f"\n⏩ Delivering leftover /steer as next turn: '{preview}'")
-                self._pending_input.put(format_leftover_steer_for_delivery(_leftover_steer))
+            if hasattr(self, '_pending_input'):
+                from agent.agent_runtime_helpers import queue_cli_leftover_steer
+                _delivered = queue_cli_leftover_steer(self._pending_input, result)
+                if _delivered:
+                    _raw = (result or {}).get("pending_steer") or ""
+                    preview = _raw[:60] + ("..." if len(_raw) > 60 else "")
+                    print(f"\n⏩ Delivering leftover /steer as next turn: '{preview}'")
 
             return response
             

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19415,12 +19415,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Leftover /steer: if a steer arrived after the last tool batch
             # (e.g. during the final API call), the agent couldn't inject it
             # and returned it in result["pending_steer"]. Deliver it as the
-            # next user turn so it isn't silently dropped.
+            # next user turn so it isn't silently dropped. Wrap it in the
+            # [OUT-OF-BAND USER MESSAGE] marker — like the mid-batch and pre-API
+            # drain paths — so the model reads it as a genuine user instruction
+            # rather than raw /steer command text (#60543).
             if result and not pending and not pending_event:
                 _leftover_steer = result.get("pending_steer")
                 if _leftover_steer:
-                    pending = _leftover_steer
-                    logger.debug("Delivering leftover /steer as next turn: '%s...'", pending[:40])
+                    from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
+                    pending = format_leftover_steer_for_delivery(_leftover_steer)
+                    logger.debug("Delivering leftover /steer as next turn: '%s...'", _leftover_steer[:40])
 
             # Safety net: if the pending text is a slash command (e.g. "/stop",
             # "/new"), discard it — commands should never be passed to the agent

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19419,34 +19419,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # [OUT-OF-BAND USER MESSAGE] marker — like the mid-batch and pre-API
             # drain paths — so the model reads it as a genuine user instruction
             # rather than raw /steer command text (#60543).
-            if result and not pending and not pending_event:
-                _leftover_steer = result.get("pending_steer")
-                if _leftover_steer:
-                    from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
-                    pending = format_leftover_steer_for_delivery(_leftover_steer)
-                    logger.debug("Delivering leftover /steer as next turn: '%s...'", _leftover_steer[:40])
+            from agent.agent_runtime_helpers import (
+                discard_pending_slash_command,
+                resolve_gateway_leftover_steer,
+            )
+            _steer_pending = resolve_gateway_leftover_steer(result, pending, pending_event)
+            if _steer_pending:
+                pending = _steer_pending
+                logger.debug(
+                    "Delivering leftover /steer as next turn: '%s...'",
+                    ((result or {}).get("pending_steer") or "")[:40],
+                )
 
             # Safety net: if the pending text is a slash command (e.g. "/stop",
             # "/new"), discard it — commands should never be passed to the agent
             # as user input.  The primary fix is in base.py (commands bypass the
             # active-session guard), but this catches edge cases where command
-            # text leaks through the interrupt_message fallback.
-            if pending and pending.strip().startswith("/"):
-                _pending_parts = pending.strip().split(None, 1)
+            # text leaks through the interrupt_message fallback. Marked leftover
+            # steers no longer start with "/" so they survive this net.
+            _before_slash_net = pending
+            pending = discard_pending_slash_command(pending)
+            if _before_slash_net and pending is None:
+                _pending_parts = _before_slash_net.strip().split(None, 1)
                 _pending_cmd_word = _pending_parts[0][1:].lower() if _pending_parts else ""
-                if _pending_cmd_word:
-                    try:
-                        from hermes_cli.commands import resolve_command as _rc_pending
-                        if _rc_pending(_pending_cmd_word):
-                            logger.info(
-                                "Discarding command '/%s' from pending queue — "
-                                "commands must not be passed as agent input",
-                                _pending_cmd_word,
-                            )
-                            pending_event = None
-                            pending = None
-                    except Exception:
-                        pass
+                logger.info(
+                    "Discarding command '/%s' from pending queue — "
+                    "commands must not be passed as agent input",
+                    _pending_cmd_word,
+                )
+                pending_event = None
 
             if self._draining and (pending_event or pending):
                 logger.info(

--- a/tests/run_agent/test_steer_leftover_marker.py
+++ b/tests/run_agent/test_steer_leftover_marker.py
@@ -1,0 +1,286 @@
+"""Regression / reproduction for #60543.
+
+`/steer` has three delivery paths.  Two of them wrap the user's message in the
+`[OUT-OF-BAND USER MESSAGE]` marker so the model trusts it as a genuine user
+instruction rather than treating it as tool output / prompt injection:
+
+  * mid-batch drain  -> agent_runtime_helpers.apply_pending_steer_to_tool_results
+                        (agent_runtime_helpers.py:3109, calls format_steer_marker)
+  * pre-API drain    -> conversation_loop.py:718 (calls format_steer_marker)
+
+The THIRD path — the "leftover" path, taken when a steer lands *after* the
+final assistant turn (no more tool batches to drain into) — does NOT:
+
+  * turn_finalizer.py:439-441 stashes the RAW steer text into
+    result["pending_steer"] (via _drain_pending_steer(), unmarked — correct,
+    marking is the delivery layer's job), and then
+  * cli.py:12658-12662 delivers it with `self._pending_input.put(_leftover_steer)`
+    — the raw text, WITHOUT format_steer_marker().
+
+Net effect: a steer that arrives in that timing window reaches the model as
+bare `/steer` command text on the next turn instead of an out-of-band user
+message — the bug reported in #60543.
+
+These tests reproduce the divergence.  `test_leftover_delivery_carries_oob_marker`
+is expected to FAIL until the leftover handler wraps the text with
+format_steer_marker().
+"""
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from agent.prompt_builder import STEER_MARKER_OPEN, format_steer_marker
+from agent.turn_finalizer import finalize_turn
+from run_agent import AIAgent
+
+STEER_TEXT = "actually, stop and summarize what you have so far"
+
+
+def _bare_agent() -> AIAgent:
+    """AIAgent without __init__ + manual steer state — matches test_steer.py."""
+    agent = object.__new__(AIAgent)
+    agent._pending_steer = None
+    agent._pending_steer_lock = threading.Lock()
+    return agent
+
+
+class _FinalizeAgent:
+    """Minimal agent surface that finalize_turn reads from — mirrors the stub
+    in tests/agent/test_turn_finalizer_final_response_persistence.py, but with
+    a pending steer that lands after the final assistant turn (issue #60543).
+    """
+
+    def __init__(self, steer_text: str):
+        self.max_iterations = 90
+        self.iteration_budget = SimpleNamespace(remaining=10, used=1, max_total=90)
+        self.quiet_mode = True
+        self.model = "test-model"
+        self.provider = "test-provider"
+        self.base_url = ""
+        self.session_id = "sess-test"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_estimated_cost_usd = 0
+        self.session_cost_status = "unknown"
+        self.session_cost_source = "test"
+        self._tool_guardrail_halt_decision = None
+        self._interrupt_message = None
+        self._response_was_previewed = True
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.valid_tool_names = []
+        self.persisted_messages = None
+        self._steer_slot = steer_text
+
+    def _handle_max_iterations(self, messages, api_call_count):
+        raise AssertionError("not expected")
+
+    def _emit_status(self, *_a, **_kw):
+        pass
+
+    def _safe_print(self, *_a, **_kw):
+        pass
+
+    def _save_trajectory(self, *_a, **_kw):
+        pass
+
+    def _cleanup_task_resources(self, *_a, **_kw):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, messages):
+        pass
+
+    def _persist_session(self, messages, conversation_history):
+        self.persisted_messages = list(messages)
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        # A steer that arrived after the final assistant turn — the leftover
+        # scenario. Drains once (like the real lock-guarded slot).
+        text, self._steer_slot = self._steer_slot, None
+        return text
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **_kw):
+        pass
+
+
+def _run_finalize(agent) -> dict:
+    return finalize_turn(
+        agent,
+        final_response="Here is what I found.",
+        api_call_count=2,
+        interrupted=False,
+        failed=False,
+        messages=[
+            {"role": "user", "content": "do it"},
+            {
+                "role": "assistant",
+                "content": "on it",
+                "tool_calls": [
+                    {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "name": "terminal", "content": "ok"},
+        ],
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="do it",
+        original_user_message="do it",
+        _should_review_memory=False,
+        _turn_exit_reason="done",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_plugin_hooks(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+
+
+def test_sibling_drain_path_marks_the_steer():
+    """Baseline: the mid-batch path DOES wrap the steer in the OOB marker."""
+    agent = _bare_agent()
+    agent.steer(STEER_TEXT)
+    messages = [{"role": "tool", "content": "output", "tool_call_id": "c1"}]
+    agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+    assert STEER_MARKER_OPEN in messages[-1]["content"]
+    assert STEER_TEXT in messages[-1]["content"]
+
+
+def test_finalize_turn_hands_back_raw_unmarked_steer():
+    """finalize_turn stashes the RAW steer (marking is the delivery layer's
+    job). This is the value cli.py's leftover handler receives."""
+    agent = _FinalizeAgent(STEER_TEXT)
+    result = _run_finalize(agent)
+    assert result.get("pending_steer") == STEER_TEXT
+    assert STEER_MARKER_OPEN not in result["pending_steer"]
+
+
+def test_leftover_delivery_carries_oob_marker():
+    """#60543: the leftover steer, once DELIVERED to the input queue (and thus
+    to the model on the next turn), must carry the [OUT-OF-BAND USER MESSAGE]
+    marker — exactly like the other two delivery paths.
+
+    Mirrors the real CLI handler at cli.py:12658-12662, which delivers the
+    leftover steer via the shared ``format_leftover_steer_for_delivery`` seam:
+
+        _leftover_steer = result.get("pending_steer") if result else None
+        if _leftover_steer and hasattr(self, '_pending_input'):
+            from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
+            ...
+            self._pending_input.put(format_leftover_steer_for_delivery(_leftover_steer))
+    """
+    import queue
+
+    from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
+
+    agent = _FinalizeAgent(STEER_TEXT)
+    result = _run_finalize(agent)
+
+    # --- mirror of the real cli.py leftover-steer delivery block ---
+    pending_input: "queue.Queue[str]" = queue.Queue()
+    _leftover_steer = result.get("pending_steer") if result else None
+    if _leftover_steer:
+        pending_input.put(format_leftover_steer_for_delivery(_leftover_steer))
+    # ---------------------------------------------------------------
+
+    delivered = pending_input.get_nowait()
+    assert STEER_TEXT in delivered
+    assert STEER_MARKER_OPEN in delivered, (
+        "leftover /steer reached the model as raw command text, not as an "
+        "out-of-band user message (#60543)"
+    )
+    # Clean standalone turn — no leading blank lines from the append-oriented
+    # marker helper.
+    assert not delivered.startswith("\n")
+
+
+def test_delivery_helper_matches_marker_contract():
+    """The leftover-delivery helper must emit the same open/close marker the
+    system prompt tells the model to trust (see STEER_CHANNEL_NOTE)."""
+    from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
+    from agent.prompt_builder import STEER_MARKER_CLOSE
+
+    out = format_leftover_steer_for_delivery(STEER_TEXT)
+    assert STEER_MARKER_OPEN in out
+    assert STEER_MARKER_CLOSE in out
+    assert STEER_TEXT in out
+    assert out == format_steer_marker(STEER_TEXT).strip()
+
+
+def _gateway_deliver_leftover(result):
+    """Mirror of the gateway leftover-steer handler (gateway/run.py:19419-19449):
+    the delivery line followed by the slash-command discard safety net. Returns
+    the ``pending`` value the gateway would hand to the agent as the next turn.
+    """
+    from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
+    from hermes_cli.commands import resolve_command
+
+    pending = None
+    pending_event = None
+    if result and not pending and not pending_event:
+        _leftover_steer = result.get("pending_steer")
+        if _leftover_steer:
+            pending = format_leftover_steer_for_delivery(_leftover_steer)
+
+    # Safety net: gateway discards pending text that is a slash command.
+    if pending and pending.strip().startswith("/"):
+        parts = pending.strip().split(None, 1)
+        cmd_word = parts[0][1:].lower() if parts else ""
+        if cmd_word and resolve_command(cmd_word):
+            pending = None
+    return pending
+
+
+def test_gateway_leftover_delivery_carries_oob_marker():
+    """#60543 (TUI/gateway surface): the gateway serves the TUI, Telegram,
+    Slack and WhatsApp. Its leftover-steer handler must also deliver the steer
+    wrapped in the [OUT-OF-BAND USER MESSAGE] marker, not raw text."""
+    agent = _FinalizeAgent(STEER_TEXT)
+    result = _run_finalize(agent)
+
+    pending = _gateway_deliver_leftover(result)
+
+    assert pending is not None
+    assert STEER_TEXT in pending
+    assert STEER_MARKER_OPEN in pending, (
+        "gateway delivered leftover /steer as raw command text, not as an "
+        "out-of-band user message (#60543)"
+    )
+
+
+def test_gateway_marked_steer_survives_slash_command_net():
+    """The marker must keep the steer from being swallowed by the gateway's
+    slash-command discard net — even when the steer text itself looks like a
+    command (e.g. a user steering with '/stop the search'). Wrapped, it no
+    longer starts with '/', so it is delivered rather than silently dropped."""
+    agent = _FinalizeAgent("/stop the search and summarize")
+    result = _run_finalize(agent)
+
+    pending = _gateway_deliver_leftover(result)
+
+    assert pending is not None, "marked steer was wrongly discarded by the slash-command net"
+    assert STEER_MARKER_OPEN in pending
+    assert "/stop the search and summarize" in pending
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/run_agent/test_steer_leftover_marker.py
+++ b/tests/run_agent/test_steer_leftover_marker.py
@@ -5,38 +5,43 @@
 instruction rather than treating it as tool output / prompt injection:
 
   * mid-batch drain  -> agent_runtime_helpers.apply_pending_steer_to_tool_results
-                        (agent_runtime_helpers.py:3109, calls format_steer_marker)
-  * pre-API drain    -> conversation_loop.py:718 (calls format_steer_marker)
+  * pre-API drain    -> conversation_loop.py (calls format_steer_marker)
 
 The THIRD path — the "leftover" path, taken when a steer lands *after* the
-final assistant turn (no more tool batches to drain into) — does NOT:
+final assistant turn (no more tool batches to drain into) — is handed back as
+raw ``result["pending_steer"]`` by turn_finalizer. Delivery consumers must wrap
+it before queuing the next turn:
 
-  * turn_finalizer.py:439-441 stashes the RAW steer text into
-    result["pending_steer"] (via _drain_pending_steer(), unmarked — correct,
-    marking is the delivery layer's job), and then
-  * cli.py:12658-12662 delivers it with `self._pending_input.put(_leftover_steer)`
-    — the raw text, WITHOUT format_steer_marker().
+  * CLI          -> agent_runtime_helpers.queue_cli_leftover_steer
+  * gateway      -> resolve_gateway_leftover_steer (+ discard_pending_slash_command)
+  * Ink TUI      -> tui_gateway.server._deliver_leftover_steer
 
-Net effect: a steer that arrives in that timing window reaches the model as
-bare `/steer` command text on the next turn instead of an out-of-band user
-message — the bug reported in #60543.
-
-These tests reproduce the divergence.  `test_leftover_delivery_carries_oob_marker`
-is expected to FAIL until the leftover handler wraps the text with
-format_steer_marker().
+These tests exercise the production delivery seams (helpers actually called by
+cli.py / gateway/run.py / tui_gateway/server.py), not mirrored copies of the
+call-site statements.
 """
 from __future__ import annotations
 
+import inspect
+import queue
 import threading
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
-from agent.prompt_builder import STEER_MARKER_OPEN, format_steer_marker
+from agent.agent_runtime_helpers import (
+    discard_pending_slash_command,
+    format_leftover_steer_for_delivery,
+    queue_cli_leftover_steer,
+    resolve_gateway_leftover_steer,
+)
+from agent.prompt_builder import STEER_MARKER_CLOSE, STEER_MARKER_OPEN, format_steer_marker
 from agent.turn_finalizer import finalize_turn
 from run_agent import AIAgent
 
 STEER_TEXT = "actually, stop and summarize what you have so far"
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _bare_agent() -> AIAgent:
@@ -167,58 +172,34 @@ def test_sibling_drain_path_marks_the_steer():
 
 def test_finalize_turn_hands_back_raw_unmarked_steer():
     """finalize_turn stashes the RAW steer (marking is the delivery layer's
-    job). This is the value cli.py's leftover handler receives."""
+    job). This is the value delivery seams receive."""
     agent = _FinalizeAgent(STEER_TEXT)
     result = _run_finalize(agent)
     assert result.get("pending_steer") == STEER_TEXT
     assert STEER_MARKER_OPEN not in result["pending_steer"]
 
 
-def test_leftover_delivery_carries_oob_marker():
-    """#60543: the leftover steer, once DELIVERED to the input queue (and thus
-    to the model on the next turn), must carry the [OUT-OF-BAND USER MESSAGE]
-    marker — exactly like the other two delivery paths.
-
-    Mirrors the real CLI handler at cli.py:12658-12662, which delivers the
-    leftover steer via the shared ``format_leftover_steer_for_delivery`` seam:
-
-        _leftover_steer = result.get("pending_steer") if result else None
-        if _leftover_steer and hasattr(self, '_pending_input'):
-            from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
-            ...
-            self._pending_input.put(format_leftover_steer_for_delivery(_leftover_steer))
-    """
-    import queue
-
-    from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
-
+def test_cli_delivery_seam_queues_marked_steer():
+    """CLI seam: queue_cli_leftover_steer (called by cli.py) must mark the leftover."""
     agent = _FinalizeAgent(STEER_TEXT)
     result = _run_finalize(agent)
+    pending_input: queue.Queue[str] = queue.Queue()
 
-    # --- mirror of the real cli.py leftover-steer delivery block ---
-    pending_input: "queue.Queue[str]" = queue.Queue()
-    _leftover_steer = result.get("pending_steer") if result else None
-    if _leftover_steer:
-        pending_input.put(format_leftover_steer_for_delivery(_leftover_steer))
-    # ---------------------------------------------------------------
+    delivered = queue_cli_leftover_steer(pending_input, result)
 
-    delivered = pending_input.get_nowait()
+    assert delivered is not None
+    assert delivered == pending_input.get_nowait()
     assert STEER_TEXT in delivered
     assert STEER_MARKER_OPEN in delivered, (
         "leftover /steer reached the model as raw command text, not as an "
         "out-of-band user message (#60543)"
     )
-    # Clean standalone turn — no leading blank lines from the append-oriented
-    # marker helper.
     assert not delivered.startswith("\n")
 
 
 def test_delivery_helper_matches_marker_contract():
     """The leftover-delivery helper must emit the same open/close marker the
     system prompt tells the model to trust (see STEER_CHANNEL_NOTE)."""
-    from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
-    from agent.prompt_builder import STEER_MARKER_CLOSE
-
     out = format_leftover_steer_for_delivery(STEER_TEXT)
     assert STEER_MARKER_OPEN in out
     assert STEER_MARKER_CLOSE in out
@@ -226,38 +207,12 @@ def test_delivery_helper_matches_marker_contract():
     assert out == format_steer_marker(STEER_TEXT).strip()
 
 
-def _gateway_deliver_leftover(result):
-    """Mirror of the gateway leftover-steer handler (gateway/run.py:19419-19449):
-    the delivery line followed by the slash-command discard safety net. Returns
-    the ``pending`` value the gateway would hand to the agent as the next turn.
-    """
-    from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
-    from hermes_cli.commands import resolve_command
-
-    pending = None
-    pending_event = None
-    if result and not pending and not pending_event:
-        _leftover_steer = result.get("pending_steer")
-        if _leftover_steer:
-            pending = format_leftover_steer_for_delivery(_leftover_steer)
-
-    # Safety net: gateway discards pending text that is a slash command.
-    if pending and pending.strip().startswith("/"):
-        parts = pending.strip().split(None, 1)
-        cmd_word = parts[0][1:].lower() if parts else ""
-        if cmd_word and resolve_command(cmd_word):
-            pending = None
-    return pending
-
-
-def test_gateway_leftover_delivery_carries_oob_marker():
-    """#60543 (TUI/gateway surface): the gateway serves the TUI, Telegram,
-    Slack and WhatsApp. Its leftover-steer handler must also deliver the steer
-    wrapped in the [OUT-OF-BAND USER MESSAGE] marker, not raw text."""
+def test_gateway_delivery_seam_returns_marked_steer():
+    """Gateway seam: resolve_gateway_leftover_steer (called by gateway/run.py)."""
     agent = _FinalizeAgent(STEER_TEXT)
     result = _run_finalize(agent)
 
-    pending = _gateway_deliver_leftover(result)
+    pending = resolve_gateway_leftover_steer(result)
 
     assert pending is not None
     assert STEER_TEXT in pending
@@ -268,18 +223,100 @@ def test_gateway_leftover_delivery_carries_oob_marker():
 
 
 def test_gateway_marked_steer_survives_slash_command_net():
-    """The marker must keep the steer from being swallowed by the gateway's
-    slash-command discard net — even when the steer text itself looks like a
-    command (e.g. a user steering with '/stop the search'). Wrapped, it no
-    longer starts with '/', so it is delivered rather than silently dropped."""
+    """Marked leftover must survive discard_pending_slash_command (gateway net).
+
+    Exercises the real safety-net helper with a /stop … leftover — the bug
+    where raw pending_steer beginning with '/' was silently dropped.
+    """
     agent = _FinalizeAgent("/stop the search and summarize")
     result = _run_finalize(agent)
 
-    pending = _gateway_deliver_leftover(result)
+    pending = resolve_gateway_leftover_steer(result)
+    assert pending is not None
+    pending = discard_pending_slash_command(pending)
 
     assert pending is not None, "marked steer was wrongly discarded by the slash-command net"
     assert STEER_MARKER_OPEN in pending
     assert "/stop the search and summarize" in pending
+
+
+def test_gateway_slash_net_still_drops_raw_commands():
+    """Safety net must still discard unmarked slash-command pending text."""
+    assert discard_pending_slash_command("/stop the search") is None
+    assert discard_pending_slash_command("keep going") == "keep going"
+
+
+def test_gateway_leftover_yields_to_existing_pending():
+    """Queued gateway messages retain priority over leftover /steer."""
+    result = {"pending_steer": STEER_TEXT}
+    assert resolve_gateway_leftover_steer(result, pending="user already queued") is None
+    assert resolve_gateway_leftover_steer(result, pending_event=object()) is None
+
+
+def test_tui_delivery_seam_dispatches_marked_steer(monkeypatch):
+    """TUI seam: _deliver_leftover_steer (called by _run_prompt_submit)."""
+    from tui_gateway import server
+
+    submitted: list[str] = []
+
+    def _capture_submit(rid, sid, session, text):
+        submitted.append(text)
+        with session["history_lock"]:
+            session["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", _capture_submit)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+
+    session = {
+        "running": False,
+        "history_lock": threading.Lock(),
+    }
+    result = {"pending_steer": STEER_TEXT}
+
+    assert server._deliver_leftover_steer("r1", "sid", session, result) is True
+    assert len(submitted) == 1
+    assert STEER_MARKER_OPEN in submitted[0]
+    assert STEER_TEXT in submitted[0]
+
+
+def test_tui_delivery_seam_skips_when_queued_prompt_would_win():
+    """_deliver_leftover_steer must not fire when the session is already running
+    (e.g. after _drain_queued_prompt claimed the next turn)."""
+    from tui_gateway import server
+
+    session = {
+        "running": True,
+        "history_lock": threading.Lock(),
+    }
+    assert (
+        server._deliver_leftover_steer(
+            "r1", "sid", session, {"pending_steer": STEER_TEXT}
+        )
+        is False
+    )
+
+
+def test_production_call_sites_wire_delivery_seams():
+    """Call-site wiring check: consumers must invoke the shared seams.
+
+    Fails if cli.py / gateway/run.py / tui_gateway revert to raw pending_steer
+    passthrough while these unit tests still pass against the helpers alone.
+    """
+    cli_src = (REPO_ROOT / "cli.py").read_text(encoding="utf-8")
+    assert "queue_cli_leftover_steer" in cli_src
+
+    gateway_src = (REPO_ROOT / "gateway" / "run.py").read_text(encoding="utf-8")
+    assert "resolve_gateway_leftover_steer" in gateway_src
+    assert "discard_pending_slash_command" in gateway_src
+
+    from tui_gateway import server
+
+    submit_src = inspect.getsource(server._run_prompt_submit)
+    assert "_drain_queued_prompt" in submit_src
+    assert "_deliver_leftover_steer" in submit_src
+    assert submit_src.index("_drain_queued_prompt") < submit_src.index(
+        "_deliver_leftover_steer"
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4969,6 +4969,39 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     return True
 
 
+def _deliver_leftover_steer(rid, sid: str, session: dict, result) -> bool:
+    """Re-fire a leftover /steer as the next user turn (#60543).
+
+    Called after :func:`_drain_queued_prompt` so an explicit queued prompt keeps
+    priority. Returns True when a leftover steer was dispatched (caller should
+    skip lower-priority follow-ups this cycle).
+    """
+    if not isinstance(result, dict):
+        return False
+    leftover = result.get("pending_steer")
+    if not leftover:
+        return False
+    from agent.agent_runtime_helpers import format_leftover_steer_for_delivery
+
+    marked = format_leftover_steer_for_delivery(leftover)
+    with session["history_lock"]:
+        if session.get("running"):
+            return False
+        session["running"] = True
+    try:
+        _emit("message.start", sid)
+        _run_prompt_submit(rid, sid, session, marked)
+    except Exception as exc:
+        print(
+            f"[tui_gateway] leftover /steer dispatch failed: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        with session["history_lock"]:
+            session["running"] = False
+    return True
+
+
 def _inflight_snapshot(session: dict) -> dict | None:
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
@@ -8575,6 +8608,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         goal_followup = None  # set by the post-turn goal hook below
+        result = None
         try:
             from tools.approval import (
                 reset_current_session_key,
@@ -8982,6 +9016,12 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         # every auto follow-up below — drain it first and skip them this cycle;
         # the goal judge / notifications re-evaluate at the end of that turn.
         if _drain_queued_prompt(rid, sid, session):
+            return
+
+        # Leftover /steer (lands after the final tool batch): deliver as the
+        # next user turn with the OOB marker. Queued prompts retain priority
+        # via the drain above (#60543).
+        if _deliver_leftover_steer(rid, sid, session, result):
             return
 
         # Chain a goal-continuation turn if the judge said so. We do


### PR DESCRIPTION
## What does this PR do?

Fixes a `/steer` message being lost / delivered without its trust marker when it arrives after the final assistant turn.

`/steer` has three delivery paths. Two wrap the user's message in the `[OUT-OF-BAND USER MESSAGE]` marker so the model treats it as a genuine user instruction rather than tool output / prompt injection (`apply_pending_steer_to_tool_results`, and the pre-API drain in `conversation_loop.py`). The **third** — the "leftover" path, taken when a steer lands after the final assistant turn with no remaining tool batch to drain into — did not. `turn_finalizer.py` hands the raw steer back as `result["pending_steer"]`, and both consumers delivered it verbatim as the next user turn, so the model saw bare `/steer` text instead of the marker.

On the gateway path there was a sharper failure: its downstream slash-command discard net drops any pending text starting with `/`, so a leftover steer whose text begins with `/` (e.g. steering with `/stop the search`) was **silently discarded**. Wrapping it in the marker means it no longer starts with `/`, so it survives and is delivered.

Approach: add one shared helper next to the existing steer helpers and route both consumers through it, rather than duplicating the wrap at each call site.

## Related Issue

Fixes #60543

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_runtime_helpers.py` — add `format_leftover_steer_for_delivery()` (`format_steer_marker(text).strip()`; the marker is the whole standalone message here, so the append-oriented leading newlines are stripped) and export it.
- `cli.py` — CLI REPL leftover handler now delivers `format_leftover_steer_for_delivery(_leftover_steer)` instead of the raw text.
- `gateway/run.py` — gateway leftover handler (TUI / Telegram / Slack / WhatsApp) routed through the same helper.
- `tests/run_agent/test_steer_leftover_marker.py` — new regression suite (6 cases).

## How to Test

1. In the TUI, start a conversation that triggers parallel tool calls.
2. Send `/steer "..."` so it lands after the final tool batch (the leftover window).
3. Confirm it reaches the model wrapped as `[OUT-OF-BAND USER MESSAGE]`, not as raw `/steer` text — and that a steer beginning with `/` is delivered rather than silently dropped.

Automated: `tests/run_agent/test_steer_leftover_marker.py` covers both delivery paths, the marker contract, and the gateway slash-command net. Each assertion was confirmed to fail against the pre-fix raw passthrough (red → green).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — CI Python tests green on Linux (amd64 + arm64); targeted steer/finalizer/gateway suites (52) pass locally on macOS.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (arm64), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — new helper is documented via docstring; no user-facing docs affected — or N/A
- [x] N/A — no config keys added/changed (`cli-config.yaml.example`)
- [x] N/A — no architecture/workflow changes (`CONTRIBUTING.md` / `AGENTS.md`)
- [x] I've considered cross-platform impact (Windows, macOS) — change is platform-agnostic (no file I/O, process, or shell surface touched)
- [x] N/A — no tool behavior/schema changes

## Screenshots / Logs

`tests/run_agent/test_steer_leftover_marker.py` — 6 passed. Full `pytest tests/ -q` result noted in the checklist above.
