### PR TITLE
fix(compression): prevent lock TTL=0 from being swallowed by truthiness check

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -557,7 +557,8 @@ def compress_context(
     # concurrent-compression session fork; an infinite no-progress loop
     # that never compresses at all is strictly worse.
     try:
-        _lock_ttl = float(getattr(agent, "_compression_lock_ttl_seconds", 300.0) or 300.0)
+        _raw_ttl = getattr(agent, "_compression_lock_ttl_seconds", None)
+        _lock_ttl = float(_raw_ttl) if _raw_ttl is not None else 300.0
     except (TypeError, ValueError):
         _lock_ttl = 300.0
     _lock_refresh_interval = getattr(agent, "_compression_lock_refresh_interval", None)

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -672,3 +672,32 @@ def test_lease_refresher_stops_on_persistent_raise() -> None:
     _no_sleep(refresher)
     refresher._run()  # must not propagate
     assert db.calls == refresher._max_consecutive_failures
+
+
+def test_lock_ttl_zero_is_respected_not_swallowed(tmp_path, monkeypatch):
+    """TTL=0 must be passed through, not swallowed by ``or 300.0``."""
+    from hermes_state import SessionDB
+
+    captured_ttl = []
+
+    def _capture_ttl(self, session_id, holder, ttl_seconds=300.0):
+        captured_ttl.append(ttl_seconds)
+        return True
+
+    monkeypatch.setattr(
+        SessionDB, "try_acquire_compression_lock", _capture_ttl,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "TTL_ZERO_TEST"
+    db.create_session(sid, source="discord")
+    agent = _build_agent_with_db(db, sid)
+    agent._compression_lock_ttl_seconds = 0
+
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+    agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+    assert len(captured_ttl) >= 1
+    assert captured_ttl[0] == 0.0, (
+        f"expected TTL=0.0, got {captured_ttl[0]}"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where setting `_compression_lock_ttl_seconds = 0` (for testing or immediate lock expiry) was silently swallowed by `or 300.0` in the truthiness check, resulting in the default 300s TTL instead of 0.

## Related Issue

N/A — discovered via source code audit.

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/conversation_compression.py`: changed `float(getattr(..., 300.0) or 300.0)` to explicit None check so TTL=0 is passed through.
- `tests/agent/test_compression_concurrent_fork.py`: added `test_lock_ttl_zero_is_respected_not_swallowed`.

## How to Test

```bash
python -m pytest tests/agent/test_compression_concurrent_fork.py -v
```

Before: `agent._compression_lock_ttl_seconds = 0` → `0 or 300.0` → 300.0.
After: → 0.0 is correctly passed to `try_acquire_compression_lock`.
