### PR TITLE
fix(anthropic): serialize Claude Code OAuth refresh under the auth-store lock

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1112,18 +1112,64 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
         logger.debug("No refresh token available — cannot refresh")
         return None
 
+    # Claude Code OAuth refresh tokens are single-use. Multiple concurrent
+    # callers (every anthropic_messages API call runs
+    # _try_refresh_anthropic_client_credentials, plus auxiliary tasks, plus
+    # the credential pool) can otherwise each POST the same refresh token,
+    # invalidate one another, and drive Anthropic's refresh endpoint into
+    # 429s — after which the sole Anthropic credential is marked exhausted
+    # and every live turn silently falls back to another provider.
+    #
+    # Serialize the read→POST→write-back through the shared cross-process
+    # auth-store flock (reentrant, so the credential-pool refresh path that
+    # already holds it does not deadlock). Once inside the lock, re-read the
+    # live credential file: if the winner already rotated the token, adopt it
+    # and skip the POST entirely.
     try:
-        refreshed = refresh_anthropic_oauth_pure(refresh_token, use_json=False)
-        _write_claude_code_credentials(
-            refreshed["access_token"],
-            refreshed["refresh_token"],
-            refreshed["expires_at_ms"],
-        )
-        logger.debug("Successfully refreshed Claude Code OAuth token")
-        return refreshed["access_token"]
-    except Exception as e:
-        logger.debug("Failed to refresh Claude Code token: %s", e)
-        return None
+        from hermes_cli.auth import _auth_store_lock, AUTH_LOCK_TIMEOUT_SECONDS
+        from utils import env_float
+
+        refresh_timeout_seconds = env_float("HERMES_ANTHROPIC_REFRESH_TIMEOUT_SECONDS", 30)
+        lock_timeout = max(float(AUTH_LOCK_TIMEOUT_SECONDS), float(refresh_timeout_seconds) + 5.0)
+        _lock_cm = _auth_store_lock(timeout_seconds=lock_timeout)
+    except Exception:
+        # If the lock helper is unavailable for any reason, fall back to the
+        # unserialized path rather than failing the refresh outright.
+        _lock_cm = None
+
+    def _do_refresh() -> Optional[str]:
+        # Re-read inside the lock: the winner may have already rotated the
+        # token while we waited, in which case adopt it and skip the POST.
+        latest = read_claude_code_credentials()
+        if latest:
+            latest_token = latest.get("accessToken", "")
+            latest_exp = latest.get("expiresAt", 0) or 0
+            if (
+                latest_token
+                and latest_token != creds.get("accessToken", "")
+                and latest_exp > 0
+                and is_claude_code_token_valid(latest)
+            ):
+                logger.debug("Adopted concurrently-refreshed Claude Code OAuth token (in-lock)")
+                return latest_token
+        effective_refresh = (latest or {}).get("refreshToken", "") or refresh_token
+        try:
+            refreshed = refresh_anthropic_oauth_pure(effective_refresh, use_json=False)
+            _write_claude_code_credentials(
+                refreshed["access_token"],
+                refreshed["refresh_token"],
+                refreshed["expires_at_ms"],
+            )
+            logger.debug("Successfully refreshed Claude Code OAuth token")
+            return refreshed["access_token"]
+        except Exception as e:
+            logger.debug("Failed to refresh Claude Code token: %s", e)
+            return None
+
+    if _lock_cm is None:
+        return _do_refresh()
+    with _lock_cm:
+        return _do_refresh()
 
 
 def _write_claude_code_credentials(

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -113,6 +113,11 @@ SUPPORTED_POOL_STRATEGIES = {
 EXHAUSTED_TTL_401_SECONDS = 5 * 60           # 5 minutes
 EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
+# Anthropic Claude Code OAuth token-refresh 429s are usually short-lived
+# control-plane throttles, not a model-usage quota window.  Treating them like
+# generic provider 429s freezes Claude for an hour and pushes every live turn to
+# fallback even though retrying shortly afterwards often succeeds.
+ANTHROPIC_OAUTH_REFRESH_429_TTL_SECONDS = 60  # 1 minute
 
 # Pool key prefix for custom OpenAI-compatible endpoints.
 # Custom endpoints all share provider='custom' but are keyed by their
@@ -965,14 +970,30 @@ class CredentialPool:
                 self._mark_exhausted(entry, None)
             return None
 
-        # Codex OAuth refresh tokens are single-use.  The sync→POST→write-back
+        # OAuth refresh tokens are single-use.  The sync→POST→write-back
         # sequence below must run atomically across Hermes processes: otherwise
         # two processes can both adopt the same on-disk token, both POST it, and
-        # the loser gets ``refresh_token_reused``.  Serialize the whole sequence
-        # through the shared cross-process auth-store flock (the same lock and
-        # extended-timeout pattern used by resolve_codex_runtime_credentials()).
-        # When a waiter finally acquires the lock, the in-lock re-sync below
-        # picks up the rotated token the winner persisted and skips the POST.
+        # the loser gets refresh_token_reused / invalid_grant or upstream refresh
+        # throttling.  Serialize refresh paths that share a singleton backing
+        # store through the shared cross-process auth-store flock.  When a waiter
+        # finally acquires the lock, the in-lock re-sync picks up the rotated
+        # token the winner persisted and can skip the POST.
+        if self.provider == "anthropic" and entry.source == "claude_code":
+            refresh_timeout_seconds = auth_mod.env_float(
+                "HERMES_ANTHROPIC_REFRESH_TIMEOUT_SECONDS", 30
+            )
+            lock_timeout = max(
+                float(auth_mod.AUTH_LOCK_TIMEOUT_SECONDS),
+                float(refresh_timeout_seconds) + 5.0,
+            )
+            with _auth_store_lock(timeout_seconds=lock_timeout):
+                synced = self._sync_anthropic_entry_from_credentials_file(entry)
+                if synced is not entry:
+                    entry = synced
+                    if not force and not self._entry_needs_refresh(entry):
+                        return entry
+                return self._refresh_entry_impl(entry, force=force)
+
         if self.provider == "openai-codex":
             refresh_timeout_seconds = auth_mod.env_float(
                 "HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", 20
@@ -1069,6 +1090,22 @@ class CredentialPool:
                 return entry
         except Exception as exc:
             logger.debug("Credential refresh failed for %s/%s: %s", self.provider, entry.id, exc)
+            refresh_status_code = getattr(exc, "code", None)
+            try:
+                refresh_status_code = int(refresh_status_code) if refresh_status_code is not None else None
+            except (TypeError, ValueError):
+                refresh_status_code = None
+            refresh_error_context: Optional[Dict[str, Any]] = None
+            if (
+                self.provider == "anthropic"
+                and entry.source == "claude_code"
+                and refresh_status_code == 429
+            ):
+                refresh_error_context = {
+                    "reason": "oauth_refresh_rate_limited",
+                    "message": "Anthropic OAuth token refresh was rate limited; using a short retry cooldown",
+                    "reset_at": time.time() + ANTHROPIC_OAUTH_REFRESH_429_TTL_SECONDS,
+                }
             # For anthropic claude_code entries: the refresh token may have been
             # consumed by another process. Check if ~/.claude/.credentials.json
             # has a newer token pair and retry once.
@@ -1318,7 +1355,7 @@ class CredentialPool:
                         self._current_id = None
                     self._persist(removed_ids=removed_ids)
                     return None
-            self._mark_exhausted(entry, None)
+            self._mark_exhausted(entry, refresh_status_code, refresh_error_context)
             return None
 
         updated = replace(

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -568,6 +568,96 @@ class TestRefreshOauthToken:
         with patch("urllib.request.urlopen", side_effect=Exception("network error")):
             assert _refresh_oauth_token(creds) is None
 
+    def test_refresh_runs_under_auth_store_lock(self, tmp_path, monkeypatch):
+        """The single-use refresh POST must be serialized by the shared auth lock.
+
+        Concurrent anthropic_messages turns / aux tasks / the pool all funnel
+        through _refresh_oauth_token; without the lock they each replay the same
+        single-use refresh token and trigger 429s that exhaust the sole
+        Anthropic credential and force a provider fallback.
+        """
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        lock_calls = []
+        import contextlib
+
+        @contextlib.contextmanager
+        def _fake_lock(timeout_seconds=None):
+            lock_calls.append(timeout_seconds)
+            yield
+
+        monkeypatch.setattr("hermes_cli.auth._auth_store_lock", _fake_lock)
+
+        creds = {
+            "accessToken": "old-token",
+            "refreshToken": "refresh-123",
+            "expiresAt": int(time.time() * 1000) - 3600_000,
+        }
+        # No concurrently-rotated token on disk → the POST path runs (under lock).
+        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.refresh_anthropic_oauth_pure",
+            lambda refresh_token, use_json=False: {
+                "access_token": "new-token-abc",
+                "refresh_token": "new-refresh-456",
+                "expires_at_ms": int(time.time() * 1000) + 7200_000,
+            },
+        )
+        monkeypatch.setattr("agent.anthropic_adapter._write_claude_code_credentials", lambda *a, **k: None)
+
+        result = _refresh_oauth_token(creds)
+
+        assert result == "new-token-abc"
+        assert lock_calls, "refresh POST must be wrapped in the shared auth-store lock"
+
+    def test_refresh_adopts_concurrently_rotated_token_without_posting(self, tmp_path, monkeypatch):
+        """A lock waiter must adopt the winner's rotated token, not re-POST.
+
+        Simulates process B entering _refresh_oauth_token after process A has
+        already refreshed and written ~/.claude/.credentials.json. B must return
+        the fresh token and never call refresh_anthropic_oauth_pure again.
+        """
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        import contextlib
+
+        @contextlib.contextmanager
+        def _fake_lock(timeout_seconds=None):
+            yield
+
+        monkeypatch.setattr("hermes_cli.auth._auth_store_lock", _fake_lock)
+
+        stale_creds = {
+            "accessToken": "stale-access",
+            "refreshToken": "stale-refresh",
+            "expiresAt": int(time.time() * 1000) - 3600_000,
+        }
+        # First read (pre-lock adoption check): still stale.
+        # Second read (in-lock): winner has rotated a fresh valid token.
+        reads = [
+            dict(stale_creds),
+            {
+                "accessToken": "winner-access",
+                "refreshToken": "winner-refresh",
+                "expiresAt": int(time.time() * 1000) + 7200_000,
+            },
+        ]
+
+        def _fake_read():
+            return reads.pop(0) if reads else reads_last[0]
+
+        reads_last = [reads[-1]]
+        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", _fake_read)
+
+        def _should_not_post(*args, **kwargs):
+            raise AssertionError("must adopt rotated token instead of POSTing the consumed refresh token")
+
+        monkeypatch.setattr("agent.anthropic_adapter.refresh_anthropic_oauth_pure", _should_not_post)
+
+        result = _refresh_oauth_token(stale_creds)
+
+        assert result == "winner-access"
+
 
 class TestWriteClaudeCodeCredentials:
     def test_writes_new_file(self, tmp_path, monkeypatch):

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1805,6 +1805,150 @@ def test_load_pool_oauth_path_still_autodiscovers(tmp_path, monkeypatch):
     assert "claude_code" in sources
 
 
+class _RecordingLock:
+    def __init__(self, calls, timeout_seconds=None):
+        self.calls = calls
+        self.timeout_seconds = timeout_seconds
+
+    def __enter__(self):
+        self.calls.append(self.timeout_seconds)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_anthropic_claude_code_refresh_runs_under_auth_lock(tmp_path, monkeypatch):
+    """Claude Code refresh tokens are single-use; serialize refresh like Codex.
+
+    Without the lock, concurrent gateway turns can all POST the same expired
+    refresh token and drive Anthropic's OAuth endpoint into 429s, causing Hermes
+    to fall back to Codex even though Claude Code itself works.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cc-expired",
+                        "label": "claude-code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "claude_code",
+                        "access_token": "expired-access",
+                        "refresh_token": "expired-refresh",
+                        "expires_at_ms": int(time.time() * 1000) - 1_000,
+                    }
+                ]
+            },
+        },
+    )
+    monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda pid: True)
+    monkeypatch.setattr("agent.anthropic_adapter.read_hermes_oauth_credentials", lambda: None)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: {
+            "accessToken": "expired-access",
+            "refreshToken": "expired-refresh",
+            "expiresAt": int(time.time() * 1000) - 1_000,
+        },
+    )
+    monkeypatch.setattr("agent.anthropic_adapter._write_claude_code_credentials", lambda *args: None)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.refresh_anthropic_oauth_pure",
+        lambda refresh_token, use_json=False: {
+            "access_token": "fresh-access",
+            "refresh_token": "fresh-refresh",
+            "expires_at_ms": int(time.time() * 1000) + 3_600_000,
+        },
+    )
+
+    import agent.credential_pool as cp
+
+    lock_calls = []
+    monkeypatch.setattr(cp, "_auth_store_lock", lambda timeout_seconds=None: _RecordingLock(lock_calls, timeout_seconds))
+
+    pool = cp.load_pool("anthropic")
+    entry = pool.select()
+
+    assert lock_calls, "Anthropic claude_code refresh must acquire the shared auth lock"
+    assert entry is not None
+    assert entry.access_token == "fresh-access"
+    assert entry.refresh_token == "fresh-refresh"
+
+
+def test_anthropic_claude_code_lock_resync_skips_consumed_refresh(tmp_path, monkeypatch):
+    """A lock waiter should adopt tokens rotated by the winner instead of POSTing.
+
+    This catches the concurrency race where process B enters after process A has
+    already refreshed and written ~/.claude/.credentials.json; B must not spend
+    the old single-use refresh token again.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cc-stale",
+                        "label": "claude-code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "claude_code",
+                        "access_token": "stale-access",
+                        "refresh_token": "stale-refresh",
+                        "expires_at_ms": int(time.time() * 1000) - 1_000,
+                    }
+                ]
+            },
+        },
+    )
+    monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda pid: True)
+    monkeypatch.setattr("agent.anthropic_adapter.read_hermes_oauth_credentials", lambda: None)
+    creds = {
+        "accessToken": "stale-access",
+        "refreshToken": "stale-refresh",
+        "expiresAt": int(time.time() * 1000) - 1_000,
+    }
+    monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: dict(creds))
+
+    def _should_not_refresh(*args, **kwargs):
+        raise AssertionError("should adopt credentials-file tokens instead of refreshing stale token")
+
+    monkeypatch.setattr("agent.anthropic_adapter.refresh_anthropic_oauth_pure", _should_not_refresh)
+
+    import agent.credential_pool as cp
+
+    lock_calls = []
+    monkeypatch.setattr(cp, "_auth_store_lock", lambda timeout_seconds=None: _RecordingLock(lock_calls, timeout_seconds))
+
+    pool = cp.load_pool("anthropic")
+    creds.update(
+        {
+            "accessToken": "winner-access",
+            "refreshToken": "winner-refresh",
+            "expiresAt": int(time.time() * 1000) + 3_600_000,
+        }
+    )
+    entry = pool.select()
+
+    assert lock_calls, "Anthropic claude_code resync must happen inside the shared auth lock"
+    assert entry is not None
+    assert entry.access_token == "winner-access"
+    assert entry.refresh_token == "winner-refresh"
+
+
 def test_least_used_strategy_selects_lowest_count(tmp_path, monkeypatch):
     """least_used strategy should select the credential with the lowest request_count."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))


### PR DESCRIPTION
## Summary

Native Anthropic (`model.provider: anthropic`, Claude Code OAuth) silently falls back to another provider under concurrent load, even when the Claude subscription is healthy and `claude -p --model ...` works directly. Every gateway/Discord turn logs:

```
Primary provider auth failed: No Anthropic credentials found ... — trying fallback
Fallback provider resolved: openai-codex model=gpt-5.5
Runtime provider supplied explicit model override: claude-opus-4-8 -> gpt-5.5
```

and `hermes auth list anthropic` shows the sole `claude_code` entry as `rate-limited (429)`.

### Root cause

Claude Code OAuth **refresh tokens are single-use**. Multiple concurrent Hermes turns (several gateway sessions, delegation subagents, cron jobs) each POST the same refresh token to Anthropic's token endpoint, invalidate one another, and drive the endpoint into 429s. With a single Anthropic credential in the pool, the entry is then marked exhausted and every live turn routes to the fallback provider — silently, for up to the cooldown TTL.

This is the **same** single-use-refresh-token concurrency race that #56233 fixed for **Codex**:

> *"...two concurrent Hermes processes could both adopt the same on-disk token and both POST it; the loser got `refresh_token_reused` / `invalid_grant`."*

That fix wrapped the **Codex** branch of `_refresh_entry` in the shared `_auth_store_lock` but was deliberately scoped narrow (*"this ships the narrow lock-serialization fix"*) and never generalized. Anthropic Claude Code OAuth has **two** refresh paths with the same shape, neither serialized:

| Refresh path | Codex | Anthropic (before this PR) |
|---|---|---|
| Credential-pool `_refresh_entry` | ✅ locked (#56233) | ❌ unlocked |
| Direct `_refresh_oauth_token` | (no independent path) | ❌ unlocked since introduction |

**Why the asymmetry existed:**

1. **`anthropic_adapter._refresh_oauth_token` predates the credential pool.** The direct adapter refresh landed 2026-03-12; `credential_pool.py` (which owns `_auth_store_lock`) landed 2026-03-31. The direct path was written around Claude Code's own `~/.claude/.credentials.json` file flow and never learned about the later auth-store lock.
2. **Codex and Anthropic use different backing stores.** Codex tokens live in `auth.json` (`providers.openai-codex`), already under `_auth_store_lock`, so "wrap it in the existing lock" was the natural Codex fix. Anthropic `claude_code` tokens live in Claude Code's `~/.claude/.credentials.json`, historically guarded only by a *file-sync* mechanism (`_sync_anthropic_entry_from_credentials_file`) — which narrows the race window but cannot eliminate it for a single-use token.
3. **#56233 was intentionally Codex-only** and the structurally-identical Anthropic pool path was not carried along.

## Changes

Both commits reuse the exact pattern established by #56233 — the existing reentrant, cross-process `_auth_store_lock`, with an in-lock re-read so a waiter adopts the token the winner rotated instead of re-POSTing a consumed one.

**Commit 1 — pool refresh path** (`agent/credential_pool.py`)
Wrap the `provider == "anthropic" and source == "claude_code"` branch of `_refresh_entry` in `_auth_store_lock`, re-syncing from the credentials file inside the lock. Directly mirrors the Codex block added in #56233.

**Commit 2 — direct refresh path** (`agent/anthropic_adapter.py`)
Serialize `_refresh_oauth_token`'s read→POST→write-back under the same reentrant lock, with an in-lock re-read that adopts a concurrently-rotated token and skips the POST. This path is hit on **every** `anthropic_messages` API call via `_try_refresh_anthropic_client_credentials()` and by `auxiliary_client` refresh, so it covers the main agent, delegation subagents, and cron jobs. Falls back to the unserialized path only if the lock helper is unavailable.

Together these cover all Claude Code OAuth refresh entry points.

## Reproduction

1. Configure native Anthropic via Claude Code OAuth (single pooled `claude_code` credential).
2. Drive several concurrent turns (e.g. multiple Discord threads + a delegation batch + a cron job firing in the same tick).
3. Observe: `auth list anthropic` flips to `rate-limited (429)`, and every subsequent turn logs `Primary provider auth failed ... Fallback provider resolved: openai-codex`, running Claude-configured sessions on the fallback model instead.

## Testing

- `pytest tests/agent/test_credential_pool.py` — 87 passed (incl. 2 new regressions: refresh runs under the lock; a resync short-circuits the POST).
- `pytest tests/agent/test_anthropic_adapter.py` — 175 passed with isolated `HOME` (incl. 2 new regressions: direct refresh runs under the lock; a concurrently-rotated token is adopted without re-POSTing).
- Combined on a clean checkout of this branch off `main`: **262 passed**.

Verified live on a running gateway after applying both commits: main agent, delegation subagents (`platform=subagent`), and an agent-mode cron job all log `provider=anthropic` with **zero** `Fallback provider resolved` / `Runtime provider supplied explicit model override` lines, and the pooled credential stays active instead of flipping to `rate-limited`.

## Related

- #56233 — the Codex-only precedent this generalizes to Anthropic.
