### PR TITLE
fix(compression): skip empty summary windows

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2822,6 +2822,17 @@ This compaction should PRIORITISE preserving all information related to the focu
             # into the summarizer prompt via the iterative-update path.
             self._previous_summary = None
 
+        if not turns_to_summarize:
+            self._ineffective_compression_count += 1
+            self._last_compression_savings_pct = 0.0
+            if not self.quiet_mode:
+                logger.warning(
+                    "Compression skipped: latest handoff summary leaves no new turns "
+                    "inside the compression window. ineffective_compression_count=%d",
+                    self._ineffective_compression_count,
+                )
+            return messages
+
         if not self.quiet_mode:
             logger.info(
                 "Context compression triggered (%d tokens >= %d threshold)",

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -85,3 +85,36 @@ def test_handoff_in_protected_head_populates_previous_summary_before_update():
     assert compressor._previous_summary == old_summary
     assert seen_turns
     assert all(old_summary not in str(msg.get("content", "")) for msg in seen_turns)
+
+
+def test_summary_boundary_with_no_new_turns_skips_summary_call():
+    """A handoff at the end of the compression window should be a cheap no-op."""
+    compressor = _compressor()
+    old_summary = "WINDOW-END-SUMMARY durable facts"
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "first resumable turn"},
+        {"role": "assistant", "content": "first resumable response"},
+        {"role": "user", "content": f"{SUMMARY_PREFIX}\n{old_summary}"},
+        {"role": "assistant", "content": "tail assistant response"},
+        {"role": "user", "content": "tail user request"},
+        {"role": "assistant", "content": "latest tail response"},
+    ]
+
+    with (
+        patch.object(compressor, "_protect_head_size", return_value=1),
+        patch.object(compressor, "_align_boundary_forward", side_effect=lambda _messages, idx: idx),
+        patch.object(compressor, "_find_tail_cut_by_tokens", return_value=4),
+        patch.object(
+            compressor,
+            "_generate_summary",
+            side_effect=AssertionError("empty summary window should not call the model"),
+        ) as mock_generate,
+    ):
+        result = compressor.compress(messages, current_tokens=90000)
+
+    assert result == messages
+    mock_generate.assert_not_called()
+    assert compressor._previous_summary == old_summary
+    assert compressor._ineffective_compression_count == 1
+    assert compressor._last_compression_savings_pct == 0.0


### PR DESCRIPTION
## Problem
Fixes #59496. After the latest persisted handoff summary is removed from the compression window, the remaining window can be empty. The compressor still proceeded to `_generate_summary([])`, spending one auxiliary model request and then surfacing the empty-window failure path.

## Solution
After rehydrating `_previous_summary` from the latest handoff, return early when there are no new turns left to summarize. The early return mirrors the existing no-compressible-window path: it records an ineffective compression attempt, sets savings to 0%, and avoids the model call.

## Validation
- `scripts/run_tests.sh tests/agent/test_context_compressor_summary_continuity.py -q`
- `scripts/run_tests.sh tests/agent/test_context_compressor.py tests/agent/test_context_compressor_cross_session_guard.py tests/agent/test_preflight_compression_gate.py tests/agent/test_context_compressor_summary_continuity.py -q`
- `.venv/bin/ruff check agent/context_compressor.py tests/agent/test_context_compressor_summary_continuity.py`
- `git diff --check`
- `uv lock --check`

## Impact
For the affected boundary case, `_generate_summary` calls drop from 1 to 0. That avoids one auxiliary context-engine request, its prompt tokens, and its latency for each no-new-turn compression trigger.

## Notes
`ty check agent/context_compressor.py tests/agent/test_context_compressor_summary_continuity.py` still reports existing annotations/type issues in `agent/context_compressor.py` around nullable defaults and `call_llm(**call_kwargs)`; this patch does not add new ty diagnostics.