### PR TITLE
fix(config): respect explicit enabled:false for Feishu and WeCom (#47804)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1603,7 +1603,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if feishu_app_id and feishu_app_secret:
         if Platform.FEISHU not in config.platforms:
             config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
+            config.platforms[Platform.FEISHU].enabled = True
+        else:
+            feishu_config = config.platforms[Platform.FEISHU]
+            enabled_was_explicit = bool(feishu_config.extra.pop("_enabled_explicit", False))
+            if not feishu_config.enabled and not enabled_was_explicit:
+                feishu_config.enabled = True
         config.platforms[Platform.FEISHU].extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,
@@ -1631,7 +1636,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if wecom_bot_id and wecom_secret:
         if Platform.WECOM not in config.platforms:
             config.platforms[Platform.WECOM] = PlatformConfig()
-        config.platforms[Platform.WECOM].enabled = True
+            config.platforms[Platform.WECOM].enabled = True
+        else:
+            wecom_config = config.platforms[Platform.WECOM]
+            enabled_was_explicit = bool(wecom_config.extra.pop("_enabled_explicit", False))
+            if not wecom_config.enabled and not enabled_was_explicit:
+                wecom_config.enabled = True
         config.platforms[Platform.WECOM].extra.update({
             "bot_id": wecom_bot_id,
             "secret": wecom_secret,


### PR DESCRIPTION
## Summary

Fixes #47804

When `FEISHU_APP_ID` / `FEISHU_APP_SECRET` (or `WECOM_BOT_ID` / `WECOM_SECRET`) environment variables are present, `_apply_env_overrides()` unconditionally sets `enabled = True`, overriding an explicit `enabled: false` in `config.yaml`. This makes it impossible to disable a platform via config when its env vars are still set (e.g., during multi-profile setups or when credentials are stored in `.env` but the platform should not be active).

## Root Cause

The Slack platform already handles this correctly (line 1345):
```python
slack_config = config.platforms[Platform.SLACK]
enabled_was_explicit = bool(slack_config.extra.pop("_enabled_explicit", False))
if not slack_config.enabled and not enabled_was_explicit:
    slack_config.enabled = True
```

But Feishu (line 1606) and WeCom (line 1639) skip the `_enabled_explicit` check:
```python
config.platforms[Platform.FEISHU].enabled = True  # unconditional
config.platforms[Platform.WECOM].enabled = True   # unconditional
```

## Fix

Apply the same `_enabled_explicit` guard pattern from Slack to both Feishu and WeCom. When the platform config already exists (yaml config present), check `_enabled_explicit` before forcing enable. When no config exists (env-only setup), enable as before.

## Testing

- **Before fix**: `config.yaml` has `feishu.enabled: false`, `.env` has `FEISHU_APP_ID` → Feishu still starts.
- **After fix**: Same setup → Feishu stays disabled (respects explicit `enabled: false`).

## Contributor Context

We (Qijing Digital) operate a multi-profile Hermes deployment (WeCom + Feishu) and hit this bug when trying to disable Feishu on a WeCom-only profile. Our related bug reports: #47564–47573 (WeCom adapter), #47788 (SIGTERM leak, PR #60610), #60350 (cron env leak, PR #60611). This is our third PR.
