### PR TITLE
Fix Discord ffmpeg discovery on Windows

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -114,6 +114,11 @@ import sys
 from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
+try:
+    from .ffmpeg_utils import resolve_ffmpeg_executable
+except ImportError:
+    from ffmpeg_utils import resolve_ffmpeg_executable
+
 from gateway.config import Platform, PlatformConfig
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
@@ -760,7 +765,7 @@ class VoiceReceiver:
 
             subprocess.run(
                 [
-                    "ffmpeg", "-y", "-loglevel", "error",
+                    resolve_ffmpeg_executable(), "-y", "-loglevel", "error",
                     "-f", "s16le",
                     "-ar", str(src_rate),
                     "-ac", str(src_channels),
@@ -3892,7 +3897,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     logger.error("Voice playback error: %s", error)
                 loop.call_soon_threadsafe(done.set)
 
-            source = discord.FFmpegPCMAudio(audio_path)
+            source = discord.FFmpegPCMAudio(
+                audio_path,
+                executable=resolve_ffmpeg_executable(),
+            )
             source = discord.PCMVolumeTransformer(source, volume=1.0)
             vc.play(source, after=_after)
             try:

--- a/plugins/platforms/discord/ffmpeg_utils.py
+++ b/plugins/platforms/discord/ffmpeg_utils.py
@@ -1,0 +1,27 @@
+"""Shared ffmpeg executable discovery for Discord voice paths."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+
+def resolve_ffmpeg_executable() -> str:
+    """Return an ffmpeg command that also covers common Windows installs."""
+    explicit = os.getenv("FFMPEG_PATH")
+    if explicit and explicit.strip():
+        return os.path.expandvars(os.path.expanduser(explicit.strip()))
+
+    discovered = shutil.which("ffmpeg")
+    if discovered:
+        return discovered
+
+    local_appdata = os.getenv("LOCALAPPDATA")
+    if local_appdata:
+        packages_dir = Path(local_appdata) / "Microsoft" / "WinGet" / "Packages"
+        candidates = sorted(packages_dir.glob("Gyan.FFmpeg_*/*/bin/ffmpeg.exe"))
+        if candidates:
+            return str(candidates[-1])
+
+    return "ffmpeg"

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -46,6 +46,11 @@ import logging
 import threading
 from typing import TYPE_CHECKING, List, Optional
 
+try:
+    from .ffmpeg_utils import resolve_ffmpeg_executable
+except ImportError:
+    from ffmpeg_utils import resolve_ffmpeg_executable
+
 if TYPE_CHECKING:  # numpy is an optional ("voice" extra) dep — never import at runtime top-level
     import numpy as np
 
@@ -311,7 +316,7 @@ def decode_to_pcm(path: str, *, timeout: float = 30.0) -> Optional[bytes]:
     try:
         proc = subprocess.run(
             [
-                "ffmpeg", "-y", "-loglevel", "error",
+                resolve_ffmpeg_executable(), "-y", "-loglevel", "error",
                 "-i", path,
                 "-f", "s16le",
                 "-ar", str(SAMPLE_RATE),

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -207,6 +207,45 @@ class TestPlayInVoiceChannelMixerPath:
         vc.play.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_mixer_decode_uses_resolved_ffmpeg_executable(self, monkeypatch):
+        adapter = _make_adapter()
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        adapter._voice_clients[111] = vc
+
+        class _Mixer:
+            def __init__(self):
+                self._polls = 0
+                self.play_speech = MagicMock()
+
+            @property
+            def speech_active(self):
+                self._polls += 1
+                return self._polls <= 1
+
+        mixer = _Mixer()
+        adapter._voice_mixers[111] = mixer
+        adapter._reset_voice_timeout = MagicMock()
+
+        resolved = r"C:\tools\ffmpeg.exe"
+        fake_pcm = b"\x00" * vm.FRAME_SIZE
+        completed = MagicMock(returncode=0, stdout=fake_pcm, stderr=b"")
+        monkeypatch.setattr(
+            vm,
+            "resolve_ffmpeg_executable",
+            lambda: resolved,
+            raising=False,
+        )
+
+        with patch("subprocess.run", return_value=completed) as run:
+            ok = await adapter.play_in_voice_channel(111, "/tmp/x.mp3")
+
+        assert ok is True
+        assert run.call_args.args[0][0] == resolved
+        mixer.play_speech.assert_called_once()
+        vc.play.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_falls_back_when_decode_fails(self):
         adapter = _make_adapter()
         vc = MagicMock()

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1,5 +1,6 @@
 """Tests for the /voice command and auto voice reply in the gateway."""
 
+import asyncio
 import importlib.util
 import json
 import os
@@ -724,6 +725,47 @@ class TestVoiceReceiver:
         receiver._last_packet_time[100] = time.monotonic() - 3.0
         completed = receiver.check_silence()
         assert len(completed) == 0
+
+    def test_ffmpeg_resolver_finds_winget_install_when_not_on_path(self, monkeypatch, tmp_path):
+        """Windows winget installs ffmpeg outside PATH; Discord voice should still find it."""
+        from plugins.platforms.discord import ffmpeg_utils
+
+        ffmpeg = (
+            tmp_path
+            / "Microsoft"
+            / "WinGet"
+            / "Packages"
+            / "Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe"
+            / "ffmpeg-7.1-full_build"
+            / "bin"
+            / "ffmpeg.exe"
+        )
+        ffmpeg.parent.mkdir(parents=True)
+        ffmpeg.write_text("", encoding="utf-8")
+
+        monkeypatch.delenv("FFMPEG_PATH", raising=False)
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+        monkeypatch.setattr(ffmpeg_utils.shutil, "which", lambda _cmd: None)
+
+        assert ffmpeg_utils.resolve_ffmpeg_executable() == str(ffmpeg)
+
+    def test_pcm_to_wav_uses_resolved_ffmpeg_executable(self, monkeypatch, tmp_path):
+        """Receiver conversion should use the same resolved executable as playback."""
+        from plugins.platforms.discord import adapter as discord_adapter
+        from plugins.platforms.discord.adapter import VoiceReceiver
+
+        calls = []
+        monkeypatch.setattr(discord_adapter, "resolve_ffmpeg_executable", lambda: r"C:\tools\ffmpeg.exe")
+
+        def fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+
+        monkeypatch.setattr(discord_adapter.subprocess, "run", fake_run)
+
+        VoiceReceiver.pcm_to_wav(b"\x00\x00" * 100, str(tmp_path / "out.wav"))
+
+        assert calls
+        assert calls[0][0][0] == r"C:\tools\ffmpeg.exe"
 
     def test_stale_buffer_discarded(self):
         receiver = self._make_receiver()
@@ -2070,6 +2112,28 @@ class TestPlaybackTimeout:
         from plugins.platforms.discord.adapter import DiscordAdapter
         assert hasattr(DiscordAdapter, "PLAYBACK_TIMEOUT")
         assert DiscordAdapter.PLAYBACK_TIMEOUT > 0
+
+    def test_voice_playback_passes_resolved_ffmpeg_executable(self, monkeypatch):
+        """discord.py playback should receive the resolved ffmpeg path via executable=."""
+        from plugins.platforms.discord import adapter as discord_adapter
+
+        adapter = self._make_discord_adapter()
+
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_vc.is_playing.return_value = False
+        mock_vc.play.side_effect = lambda _source, after=None: after and after(None)
+        adapter._voice_clients[111] = mock_vc
+        adapter._voice_timeout_tasks[111] = MagicMock()
+
+        monkeypatch.setattr(discord_adapter, "resolve_ffmpeg_executable", lambda: r"C:\tools\ffmpeg.exe")
+
+        with patch("discord.FFmpegPCMAudio") as ffmpeg_audio, \
+             patch("discord.PCMVolumeTransformer", side_effect=lambda source, **_kw: source):
+            result = asyncio.run(adapter.play_in_voice_channel(111, "/tmp/test.mp3"))
+
+        assert result is True
+        ffmpeg_audio.assert_called_once_with("/tmp/test.mp3", executable=r"C:\tools\ffmpeg.exe")
 
     @pytest.mark.asyncio
     async def test_playback_timeout_fires(self):


### PR DESCRIPTION
## Summary
- add a shared Discord ffmpeg resolver that honors `FFMPEG_PATH`, PATH, and Windows winget installs under `%LOCALAPPDATA%\Microsoft\WinGet\Packages`
- use the resolver for voice transcription conversion, voice-FX mixer decoding, and legacy Discord `FFmpegPCMAudio` playback
- add regression coverage for winget discovery and all three Discord voice call paths

Fixes #60624.

## Validation
- rebased onto current `main@56e2ba5e7`; `git range-diff` confirms the one-commit patch is unchanged from prior head `c9eb9ca4c`
- direct Pytest on `tests/gateway/test_voice_command.py` and `tests/gateway/test_discord_voice_mixer.py` -> **190 passed, 1 skipped** on exact head `7a091f8e8`
- `ruff check` on all five touched files
- `ruff format --check plugins/platforms/discord/ffmpeg_utils.py`
- `python -m py_compile` on all five touched files
- `python scripts/check-windows-footguns.py` on all five touched files
- `git diff --check origin/main...HEAD`

The branch remains non-Draft; the earlier review request is implemented in the shared helper and mixer decode path, with zero current unresolved review threads.
