### PR TITLE
fix(gateway): drain in-flight cron jobs during /update shutdown (#60432)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -298,6 +298,13 @@ _parallel_pool_max_workers: Optional[int] = None
 _running_job_ids: set = set()
 _running_lock = threading.Lock()
 
+
+def cron_jobs_in_flight() -> int:
+    """Return how many cron jobs are currently executing agent/tool work."""
+    with _running_lock:
+        return len(_running_job_ids)
+
+
 # Sequential (env-mutating) cron jobs — workdir jobs that touch
 # process-global runtime state — must run one at a time, but must NOT block the
 # ticker thread.  A persistent single-thread executor preserves ordering across

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5548,20 +5548,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return True
 
     async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
+        from cron.scheduler import cron_jobs_in_flight
+
         snapshot = self._snapshot_running_agents()
         last_active_count = self._running_agent_count()
+        last_cron_count = cron_jobs_in_flight()
         last_status_at = 0.0
 
         def _maybe_update_status(force: bool = False) -> None:
-            nonlocal last_active_count, last_status_at
+            nonlocal last_active_count, last_cron_count, last_status_at
             now = asyncio.get_running_loop().time()
             active_count = self._running_agent_count()
-            if force or active_count != last_active_count or (now - last_status_at) >= 1.0:
+            cron_count = cron_jobs_in_flight()
+            if (
+                force
+                or active_count != last_active_count
+                or cron_count != last_cron_count
+                or (now - last_status_at) >= 1.0
+            ):
                 self._update_runtime_status("draining")
                 last_active_count = active_count
+                last_cron_count = cron_count
                 last_status_at = now
 
-        if not self._running_agents:
+        if not self._running_agents and last_cron_count == 0:
             _maybe_update_status(force=True)
             return snapshot, False
 
@@ -5570,10 +5580,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return snapshot, True
 
         deadline = asyncio.get_running_loop().time() + timeout
-        while self._running_agents and asyncio.get_running_loop().time() < deadline:
+        while (
+            (self._running_agents or cron_jobs_in_flight())
+            and asyncio.get_running_loop().time() < deadline
+        ):
             _maybe_update_status()
             await asyncio.sleep(0.1)
-        timed_out = bool(self._running_agents)
+        timed_out = bool(self._running_agents or cron_jobs_in_flight())
         _maybe_update_status(force=True)
         return snapshot, timed_out
 
@@ -8004,16 +8017,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as _e:
                     logger.debug("pre-drain mark_resume_pending failed for %s: %s", _sk, _e)
 
+            from cron.scheduler import cron_jobs_in_flight
+
+            _cron_at_start = cron_jobs_in_flight()
             _drain_started_at = time.monotonic()
             active_agents, timed_out = await self._drain_active_agents(timeout)
             logger.info(
                 "Shutdown phase: drain done at +%.2fs (drain took %.2fs, "
-                "timed_out=%s, active_at_start=%d, active_now=%d)",
+                "timed_out=%s, active_at_start=%d, active_now=%d, "
+                "cron_at_start=%d, cron_now=%d)",
                 _phase_elapsed(),
                 time.monotonic() - _drain_started_at,
                 timed_out,
                 len(active_agents),
                 self._running_agent_count(),
+                _cron_at_start,
+                cron_jobs_in_flight(),
             )
 
             if not timed_out:
@@ -8032,9 +8051,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             if timed_out:
                 logger.warning(
-                    "Gateway drain timed out after %.1fs with %d active agent(s); interrupting remaining work.",
+                    "Gateway drain timed out after %.1fs with %d active agent(s) "
+                    "and %d in-flight cron job(s); interrupting remaining work.",
                     timeout,
                     self._running_agent_count(),
+                    cron_jobs_in_flight(),
                 )
                 # Mark forcibly-interrupted sessions as resume_pending BEFORE
                 # interrupting the agents.  This preserves each session's

--- a/tests/gateway/test_update_cron_drain.py
+++ b/tests/gateway/test_update_cron_drain.py
@@ -1,0 +1,86 @@
+"""Regression tests for #60432.
+
+``/update`` (and other gateway shutdown paths) must drain in-flight cron jobs
+before ``process_registry.kill_all()`` runs in final-cleanup.  Cron work runs on
+a thread-pool worker and is tracked in ``cron.scheduler._running_job_ids``, not
+in ``GatewayRunner._running_agents`` — so a zero-agent drain must still wait
+for cron to finish (or time out and take the interrupt/kill path).
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+@pytest.mark.asyncio
+async def test_drain_active_agents_waits_for_in_flight_cron_jobs():
+    runner, _adapter = make_restart_runner()
+    runner._running_agents = {}
+
+    cron_count = [1]
+
+    def _cron_in_flight():
+        return cron_count[0]
+
+    async def finish_cron():
+        await asyncio.sleep(0.15)
+        cron_count[0] = 0
+
+    with patch("cron.scheduler.cron_jobs_in_flight", side_effect=_cron_in_flight):
+        task = asyncio.create_task(finish_cron())
+        _snapshot, timed_out = await runner._drain_active_agents(1.0)
+        await task
+
+    assert timed_out is False
+    assert _snapshot == {}
+
+
+@pytest.mark.asyncio
+async def test_drain_active_agents_times_out_when_cron_still_running():
+    runner, _adapter = make_restart_runner()
+    runner._running_agents = {}
+
+    with patch("cron.scheduler.cron_jobs_in_flight", return_value=1):
+        _snapshot, timed_out = await runner._drain_active_agents(0.05)
+
+    assert timed_out is True
+    assert _snapshot == {}
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_waits_for_cron_before_final_tool_kill():
+    """Graceful cron completion must finish before final-cleanup kill_all."""
+    runner, adapter = make_restart_runner()
+    runner._restart_drain_timeout = 1.0
+
+    cron_count = [1]
+    call_order: list[str] = []
+
+    def _cron_in_flight():
+        return cron_count[0]
+
+    def _fake_kill_all(task_id=None):
+        call_order.append("kill_all")
+        return 0
+
+    async def finish_cron():
+        await asyncio.sleep(0.12)
+        cron_count[0] = 0
+
+    with (
+        patch("cron.scheduler.cron_jobs_in_flight", side_effect=_cron_in_flight),
+        patch("gateway.status.remove_pid_file"),
+        patch("gateway.status.write_runtime_status"),
+        patch("agent.auxiliary_client.shutdown_cached_clients"),
+        patch("tools.process_registry.process_registry") as registry_mock,
+    ):
+        registry_mock.kill_all.side_effect = _fake_kill_all
+        adapter.disconnect = AsyncMock()
+
+        cron_task = asyncio.create_task(finish_cron())
+        await runner.stop()
+        await cron_task
+
+    assert call_order == ["kill_all"]


### PR DESCRIPTION
## Summary
- Treat in-flight cron jobs as active gateway work during shutdown drain, not just `_running_agents` messaging sessions.
- Wait up to `restart_drain_timeout` for cron workers to finish before `final-cleanup` kills tool subprocesses.
- Log `cron_at_start` / `cron_now` in shutdown drain forensics.

Fixes #60432.

## Root cause
Cron jobs run on a thread-pool worker tracked in `cron.scheduler._running_job_ids`. Gateway shutdown only drained `_running_agents`, so `/update` reported `active_at_start=0` and immediately ran `process_registry.kill_all()` while cron tool work was still running.

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_update_cron_drain.py -q`
- [ ] Repro on gateway: start long cron job (`sleep 1800`), run `/update`, confirm drain waits and logs non-zero `cron_at_start`