### PR TITLE
fix(tui): prevent ws_orphan_reap from ending gateway-originated sessions

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -586,7 +586,23 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
         try:
             db = _get_db()
             if db is not None:
-                db.end_session(session_id, end_reason)
+                # Don't end gateway-originated sessions — the gateway owns their
+                # lifecycle.  The TUI is a viewer, not the owner.  Ending a
+                # gateway session in state.db triggers a Groundhog Day routing
+                # loop: the gateway's #54878 self-heal detects the stale entry,
+                # recovers to the parent session, context compression splits
+                # back to the reaped child, and the cycle repeats on every
+                # inbound message.  (#60609)
+                _GATEWAY_SOURCES = frozenset({
+                    "bluebubbles", "telegram", "discord", "signal",
+                    "whatsapp", "sms", "slack", "mattermost",
+                    "matrix", "line", "wechat", "facebook",
+                    "imessage", "googlechat",
+                })
+                row = db.get_session(session_id)
+                source = (row or {}).get("source", "")
+                if source not in _GATEWAY_SOURCES:
+                    db.end_session(session_id, end_reason)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary

Guard `_finalize_session`'s `db.end_session()` call against gateway-owned sessions (telegram, bluebubbles, discord, etc.).  

The TUI is a **viewer** for these sessions, not the lifecycle owner.  Unconditionally  
ending a gateway session in `state.db` creates a Groundhog Day routing loop:

1. Message arrives → routing points to the ended session
2. `#54878` self-heal detects stale entry → drops it  
3. Recovery finds the pre-compression parent session (hours-old context)
4. Context compression splits back to the reaped child
5. Gateway updates routing to the reaped child — but it's still ended
6. Next message → back to (1)

**User-visible symptoms:** The agent reverts to old conversations, re-asks  
questions already answered, forgets recent context — complete conversational amnesia.

## Fix

Before calling `db.end_session()`, query the session's `source` field.  
If the source is a gateway platform (4+ platforms covered), skip the  
`end_session()` call — the gateway is the authoritative lifecycle owner.

## Test Plan

- [x] 232 existing `test_tui_gateway_server` tests pass (1 pre-existing browser/Chromium failure unrelated)
- [x] Existing tests confirm TUI-owned sessions (source=cli/webui) still get `end_session()` called
- [ ] Manual repro: per `#60609` — start gateway session, resume in TUI, disconnect, wait 20s, send message → agent should NOT revert to old context

## Affected Code

- `tui_gateway/server.py`: `_finalize_session()` — 17 lines added, 1 modified

Fixes #60609