### PR TITLE
fix(guardrails): prevent same-tool failure counter bypass via alternating success

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -345,7 +345,12 @@ class ToolCallGuardrailController:
             return ToolGuardrailDecision(tool_name=tool_name, count=exact_count, signature=signature)
 
         self._exact_failure_counts.pop(signature, None)
-        self._same_tool_failure_counts.pop(tool_name, None)
+        # Do NOT reset _same_tool_failure_counts here — it tracks failures
+        # across varying signatures within a turn.  Resetting the entire
+        # tool counter on a single signature's success allows a model to
+        # bypass the threshold by alternating failing and successful calls
+        # (the success wipes the counter).  The counter naturally resets
+        # at the end of each turn via reset_for_turn().
 
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -256,3 +256,28 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+def test_same_tool_success_does_not_reset_varying_args_failure_counter():
+    """A single signature's success must not wipe the entire same-tool counter."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            exact_failure_block_after=99,
+            same_tool_failure_warn_after=2,
+            same_tool_failure_halt_after=3,
+        )
+    )
+
+    # Two different signatures fail → count = 2
+    controller.after_call("terminal", {"command": "cmd-1"}, '{"exit_code":1}', failed=True)
+    controller.after_call("terminal", {"command": "cmd-2"}, '{"exit_code":1}', failed=True)
+
+    # A third signature succeeds — must NOT reset the counter
+    controller.after_call("terminal", {"command": "ok"}, '{"exit_code":0}', failed=False)
+
+    # One more failure should trigger halt (counter was 2, now 3)
+    third_fail = controller.after_call("terminal", {"command": "cmd-3"}, '{"exit_code":1}', failed=True)
+    assert third_fail.action == "halt"
+    assert third_fail.code == "same_tool_failure_halt"
+    assert third_fail.count == 3


### PR DESCRIPTION
## What does this PR do?

Fixes a bypass in the tool call guardrail system: the `_same_tool_failure_counts` counter was entirely wiped when ANY signature of the same tool succeeded, allowing a model to avoid the halt/warn threshold by alternating failing and successful calls.

## Related Issue

N/A — discovered via source code audit.

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/tool_guardrails.py`: removed `_same_tool_failure_counts.pop(tool_name)` on success (line 348). The counter now accumulates across varying signatures within a turn and resets only via `reset_for_turn()` at turn boundaries.
- `tests/agent/test_tool_guardrails.py`: added `test_same_tool_success_does_not_reset_varying_args_failure_counter`.

## How to Test

```bash
python -m pytest tests/agent/test_tool_guardrails.py -v
```

Before: `terminal("cmd-1")` fails, `terminal("cmd-2")` fails, `terminal("ok")` succeeds → counter wiped → `terminal("cmd-3")` fails → counter = 1 (no halt).
After: counter accumulates (2 → success → 3) → halt fires as expected.
