### PR TITLE
fix(wecom): heartbeat uses request-response to detect half-open connections (#58649)

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -365,22 +365,39 @@ class WeComAdapter(BasePlatformAdapter):
                 raise RuntimeError("WeCom websocket closed")
 
     async def _heartbeat_loop(self) -> None:
-        """Send lightweight application-level pings."""
+        """Send application-level pings and verify pong responses.
+
+        Uses _send_request (await response) instead of _send_json
+        (fire-and-forget) so that a half-open TCP connection (CLOSE_WAIT)
+        is detected when the ping response times out.  On timeout, marks
+        the connection as disconnected so _listen_loop triggers a
+        reconnect (#58649).
+        """
         try:
             while self._running:
                 await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
                 if not self._ws or self._ws.closed:
                     continue
                 try:
-                    await self._send_json(
-                        {
-                            "cmd": APP_CMD_PING,
-                            "headers": {"req_id": self._new_req_id("ping")},
-                            "body": {},
-                        }
+                    await self._send_request(
+                        APP_CMD_PING,
+                        {},
+                        timeout=HEARTBEAT_INTERVAL_SECONDS,
                     )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "[%s] Heartbeat ping timed out — marking connection stale for reconnect",
+                        self.name,
+                    )
+                    self._mark_disconnected()
+                    if self._ws and not self._ws.closed:
+                        try:
+                            await self._ws.close()
+                        except Exception:
+                            pass
                 except Exception as exc:
                     logger.debug("[%s] Heartbeat send failed: %s", self.name, exc)
+                    self._mark_disconnected()
         except asyncio.CancelledError:
             pass
 


### PR DESCRIPTION
## Summary

Relates to #58649 (upstream #11554 fix was incomplete)

The WeCom heartbeat loop used `_send_json` (fire-and-forget) to send application-level pings. On a half-open TCP connection (CLOSE_WAIT state), the ping payload could be buffered locally by the OS without raising an error, but the server never receives it. The adapter appeared "connected" — DM messages to the bot kept the `_read_events` loop alive — but group chat messages were silently dropped because the server-side WebSocket subscription had expired.

## Root Cause

```python
# Before: fire-and-forget — no way to detect if server received the ping
await self._send_json({"cmd": APP_CMD_PING, ...})
```

If the TCP connection is in CLOSE_WAIT (common after network interruptions or NAT timeout), `send_json` succeeds (buffered by OS), but the data never reaches the WeCom server. The heartbeat loop continues indefinitely, believing the connection is healthy.

Meanwhile, the WeCom server drops the subscription after not receiving ACKs. DM messages that happen to arrive (via a separate HTTP callback path) keep the `_read_events` loop active, masking the problem. Group chat messages, which require the WebSocket subscription, are silently lost.

## Fix

```python
# After: await correlated response — timeout means connection is stale
await self._send_request(APP_CMD_PING, {}, timeout=HEARTBEAT_INTERVAL_SECONDS)
```

Switch from `_send_json` to `_send_request`, which awaits a correlated response (pong). If the response does not arrive within `HEARTBEAT_INTERVAL_SECONDS`, the request times out — proving the connection is stale. On timeout:

1. Log a warning with the adapter name
2. Call `_mark_disconnected()` to update connection state
3. Close `self._ws` to trigger `_listen_loop`'s reconnect logic with exponential backoff

## Context

Upstream #11554 addressed CLOSE_WAIT detection by tightening keepalive (`heartbeat=HEARTBEAT_INTERVAL_SECONDS * 2` at the ws_connect level), but this only detects TCP-level closures. It does not detect application-level subscription loss where the TCP connection is alive but the WeCom server has dropped the subscription. This PR fills that gap.

## Testing

Validated in production over multiple network interruption events. Before the fix, group chat messages were silently lost after NAT timeouts. After the fix, the heartbeat timeout triggers a reconnect within one `HEARTBEAT_INTERVAL_SECONDS` cycle.

## Contributor Context

We (Qijing Digital) operate a multi-profile Hermes deployment on WeCom. Related PRs: #60610 (killpg guard), #60611 (cron env var cleanup), #60621 (Feishu/WeCom env forced enable), #60622 (post_tool_call turn_id), #60625 (WeCom adapter fixes).
