### PR TITLE
fix(cli): reap dashboard/serve backends launched with pre-subcommand flags on update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5785,6 +5785,81 @@ def cmd_gui(args: argparse.Namespace):
     sys.exit(launch_result.returncode)
 
 
+_DASHBOARD_SERVER_SUBCOMMANDS = frozenset({"dashboard", "serve"})
+
+# Pre-subcommand flags that consume a separate value token ("--profile ops",
+# "-p ops"). Mirrors the value-flag handling in ``_apply_profile_override()``;
+# keep the two in sync. A value-taking flag missing from this set makes the
+# scan below read the flag's value as the subcommand and not match — a false
+# negative (the process survives, exactly as before this matcher existed),
+# never a false kill. Optional-value flags (``-c``/``--continue``) are
+# deliberately absent: treating them as bare flags is correct for every real
+# server launch line.
+_CMDLINE_VALUE_FLAGS = frozenset({
+    "-p", "--profile",
+    "-z", "--oneshot",
+    "-m", "--model",
+    "--provider",
+    "-t", "--toolsets",
+    "-r", "--resume",
+    "-s", "--skills",
+    "--usage-file",
+})
+
+
+def _cmdline_matches_dashboard_server(command: str) -> bool:
+    """True if *command* launches the ``hermes dashboard``/``serve`` server.
+
+    Used by ``_find_stale_dashboard_pids`` on both the POSIX (ps) and
+    Windows (wmic) scan branches. The previous detection matched adjacent
+    substrings ("hermes_cli.main dashboard"), which missed any launch with
+    flags between the program and the subcommand — most importantly the
+    Hermes Desktop backend pool, spawned one-per-profile as
+    ``python -m hermes_cli.main --profile <name> dashboard --no-open``.
+    Those backends survived ``hermes update`` indefinitely, serving stale
+    code against the freshly updated frontend bundle.
+
+    Matching rule: find the Hermes program token (a ``hermes`` /
+    ``hermes.exe`` executable, ``-m hermes_cli.main``, or a
+    ``hermes_cli/main.py`` script path), then take the first positional
+    token after it — skipping flags and the values of known value-taking
+    flags — and require it to be ``dashboard`` or ``serve``.
+    First-positional-only keeps the promise of the old explicit patterns:
+    a cmdline that merely *mentions* dashboard/serve (a chat session about
+    dashboards, a profile literally named "dashboard") never matches,
+    because this result is used to kill.
+    """
+    tokens = command.split()
+    prog_index = None
+    for i, raw in enumerate(tokens):
+        # wmic reports quoted executable paths when they contain spaces.
+        tok = raw.strip('"')
+        base = tok.replace("\\", "/").rsplit("/", 1)[-1].lower()
+        if base in ("hermes", "hermes.exe"):
+            prog_index = i
+            break
+        if tok == "hermes_cli.main" and i > 0 and tokens[i - 1] == "-m":
+            prog_index = i
+            break
+        if tok.replace("\\", "/").endswith("hermes_cli/main.py"):
+            prog_index = i
+            break
+    if prog_index is None:
+        return False
+
+    j = prog_index + 1
+    while j < len(tokens):
+        tok = tokens[j]
+        if tok in _CMDLINE_VALUE_FLAGS:
+            j += 2
+            continue
+        if tok.startswith("-"):
+            j += 1
+            continue
+        return tok in _DASHBOARD_SERVER_SUBCOMMANDS
+    return False
+
+
 def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
