### PR TITLE
fix(gateway/streaming): deliver [[audio_as_voice]] via send_voice during streaming

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -195,9 +195,17 @@ class GatewayStreamConsumer:
         # continuing to edit and deliver stale deltas.
         self._run_still_current = run_still_current or (lambda: True)
 
+        # Voice media paths for send_voice delivery during streaming.
+        # When streaming is enabled, [[audio_as_voice]] + MEDIA: tags are
+        # intercepted here and delivered via adapter.send_voice after the
+        # stream completes. This prevents the MEDIA tag from being sent as
+        # plain text, which would render as a file attachment instead of a
+        # voice bubble on platforms like Telegram. See issue #60556.
+        self._voice_media_paths: "set[str]" = set()
+
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
-        self._in_think_block = False
         self._think_buffer = ""
+        self._in_think_block = False
 
         # Native draft-streaming state.  Resolved at the start of run() based
         # on cfg.transport, cfg.chat_type, and the adapter's
@@ -358,6 +366,38 @@ class GatewayStreamConsumer:
             type(self)._draft_id_counter += 1
             self._draft_id = type(self)._draft_id_counter
 
+    # ── Voice media handling ──────────────────────────────────────────
+    # When streaming is enabled, [[audio_as_voice]] + MEDIA: tags are
+    # intercepted here and delivered via adapter.send_voice after the
+    # stream completes. This prevents the MEDIA tag from being sent as
+    # plain text, which would render as a file attachment instead of a
+    # voice bubble on platforms like Telegram. See issue #60556.
+
+    _VOICE_DIRECTIVE_PATTERN = re.compile(
+        r"\[\[audio_as_voice\]\]\s*MEDIA:([^\n]+)",
+        re.MULTILINE,
+    )
+
+    def _extract_voice_media_paths(self, text: str) -> tuple[str, set[str]]:
+        """Extract [[audio_as_voice]] + MEDIA: paths from text.
+
+        Returns:
+            A tuple of (text_without_directives, media_paths_set).
+
+        The directives are stripped from the returned text so they don't
+        appear in the streamed message. The media paths are stored and
+        delivered via adapter.send_voice after the stream completes.
+        """
+        paths: set[str] = set()
+        # Find all matches and collect paths
+        for match in self._VOICE_DIRECTIVE_PATTERN.finditer(text):
+            path = match.group(1).strip()
+            if path:
+                paths.add(path)
+        # Remove all matches from the text
+        clean_text = self._VOICE_DIRECTIVE_PATTERN.sub("", text)
+        return clean_text, paths
+
     def on_delta(self, text: str) -> None:
         """Thread-safe callback — called from the agent's worker thread.
 
@@ -389,7 +429,14 @@ class GatewayStreamConsumer:
         reasoning/thinking block.  Text inside such blocks is silently
         discarded.  Partial tags at buffer boundaries are held back in
         ``_think_buffer`` until enough characters arrive to decide.
+
+        Also extracts [[audio_as_voice]] + MEDIA: paths for voice delivery
+        after the stream completes.
         """
+        # Extract voice media paths before any other processing
+        text, voice_paths = self._extract_voice_media_paths(text)
+        self._voice_media_paths.update(voice_paths)
+
         buf = self._think_buffer + text
         self._think_buffer = ""
 
@@ -593,6 +640,22 @@ class GatewayStreamConsumer:
                 # tag is not lost.
                 if got_done:
                     self._flush_think_buffer()
+
+                    # Send voice media via adapter.send_voice. This must happen
+                    # BEFORE finalizing the streamed message so voice messages
+                    # appear in correct order (text first, then voice bubble).
+                    if self._voice_media_paths and hasattr(self.adapter, "send_voice"):
+                        for path in self._voice_media_paths:
+                            try:
+                                await self.adapter.send_voice(
+                                    chat_id=self.chat_id,
+                                    audio_path=path,
+                                    reply_to=self._message_id or self._initial_reply_to_id,
+                                )
+                                logger.debug("Stream consumer sent voice message: %s", path)
+                            except Exception as e:
+                                logger.error("Stream consumer send_voice error: %s", e)
+                        self._voice_media_paths.clear()
 
                     # Intentional-silence suppression.  When the agent chose
                     # not to reply it emits a bare control marker (NO_REPLY /

