### PR TITLE
fix: verify Discord voice doctor channel access

### DIFF
--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -12,6 +12,7 @@ Usage:
 import os
 import sys
 import shutil
+import json
 from pathlib import Path
 
 # Resolve project root
@@ -278,6 +279,113 @@ def check_config(groq_key, eleven_key):
         check("Voice mode state", True, "no saved state (fresh)")
 
 
+def _extract_discord_channel_id(value):
+    if value is None:
+        return None
+
+    channel_id = str(value).strip()
+    if channel_id.startswith("discord:"):
+        channel_id = channel_id.split(":", 1)[1].strip()
+    if channel_id.isdigit():
+        return channel_id
+    return None
+
+
+def configured_discord_channel_ids():
+    """Return Discord channel IDs configured for Hermes Drive Mode."""
+    channel_ids = set()
+
+    config_path = HERMES_HOME / "config.yaml"
+    if config_path.exists():
+        try:
+            import yaml
+
+            with open(config_path, encoding="utf-8") as f:
+                cfg = yaml.safe_load(f) or {}
+
+            discord_cfg = cfg.get("discord", {}) if isinstance(cfg, dict) else {}
+            channel_prompts = discord_cfg.get("channel_prompts", {})
+            if isinstance(channel_prompts, dict):
+                for raw_channel_id in channel_prompts:
+                    channel_id = _extract_discord_channel_id(raw_channel_id)
+                    if channel_id:
+                        channel_ids.add(channel_id)
+            elif channel_prompts:
+                warn("Configured Discord channels", "discord.channel_prompts is not a mapping")
+        except Exception as e:
+            warn("Configured Discord channels", f"could not read config.yaml: {e}")
+
+    voice_mode_path = HERMES_HOME / "gateway_voice_mode.json"
+    if voice_mode_path.exists():
+        try:
+            modes = json.loads(voice_mode_path.read_text(encoding="utf-8"))
+            if isinstance(modes, dict):
+                for raw_key in modes:
+                    channel_id = _extract_discord_channel_id(raw_key)
+                    if channel_id:
+                        channel_ids.add(channel_id)
+            else:
+                warn("Configured Discord channels", "gateway_voice_mode.json is not a mapping")
+        except Exception as e:
+            warn("Configured Discord channels", f"could not read gateway_voice_mode.json: {e}")
+
+    return sorted(channel_ids, key=int)
+
+
+def check_configured_discord_channel_access(requests_module, headers):
+    """Verify direct bot REST access to every configured Discord channel ID."""
+    channel_ids = configured_discord_channel_ids()
+    if not channel_ids:
+        warn("Configured Discord channels", "none found in config/state")
+        return True
+
+    ok = True
+    for channel_id in channel_ids:
+        label = f"Configured channel {channel_id}"
+        try:
+            r = requests_module.get(
+                f"https://discord.com/api/v10/channels/{channel_id}",
+                headers=headers,
+                timeout=5,
+            )
+        except requests_module.exceptions.Timeout:
+            check(label, False, "Discord API timeout — could not verify channel access")
+            ok = False
+            continue
+        except requests_module.exceptions.ConnectionError:
+            check(label, False, "cannot reach Discord API — could not verify channel access")
+            ok = False
+            continue
+        except Exception as e:
+            check(label, False, f"check failed: {type(e).__name__}")
+            ok = False
+            continue
+
+        if r.status_code == 200:
+            try:
+                payload = r.json()
+            except Exception:
+                payload = {}
+            name = payload.get("name") if isinstance(payload, dict) else ""
+            detail = f"accessible: #{name}" if name else "accessible"
+            check(label, True, detail)
+        elif r.status_code == 403:
+            check(
+                label,
+                False,
+                "Missing Access — add the Alfred Drive bot role to this private channel or update config/state",
+            )
+            ok = False
+        elif r.status_code == 404:
+            check(label, False, "Not Found — channel ID is stale; update config/state")
+            ok = False
+        else:
+            check(label, False, f"HTTP {r.status_code} — could not verify channel access")
+            ok = False
+
+    return ok
+
+
 def check_bot_permissions(token):
     """Check bot permissions via Discord API. Returns True if all OK."""
     section("Bot Permissions")
