### PR TITLE
fix(whatsapp): hide bridge console window on Windows

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -638,6 +638,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["HERMES_AUDIO_CACHE_DIR"] = str(_get_audio_dir())
             bridge_env["HERMES_DOCUMENT_CACHE_DIR"] = str(_get_doc_dir())
 
+            # Hide the console window on Windows. Without CREATE_NO_WINDOW the
+            # long-lived Node bridge pops a visible black console; start_new_session
+            # is a no-op on Windows so it does not suppress the window. Returns 0
+            # on POSIX (harmless). Output still flows to bridge_log_fh.
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
             self._bridge_process = subprocess.Popen(
                 [
                     find_node_executable("node") or "node",
@@ -649,6 +655,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 stdout=bridge_log_fh,
                 stderr=bridge_log_fh,
                 start_new_session=True,
+                creationflags=windows_hide_flags(),
                 env=bridge_env,
             )
             _write_bridge_pidfile(self._session_path, self._bridge_process.pid)


### PR DESCRIPTION
## Summary
On Windows the WhatsApp bridge (`node.exe ... whatsapp-bridge/bridge.js`) is spawned with `start_new_session=True`, which is a **no-op on Windows** — `subprocess` accepts the kwarg but ignores it, so the long-lived bridge pops a visible black console window. Closing it kills the bridge, and the gateway's reconnection watcher relaunches it, so it never stays closed.

Other subprocess calls in the same file (`_kill_stale_bridge_by_pidfile`, `_kill_port_process`) already use `windows_hide_flags()` (`CREATE_NO_WINDOW`); the bridge spawn simply omitted it.

## Change
Add `creationflags=windows_hide_flags()` to the bridge `Popen`. `windows_hide_flags()` returns `0` on POSIX, so this is a no-op there. Bridge output still routes to the log file, so stdio capture is unaffected.

## Verification
- Live bridge now reports `MainWindowHandle=0` (no window) and the gateway logs `✓ whatsapp connected`.
- `tests/gateway/test_whatsapp_connect.py` (29 tests), `test_whatsapp_stale_bridge.py`, `test_whatsapp_reply_prefix.py` pass.
- `test_whatsapp_bridge_pidfile.py::TestKillPortProcess::test_kill_port_spares_client_process` is pre-existing flaky on Windows (real socket + `taskkill` timing) — fails identically on unmodified code.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)