### PR TITLE
fix: show Copilot ACP account status

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7879,19 +7879,42 @@ def _claude_code_only_status() -> Dict[str, Any]:
 
 
 def _copilot_acp_status() -> Dict[str, Any]:
-    """Status for copilot-acp — credentials are owned by the Copilot CLI.
+    """Status for copilot-acp, delegated to the canonical auth dispatcher."""
+    try:
+        from hermes_cli import auth as hauth
 
-    There is no cheap programmatic credential probe for the ACP subprocess, so
-    this is a read-only "managed by the Copilot CLI" card (like claude-code):
-    Hermes never claims a login state it can't verify.
-    """
+        raw = hauth.get_auth_status("copilot-acp")
+    except Exception as e:
+        return {
+            "logged_in": False,
+            "configured": False,
+            "source": "copilot_cli",
+            "source_label": "Managed by the GitHub Copilot CLI",
+            "token_preview": None,
+            "expires_at": None,
+            "has_refresh_token": False,
+            "error": str(e),
+        }
+    if not isinstance(raw, dict):
+        raw = {}
+    source_label = (
+        raw.get("resolved_command")
+        or raw.get("base_url")
+        or raw.get("name")
+        or "Managed by the GitHub Copilot CLI"
+    )
     return {
-        "logged_in": False,
+        "logged_in": bool(raw.get("logged_in")),
+        "configured": bool(raw.get("configured")),
         "source": "copilot_cli",
-        "source_label": "Managed by the GitHub Copilot CLI",
+        "source_label": source_label,
         "token_preview": None,
         "expires_at": None,
         "has_refresh_token": False,
+        "command": raw.get("command"),
+        "args": raw.get("args") or [],
+        "resolved_command": raw.get("resolved_command"),
+        "base_url": raw.get("base_url"),
     }
 
 

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -502,6 +502,33 @@ def test_copilot_acp_now_in_accounts():
     assert providers["copilot-acp"]["disconnectable"] is False
 
 
+def test_copilot_acp_accounts_status_uses_auth_dispatcher():
+    with patch("hermes_cli.auth.get_auth_status") as get_auth_status:
+        get_auth_status.return_value = {
+            "provider": "copilot-acp",
+            "name": "GitHub Copilot ACP",
+            "configured": True,
+            "logged_in": True,
+            "command": "copilot",
+            "args": ["--acp", "--stdio"],
+            "resolved_command": "/usr/local/bin/copilot",
+            "base_url": "acp://copilot",
+        }
+
+        resp = client.get("/api/providers/oauth", headers=HEADERS)
+
+    assert resp.status_code == 200, resp.text
+    get_auth_status.assert_called_once_with("copilot-acp")
+    providers = {p["id"]: p for p in resp.json()["providers"]}
+    status = providers["copilot-acp"]["status"]
+    assert status["logged_in"] is True
+    assert status["configured"] is True
+    assert status["source"] == "copilot_cli"
+    assert status["source_label"] == "/usr/local/bin/copilot"
+    assert status["resolved_command"] == "/usr/local/bin/copilot"
+    assert status["base_url"] == "acp://copilot"
+
+
 def test_oauth_catalog_marks_external_providers_not_disconnectable():
     """External CLI credentials are visible in Accounts but cannot be removed by Hermes."""
     resp = client.get("/api/providers/oauth", headers=HEADERS)


### PR DESCRIPTION
Summary
- Delegate the Copilot ACP Accounts status card to the canonical auth dispatcher.
- Preserve external-provider card metadata while returning configured/login state and resolved command details.
- Add regression coverage for the Accounts endpoint status response.

Problem
The desktop Accounts page had a Copilot ACP card, but its status helper always returned logged_in=false. The CLI auth dispatcher could already detect configured Copilot ACP installs, so the desktop UI could show disconnected even when Hermes could use the provider.

Validation
- `pytest -q tests/hermes_cli/test_web_oauth_dispatch.py::test_copilot_acp_now_in_accounts tests/hermes_cli/test_web_oauth_dispatch.py::test_copilot_acp_accounts_status_uses_auth_dispatcher`
- `pytest -q tests/hermes_cli/test_web_oauth_dispatch.py`
- `python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_oauth_dispatch.py`
- `python -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_oauth_dispatch.py`

Fixes #60614