### PR TITLE
fix(desktop): fall back to the engine's most recent session when the boot-restored chat is dead

### DIFF
--- a/apps/desktop/src/app/desktop-controller-utils.test.ts
+++ b/apps/desktop/src/app/desktop-controller-utils.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
 
-import { sameCronSignature } from './desktop-controller-utils'
+import { pickMostRecentSessionId, sameCronSignature } from './desktop-controller-utils'
 
 const session = (id: string, title: string | null): SessionInfo => ({ id, title }) as SessionInfo
+
+const recent = (id: string, over: Partial<SessionInfo> = {}): SessionInfo =>
+  ({ id, archived: false, is_active: false, last_active: 0, ...over }) as SessionInfo
 
 describe('sameCronSignature', () => {
   it('is false when the lengths differ', () => {
@@ -27,5 +30,41 @@ describe('sameCronSignature', () => {
     const a = [session('a', 't'), session('b', 't')]
     const b = [session('b', 't'), session('a', 't')]
     expect(sameCronSignature(a, b)).toBe(false)
+  })
+})
+
+describe('pickMostRecentSessionId', () => {
+  it('returns null for an empty list', () => {
+    expect(pickMostRecentSessionId([], null)).toBeNull()
+  })
+
+  it('picks the newest session by last_active', () => {
+    const sessions = [recent('old', { last_active: 100 }), recent('new', { last_active: 300 }), recent('mid', { last_active: 200 })]
+    expect(pickMostRecentSessionId(sessions, null)).toBe('new')
+  })
+
+  it('prefers an active session over a newer inactive one', () => {
+    const sessions = [recent('live', { is_active: true, last_active: 100 }), recent('newer-but-ended', { last_active: 900 })]
+    expect(pickMostRecentSessionId(sessions, null)).toBe('live')
+  })
+
+  it('skips archived sessions', () => {
+    const sessions = [recent('archived-new', { archived: true, last_active: 900 }), recent('plain-old', { last_active: 100 })]
+    expect(pickMostRecentSessionId(sessions, null)).toBe('plain-old')
+  })
+
+  it('excludes the stale session by stored id and by lineage root', () => {
+    const sessions = [
+      recent('dead', { last_active: 900 }),
+      recent('dead-tip', { _lineage_root_id: 'dead', last_active: 800 }),
+      recent('alive', { last_active: 100 })
+    ]
+
+    expect(pickMostRecentSessionId(sessions, 'dead')).toBe('alive')
+  })
+
+  it('returns null when everything is excluded or archived', () => {
+    const sessions = [recent('dead', { last_active: 900 }), recent('gone', { archived: true, last_active: 800 })]
+    expect(pickMostRecentSessionId(sessions, 'dead')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/desktop-controller-utils.ts
+++ b/apps/desktop/src/app/desktop-controller-utils.ts
@@ -1,5 +1,38 @@
 import type { SessionInfo } from '@/hermes'
 
+/**
+ * Engine-most-recent fallback for a cold-boot restore whose pinned session id
+ * turned out to be dead (deleted/rotated while the app was closed). Prefers a
+ * currently-active session (a runtime is live on it right now), then the
+ * newest by last_active; skips archived rows and the dead session itself —
+ * matched by stored id or lineage root, mirroring sessionMatchesStoredId().
+ * Returns null when nothing qualifies (caller falls back to the new-chat
+ * route).
+ */
+export function pickMostRecentSessionId(sessions: SessionInfo[], excludeStoredId: null | string): null | string {
+  let best: null | SessionInfo = null
+
+  for (const session of sessions) {
+    if (session.archived) {
+      continue
+    }
+
+    if (excludeStoredId && (session.id === excludeStoredId || session._lineage_root_id === excludeStoredId)) {
+      continue
+    }
+
+    if (
+      !best ||
+      (session.is_active && !best.is_active) ||
+      (session.is_active === best.is_active && (session.last_active ?? 0) > (best.last_active ?? 0))
+    ) {
+      best = session
+    }
+  }
+
+  return best?.id ?? null
+}
+
 // Cheap signature compare so a poll only swaps the atom (and re-renders the
 // sidebar) when the visible rows actually changed.
 export function sameCronSignature(a: SessionInfo[], b: SessionInfo[]): boolean {

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -88,6 +88,7 @@ import {
 } from './chat/right-rail'
 import { ChatSidebar } from './chat/sidebar'
 import { CommandPalette } from './command-palette'
+import { pickMostRecentSessionId } from './desktop-controller-utils'
 import { useGatewayBoot } from './gateway/hooks/use-gateway-boot'
 import { useGatewayRequest } from './gateway/hooks/use-gateway-request'
 import { useKeybinds } from './hooks/use-keybinds'
@@ -278,9 +279,11 @@ export function DesktopController() {
   }, [routedSessionId])
 
   // Restore that chat once, on cold start only (we're at the new-chat route and
-  // haven't navigated yet). A dead/deleted id self-clears via the exhausted latch
-  // below, so we never boot-loop into an error screen.
+  // haven't navigated yet). The restore is optimistic — the pinned id is not
+  // validated first, so the happy path costs no round trip and no new-chat
+  // flash. A dead/deleted id self-heals via the exhausted latch below.
   const restoredLastSessionRef = useRef(false)
+  const bootRestoredSessionIdRef = useRef<null | string>(null)
   useEffect(() => {
     if (restoredLastSessionRef.current) {
       return
@@ -290,15 +293,41 @@ export function DesktopController() {
     const last = getRememberedSessionId()
 
     if (last && location.pathname === NEW_CHAT_ROUTE) {
+      bootRestoredSessionIdRef.current = last
       navigate(sessionRoute(last), { replace: true })
     }
   }, [location.pathname, navigate])
 
+  // Once the user routes anywhere else, the boot restore is no longer ours to
+  // correct — coming back to that session later is a deliberate open and keeps
+  // the normal error + Retry UI if it turns out dead.
   useEffect(() => {
-    if (resumeExhaustedSessionId && getRememberedSessionId() === resumeExhaustedSessionId) {
+    if (bootRestoredSessionIdRef.current && routedSessionId && routedSessionId !== bootRestoredSessionIdRef.current) {
+      bootRestoredSessionIdRef.current = null
+    }
+  }, [routedSessionId])
+
+  useEffect(() => {
+    if (!resumeExhaustedSessionId) {
+      return
+    }
+
+    if (getRememberedSessionId() === resumeExhaustedSessionId) {
       setRememberedSessionId(null)
     }
-  }, [resumeExhaustedSessionId])
+
+    // The session this window cold-booted onto proved dead (the exhausted
+    // latch only arms with the gateway open, after the bounded resume retries
+    // gave up — so this is a stale pin, not a down backend). Fall back to the
+    // engine's most recent session instead of stranding the boot on an error
+    // screen the user never chose. Sessions the user opened deliberately keep
+    // the explicit error + Retry UI — this fires only for the boot restore.
+    if (bootRestoredSessionIdRef.current === resumeExhaustedSessionId && routedSessionId === resumeExhaustedSessionId) {
+      bootRestoredSessionIdRef.current = null
+      const fallback = pickMostRecentSessionId($sessions.get(), resumeExhaustedSessionId)
+      navigate(fallback ? sessionRoute(fallback) : NEW_CHAT_ROUTE, { replace: true })
+    }
+  }, [resumeExhaustedSessionId, routedSessionId, navigate])
 
   // Notification click: the main process already focused the window; jump to its
   // session. Notifications are tagged with the gateway *runtime* session id, but


### PR DESCRIPTION
## What does this PR do?

On cold start the desktop app navigates straight to the localStorage-pinned `hermes.desktop.lastSessionId` without validating it against the backend. When that pin is stale (the session was deleted or rotated while the app was closed), the boot strands on the resume-error screen for a chat the user never chose; the engine's actual most recent session is never considered.

This PR keeps the optimistic restore — the happy path still costs no round trip and no new-chat flash — and adds a fallback using the **existing resume-exhausted latch as the staleness verdict**: the latch only arms while the gateway is open, after the bounded resume retries gave up (`use-route-resume.ts`), so it cleanly distinguishes a dead pin from a down backend. No extra validation RPC, and no false positives from checking membership in the paginated session list.

When the latch fires for the boot-restored session while it's still the routed one, the controller replace-navigates to the engine's most recent session — preferring an `is_active` session (a runtime is live on it right now), then newest `last_active`, skipping archived rows and the dead session's own lineage — or to the new-chat route when nothing qualifies. The dead pin is still cleared, as before.

Deliberately narrow: sessions the user opened by hand keep the explicit error + Retry UI — the fallback fires only for the automatic boot restore, so it never yanks a session the user explicitly chose out from under them.

## Related Issue

Fixes #60541

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/desktop-controller.tsx`: track which session id the cold-boot restore navigated to (`bootRestoredSessionIdRef`); on resume-exhaustion of exactly that session while routed to it, replace-navigate to `pickMostRecentSessionId($sessions, deadId)` or the new-chat route.
- `apps/desktop/src/app/desktop-controller-utils.ts`: new pure helper `pickMostRecentSessionId()` (active-first, then `last_active`; skips archived and the dead lineage — id matching mirrors `sessionMatchesStoredId()`).
- `apps/desktop/src/app/desktop-controller-utils.test.ts`: six cases — empty list, newest-by-last_active, active-over-newer-inactive, archived skipped, exclusion by id and lineage root, all-excluded → null.

## How to Test

1. `cd apps/desktop && npx vitest run --environment jsdom src/app/desktop-controller-utils.test.ts` — 10 pass (4 existing + 6 new; the new ones fail on current `main`).
2. Manual reproduction: open a chat in the desktop app, quit, delete that session from the CLI (`hermes sessions` tooling) or another surface, relaunch.
   - Current `main`: boot lands on the resume-error screen for the deleted session.
   - This branch: after the bounded retries exhaust, the window jumps to the engine's most recent session (or new-chat when none), and the stale pin is replaced by the new session id.
3. Deliberate-open path unchanged: open an old dead session from the sidebar → error + Retry UI still shown, no auto-navigation.
4. `npm run typecheck` and `npx eslint` on the touched files pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(desktop):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q`: no Python changes in this diff; full-suite comparison against a pristine `main` checkout on the same machine shows no new failures (environment-dependent failures reproduce identically on base)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (Darwin 25.5), Node 22.23.0
- Full desktop unit suite (`vitest run --environment jsdom`): no new failures vs. a pristine checkout of the same base commit (24 pre-existing environment-dependent failures on both, identical set)

### Documentation & Housekeeping

- [x] Comments updated in the touched effects — or N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact: renderer-only
- [x] Tool descriptions/schemas — N/A
