### PR TITLE
feat(tools): use sequential auto-incrementing IDs for pending writes

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -439,3 +439,69 @@ def test_memory_invalid_params_rejected_before_staging(hermes_home):
     r = json.loads(memory_tool("add", "memory", None, store=store))
     assert r["success"] is False
     assert wa.pending_count("memory") == 0
+
+
+# ── Sequential pending IDs ─────────────────────────────────────────────
+
+
+def test_stage_write_sequential_ids_increment(hermes_home):
+    """Pending IDs should be sequential (1, 2, 3...) not random UUIDs."""
+    from tools import write_approval as wa
+
+    rec1 = wa.stage_write(
+        "memory", {"action": "add", "target": "user", "content": "a"},
+        summary="first", origin="foreground",
+    )
+    rec2 = wa.stage_write(
+        "memory", {"action": "add", "target": "user", "content": "b"},
+        summary="second", origin="foreground",
+    )
+    rec3 = wa.stage_write(
+        "memory", {"action": "add", "target": "user", "content": "c"},
+        summary="third", origin="foreground",
+    )
+    assert rec1["id"] == "1"
+    assert rec2["id"] == "2"
+    assert rec3["id"] == "3"
+
+
+def test_stage_write_sequential_ids_per_subsystem(hermes_home):
+    """Memory and skills subsystems have independent ID counters."""
+    from tools import write_approval as wa
+
+    m1 = wa.stage_write(
+        "memory", {"action": "add", "target": "user", "content": "x"},
+        summary="m1", origin="foreground",
+    )
+    s1 = wa.stage_write(
+        "skills", {"action": "create", "name": "s"},
+        summary="s1", origin="foreground",
+    )
+    m2 = wa.stage_write(
+        "memory", {"action": "add", "target": "user", "content": "y"},
+        summary="m2", origin="foreground",
+    )
+    assert m1["id"] == "1"
+    assert s1["id"] == "1"  # skills starts at 1 independently
+    assert m2["id"] == "2"  # memory continues from 2
+
+
+def test_stage_write_sequential_ids_after_clear(hermes_home):
+    """After pending records are cleared, IDs restart from 1."""
+    from tools import write_approval as wa
+
+    rec1 = wa.stage_write(
+        "memory", {"action": "add", "target": "user", "content": "z"},
+        summary="z", origin="foreground",
+    )
+    assert rec1["id"] == "1"
+
+    # Clear all pending records by discarding each one
+    for r in wa.list_pending("memory"):
+        wa.discard_pending("memory", r["id"])
+
+    rec2 = wa.stage_write(
+        "memory", {"action": "add", "target": "user", "content": "w"},
+        summary="w", origin="foreground",
+    )
+    assert rec2["id"] == "1"  # restarts from 1 after clear

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -46,7 +46,6 @@ import json
 import logging
 import os
 import time
-import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -129,7 +128,16 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
     logs and still returns a record (the write is simply lost, which is the
     safe failure for an approval gate — nothing is silently committed).
     """
-    pid = uuid.uuid4().hex[:8]
+        # Sequential auto-incrementing ID: count existing pending files + 1.
+    # This replaces uuid4().hex[:8] (random 8-char hex) so IDs are short,
+    # sortable, and easy to reference in approval commands (e.g. /skills approve 3).
+    # Old UUID-based IDs are untouched; they coexist harmlessly as string keys.
+    d = _pending_dir(subsystem)
+    try:
+        existing = len(list(d.glob("*.json"))) if d.exists() else 0
+    except Exception:  # pragma: no cover - disk scan failure
+        existing = 0
+    pid = str(existing + 1)
     record = {
         "id": pid,
         "subsystem": subsystem,


### PR DESCRIPTION
## Summary

Pending write records (for skills and memory approval gates) used `uuid.uuid4().hex[:8]` to generate random 8-char hex IDs. This replaces them with sequential auto-incrementing IDs (1, 2, 3...) based on the count of existing pending files in each subsystem directory.

## Changes

`tools/write_approval.py`: `stage_write()` now counts existing `.json` files in `pending/{memory,skills}/` and uses `count + 1` as the new ID. Removed unused `uuid` import. Memory and skills subsystems have independent counters.

`tests/tools/test_write_approval.py`: 3 new tests — sequential increment, per-subsystem independence, restart-from-1 after clear.

## How to Test

```
pytest tests/tools/test_write_approval.py -xvs -k sequential
# 3/3 passed

pytest tests/tools/test_write_approval.py -x -q
# 30/30 passed (zero regressions)
```

Closes #60446