### PR TITLE
fix(cron): summarize no-agent script failures accurately

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -58,6 +58,28 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     text = (error or "unknown error").strip()
     lower = text.lower()
 
+    # no_agent jobs are script-only; their failures must not be mislabeled as
+    # provider/fallback-chain failures just because the script output contains
+    # words like "timeout". The detailed, redacted script output is saved in the
+    # cron output file; chat gets a concise watchdog failure.
+    if job.get("no_agent"):
+        cleaned = re.sub(
+            r"^(RuntimeError|Exception|ValueError):\s*",
+            "",
+            text[:2000],
+        )
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        if len(cleaned) > 180:
+            cleaned = cleaned[:177].rstrip() + "..."
+        if "script timed out" in lower or "timed out" in lower or "timeout" in lower:
+            return (
+                f"⚠️ Cron watchdog '{job_name}' script timed out. "
+                "Full details saved in cron output."
+            )
+        if cleaned:
+            return f"⚠️ Cron watchdog '{job_name}' script failed: {cleaned}"
+        return f"⚠️ Cron watchdog '{job_name}' script failed."
+
     # Provider/API failures are the common noisy path. Keep these short.
     if "429" in text or "rate limit" in lower or "usage limit" in lower:
         reason = "rate limit"

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -261,6 +261,20 @@ def test_run_job_no_agent_script_failure_delivers_error(hermes_env):
     assert "Cron watchdog" in final_response  # alert header
 
 
+def test_no_agent_script_timeout_summary_is_not_provider_timeout(hermes_env):
+    """Script-only cron timeouts must not be mislabeled as provider failures."""
+    from cron.scheduler import _summarize_cron_failure_for_delivery
+
+    message = _summarize_cron_failure_for_delivery(
+        {"name": "snapshot publisher", "no_agent": True},
+        "Script timed out after 300s: /tmp/publisher.sh",
+    )
+
+    assert "script timed out" in message
+    assert "provider" not in message
+    assert "Fallback chain" not in message
+
+
 def test_run_job_no_agent_never_invokes_aiagent(hermes_env):
     """no_agent jobs must NOT import/construct the AIAgent."""
     from cron.jobs import create_job


### PR DESCRIPTION
## Summary
- Treat `no_agent` cron failures as script/watchdog failures before provider/API classification.
- Avoid labeling script timeouts as provider fallback-chain exhaustion.
- Add a regression test for script-only timeout wording.

## Testing
- `HERMES_HOME=$(mktemp -d) uv run --frozen pytest tests/cron/test_cron_no_agent.py -q`
