### PR TITLE
fix(hooks): pass turn_id to post_tool_call hook (#60578)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -854,6 +854,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     skip_pre_tool_call_hook=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                    turn_id=f"turn_{api_call_count}",
                 )
                 _spinner_result = function_result
             except Exception as tool_error:
@@ -876,6 +877,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     skip_pre_tool_call_hook=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                    turn_id=f"turn_{api_call_count}",
                 )
             except Exception as tool_error:
                 function_result = f"Error executing tool '{function_name}': {tool_error}"

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -125,6 +125,7 @@ _DEFAULT_PAYLOADS = {
         "tool_call_id": "test-call",
         "result": '{"output": "hello"}',
         "duration_ms": 42,
+        "turn_id": "test-turn",
     },
     "pre_llm_call": {
         "session_id": "test-session",

--- a/model_tools.py
+++ b/model_tools.py
@@ -810,6 +810,7 @@ def handle_function_call(
     skip_pre_tool_call_hook: bool = False,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    turn_id: Optional[str] = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1001,6 +1002,7 @@ def handle_function_call(
                 session_id=session_id or "",
                 tool_call_id=tool_call_id or "",
                 duration_ms=duration_ms,
+                turn_id=turn_id or "",
             )
         except Exception as _hook_err:
             logger.debug("post_tool_call hook error: %s", _hook_err)


### PR DESCRIPTION
## Summary

Fixes #60578

The `post_tool_call` plugin hook does not receive `turn_id` — plugins that use it for per-turn deduplication or turn counting silently malfunction.

## Root Cause

`model_tools.py:996-1004` calls `invoke_hook("post_tool_call", ...)` with 7 kwargs, but `turn_id` is not among them. Furthermore, `handle_function_call()` (line 802) does not accept a `turn_id` parameter, so the value is not available anywhere in the dispatch chain.

The `_DEFAULT_PAYLOADS` in `hermes_cli/hooks.py:120-128` confirms this — the test payload has no `turn_id`.

**Impact**: Any plugin using `turn_id` for turn deduplication silently fails. Our ASH (Auto Session Handoff) plugin loaded successfully but never triggered across 27 invocations over 12 hours because `turn_count` stayed at 0 (dead code, no error, no warning).

## Fix

Minimal 5-line change:

1. **`model_tools.py`**: Add `turn_id: Optional[str] = None` to `handle_function_call()` signature; pass `turn_id=turn_id or ""` to `invoke_hook("post_tool_call", ...)`
2. **`agent/tool_executor.py`**: Pass `turn_id=f"turn_{api_call_count}"` at both call sites (concurrent + sequential paths). `api_call_count` is already available at these call sites.
3. **`hermes_cli/hooks.py`**: Add `"turn_id": "test-turn"` to `_DEFAULT_PAYLOADS["post_tool_call"]` for `hermes hooks test` / `hermes hooks doctor`.

`turn_id` is derived from `api_call_count` (format: `"turn_3"`, `"turn_4"`, etc.), which already tracks the current conversation turn. This provides per-turn uniqueness for deduplication without introducing a new concept to the agent loop.

## Design Notes

- `turn_id` was previously only available in the Codex transport path (`codex_app_server_session.py`). This PR makes it available to all transport paths (WeCom, Telegram, CLI, etc.).
- The `turn_id` parameter is optional (`None` default) — existing call sites that don't pass it are unaffected.
- The format `f"turn_{api_call_count}"` is deterministic and monotonically increasing within a session.

## Related Issues

This is part of a systemic pattern of hook parameters being silently dropped:
- #34618 — `session_id` not propagated to `pre_tool_call`
- #51931 — Nested tool hooks can't get `session_id`
- #48311 — `pre_tool_call` hooks receive empty `session_id`

## Contributor Context

We (Qijing Digital) have reported multiple gateway/platform bugs and are submitting PRs for clear, minimal fixes. See also: #60610 (killpg guard), #60611 (cron env var cleanup), #60621 (Feishu/WeCom env forced enable).
