### PR TITLE
fix(kanban): probe integrity_check in read-only immutable mode to avoid WAL checkpoint race

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1327,6 +1327,37 @@ def _sqlite_connect(path: Path) -> sqlite3.Connection:
     return conn
 
 
+def _sqlite_connect_readonly(path: Path) -> sqlite3.Connection:
+    """Open a read-only Kanban SQLite connection for integrity probes.
+
+    Uses the ``immutable=1`` URI so SQLite skips WAL/SHM entirely: no
+    checkpoint is triggered, no SHM file is written, no lock is taken on
+    the WAL. This matters because :func:`_guard_existing_db_is_healthy`
+    runs on every new process's first ``connect()`` — under a worker
+    stampede (nightly cron spawning N workers + web-ui spawning
+    ``hermes kanban watch`` children) many processes would otherwise
+    concurrently run ``PRAGMA integrity_check`` in read/write mode,
+    each triggering a WAL checkpoint while the gateway is the active
+    writer. The racing checkpoint vs. writer corrupts indexes
+    (``wrong # of entries in index idx_events_*``).
+
+    ``immutable=1`` reads only the main DB file (the post-checkpoint
+    stable state), which is sufficient for structural integrity
+    verification. WAL contents are data, not structure; a deferred
+    WAL-resident corruption surfaces on the next checkpoint by the
+    gateway (the single writer) rather than racing it.
+
+    The probe still sets ``busy_timeout`` for the rare case where
+    immutable mode falls back to locking.
+    """
+    busy_timeout_ms = _resolve_busy_timeout_ms()
+    uri = f"file:{path}?immutable=1"
+    conn = sqlite3.connect(uri, uri=True, isolation_level=None,
+                           timeout=busy_timeout_ms / 1000.0)
+    conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+    return conn
+
+
 @contextlib.contextmanager
 def _cross_process_init_lock(path: Path):
     """Serialize first-connect WAL/schema/integrity setup across processes.
@@ -1623,12 +1654,18 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
 def _guard_existing_db_is_healthy(path: Path) -> None:
     """Run ``PRAGMA integrity_check`` on an existing non-empty DB file.
 
-    Opens the probe in read/write mode so SQLite can recover or
-    checkpoint a healthy WAL/hot-journal DB before we declare it
-    corrupt. If the file is malformed, copy it (and any WAL/SHM
-    sidecars) to a timestamped backup and raise
-    :class:`KanbanDbCorruptError` so callers cannot silently recreate
-    the schema on top of a damaged DB.
+    Opens the probe in **read-only immutable mode** (see
+    :func:`_sqlite_connect_readonly`) so SQLite skips WAL/SHM entirely
+    and does **not** trigger a checkpoint. This is the fix for the
+    recurring ``wrong # of entries in index idx_events_*`` corruption:
+    previously the probe opened in read/write mode, and under a worker
+    stampede (nightly cron + web-ui watch spawns) many processes would
+    concurrently checkpoint the WAL while the gateway was writing,
+    racing the checkpoint against the writer and corrupting indexes.
+
+    If the file is malformed, copy it (and any WAL/SHM sidecars) to a
+    timestamped backup and raise :class:`KanbanDbCorruptError` so
+    callers cannot silently recreate the schema on top of a damaged DB.
 
     Transient lock/busy errors (``sqlite3.OperationalError``) are NOT
     treated as corruption; they propagate raw so the caller sees a
@@ -1660,7 +1697,7 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         return
     reason: Optional[str] = None
     try:
-        probe = _sqlite_connect(resolved)
+        probe = _sqlite_connect_readonly(resolved)
         try:
             row = probe.execute("PRAGMA integrity_check").fetchone()
         finally:


### PR DESCRIPTION
## Summary

`_guard_existing_db_is_healthy` runs `PRAGMA integrity_check` on every new process's first `connect()`. Previously the probe opened the DB in **read/write mode**, which under SQLite WAL mode opens the `-wal`/`-shm` sidecars and can trigger a WAL checkpoint. Under a worker stampede this races the gateway (the active writer) and corrupts indexes.

This PR switches the probe to **read-only `immutable=1` URI mode** so SQLite skips WAL/SHM entirely — no sidecars opened, no locks taken, no checkpoint triggered.

## Root cause

Recurring `wrong # of entries in index idx_events_*` corruption, nightly at cron-burst moments (02:00). Pattern observed across ~11 incidents:

1. 02:00 cron spawns N worker subprocesses + web-ui spawns `hermes kanban watch` children.
2. Each new process hits `_guard_existing_db_is_healthy` on first `connect()` (`_INITIALIZED_PATHS` is per-process, so the cache does not help across processes).
3. Each probe opens the DB r/w → opens `-wal`/`-shm` (`O_RDWR|O_CREAT`) → may trigger a WAL checkpoint.
4. N concurrent checkpoints race the gateway dispatcher (the single active writer) → WAL inconsistency → index corruption.
5. Recovery cascade: corruption detected → backup + REINDEX by N processes simultaneously → re-corrupts, generates 5–10 backups/minute.

## Fix

Add `_sqlite_connect_readonly(path)` that opens via `file:{path}?immutable=1` URI. SQLite treats the file as immutable: it does **not** open `-wal`/`-shm`, does **not** take a WAL lock, does **not** checkpoint.

`_guard_existing_db_is_healthy` now uses the readonly probe. Structural integrity is fully verifiable from the main DB file alone (the post-checkpoint stable state). WAL contents are data, not structure; any deferred WAL-resident corruption surfaces on the next checkpoint by the gateway (the single writer) rather than racing it.

## Verification (strace)

| | Files opened | Writes |
|---|---|---|
| Before (r/w probe) | `kanban.db` + `kanban.db-wal` + `kanban.db-shm` (latter two `O_RDWR\|O_CREAT`) | `fsync`/`fdatasync` on WAL |
| After (readonly probe) | `kanban.db` only | none |

- 10 concurrent readonly probes complete cleanly; `-wal`/`-shm` never created.
- Intentionally corrupted DB still detected: `sqlite refused to open file: database disk image is malformed`.
- Full `connect() → query → write` flow unchanged (writes still go through the normal r/w `_sqlite_connect`).

## Relationship to existing issues

- Closes #34385 (recurring index corruption under concurrent multi-process WAL access) — this PR addresses the **probe-checkpoint-vs-writer race**.
- Complements #53819's writer-serialization proposal (file-scoped `fcntl.flock` on writes) — that targets a **different race** (multi-writer contention). Both can coexist; this PR is the smaller, more surgical fix for the probe-triggered races we observe nightly.
- Does **not** require the dispatcher hardening from #30417 / #30896 — those address spawn-crash loops; this addresses the probe race alone.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('hermes_cli/kanban_db.py').read())"` — syntax OK
- [x] strace: readonly probe opens 1 file, no `write`/`fsync`/`fdatasync` syscalls
- [x] strace: r/w probe (before) opened 3 files including `O_RDWR|O_CREAT` on `-wal`/`-shm`
- [x] 10-process concurrent readonly probe stress — no WAL/SHM artifacts
- [x] Malformed DB still raises `KanbanDbCorruptError` with backup
- [ ] CI: existing kanban_db test suite passes (no new failures expected — probe result is identical `ok`/`malformed` either way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)