### PR TITLE
chore: release v0.18.2 (2026.7.7.2)

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.18.1",
+      "package": "hermes-agent[acp]==0.18.2",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.18.1"
-__release_date__ = "2026.7.7"
+__version__ = "0.18.2"
+__release_date__ = "2026.7.7.2"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.18.1"
+version = "0.18.2"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/uv.lock
+++ b/uv.lock
@@ -1516,7 +1516,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
Release v0.18.2 (CalVer v2026.7.7.2) — same-day patch on v0.18.1 so tagged-release Docker builds pick up the WhatsApp Baileys fix (#60643).

## Changes
- `hermes_cli/__init__.py`: `__version__` 0.18.1 → 0.18.2, `__release_date__` → 2026.7.7.2
- `pyproject.toml`: version → 0.18.2
- `acp_registry/agent.json`: version + uvx package pin → 0.18.2
- `uv.lock`: regenerated (`uv lock --check` clean)

## Validation
| Check | Result |
|---|---|
| `rg` for stale `0.18.1` in version files | zero hits |
| `uv lock --check` | clean |
| Wheel data-file verify | OK |

## Infographic

![v0.18.2 same-day patch](https://v3b.fal.media/files/b/0aa15f91/kRosLKY37Sfw95RK7nLrT_1eUCkbxw.png)
