### PR TITLE
fix: forward max_tokens to all providers in _build_call_kwargs (#60388)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6243,6 +6243,14 @@ def _build_call_kwargs(
             or _is_nvidia_nim
         ):
             kwargs["max_tokens"] = max_tokens
+        else:
+            # For all other providers (OpenRouter, custom, OpenAI direct,
+            # Nous, Copilot, etc.), forward the cap using the correct
+            # wire-format field.  auxiliary_max_tokens_param() picks
+            # max_tokens vs max_completion_tokens per model/provider.
+            # The retry logic in call_llm() already handles providers
+            # that reject the param by stripping and retrying.  #60388
+            kwargs.update(auxiliary_max_tokens_param(max_tokens, model=model))
 
     if tools:
         # Defensive dedup: providers like Google Vertex, Azure, and Bedrock


### PR DESCRIPTION
## Summary

`_build_call_kwargs()` in `agent/auxiliary_client.py` only injected `max_tokens` into the API request for Anthropic-compat and NVIDIA NIM endpoints. For all other providers (OpenRouter, custom, OpenAI direct, Nous, Copilot), the value was computed upstream but **silently dropped** — the request went out without any output cap.

## Impact

This affects:
- **MoA `reference_max_tokens`**: preset-level caps are ignored, reference models produce unbounded output
- **Title generation**: explicit cap of 500 tokens not forwarded
- **Any auxiliary caller** passing `max_tokens` to `call_llm()` — the value is accepted but never merged into wire-format kwargs

## Root Cause

In `_build_call_kwargs()` (line ~6241), the `if` block only sets `kwargs["max_tokens"]` for Anthropic-compat or NVIDIA NIM. All other providers fall through with no output cap. The function already has `auxiliary_max_tokens_param()` available to pick the correct wire field (`max_tokens` vs `max_completion_tokens`) per model, but doesn't use it for the general case.

## Fix

Add an `else` branch that forwards the cap via `auxiliary_max_tokens_param(max_tokens, model=model)` for non-Anthropic/NIM providers. The existing retry logic in `call_llm()` already handles providers that reject the param by stripping and retrying.

## Testing

- `auxiliary_max_tokens_param()` is already well-tested and handles per-model wire-format selection
- The retry fallback in `call_llm()` catches 400 errors from providers that reject the param
- No behavioral change for Anthropic/NIM (same code path as before)

Closes #60388
