### PR TITLE
fix: include final reasoning in run events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4119,6 +4119,60 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_statuses[run_id] = current
         return current
 
+    @staticmethod
+    def _reasoning_details_text(details: Any) -> str:
+        if isinstance(details, str):
+            return details
+        if not isinstance(details, list):
+            return ""
+        parts: List[str] = []
+        for item in details:
+            if isinstance(item, str):
+                text = item
+            elif isinstance(item, dict):
+                text = item.get("text") or item.get("summary") or ""
+            else:
+                text = ""
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+        return "\n".join(parts)
+
+    @classmethod
+    def _run_reasoning_payload(cls, result: Any) -> Dict[str, Any]:
+        if not isinstance(result, dict):
+            return {}
+
+        payload: Dict[str, Any] = {}
+        last_reasoning = result.get("last_reasoning")
+        if isinstance(last_reasoning, str) and last_reasoning.strip():
+            payload["reasoning"] = last_reasoning
+
+        messages = result.get("messages")
+        if isinstance(messages, list):
+            for msg in reversed(messages):
+                if not isinstance(msg, dict):
+                    continue
+                role = msg.get("role")
+                if role == "user":
+                    break
+                if role != "assistant":
+                    continue
+                for key in ("reasoning_content", "reasoning_details", "reasoning"):
+                    value = msg.get(key)
+                    if key not in payload and value not in (None, "", []):
+                        payload[key] = value
+
+        text = (
+            payload.get("reasoning_content")
+            or payload.get("reasoning")
+            or cls._reasoning_details_text(payload.get("reasoning_details"))
+        )
+        if isinstance(text, str) and text.strip():
+            payload["text"] = text
+        elif payload:
+            payload["text"] = ""
+        return payload
+
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
         def _push(event: Dict[str, Any]) -> None:
@@ -4391,19 +4445,35 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                    q.put_nowait({
+                    reasoning_payload = self._run_reasoning_payload(result)
+                    completed_event = {
                         "event": "run.completed",
                         "run_id": run_id,
                         "timestamp": time.time(),
                         "output": final_response,
                         "usage": usage,
-                    })
+                    }
+                    status_fields: Dict[str, Any] = {
+                        "output": final_response,
+                        "usage": usage,
+                        "last_event": "run.completed",
+                    }
+                    if reasoning_payload:
+                        now = time.time()
+                        q.put_nowait({
+                            "event": "reasoning.available",
+                            "run_id": run_id,
+                            "timestamp": now,
+                            "source": "final_result",
+                            **reasoning_payload,
+                        })
+                        completed_event["reasoning"] = reasoning_payload
+                        status_fields["reasoning"] = reasoning_payload
+                    q.put_nowait(completed_event)
                     self._set_run_status(
                         run_id,
                         "completed",
-                        output=final_response,
-                        usage=usage,
-                        last_event="run.completed",
+                        **status_fields,
                     )
             except asyncio.CancelledError:
                 self._set_run_status(

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -51,6 +52,15 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
+
+
+def _sse_data_events(body: str) -> list[dict]:
+    events: list[dict] = []
+    for line in body.splitlines():
+        if not line.startswith("data: "):
+            continue
+        events.append(json.loads(line.removeprefix("data: ")))
+    return events
 
 
 def _make_slow_agent(**kwargs):
@@ -305,6 +315,56 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+
+    @pytest.mark.asyncio
+    async def test_events_stream_exposes_final_reasoning_payload(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "Visible answer",
+                    "last_reasoning": "short summary",
+                    "messages": [
+                        {"role": "user", "content": "hello"},
+                        {
+                            "role": "assistant",
+                            "content": "Visible answer",
+                            "reasoning": "short summary",
+                            "reasoning_content": "provider-native scratchpad",
+                            "reasoning_details": [
+                                {"type": "reasoning.summary", "text": "step one"}
+                            ],
+                        },
+                    ],
+                }
+                mock_agent.session_prompt_tokens = 10
+                mock_agent.session_completion_tokens = 5
+                mock_agent.session_total_tokens = 15
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                events = _sse_data_events(await events_resp.text())
+
+        reasoning_events = [e for e in events if e.get("event") == "reasoning.available"]
+        assert reasoning_events
+        final_reasoning = reasoning_events[-1]
+        assert final_reasoning["source"] == "final_result"
+        assert final_reasoning["text"] == "provider-native scratchpad"
+        assert final_reasoning["reasoning"] == "short summary"
+        assert final_reasoning["reasoning_content"] == "provider-native scratchpad"
+        assert final_reasoning["reasoning_details"] == [
+            {"type": "reasoning.summary", "text": "step one"}
+        ]
+
+        completed = [e for e in events if e.get("event") == "run.completed"][-1]
+        assert completed["reasoning"]["text"] == "provider-native scratchpad"
+        assert completed["reasoning"]["reasoning_content"] == "provider-native scratchpad"
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Summary
- Extract current-turn reasoning fields from completed run results.
- Emit a final `reasoning.available` event sourced from the completed result when richer reasoning exists.
- Include the same structured reasoning payload on `run.completed` and pollable run status.

Problem
The live `/v1/runs/{run_id}/events` stream only forwarded reasoning progress callback previews. Those previews could be empty or answer-like, while the final session messages preserved richer `reasoning`, `reasoning_content`, and `reasoning_details`, so clients rendered different reasoning before and after refresh.

Validation
- `pytest -q tests/gateway/test_api_server_runs.py::TestRunEvents::test_events_stream_returns_completed tests/gateway/test_api_server_runs.py::TestRunEvents::test_events_stream_exposes_final_reasoning_payload`
- `pytest -q tests/gateway/test_api_server_runs.py`
- `python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py`
- `python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py`

Fixes #60634