@@ -5812,19 +5887,14 @@ def _find_stale_dashboard_pids(
     backend process; ``_kill_stale_dashboard_processes`` reads it and
     passes it here.  (#37532)
 
+    Detection matches ``hermes dashboard`` and — because the headless
+    backend (``hermes serve``) is the same long-lived server under a
+    different command name — ``hermes serve``, including launches with
+    flags before the subcommand (``--profile <name>``); see
+    ``_cmdline_matches_dashboard_server`` for the exact rule.
+
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
-    patterns = [
-        "hermes dashboard",
-        "hermes_cli.main dashboard",
-        "hermes_cli/main.py dashboard",
-        # The headless backend (`hermes serve`) is the same long-lived server
-        # under a different command name — the desktop app spawns it. Reap it
-        # on update for the same frontend/backend-mismatch reason.
-        "hermes serve",
-        "hermes_cli.main serve",
-        "hermes_cli/main.py serve",
-    ]
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -5861,7 +5931,7 @@ def _find_stale_dashboard_pids(
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
                     if (
-                        any(p in current_cmd for p in patterns)
+                        _cmdline_matches_dashboard_server(current_cmd)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -5869,12 +5939,12 @@ def _find_stale_dashboard_pids(
                         except ValueError:
                             pass
         else:
-            # Linux / macOS: scan the process table via ps and match against
-            # the same explicit patterns list used on Windows.  Using ps
-            # (rather than `pgrep -f "hermes.*dashboard"`) keeps us consistent
-            # with `hermes_cli.gateway._scan_gateway_pids` and avoids the
-            # greedy regex matching unrelated cmdlines that merely contain
-            # both words (e.g. a chat session discussing "dashboard").
+            # Linux / macOS: scan the process table via ps and match with
+            # the same matcher used on Windows.  Using ps (rather than
+            # `pgrep -f "hermes.*dashboard"`) keeps us consistent with
+            # `hermes_cli.gateway._scan_gateway_pids` and avoids a greedy
+            # regex matching unrelated cmdlines that merely contain both
+            # words (e.g. a chat session discussing "dashboard").
             result = subprocess.run(
                 ["ps", "-A", "-o", "pid=,command="],
                 capture_output=True,
@@ -5894,7 +5964,7 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if _cmdline_matches_dashboard_server(command) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -131,7 +131,7 @@ class TestFindStaleDashboardPids:
             mock_run.return_value = MagicMock(
                 returncode=0,
                 stdout="\n".join([
-                    _ps_line(30001, "/usr/bin/python3 -m hermes_cli.main --profile lonelylofi dashboard --no-open"),
+                    _ps_line(30001, "/usr/bin/python3 -m hermes_cli.main --profile exampleprofile dashboard --no-open"),
                     _ps_line(30002, "hermes -p vc-athena serve"),
                     _ps_line(30003, "hermes --profile=coder dashboard --port 9200"),
                     _ps_line(30004, "/opt/hermes/venv/bin/hermes --profile ops serve --host 127.0.0.1"),

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -117,6 +117,50 @@ class TestFindStaleDashboardPids:
             )
             assert sorted(_find_stale_dashboard_pids()) == [12345, 12346, 12347]
 
+    def test_matches_profile_flag_variants(self):
+        """Backends launched with --profile/-p between the program and the
+        subcommand must still be detected.
+
+        The Hermes Desktop Electron app keeps a backend pool, one per
+        profile, spawned as ``python -m hermes_cli.main --profile <name>
+        dashboard --no-open``. The old adjacent-substring patterns
+        ("hermes_cli.main dashboard") missed these, so profile backends
+        survived ``hermes update`` indefinitely, serving stale code.
+        """
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(30001, "/usr/bin/python3 -m hermes_cli.main --profile lonelylofi dashboard --no-open"),
+                    _ps_line(30002, "hermes -p vc-athena serve"),
+                    _ps_line(30003, "hermes --profile=coder dashboard --port 9200"),
+                    _ps_line(30004, "/opt/hermes/venv/bin/hermes --profile ops serve --host 127.0.0.1"),
+                ]) + "\n",
+                stderr="",
+            )
+            assert sorted(_find_stale_dashboard_pids()) == [30001, 30002, 30003, 30004]
+
+    def test_profile_flag_values_and_other_subcommands_not_matched(self):
+        """The subcommand is the first positional after the program token.
+
+        A profile literally named "dashboard" (flag value), a ``profile``
+        subcommand taking "dashboard" as its argument, and a chat session
+        launched under a profile that merely *mentions* dashboard must all
+        stay unmatched — the reaper kills processes, so no false positives.
+        """
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(41001, "hermes -p dashboard chat"),
+                    _ps_line(41002, "hermes profile use dashboard"),
+                    _ps_line(41003, "python3 -m hermes_cli.main --profile ops chat -q 'restart the dashboard'"),
+                    _ps_line(41004, "hermes gateway run --profile serve"),
+                ]) + "\n",
+                stderr="",
+            )
+            assert _find_stale_dashboard_pids() == []
+
     def test_self_pid_excluded(self):
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
@@ -130,6 +174,18 @@ class TestFindStaleDashboardPids:
             pids = _find_stale_dashboard_pids()
         assert os.getpid() not in pids
         assert 12345 in pids
+
+    def test_windows_style_cmdlines_use_same_matcher(self):
+        """The wmic (Windows) branch feeds raw CommandLine strings through the
+        same matcher as the POSIX ps branch — exercise it directly with
+        Windows paths, including the console-script ``hermes.exe`` form."""
+        live = sys.modules["hermes_cli.main"]
+        matcher = live._cmdline_matches_dashboard_server
+        assert matcher(r"C:\Python312\python.exe -m hermes_cli.main --profile ops dashboard --no-open")
+        assert matcher(r"C:\Users\a\venv\Scripts\hermes.exe serve --port 8642")
+        # wmic reports quoted executable paths when they contain spaces.
+        assert matcher(r'"C:\Program Files\Hermes\hermes.exe" dashboard')
+        assert not matcher(r"C:\Python312\python.exe -m hermes_cli.main --profile ops chat")
 
     def test_ps_not_found_returns_empty(self):
         with patch("subprocess.run", side_effect=FileNotFoundError):


### PR DESCRIPTION
## What does this PR do?

`hermes update` kills stale `hermes dashboard` / `hermes serve` processes at the end of an update so they don't keep serving old code against the freshly updated frontend bundle. The detection (`_find_stale_dashboard_pids`) matched only **adjacent substrings** (`"hermes_cli.main dashboard"`, `"hermes serve"`, ...), so any server launched with flags between the program and the subcommand escaped the sweep. The main real-world casualty is the Hermes Desktop backend pool, spawned one-per-profile as `python -m hermes_cli.main --profile <name> dashboard --no-open`: those backends survive every `hermes update` and keep running old Python indefinitely — the silent frontend/backend mismatch (401s from new auth headers) and the torn-process ImportErrors described in #56717.

This PR replaces the substring patterns with a small **positional cmdline matcher** shared by the POSIX (`ps`) and Windows (`wmic`) scan branches: find the Hermes program token (`hermes` / `hermes.exe` / `-m hermes_cli.main` / `hermes_cli/main.py`), then require the **first positional token after it** — skipping flags and the values of known value-taking flags such as `--profile`/`-p` (set mirrors `_apply_profile_override()`, cross-referenced in a comment) — to be `dashboard` or `serve`.

Why this approach:

- **The escape class is wider than profile selectors.** Any pre-subcommand flag hides a server from the sweep. Live-verified on this machine (detection step only): the old matcher returns `[37726]` (an adjacent `-m hermes_cli.main serve ...`); the new matcher returns `[37726, 38004]`, additionally catching `.../venv/bin/hermes --yolo dashboard` — a real running server the sweep has been missing that no profile-stripping fix would catch. The equals-form `--profile=name` is covered too.
- **Precision is load-bearing (the result is used to kill), and positional matching improves it.** Cmdlines that merely *mention* dashboard/serve never match: a profile literally named "dashboard" (`hermes -p dashboard chat`), `hermes profile use dashboard`, and — a false-positive class that plain substring matching has always had — a chat/agent process whose *arguments* contain the words `hermes dashboard` adjacently. The subcommand position disambiguates all of these; a greedy `hermes.*dashboard` regex was already rejected in the existing comments for exactly this reason.

**Relation to existing work:** #56723 strips `--profile <name>` / `-p <name>` and then substring-matches; draft #56745 extends that with token-aware selector stripping plus systemd-unit hardening. This PR is an alternative for the process-scan half that covers the full flag class (not just profile selectors) and tightens precision rather than preserving substring semantics. Happy to converge however the maintainers prefer — the detection test cases from those PRs should pass against this matcher, and the systemd half of #56745 is orthogonal and composes with this.

The desktop's own managed backends stay protected during desktop-triggered auto-updates via the existing `HERMES_DESKTOP_CHILD_PID` exclusion (#37532), unchanged.

## Related Issue

Fixes #56717

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: new `_cmdline_matches_dashboard_server()` with `_DASHBOARD_SERVER_SUBCOMMANDS` / `_CMDLINE_VALUE_FLAGS` module constants; `_find_stale_dashboard_pids()` now calls the matcher on both the POSIX and Windows branches; docstrings updated. No signature changes; `_kill_stale_dashboard_processes` untouched.
- `tests/hermes_cli/test_update_stale_dashboard.py`: profile-flag variants (`--profile x dashboard`, `-p x serve`, `--profile=x dashboard`, venv-path `hermes`), first-positional negative cases (profile named "dashboard", `profile use dashboard`, chat under a profile mentioning "dashboard", `gateway run --profile serve`), and a direct matcher test with Windows-style cmdlines (`C:\...\python.exe -m hermes_cli.main --profile ops dashboard`, `Scripts\hermes.exe serve`).

## How to Test

1. `pytest tests/hermes_cli/test_update_stale_dashboard.py -q` — 25 tests, including the new profile-flag and precision cases (the profile-variant test fails on current `main`, passes here).
2. Manual reproduction: start a backend with a pre-subcommand flag, e.g. `hermes --profile <name> dashboard --no-open` (or let Hermes Desktop spawn its per-profile pool), then run the detection step:
   `python -c "from hermes_cli.main import _find_stale_dashboard_pids; print(_find_stale_dashboard_pids())"`
   The flagged backend's PID appears; on current `main` it doesn't.
3. Full flow: `hermes update` now stops such backends at the end of the update and prints the usual restart hint.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli):`)
- [x] I searched for existing PRs — #56723/#56745 overlap on the profile-selector subset; relation explained above
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q`: **no new failures vs a pristine `main` checkout on the same machine.** The touched suites pass 50/50 (`test_update_stale_dashboard`, `test_dashboard_lifecycle_flags`, `test_windows_subprocess_no_window_flags`). My machine's full run carries environment-dependent failures (network-gated web providers, a live local Hermes install) that reproduce identically on unmodified `main`; every failure that appeared on this branch but not on base passes on rerun, and the small residual set fails identically on base (pre-existing, order-dependent)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] Docstrings updated; no user-facing docs affected — or N/A
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform: one matcher shared by the `ps` (POSIX) and `wmic` (Windows) branches; Windows-style cmdlines covered in tests
- [x] Tool descriptions/schemas — N/A
