### PR TITLE
fix(sessions): sanitize session_id in export filename to block path traversal

### DIFF
--- a/hermes_cli/session_export_md.py
+++ b/hermes_cli/session_export_md.py
@@ -180,11 +180,37 @@ def render_session_markdown(
     return before_verification
 
 
+def _safe_id_component(session_id: str) -> str:
+    """Return a traversal-free filename component for a session ID.
+
+    Session IDs can originate from untrusted input (e.g. the
+    ``X-Hermes-Session-Id`` API header) and are interpolated into the export
+    filename below. Without sanitization a traversal-shaped ID such as
+    ``../../../../tmp/pwned`` would let the caller write the transcript
+    outside the chosen export directory. Mirrors
+    ``run_agent._safe_session_filename_component``: collapse every non
+    ``[A-Za-z0-9_-]`` character to ``_`` (so no path separators or ``.``
+    survive), cap the length, and — when sanitization changed the string —
+    append a short content hash so two distinct IDs that sanitize to the same
+    component don't collide. Clean IDs pass through unchanged.
+    """
+    raw = str(session_id or "").strip()
+    # Match the documented class exactly. ``\w`` is Unicode-aware in Python, so
+    # ``[^\w-]`` would let Unicode letters/digits (including homoglyphs) survive
+    # into the filename; an explicit ASCII class strips them.
+    sanitized = re.sub(r"[^A-Za-z0-9_-]", "_", raw).strip("._")
+    sanitized = sanitized[:96] or "session"
+    if raw and sanitized == raw:
+        return sanitized
+    digest = hashlib.sha256(raw.encode("utf-8", errors="surrogatepass")).hexdigest()[:12]
+    return f"{sanitized}_{digest}"
+
+
 def safe_session_filename(session: dict[str, Any], *, fmt: str = "md") -> str:
     """Return a deterministic, path-safe filename for a session export."""
     if fmt not in {"md", "qmd"}:
         raise ValueError("fmt must be 'md' or 'qmd'")
-    session_id = _session_id(session)
+    session_id = _safe_id_component(_session_id(session))
     title = str(session.get("title") or "session")
     slug = re.sub(r"[^A-Za-z0-9._-]+", "-", title).strip(".-_").lower()
     if not slug:

--- a/tests/hermes_cli/test_session_export_md.py
+++ b/tests/hermes_cli/test_session_export_md.py
@@ -57,6 +57,39 @@ def test_safe_session_filename_is_deterministic_and_path_safe():
     assert "?" not in filename
 
 
+def test_safe_session_filename_sanitizes_traversal_id():
+    # Session ids can come from the untrusted X-Hermes-Session-Id header and
+    # are interpolated raw into the export filename; a traversal-shaped id must
+    # collapse to a single path-free segment.
+    filename = safe_session_filename(
+        _session(id="../../../../tmp/pwned", title="x"), fmt="md"
+    )
+
+    assert "/" not in filename
+    assert ".." not in filename
+    assert filename.endswith(".md")
+
+
+def test_safe_session_filename_strips_non_ascii_session_id():
+    # ``\w`` is Unicode-aware in Python, so a naive ``[^\w-]`` class would let
+    # Unicode homoglyphs (e.g. a Cyrillic "а") survive into the filename. The
+    # sanitizer must be ASCII-only so only ``[A-Za-z0-9_-]`` pass through.
+    filename = safe_session_filename(_session(id="аdmin", title="x"), fmt="md")
+
+    assert "а" not in filename
+    # The Cyrillic char collapses to "_" (stripped from the head), the ASCII
+    # tail survives, and a disambiguating hash is appended since the id changed.
+    assert filename.startswith("dmin_")
+
+
+def test_write_session_markdown_contains_traversal_id_within_output_dir(tmp_path):
+    path = write_session_markdown(_session(id="../pwned", title="x"), tmp_path)
+
+    resolved = path.resolve()
+    assert resolved.is_file()
+    assert tmp_path.resolve() in resolved.parents
+
+
 
 
 


### PR DESCRIPTION
## This is a sibling follow-up to `run_agent._safe_session_filename_component`

- **What the parent covers:** `run_agent._safe_session_filename_component` documents that session IDs can originate from untrusted input (the `X-Hermes-Session-Id` API header) and are otherwise interpolated raw into on-disk artifact filenames under `~/.hermes/sessions/`. It sanitizes the id (collapse non-`[A-Za-z0-9_-]` to `_`, cap length, hash-suffix on change) before use.
- **What the parent did NOT touch:** the Markdown/QMD session-export path in `hermes_cli/session_export_md.py`, which derives a *different* on-disk filename from the same session id.
- **What this adds:** the same sanitization on the export filename, closing an arbitrary-location file-write primitive on the transcript.

## What does this PR do?

`safe_session_filename` sanitizes the session *title* into a slug but interpolates the session *id* raw:

```python
session_id = _session_id(session)          # str(session["id"] ...)
title = str(session.get("title") or "session")
slug = re.sub(r"[^A-Za-z0-9._-]+", "-", title).strip(".-_").lower()
...
return f"{session_id}-{slug}.{fmt}"         # <-- id is un-sanitized
```

`write_session_markdown` then does `out_dir / safe_session_filename(...)` followed by `path.write_text(...)` with no `.resolve()`/containment guard. Because a session id is attacker-influenceable (it can come from the untrusted `X-Hermes-Session-Id` header), a traversal-shaped id such as `../../../../tmp/pwned` escapes the chosen export directory:

```
hermes sessions export --format md   (session id = "../../../../tmp/pwned")
  -> safe_session_filename -> "../../../../tmp/pwned-<slug>.md"
  -> write_session_markdown -> out_dir / "../../../../tmp/pwned-<slug>.md"
  -> path.write_text(...)   -> transcript written outside out_dir
```

The docstring already claims a "path-safe filename" — it wasn't, with respect to the id.

The fix routes the id through a local `_safe_id_component` that **mirrors the existing sibling** `run_agent._safe_session_filename_component`: collapse every non-`[A-Za-z0-9_-]` character to `_` (so no path separators or `.` survive), cap the length, and append a short content hash when sanitization changed the string so two distinct ids that sanitize to the same component don't collide. It's replicated locally rather than imported because this module is intentionally filesystem-only and importing `run_agent` would pull the whole agent runtime into it. Clean ids (`20260706_123456_abcd1234`, `unknown-session`) pass through unchanged, so the existing determinism assertions still hold; malicious ids collapse to one traversal-free segment.

## Related Issue

<!-- No filed issue; net-new file-safety finding with a concrete attack flow. -->

## Type of Change

- [x] 🔒 Security fix
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/session_export_md.py`: add `_safe_id_component` (mirrors `run_agent._safe_session_filename_component`) and route `session_id` through it in `safe_session_filename` before interpolating it into the export filename.
- `tests/hermes_cli/test_session_export_md.py`: add a filename-level traversal test and a write-level containment test.

## How to Test

1. `safe_session_filename(_session(id="../../../../tmp/pwned"), fmt="md")` — before the fix returns `../../../../tmp/pwned-x.md`; after, a single `..`/`/`-free segment.
2. `write_session_markdown(_session(id="../pwned"), tmp_path)` — before the fix the file lands at `tmp_path/../pwned-x.md` (outside `tmp_path`); after, it stays within `tmp_path`.
3. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_session_export_md.py -v` → 9 passed. The two new tests fail before the change and pass after; the pre-existing determinism test is unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A