### PR TITLE
fix(whatsapp): use windows_detach_popen_kwargs to prevent console window flash on Windows

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -27,6 +27,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
 from typing import Dict, Optional, Any
 
+from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
 from hermes_constants import (
     find_node_executable,
     get_hermes_dir,
@@ -648,8 +649,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 ],
                 stdout=bridge_log_fh,
                 stderr=bridge_log_fh,
-                start_new_session=True,
                 env=bridge_env,
+                **windows_detach_popen_kwargs(),
             )
             _write_bridge_pidfile(self._session_path, self._bridge_process.pid)
             


### PR DESCRIPTION
Fixes #60508. The WhatsApp bridge `connect()` spawned the Node.js bridge process with `start_new_session=True` and no `creationflags`. On Windows, `start_new_session=True` is a no-op (per `hermes_cli/_subprocess_compat.py`), so the bridge kept a visible console window that flashed on every spawn. Worse, being attached to the console group meant it was killed by CTRL events with exit code `0xC000013A` (STATUS_CONTROL_C_EXIT), triggering an endless reconnect loop.

Replaced with `**windows_detach_popen_kwargs()` which provides proper `DETACHED_PROCESS | CREATE_NO_WINDOW` flags. This is consistent with other spawn sites in the same adapter and standard practice across the codebase.