### PR TITLE
fix(qqbot): accept is_reconnect kwarg on QQAdapter.connect

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,18 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        ``is_reconnect`` is part of the ``BasePlatformAdapter.connect``
+        contract (see ``#46621``). The gateway reconnect watcher invokes
+        ``connect(is_reconnect=True)`` after a prolonged outage so adapters
+        with a server-side update queue (e.g. Telegram) can preserve it.
+        QQ Bot has no such queue concept, so the flag is accepted for
+        contract compliance and currently does not alter connection
+        behaviour, but ignoring it raised ``TypeError: connect() got an
+        unexpected keyword argument 'is_reconnect'`` and broke reconnect.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)


### PR DESCRIPTION
## Summary

The gateway reconnect watcher (`gateway/run.py:7784`) calls
`adapter.connect(is_reconnect=True)` after a prolonged outage so adapters with a
server-side update queue can preserve it (#46621). `BasePlatformAdapter.connect`
already declares the keyword (`gateway/platforms/base.py:2864`), and ~30 sibling
adapters implement the signature.

`QQAdapter.connect` was missed during that rollout: its signature still took no
arguments, so the keyword-only kwarg crashed with
`TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'`.
On a cold first boot the watcher does not pass the flag and the adapter connects
fine, but every reconnect attempt after an outage would throw before the WebSocket
opened, leaving QQ stuck `disconnected` until the gateway restarted.

Accept the kwarg for contract compliance. QQ Bot has no server-side queue
concept, so `is_reconnect` does not alter connection behaviour; this is a pure
signature fix that aligns the adapter with the abstract contract.

No behaviour change. No body changes.

## Diff

```diff
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        ``is_reconnect`` is part of the ``BasePlatformAdapter.connect``
+        contract (see ``#46621``). ..."""
         if not AIOHTTP_AVAILABLE:
             ...
```

## Verification (planned before merge)

- [ ] `pytest tests/gateway/test_qqbot.py -q` passes
- [ ] Cold first boot of the QQ adapter still connects (no kwargs path)
- [ ] Reconnect path no longer raises `TypeError` (`is_reconnect=True` accepted)

Refs #46621
