### PR TITLE
fix(gateway): scope pairing platform discovery to the profile dir

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -653,7 +653,7 @@ class PairingStore:
     def _all_platforms(self, suffix: str) -> list:
         """List all platforms that have data files of a given suffix."""
         platforms = []
-        for f in PAIRING_DIR.iterdir():
+        for f in self._dir.iterdir():
             if f.name.endswith(f"-{suffix}.json"):
                 platform = f.name.replace(f"-{suffix}.json", "")
                 if not platform.startswith("_"):

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -69,6 +69,34 @@ class TestSplitPairingDirMigration:
         assert migrated["ou_other"]["user_name"] == "Other"
 
 
+class TestProfileScopedDiscovery:
+    def test_list_approved_scopes_platform_discovery_to_profile_dir(self, tmp_path):
+        # A profile-scoped store must enumerate platforms from its own
+        # per-profile directory (self._dir), not the module-global PAIRING_DIR.
+        # Regression: _all_platforms iterated PAIRING_DIR while every per-file
+        # path helper routed through self._dir, so a profile store confirmed a
+        # user via is_approved() (reads self._dir) yet returned [] from
+        # list_approved() (scanned the empty global dir).
+        home = tmp_path / "home"
+        global_dir = tmp_path / "global-pairing"
+        global_dir.mkdir(parents=True)
+
+        with patch("gateway.pairing.PAIRING_DIR", global_dir), patch(
+            "gateway.pairing.get_hermes_home", return_value=home
+        ):
+            store = PairingStore(profile="alice")
+            # Store lives under the profile dir, provably distinct from PAIRING_DIR.
+            assert store._dir != global_dir
+            with store._lock:
+                store._approve_user("telegram", "tg-456", "Bob")
+
+            assert store.is_approved("telegram", "tg-456") is True
+            approved = store.list_approved()
+
+        assert [r["user_id"] for r in approved] == ["tg-456"]
+        assert approved[0]["platform"] == "telegram"
+
+
 # ---------------------------------------------------------------------------
 # _secure_write
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -81,11 +81,19 @@ class TestProfileScopedDiscovery:
         global_dir = tmp_path / "global-pairing"
         global_dir.mkdir(parents=True)
 
+        # PairingStore.__init__ resolves the profile dir via a *function-local*
+        # ``from hermes_constants import get_hermes_home``, so the patch must
+        # target ``hermes_constants.get_hermes_home`` (the source module) — not
+        # ``gateway.pairing.get_hermes_home`` (the module-global binding, which
+        # the local re-import bypasses). Patching the wrong target would leave
+        # ``self._dir`` rooted at the real HERMES_HOME.
         with patch("gateway.pairing.PAIRING_DIR", global_dir), patch(
-            "gateway.pairing.get_hermes_home", return_value=home
+            "hermes_constants.get_hermes_home", return_value=home
         ):
             store = PairingStore(profile="alice")
-            # Store lives under the profile dir, provably distinct from PAIRING_DIR.
+            # Store lives under the mocked home's profile dir — provably scoped
+            # there, and distinct from the module-global PAIRING_DIR.
+            assert store._dir == home / "profiles" / "alice" / "pairing"
             assert store._dir != global_dir
             with store._lock:
                 store._approve_user("telegram", "tg-456", "Bob")


### PR DESCRIPTION
## What does this PR do?

The per-profile pairing isolation introduced `self._dir` and scoped every per-file path helper to it (`_pending_path` → `self._dir / f"{platform}-pending.json"`, `_approved_path` → `self._dir / f"{platform}-approved.json"`). But `_all_platforms(suffix)` — the helper that enumerates which platforms have data files — still iterates the module-global `PAIRING_DIR`:

```python
def _all_platforms(self, suffix: str) -> list:
    platforms = []
    for f in PAIRING_DIR.iterdir():   # <-- global dir, not self._dir
        ...
```

For a `PairingStore(profile="<name>")`, `self._dir` is `<HERMES_HOME>/profiles/<name>/pairing/`, which is **not** `PAIRING_DIR`. So every caller that passes `platform=None` — `list_approved`, `list_pending`, `clear_pending` — enumerates the platform set from the **global** dir but then loads each platform's file from the **profile** dir. The result is a silent divergence between the authz surface and the list/inspect/clear surface: `is_approved("telegram", uid)` reads `self._dir` and returns `True`, while `list_approved()` scans the (empty, for that profile) global dir and returns `[]` for that same user. Operators inspecting or clearing a profile's whitelist see the wrong platform set.

The one-line fix routes discovery through `self._dir`. This is byte-identical for the global store, where `self._dir == PAIRING_DIR` (set in `__init__` when no profile is given), so the existing `hermes pairing` CLI / dashboard path is unchanged; only the profile-scoped case is corrected. `self._dir` is guaranteed to exist because `__init__` does `self._dir.mkdir(parents=True, exist_ok=True)`.

## Related Issue

<!-- No filed issue; author-found regression in the per-profile pairing isolation. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/pairing.py`: `_all_platforms` now iterates `self._dir` instead of the module-global `PAIRING_DIR`, so platform discovery is scoped to the same directory the per-file path helpers already use.
- `tests/gateway/test_pairing.py`: add `TestProfileScopedDiscovery` — a profile-scoped store approves a user, then asserts `is_approved()` and `list_approved()` agree.

## How to Test

1. Build a `PairingStore(profile="alice")` with `PAIRING_DIR` patched to a distinct empty directory (so the global dir provably isn't the profile dir).
2. Approve a user, then check both surfaces: before the fix, `is_approved("telegram", "tg-456")` is `True` but `list_approved()` returns `[]` (it scanned the empty global dir). After the fix both agree.
3. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_pairing.py -v` → 53 passed. The new test fails before the one-line change (`assert [] == ['tg-456']`) and passes after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A