### PR TITLE
fix(tools): fail-closed syntax gate for JSON/YAML/TOML writes (#60525)

### DIFF
--- a/tests/tools/test_write_file_syntax_gate.py
+++ b/tests/tools/test_write_file_syntax_gate.py
@@ -1,0 +1,134 @@
+"""Structured-config write must fail-closed on a syntax error.
+
+Regression tests for the defect where ``write_file()`` ran its syntax
+check *after* the atomic write and only attached the lint result to the
+response, never setting the top-level ``error`` key. The wrapper in
+``tools/file_tools.py`` gates ``files_modified`` on ``not result.error``,
+so a corrupt JSON/YAML/TOML write was reported as a success and the
+invalid file landed on disk undetected (real-world: a malformed
+``cron/jobs.json`` silently disabled scheduled jobs).
+
+The fix moves the in-process syntax check for JSON/YAML/TOML *ahead* of
+the atomic write and refuses the write outright on a parse failure:
+
+* no temp file, no rename — the original file (if any) is untouched
+* the top-level ``error`` key is set so the existing ``files_modified``
+  gating suppresses the success report
+* scope is deliberately limited to JSON/YAML/TOML. ``.py`` is excluded:
+  writing a partial/in-progress Python draft is a legitimate workflow,
+  and gating it would break existing write-mechanics fixtures that push
+  non-Python text through ``*.py`` paths.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ShellFileOperations
+
+
+@pytest.fixture
+def ops(tmp_path: Path):
+    env = LocalEnvironment(cwd=str(tmp_path))
+    return ShellFileOperations(env, cwd=str(tmp_path))
+
+
+# --------------------------------------------------------------------------
+# JSON
+# --------------------------------------------------------------------------
+
+def test_invalid_json_refused_and_error_set(ops, tmp_path: Path):
+    target = tmp_path / "config.json"
+    res = ops.write_file(str(target), '{"a": 1,')  # truncated / invalid
+    assert res.error is not None
+    assert "json" in res.error.lower() or "JSON" in res.error
+
+
+def test_invalid_json_not_written_to_disk(ops, tmp_path: Path):
+    target = tmp_path / "config.json"
+    ops.write_file(str(target), '{"a": 1,')
+    assert not target.exists()
+
+
+def test_invalid_json_preserves_existing_file(ops, tmp_path: Path):
+    target = tmp_path / "cron.json"
+    good = '{"jobs": [1, 2, 3]}\n'
+    target.write_text(good)
+    res = ops.write_file(str(target), '{"jobs": [1, 2,')  # invalid
+    assert res.error is not None
+    # original content must survive an atomic-write refusal
+    assert target.read_text() == good
+
+
+def test_valid_json_still_writes(ops, tmp_path: Path):
+    target = tmp_path / "config.json"
+    res = ops.write_file(str(target), '{"a": 1}\n')
+    assert res.error is None, res.error
+    assert target.read_text() == '{"a": 1}\n'
+
+
+def test_no_temp_file_leaked_on_refusal(ops, tmp_path: Path):
+    ops.write_file(str(target := tmp_path / "config.json"), '{"a": 1,')
+    # The gate returns before _atomic_write, so no .hermes-tmp staging
+    # file is ever created next to the target.
+    leaked = [p.name for p in tmp_path.iterdir() if ".hermes-tmp" in p.name]
+    assert leaked == [], f"leaked temp files: {leaked}"
+    assert not target.exists()
+
+
+# --------------------------------------------------------------------------
+# YAML
+# --------------------------------------------------------------------------
+
+def test_invalid_yaml_refused(ops, tmp_path: Path):
+    target = tmp_path / "config.yaml"
+    # unclosed flow mapping — a hard YAML syntax error
+    res = ops.write_file(str(target), "a: [1, 2\nb: {x\n")
+    assert res.error is not None
+    assert not target.exists()
+
+
+def test_valid_yaml_still_writes(ops, tmp_path: Path):
+    target = tmp_path / "config.yml"
+    res = ops.write_file(str(target), "a: 1\nb:\n  - x\n  - y\n")
+    assert res.error is None, res.error
+    assert target.exists()
+
+
+# --------------------------------------------------------------------------
+# TOML
+# --------------------------------------------------------------------------
+
+def test_invalid_toml_refused(ops, tmp_path: Path):
+    target = tmp_path / "config.toml"
+    res = ops.write_file(str(target), "a = = 1\n")  # invalid TOML
+    assert res.error is not None
+    assert not target.exists()
+
+
+def test_valid_toml_still_writes(ops, tmp_path: Path):
+    target = tmp_path / "config.toml"
+    res = ops.write_file(str(target), 'a = 1\n[section]\nk = "v"\n')
+    assert res.error is None, res.error
+    assert target.exists()
+
+
+# --------------------------------------------------------------------------
+# Scope guard: .py is intentionally NOT gated
+# --------------------------------------------------------------------------
+
+def test_python_syntax_error_still_writes(ops, tmp_path: Path):
+    """A .py file with a syntax error must still be written — partial
+    drafts are a legitimate workflow and the lint result is surfaced
+    separately, not turned into a hard refusal."""
+    target = tmp_path / "draft.py"
+    res = ops.write_file(str(target), "def f(:\n    pass\n")  # invalid Python
+    assert res.error is None
+    assert target.exists()
+    # the syntax problem is still reported, just not as a top-level error
+    assert res.lint is not None
+    assert res.lint.get("status") == "error"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1388,6 +1388,28 @@ class ShellFileOperations(FileOperations):
         if self._file_has_bom(path, pre_content) and not _has_bom(content):
             content = _UTF8_BOM + content
 
+        # ── Fail-closed syntax gate for structured config formats ─────
+        # JSON / YAML / TOML are structured config formats where an
+        # unparseable write is data corruption, not a partial draft:
+        # a malformed ``cron/jobs.json`` silently disables scheduled
+        # jobs, a broken ``config.yaml`` breaks startup, etc.  The
+        # post-write lint layer below *reports* a parse failure but
+        # never sets the top-level ``error`` key, so the file_tools
+        # wrapper — which gates ``files_modified`` on ``not error`` —
+        # reports the corrupt write as a success and the bad file lands
+        # on disk undetected.  Check syntax on the final content BEFORE
+        # the atomic write and refuse outright on failure: no temp file,
+        # no rename, ``error`` set so the write is correctly reported as
+        # failed and any existing file is left untouched.
+        #
+        # Deliberately scoped to JSON/YAML/TOML.  ``.py`` is excluded on
+        # purpose — writing an in-progress / partial Python draft is a
+        # legitimate workflow, and the post-write lint already surfaces
+        # the syntax problem as a non-fatal signal for those.
+        gate = self._structured_syntax_gate(path, content)
+        if gate is not None:
+            return WriteResult(error=gate)
+
         # Snapshot LSP diagnostics for this file (best-effort) so the
         # post-write LSP layer can return only diagnostics introduced
         # by this specific edit.  Mirrors claude-code's
@@ -1615,6 +1637,49 @@ class ShellFileOperations(FileOperations):
         result = apply_v4a_operations(operations, self)
         return result
     
+    # Structured config formats that are gated fail-closed on write: an
+    # unparseable write is data corruption, not a partial draft.  A subset
+    # of ``LINTERS_INPROC`` — ``.py`` is intentionally excluded so partial
+    # Python drafts still write (their lint result is surfaced separately).
+    _SYNTAX_GATE_EXTS = frozenset({'.json', '.yaml', '.yml', '.toml'})
+
+    def _structured_syntax_gate(self, path: str, content: str) -> Optional[str]:
+        """Pre-write syntax gate for structured config formats.
+
+        Returns an error string when ``content`` fails to parse for a gated
+        extension (JSON/YAML/TOML), or ``None`` when the write should
+        proceed (extension not gated, no in-process linter, linter
+        unavailable, or content parses cleanly).
+
+        Called BEFORE the atomic write so a parse failure refuses the
+        write outright — the original file (if any) is left untouched and
+        the top-level ``error`` key is set so the file_tools wrapper
+        reports the write as failed instead of a silent success.
+        """
+        ext = os.path.splitext(path)[1].lower()
+        if ext not in self._SYNTAX_GATE_EXTS:
+            return None
+        linter = LINTERS_INPROC.get(ext)
+        if linter is None:
+            return None
+        # Strip a BOM before parsing: json/yaml/tomllib all choke on a
+        # leading U+FEFF even though the file is otherwise valid, and the
+        # BOM was only re-attached above to preserve the byte signature.
+        probe, _ = _strip_bom(content)
+        ok, message = linter(probe)
+        # ``__SKIP__`` signals the linter dependency is missing (e.g. no
+        # PyYAML) — treat as "no linter" and let the write through rather
+        # than blocking on an unavailable check.
+        if ok or message == "__SKIP__":
+            return None
+        return (
+            f"Refusing to write {os.path.basename(path)}: content is not "
+            f"valid {ext.lstrip('.').upper()} and would corrupt this "
+            f"structured config file. {message}. "
+            "Fix the syntax and write again; the file on disk was left "
+            "unchanged."
+        )
+
     def _check_lint(self, path: str, content: Optional[str] = None) -> LintResult:
         """
         Run syntax check on a file after editing.


### PR DESCRIPTION
## Summary

Fixes #60525.

`write_file()` in `tools/file_operations.py` ran its syntax check **after** `_atomic_write()` and only attached the lint result to the response — it never set the top-level `error` key. Because `tools/file_tools.py`'s `write_file_tool()`/`patch_tool()` wrapper gates `files_modified` reporting on `not result_dict.get("error")`, a corrupt JSON/YAML/TOML write was reported as a **success** even though the content it just wrote didn't parse. The invalid file landed on disk undetected.

Real-world impact (from the issue): an agent session wrote syntactically-invalid JSON to a live `cron/jobs.json` after an upstream redaction pass mangled the content mid-write. The tool call reported success (`lint.status: "error"` was present, but no top-level `error`), and the corrupted file went unnoticed until a later manual audit — both scheduled cron jobs were non-functional in the interim.

## Root cause

`write_file()` → `_atomic_write(path, content)` (file hits disk) → `_check_lint_delta()` (result merely attached, `error` never set) → wrapper sees no `error` → reports success.

## Fix

Add `_structured_syntax_gate()` and call it **before** `_atomic_write()`. On a parse failure for a gated extension it returns an error string; `write_file()` returns `WriteResult(error=...)` immediately:

- no temp file, no rename — the original file (if any) is left untouched
- top-level `error` is set, so the existing `files_modified` gating correctly suppresses the success report
- `patch_replace()` / `patch_v4a()` inherit the gate for free, since they route their write through `write_file()`

### Scope: JSON / YAML / TOML only — `.py` intentionally excluded

- These are structured config formats where an unparseable write is data corruption, not a partial draft.
- `.py` is left out on purpose: writing a partial/in-progress Python draft is a legitimate workflow, and the post-write lint already surfaces the syntax problem as a non-fatal signal for those. A naive full-`LINTERS_INPROC` scope would also break existing write-mechanics fixtures that push non-Python text through `*.py` paths.

### Edge cases handled

- **BOM**: stripped before parsing, so a preserved UTF-8 byte signature doesn't trip the check.
- **Missing linter dependency** (e.g. no PyYAML → `__SKIP__`): lets the write through rather than blocking on an unavailable check.

## Testing

New: `tests/tools/test_write_file_syntax_gate.py` — 10 tests, fail-then-pass proven (6 failed before the fix, all pass after):

- invalid JSON/YAML/TOML → `error` set, file not written, existing file preserved, no `.hermes-tmp` leak
- valid JSON/YAML/TOML → still writes normally
- `.py` with a syntax error → **still writes** (scope guard), lint reported separately

Regression: **zero new failures** across the write/patch surface — `test_file_operations.py`, `test_file_write_safety.py`, `test_file_read_guards.py` all green (178 passed). The 7 failures in `test_file_tools.py` are pre-existing on `main` (unrelated `KeyError: 'lifetime_seconds'` env/config-dependent tests), confirmed identical before and after this change.

```
tests/tools/test_write_file_syntax_gate.py ..........  [10/10]
test_file_operations.py + test_file_write_safety.py + test_file_read_guards.py  178 passed
```

---
🤖 Authored with [bob] — an autonomous assistant harness on Hermes Agent.
