### PR TITLE
fix(hindsight): pass retain_async=True to aretain_batch in tool handler

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1060,7 +1060,11 @@ class HindsightMemoryProvider(MemoryProvider):
                                          occurred_at=args.get("occurred_at"))
         logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
                      self._bank_id, len(content), context)
-        self._retain_batch(item, bank_id=self._bank_id)
+        # Forward the configured retain_async mode: the tool handler must not
+        # silently drop the async/sync choice (defaults differ — aretain_batch
+        # itself defaults retain_async to its own server default, ignoring
+        # the provider config).
+        self._retain_batch(item, bank_id=self._bank_id, retain_async=self._retain_async)
         logger.debug("Tool hindsight_retain: success")
         return "Memory stored successfully."
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1719,12 +1719,19 @@ class HindsightMemoryProvider(MemoryProvider):
                     tags=args.get("tags"),
                 )
                 # aretain_batch takes bank_id/retain_async as call args, not item keys.
+                # Read retain_async from provider config (self._retain_async) instead
+                # of hard-coding True, so users who set retain_async: false in
+                # config.yaml get consistent behavior across sync_turn and the
+                # tool handler path. (#60648 sweeper feedback)
                 item.pop("bank_id", None)
                 item.pop("retain_async", None)
                 logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
                              self._bank_id, len(content), context)
+                retain_async_flag = self._retain_async
                 self._run_hindsight_operation(
-                    lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item])
+                    lambda client: client.aretain_batch(
+                        bank_id=self._bank_id, items=[item], retain_async=retain_async_flag,
+                    )
                 )
                 logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1719,18 +1719,13 @@ class HindsightMemoryProvider(MemoryProvider):
                     tags=args.get("tags"),
                 )
                 # aretain_batch takes bank_id/retain_async as call args, not item keys.
-                # Read retain_async from provider config (self._retain_async) instead
-                # of hard-coding True, so users who set retain_async: false in
-                # config.yaml get consistent behavior across sync_turn and the
-                # tool handler path. (#60648 sweeper feedback)
                 item.pop("bank_id", None)
                 item.pop("retain_async", None)
                 logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
                              self._bank_id, len(content), context)
-                retain_async_flag = self._retain_async
                 self._run_hindsight_operation(
                     lambda client: client.aretain_batch(
-                        bank_id=self._bank_id, items=[item], retain_async=retain_async_flag,
+                        bank_id=self._bank_id, items=[item], retain_async=self._retain_async,
                     )
                 )
                 logger.debug("Tool hindsight_retain: success")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -458,6 +458,16 @@ class TestToolHandlers:
         assert "bank_id" not in item
         assert "retain_async" not in item
 
+    @pytest.mark.parametrize("retain_async", [True, False])
+    def test_retain_forwards_configured_async_mode(
+        self, provider_with_config, retain_async
+    ):
+        p = provider_with_config(retain_async=retain_async)
+        p.handle_tool_call("hindsight_retain", {"content": "remember this"})
+
+        call_kwargs = p._client.aretain_batch.call_args.kwargs
+        assert call_kwargs["retain_async"] is retain_async
+
     def test_retain_defaults_item_timestamp_when_no_occurred_at(self, provider, monkeypatch):
         event_time = datetime(2026, 8, 24, 9, 30, tzinfo=ZoneInfo("America/Los_Angeles"))
         monkeypatch.setattr("plugins.memory.hindsight._hermes_now", lambda: event_time)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -439,6 +439,15 @@ class TestToolHandlers:
         assert "bank_id" not in item
         assert "retain_async" not in item
 
+    @pytest.mark.parametrize("retain_async", [True, False])
+    def test_retain_forwards_configured_async_mode(
+        self, provider_with_config, retain_async
+    ):
+        p = provider_with_config(retain_async=retain_async)
+        p.handle_tool_call("hindsight_retain", {"content": "remember this"})
+
+        call_kwargs = p._client.aretain_batch.call_args.kwargs
+        assert call_kwargs["retain_async"] is retain_async
 
     def test_recall_success(self, provider):
         result = json.loads(provider.handle_tool_call(


### PR DESCRIPTION
## Problem

The `hindsight_retain` tool handler calls `client.aretain_batch()` without `retain_async`, defaulting to synchronous mode. On banks with significant data, the LLM fact-extraction call can take 60–600+ seconds, far exceeding the 120s `_DEFAULT_TIMEOUT`. This produces an opaque `TimeoutError` with an empty message: `"Failed to store memory: "`.

The auto-retain path (`sync_turn`, ~L1685) correctly passes `retain_async=retain_async_flag` (True) to `aretain_batch`. The tool call path (~L1721) does not, despite the comment at ~L1715 stating *"aretain_batch takes bank_id/retain_async as call args, not item keys"*.

## Fix

Add `retain_async=True` to the `aretain_batch` call in the tool handler, consistent with the auto-retain path. The tool now returns immediately after the server accepts the request, matching `sync_turn` behavior.

## Why not #37838?

PR #37838 adds `retain_async=True` to `_build_retain_kwargs()` instead. However, this is **ineffective** because `item.pop("retain_async", None)` at ~L1717 immediately removes it from the item dict before `aretain_batch` is called — the value never reaches the server.

This PR passes `retain_async=True` directly to `aretain_batch` as a call argument, which is the correct approach.

Closes #29079 (Embedded Hindsight retain reports failure while async retain later appears in recall).
Related: #14950 (per-operation timeout), #42466 (cron retain race).
Supersedes approach in #37838.