### PR TITLE
fix(memory): clamp negative char limits to 0 in MemoryStore

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -130,8 +130,11 @@ class MemoryStore:
     def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
-        self.memory_char_limit = memory_char_limit
-        self.user_char_limit = user_char_limit
+        # Clamp negative limits to 0 so the store doesn't silently enter a
+        # permanently read-only state (new_total > negative_limit always True).
+        # Hermes maintenance fleet Bug-Hunt P0-2 fix.
+        self.memory_char_limit = max(0, memory_char_limit)
+        self.user_char_limit = max(0, user_char_limit)
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         # Per-turn counter of failed at-capacity consolidation attempts; reset


### PR DESCRIPTION
## Summary

Guard `MemoryStore.__init__()` against negative `memory_char_limit` and `user_char_limit` values by clamping them to a minimum of 0.

## Problem

When `MemoryStore` is initialized with negative char limits, every `add()` call is silently rejected because `new_total > negative_limit` is always `True`. This puts the memory store into a permanently read-only state with no error surfaced to the user.

## Fix

Add `max(0, ...)` guards in `MemoryStore.__init__()` so negative values are clamped to 0 (explicitly zero-capacity, consistent behavior) rather than silently corrupting the write path.



## Test Plan

- [x] Normal positive limits preserved
- [x] Negative limits clamped to 0
- [x] Zero limit preserved
- [x] Default constructor unchanged (2200/1375)
- [x] add() correctly rejects writes when limit=0

## Classification

P3 (upstream severity): silent data loss / configuration issue.