@@ -289,8 +397,8 @@ def check_bot_permissions(token):
     try:
         import requests
     except ImportError:
-        warn("Bot permissions", "requests not installed — skipping")
-        return True
+        check("Bot permissions", False, "requests not installed — cannot verify Discord access")
+        return False
 
     VOICE_PERMS = {
         "Priority Speaker":      8,
@@ -329,10 +437,18 @@ def check_bot_permissions(token):
         # Check guilds
         r2 = requests.get("https://discord.com/api/v10/users/@me/guilds", headers=headers, timeout=5)
         if r2.status_code != 200:
-            warn("Guilds", f"HTTP {r2.status_code}")
-            return ok
+            check("Guilds", False, f"HTTP {r2.status_code}")
+            return False
 
         guilds = r2.json()
+        if not guilds:
+            check(
+                "Guilds",
+                False,
+                "0 guild(s) — bot is not in any server; invite it before voice testing",
+            )
+            return False
+
         check("Guilds", True, f"{len(guilds)} guild(s)")
 
         for g in guilds[:5]:
@@ -357,17 +473,22 @@ def check_bot_permissions(token):
             else:
                 print(f"    {OK} {g['name']}: {', '.join(has)}")
 
+        ok &= check_configured_discord_channel_access(requests, headers)
+
     except requests.exceptions.Timeout:
-        warn("Bot permissions", "Discord API timeout")
+        check("Bot permissions", False, "Discord API timeout")
+        return False
     except requests.exceptions.ConnectionError:
-        warn("Bot permissions", "cannot reach Discord API")
+        check("Bot permissions", False, "cannot reach Discord API")
+        return False
     except Exception as e:
-        warn("Bot permissions", f"check failed: {e}")
+        check("Bot permissions", False, f"check failed: {type(e).__name__}")
+        return False
 
     return ok
 
 
-def main():
+def main() -> int:
     print()
     print("\033[1m" + "=" * 50 + "\033[0m")
     print("\033[1m  Discord Voice Doctor\033[0m")
@@ -387,10 +508,13 @@ def main():
     print("\033[1m" + "-" * 50 + "\033[0m")
     if all_ok:
         print(f"  {OK} \033[92mAll checks passed — voice mode ready!\033[0m")
+        exit_code = 0
     else:
         print(f"  {FAIL} \033[91mSome checks failed — fix issues above.\033[0m")
+        exit_code = 1
     print()
+    return exit_code
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/scripts/test_discord_voice_doctor.py
+++ b/tests/scripts/test_discord_voice_doctor.py
@@ -1,0 +1,142 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import requests
+
+
+class _Response:
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def _load_doctor(monkeypatch, hermes_home):
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    repo_root = Path(__file__).resolve().parents[2]
+    path = repo_root / "scripts" / "discord-voice-doctor.py"
+    spec = importlib.util.spec_from_file_location("discord_voice_doctor", path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _guild_with_required_permissions():
+    required_permissions = (1 << 10) | (1 << 11) | (1 << 20) | (1 << 21)
+    return {
+        "id": "guild-1",
+        "name": "Alfred server",
+        "permissions": str(required_permissions),
+    }
+
+
+def _write_config_with_channel_prompt(hermes_home, channel_id):
+    (hermes_home / "config.yaml").write_text(
+        "discord:\n"
+        "  channel_prompts:\n"
+        f"    '{channel_id}': Drive Mode prompt\n",
+        encoding="utf-8",
+    )
+
+
+def test_check_bot_permissions_fails_when_bot_has_no_guilds(monkeypatch, tmp_path, capsys):
+    doctor = _load_doctor(monkeypatch, tmp_path)
+
+    def fake_get(url, headers, timeout):
+        if url.endswith("/users/@me"):
+            return _Response(200, {"username": "Alfred Drive"})
+        if url.endswith("/users/@me/guilds"):
+            return _Response(200, [])
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert doctor.check_bot_permissions("test-token") is False
+    output = capsys.readouterr().out
+    assert "Guilds" in output
+    assert "0 guild(s)" in output
+    assert "invite it before voice testing" in output
+
+
+def test_check_bot_permissions_passes_when_no_configured_channels_exist(monkeypatch, tmp_path):
+    doctor = _load_doctor(monkeypatch, tmp_path)
+
+    def fake_get(url, headers, timeout):
+        if url.endswith("/users/@me"):
+            return _Response(200, {"username": "Alfred Drive"})
+        if url.endswith("/users/@me/guilds"):
+            return _Response(200, [_guild_with_required_permissions()])
+        if "/channels/" in url:
+            raise AssertionError(f"unexpected channel check: {url}")
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert doctor.check_bot_permissions("test-token") is True
+
+
+def test_check_bot_permissions_fails_when_configured_channel_is_forbidden(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    doctor = _load_doctor(monkeypatch, tmp_path)
+    _write_config_with_channel_prompt(tmp_path, "1234567890")
+
+    def fake_get(url, headers, timeout):
+        if url.endswith("/users/@me"):
+            return _Response(200, {"username": "Alfred Drive"})
+        if url.endswith("/users/@me/guilds"):
+            return _Response(200, [_guild_with_required_permissions()])
+        if url.endswith("/channels/1234567890"):
+            return _Response(403, {"message": "Missing Access"})
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert doctor.check_bot_permissions("test-token") is False
+    output = capsys.readouterr().out
+    assert "Configured channel 1234567890" in output
+    assert "Missing Access" in output
+    assert "add the Alfred Drive bot role" in output
+
+
+def test_check_bot_permissions_passes_when_configured_channels_are_accessible(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    doctor = _load_doctor(monkeypatch, tmp_path)
+    _write_config_with_channel_prompt(tmp_path, "1234567890")
+    (tmp_path / "gateway_voice_mode.json").write_text(
+        json.dumps({"discord:9876543210": "off"}),
+        encoding="utf-8",
+    )
+
+    checked_channel_ids = set()
+
+    def fake_get(url, headers, timeout):
+        if url.endswith("/users/@me"):
+            return _Response(200, {"username": "Alfred Drive"})
+        if url.endswith("/users/@me/guilds"):
+            return _Response(200, [_guild_with_required_permissions()])
+        if "/channels/" in url:
+            channel_id = url.rsplit("/", 1)[-1]
+            checked_channel_ids.add(channel_id)
+            return _Response(200, {"id": channel_id, "name": f"channel-{channel_id}"})
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert doctor.check_bot_permissions("test-token") is True
+    assert checked_channel_ids == {"1234567890", "9876543210"}
+    output = capsys.readouterr().out
+    assert "Configured channel 1234567890" in output
+    assert "Configured channel 9876543210" in output
+    assert "accessible" in output


### PR DESCRIPTION
## Summary
- add Discord Voice Doctor checks for configured Drive Mode Discord channel IDs from `config.yaml` and `gateway_voice_mode.json`
- fail clearly when the bot has no guilds, lacks access to a configured private channel, or cannot verify Discord API access
- add regression coverage for no-guild, no-configured-channel, forbidden-channel, and accessible-channel cases

## Tests
- `python3 -m py_compile scripts/discord-voice-doctor.py tests/scripts/test_discord_voice_doctor.py`
- `scripts/run_tests.sh tests/scripts/test_discord_voice_doctor.py -v --tb=short`
- `git diff --cached --check`
- expected-failure smoke: `HERMES_HOME=$(mktemp -d) python3 scripts/discord-voice-doctor.py` exits 1 and reports missing local voice dependencies/token