--- a/tests/gateway/test_stream_consumer_voice_delivery.py
+++ b/tests/gateway/test_stream_consumer_voice_delivery.py
@@ -1,0 +1,176 @@
+"""Regression test for Telegram streaming voice message delivery.
+
+When streaming is enabled, [[audio_as_voice]] + MEDIA: tags must be
+delivered via adapter.send_voice, not as plain text in the streamed
+message. This ensures the audio appears as a voice bubble on Telegram
+instead of a file attachment.
+
+Issue: #60556
+"""
+
+import asyncio
+import queue
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+@pytest.fixture
+def mock_adapter():
+    """Mock platform adapter with send_voice support."""
+    adapter = MagicMock()
+    adapter.message_len_fn = len
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(return_value=MagicMock(success=True, message_id="msg123"))
+    adapter.send_voice = AsyncMock()
+    return adapter
+
+
+@pytest.fixture
+def consumer(mock_adapter):
+    """Create a stream consumer for testing."""
+    return GatewayStreamConsumer(
+        adapter=mock_adapter,
+        chat_id="test_chat",
+        config=StreamConsumerConfig(edit_interval=0.1, buffer_only=True),
+    )
+
+
+@pytest.mark.asyncio
+async def test_voice_media_extraction_from_stream(consumer, mock_adapter):
+    """Verify [[audio_as_voice]] + MEDIA: paths are extracted and sent via send_voice."""
+    # Stream content with voice directive
+    voice_text = "[[audio_as_voice]]\nMEDIA:/path/to/audio.ogg\nHere is the response."
+
+    # Simulate streaming
+    consumer.on_delta(voice_text)
+    consumer.finish()
+
+    # Run the consumer
+    await consumer.run()
+
+    # Verify send_voice was called with the correct path
+    mock_adapter.send_voice.assert_called_once()
+    call_kwargs = mock_adapter.send_voice.call_args.kwargs
+    assert call_kwargs["chat_id"] == "test_chat"
+    assert call_kwargs["audio_path"] == "/path/to/audio.ogg"
+    # reply_to may be None (first message) or msg123 (if message was already sent)
+
+    # Verify the voice directive was stripped from the streamed text
+    mock_adapter.send.assert_called_once()
+    sent_text = mock_adapter.send.call_args.kwargs["content"]
+    assert "[[audio_as_voice]]" not in sent_text
+    assert "MEDIA:/path/to/audio.ogg" not in sent_text
+    assert "Here is the response." in sent_text
+
+
+@pytest.mark.asyncio
+async def test_multiple_voice_media_paths(consumer, mock_adapter):
+    """Verify multiple voice messages are sent correctly."""
+    # Stream content with multiple voice directives
+    voice_text = (
+        "[[audio_as_voice]]\nMEDIA:/path/to/audio1.ogg\n"
+        "First response.\n"
+        "[[audio_as_voice]]\nMEDIA:/path/to/audio2.ogg\n"
+        "Second response."
+    )
+
+    # Simulate streaming
+    consumer.on_delta(voice_text)
+    consumer.finish()
+
+    # Run the consumer
+    await consumer.run()
+
+    # Verify send_voice was called twice
+    assert mock_adapter.send_voice.call_count == 2
+
+    # Verify both paths were sent
+    call_args_list = [call.kwargs["audio_path"] for call in mock_adapter.send_voice.call_args_list]
+    assert "/path/to/audio1.ogg" in call_args_list
+    assert "/path/to/audio2.ogg" in call_args_list
+
+
+@pytest.mark.asyncio
+async def test_voice_media_without_send_voice_support():
+    """Verify graceful handling when adapter lacks send_voice."""
+    # Mock adapter without send_voice
+    adapter = MagicMock()
+    adapter.message_len_fn = len
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(return_value=MagicMock(success=True, message_id="msg123"))
+    # Intentionally no send_voice method
+
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="test_chat",
+        config=StreamConsumerConfig(edit_interval=0.1, buffer_only=True),
+    )
+
+    # Stream content with voice directive
+    voice_text = "[[audio_as_voice]]\nMEDIA:/path/to/audio.ogg\nResponse."
+
+    # Simulate streaming
+    consumer.on_delta(voice_text)
+    consumer.finish()
+
+    # Run the consumer (should not raise)
+    await consumer.run()
+
+    # Verify the text was still sent (directive stripped)
+    adapter.send.assert_called_once()
+    sent_text = adapter.send.call_args.kwargs["content"]
+    assert "[[audio_as_voice]]" not in sent_text
+    assert "Response." in sent_text
+
+
+def test_extract_voice_media_paths_single(consumer):
+    """Verify _extract_voice_media_paths extracts a single path."""
+    text = "[[audio_as_voice]]\nMEDIA:/path/to/audio.ogg\nRest of message."
+    clean_text, paths = consumer._extract_voice_media_paths(text)
+
+    assert "/path/to/audio.ogg" in paths
+    assert "[[audio_as_voice]]" not in clean_text
+    assert "MEDIA:/path/to/audio.ogg" not in clean_text
+    assert "Rest of message." in clean_text
+
+
+def test_extract_voice_media_paths_multiple(consumer):
+    """Verify _extract_voice_media_paths extracts multiple paths."""
+    text = (
+        "[[audio_as_voice]]\nMEDIA:/path1.ogg\n"
+        "Text between.\n"
+        "[[audio_as_voice]]\nMEDIA:/path2.ogg\n"
+        "End."
+    )
+    clean_text, paths = consumer._extract_voice_media_paths(text)
+
+    assert "/path1.ogg" in paths
+    assert "/path2.ogg" in paths
+    assert "[[audio_as_voice]]" not in clean_text
+    assert "MEDIA:" not in clean_text
+    assert "Text between." in clean_text
+    assert "End." in clean_text
+
+
+def test_extract_voice_media_paths_none(consumer):
+    """Verify _extract_voice_media_paths handles text without directives."""
+    text = "Just plain text with no voice directives."
+    clean_text, paths = consumer._extract_voice_media_paths(text)
+
+    assert len(paths) == 0
+    assert clean_text == text
+
+
+def test_extract_voice_media_paths_whitespace_handling(consumer):
+    """Verify _extract_voice_media_paths handles whitespace correctly."""
+    text = "[[audio_as_voice]]\n  MEDIA:  /path/to/audio.ogg  \nEnd."
+    clean_text, paths = consumer._extract_voice_media_paths(text)
+
+    # Path should be stripped
+    assert "/path/to/audio.ogg" in paths
+    # Original whitespace preserved in clean text (directive removed)
+    assert "[[audio_as_voice]]" not in clean_text
+    assert "End." in clean_text


