### PR TITLE
fix(cron): clean up HERMES_CRON_SESSION env var after job completes (#60350)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1821,6 +1821,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 os.environ.pop("TERMINAL_CWD", None)
             else:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
+        # Clean up the cron session marker so it doesn't leak into
+        # interactive sessions that share this process (issue #60350).
+        # The env var was set at the top of _run_job_impl; without this
+        # cleanup, every subsequent call to execute_code in interactive
+        # sessions is misidentified as a cron session and denied.
+        os.environ.pop("HERMES_CRON_SESSION", None)
         # Clean up ContextVar session/delivery state for this job.
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:


### PR DESCRIPTION
## Summary

Fixes #60350

`os.environ["HERMES_CRON_SESSION"] = "1"` is set at the start of `_run_job_impl` (line 1402) but never cleaned up after the job completes. Since the cron scheduler runs inside the gateway process, this env var persists across jobs and leaks into interactive sessions — causing `execute_code` calls from WeCom/Telegram/CLI to be misidentified as cron sessions and silently denied by the approval system.

## Root Cause

```python
# cron/scheduler.py:1402
os.environ["HERMES_CRON_SESSION"] = "1"
```

This env var is **process-global** and **never popped**. After any cron job runs, every subsequent interactive session in the same gateway process inherits `HERMES_CRON_SESSION=1`. The `execute_code` approval check sees this and routes to the cron denial path:

```
BLOCKED: execute_code is not allowed in cron sessions
```

This affects all interactive platforms (WeCom, Telegram, CLI, API server) — not just the cron job itself.

## Impact

- **Severity**: High — interactive `execute_code` is completely blocked after the first cron job runs
- **Affected versions**: All versions with embedded cron scheduler
- **Reproduction**: Start gateway → wait for any cron job to execute → try `execute_code` in an interactive session → blocked
- **Workaround**: Restart the gateway after each cron job (not practical)

## Fix

Add `os.environ.pop("HERMES_CRON_SESSION", None)` to the existing `finally` block in `_run_job_impl`, alongside the `TERMINAL_CWD` and ContextVar cleanup that already runs there:

```python
finally:
    # ... existing TERMINAL_CWD cleanup ...
    
    # Clean up the cron session marker so it doesn't leak into
    # interactive sessions that share this process (issue #60350).
    os.environ.pop("HERMES_CRON_SESSION", None)
    
    # ... existing ContextVar cleanup ...
```

This is a 1-line fix (6 lines with comments) in the correct location — the `finally` block that already handles all other per-job cleanup.

## Related Issues

- #56771 — earliest report of cron env var leaking
- #57736 — same pattern
- #58662 — same pattern
- #60350 — our report with root cause analysis

## Contributor Context

We (Qijing Digital) have reported multiple gateway/platform bugs (#47564–47573, #47788, #47804, #60350, #60578) and are now submitting PRs for the ones with clear, minimal fixes. This is our second PR — see also #60610 (killpg guard for #47788). Happy to adjust as maintainers prefer.
