### PR TITLE
feat(relay): carry routed profile from the connector wire source

### DIFF
--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -120,6 +120,15 @@ def _event_from_wire(raw: Dict[str, Any]) -> MessageEvent:
         scope_id=src.get("scope_id"),
         parent_chat_id=src.get("parent_chat_id"),
         message_id=src.get("message_id"),
+        # The HERMES profile this event is routed to (multiplex mode). The
+        # connector stamps it on the wire source when NAS resolves the target
+        # profile for a Team-Gateway message; absent for a single-profile
+        # gateway, where it stays None and session keys keep the legacy
+        # ``agent:main`` namespace (SessionStore._resolve_profile_for_key).
+        # Consumed by build_session_key's profile namespacing + the per-turn
+        # config/credential scope — the same field the /p/<profile>/ HTTP
+        # prefix and per-credential polling adapters already set.
+        profile=src.get("profile"),
         # Authentic upstream-trust signal: this event arrived over the
         # per-instance-authenticated relay WS, so the connector already resolved
         # it to this instance's owner-bound author. ``platform`` is the

--- a/tests/gateway/test_relay_upstream_authz.py
+++ b/tests/gateway/test_relay_upstream_authz.py
@@ -243,3 +243,51 @@ def test_event_from_wire_sets_relay_delivery_marker():
     )
     assert event.source.platform is Platform.DISCORD
     assert event.source.delivered_via_upstream_relay is True
+
+
+def test_event_from_wire_stamps_routed_profile():
+    """A connector-routed profile on the wire source lands on SessionSource.
+
+    In multiplex mode the connector resolves the target HERMES profile for a
+    Team-Gateway message and stamps ``profile`` on the wire source. The relay
+    transport must carry it through so build_session_key namespaces the session
+    and the agent turn resolves that profile's config/credentials.
+    """
+    from gateway.relay.ws_transport import _event_from_wire
+
+    event = _event_from_wire(
+        {
+            "text": "hello!",
+            "source": {
+                "platform": "discord",
+                "chat_id": "123",
+                "chat_type": "dm",
+                "user_id": "267171776755269633",
+                "user_name": "rewbs",
+                "profile": "reviewer",
+            },
+        }
+    )
+    assert event.source.profile == "reviewer"
+
+
+def test_event_from_wire_profile_absent_is_none():
+    """No ``profile`` on the wire (single-profile gateway) → None.
+
+    Back-compat: a connector that never sets ``profile`` yields the legacy
+    behaviour, and session keys stay in the ``agent:main`` namespace.
+    """
+    from gateway.relay.ws_transport import _event_from_wire
+
+    event = _event_from_wire(
+        {
+            "text": "hi",
+            "source": {
+                "platform": "discord",
+                "chat_id": "123",
+                "chat_type": "dm",
+                "user_id": "1",
+            },
+        }
+    )
+    assert event.source.profile is None


### PR DESCRIPTION
## Summary

The multiplex machinery already routes an inbound message to a profile: `SessionSource.profile` drives `build_session_key`'s namespacing and the per-turn config/credential scope (`SessionStore._resolve_profile_for_key`). It's set today by the `/p/<profile>/` HTTP prefix and by per-credential polling adapters — **but never on the relay path.**

`gateway/relay/ws_transport.py::_event_from_wire` rebuilds the `SessionSource` field-by-field and dropped any `profile` the connector sent, so a **Team-Gateway (connector + relay)** message could not be routed to a specific profile. This PR closes that gap.

## Changes

- `gateway/relay/ws_transport.py`: `_event_from_wire` now stamps `profile=src.get("profile")` onto the rebuilt `SessionSource`, the same way it already carries `scope_id`, `user_id`, etc. This is the authentic injection point — it only runs for frames that arrived over the per-instance-authenticated relay WS.
- `tests/gateway/test_relay_upstream_authz.py`: two tests — a routed `profile` on the wire lands on `source.profile`; an absent `profile` yields `None`.

## Validation

| | Result |
|---|---|
| `test_relay_upstream_authz.py` | 12/12 pass |
| Prove-fail-without-fix | reverted the one-line stamp → `assert None == 'reviewer'` (test fails without the change), restored → passes |

## Scope / back-compat

- **Multiplex first**, as intended. For a single-profile gateway "route to a specific profile" is a no-op (the one profile *is* the target), so nothing changes there.
- Back-compat: absent `profile` → `None` → legacy `agent:main` session-key namespace, byte-identical to today.
- The connector **populating** the field ships separately — see the companion gateway-gateway PR adding the optional `profile?` wire field to `SessionSource`. This PR is the agent-side consumer; it's inert until the connector sends the field.

Companion PRs:
- Discovery half (NAS lists a hosted agent's profiles): NousResearch/hermes-agent (profile names on gated `/api/status`).
- Connector wire field: NousResearch/gateway-gateway (optional `profile?` on `SessionSource`).

## Infographic

![relay-learns-the-profile](https://v3b.fal.media/files/b/0aa15bd0/74GthCH0PWQoYxSej_N86_4LXBmY1A.png)
