### PR TITLE
feat: add vim mode for CLI and TUI input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -60,6 +60,7 @@ from prompt_toolkit.history import FileHistory
 from prompt_toolkit.styles import Style as PTStyle
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.application import Application
+from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.layout import Layout, HSplit, Window, FormattedTextControl, ConditionalContainer, WindowAlign
 from prompt_toolkit.layout.processors import Processor, Transformation, PasswordProcessor, ConditionalProcessor
 from prompt_toolkit.filters import Condition
@@ -14942,10 +14943,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         )
 
         # Create the application
+        # Check for vim mode from config (display.tui_vim_mode works for both CLI and TUI)
+        _vim_mode = CLI_CONFIG.get("display", {}).get("tui_vim_mode", False)
+        _editing_mode = EditingMode.VI if _vim_mode else EditingMode.EMACS
         app = Application(
             layout=layout,
             key_bindings=kb,
             style=style,
+            editing_mode=_editing_mode,
             full_screen=False,
             mouse_support=False,
             **({"output": _cpr_disabled_output} if _cpr_disabled_output is not None else {}),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1769,6 +1769,11 @@ DEFAULT_CONFIG = {
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.
         "tui_status_indicator": "kaomoji",
+        # Enable vim/vi keybindings in the TUI input area. When true, the input
+        # starts in insert mode but supports Escape to enter normal mode with
+        # vim-style navigation (h/j/k/l, w/b/e) and editing (d/c/y operators,
+        # dd, x, etc.). Override per-session via HERMES_TUI_VIM_MODE env var.
+        "tui_vim_mode": False,
         # Seconds between prompt_toolkit redraws in the classic CLI when idle.
         # Default 1.0 keeps the wall-clock status-bar read-outs (idle-since-
         # last-turn) ticking and keeps the bottom chrome alive during idle —

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2082,6 +2082,16 @@ def _launch_tui(
         env["HERMES_TUI_TOOL_PROGRESS"] = "off"
     if accept_hooks:
         env["HERMES_ACCEPT_HOOKS"] = "1"
+
+    # Bridge display.tui_vim_mode config to env var for TUI
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly()
+        display_cfg = cfg.get("display", {})
+        if display_cfg.get("tui_vim_mode"):
+            env["HERMES_TUI_VIM_MODE"] = "1"
+    except Exception:
+        pass  # Fail silently, vim mode just won't be enabled from config
     # Guarantee a generous V8 heap for the TUI. Default node cap is ~1.5–4GB
     # depending on version and can fatal-OOM on long sessions with large
     # transcripts / reasoning blobs. We target 8GB on an unconstrained host,

--- a/ui-tui/src/__tests__/viMode.test.ts
+++ b/ui-tui/src/__tests__/viMode.test.ts
@@ -288,6 +288,119 @@ describe('viMode', () => {
     })
   })
 
+  describe('processViKey - find character (f/F/t/T) and replace (r)', () => {
+    const normalState: ViState = {
+      mode: 'normal',
+      operator: null,
+      count: 0,
+      visualAnchor: null,
+      lastFindChar: null,
+      register: ''
+    }
+
+    const pending = (op: string): ViState => ({ ...normalState, operator: op, mode: 'operator-pending' })
+
+    it('f<char> jumps onto the character', () => {
+      const { action, newState } = processViKey(pending('f'), 'hello world', 0, mkEvent('o'))
+      expect(action.type).toBe('cursor')
+      expect(action.cursor).toBe(4)
+      expect(newState.mode).toBe('normal')
+      expect(newState.lastFindChar).toEqual({ char: 'o', forward: true, till: false })
+    })
+
+    it('t<char> stops before the character', () => {
+      const { action } = processViKey(pending('t'), 'hello world', 0, mkEvent('w'))
+      expect(action.cursor).toBe(5)
+    })
+
+    it('F<char> searches backward', () => {
+      const { action } = processViKey(pending('F'), 'hello world', 10, mkEvent('o'))
+      expect(action.cursor).toBe(7)
+    })
+
+    it('f<char> with no match is a no-op that clears the pending state', () => {
+      const { action, newState } = processViKey(pending('f'), 'hello', 0, mkEvent('z'))
+      expect(action.type).toBe('none')
+      expect(newState.operator).toBeNull()
+      expect(newState.mode).toBe('normal')
+    })
+
+    it('fh consumes h as the target char, not as a motion', () => {
+      const { action } = processViKey(pending('f'), 'ahb', 0, mkEvent('h'))
+      expect(action.type).toBe('cursor')
+      expect(action.cursor).toBe(1)
+    })
+
+    it('f3 consumes 3 as the target char, not as a count', () => {
+      const { action, newState } = processViKey(pending('f'), 'a3b', 0, mkEvent('3'))
+      expect(action.type).toBe('cursor')
+      expect(action.cursor).toBe(1)
+      expect(newState.count).toBe(0)
+    })
+
+    it('r<char> replaces the character under the cursor', () => {
+      const { action, newState } = processViKey(pending('r'), 'hello', 1, mkEvent('a'))
+      expect(action.type).toBe('replace')
+      expect(action.deleteRange).toEqual({ start: 1, end: 2 })
+      expect(action.text).toBe('a')
+      expect(newState.mode).toBe('normal')
+    })
+
+    it('r at end of buffer is a no-op', () => {
+      const { action } = processViKey(pending('r'), 'hello', 5, mkEvent('a'))
+      expect(action.type).toBe('none')
+    })
+
+    it('; repeats the last find', () => {
+      const withFind: ViState = { ...normalState, lastFindChar: { char: 'o', forward: true, till: false } }
+      const { action } = processViKey(withFind, 'hello world', 4, mkEvent(';'))
+      expect(action.type).toBe('cursor')
+      expect(action.cursor).toBe(7)
+    })
+  })
+
+  describe('processViKey - escape resets pending state', () => {
+    it('escape cancels a pending operator', () => {
+      const pendingD: ViState = {
+        mode: 'operator-pending',
+        operator: 'd',
+        count: 0,
+        visualAnchor: null,
+        lastFindChar: null,
+        register: ''
+      }
+      const { newState } = processViKey(pendingD, 'hello', 2, mkEvent('', { escape: true }))
+      expect(newState.mode).toBe('normal')
+      expect(newState.operator).toBeNull()
+    })
+
+    it('escape clears a pending count', () => {
+      const withCount: ViState = {
+        mode: 'normal',
+        operator: null,
+        count: 42,
+        visualAnchor: null,
+        lastFindChar: null,
+        register: ''
+      }
+      const { newState } = processViKey(withCount, 'hello', 2, mkEvent('', { escape: true }))
+      expect(newState.count).toBe(0)
+    })
+
+    it('escape in normal mode does not move the cursor', () => {
+      const normal: ViState = {
+        mode: 'normal',
+        operator: null,
+        count: 0,
+        visualAnchor: null,
+        lastFindChar: null,
+        register: ''
+      }
+      const { action } = processViKey(normal, 'hello', 3, mkEvent('', { escape: true }))
+      expect(action.cursor).toBe(3)
+    })
+  })
+
   describe('processViKey - submit', () => {
     const normalState: ViState = {
       mode: 'normal',

--- a/ui-tui/src/__tests__/viMode.test.ts
+++ b/ui-tui/src/__tests__/viMode.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  initialViState,
+  processViKey,
+  viModeIndicator,
+  type ViKeyEvent,
+  type ViState
+} from '../lib/viMode.js'
+
+const mkEvent = (input: string, key: Partial<ViKeyEvent['key']> = {}): ViKeyEvent => ({
+  input,
+  key: {
+    ctrl: false,
+    shift: false,
+    meta: false,
+    escape: false,
+    backspace: false,
+    delete: false,
+    return: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    ...key
+  }
+})
+
+describe('viMode', () => {
+  describe('initialViState', () => {
+    it('starts in insert mode', () => {
+      const state = initialViState()
+      expect(state.mode).toBe('insert')
+      expect(state.operator).toBeNull()
+      expect(state.count).toBe(0)
+    })
+  })
+
+  describe('viModeIndicator', () => {
+    it('returns correct labels for each mode', () => {
+      expect(viModeIndicator('normal')).toBe('NORMAL')
+      expect(viModeIndicator('insert')).toBe('INSERT')
+      expect(viModeIndicator('visual')).toBe('VISUAL')
+      expect(viModeIndicator('operator-pending')).toBe('OPERATOR')
+    })
+  })
+
+  describe('processViKey - insert mode', () => {
+    it('passes through regular keys in insert mode', () => {
+      const state = initialViState()
+      const { action, newState } = processViKey(state, 'hello', 5, mkEvent('x'))
+      expect(action.type).toBe('passthrough')
+      expect(newState.mode).toBe('insert')
+    })
+
+    it('exits insert mode on Escape', () => {
+      const state = initialViState()
+      const { action, newState } = processViKey(state, 'hello', 5, mkEvent('', { escape: true }))
+      expect(newState.mode).toBe('normal')
+      expect(action.type).toBe('cursor')
+      // Cursor moves back one on exit from insert mode
+      expect(action.cursor).toBe(4)
+    })
+
+    it('exits insert mode on Ctrl+C', () => {
+      const state = initialViState()
+      const { action, newState } = processViKey(state, 'hello', 3, mkEvent('c', { ctrl: true }))
+      expect(newState.mode).toBe('normal')
+      expect(action.cursor).toBe(2)
+    })
+  })
+
+  describe('processViKey - normal mode navigation', () => {
+    const normalState: ViState = {
+      mode: 'normal',
+      operator: null,
+      count: 0,
+      visualAnchor: null,
+      lastFindChar: null,
+      register: ''
+    }
+
+    it('h moves cursor left', () => {
+      const { action } = processViKey(normalState, 'hello', 3, mkEvent('h'))
+      expect(action.type).toBe('cursor')
+      expect(action.cursor).toBe(2)
+    })
+
+    it('l moves cursor right', () => {
+      const { action } = processViKey(normalState, 'hello', 2, mkEvent('l'))
+      expect(action.type).toBe('cursor')
+      expect(action.cursor).toBe(3)
+    })
+
+    it('0 moves to line start', () => {
+      const { action } = processViKey(normalState, 'hello', 3, mkEvent('0'))
+      expect(action.type).toBe('cursor')
+      expect(action.cursor).toBe(0)
+    })
+
+    it('$ moves to line end', () => {
+      const { action } = processViKey(normalState, 'hello', 1, mkEvent('$'))
+      expect(action.type).toBe('cursor')
+      expect(action.cursor).toBe(4) // End is length - 1 in normal mode
+    })
+
+    it('w moves to next word start', () => {
+      const { action } = processViKey(normalState, 'hello world', 0, mkEvent('w'))
+      expect(action.type).toBe('cursor')
+      expect(action.cursor).toBe(6)
+    })
+
+    it('b moves to previous word start', () => {
+      const { action } = processViKey(normalState, 'hello world', 8, mkEvent('b'))
+      expect(action.type).toBe('cursor')
+      expect(action.cursor).toBe(6)
+    })
+
+    it('numeric prefix multiplies movement', () => {
+      const stateWith3 = { ...normalState, count: 3 }
+      const { action } = processViKey(stateWith3, 'hello world test', 0, mkEvent('l'))
+      expect(action.cursor).toBe(3)
+    })
+  })
+
+  describe('processViKey - insert mode entry', () => {
+    const normalState: ViState = {
+      mode: 'normal',
+      operator: null,
+      count: 0,
+      visualAnchor: null,
+      lastFindChar: null,
+      register: ''
+    }
+
+    it('i enters insert mode at cursor', () => {
+      const { action, newState } = processViKey(normalState, 'hello', 2, mkEvent('i'))
+      expect(newState.mode).toBe('insert')
+      expect(action.type).toBe('insert')
+      expect(action.cursor).toBe(2)
+    })
+
+    it('a enters insert mode after cursor', () => {
+      const { action, newState } = processViKey(normalState, 'hello', 2, mkEvent('a'))
+      expect(newState.mode).toBe('insert')
+      expect(action.type).toBe('insert')
+      expect(action.cursor).toBe(3)
+    })
+
+    it('A enters insert mode at end of line', () => {
+      const { action, newState } = processViKey(normalState, 'hello', 2, mkEvent('A'))
+      expect(newState.mode).toBe('insert')
+      expect(action.cursor).toBe(5)
+    })
+
+    it('I enters insert mode at first non-whitespace', () => {
+      const { action, newState } = processViKey(normalState, '  hello', 4, mkEvent('I'))
+      expect(newState.mode).toBe('insert')
+      expect(action.cursor).toBe(2)
+    })
+  })
+
+  describe('processViKey - delete operations', () => {
+    const normalState: ViState = {
+      mode: 'normal',
+      operator: null,
+      count: 0,
+      visualAnchor: null,
+      lastFindChar: null,
+      register: ''
+    }
+
+    it('x deletes character under cursor', () => {
+      const { action, newState } = processViKey(normalState, 'hello', 2, mkEvent('x'))
+      expect(action.type).toBe('delete')
+      expect(action.deleteRange).toEqual({ start: 2, end: 3 })
+      expect(newState.register).toBe('l')
+    })
+
+    it('X deletes character before cursor', () => {
+      const { action, newState } = processViKey(normalState, 'hello', 2, mkEvent('X'))
+      expect(action.type).toBe('delete')
+      expect(action.deleteRange).toEqual({ start: 1, end: 2 })
+      expect(newState.register).toBe('e')
+    })
+
+    it('dd deletes entire line', () => {
+      const stateWithD = { ...normalState, operator: 'd' }
+      const { action, newState } = processViKey(stateWithD, 'hello', 2, mkEvent('d'))
+      expect(action.type).toBe('delete')
+      expect(action.deleteRange).toEqual({ start: 0, end: 5 })
+      expect(newState.register).toBe('hello')
+    })
+
+    it('dw deletes word', () => {
+      const stateWithD: ViState = { ...normalState, operator: 'd', mode: 'operator-pending' }
+      const { action, newState } = processViKey(stateWithD, 'hello world', 0, mkEvent('w'))
+      expect(action.type).toBe('delete')
+      expect(action.deleteRange).toEqual({ start: 0, end: 6 })
+      expect(newState.register).toBe('hello ')
+    })
+  })
+
+  describe('processViKey - change operations', () => {
+    const normalState: ViState = {
+      mode: 'normal',
+      operator: null,
+      count: 0,
+      visualAnchor: null,
+      lastFindChar: null,
+      register: ''
+    }
+
+    it('s substitutes character and enters insert mode', () => {
+      const { action, newState } = processViKey(normalState, 'hello', 2, mkEvent('s'))
+      expect(action.type).toBe('change')
+      expect(newState.mode).toBe('insert')
+      expect(action.deleteRange).toEqual({ start: 2, end: 3 })
+    })
+
+    it('C changes to end of line', () => {
+      const { action, newState } = processViKey(normalState, 'hello', 2, mkEvent('C'))
+      expect(action.type).toBe('change')
+      expect(newState.mode).toBe('insert')
+      expect(action.deleteRange).toEqual({ start: 2, end: 5 })
+    })
+
+    it('cw changes word and enters insert mode', () => {
+      const stateWithC: ViState = { ...normalState, operator: 'c', mode: 'operator-pending' }
+      const { action, newState } = processViKey(stateWithC, 'hello world', 0, mkEvent('w'))
+      expect(action.type).toBe('change')
+      expect(newState.mode).toBe('insert')
+    })
+  })
+
+  describe('processViKey - yank and paste', () => {
+    const normalState: ViState = {
+      mode: 'normal',
+      operator: null,
+      count: 0,
+      visualAnchor: null,
+      lastFindChar: null,
+      register: ''
+    }
+
+    it('yy yanks entire line', () => {
+      const stateWithY = { ...normalState, operator: 'y' }
+      const { action, newState } = processViKey(stateWithY, 'hello', 2, mkEvent('y'))
+      expect(action.type).toBe('yank')
+      expect(newState.register).toBe('hello')
+    })
+
+    it('p pastes after cursor', () => {
+      const stateWithRegister = { ...normalState, register: 'world' }
+      const { action } = processViKey(stateWithRegister, 'hello', 2, mkEvent('p'))
+      expect(action.type).toBe('paste')
+      expect(action.cursor).toBe(3)
+      expect(action.text).toBe('world')
+    })
+
+    it('P pastes before cursor', () => {
+      const stateWithRegister = { ...normalState, register: 'world' }
+      const { action } = processViKey(stateWithRegister, 'hello', 2, mkEvent('P'))
+      expect(action.type).toBe('paste')
+      expect(action.cursor).toBe(2)
+      expect(action.text).toBe('world')
+    })
+  })
+
+  describe('processViKey - undo/redo', () => {
+    const normalState: ViState = {
+      mode: 'normal',
+      operator: null,
+      count: 0,
+      visualAnchor: null,
+      lastFindChar: null,
+      register: ''
+    }
+
+    it('u triggers undo', () => {
+      const { action } = processViKey(normalState, 'hello', 2, mkEvent('u'))
+      expect(action.type).toBe('undo')
+    })
+
+    it('Ctrl+R triggers redo', () => {
+      const { action } = processViKey(normalState, 'hello', 2, mkEvent('\x12', { ctrl: true }))
+      expect(action.type).toBe('redo')
+    })
+  })
+
+  describe('processViKey - submit', () => {
+    const normalState: ViState = {
+      mode: 'normal',
+      operator: null,
+      count: 0,
+      visualAnchor: null,
+      lastFindChar: null,
+      register: ''
+    }
+
+    it('Enter in normal mode submits', () => {
+      const { action } = processViKey(normalState, 'hello', 2, mkEvent('\r', { return: true }))
+      expect(action.type).toBe('submit')
+    })
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -182,6 +182,8 @@ export interface UiState {
   streaming: boolean
   theme: Theme
   usage: Usage
+  /** Vim mode for input area - toggled via /vim command */
+  viModeEnabled: boolean
 }
 
 export interface VirtualHistoryState {

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -16,7 +16,7 @@ import { fmtK } from '../../../lib/text.js'
 import type { PanelSection } from '../../../types.js'
 import { DEFAULT_INDICATOR_STYLE, INDICATOR_STYLES, type IndicatorStyle } from '../../interfaces.js'
 import { patchOverlayState } from '../../overlayStore.js'
-import { patchUiState } from '../../uiStore.js'
+import { getUiState, patchUiState } from '../../uiStore.js'
 import type { SlashCommand } from '../types.js'
 
 const TUI_SESSION_MODEL_RE = new RegExp(`(?:^|\\s)${TUI_SESSION_MODEL_FLAG}(?:\\s|$)`)
@@ -426,6 +426,17 @@ export const sessionCommands: SlashCommand[] = [
           ctx.transcript.sys(`indicator → ${r.value}`)
         })
       )
+    }
+  },
+
+  {
+    help: 'toggle vim mode for input (hjkl navigation, d/c/y operators)',
+    name: 'vim',
+    run: (arg, ctx) => {
+      const current = getUiState().viModeEnabled
+      const next = arg.toLowerCase() === 'on' ? true : arg.toLowerCase() === 'off' ? false : !current
+      patchUiState({ viModeEnabled: next })
+      ctx.transcript.sys(`vim mode ${next ? 'on' : 'off'}`)
     }
   },
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -1,6 +1,6 @@
 import { atom, computed } from 'nanostores'
 
-import { MOUSE_TRACKING } from '../config/env.js'
+import { MOUSE_TRACKING, VIM_MODE } from '../config/env.js'
 import { ZERO } from '../domain/usage.js'
 import { DEFAULT_THEME } from '../theme.js'
 
@@ -29,7 +29,8 @@ const buildUiState = (): UiState => ({
   statusBar: 'top',
   streaming: true,
   theme: DEFAULT_THEME,
-  usage: ZERO
+  usage: ZERO,
+  viModeEnabled: VIM_MODE
 })
 
 export const $uiState = atom<UiState>(buildUiState())

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -1,6 +1,6 @@
 import { AlternateScreen, Box, NoSelect, ScrollBox, Text } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
-import { Fragment, memo, useEffect, useMemo, useRef } from 'react'
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useGateway } from '../app/gatewayContext.js'
 import type { AppLayoutProps } from '../app/interfaces.js'
@@ -31,7 +31,7 @@ import { MessageLine } from './messageLine.js'
 import { PetKitty, PetSprite } from './petSprite.js'
 import { QueuedMessages } from './queuedMessages.js'
 import { LiveTodoPanel, StreamingAssistant } from './streamingAssistant.js'
-import { TextInput, type TextInputMouseApi } from './textInput.js'
+import { TextInput, type TextInputMouseApi, viModeIndicator, type ViModeType } from './textInput.js'
 
 // Box geometry, kept here so the transcript's reservation math matches the
 // rendered overlay exactly.
@@ -265,6 +265,7 @@ const ComposerPane = memo(function ComposerPane({
 }: Pick<AppLayoutProps, 'actions' | 'composer' | 'status'>) {
   const ui = useStore($uiState)
   const isBlocked = useStore($isBlocked)
+  const [viMode, setViMode] = useState<ViModeType>('insert')
   const sh = (composer.inputBuf[0] ?? composer.input).startsWith('!')
 
   const promptText = composerPromptText(
@@ -409,11 +410,26 @@ const ComposerPane = memo(function ComposerPane({
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}
+                  onViModeChange={setViMode}
                   placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
                   value={composer.input}
+                  viModeEnabled={ui.viModeEnabled}
                   voiceRecordKey={composer.voiceRecordKey}
                 />
               </Box>
+
+              {/* Vim mode indicator */}
+              {ui.viModeEnabled && (
+                <Box marginLeft={1}>
+                  <Text
+                    backgroundColor={viMode === 'normal' ? ui.theme.color.label : ui.theme.color.ok}
+                    bold
+                    color={ui.theme.color.statusBg}
+                  >
+                    {' '}{viModeIndicator(viMode)}{' '}
+                  </Text>
+                </Box>
+              )}
 
               <Box position="absolute" right={0}>
                 <GoodVibesHeart t={ui.theme} tick={status.goodVibesTick} />

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1,8 +1,9 @@
 import type { InputEvent, Key } from '@hermes/ink'
 import * as Ink from '@hermes/ink'
-import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
+import { VIM_MODE } from '../config/env.js'
 import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
 import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
@@ -14,6 +15,13 @@ import {
   type ParsedVoiceRecordKey
 } from '../lib/platform.js'
 import { isTermuxTuiMode } from '../lib/termux.js'
+import {
+  initialViState,
+  processViKey,
+  viModeIndicator,
+  type ViModeType,
+  type ViState
+} from '../lib/viMode.js'
 
 type InkExt = typeof Ink & {
   stringWidth: (s: string) => number
@@ -461,14 +469,17 @@ export function TextInput({
   onChange,
   onPaste,
   onSubmit,
+  onViModeChange,
   mask,
   mouseApiRef,
+  viModeEnabled = VIM_MODE,
   voiceRecordKey = DEFAULT_VOICE_RECORD_KEY,
   placeholder = '',
   focus = true
 }: TextInputProps) {
   const [cur, setCur] = useState(value.length)
   const [sel, setSel] = useState<null | { end: number; start: number }>(null)
+  const [viState, setViState] = useState<ViState>(initialViState)
   const fwdDel = useFwdDelete(focus)
   const termFocus = useTerminalFocus()
   const { stdout } = useStdout()
@@ -492,9 +503,22 @@ export function TextInput({
   const cbChange = useRef(onChange)
   const cbSubmit = useRef(onSubmit)
   const cbPaste = useRef(onPaste)
+  const cbViModeChange = useRef(onViModeChange)
   cbChange.current = onChange
   cbSubmit.current = onSubmit
   cbPaste.current = onPaste
+  cbViModeChange.current = onViModeChange
+
+  // Ref for vim state to avoid stale closures in useInput
+  const viStateRef = useRef(viState)
+  viStateRef.current = viState
+
+  // Notify parent of vim mode changes
+  useEffect(() => {
+    if (viModeEnabled && cbViModeChange.current) {
+      cbViModeChange.current(viState.mode)
+    }
+  }, [viModeEnabled, viState.mode])
 
   const raw = self.current ? vRef.current : value
   const display = mask ? raw.replace(/[^\n]/g, mask[0] ?? '*') : raw
@@ -931,9 +955,121 @@ export function TextInput({
       // follow-up on #19835). The pass-through predicate is a no-op for
       // ordinary typing and plain paste when voice is unbound to 'v'.
       if (shouldPassThroughToGlobalHandler(inp, k, voiceRecordKey)) {
+        // In vim normal mode, Escape should NOT pass through - it's just a no-op
+        if (viModeEnabled && k.escape && viStateRef.current.mode === 'normal') {
+          return
+        }
         flushKeyBurst()
 
         return
+      }
+
+      // Vim mode key processing
+      if (viModeEnabled) {
+        const viEvent = {
+          input: inp,
+          key: {
+            ctrl: k.ctrl,
+            shift: k.shift,
+            meta: k.meta,
+            escape: k.escape,
+            backspace: k.backspace,
+            delete: k.delete,
+            return: k.return,
+            upArrow: k.upArrow,
+            downArrow: k.downArrow,
+            leftArrow: k.leftArrow,
+            rightArrow: k.rightArrow
+          }
+        }
+
+        const { action, newState } = processViKey(viStateRef.current, vRef.current, curRef.current, viEvent)
+        setViState(newState)
+
+        // Handle vim action
+        switch (action.type) {
+          case 'passthrough':
+            // Let default handler process this key
+            break
+
+          case 'none':
+            // Key consumed but no action needed
+            return
+
+          case 'cursor':
+            if (action.cursor !== undefined) {
+              clearSel()
+              setCur(action.cursor)
+              curRef.current = action.cursor
+            }
+            return
+
+          case 'insert':
+            if (action.cursor !== undefined) {
+              clearSel()
+              setCur(action.cursor)
+              curRef.current = action.cursor
+            }
+            if (action.text) {
+              // Insert text (e.g., newline for o/O commands)
+              const c = curRef.current
+              const v = vRef.current
+              const newValue = v.slice(0, c) + action.text + v.slice(c)
+              const newCursor = c + (action.text === '\n' && inp === 'O' ? 0 : action.text.length)
+              commit(newValue, newCursor)
+            }
+            return
+
+          case 'delete':
+            if (action.deleteRange) {
+              const { start, end } = action.deleteRange
+              const newValue = vRef.current.slice(0, start) + vRef.current.slice(end)
+              commit(newValue, action.cursor ?? start)
+            }
+            return
+
+          case 'change':
+            if (action.deleteRange) {
+              const { start, end } = action.deleteRange
+              const newValue = vRef.current.slice(0, start) + vRef.current.slice(end)
+              commit(newValue, action.cursor ?? start)
+            }
+            return
+
+          case 'yank':
+            // Text is stored in viState.register, nothing else to do
+            return
+
+          case 'paste':
+            if (action.text && action.cursor !== undefined) {
+              const c = action.cursor
+              const v = vRef.current
+              const newValue = v.slice(0, c) + action.text + v.slice(c)
+              commit(newValue, c + action.text.length)
+            }
+            return
+
+          case 'replace':
+            if (action.deleteRange && action.text !== undefined) {
+              const { start, end } = action.deleteRange
+              const newValue = vRef.current.slice(0, start) + action.text + vRef.current.slice(end)
+              commit(newValue, start)
+            }
+            return
+
+          case 'undo':
+            swap(undo, redo)
+            return
+
+          case 'redo':
+            swap(redo, undo)
+            return
+
+          case 'submit':
+            flushKeyBurst()
+            cbSubmit.current?.(vRef.current)
+            return
+        }
       }
 
       if (
@@ -1308,8 +1444,12 @@ interface TextInputProps {
     e: PasteEvent
   ) => { cursor: number; value: string } | Promise<{ cursor: number; value: string } | null> | null
   onSubmit?: (v: string) => void
+  /** Callback to report vim mode changes to parent (for mode indicator display) */
+  onViModeChange?: (mode: ViModeType) => void
   placeholder?: string
   value: string
+  /** Override vim mode enable (default: reads from HERMES_TUI_VIM_MODE env) */
+  viModeEnabled?: boolean
   voiceRecordKey?: ParsedVoiceRecordKey
 }
 
@@ -1360,3 +1500,6 @@ export interface TextInputMouseApi {
   end: () => void
   startAtBeginning: () => void
 }
+
+// Re-export vim mode utilities for parent components
+export { viModeIndicator, type ViModeType } from '../lib/viMode.js'

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -949,16 +949,33 @@ export function TextInput({
     (inp: string, k: Key, event: InputEvent) => {
       const eventRaw = event.keypress.raw
 
+      // Vim: Escape is a mode switch, not a global key — consume it before
+      // the global pass-through (which would swallow it and leave the user
+      // stuck in insert mode forever).
+      if (viModeEnabled && k.escape) {
+        flushKeyBurst()
+
+        const { action, newState } = processViKey(viStateRef.current, vRef.current, curRef.current, {
+          input: inp,
+          key: { escape: true }
+        })
+        setViState(newState)
+
+        if (action.type === 'cursor' && action.cursor !== undefined) {
+          clearSel()
+          setCur(action.cursor)
+          curRef.current = action.cursor
+        }
+
+        return
+      }
+
       // Configured voice shortcut wins over composer-level defaults like
       // paste/copy so users who bind voice to ctrl+v / alt+v / cmd+v
       // actually get voice toggled instead of a paste (Copilot round-7
       // follow-up on #19835). The pass-through predicate is a no-op for
       // ordinary typing and plain paste when voice is unbound to 'v'.
       if (shouldPassThroughToGlobalHandler(inp, k, voiceRecordKey)) {
-        // In vim normal mode, Escape should NOT pass through - it's just a no-op
-        if (viModeEnabled && k.escape && viStateRef.current.mode === 'normal') {
-          return
-        }
         flushKeyBurst()
 
         return

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -73,3 +73,8 @@ export const INLINE_MODE = inlineOverride ?? TERMUX_TUI_MODE
 // Live FPS counter overlay, fed by ink's onFrame (real render rate, not a
 // synthetic timer).
 export const SHOW_FPS = truthy(process.env.HERMES_TUI_FPS)
+
+// Vim/vi mode for the text input. When enabled, the composer starts in insert
+// mode but supports Escape to enter normal mode with vim-style navigation and
+// editing commands (h/j/k/l, w/b/e, d/c/y operators, etc.).
+export const VIM_MODE = truthy(process.env.HERMES_TUI_VIM_MODE)

--- a/ui-tui/src/lib/viMode.ts
+++ b/ui-tui/src/lib/viMode.ts
@@ -234,6 +234,34 @@ export function processViKey(
 
   // Normal mode key handling
   if (state.mode === 'normal' || state.mode === 'operator-pending') {
+    // Pending char-argument operators (f/F/t/T/r) consume the NEXT key as a
+    // literal character — this must run before count parsing and the motion
+    // switch, otherwise `fh` runs the h-motion and `f3` is eaten as a count.
+    if (state.operator && 'fFtTr'.includes(state.operator) && input.length === 1 && !key.ctrl && !key.meta) {
+      const op = state.operator
+      newState.operator = null
+      newState.mode = 'normal'
+      newState.count = 0
+
+      if (op === 'r') {
+        if (cursor < value.length) {
+          return {
+            action: { type: 'replace', deleteRange: { start: cursor, end: cursor + 1 }, text: input, cursor },
+            newState
+          }
+        }
+
+        return { action: { type: 'none' }, newState }
+      }
+
+      const forward = op === 'f' || op === 't'
+      const till = op === 't' || op === 'T'
+      newState.lastFindChar = { char: input, forward, till }
+      const found = forward ? findCharForward(value, cursor, input, till) : findCharBackward(value, cursor, input, till)
+
+      return { action: found === null ? { type: 'none' } : { type: 'cursor', cursor: found }, newState }
+    }
+
     // Numeric prefix (count)
     if (/^[1-9]$/.test(input) || (state.count > 0 && input === '0')) {
       newState.count = state.count * 10 + parseInt(input, 10)
@@ -247,7 +275,6 @@ export function processViKey(
 
     // Motion keys
     let targetPos: number | null = null
-    let isLineWise = false
 
     switch (input) {
       // Basic movement
@@ -591,37 +618,9 @@ export function processViKey(
         break
 
       default:
-        // Handle pending operator with character argument (f, F, t, T, r)
-        if (state.mode === 'operator-pending' && state.operator && input.length === 1) {
-          const op = state.operator
-          resetCount()
-          newState.operator = null
-          newState.mode = 'normal'
-
-          if (op === 'f' || op === 'F' || op === 't' || op === 'T') {
-            const forward = op === 'f' || op === 't'
-            const till = op === 't' || op === 'T'
-            newState.lastFindChar = { char: input, forward, till }
-            targetPos = forward ? findCharForward(value, cursor, input, till) : findCharBackward(value, cursor, input, till)
-            if (targetPos === null) {
-              return { action: { type: 'none' }, newState }
-            }
-          } else if (op === 'r') {
-            // Replace character
-            if (cursor < value.length) {
-              return {
-                action: {
-                  type: 'replace',
-                  deleteRange: { start: cursor, end: cursor + 1 },
-                  text: input,
-                  cursor
-                },
-                newState
-              }
-            }
-            return { action: { type: 'none' }, newState }
-          }
-        }
+        // Unhandled key in normal mode — fall through to the no-op return.
+        // (f/F/t/T/r char arguments are consumed by the pending-operator
+        // guard at the top of normal-mode handling, before count parsing.)
         break
     }
 

--- a/ui-tui/src/lib/viMode.ts
+++ b/ui-tui/src/lib/viMode.ts
@@ -1,0 +1,697 @@
+/**
+ * Vi/Vim mode state machine for the TUI text input.
+ *
+ * Implements a subset of vim's command language for single-line and
+ * multi-line editing. Supports normal mode, insert mode, and operator-pending
+ * mode for motions like dw, cw, etc.
+ *
+ * Enabled via HERMES_TUI_VIM_MODE=1 environment variable.
+ */
+
+export type ViModeType = 'normal' | 'insert' | 'visual' | 'operator-pending'
+
+export interface ViState {
+  mode: ViModeType
+  /** Pending operator (d, c, y) waiting for a motion */
+  operator: string | null
+  /** Numeric repeat count (e.g., 3w moves 3 words) */
+  count: number
+  /** Visual mode anchor position */
+  visualAnchor: number | null
+  /** Last f/F/t/T character for ; and , repeat */
+  lastFindChar: { char: string; forward: boolean; till: boolean } | null
+  /** Register for yank/paste (simplified: just one unnamed register) */
+  register: string
+}
+
+export const initialViState = (): ViState => ({
+  mode: 'insert', // Start in insert mode for familiarity
+  operator: null,
+  count: 0,
+  visualAnchor: null,
+  lastFindChar: null,
+  register: ''
+})
+
+export interface ViAction {
+  type:
+    | 'cursor' // Move cursor
+    | 'insert' // Enter insert mode at position
+    | 'delete' // Delete text
+    | 'change' // Delete and enter insert mode
+    | 'yank' // Copy text
+    | 'paste' // Paste register
+    | 'replace' // Replace single char
+    | 'undo'
+    | 'redo'
+    | 'submit' // Submit the input (Enter in normal mode)
+    | 'none' // No action (consumed but no effect)
+    | 'passthrough' // Let the default handler process this
+  cursor?: number
+  deleteRange?: { start: number; end: number }
+  text?: string
+  newMode?: ViModeType
+}
+
+/**
+ * Find the start of the current word (for b/B motion).
+ */
+function wordStart(s: string, pos: number, bigWord = false): number {
+  if (pos <= 0) return 0
+  let i = pos - 1
+
+  // Skip whitespace backwards
+  while (i > 0 && /\s/.test(s[i]!)) i--
+
+  if (bigWord) {
+    // WORD: non-whitespace sequence
+    while (i > 0 && !/\s/.test(s[i - 1]!)) i--
+  } else {
+    // word: alphanumeric or punctuation sequence
+    const isWord = (c: string) => /\w/.test(c)
+    const startType = isWord(s[i]!)
+
+    while (i > 0 && isWord(s[i - 1]!) === startType && !/\s/.test(s[i - 1]!)) i--
+  }
+
+  return Math.max(0, i)
+}
+
+/**
+ * Find the end of the current/next word (for e/E motion).
+ */
+function wordEnd(s: string, pos: number, bigWord = false): number {
+  const len = s.length
+  if (pos >= len - 1) return len - 1
+  let i = pos + 1
+
+  // Skip whitespace forward
+  while (i < len && /\s/.test(s[i]!)) i++
+  if (i >= len) return len - 1
+
+  if (bigWord) {
+    while (i < len - 1 && !/\s/.test(s[i + 1]!)) i++
+  } else {
+    const isWord = (c: string) => /\w/.test(c)
+    const startType = isWord(s[i]!)
+
+    while (i < len - 1 && isWord(s[i + 1]!) === startType && !/\s/.test(s[i + 1]!)) i++
+  }
+
+  return i
+}
+
+/**
+ * Find the start of the next word (for w/W motion).
+ */
+function nextWordStart(s: string, pos: number, bigWord = false): number {
+  const len = s.length
+  if (pos >= len) return len
+  let i = pos
+
+  if (bigWord) {
+    // Skip current WORD
+    while (i < len && !/\s/.test(s[i]!)) i++
+    // Skip whitespace
+    while (i < len && /\s/.test(s[i]!)) i++
+  } else {
+    const isWord = (c: string) => /\w/.test(c)
+    const startType = /\s/.test(s[i]!) ? null : isWord(s[i]!)
+
+    if (startType === null) {
+      // Already on whitespace, skip it
+      while (i < len && /\s/.test(s[i]!)) i++
+    } else {
+      // Skip current word/punct sequence
+      while (i < len && isWord(s[i]!) === startType && !/\s/.test(s[i]!)) i++
+      // Skip whitespace
+      while (i < len && /\s/.test(s[i]!)) i++
+    }
+  }
+
+  return i
+}
+
+/**
+ * Find character forward (f/t motion).
+ */
+function findCharForward(s: string, pos: number, char: string, till: boolean): number | null {
+  const idx = s.indexOf(char, pos + 1)
+  if (idx === -1) return null
+  return till ? idx - 1 : idx
+}
+
+/**
+ * Find character backward (F/T motion).
+ */
+function findCharBackward(s: string, pos: number, char: string, till: boolean): number | null {
+  const idx = s.lastIndexOf(char, pos - 1)
+  if (idx === -1) return null
+  return till ? idx + 1 : idx
+}
+
+/**
+ * Get line start position (for 0 and ^ motions).
+ */
+function lineStart(s: string, pos: number): number {
+  const lineBreak = s.lastIndexOf('\n', pos - 1)
+  return lineBreak === -1 ? 0 : lineBreak + 1
+}
+
+/**
+ * Get first non-whitespace position on current line (for ^ motion).
+ */
+function lineFirstNonWhitespace(s: string, pos: number): number {
+  const start = lineStart(s, pos)
+  let i = start
+  while (i < s.length && s[i] !== '\n' && /\s/.test(s[i]!)) i++
+  return i
+}
+
+/**
+ * Get line end position (for $ motion).
+ */
+function lineEnd(s: string, pos: number): number {
+  const lineBreak = s.indexOf('\n', pos)
+  return lineBreak === -1 ? s.length : lineBreak
+}
+
+export interface ViKeyEvent {
+  input: string
+  key: {
+    ctrl?: boolean
+    shift?: boolean
+    meta?: boolean
+    escape?: boolean
+    backspace?: boolean
+    delete?: boolean
+    return?: boolean
+    upArrow?: boolean
+    downArrow?: boolean
+    leftArrow?: boolean
+    rightArrow?: boolean
+  }
+}
+
+/**
+ * Process a key in vi mode and return the resulting action.
+ */
+export function processViKey(
+  state: ViState,
+  value: string,
+  cursor: number,
+  event: ViKeyEvent
+): { action: ViAction; newState: ViState } {
+  const { input, key } = event
+  let newState = { ...state }
+
+  // Handle Escape - always returns to normal mode
+  if (key.escape || (key.ctrl && input === '[')) {
+    // In insert mode, move cursor back one (vim behavior)
+    const newCursor = state.mode === 'insert' && cursor > 0 ? cursor - 1 : cursor
+    newState = { ...newState, mode: 'normal', operator: null, count: 0, visualAnchor: null }
+    return {
+      action: { type: 'cursor', cursor: newCursor, newMode: 'normal' },
+      newState
+    }
+  }
+
+  // Insert mode - pass through most keys
+  if (state.mode === 'insert') {
+    // Ctrl+C exits insert mode (alternative to Escape)
+    if (key.ctrl && input === 'c') {
+      const newCursor = cursor > 0 ? cursor - 1 : cursor
+      newState = { ...newState, mode: 'normal', operator: null, count: 0 }
+      return {
+        action: { type: 'cursor', cursor: newCursor, newMode: 'normal' },
+        newState
+      }
+    }
+
+    // Let all other keys pass through to default handling
+    return { action: { type: 'passthrough' }, newState }
+  }
+
+  // Normal mode key handling
+  if (state.mode === 'normal' || state.mode === 'operator-pending') {
+    // Numeric prefix (count)
+    if (/^[1-9]$/.test(input) || (state.count > 0 && input === '0')) {
+      newState.count = state.count * 10 + parseInt(input, 10)
+      return { action: { type: 'none' }, newState }
+    }
+
+    const count = Math.max(1, state.count)
+    const resetCount = () => {
+      newState.count = 0
+    }
+
+    // Motion keys
+    let targetPos: number | null = null
+    let isLineWise = false
+
+    switch (input) {
+      // Basic movement
+      case 'h':
+      case '\x08': // Backspace in some terminals
+        targetPos = Math.max(0, cursor - count)
+        break
+      case 'l':
+      case ' ':
+        targetPos = Math.min(value.length, cursor + count)
+        break
+      case 'j':
+        // Move down (in multiline) or to end
+        {
+          const lineBreak = value.indexOf('\n', cursor)
+          if (lineBreak !== -1) {
+            const col = cursor - lineStart(value, cursor)
+            const nextLineStart = lineBreak + 1
+            const nextLineEnd = lineEnd(value, nextLineStart)
+            targetPos = Math.min(nextLineStart + col, nextLineEnd)
+          } else {
+            targetPos = value.length
+          }
+        }
+        break
+      case 'k':
+        // Move up (in multiline) or to start
+        {
+          const currentLineStart = lineStart(value, cursor)
+          if (currentLineStart > 0) {
+            const col = cursor - currentLineStart
+            const prevLineEnd = currentLineStart - 1
+            const prevLineStart = lineStart(value, prevLineEnd)
+            targetPos = Math.min(prevLineStart + col, prevLineEnd)
+          } else {
+            targetPos = 0
+          }
+        }
+        break
+
+      // Word motions
+      case 'w':
+        targetPos = cursor
+        for (let i = 0; i < count; i++) targetPos = nextWordStart(value, targetPos)
+        break
+      case 'W':
+        targetPos = cursor
+        for (let i = 0; i < count; i++) targetPos = nextWordStart(value, targetPos, true)
+        break
+      case 'b':
+        targetPos = cursor
+        for (let i = 0; i < count; i++) targetPos = wordStart(value, targetPos)
+        break
+      case 'B':
+        targetPos = cursor
+        for (let i = 0; i < count; i++) targetPos = wordStart(value, targetPos, true)
+        break
+      case 'e':
+        targetPos = cursor
+        for (let i = 0; i < count; i++) targetPos = wordEnd(value, targetPos)
+        break
+      case 'E':
+        targetPos = cursor
+        for (let i = 0; i < count; i++) targetPos = wordEnd(value, targetPos, true)
+        break
+
+      // Line motions
+      case '0':
+        targetPos = lineStart(value, cursor)
+        break
+      case '^':
+        targetPos = lineFirstNonWhitespace(value, cursor)
+        break
+      case '$':
+        targetPos = lineEnd(value, cursor) - (state.operator ? 0 : 1)
+        targetPos = Math.max(lineStart(value, cursor), targetPos)
+        break
+      case 'g':
+        // gg = go to start
+        // We'd need to track 'g' as pending, simplify for now
+        targetPos = 0
+        break
+      case 'G':
+        targetPos = value.length
+        break
+
+      // Find character
+      case 'f':
+      case 'F':
+      case 't':
+      case 'T':
+        // Need next character - enter a pending state
+        // For simplicity, we'll handle this differently - queue input
+        newState.operator = input
+        newState.mode = 'operator-pending'
+        return { action: { type: 'none' }, newState }
+
+      // Repeat find
+      case ';':
+        if (state.lastFindChar) {
+          const { char, forward, till } = state.lastFindChar
+          targetPos = forward ? findCharForward(value, cursor, char, till) : findCharBackward(value, cursor, char, till)
+        }
+        break
+      case ',':
+        if (state.lastFindChar) {
+          const { char, forward, till } = state.lastFindChar
+          targetPos = forward
+            ? findCharBackward(value, cursor, char, till)
+            : findCharForward(value, cursor, char, till)
+        }
+        break
+
+      // Operators
+      case 'd':
+        if (state.operator === 'd') {
+          // dd - delete whole line(s)
+          const start = lineStart(value, cursor)
+          let end = lineEnd(value, cursor)
+          // Include the newline if not at end
+          if (end < value.length && value[end] === '\n') end++
+          else if (start > 0) {
+            // At last line, delete preceding newline
+            const newStart = start - 1
+            resetCount()
+            newState.operator = null
+            newState.register = value.slice(newStart, end)
+            return {
+              action: { type: 'delete', deleteRange: { start: newStart, end }, cursor: Math.max(0, newStart) },
+              newState
+            }
+          }
+          resetCount()
+          newState.operator = null
+          newState.register = value.slice(start, end)
+          return {
+            action: { type: 'delete', deleteRange: { start, end }, cursor: Math.max(0, start) },
+            newState
+          }
+        }
+        newState.operator = 'd'
+        newState.mode = 'operator-pending'
+        return { action: { type: 'none' }, newState }
+
+      case 'c':
+        if (state.operator === 'c') {
+          // cc - change whole line (keep newline)
+          const start = lineStart(value, cursor)
+          const end = lineEnd(value, cursor)
+          resetCount()
+          newState.operator = null
+          newState.mode = 'insert'
+          newState.register = value.slice(start, end)
+          return {
+            action: { type: 'change', deleteRange: { start, end }, cursor: start, newMode: 'insert' },
+            newState
+          }
+        }
+        newState.operator = 'c'
+        newState.mode = 'operator-pending'
+        return { action: { type: 'none' }, newState }
+
+      case 'y':
+        if (state.operator === 'y') {
+          // yy - yank whole line
+          const start = lineStart(value, cursor)
+          let end = lineEnd(value, cursor)
+          if (end < value.length && value[end] === '\n') end++
+          resetCount()
+          newState.operator = null
+          newState.register = value.slice(start, end)
+          return { action: { type: 'yank', text: newState.register }, newState }
+        }
+        newState.operator = 'y'
+        newState.mode = 'operator-pending'
+        return { action: { type: 'none' }, newState }
+
+      // Insert mode entry points
+      case 'i':
+        resetCount()
+        newState.mode = 'insert'
+        return { action: { type: 'insert', cursor, newMode: 'insert' }, newState }
+
+      case 'I':
+        resetCount()
+        newState.mode = 'insert'
+        targetPos = lineFirstNonWhitespace(value, cursor)
+        return { action: { type: 'insert', cursor: targetPos, newMode: 'insert' }, newState }
+
+      case 'a':
+        resetCount()
+        newState.mode = 'insert'
+        return { action: { type: 'insert', cursor: Math.min(cursor + 1, value.length), newMode: 'insert' }, newState }
+
+      case 'A':
+        resetCount()
+        newState.mode = 'insert'
+        targetPos = lineEnd(value, cursor)
+        return { action: { type: 'insert', cursor: targetPos, newMode: 'insert' }, newState }
+
+      case 'o':
+        // Open line below
+        resetCount()
+        newState.mode = 'insert'
+        targetPos = lineEnd(value, cursor)
+        return {
+          action: { type: 'insert', cursor: targetPos, text: '\n', newMode: 'insert' },
+          newState
+        }
+
+      case 'O':
+        // Open line above
+        resetCount()
+        newState.mode = 'insert'
+        targetPos = lineStart(value, cursor)
+        return {
+          action: { type: 'insert', cursor: targetPos, text: '\n', newMode: 'insert' },
+          newState
+        }
+
+      case 's':
+        // Substitute character(s)
+        resetCount()
+        newState.mode = 'insert'
+        {
+          const end = Math.min(cursor + count, value.length)
+          newState.register = value.slice(cursor, end)
+          return {
+            action: { type: 'change', deleteRange: { start: cursor, end }, cursor, newMode: 'insert' },
+            newState
+          }
+        }
+
+      case 'S':
+        // Substitute line
+        resetCount()
+        newState.mode = 'insert'
+        {
+          const start = lineStart(value, cursor)
+          const end = lineEnd(value, cursor)
+          newState.register = value.slice(start, end)
+          return {
+            action: { type: 'change', deleteRange: { start, end }, cursor: start, newMode: 'insert' },
+            newState
+          }
+        }
+
+      case 'C':
+        // Change to end of line
+        resetCount()
+        newState.mode = 'insert'
+        {
+          const end = lineEnd(value, cursor)
+          newState.register = value.slice(cursor, end)
+          return {
+            action: { type: 'change', deleteRange: { start: cursor, end }, cursor, newMode: 'insert' },
+            newState
+          }
+        }
+
+      case 'D':
+        // Delete to end of line
+        resetCount()
+        {
+          const end = lineEnd(value, cursor)
+          newState.register = value.slice(cursor, end)
+          return {
+            action: { type: 'delete', deleteRange: { start: cursor, end }, cursor: Math.max(0, cursor - 1) },
+            newState
+          }
+        }
+
+      // Delete/change single character
+      case 'x':
+        resetCount()
+        {
+          const end = Math.min(cursor + count, value.length)
+          newState.register = value.slice(cursor, end)
+          return {
+            action: { type: 'delete', deleteRange: { start: cursor, end }, cursor: Math.min(cursor, value.length - count) },
+            newState
+          }
+        }
+
+      case 'X':
+        resetCount()
+        {
+          const start = Math.max(0, cursor - count)
+          newState.register = value.slice(start, cursor)
+          return {
+            action: { type: 'delete', deleteRange: { start, end: cursor }, cursor: start },
+            newState
+          }
+        }
+
+      case 'r':
+        // Replace single character - need next char
+        newState.operator = 'r'
+        newState.mode = 'operator-pending'
+        return { action: { type: 'none' }, newState }
+
+      // Paste
+      case 'p':
+        resetCount()
+        if (newState.register) {
+          const insertPos = newState.register.includes('\n') ? lineEnd(value, cursor) : cursor + 1
+          return {
+            action: { type: 'paste', cursor: insertPos, text: newState.register },
+            newState
+          }
+        }
+        return { action: { type: 'none' }, newState }
+
+      case 'P':
+        resetCount()
+        if (newState.register) {
+          const insertPos = newState.register.includes('\n') ? lineStart(value, cursor) : cursor
+          return {
+            action: { type: 'paste', cursor: insertPos, text: newState.register },
+            newState
+          }
+        }
+        return { action: { type: 'none' }, newState }
+
+      // Undo/Redo
+      case 'u':
+        resetCount()
+        return { action: { type: 'undo' }, newState }
+
+      case '\x12': // Ctrl+R
+        resetCount()
+        return { action: { type: 'redo' }, newState }
+
+      // Submit (Enter in normal mode)
+      case '\r':
+      case '\n':
+        if (!key.shift && !key.ctrl) {
+          resetCount()
+          return { action: { type: 'submit' }, newState }
+        }
+        break
+
+      default:
+        // Handle pending operator with character argument (f, F, t, T, r)
+        if (state.mode === 'operator-pending' && state.operator && input.length === 1) {
+          const op = state.operator
+          resetCount()
+          newState.operator = null
+          newState.mode = 'normal'
+
+          if (op === 'f' || op === 'F' || op === 't' || op === 'T') {
+            const forward = op === 'f' || op === 't'
+            const till = op === 't' || op === 'T'
+            newState.lastFindChar = { char: input, forward, till }
+            targetPos = forward ? findCharForward(value, cursor, input, till) : findCharBackward(value, cursor, input, till)
+            if (targetPos === null) {
+              return { action: { type: 'none' }, newState }
+            }
+          } else if (op === 'r') {
+            // Replace character
+            if (cursor < value.length) {
+              return {
+                action: {
+                  type: 'replace',
+                  deleteRange: { start: cursor, end: cursor + 1 },
+                  text: input,
+                  cursor
+                },
+                newState
+              }
+            }
+            return { action: { type: 'none' }, newState }
+          }
+        }
+        break
+    }
+
+    // Apply operator if we have a motion target
+    if (targetPos !== null && state.operator) {
+      const start = Math.min(cursor, targetPos)
+      const end = Math.max(cursor, targetPos)
+      const op = state.operator
+
+      resetCount()
+      newState.operator = null
+      newState.mode = op === 'c' ? 'insert' : 'normal'
+
+      if (op === 'd') {
+        newState.register = value.slice(start, end)
+        return {
+          action: { type: 'delete', deleteRange: { start, end }, cursor: start },
+          newState
+        }
+      } else if (op === 'c') {
+        newState.register = value.slice(start, end)
+        return {
+          action: { type: 'change', deleteRange: { start, end }, cursor: start, newMode: 'insert' },
+          newState
+        }
+      } else if (op === 'y') {
+        newState.register = value.slice(start, end)
+        return { action: { type: 'yank', text: newState.register }, newState }
+      }
+    }
+
+    // Just a motion (no operator)
+    if (targetPos !== null) {
+      resetCount()
+      newState.operator = null
+      newState.mode = 'normal'
+      return { action: { type: 'cursor', cursor: targetPos }, newState }
+    }
+
+    // Unknown key in normal mode - do nothing
+    resetCount()
+    return { action: { type: 'none' }, newState }
+  }
+
+  // Fallback
+  return { action: { type: 'passthrough' }, newState }
+}
+
+/**
+ * Check if vim mode is enabled via environment variable.
+ */
+export const isViModeEnabled = (): boolean => {
+  const env = process.env.HERMES_TUI_VIM_MODE ?? ''
+  return /^(?:1|true|yes|on)$/i.test(env.trim())
+}
+
+/**
+ * Get display indicator for current mode.
+ */
+export const viModeIndicator = (mode: ViModeType): string => {
+  switch (mode) {
+    case 'normal':
+      return 'NORMAL'
+    case 'insert':
+      return 'INSERT'
+    case 'visual':
+      return 'VISUAL'
+    case 'operator-pending':
+      return 'OPERATOR'
+    default:
+      return ''
+  }
+}


### PR DESCRIPTION
Enable vi-style keybindings in the input area via:

```bash
hermes config set display.tui_vim_mode true
```

**CLI**: Uses prompt_toolkit's built-in `EditingMode.VI`
**TUI**: Custom vim state machine with hjkl, w/b/e, d/c/y operators, toggle live with `/vim`

Supports: h/l/j/k navigation, w/b/e word motions, 0/$ line motions, d/c/y operators (dd, dw, cw, yy), x/X delete, i/a/I/A/o/O insert entry, p/P paste, u/Ctrl+R undo/redo.

Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>