### PR TITLE
fix(delegation): make active config authoritative for delegation limits

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -13,6 +13,7 @@ import json
 import os
 import threading
 import time
+import types
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -21,6 +22,7 @@ from tools.delegate_tool import (
     DELEGATE_TASK_SCHEMA,
     DelegateEvent,
     _get_max_concurrent_children,
+    _load_config,
     _LEGACY_EVENT_MAP,
     MAX_DEPTH,
     check_delegate_requirements,
@@ -2389,6 +2391,43 @@ class TestDelegateEventEnum(unittest.TestCase):
 
 class TestConcurrencyDefaults(unittest.TestCase):
     """Tests for the concurrency default and no hard ceiling."""
+
+    def test_load_config_prefers_active_persistent_config_over_cli_defaults(self):
+        stale_cli = types.ModuleType("cli")
+        stale_cli.CLI_CONFIG = {
+            "delegation": {
+                "max_iterations": 45,
+                "model": "",
+                "provider": "",
+                "base_url": "",
+                "api_key": "",
+            }
+        }
+        active_config = {
+            "delegation": {
+                "max_iterations": 50,
+                "max_concurrent_children": 50,
+                "max_spawn_depth": 10,
+            }
+        }
+
+        with patch.dict("sys.modules", {"cli": stale_cli}):
+            with patch("hermes_cli.config.load_config", return_value=active_config):
+                self.assertEqual(_load_config()["max_concurrent_children"], 50)
+                self.assertEqual(_get_max_concurrent_children(), 50)
+
+    def test_load_config_falls_back_to_cli_config_when_persistent_load_fails(self):
+        fallback_cli = types.ModuleType("cli")
+        fallback_cli.CLI_CONFIG = {
+            "delegation": {
+                "max_iterations": 45,
+                "max_concurrent_children": 8,
+            }
+        }
+
+        with patch.dict("sys.modules", {"cli": fallback_cli}):
+            with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+                self.assertEqual(_load_config()["max_concurrent_children"], 8)
 
     @patch("tools.delegate_tool._load_config", return_value={})
     def test_default_is_three(self, mock_cfg):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2412,7 +2412,9 @@ class TestConcurrencyDefaults(unittest.TestCase):
         }
 
         with patch.dict("sys.modules", {"cli": stale_cli}):
-            with patch("hermes_cli.config.load_config", return_value=active_config):
+            with patch(
+                "hermes_cli.config.load_config_readonly", return_value=active_config
+            ):
                 self.assertEqual(_load_config()["max_concurrent_children"], 50)
                 self.assertEqual(_get_max_concurrent_children(), 50)
 
@@ -2426,8 +2428,34 @@ class TestConcurrencyDefaults(unittest.TestCase):
         }
 
         with patch.dict("sys.modules", {"cli": fallback_cli}):
-            with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+            with patch(
+                "hermes_cli.config.load_config_readonly",
+                side_effect=RuntimeError("boom"),
+            ):
                 self.assertEqual(_load_config()["max_concurrent_children"], 8)
+
+    def test_load_config_prefers_cli_config_when_user_config_ignored(self):
+        # `hermes chat --ignore-user-config` sets HERMES_IGNORE_USER_CONFIG=1,
+        # which only load_cli_config() honors. The delegation loader must keep
+        # CLI_CONFIG authoritative under the flag so user config.yaml
+        # delegation keys stay suppressed.
+        ignoring_cli = types.ModuleType("cli")
+        ignoring_cli.CLI_CONFIG = {
+            "delegation": {
+                "max_iterations": 45,
+                "max_concurrent_children": 4,
+            }
+        }
+        user_config = {"delegation": {"max_concurrent_children": 50}}
+
+        with patch.dict("sys.modules", {"cli": ignoring_cli}):
+            with patch.dict(os.environ, {"HERMES_IGNORE_USER_CONFIG": "1"}):
+                with patch(
+                    "hermes_cli.config.load_config_readonly",
+                    return_value=user_config,
+                ) as mock_loader:
+                    self.assertEqual(_load_config()["max_concurrent_children"], 4)
+                    mock_loader.assert_not_called()
 
     @patch("tools.delegate_tool._load_config", return_value={})
     def test_default_is_three(self, mock_cfg):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3105,16 +3105,28 @@ def _load_config() -> dict:
     points that cannot import the shared loader; importing it first can return
     an old default ``delegation`` block and hide user-set keys such as
     ``max_concurrent_children``.
