### PR TITLE
chore: release v0.18.1 (2026.7.7)

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.18.0",
+      "package": "hermes-agent[acp]==0.18.1",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.18.0"
-__release_date__ = "2026.7.1"
+__version__ = "0.18.1"
+__release_date__ = "2026.7.7"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.18.0"
+version = "0.18.1"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/uv.lock
+++ b/uv.lock
@@ -1516,7 +1516,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
Release v0.18.1 (CalVer v2026.7.7) — patch tag so Hermes Cloud / Docker images can build from the latest tagged release.

## Changes
- `hermes_cli/__init__.py`: `__version__` 0.18.0 → 0.18.1, `__release_date__` → 2026.7.7
- `pyproject.toml`: version → 0.18.1
- `acp_registry/agent.json`: version + uvx package pin → 0.18.1
- `uv.lock`: regenerated for the version bump (`uv lock --check` clean)

## Validation
| Check | Result |
|---|---|
| `rg` for stale `0.18.0` in version files | zero hits |
| `uv lock --check` | clean |
| Wheel data-file verify (`verify_wheel_data_files.sh`) | OK — 88 plugin.yaml manifests shipped |

Full curated release notes for the v0.18.0→ window ship with v0.19.0; this tag carries brief patch notes only.

## Infographic

![v0.18.1 patch release](https://v3b.fal.media/files/b/0aa15cbc/ocHck-6uEtyH-kiIHHAjn_toPYTnRG.png)