### PR DESCRIPTION
## What does this PR do?

When Telegram streaming is enabled, the TTS tool's `[[audio_as_voice]]` + `MEDIA:` tags were being delivered as plain text in the streamed message. This caused Telegram's client-side `MEDIA:` parser to render the OGG path as a regular audio file attachment instead of calling `sendVoice` to produce a voice bubble.

This fix intercepts the voice directives during streaming, extracts the media paths, and delivers them via `adapter.send_voice` after the stream completes. The directives are stripped from the streamed text so they don't appear to the user.

The fix is implemented entirely in `GatewayStreamConsumer`:
- Added `_voice_media_paths` set to store voice media file paths
- Added `_extract_voice_media_paths()` helper to extract paths and strip directives
- Modified `_filter_and_accumulate()` to call the helper before processing text
- Added voice message delivery in `run()` after stream completes (`got_done` path)

This approach ensures that:
1. Voice messages are delivered via `sendVoice` (voice bubble) on Telegram
2. The voice directives don't appear in the streamed text
3. Non-streaming behavior is unchanged (existing `send_voice` path in `gateway/run.py` still works)
4. Platforms without `send_voice` support gracefully skip voice delivery

## Related Issue

Fixes #60556

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/stream_consumer.py`:
  - Added `_voice_media_paths` instance variable to store voice media file paths
  - Added `_VOICE_DIRECTIVE_PATTERN` regex to match `[[audio_as_voice]]` + `MEDIA:` tags
  - Added `_extract_voice_media_paths()` helper method to extract paths and strip directives
  - Modified `_filter_and_accumulate()` to extract voice media paths before text processing
  - Modified `run()` to deliver voice media via `adapter.send_voice` after stream completes
- `tests/gateway/test_stream_consumer_voice_delivery.py`: Added 7 regression tests

## How to Test

1. Configure TTS with a provider that supports `voice_compatible: true` (e.g. `edge` or `piper`):
   ```yaml
   tts:
     provider: edge
     edge:
       voice: zh-CN-XiaoxiaoNeural
       voice_compatible: true
   ```
2. Enable Telegram streaming:
   ```yaml
   display:
     platforms:
       telegram:
         streaming: true
   ```
3. Start the gateway and trigger a TTS response with `text_to_speech` tool
4. Observe the message on Telegram — it should arrive as a voice bubble (round shape, auto-playable), not a file attachment
5. Run regression tests: `pytest tests/gateway/test_stream_consumer_voice_delivery.py -v` — should pass all 7 tests

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comments only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — the fix is a code-path change in the streaming consumer. Regression tests verify the behavior.