-    """
-    try:
-        from hermes_cli.config import load_config
 
-        full = load_config()
-        cfg = full.get("delegation") or {}
-        if isinstance(cfg, dict):
-            return cfg
-    except Exception:
-        pass
+    Uses ``load_config_readonly()``: every consumer of this dict is read-only
+    (``.get()`` lookups), and this runs on each ``get_definitions()`` schema
+    rebuild via ``_get_max_concurrent_children``, so skipping the defensive
+    deepcopy matters. Do NOT mutate the returned dict.
+
+    ``HERMES_IGNORE_USER_CONFIG=1`` (``hermes chat --ignore-user-config``) is
+    only honored by the legacy ``cli`` loader, not the shared one, so when the
+    flag is set we keep ``cli.CLI_CONFIG`` authoritative to preserve the
+    flag's contract of suppressing user config.yaml settings.
+    """
+    prefer_legacy = os.environ.get("HERMES_IGNORE_USER_CONFIG") == "1"
+    if not prefer_legacy:
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            full = load_config_readonly()
+            cfg = full.get("delegation") or {}
+            if isinstance(cfg, dict):
+                return cfg
+        except Exception:
+            pass
     try:
         from cli import CLI_CONFIG
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3098,26 +3098,28 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config from the active Hermes config.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Prefer the shared persistent loader because it follows the active
+    HERMES_HOME/profile. ``cli.CLI_CONFIG`` is a legacy fallback for entry
+    points that cannot import the shared loader; importing it first can return
+    an old default ``delegation`` block and hide user-set keys such as
+    ``max_concurrent_children``.
     """
-    try:
-        from cli import CLI_CONFIG
-
-        cfg = CLI_CONFIG.get("delegation") or {}
-        if cfg:
-            return cfg
-    except Exception:
-        pass
     try:
         from hermes_cli.config import load_config
 
         full = load_config()
-        return full.get("delegation") or {}
+        cfg = full.get("delegation") or {}
+        if isinstance(cfg, dict):
+            return cfg
+    except Exception:
+        pass
+    try:
+        from cli import CLI_CONFIG
+
+        cfg = CLI_CONFIG.get("delegation") or {}
+        return cfg if isinstance(cfg, dict) else {}
     except Exception:
         return {}
 


### PR DESCRIPTION
## Summary
Salvage of PR #59982 by @shannonsands — `delegate_task` config limits (`max_concurrent_children`, `max_spawn_depth`, timeouts, model overrides) now read from the active Hermes config authoritatively instead of a frozen import-time CLI snapshot.

Root cause: `_load_config()` in `tools/delegate_tool.py` preferred `cli.CLI_CONFIG` and only fell back to the shared loader when the delegation block was empty — but the CLI defaults always include a non-empty delegation block (without `max_concurrent_children`), so user-set limits in `config.yaml` were silently ignored and the runtime capped at the default of 3.

## Changes
- `tools/delegate_tool.py`: `_load_config()` now prefers `hermes_cli.config.load_config_readonly()` (profile/HERMES_HOME-aware, mtime-cached so mid-session config edits are picked up); `cli.CLI_CONFIG` is a legacy fallback only. `HERMES_IGNORE_USER_CONFIG=1` (`hermes chat --ignore-user-config`) keeps `CLI_CONFIG` authoritative so the flag's suppress-user-config contract is preserved. Uses the readonly loader because this runs on every `get_definitions()` schema rebuild and all consumers are read-only.
- `tests/tools/test_delegate.py`: 3 regression tests — precedence over stale CLI defaults, fallback when the shared loader fails, ignore-user-config contract.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_delegate.py` | 154/154 passed |
| E2E (isolated HERMES_HOME, real config.yaml, stale `cli.CLI_CONFIG` in sys.modules) | cap reads 50 from config.yaml; live edit to 7 picked up via mtime cache; `HERMES_IGNORE_USER_CONFIG=1` suppresses user yaml |
| Original PR's CI | fully green |

Duplicate cluster fixing the same bug (to be closed with credit after merge): #30581 (@pietergatehouse, earliest — May 22), #51516 (@markoub), #55478 (@0xDevNinja), #58657 (@tianma-if).

Closes #59982.

## Infographic

![delegation-config-precedence](https://v3b.fal.media/files/b/0aa15b79/wgJOcLfASGlbTNJLVC4UB_mGYFLkEf.png)
