### PR TITLE
fix: wire Discord voice input on connect

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3288,6 +3288,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Restore persisted /voice state into a live platform adapter.
 
         Populates three fields from config + ``self._voice_mode``:
+          - ``_voice_input_callback``: inbound voice transcripts → gateway handler
           - ``_auto_tts_default``: global default from ``voice.auto_tts``
           - ``_auto_tts_enabled_chats``: chats with mode ``voice_only``/``all``
           - ``_auto_tts_disabled_chats``: chats with mode ``off``
@@ -3295,6 +3296,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform = getattr(adapter, "platform", None)
         if not isinstance(platform, Platform):
             return
+
+        if hasattr(adapter, "_voice_input_callback"):
+            adapter._voice_input_callback = self._handle_voice_channel_input
 
         disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
         enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -224,6 +224,19 @@ class TestHandleVoiceCommand:
 
         assert adapter._auto_tts_default is True
 
+    def test_sync_wires_voice_input_callback_without_tts_sets(self, runner):
+        """Voice transcripts must reach the gateway even outside /voice join."""
+        from gateway.config import Platform
+
+        adapter = SimpleNamespace(
+            platform=Platform.DISCORD,
+            _voice_input_callback=None,
+        )
+
+        runner._sync_voice_mode_state_to_adapter(adapter)
+
+        assert adapter._voice_input_callback == runner._handle_voice_channel_input
+
     def test_restart_restores_voice_off_state(self, runner, tmp_path):
         from gateway.config import Platform
         runner._VOICE_MODE_PATH.write_text(json.dumps({"telegram:123": "off"}))


### PR DESCRIPTION
Summary
- Wire voice transcript callbacks during platform adapter sync.
- Keep the existing /voice join callback behavior intact.
- Add regression coverage for callback-capable adapters that do not expose auto-TTS state sets.

Problem
Discord voice transcripts were only forwarded to the gateway when /voice join installed `_voice_input_callback`. If Discord joined voice through startup restore or another programmatic path, transcripts could be logged by the adapter but never delivered to the agent.

Validation
- `pytest -q tests/gateway/test_voice_command.py::TestHandleVoiceCommand::test_sync_wires_voice_input_callback_without_tts_sets tests/gateway/test_voice_command.py::TestVoiceChannelCommands::test_join_success`
- `pytest -q tests/gateway/test_voice_command.py`
- `python -m py_compile gateway/run.py tests/gateway/test_voice_command.py`
- `python -m ruff check gateway/run.py tests/gateway/test_voice_command.py`

Fixes #60623