### PR TITLE
fix: recover truncated file tool arguments

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -255,23 +255,36 @@ def sanitize_tool_call_arguments(
 
     repaired = 0
     marker = _ra().AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
+    from agent.message_sanitization import (
+        _TOOL_ARGUMENT_ERROR_KEY,
+        _repair_tool_call_arguments,
+    )
 
-    def _prepend_marker(tool_msg: dict) -> None:
+    def _recovery_content(repaired_args: str) -> str:
+        try:
+            parsed = json.loads(repaired_args)
+        except Exception:
+            return marker
+        if isinstance(parsed, dict) and parsed.get(_TOOL_ARGUMENT_ERROR_KEY):
+            return repaired_args
+        return marker
+
+    def _prepend_marker(tool_msg: dict, content: str) -> None:
         existing = tool_msg.get("content")
         if isinstance(existing, str):
             if not existing:
-                tool_msg["content"] = marker
-            elif not existing.startswith(marker):
-                tool_msg["content"] = f"{marker}\n{existing}"
+                tool_msg["content"] = content
+            elif not existing.startswith(content):
+                tool_msg["content"] = f"{content}\n{existing}"
             return
         if existing is None:
-            tool_msg["content"] = marker
+            tool_msg["content"] = content
             return
         try:
             existing_text = json.dumps(existing)
         except TypeError:
             existing_text = str(existing)
-        tool_msg["content"] = f"{marker}\n{existing_text}"
+        tool_msg["content"] = f"{content}\n{existing_text}"
 
     message_index = 0
     while message_index < len(messages):
@@ -293,6 +306,7 @@ def sanitize_tool_call_arguments(
             if not isinstance(function, dict):
                 continue
 
+            function_name = function.get("name", "?")
             arguments = function.get("arguments")
             if arguments is None or arguments == "":
                 function["arguments"] = "{}"
@@ -313,7 +327,6 @@ def sanitize_tool_call_arguments(
                 # (Codex Responses format) and insert a duplicate stub that
                 # itself becomes an orphan (#58168).
                 tool_call_id = _ra().AIAgent._get_tool_call_id_static(tool_call) or None
-                function_name = function.get("name", "?")
                 preview = arguments[:80]
                 log.warning(
                     "Corrupted tool_call arguments repaired before request "
@@ -324,7 +337,9 @@ def sanitize_tool_call_arguments(
                     function_name,
                     preview,
                 )
-                function["arguments"] = "{}"
+                repaired_arguments = _repair_tool_call_arguments(arguments, function_name)
+                function["arguments"] = repaired_arguments
+                recovery_content = _recovery_content(repaired_arguments)
 
                 existing_tool_msg = None
                 scan_index = message_index + 1
@@ -342,13 +357,13 @@ def sanitize_tool_call_arguments(
                         insert_at,
                         make_tool_result_message(
                             function_name if function_name != "?" else "",
-                            marker,
+                            recovery_content,
                             tool_call_id,
                         ),
                     )
                     insert_at += 1
                 else:
-                    _prepend_marker(existing_tool_msg)
+                    _prepend_marker(existing_tool_msg, recovery_content)
 
                 repaired += 1
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -33,6 +33,7 @@ from agent.model_metadata import is_local_endpoint
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
+    _TOOL_ARGUMENT_ERROR_KEY,
 )
 from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
@@ -2355,10 +2356,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # commas, unclosed brackets, Python None, etc.
                         # Without repair, these hit the truncation handler
                         # and kill the session.  _repair_tool_call_arguments
-                        # returns "{}" for unrepairable args, which is far
-                        # better than a crashed session.
+                        # returns "{}" for generic unrepairable args and a
+                        # retryable sentinel for write-style tools. The
+                        # sentinel is useful once a tool call is already in
+                        # history, but here it still means the live stream cut
+                        # off before the call was executable.
                         repaired = _repair_tool_call_arguments(arguments, tool_name)
-                        if repaired != "{}":
+                        try:
+                            repaired_obj = json.loads(repaired)
+                        except (json.JSONDecodeError, TypeError, ValueError):
+                            repaired_obj = None
+                        if isinstance(repaired_obj, dict) and repaired_obj.get(_TOOL_ARGUMENT_ERROR_KEY):
+                            has_truncated_tool_args = True
+                        elif repaired != "{}":
                             # Successfully repaired — use the fixed args
                             arguments = repaired
                         else:

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -21,6 +21,12 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_TOOL_ARGUMENT_ERROR_KEY = "__hermes_tool_argument_error__"
+_RETRYABLE_TOOL_ARGUMENTS: dict[str, tuple[str, ...]] = {
+    "write_file": ("path", "content"),
+    "patch": ("patch",),
+}
+
 # Lone surrogate code points are invalid in UTF-8 and crash json.dumps
 # inside the OpenAI SDK.  Used by every surrogate-sanitization helper
 # below as well as by run_agent and the CLI for paste-from-clipboard
@@ -182,6 +188,32 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
     return "".join(out)
 
 
+def _tool_argument_retry_payload(tool_name: str, raw_args: str) -> str | None:
+    required = _RETRYABLE_TOOL_ARGUMENTS.get(tool_name)
+    if not required:
+        return None
+    return json.dumps(
+        {
+            _TOOL_ARGUMENT_ERROR_KEY: "truncated_or_malformed",
+            "success": False,
+            "retryable": True,
+            "tool": tool_name,
+            "required": list(required),
+            "error": (
+                f"The {tool_name} tool call arguments were truncated or malformed "
+                "before Hermes could execute the tool."
+            ),
+            "instruction": (
+                f"Re-emit {tool_name} with complete JSON arguments, including "
+                f"{', '.join(required)}. Do not assume the tool ran."
+            ),
+            "arguments_preview": raw_args[:200],
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     """Attempt to repair malformed tool_call argument JSON.
 
@@ -268,6 +300,15 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
             return escaped
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
+
+    retry_payload = _tool_argument_retry_payload(tool_name, raw_stripped)
+    if retry_payload is not None:
+        logger.warning(
+            "Unrepairable tool_call arguments for %s — "
+            "replaced with retryable argument-error payload (was: %s)",
+            tool_name, raw_stripped[:80],
+        )
+        return retry_payload
 
     # Last resort: replace with empty object so the API request doesn't
     # crash the entire session.
@@ -469,6 +510,7 @@ __all__ = [
     "_sanitize_messages_surrogates",
     "_escape_invalid_chars_in_json_strings",
     "_repair_tool_call_arguments",
+    "_TOOL_ARGUMENT_ERROR_KEY",
     "_strip_non_ascii",
     "_sanitize_messages_non_ascii",
     "_sanitize_tools_non_ascii",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -31,6 +31,7 @@ from agent.display import (
     _detect_tool_failure,
 )
 from agent.tool_guardrails import ToolGuardrailDecision
+from agent.message_sanitization import _TOOL_ARGUMENT_ERROR_KEY
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
     _is_multimodal_tool_result,
@@ -72,6 +73,25 @@ _MAX_TOOL_WORKERS = 8
 # Keep this above the stock auxiliary.web_extract timeout (360s) so the batch
 # guard does not preempt a slow-but-valid summarization attempt.
 _DEFAULT_CONCURRENT_TOOL_TIMEOUT_S = 420.0
+
+
+def _tool_argument_error_result(function_name: str, function_args: dict) -> str | None:
+    if not isinstance(function_args, dict):
+        return None
+    if not function_args.get(_TOOL_ARGUMENT_ERROR_KEY):
+        return None
+    payload = dict(function_args)
+    payload.setdefault("success", False)
+    payload.setdefault("retryable", True)
+    payload.setdefault("tool", function_name)
+    payload.setdefault(
+        "error",
+        (
+            f"The {function_name} tool call arguments were truncated or malformed "
+            "before Hermes could execute the tool."
+        ),
+    )
+    return json.dumps(payload, ensure_ascii=False)
 
 
 def _resolve_concurrent_tool_timeout() -> float | None:
@@ -349,6 +369,25 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             function_args = {}
         if not isinstance(function_args, dict):
             function_args = {}
+
+        argument_error_result = _tool_argument_error_result(function_name, function_args)
+        if argument_error_result is not None:
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=argument_error_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status="blocked",
+                error_type="invalid_tool_arguments",
+                error_message=function_args.get("error") or "Tool call arguments were invalid",
+                middleware_trace=[],
+            )
+            parsed_calls.append(
+                (tool_call, function_name, function_args, [], argument_error_result, False)
+            )
+            continue
 
         # ── Tool Search unwrap ────────────────────────────────────────
         # When the model invokes the tool_call bridge, peel it open so
@@ -997,6 +1036,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             function_args = {}
         if not isinstance(function_args, dict):
             function_args = {}
+        argument_error_result = _tool_argument_error_result(function_name, function_args)
 
         # Tool Search unwrap — see execute_tool_calls_concurrent for full
         # rationale, including the scope gate (the unwrap dispatches the
@@ -1049,12 +1089,16 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 pass
 
         _guardrail_block_decision: ToolGuardrailDecision | None = None
-        if _block_msg is None:
+        if argument_error_result is None and _block_msg is None:
             guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
             if not guardrail_decision.allows_execution:
                 _guardrail_block_decision = guardrail_decision
 
-        _execution_blocked = _block_msg is not None or _guardrail_block_decision is not None
+        _execution_blocked = (
+            argument_error_result is not None
+            or _block_msg is not None
+            or _guardrail_block_decision is not None
+        )
 
         if _execution_blocked:
             # Tool blocked by plugin or guardrail policy — skip counters,
@@ -1131,7 +1175,22 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         tool_start_time = time.time()
 
-        if _block_msg is not None:
+        if argument_error_result is not None:
+            function_result = argument_error_result
+            tool_duration = 0.0
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=function_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status="blocked",
+                error_type="invalid_tool_arguments",
+                error_message=function_args.get("error") or "Tool call arguments were invalid",
+                middleware_trace=list(middleware_trace),
+            )
+        elif _block_msg is not None:
             # Tool blocked by plugin policy — return error without executing.
             function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
             tool_duration = 0.0

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -24,6 +24,7 @@ import run_agent
 from run_agent import AIAgent
 from agent.error_classifier import FailoverReason
 from agent.memory_manager import MemoryManager
+from agent.message_sanitization import _repair_tool_call_arguments
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 
 
@@ -2885,6 +2886,26 @@ class TestConcurrentToolExecution:
 
         assert starts == [("c1", "web_search", {"query": "hello"})]
         assert completes == [("c1", "web_search", {"query": "hello"}, '{"success": true}')]
+
+    def test_sequential_argument_error_payload_blocks_real_tool(self, agent):
+        agent.valid_tool_names.add("write_file")
+        payload = _repair_tool_call_arguments(
+            '{"path": "/tmp/out.py", "content": "print(',
+            "write_file",
+        )
+        tool_call = _mock_tool_call(name="write_file", arguments=payload, call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        with patch("run_agent.handle_function_call", side_effect=AssertionError("should not run")):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert len(messages) == 1
+        result = json.loads(messages[0]["content"])
+        assert result["success"] is False
+        assert result["retryable"] is True
+        assert result["tool"] == "write_file"
+        assert "Re-emit write_file" in result["instruction"]
 
     def test_sequential_browser_type_callbacks_redact_api_key(self, agent):
         secret = "sk-proj-ABCD1234567890EFGH"

--- a/tests/run_agent/test_streaming_tool_call_repair.py
+++ b/tests/run_agent/test_streaming_tool_call_repair.py
@@ -106,6 +106,16 @@ class TestStreamingAssemblyRepair:
         parsed = json.loads(result)
         assert parsed == {}
 
+    def test_unrepairable_write_file_returns_retry_payload(self):
+        raw = '{"path": "/tmp/out.py", "content": "print('
+        result = _repair_tool_call_arguments(raw, "write_file")
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert parsed["retryable"] is True
+        assert parsed["tool"] == "write_file"
+        assert parsed["required"] == ["path", "content"]
+        assert "Re-emit write_file" in parsed["instruction"]
+
     def test_glm_truncation_repairable(self):
         """GLM-5.1 truncation pattern that IS repairable."""
         raw = '{"command": "ls -la /tmp", "timeout": 30'

--- a/tests/run_agent/test_tool_call_args_sanitizer.py
+++ b/tests/run_agent/test_tool_call_args_sanitizer.py
@@ -1,6 +1,7 @@
 """Tests for AIAgent._sanitize_tool_call_arguments."""
 
 import copy
+import json
 import logging
 
 from run_agent import AIAgent
@@ -91,6 +92,28 @@ def test_marker_message_inserted_when_missing():
     pass
 
 
+def test_write_file_truncated_arguments_insert_retry_payload():
+    messages = [
+        _assistant_message(
+            _tool_call(
+                name="write_file",
+                arguments='{"path": "/tmp/out.py", "content": "print(',
+            )
+        ),
+    ]
+
+    repaired = AIAgent._sanitize_tool_call_arguments(messages)
+
+    assert repaired == 1
+    repaired_args = json.loads(messages[0]["tool_calls"][0]["function"]["arguments"])
+    assert repaired_args["tool"] == "write_file"
+    assert repaired_args["retryable"] is True
+    assert repaired_args["required"] == ["path", "content"]
+    tool_result = json.loads(messages[1]["content"])
+    assert tool_result["tool"] == "write_file"
+    assert "Re-emit write_file" in tool_result["instruction"]
+
+
 def _disabled_test_marker_message_inserted_when_missing():
     marker = AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
     messages = [
@@ -125,7 +148,7 @@ def test_multiple_corrupted_tool_calls_in_one_message():
     assert repaired == 2
     assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
     assert messages[0]["tool_calls"][1]["function"]["arguments"] == '{"path":"/tmp/bar"}'
-    assert messages[0]["tool_calls"][2]["function"]["arguments"] == "{}"
+    assert messages[0]["tool_calls"][2]["function"]["arguments"] == '{"mode":"tail"}'
     assert messages[1]["tool_call_id"] == "call_1"
     assert messages[1]["content"] == marker
     assert messages[2]["tool_call_id"] == "call_3"


### PR DESCRIPTION
Summary
- Return a retryable argument-error payload when write_file/patch arguments are unrepairably truncated.
- Preserve that payload through history sanitization so the next model turn gets an actionable tool result.
- Block executor dispatch for the argument-error payload so no file tool runs with empty or corrupted args.
- Keep live streaming truncation handling intact so partial tool-argument streams still route through the existing continuation path.

Problem
Some models can truncate large `write_file` JSON arguments mid-string. Hermes repaired generic malformed arguments, but unrepairable write-style calls could collapse to `{}`, leaving the subagent without the path/content it needed and causing long delegate timeouts instead of a visible retry signal.

Validation
- `pytest -q tests/run_agent/test_streaming_tool_call_repair.py::TestStreamingAssemblyRepair::test_unrepairable_write_file_returns_retry_payload tests/run_agent/test_tool_call_args_sanitizer.py::test_write_file_truncated_arguments_insert_retry_payload tests/run_agent/test_run_agent.py::TestConcurrentToolExecution::test_sequential_argument_error_payload_blocks_real_tool`
- `pytest -q tests/run_agent/test_run_agent.py::TestStreamingApiCall::test_truncated_tool_call_args_no_finish_reason_routes_to_stub tests/run_agent/test_run_agent.py::TestStreamingApiCall::test_truncated_tool_call_args_with_length_finish_reason_upgrades`
- `pytest -q tests/run_agent/test_streaming_tool_call_repair.py tests/run_agent/test_tool_call_args_sanitizer.py tests/run_agent/test_run_agent.py::TestStreamingApiCall tests/run_agent/test_run_agent.py::TestConcurrentToolExecution`
- `python -m py_compile agent/chat_completion_helpers.py agent/message_sanitization.py agent/agent_runtime_helpers.py agent/tool_executor.py tests/run_agent/test_run_agent.py tests/run_agent/test_streaming_tool_call_repair.py tests/run_agent/test_tool_call_args_sanitizer.py`
- `python -m ruff check agent/chat_completion_helpers.py agent/message_sanitization.py agent/agent_runtime_helpers.py agent/tool_executor.py tests/run_agent/test_run_agent.py tests/run_agent/test_streaming_tool_call_repair.py tests/run_agent/test_tool_call_args_sanitizer.py`

Fixes #60655