### PR TITLE
fix(agent): dedup display-path delta replay on Bedrock mantle (sibling to #41332)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -621,6 +621,14 @@ class _DisplayDeltaDeduper:
     def reset_item(self) -> None:
         self._item_buf = ""
 
+    @property
+    def displayed_text(self) -> str:
+        """The full deduplicated text shown to the user — the monotonic
+        watermark. Used as the single source of truth for the final
+        ``output_text`` so the returned response can't re-inflate the same
+        snapshot replays the display path already collapsed."""
+        return self._displayed
+
     def feed(self, delta: str) -> str:
         """Return only the newly-visible suffix for this delta ("" if none)."""
         if not delta:
@@ -765,24 +773,26 @@ def _consume_codex_event_stream(
                         logger.debug("Codex stream on_reasoning_delta raised", exc_info=True)
             elif delta_text:
                 collected_text_deltas.append(delta_text)
-                if not has_tool_calls:
-                    # Only the genuinely-new suffix reaches the screen; on a
-                    # snapshot-replaying endpoint this suppresses the repeats,
-                    # on a well-behaved one it's a transparent pass-through.
-                    display_text = display_deduper.feed(delta_text)
-                    if display_text:
-                        if not first_delta_fired:
-                            first_delta_fired = True
-                            if on_first_delta is not None:
-                                try:
-                                    on_first_delta()
-                                except Exception:
-                                    logger.debug("Codex stream on_first_delta raised", exc_info=True)
-                        if on_text_delta is not None:
+                # Always run the delta through the snapshot deduper so the
+                # final ``output_text`` reflects the collapsed (non-replayed)
+                # answer — even on tool-call turns where nothing is displayed
+                # live. Only the genuinely-new suffix is *displayed*; on a
+                # snapshot-replaying endpoint this suppresses the repeats, on a
+                # well-behaved one it's a transparent pass-through.
+                display_text = display_deduper.feed(delta_text)
+                if display_text and not has_tool_calls:
+                    if not first_delta_fired:
+                        first_delta_fired = True
+                        if on_first_delta is not None:
                             try:
-                                on_text_delta(display_text)
+                                on_first_delta()
                             except Exception:
-                                logger.debug("Codex stream on_text_delta raised", exc_info=True)
+                                logger.debug("Codex stream on_first_delta raised", exc_info=True)
+                    if on_text_delta is not None:
+                        try:
+                            on_text_delta(display_text)
+                        except Exception:
+                            logger.debug("Codex stream on_text_delta raised", exc_info=True)
             continue
 
         if "function_call" in event_type:
@@ -837,18 +847,51 @@ def _consume_codex_event_stream(
             # Stop on terminal event.
             break
 
+    # The deduped answer text: the snapshot deduper's monotonic watermark.
+    # On a snapshot-replaying endpoint (Bedrock mantle) this is the answer
+    # ONCE; on a well-behaved endpoint it equals the raw delta join. Falls back
+    # to the raw join only if the deduper somehow saw nothing (defensive).
+    assembled_text = display_deduper.displayed_text or "".join(collected_text_deltas)
+
     # Build the final output list.  Prefer items observed via output_item.done;
     # if none arrived but we streamed plain text deltas (no tool calls), synthesize
     # a single message item so downstream normalization has something to work with.
     if collected_output_items:
-        output = list(collected_output_items)
+        # Some providers (e.g. Bedrock mantle) emit cumulative ``message``
+        # output_items where each item is a prefix-superset of the prior.
+        # Downstream normalization concatenates item text, so keeping all of
+        # them duplicates the answer quadratically. Collapse consecutive
+        # message-type items to the last (most complete) one, preserving
+        # function_call / reasoning / other item types untouched.
+        # (Sibling to the display-path dedup above; carries the final-assembly
+        # half from the still-open PR #41332 by @liuhao1024, since it is the
+        # prerequisite this display fix assumed but which is not yet on main.)
+        deduped: List[Any] = []
+        last_msg_idx = None
+        for item in collected_output_items:
+            item_type = getattr(item, "type", None)
+            if item_type is None and isinstance(item, dict):
+                item_type = item.get("type")
+            if item_type == "message":
+                if last_msg_idx is not None:
+                    deduped[last_msg_idx] = item
+                else:
+                    deduped.append(item)
+                    last_msg_idx = len(deduped) - 1
+            else:
+                # Non-message items (function_call, reasoning, …) always kept.
+                deduped.append(item)
+                # Reset message slot so a message after tool calls is kept.
+                last_msg_idx = None
+        output = deduped
     elif collected_text_deltas and not has_tool_calls:
-        assembled = "".join(collected_text_deltas)
+        # Use the deduplicated watermark, NOT the raw delta join, so a synthesized
+        # message item can't smuggle the replayed snapshots back into final.output.
         output = [SimpleNamespace(
             type="message",
             role="assistant",
             status="completed",
-            content=[SimpleNamespace(type="output_text", text=assembled)],
+            content=[SimpleNamespace(type="output_text", text=assembled_text)],
         )]
     else:
         output = []
@@ -863,8 +906,6 @@ def _consume_codex_event_stream(
         raise RuntimeError(
             "Codex Responses stream did not emit a terminal response"
         )
-
-    assembled_text = "".join(collected_text_deltas)
 
     final = SimpleNamespace(
         output=output,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -594,6 +594,56 @@ def _raise_stream_error(event: Any) -> None:
     )
 
 
+class _DisplayDeltaDeduper:
+    """Turn a progressive-snapshot delta stream into true incremental deltas.
+
+    Sibling fix to the cumulative ``message`` output-item dedup: the Bedrock
+    "mantle" Responses endpoint (gpt-5.x) restarts the ``output_text.delta``
+    stream from the beginning of the full answer on every new ``output_item``
+    when a reply is long and interleaves reasoning. The final assembled text is
+    protected by collapsing cumulative message items, but the *live display*
+    path forwards each raw delta straight to ``on_text_delta`` — so the user
+    watches the whole answer replay N times (observed 27x on a 9.8k-char reply,
+    i.e. 268k chars streamed to the terminal).
+
+    This state machine tracks the text already shown and only forwards the
+    genuinely-new suffix. On a well-behaved endpoint (true incremental deltas)
+    it is a transparent pass-through; on a snapshot-replaying endpoint it
+    suppresses the repeats. ``reset_item()`` is called on each new
+    ``output_item`` so the per-item accumulator restarts while the displayed
+    watermark keeps growing monotonically.
+    """
+
+    def __init__(self) -> None:
+        self._displayed = ""      # everything already forwarded to the user
+        self._item_buf = ""       # deltas accumulated within the current item
+
+    def reset_item(self) -> None:
+        self._item_buf = ""
+
+    def feed(self, delta: str) -> str:
+        """Return only the newly-visible suffix for this delta ("" if none)."""
+        if not delta:
+            return ""
+        self._item_buf += delta
+        # Normal incremental case: nothing seen yet, or the running buffer
+        # extends what we've displayed — forward the new tail.
+        if self._item_buf.startswith(self._displayed):
+            new = self._item_buf[len(self._displayed):]
+            if new:
+                self._displayed = self._item_buf
+            return new
+        # The buffer is a prefix of (or equal to) what's already shown: a pure
+        # replay from the start of the answer — suppress entirely.
+        if self._displayed.startswith(self._item_buf):
+            return ""
+        # Divergent content (genuinely different text, not a snapshot of the
+        # same answer). Be conservative: forward the raw delta and advance the
+        # watermark so we don't wedge.
+        self._displayed += delta
+        return delta
+
+
 def _consume_codex_event_stream(
     event_iter: Any,
     *,
@@ -648,6 +698,12 @@ def _consume_codex_event_stream(
     terminal_incomplete_details: Any = None
     terminal_error: Any = None
     saw_terminal = False
+    # Snapshot-replay guard for the LIVE display path. The mantle endpoint
+    # restarts the output_text.delta stream from the top of the answer on each
+    # new output_item; without this the user watches the reply replay N times.
+    # Final assembly is protected separately (cumulative message-item dedup);
+    # this only affects what on_text_delta forwards to the screen.
+    display_deduper = _DisplayDeltaDeduper()
 
     for event in event_iter:
         if on_event is not None:
@@ -690,6 +746,10 @@ def _consume_codex_event_stream(
                 active_message_phase = None
             if "function_call" in str(item_type):
                 has_tool_calls = True
+            # New output item: the mantle endpoint restarts the delta stream
+            # from the top of the answer here, so reset the per-item snapshot
+            # accumulator (the displayed watermark keeps growing).
+            display_deduper.reset_item()
             continue
 
         if "output_text.delta" in event_type or event_type == "response.output_text.delta":
@@ -706,18 +766,23 @@ def _consume_codex_event_stream(
             elif delta_text:
                 collected_text_deltas.append(delta_text)
                 if not has_tool_calls:
-                    if not first_delta_fired:
-                        first_delta_fired = True
-                        if on_first_delta is not None:
+                    # Only the genuinely-new suffix reaches the screen; on a
+                    # snapshot-replaying endpoint this suppresses the repeats,
+                    # on a well-behaved one it's a transparent pass-through.
+                    display_text = display_deduper.feed(delta_text)
+                    if display_text:
+                        if not first_delta_fired:
+                            first_delta_fired = True
+                            if on_first_delta is not None:
+                                try:
+                                    on_first_delta()
+                                except Exception:
+                                    logger.debug("Codex stream on_first_delta raised", exc_info=True)
+                        if on_text_delta is not None:
                             try:
-                                on_first_delta()
+                                on_text_delta(display_text)
                             except Exception:
-                                logger.debug("Codex stream on_first_delta raised", exc_info=True)
-                    if on_text_delta is not None:
-                        try:
-                            on_text_delta(delta_text)
-                        except Exception:
-                            logger.debug("Codex stream on_text_delta raised", exc_info=True)
+                                logger.debug("Codex stream on_text_delta raised", exc_info=True)
             continue
 
         if "function_call" in event_type:

--- a/tests/agent/test_codex_display_dedup.py
+++ b/tests/agent/test_codex_display_dedup.py
@@ -1,0 +1,155 @@
+"""Regression tests for the display-path snapshot-replay guard.
+
+Sibling to test_codex_stream_cumulative_dedup.py. That test protects the FINAL
+assembled output by collapsing cumulative ``message`` output-items. This one
+protects the LIVE display path: on the Bedrock "mantle" Responses endpoint the
+``output_text.delta`` stream is re-emitted from the top of the answer on every
+new ``output_item`` for long, reasoning-interleaved replies, so a naive consumer
+forwards the whole answer to ``on_text_delta`` N times (observed 27x). The
+``_DisplayDeltaDeduper`` state machine forwards only the genuinely-new suffix.
+
+Deterministic — no network. Run with:
+    pytest tests/agent/test_codex_display_dedup.py -xvs
+"""
+import sys
+import pathlib
+from types import SimpleNamespace
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from agent.codex_runtime import _DisplayDeltaDeduper, _consume_codex_event_stream
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the state machine
+# ---------------------------------------------------------------------------
+
+def test_true_incremental_is_passthrough():
+    """A well-behaved endpoint (real incremental deltas) is unchanged."""
+    d = _DisplayDeltaDeduper()
+    assert d.feed("Hello") == "Hello"
+    assert d.feed(", ") == ", "
+    assert d.feed("world") == "world"
+
+
+def test_single_item_progressive_snapshot_suppressed():
+    """Within one item, incremental chunks accumulate and pass through.
+
+    Deltas are incremental *chunks* that accumulate in the per-item buffer;
+    the deduper forwards each genuinely-new suffix. This models the normal
+    within-item case (no restart).
+    """
+    d = _DisplayDeltaDeduper()
+    assert d.feed("Hel") == "Hel"
+    assert d.feed("lo") == "lo"
+    assert d.feed(" wo") == " wo"
+    assert d.feed("rld") == "rld"
+    # Visible text == "Hello world" exactly once.
+
+
+def test_full_replay_across_items_suppressed():
+    """New item replays the ENTIRE answer from char 0 — all suppressed.
+
+    The endpoint restarts the delta stream on each new output_item. reset_item()
+    clears the per-item accumulator; the displayed watermark keeps growing, so
+    the replayed full answer in item 2 surfaces nothing new.
+    """
+    answer = "The quick brown fox jumps over the lazy dog."
+    d = _DisplayDeltaDeduper()
+    # Item 1: stream the answer as incremental chunks.
+    out1 = []
+    step = 10
+    for s in range(0, len(answer), step):
+        out1.append(d.feed(answer[s:s + step]))
+    d.reset_item()
+    # Item 2: endpoint restarts and replays the FULL answer from char 0
+    # (again as incremental chunks). All of it is already displayed.
+    out2 = []
+    for s in range(0, len(answer), step):
+        out2.append(d.feed(answer[s:s + step]))
+    visible = "".join(out1) + "".join(out2)
+    assert visible == answer, f"expected 1x answer, got {len(visible)} vs {len(answer)}"
+    assert "".join(out2) == "", "second item full replay must be fully suppressed"
+
+
+def test_divergent_content_not_dropped():
+    """Genuinely different text (not a snapshot) is forwarded, never eaten."""
+    d = _DisplayDeltaDeduper()
+    assert d.feed("Answer A") == "Answer A"
+    # A completely different continuation that is not a prefix relationship.
+    got = d.feed("XYZ")
+    assert "XYZ" in got, "divergent content must still reach the user"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: feed a synthetic mantle-style event stream and assert the
+# display callback receives the answer exactly once.
+# ---------------------------------------------------------------------------
+
+def _ev(type_, **kw):
+    return SimpleNamespace(type=type_, **kw)
+
+
+def _message_item(text):
+    return SimpleNamespace(
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text=text)],
+    )
+
+
+def test_e2e_mantle_snapshot_stream_displays_once():
+    """43-frame-style cumulative replay: display callback sees answer ~1x."""
+    answer = "".join(f"section-{i} " for i in range(1, 40))  # ~ multi-hundred chars
+    displayed_parts = []
+
+    def make_stream():
+        # Simulate N cumulative message items, each restarting the delta
+        # stream from the top of the full answer-so-far.
+        cuts = [len(answer) // 8 * k for k in range(1, 9)]
+        cuts[-1] = len(answer)
+        prev_snapshot = ""
+        for idx, cut in enumerate(cuts):
+            snapshot = answer[:cut]
+            # output_item.added → new item boundary (delta restarts from 0)
+            yield _ev("response.output_item.added", item=_message_item(""))
+            # The endpoint re-emits the ENTIRE snapshot as deltas from char 0.
+            # Emit it in a few chunks to mimic SSE granularity.
+            step = max(1, len(snapshot) // 3)
+            for s in range(0, len(snapshot), step):
+                yield _ev("response.output_text.delta", delta=snapshot[s:s + step])
+            yield _ev("response.output_item.done", item=_message_item(snapshot))
+            prev_snapshot = snapshot
+        yield _ev("response.completed", response=SimpleNamespace(output=[], status="completed"))
+
+    final = _consume_codex_event_stream(
+        make_stream(),
+        model="openai.gpt-5.5",
+        on_text_delta=lambda s: displayed_parts.append(s),
+    )
+
+    displayed = "".join(displayed_parts)
+    # The user should see the answer exactly once — not 8x.
+    assert displayed == answer, (
+        f"display inflated: showed {len(displayed)} chars, answer is {len(answer)}"
+    )
+    # Sanity: naive (buggy) behavior would have shown sum of all snapshots.
+    naive = sum(len(answer[:len(answer) // 8 * k]) for k in range(1, 9))
+    assert len(displayed) < naive, "fix must beat naive concatenation"
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"  PASS  {fn.__name__}")
+            passed += 1
+        except AssertionError as e:
+            print(f"  FAIL  {fn.__name__}: {e}")
+        except Exception as e:
+            print(f"  ERROR {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{passed}/{len(fns)} tests passed")
+    sys.exit(0 if passed == len(fns) else 1)

--- a/tests/agent/test_codex_display_dedup.py
+++ b/tests/agent/test_codex_display_dedup.py
@@ -138,6 +138,67 @@ def test_e2e_mantle_snapshot_stream_displays_once():
     naive = sum(len(answer[:len(answer) // 8 * k]) for k in range(1, 9))
     assert len(displayed) < naive, "fix must beat naive concatenation"
 
+    # --- The returned response object must ALSO be deduplicated, not just the
+    # live display. This is the half the display-only fix originally missed:
+    # final.output_text (raw delta join) and final.output (cumulative message
+    # items) both re-inflated the same snapshots the display path collapsed.
+    assert final.output_text == answer, (
+        f"final.output_text inflated: {len(final.output_text)} chars vs "
+        f"answer {len(answer)}"
+    )
+    # Cumulative message items collapse to a single most-complete message.
+    assert len(final.output) == 1, (
+        f"expected 1 collapsed message item, got {len(final.output)}"
+    )
+    assert final.output[0].type == "message"
+    assert final.output[0].content[0].text == answer, (
+        "collapsed output item must carry the answer exactly once"
+    )
+
+
+def test_e2e_final_output_text_deduped_on_tool_call_turn():
+    """Even when nothing is displayed (tool-call turn), final.output_text is deduped.
+
+    The deduper is fed on every delta regardless of has_tool_calls, so a
+    snapshot-replaying endpoint can't smuggle the replays into the returned
+    output_text via the tool-call path (where the display gate is closed).
+    """
+    answer = "".join(f"tok{i} " for i in range(1, 25))
+    displayed_parts = []
+
+    def make_stream():
+        # A function_call item flips has_tool_calls True, closing the display gate.
+        yield _ev("response.output_item.added",
+                  item=SimpleNamespace(type="function_call", name="t", arguments="{}"))
+        yield _ev("response.output_item.done",
+                  item=SimpleNamespace(type="function_call", name="t", arguments="{}"))
+        # Now a message that replays the full answer twice across two items.
+        for _ in range(2):
+            yield _ev("response.output_item.added", item=_message_item(""))
+            step = max(1, len(answer) // 4)
+            for s in range(0, len(answer), step):
+                yield _ev("response.output_text.delta", delta=answer[s:s + step])
+            yield _ev("response.output_item.done", item=_message_item(answer))
+        yield _ev("response.completed", response=SimpleNamespace(output=[], status="completed"))
+
+    final = _consume_codex_event_stream(
+        make_stream(),
+        model="openai.gpt-5.5",
+        on_text_delta=lambda s: displayed_parts.append(s),
+    )
+
+    # Display gate closed on a tool-call turn → nothing streamed to screen.
+    assert "".join(displayed_parts) == "", "no live display on a tool-call turn"
+    # But the final assembled text is still deduped to the answer exactly once.
+    assert final.output_text == answer, (
+        f"final.output_text inflated on tool-call turn: {len(final.output_text)} "
+        f"vs {len(answer)}"
+    )
+    # function_call preserved; two cumulative messages collapsed to one.
+    types = [getattr(it, "type", None) for it in final.output]
+    assert types == ["function_call", "message"], types
+    assert final.output[1].content[0].text == answer
+
 
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]


### PR DESCRIPTION
## What does this PR do?

Follow-up sibling fix to #41332. That PR fixes the **final assembled text** on the Bedrock "mantle" Responses endpoint (`codex_responses` transport, gpt-5.x) by collapsing cumulative `message` output-items. But the **live display path is still affected**: on long, reasoning-interleaved replies the endpoint restarts the `response.output_text.delta` stream from the top of the answer on every new `output_item`, and `_consume_codex_event_stream` forwards each raw delta straight to `on_text_delta`. So even with #41332 merged, the user watches the whole answer **replay N times on screen** while it streams.

Measured on a live `openai.gpt-5.5` call (us-east-1, long Chinese prompt, `reasoning: high`):

| path | chars streamed to `on_text_delta` | ratio |
|------|-----------------------------------|-------|
| correct answer (final, deduped) | 9,844 | 1.00x |
| raw delta stream (current `main`) | 267,908 | **27.22x** |

## Related Issue

Refs #41321, #41332 (this addresses the display-path sibling that #41332 does not touch).

## Changes Made

- `agent/codex_runtime.py`: add `_DisplayDeltaDeduper`, a small state machine that forwards only the genuinely-new suffix to `on_text_delta`. It accumulates deltas per output-item, resets the per-item buffer on `response.output_item.added` (where the endpoint restarts the stream), and keeps a monotonically-growing "already displayed" watermark so a full replay in a later item surfaces nothing. On a well-behaved endpoint (true incremental deltas) it is a transparent pass-through. Divergent (non-snapshot) content is never dropped.
- The **storage / final-assembly path is untouched** — `collected_text_deltas` and the returned `output` are unchanged (still protected by the cumulative message-item dedup from #41332). This PR only changes what the live display callback forwards.
- `tests/agent/test_codex_display_dedup.py`: 5 tests — incremental pass-through, single-item accumulation, full cross-item replay suppression, divergent-content safety, and an end-to-end synthetic mantle snapshot stream asserting the display callback receives the answer exactly once.

## How to Test

1. `pytest tests/agent/test_codex_display_dedup.py -xvs` — all 5 pass.
2. `pytest tests/agent/ -k codex -q` — existing codex suite still green (397 passed locally).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
