### PR TITLE
fix(dashboard): avoid eager MCP discovery at startup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12504,26 +12504,6 @@ def cmd_dashboard(args):
         # the missing-provider state if it matters.
         print(f"⚠ Plugin discovery failed: {exc}", file=sys.stderr)
 
-    # Desktop chat uses the dashboard's in-process /api/ws gateway, which builds
-    # agents via tui_gateway.server._make_agent.  That path only snapshots the
-    # tool registry — it never starts MCP discovery (the stdio TUI does that in
-    # tui_gateway/entry.py, which the dashboard process doesn't run).  Without
-    # this, a profile's configured MCP servers never connect, so desktop
-    # sessions show no MCP tools.  Spawn discovery in the background here so a
-    # slow/dead server can't block dashboard startup.
-    try:
-        from hermes_cli.mcp_startup import start_background_mcp_discovery
-
-        start_background_mcp_discovery(
-            logger=logger,
-            thread_name="dashboard-mcp-discovery",
-        )
-    except Exception:
-        logger.debug(
-            "Background MCP tool discovery failed at dashboard startup",
-            exc_info=True,
-        )
-
     from hermes_cli.web_server import start_server
 
     # Interactive auth setup: if this bind will engage the auth gate but no

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -105,8 +105,8 @@ def mcp_discovery_in_flight() -> bool:
 
     Mirrors ``tui_gateway.entry.mcp_discovery_in_flight`` for the surfaces that
     start discovery through ``start_background_mcp_discovery`` here (the desktop
-    app + dashboard WebSocket sidecar via ``tui_gateway/ws.py``, and
-    ``hermes dashboard``).  Those processes populate THIS module's
+    app + dashboard WebSocket sidecar via ``tui_gateway/ws.py``).  Those
+    processes populate THIS module's
     ``_mcp_discovery_thread``, not ``tui_gateway.entry``'s, so the late-refresh
     scheduler must consult both to decide whether a slow server's tools are
     still pending (see #51587).

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -191,10 +191,12 @@ class TestUnifiedDashboardRouting:
             main_mod.cmd_dashboard(_args(open_profile="worker_x"))
         assert execs == []
 
-    def test_dashboard_starts_mcp_discovery_for_ws_backend(self, main_mod, monkeypatch):
-        """The dashboard process serves the /api/ws gateway but never runs
-        tui_gateway/entry.py, so it must kick off MCP discovery itself or
-        desktop sessions never see a profile's MCP tools."""
+    def test_dashboard_open_profile_does_not_start_mcp_discovery_at_startup(
+        self, main_mod, monkeypatch
+    ):
+        """Dashboard --open-profile startup should not spawn MCP discovery.
+        Chat WebSocket startup handles MCP discovery lazily when a real
+        chat session opens."""
         monkeypatch.setattr(
             "hermes_cli.profiles.get_active_profile_name", lambda: "default"
         )
@@ -224,11 +226,6 @@ class TestUnifiedDashboardRouting:
             types.SimpleNamespace(start_server=lambda **_kwargs: None),
         )
 
-        main_mod.cmd_dashboard(_args())
+        main_mod.cmd_dashboard(_args(open_profile="worker_x"))
 
-        assert calls == [
-            {
-                "logger": main_mod.logger,
-                "thread_name": "dashboard-mcp-discovery",
-            }
-        ]
+        assert calls == []


### PR DESCRIPTION
## What does this PR do?

Stops `hermes dashboard` / `hermes serve` from starting MCP discovery eagerly during process startup. MCP discovery remains available through the real Desktop/Dashboard chat path and begins lazily when `/api/ws` accepts a connection.

This avoids launching configured MCP server processes when a user only opens the Dashboard for non-chat UI, while preserving MCP tools for actual Dashboard and Desktop conversations.

## Related Issue

Fixes #60572.

## Type of Change

- [x] Bug fix
- [x] Startup/lifecycle fix
- [x] Tests

## Root Cause and Intent

Dashboard-level discovery was added before the WebSocket sidecar had its own startup hook. Current main now has both paths:

1. `cmd_dashboard()` starts `dashboard-mcp-discovery` immediately.
2. `tui_gateway.ws.handle_ws()` starts the shared, idempotent discovery after a real chat WebSocket is accepted and before `gateway.ready`.

The second path is the correct lifecycle boundary. `_make_agent()` already performs a bounded wait before taking its first tool snapshot, and the existing late-refresh path handles slow MCP servers before the first turn. Removing the process-start call therefore avoids eager work without removing MCP from Desktop or Dashboard chat.

The shared guard is process-local, so it prevents two discovery threads inside one Dashboard process but cannot prevent a separate gateway process and an otherwise-idle Dashboard process from each launching their own MCP servers. Deferring Dashboard discovery until chat is actually used addresses that case without disabling the chat feature.

## Changes Made

- Remove eager `start_background_mcp_discovery()` from `cmd_dashboard()`.
- Update the Dashboard startup regression to require zero MCP discovery calls, including with `--open-profile`.
- Preserve the existing `/api/ws` regression that starts discovery after WebSocket acceptance.
- Update `mcp_startup.py` lifecycle documentation so it no longer lists `hermes dashboard` as a direct startup caller.

## How to Test

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_dashboard_unified_launch.py \
  tests/test_tui_gateway_ws.py \
  tests/hermes_cli/test_mcp_startup.py \
  tests/hermes_cli/test_dashboard_web_dist_validation.py \
  tests/test_tui_gateway_server.py -- -q
```

Validation after rebasing onto current `main` (`659d1123c`):

- Relevant suites: **361 passed, 0 failed**.
- Ruff: passed.
- `git diff --check`: clean.
- Fix-forward proof: applying the final Dashboard regression to the unfixed current `main` produces the expected failure because `cmd_dashboard()` calls `dashboard-mcp-discovery`; the rebased fix removes that call.

## Behavior Contract

```text
Dashboard/serve process starts  -> no MCP discovery
Real /api/ws chat connects      -> shared MCP discovery starts
First agent is built            -> bounded wait + late refresh preserve tools
```

## Risk Assessment

Low. The change removes one obsolete caller and retains the tested WebSocket caller, bounded agent wait, late refresh, and process-wide idempotence. No tool schema or mid-conversation toolset changes are introduced.
