### PR TITLE
fix: gate JSON/YAML/TOML syntax check before disk write (#60525)

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1388,6 +1388,33 @@ class ShellFileOperations(FileOperations):
         if self._file_has_bom(path, pre_content) and not _has_bom(content):
             content = _UTF8_BOM + content
 
+        # ── Pre-write syntax gate (JSON / YAML / TOML) ─────────────
+        # For structured-data formats whose in-process linters do a
+        # full parse, validate *before* _atomic_write() so that
+        # syntactically-invalid content is never persisted to disk.
+        # Previously the check ran post-write (post-first) and merely
+        # attached the lint result to the response — the write was
+        # already committed, so callers gating on ``error`` reported
+        # success for files that don't even parse.  See #60525.
+        #
+        # Deliberately scoped to JSON/YAML/TOML only (not .py):
+        # the existing test suite writes non-Python text through .py
+        # paths as generic write-mechanics fixtures; a naive full-
+        # LINTERS_INPROC scope broke 3 previously-green tests.
+        _SYNTAX_GATE_EXTS = {'.json', '.yaml', '.yml', '.toml'}
+        if ext in _SYNTAX_GATE_EXTS:
+            _linter = LINTERS_INPROC.get(ext)
+            if _linter is not None:
+                ok, err_msg = _linter(content)
+                if not ok and err_msg != "__SKIP__":
+                    return WriteResult(
+                        error=(
+                            f"Pre-write syntax check failed for {path}: "
+                            f"{err_msg}. File NOT written — fix the syntax "
+                            f"and retry."
+                        ),
+                    )
+
         # Snapshot LSP diagnostics for this file (best-effort) so the
         # post-write LSP layer can return only diagnostics introduced
         # by this specific edit.  Mirrors claude-code's


### PR DESCRIPTION
## Summary

`write_file()` in `tools/file_operations.py` called `_atomic_write()` **before** running `_check_lint_delta()`. For JSON/YAML/TOML files, syntactically-invalid content was persisted to disk and reported as successful (no top-level `error` key set). The lint result was merely attached to the response as metadata.

A real production incident saw a malformed `cron/jobs.json` (caused by an upstream redaction pass producing truncated JSON) go undetected until a later manual audit — both scheduled cron jobs were non-functional in the interim.

## Root Cause

In `ShellFileOperations.write_file()` (line ~1423):
1. `_atomic_write(path, content)` commits to disk **first**
2. `_check_lint_delta(path, ...)` runs **after** — parse failures only surface as `lint.status: "error"` in the response, never as a top-level `error`

The `file_tools.py` wrapper gates `files_modified` reporting on `not result_dict.get("error")`, so it reports success even when the content doesn't parse.

## Fix

Add a **pre-write syntax gate** for `.json`, `.yaml`, `.yml`, `.toml` that runs the in-process linter **before** `_atomic_write()`. On parse failure, the write is refused outright with a clear error message — no temp file, no rename.

Deliberately scoped to structured-data formats only (`.py` excluded): the test suite uses `.py` paths as generic write-mechanics fixtures; a naive full-`LINTERS_INPROC` scope broke 3 previously-green tests.

## Testing

- The in-process linters (`_lint_json_inproc`, `_lint_yaml_inproc`, `_lint_toml_inproc`) are already tested by the existing test suite
- The new guard runs the same linters but **before** the write instead of after
- Valid files pass through unchanged (linter returns `ok=True`)
- Invalid files are rejected with a clear error and never touch disk

Closes #60525
