### PR TITLE
fix(file-ops): pre-write syntax gate for JSON/YAML/TOML

### DIFF
--- a/tests/tools/test_write_file_syntax_gate.py
+++ b/tests/tools/test_write_file_syntax_gate.py
@@ -1,0 +1,255 @@
+"""Tests for the pre-write syntax gate in write_file().
+
+When write_file() is called with JSON/YAML/TOML content, the
+in-process syntax check must fire BEFORE _atomic_write().  A parse
+failure should set result.error so that the file_tools wrapper
+correctly suppresses ``files_modified`` reporting.
+
+Fixes: #60525
+"""
+
+import json
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+from tools.file_operations import (
+    ShellFileOperations,
+    _lint_json_inproc,
+    _lint_yaml_inproc,
+    _lint_toml_inproc,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def mock_env(tmp_path):
+    """Create a mock terminal environment backed by a real tmp dir."""
+    env = MagicMock()
+    env.cwd = str(tmp_path)
+
+    def fake_execute(cmd, cwd=None, **kwargs):
+        # Simulate shell execution for file I/O commands we care about.
+        # kwargs may include stdin_data, timeout, etc. — ignore them.
+        if cmd.startswith("cat ") or cmd.startswith("wc -c < "):
+            return {"output": "", "returncode": 1}
+        if cmd.startswith("mkdir -p "):
+            return {"output": "", "returncode": 0}
+        return {"output": "", "returncode": 0}
+
+    env.execute = MagicMock(side_effect=fake_execute)
+    return env
+
+
+@pytest.fixture()
+def file_ops(mock_env):
+    return ShellFileOperations(mock_env)
+
+
+# ===========================================================================
+# JSON syntax gate
+# ===========================================================================
+
+class TestJSONSyntaxGate:
+    """write_file() must reject invalid JSON before writing to disk."""
+
+    def test_valid_json_succeeds(self, file_ops, tmp_path):
+        """Valid JSON should pass through and be written."""
+        path = str(tmp_path / "config.json")
+        content = '{"name": "test", "value": 42}'
+        result = file_ops.write_file(path, content)
+        assert result.error is None
+
+    def test_truncated_json_aborted(self, file_ops, tmp_path):
+        """Truncated JSON must be rejected before disk write."""
+        path = str(tmp_path / "config.json")
+        content = '{"a": 1,'
+        result = file_ops.write_file(path, content)
+        assert result.error is not None
+        assert "Syntax check failed" in result.error
+        assert "JSONDecodeError" in result.error
+        # File must NOT exist on disk
+        assert not os.path.exists(path)
+
+    def test_invalid_json_type_aborted(self, file_ops, tmp_path):
+        """JSON with trailing garbage must be rejected."""
+        path = str(tmp_path / "data.json")
+        content = '{"a": 1}garbage'
+        result = file_ops.write_file(path, content)
+        assert result.error is not None
+        assert not os.path.exists(path)
+
+    def test_empty_object_json_succeeds(self, file_ops, tmp_path):
+        """Empty JSON object is valid syntax."""
+        path = str(tmp_path / "empty.json")
+        result = file_ops.write_file(path, '{}')
+        assert result.error is None
+
+    def test_json_array_succeeds(self, file_ops, tmp_path):
+        """JSON array is valid syntax."""
+        path = str(tmp_path / "list.json")
+        result = file_ops.write_file(path, '[1, 2, 3]')
+        assert result.error is None
+
+    def test_error_response_has_lint_field(self, file_ops, tmp_path):
+        """The WriteResult must carry a lint dict when the gate fires."""
+        path = str(tmp_path / "bad.json")
+        result = file_ops.write_file(path, '{invalid')
+        assert result.error is not None
+        assert result.lint is not None
+        assert result.lint["status"] == "error"
+        assert "JSONDecodeError" in result.lint["message"]
+
+
+# ===========================================================================
+# YAML syntax gate
+# ===========================================================================
+
+class TestYAMLSyntaxGate:
+    """write_file() must reject invalid YAML before writing to disk."""
+
+    def test_valid_yaml_succeeds(self, file_ops, tmp_path):
+        """Valid YAML should pass through."""
+        path = str(tmp_path / "config.yaml")
+        content = "key: value\nlist:\n  - one\n  - two\n"
+        result = file_ops.write_file(path, content)
+        assert result.error is None
+
+    def test_unclosed_quote_yaml_aborted(self, file_ops, tmp_path):
+        """YAML with unclosed quote must be rejected."""
+        path = str(tmp_path / "bad.yaml")
+        content = 'key: "unclosed\n'
+        result = file_ops.write_file(path, content)
+        assert result.error is not None
+        assert "Syntax check failed" in result.error
+        assert not os.path.exists(path)
+
+    def test_yml_extension_also_gated(self, file_ops, tmp_path):
+        """The .yml extension must also trigger the syntax gate."""
+        path = str(tmp_path / "app.yml")
+        content = '{invalid: [unclosed'
+        result = file_ops.write_file(path, content)
+        assert result.error is not None
+        assert not os.path.exists(path)
+
+
+# ===========================================================================
+# TOML syntax gate
+# ===========================================================================
+
+class TestTOMLSyntaxGate:
+    """write_file() must reject invalid TOML before writing to disk."""
+
+    def test_valid_toml_succeeds(self, file_ops, tmp_path):
+        """Valid TOML should pass through."""
+        path = str(tmp_path / "pyproject.toml")
+        content = '[section]\nkey = "value"\n'
+        result = file_ops.write_file(path, content)
+        assert result.error is None
+
+    def test_invalid_toml_aborted(self, file_ops, tmp_path):
+        """Invalid TOML must be rejected before disk write."""
+        path = str(tmp_path / "pyproject.toml")
+        content = '[section\nkey = "value"'  # missing closing bracket
+        result = file_ops.write_file(path, content)
+        assert result.error is not None
+        assert "Syntax check failed" in result.error
+        assert not os.path.exists(path)
+
+
+# ===========================================================================
+# Non-gated extensions must NOT be affected
+# ===========================================================================
+
+class TestNonGatedExtensions:
+    """Extensions outside the syntax gate must behave as before."""
+
+    def test_python_not_gated(self, file_ops, tmp_path):
+        """Python files must NOT be syntax-gated (would break test fixtures)."""
+        path = str(tmp_path / "fixture.py")
+        # This is not valid Python but should NOT be gated — only linted post-write.
+        # The gate is intentionally scoped to JSON/YAML/TOML only.
+        content = "this is not valid python syntax at all"
+        # With a mock env that doesn't actually write, we only test that
+        # the gate does NOT intercept .py writes.
+        result = file_ops.write_file(path, content)
+        # Should NOT have a syntax gate error
+        assert result.error is None or "Syntax check failed" not in (result.error or "")
+
+    def test_markdown_not_gated(self, file_ops, tmp_path):
+        """Markdown files have no linter and should pass through."""
+        path = str(tmp_path / "readme.md")
+        content = "# Title\n\nSome **markdown** content.\n"
+        result = file_ops.write_file(path, content)
+        assert result.error is None or "Syntax check failed" not in (result.error or "")
+
+    def test_txt_not_gated(self, file_ops, tmp_path):
+        """Plain text files should pass through."""
+        path = str(tmp_path / "notes.txt")
+        content = "Just some text.\n"
+        result = file_ops.write_file(path, content)
+        assert result.error is None or "Syntax check failed" not in (result.error or "")
+
+
+# ===========================================================================
+# Regression: gate does not interfere with post-write lint delta
+# ===========================================================================
+
+class TestGateAndLintDeltaCoexist:
+    """The pre-write gate and post-write lint-delta should coexist."""
+
+    def test_valid_json_lint_still_runs(self, file_ops, tmp_path):
+        """After a successful gate pass, the post-write lint should still fire."""
+        path = str(tmp_path / "clean.json")
+        content = '{"valid": true}'
+        with patch.object(file_ops, '_check_lint_delta', wraps=file_ops._check_lint_delta) as spy:
+            result = file_ops.write_file(path, content)
+            # _check_lint_delta should have been called (post-write lint)
+            spy.assert_called_once()
+
+    def test_invalid_json_lint_delta_not_called(self, file_ops, tmp_path):
+        """When the gate fires, _check_lint_delta should NOT be called."""
+        path = str(tmp_path / "bad.json")
+        content = '{broken json'
+        with patch.object(file_ops, '_check_lint_delta', return_value=None) as spy:
+            result = file_ops.write_file(path, content)
+            spy.assert_not_called()
+            assert result.error is not None
+
+
+# ===========================================================================
+# Linter unit sanity checks (direct function calls)
+# ===========================================================================
+
+class TestLinterFunctionsSanity:
+    """Quick sanity on the in-process linter functions used by the gate."""
+
+    def test_json_valid(self):
+        ok, msg = _lint_json_inproc('{"a": 1}')
+        assert ok is True
+        assert msg == ""
+
+    def test_json_invalid(self):
+        ok, msg = _lint_json_inproc('{"a": 1,')
+        assert ok is False
+        assert "JSONDecodeError" in msg
+
+    def test_yaml_valid(self):
+        ok, msg = _lint_yaml_inproc("a: 1\n")
+        assert ok is True
+
+    def test_yaml_invalid(self):
+        ok, msg = _lint_yaml_inproc('key: "unclosed\n')
+        assert ok is False
+        assert "YAMLError" in msg
+
+    def test_toml_valid(self):
+        ok, msg = _lint_toml_inproc("[s]\nk = 'v'\n")
+        assert ok is True
+
+    def test_toml_invalid(self):
+        ok, msg = _lint_toml_inproc("[s\nk = 'v'")
+        assert ok is False

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1388,6 +1388,30 @@ class ShellFileOperations(FileOperations):
         if self._file_has_bom(path, pre_content) and not _has_bom(content):
             content = _UTF8_BOM + content
 
+        # ── Pre-write syntax gate (JSON / YAML / TOML) ──────────────
+        # For structured data formats, validate the content *before* any
+        # disk write so that malformed content never lands on disk.  The
+        # post-write lint check (`_check_lint_delta`) still runs and
+        # reports issues, but it fires *after* the file is committed — too
+        # late for cases like corrupted cron config or live JSON manifests.
+        #
+        # Deliberately scoped to JSON, YAML, and TOML only.  Python is
+        # excluded because existing test suites write non-Python text
+        # through ``*.py`` paths as generic write-mechanics fixtures — a
+        # naive blanket scope broke 3 previously-green tests.
+        _SYNTAX_GATE_EXTENSIONS = ('.json', '.yaml', '.yml', '.toml')
+        _inproc_linter = LINTERS_INPROC.get(ext)
+        if ext in _SYNTAX_GATE_EXTENSIONS and _inproc_linter is not None:
+            _gate_ok, _gate_msg = _inproc_linter(content)
+            if not _gate_ok:
+                return WriteResult(
+                    error=(
+                        f"Syntax check failed for {path}: {_gate_msg}. "
+                        "Write aborted — no content was written to disk."
+                    ),
+                    lint={"status": "error", "message": _gate_msg},
+                )
+
         # Snapshot LSP diagnostics for this file (best-effort) so the
         # post-write LSP layer can return only diagnostics introduced
         # by this specific edit.  Mirrors claude-code's


### PR DESCRIPTION
## Summary

**Fixes #60525** — `write_file()` now validates JSON, YAML, and TOML content *before* any disk write.

### Problem

Previously, `write_file()` only validated structured data formats *after* writing to disk via `_check_lint_delta`. This meant malformed JSON/YAML/TOML could land on disk before being flagged — too late for live manifests, cron configs, or CI pipelines that read the file immediately.

### Solution

Added a **pre-write syntax gate** that fires *before* `_atomic_write()`:

1. Checks if the target file extension is `.json`, `.yaml`, `.yml`, or `.toml`
2. Runs the existing in-process linter (`LINTERS_INPROC` map) against the content
3. If validation fails, returns early with `result.error` + `result.lint` set — no content touches disk
4. The `file_tools` wrapper correctly suppresses `files_modified` reporting when `result.error` is set

Deliberately scoped to JSON/YAML/TOML only. Python is excluded because existing test suites use `*.py` paths as generic write-mechanics fixtures.

### Testing

- **22 new tests** in `tests/tools/test_write_file_syntax_gate.py`
- **181 existing tests pass** (zero regressions)
- Coverage: valid content passes through, invalid content aborted, non-gated extensions unaffected, gate + lint-delta coexistence, direct linter sanity checks

### How to verify

\`\`\`bash
python -m pytest tests/tools/test_write_file_syntax_gate.py -v
python -m pytest tests/tools/test_file_operations*.py -v
\`\`\`
