### PR TITLE
fix(email): skip startup UID backlog after trim

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -169,7 +169,7 @@ class _IPv4SMTP_SSL(smtplib.SMTP_SSL):
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
-def _send_imap_id(imap: "imaplib.IMAP4") -> None:
+def _send_imap_id(imap: imaplib.IMAP4) -> None:
     """Send RFC 2971 IMAP ID command identifying this client.
 
     Required by 163/NetEase mailbox after LOGIN: without it, every UID
@@ -633,7 +633,7 @@ class EmailAdapter(BasePlatformAdapter):
             _send_imap_id(imap)
             # Establish a startup UID boundary so we only process later messages.
             imap.select("INBOX")
-            startup_count = self._establish_uid_baseline(imap, reset_seen_uids=True)
+            startup_count = self._establish_uid_baseline(imap)
             if startup_count is None:
                 try:
                     imap.logout()
@@ -716,11 +716,10 @@ class EmailAdapter(BasePlatformAdapter):
                         "[Email] INBOX UIDVALIDITY changed; clearing cached UID state"
                     )
                     # UIDs from the previous namespace are no longer comparable.
-                    # Rebaseline and defer dispatch until the next poll.
+                    # Rebaseline and permanently exclude mail already present.
                     startup_count = self._establish_uid_baseline(
                         imap,
                         uidvalidity=current_uidvalidity,
-                        reset_seen_uids=True,
                     )
                     if startup_count is not None:
                         logger.info(
@@ -829,10 +828,9 @@ class EmailAdapter(BasePlatformAdapter):
 
     def _establish_uid_baseline(
         self,
-        imap: "imaplib.IMAP4",
+        imap: imaplib.IMAP4,
         *,
         uidvalidity: Optional[bytes] = None,
-        reset_seen_uids: bool = False,
     ) -> Optional[int]:
         """Capture the selected mailbox's current UID high-water mark."""
         if uidvalidity is None:
@@ -872,15 +870,12 @@ class EmailAdapter(BasePlatformAdapter):
                 )
         self._startup_seen_uidvalidity = uidvalidity
         self._startup_seen_uid_cutoff = startup_cutoff
-        if reset_seen_uids:
-            self._seen_uids = malformed_uids
-        else:
-            self._seen_uids.update(malformed_uids)
+        self._seen_uids = malformed_uids
         self._trim_seen_uids()
         return startup_count
 
     @staticmethod
-    def _selected_uidvalidity(imap: "imaplib.IMAP4") -> Optional[bytes]:
+    def _selected_uidvalidity(imap: imaplib.IMAP4) -> Optional[bytes]:
         """Return the selected mailbox UIDVALIDITY when the server exposes it."""
         try:
             _status, values = imap.response("UIDVALIDITY")

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -524,6 +524,7 @@ class EmailAdapter(BasePlatformAdapter):
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
+        self._startup_seen_uid_cutoff: Optional[int] = None
         self._poll_task: Optional[asyncio.Task] = None
 
         # Map chat_id (sender email) -> last subject + message-id for threading
@@ -535,9 +536,9 @@ class EmailAdapter(BasePlatformAdapter):
         """Keep only the most recent UIDs to prevent unbounded memory growth.
 
         IMAP UIDs are monotonically increasing integers. When the set grows
-        beyond the cap, we keep only the highest half — old UIDs are safe to
-        drop because new messages always have higher UIDs and IMAP's UNSEEN
-        flag prevents re-delivery regardless.
+        beyond the cap, we keep only the highest half. UIDs observed during
+        startup remain covered by ``_startup_seen_uid_cutoff`` even after they
+        are trimmed from the in-memory duplicate set.
         """
         if len(self._seen_uids) <= self._seen_uids_max:
             return
@@ -634,8 +635,21 @@ class EmailAdapter(BasePlatformAdapter):
             imap.select("INBOX")
             status, data = imap.uid("search", None, "ALL")
             if status == "OK" and data and data[0]:
+                startup_cutoff: Optional[int] = None
                 for uid in data[0].split():
                     self._seen_uids.add(uid)
+                    try:
+                        numeric_uid = int(uid)
+                    except (ValueError, TypeError):
+                        continue
+                    startup_cutoff = (
+                        numeric_uid
+                        if startup_cutoff is None
+                        else max(startup_cutoff, numeric_uid)
+                    )
+                self._startup_seen_uid_cutoff = startup_cutoff
+            else:
+                self._startup_seen_uid_cutoff = None
             # Keep only the most recent UIDs to prevent unbounded growth
             self._trim_seen_uids()
             imap.logout()
@@ -708,6 +722,8 @@ class EmailAdapter(BasePlatformAdapter):
 
                 for uid in data[0].split():
                     if uid in self._seen_uids:
+                        continue
+                    if self._is_startup_seen_uid(uid):
                         continue
                     self._seen_uids.add(uid)
                     # Trim periodically to prevent unbounded memory growth
@@ -789,6 +805,15 @@ class EmailAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
         return results
+
+    def _is_startup_seen_uid(self, uid: bytes) -> bool:
+        """Return True when *uid* was already present at adapter startup."""
+        if self._startup_seen_uid_cutoff is None:
+            return False
+        try:
+            return int(uid) <= self._startup_seen_uid_cutoff
+        except (ValueError, TypeError):
+            return False
 
     @staticmethod
     def _allow_all_senders() -> bool:

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -632,30 +632,20 @@ class EmailAdapter(BasePlatformAdapter):
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             imap.login(self._address, self._password)
             _send_imap_id(imap)
-            # Mark all existing messages as seen so we only process new ones
+            # Establish a startup UID boundary so we only process later messages.
             imap.select("INBOX")
-            self._startup_seen_uidvalidity = self._selected_uidvalidity(imap)
-            status, data = imap.uid("search", None, "ALL")
-            if status == "OK" and data and data[0]:
-                startup_cutoff: Optional[int] = None
-                for uid in data[0].split():
-                    self._seen_uids.add(uid)
-                    try:
-                        numeric_uid = int(uid)
-                    except (ValueError, TypeError):
-                        continue
-                    startup_cutoff = (
-                        numeric_uid
-                        if startup_cutoff is None
-                        else max(startup_cutoff, numeric_uid)
-                    )
-                self._startup_seen_uid_cutoff = startup_cutoff
-            else:
-                self._startup_seen_uid_cutoff = None
-            # Keep only the most recent UIDs to prevent unbounded growth
-            self._trim_seen_uids()
+            startup_count = self._establish_uid_baseline(imap)
+            if startup_count is None:
+                try:
+                    imap.logout()
+                except Exception:
+                    pass
+                return False
             imap.logout()
-            logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
+            logger.info(
+                "[Email] IMAP connection test passed. %d existing messages skipped.",
+                startup_count,
+            )
         except Exception as e:
             logger.error("[Email] IMAP connection failed: %s", e)
             return False
@@ -727,8 +717,13 @@ class EmailAdapter(BasePlatformAdapter):
                         "[Email] INBOX UIDVALIDITY changed; clearing cached UID state"
                     )
                     self._seen_uids.clear()
-                    self._startup_seen_uid_cutoff = None
-                    self._startup_seen_uidvalidity = current_uidvalidity
+                    startup_count = self._establish_uid_baseline(imap)
+                    if startup_count is not None:
+                        logger.info(
+                            "[Email] Re-established INBOX UID baseline with %d existing messages skipped.",
+                            startup_count,
+                        )
+                    return results
 
                 status, data = imap.uid("search", None, "UNSEEN")
                 if status != "OK" or not data or not data[0]:
@@ -819,6 +814,34 @@ class EmailAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
         return results
+
+    def _establish_uid_baseline(self, imap: "imaplib.IMAP4") -> Optional[int]:
+        """Capture the selected mailbox's current UID high-water mark."""
+        self._startup_seen_uidvalidity = self._selected_uidvalidity(imap)
+        status, data = imap.uid("search", None, "ALL")
+        if status != "OK":
+            logger.error("[Email] Could not establish startup UID baseline")
+            self._startup_seen_uid_cutoff = None
+            return None
+
+        startup_count = 0
+        startup_cutoff: Optional[int] = None
+        if data and data[0]:
+            for uid in data[0].split():
+                startup_count += 1
+                try:
+                    numeric_uid = int(uid)
+                except (ValueError, TypeError):
+                    self._seen_uids.add(uid)
+                    continue
+                startup_cutoff = (
+                    numeric_uid
+                    if startup_cutoff is None
+                    else max(startup_cutoff, numeric_uid)
+                )
+        self._startup_seen_uid_cutoff = startup_cutoff
+        self._trim_seen_uids()
+        return startup_count
 
     @staticmethod
     def _selected_uidvalidity(imap: "imaplib.IMAP4") -> Optional[bytes]:

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -633,7 +633,7 @@ class EmailAdapter(BasePlatformAdapter):
             _send_imap_id(imap)
             # Establish a startup UID boundary so we only process later messages.
             imap.select("INBOX")
-            startup_count = self._establish_uid_baseline(imap)
+            startup_count = self._establish_uid_baseline(imap, reset_seen_uids=True)
             if startup_count is None:
                 try:
                     imap.logout()

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -855,8 +855,18 @@ class EmailAdapter(BasePlatformAdapter):
         startup_count = 0
         startup_cutoff: Optional[int] = None
         malformed_uids: set = set()
-        if data and data[0]:
-            for uid in data[0].split():
+        if not data:
+            logger.error("[Email] UID SEARCH ALL returned no baseline payload")
+            return None
+        uid_payload = data[0]
+        if uid_payload not in (b"", ""):
+            if uid_payload is None or not isinstance(uid_payload, (bytes, str)):
+                logger.error(
+                    "[Email] UID SEARCH ALL returned malformed baseline payload: %r",
+                    uid_payload,
+                )
+                return None
+            for uid in uid_payload.split():
                 startup_count += 1
                 try:
                     numeric_uid = int(uid)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -536,10 +536,9 @@ class EmailAdapter(BasePlatformAdapter):
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
 
-        IMAP UIDs are monotonically increasing integers. When the set grows
-        beyond the cap, we keep only the highest half. UIDs observed during
-        startup remain covered by ``_startup_seen_uid_cutoff`` even after they
-        are trimmed from the in-memory duplicate set.
+        IMAP UIDs are monotonically increasing integers. Startup history is
+        covered by ``_startup_seen_uid_cutoff``; this bounded set handles
+        in-process duplicate suppression after startup.
         """
         if len(self._seen_uids) <= self._seen_uids_max:
             return
@@ -830,11 +829,19 @@ class EmailAdapter(BasePlatformAdapter):
             uidvalidity = self._selected_uidvalidity(imap)
         try:
             status, data = imap.uid("search", None, "ALL")
-        except Exception:
-            logger.error("[Email] Could not establish startup UID baseline")
+        except Exception as e:
+            logger.error(
+                "[Email] Could not establish startup UID baseline: %s",
+                e,
+                exc_info=True,
+            )
             return None
         if status != "OK":
-            logger.error("[Email] Could not establish startup UID baseline")
+            logger.error(
+                "[Email] UID SEARCH ALL failed establishing baseline: %s %s",
+                status,
+                data,
+            )
             return None
 
         startup_count = 0

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -715,6 +715,8 @@ class EmailAdapter(BasePlatformAdapter):
                     logger.info(
                         "[Email] INBOX UIDVALIDITY changed; clearing cached UID state"
                     )
+                    # UIDs from the previous namespace are no longer comparable.
+                    # Rebaseline and defer dispatch until the next poll.
                     startup_count = self._establish_uid_baseline(
                         imap,
                         uidvalidity=current_uidvalidity,
@@ -727,7 +729,15 @@ class EmailAdapter(BasePlatformAdapter):
                         )
                     return results
 
-                status, data = imap.uid("search", None, "UNSEEN")
+                search_args = (None, "UNSEEN")
+                if self._startup_seen_uid_cutoff is not None:
+                    search_args = (
+                        None,
+                        "UID",
+                        f"{self._startup_seen_uid_cutoff + 1}:*",
+                        "UNSEEN",
+                    )
+                status, data = imap.uid("search", *search_args)
                 if status != "OK" or not data or not data[0]:
                     return results
 

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -521,7 +521,7 @@ class EmailAdapter(BasePlatformAdapter):
             extra.get("authserv_id", "") or _get_secret("EMAIL_AUTHSERV_ID", "")
         ).strip().lower()
 
-        # Track message IDs we've already processed to avoid duplicates
+        # Track UIDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._startup_seen_uid_cutoff: Optional[int] = None
@@ -716,8 +716,11 @@ class EmailAdapter(BasePlatformAdapter):
                     logger.info(
                         "[Email] INBOX UIDVALIDITY changed; clearing cached UID state"
                     )
-                    self._seen_uids.clear()
-                    startup_count = self._establish_uid_baseline(imap)
+                    startup_count = self._establish_uid_baseline(
+                        imap,
+                        uidvalidity=current_uidvalidity,
+                        reset_seen_uids=True,
+                    )
                     if startup_count is not None:
                         logger.info(
                             "[Email] Re-established INBOX UID baseline with %d existing messages skipped.",
@@ -815,31 +818,47 @@ class EmailAdapter(BasePlatformAdapter):
             logger.error("[Email] IMAP fetch error: %s", e)
         return results
 
-    def _establish_uid_baseline(self, imap: "imaplib.IMAP4") -> Optional[int]:
+    def _establish_uid_baseline(
+        self,
+        imap: "imaplib.IMAP4",
+        *,
+        uidvalidity: Optional[bytes] = None,
+        reset_seen_uids: bool = False,
+    ) -> Optional[int]:
         """Capture the selected mailbox's current UID high-water mark."""
-        self._startup_seen_uidvalidity = self._selected_uidvalidity(imap)
-        status, data = imap.uid("search", None, "ALL")
+        if uidvalidity is None:
+            uidvalidity = self._selected_uidvalidity(imap)
+        try:
+            status, data = imap.uid("search", None, "ALL")
+        except Exception:
+            logger.error("[Email] Could not establish startup UID baseline")
+            return None
         if status != "OK":
             logger.error("[Email] Could not establish startup UID baseline")
-            self._startup_seen_uid_cutoff = None
             return None
 
         startup_count = 0
         startup_cutoff: Optional[int] = None
+        malformed_uids: set = set()
         if data and data[0]:
             for uid in data[0].split():
                 startup_count += 1
                 try:
                     numeric_uid = int(uid)
                 except (ValueError, TypeError):
-                    self._seen_uids.add(uid)
+                    malformed_uids.add(uid)
                     continue
                 startup_cutoff = (
                     numeric_uid
                     if startup_cutoff is None
                     else max(startup_cutoff, numeric_uid)
                 )
+        self._startup_seen_uidvalidity = uidvalidity
         self._startup_seen_uid_cutoff = startup_cutoff
+        if reset_seen_uids:
+            self._seen_uids = malformed_uids
+        else:
+            self._seen_uids.update(malformed_uids)
         self._trim_seen_uids()
         return startup_count
 

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -169,7 +169,7 @@ class _IPv4SMTP_SSL(smtplib.SMTP_SSL):
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
-def _send_imap_id(imap: imaplib.IMAP4) -> None:
+def _send_imap_id(imap: "imaplib.IMAP4") -> None:
     """Send RFC 2971 IMAP ID command identifying this client.
 
     Required by 163/NetEase mailbox after LOGIN: without it, every UID
@@ -631,6 +631,13 @@ class EmailAdapter(BasePlatformAdapter):
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             imap.login(self._address, self._password)
             _send_imap_id(imap)
+            if is_reconnect:
+                logger.warning(
+                    "[Email] Reconnect is establishing a fresh UID baseline; "
+                    "unread mail received while disconnected may be treated as "
+                    "existing backlog because UID state is not persisted across "
+                    "adapter instances."
+                )
             # Establish a startup UID boundary so we only process later messages.
             imap.select("INBOX")
             startup_count = self._establish_uid_baseline(imap)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -525,6 +525,7 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._startup_seen_uid_cutoff: Optional[int] = None
+        self._startup_seen_uidvalidity: Optional[bytes] = None
         self._poll_task: Optional[asyncio.Task] = None
 
         # Map chat_id (sender email) -> last subject + message-id for threading
@@ -633,6 +634,7 @@ class EmailAdapter(BasePlatformAdapter):
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
+            self._startup_seen_uidvalidity = self._selected_uidvalidity(imap)
             status, data = imap.uid("search", None, "ALL")
             if status == "OK" and data and data[0]:
                 startup_cutoff: Optional[int] = None
@@ -715,6 +717,18 @@ class EmailAdapter(BasePlatformAdapter):
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
                 imap.select("INBOX")
+                current_uidvalidity = self._selected_uidvalidity(imap)
+                if (
+                    self._startup_seen_uidvalidity
+                    and current_uidvalidity
+                    and current_uidvalidity != self._startup_seen_uidvalidity
+                ):
+                    logger.info(
+                        "[Email] INBOX UIDVALIDITY changed; clearing cached UID state"
+                    )
+                    self._seen_uids.clear()
+                    self._startup_seen_uid_cutoff = None
+                    self._startup_seen_uidvalidity = current_uidvalidity
 
                 status, data = imap.uid("search", None, "UNSEEN")
                 if status != "OK" or not data or not data[0]:
@@ -805,6 +819,22 @@ class EmailAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
         return results
+
+    @staticmethod
+    def _selected_uidvalidity(imap: "imaplib.IMAP4") -> Optional[bytes]:
+        """Return the selected mailbox UIDVALIDITY when the server exposes it."""
+        try:
+            _status, values = imap.response("UIDVALIDITY")
+        except Exception:  # noqa: BLE001 - UIDVALIDITY is a best-effort guard
+            return None
+        if not values:
+            return None
+        value = values[-1]
+        if isinstance(value, bytes):
+            return value
+        if isinstance(value, str):
+            return value.encode("ascii", errors="ignore")
+        return None
 
     def _is_startup_seen_uid(self, uid: bytes) -> bool:
         """Return True when *uid* was already present at adapter startup."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -527,6 +527,22 @@ class TestConnectDisconnect(unittest.TestCase):
         self.assertFalse(result)
         mock_smtp.assert_not_called()
 
+    def test_connect_fails_when_startup_uid_baseline_raises(self):
+        """The initial UID baseline must fail closed on IMAP exceptions."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+        mock_imap.uid.side_effect = Exception("connection dropped")
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            result = asyncio.run(adapter.connect())
+
+        self.assertFalse(result)
+        self.assertFalse(adapter._running)
+        mock_smtp.assert_not_called()
+
 class TestFetchNewMessages(unittest.TestCase):
     """Test IMAP message fetching logic."""
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -632,6 +632,70 @@ class TestFetchNewMessages(unittest.TestCase):
 
         self.assertEqual([msg["uid"] for msg in results], [b"1001"])
 
+    def test_fetch_searches_only_uids_above_startup_cutoff(self):
+        """Poll search narrows to UIDs above the startup cutoff when possible."""
+        adapter = self._make_adapter()
+        adapter._startup_seen_uid_cutoff = 1000
+        adapter._startup_seen_uidvalidity = b"123"
+
+        raw_email = MIMEText("Fresh", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Fresh"
+        raw_email["Message-ID"] = "<fresh@test.com>"
+
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"123"])
+        search_args = []
+
+        def uid_handler(command, *args):
+            if command == "search":
+                search_args.append(args)
+                return ("OK", [b"1001"])
+            if command == "fetch":
+                return ("OK", [(args[0], raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(search_args, [(None, "UID", "1001:*", "UNSEEN")])
+        self.assertEqual([msg["uid"] for msg in results], [b"1001"])
+
+    def test_check_inbox_does_not_dispatch_startup_cutoff_uid(self):
+        """The cutoff guard prevents dispatch even if search returns old UIDs."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._startup_seen_uid_cutoff = 1000
+        dispatched = []
+
+        async def mock_dispatch(msg_data):
+            dispatched.append(msg_data)
+
+        adapter._dispatch_message = mock_dispatch
+
+        raw_email = MIMEText("Fresh", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Fresh"
+        raw_email["Message-ID"] = "<fresh@test.com>"
+
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"999 1001"])
+            if command == "fetch":
+                return ("OK", [(args[0], raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            asyncio.run(adapter._check_inbox())
+
+        self.assertEqual([msg["uid"] for msg in dispatched], [b"1001"])
+
     def test_connect_cutoff_suppresses_startup_uid_on_next_fetch(self):
         """The startup cutoff protects the first poll even after connect trimming."""
         import asyncio
@@ -749,6 +813,40 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(adapter._startup_seen_uid_cutoff, 999)
         self.assertEqual(adapter._startup_seen_uidvalidity, b"new")
         self.assertEqual(adapter._seen_uids, set())
+
+    def test_fetch_resumes_dispatch_after_uidvalidity_rebaseline(self):
+        """The next poll after a successful rebaseline dispatches fresh mail."""
+        adapter = self._make_adapter()
+        adapter._seen_uids = {b"1001"}
+        adapter._startup_seen_uid_cutoff = 1001
+        adapter._startup_seen_uidvalidity = b"old"
+
+        raw_email = MIMEText("Fresh after rebaseline", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Fresh"
+        raw_email["Message-ID"] = "<fresh@test.com>"
+
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"new"])
+
+        def uid_handler(command, *args):
+            if command == "search" and args[-1] == "ALL":
+                return ("OK", [b"1 500"])
+            if command == "search":
+                return ("OK", [b"501"])
+            if command == "fetch":
+                return ("OK", [(args[0], raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            self.assertEqual(adapter._fetch_new_messages(), [])
+            self.assertEqual(adapter._startup_seen_uid_cutoff, 500)
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual([msg["subject"] for msg in results], ["Fresh"])
+        self.assertIn(b"501", adapter._seen_uids)
 
     def test_fetch_retries_failed_uidvalidity_rebaseline(self):
         """A failed rebaseline keeps old state so the next poll retries safely."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -674,6 +674,47 @@ class TestFetchNewMessages(unittest.TestCase):
         if adapter._poll_task:
             adapter._poll_task.cancel()
 
+    def test_connect_rebaseline_clears_stale_seen_uids(self):
+        """A new connect baseline must not let old UID cache suppress fresh mail."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._poll_loop = AsyncMock()
+        adapter._seen_uids = {b"500"}
+        adapter._startup_seen_uid_cutoff = 1000
+        adapter._startup_seen_uidvalidity = b"old"
+
+        raw_email = MIMEText("Fresh after mailbox reset", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Fresh"
+        raw_email["Message-ID"] = "<fresh@test.com>"
+
+        startup_imap = MagicMock()
+        startup_imap.response.return_value = ("UIDVALIDITY", [b"new"])
+        startup_imap.uid.return_value = ("OK", [b"1 400"])
+
+        poll_imap = MagicMock()
+        poll_imap.response.return_value = ("UIDVALIDITY", [b"new"])
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"500"])
+            if command == "fetch":
+                return ("OK", [(args[0], raw_email.as_bytes())])
+            return ("NO", [])
+
+        poll_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", side_effect=[startup_imap, poll_imap]), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            self.assertTrue(asyncio.run(adapter.connect(is_reconnect=True)))
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual([msg["uid"] for msg in results], [b"500"])
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
+
     def test_fetch_rebaselines_without_dispatch_when_uidvalidity_changes(self):
         """A UIDVALIDITY reset establishes a fresh baseline before dispatch."""
         adapter = self._make_adapter()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -604,6 +604,34 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(fetched_uids, [b"1002"])
         self.assertNotIn(b"999", adapter._seen_uids)
 
+    def test_fetch_skips_uid_equal_to_startup_cutoff(self):
+        """The startup cutoff is inclusive."""
+        adapter = self._make_adapter()
+        adapter._startup_seen_uid_cutoff = 1000
+        adapter._startup_seen_uidvalidity = b"123"
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"123"])
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1000 1001"])
+            if command == "fetch":
+                return ("OK", [(args[0], raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual([msg["uid"] for msg in results], [b"1001"])
+
     def test_connect_cutoff_suppresses_startup_uid_on_next_fetch(self):
         """The startup cutoff protects the first poll even after connect trimming."""
         import asyncio
@@ -759,6 +787,32 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(adapter._startup_seen_uid_cutoff, 10)
         self.assertEqual(adapter._startup_seen_uidvalidity, b"123")
         self.assertEqual(adapter._seen_uids, set())
+
+    def test_establish_uid_baseline_handles_empty_inbox(self):
+        """An empty baseline leaves the startup cutoff unset."""
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"123"])
+        mock_imap.uid.return_value = ("OK", [b""])
+
+        self.assertEqual(adapter._establish_uid_baseline(mock_imap), 0)
+        self.assertIsNone(adapter._startup_seen_uid_cutoff)
+        self.assertEqual(adapter._startup_seen_uidvalidity, b"123")
+        self.assertEqual(adapter._seen_uids, set())
+
+    def test_establish_uid_baseline_keeps_malformed_uids_in_duplicate_cache(self):
+        """Non-numeric UID tokens fall back to exact duplicate tracking."""
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"123"])
+        mock_imap.uid.return_value = ("OK", [b"bad 10 2"])
+
+        self.assertEqual(adapter._establish_uid_baseline(mock_imap), 3)
+        self.assertEqual(adapter._startup_seen_uid_cutoff, 10)
+        self.assertEqual(adapter._startup_seen_uidvalidity, b"123")
+        self.assertEqual(adapter._seen_uids, {b"bad"})
 
 class TestPollLoop(unittest.TestCase):
     """Test the async polling loop."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -486,6 +486,26 @@ class TestConnectDisconnect(unittest.TestCase):
             if adapter._poll_task:
                 adapter._poll_task.cancel()
 
+    def test_connect_records_startup_uid_cutoff_before_trimming(self):
+        """The startup high-water UID survives trimming the duplicate set."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._seen_uids_max = 4
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b"1 2 3 4 5 6"])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp, \
+             patch("asyncio.create_task", return_value=None):
+            mock_smtp.return_value = MagicMock()
+
+            result = asyncio.run(adapter.connect())
+
+            self.assertTrue(result)
+            self.assertEqual(adapter._startup_seen_uid_cutoff, 6)
+            self.assertEqual(adapter._seen_uids, {b"5", b"6"})
+            adapter._running = False
 
 class TestFetchNewMessages(unittest.TestCase):
     """Test IMAP message fetching logic."""
@@ -531,6 +551,37 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(results[0]["sender_addr"], "user@test.com")
         self.assertIn(b"3", adapter._seen_uids)
 
+    def test_fetch_skips_trimmed_startup_uids(self):
+        """Old unread startup messages trimmed from _seen_uids are not replayed."""
+        adapter = self._make_adapter()
+        adapter._seen_uids = {b"1001"}
+        adapter._startup_seen_uid_cutoff = 1001
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        mock_imap = MagicMock()
+        fetched_uids = []
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"999 1002"])
+            if command == "fetch":
+                fetched_uids.append(args[0])
+                return ("OK", [(args[0], raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["uid"], b"1002")
+        self.assertEqual(fetched_uids, [b"1002"])
+        self.assertNotIn(b"999", adapter._seen_uids)
 
 class TestPollLoop(unittest.TestCase):
     """Test the async polling loop."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -620,25 +620,22 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(fetched_uids, [b"1002"])
         self.assertNotIn(b"999", adapter._seen_uids)
 
-    def test_fetch_skips_uid_equal_to_startup_cutoff(self):
-        """The startup cutoff is inclusive."""
+    def test_fetch_filters_range_boundary_uid_returned_by_server(self):
+        """The cutoff guard rejects a reordered IMAP UID range boundary."""
         adapter = self._make_adapter()
         adapter._startup_seen_uid_cutoff = 1000
         adapter._startup_seen_uidvalidity = b"123"
-
-        raw_email = MIMEText("Hello", "plain", "utf-8")
-        raw_email["From"] = "user@test.com"
-        raw_email["Subject"] = "Test"
-        raw_email["Message-ID"] = "<msg@test.com>"
 
         mock_imap = MagicMock()
         mock_imap.response.return_value = ("UIDVALIDITY", [b"123"])
 
         def uid_handler(command, *args):
             if command == "search":
-                return ("OK", [b"1000 1001"])
+                # Some servers may reorder ``1001:*`` when 1000 is the
+                # mailbox's highest UID and return the cutoff boundary.
+                return ("OK", [b"1000"])
             if command == "fetch":
-                return ("OK", [(args[0], raw_email.as_bytes())])
+                raise AssertionError("the startup cutoff UID must not be fetched")
             return ("NO", [])
 
         mock_imap.uid.side_effect = uid_handler
@@ -646,7 +643,7 @@ class TestFetchNewMessages(unittest.TestCase):
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
             results = adapter._fetch_new_messages()
 
-        self.assertEqual([msg["uid"] for msg in results], [b"1001"])
+        self.assertEqual(results, [])
 
     def test_fetch_searches_only_uids_above_startup_cutoff(self):
         """Poll search narrows to UIDs above the startup cutoff when possible."""
@@ -784,13 +781,20 @@ class TestFetchNewMessages(unittest.TestCase):
 
         poll_imap.uid.side_effect = uid_handler
 
-        with patch("imaplib.IMAP4_SSL", side_effect=[startup_imap, poll_imap]), \
-             patch("smtplib.SMTP") as mock_smtp:
-            mock_smtp.return_value = MagicMock()
-            self.assertTrue(asyncio.run(adapter.connect(is_reconnect=True)))
-            results = adapter._fetch_new_messages()
+        with self.assertLogs(
+            "plugins.platforms.email.adapter", level="WARNING"
+        ) as reconnect_logs:
+            with patch("imaplib.IMAP4_SSL", side_effect=[startup_imap, poll_imap]), \
+                 patch("smtplib.SMTP") as mock_smtp:
+                mock_smtp.return_value = MagicMock()
+                self.assertTrue(asyncio.run(adapter.connect(is_reconnect=True)))
+                results = adapter._fetch_new_messages()
 
         self.assertEqual([msg["uid"] for msg in results], [b"500"])
+        self.assertTrue(any(
+            "unread mail received while disconnected" in message
+            for message in reconnect_logs.output
+        ))
         adapter._running = False
         if adapter._poll_task:
             adapter._poll_task.cancel()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -654,7 +654,10 @@ class TestFetchNewMessages(unittest.TestCase):
         adapter._startup_seen_uidvalidity = b"old"
 
         mock_imap = MagicMock()
-        mock_imap.response.return_value = ("UIDVALIDITY", [b"new"])
+        mock_imap.response.side_effect = [
+            ("UIDVALIDITY", [b"new"]),
+            (None, []),
+        ]
         search_criteria = []
 
         def uid_handler(command, *args):
@@ -676,6 +679,85 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(search_criteria, ["ALL"])
         self.assertEqual(adapter._startup_seen_uid_cutoff, 999)
         self.assertEqual(adapter._startup_seen_uidvalidity, b"new")
+        self.assertEqual(adapter._seen_uids, set())
+
+    def test_fetch_retries_failed_uidvalidity_rebaseline(self):
+        """A failed rebaseline keeps old state so the next poll retries safely."""
+        adapter = self._make_adapter()
+        adapter._seen_uids = {b"1001"}
+        adapter._startup_seen_uid_cutoff = 1001
+        adapter._startup_seen_uidvalidity = b"old"
+
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"new"])
+        search_all_attempts = 0
+
+        def uid_handler(command, *args):
+            nonlocal search_all_attempts
+            if command == "search" and args[-1] == "ALL":
+                search_all_attempts += 1
+                if search_all_attempts == 1:
+                    return ("NO", [b"server error"])
+                return ("OK", [b"1 999"])
+            if command == "search":
+                raise AssertionError("unsafe rebaseline should not reach UNSEEN search")
+            if command == "fetch":
+                raise AssertionError("failed rebaseline should not fetch messages")
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            self.assertEqual(adapter._fetch_new_messages(), [])
+            self.assertEqual(adapter._startup_seen_uid_cutoff, 1001)
+            self.assertEqual(adapter._startup_seen_uidvalidity, b"old")
+            self.assertEqual(adapter._seen_uids, {b"1001"})
+
+            self.assertEqual(adapter._fetch_new_messages(), [])
+
+        self.assertEqual(adapter._startup_seen_uid_cutoff, 999)
+        self.assertEqual(adapter._startup_seen_uidvalidity, b"new")
+        self.assertEqual(adapter._seen_uids, set())
+        self.assertEqual(search_all_attempts, 2)
+
+    def test_fetch_keeps_state_when_uidvalidity_rebaseline_raises(self):
+        """A rebaseline exception should not publish partial mailbox state."""
+        adapter = self._make_adapter()
+        adapter._seen_uids = {b"1001"}
+        adapter._startup_seen_uid_cutoff = 1001
+        adapter._startup_seen_uidvalidity = b"old"
+
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"new"])
+
+        def uid_handler(command, *args):
+            if command == "search" and args[-1] == "ALL":
+                raise Exception("connection dropped")
+            if command == "search":
+                raise AssertionError("failed rebaseline should not reach UNSEEN search")
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+        self.assertEqual(adapter._startup_seen_uid_cutoff, 1001)
+        self.assertEqual(adapter._startup_seen_uidvalidity, b"old")
+        self.assertEqual(adapter._seen_uids, {b"1001"})
+
+    def test_establish_uid_baseline_uses_highest_uid_not_response_order(self):
+        """The startup cutoff uses max UID rather than the final response token."""
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"123"])
+        mock_imap.uid.return_value = ("OK", [b"10 2 9"])
+
+        self.assertEqual(adapter._establish_uid_baseline(mock_imap), 3)
+        self.assertEqual(adapter._startup_seen_uid_cutoff, 10)
+        self.assertEqual(adapter._startup_seen_uidvalidity, b"123")
         self.assertEqual(adapter._seen_uids, set())
 
 class TestPollLoop(unittest.TestCase):

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -956,6 +956,19 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(adapter._startup_seen_uidvalidity, b"123")
         self.assertEqual(adapter._seen_uids, set())
 
+    def test_establish_uid_baseline_rejects_malformed_ok_payload(self):
+        """A malformed OK SEARCH payload is not a safe startup boundary."""
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"123"])
+        mock_imap.uid.return_value = ("OK", [None])
+
+        self.assertIsNone(adapter._establish_uid_baseline(mock_imap))
+        self.assertIsNone(adapter._startup_seen_uid_cutoff)
+        self.assertIsNone(adapter._startup_seen_uidvalidity)
+        self.assertEqual(adapter._seen_uids, set())
+
     def test_establish_uid_baseline_keeps_malformed_uids_in_duplicate_cache(self):
         """Non-numeric UID tokens fall back to exact duplicate tracking."""
         adapter = self._make_adapter()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -479,15 +479,16 @@ class TestConnectDisconnect(unittest.TestCase):
 
             self.assertTrue(result)
             self.assertTrue(adapter._running)
-            # Should have skipped existing messages
-            self.assertEqual(len(adapter._seen_uids), 3)
+            # Should have skipped existing messages without caching every UID
+            self.assertEqual(adapter._startup_seen_uid_cutoff, 3)
+            self.assertEqual(adapter._seen_uids, set())
             # Cleanup
             adapter._running = False
             if adapter._poll_task:
                 adapter._poll_task.cancel()
 
-    def test_connect_records_startup_uid_cutoff_before_trimming(self):
-        """The startup high-water UID survives trimming the duplicate set."""
+    def test_connect_records_startup_uid_cutoff_without_historical_uid_cache(self):
+        """The startup high-water UID avoids seeding every historical UID."""
         import asyncio
         adapter = self._make_adapter()
         adapter._seen_uids_max = 4
@@ -506,10 +507,25 @@ class TestConnectDisconnect(unittest.TestCase):
             self.assertTrue(result)
             self.assertEqual(adapter._startup_seen_uid_cutoff, 6)
             self.assertEqual(adapter._startup_seen_uidvalidity, b"123")
-            self.assertEqual(adapter._seen_uids, {b"5", b"6"})
+            self.assertEqual(adapter._seen_uids, set())
             adapter._running = False
             if adapter._poll_task:
                 adapter._poll_task.cancel()
+
+    def test_connect_fails_when_startup_uid_baseline_fails(self):
+        """The adapter should not start if the initial UID baseline is unsafe."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("NO", [b"server error"])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            result = asyncio.run(adapter.connect())
+
+        self.assertFalse(result)
+        mock_smtp.assert_not_called()
 
 class TestFetchNewMessages(unittest.TestCase):
     """Test IMAP message fetching logic."""
@@ -630,26 +646,25 @@ class TestFetchNewMessages(unittest.TestCase):
         if adapter._poll_task:
             adapter._poll_task.cancel()
 
-    def test_fetch_clears_startup_cutoff_when_uidvalidity_changes(self):
-        """A UIDVALIDITY reset invalidates the old startup cutoff."""
+    def test_fetch_rebaselines_without_dispatch_when_uidvalidity_changes(self):
+        """A UIDVALIDITY reset establishes a fresh baseline before dispatch."""
         adapter = self._make_adapter()
         adapter._seen_uids = {b"1001"}
         adapter._startup_seen_uid_cutoff = 1001
         adapter._startup_seen_uidvalidity = b"old"
 
-        raw_email = MIMEText("Hello", "plain", "utf-8")
-        raw_email["From"] = "user@test.com"
-        raw_email["Subject"] = "Test"
-        raw_email["Message-ID"] = "<msg@test.com>"
-
         mock_imap = MagicMock()
         mock_imap.response.return_value = ("UIDVALIDITY", [b"new"])
+        search_criteria = []
 
         def uid_handler(command, *args):
             if command == "search":
-                return ("OK", [b"999"])
+                search_criteria.append(args[-1])
+                if args[-1] == "ALL":
+                    return ("OK", [b"1 999"])
+                raise AssertionError("existing unread backlog should not be fetched")
             if command == "fetch":
-                return ("OK", [(args[0], raw_email.as_bytes())])
+                raise AssertionError("UIDVALIDITY rebaseline should skip this poll")
             return ("NO", [])
 
         mock_imap.uid.side_effect = uid_handler
@@ -657,10 +672,11 @@ class TestFetchNewMessages(unittest.TestCase):
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
             results = adapter._fetch_new_messages()
 
-        self.assertEqual([msg["uid"] for msg in results], [b"999"])
-        self.assertIsNone(adapter._startup_seen_uid_cutoff)
+        self.assertEqual(results, [])
+        self.assertEqual(search_criteria, ["ALL"])
+        self.assertEqual(adapter._startup_seen_uid_cutoff, 999)
         self.assertEqual(adapter._startup_seen_uidvalidity, b"new")
-        self.assertIn(b"999", adapter._seen_uids)
+        self.assertEqual(adapter._seen_uids, set())
 
 class TestPollLoop(unittest.TestCase):
     """Test the async polling loop."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -491,21 +491,25 @@ class TestConnectDisconnect(unittest.TestCase):
         import asyncio
         adapter = self._make_adapter()
         adapter._seen_uids_max = 4
+        adapter._poll_loop = AsyncMock()
 
         mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"123"])
         mock_imap.uid.return_value = ("OK", [b"1 2 3 4 5 6"])
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
-             patch("smtplib.SMTP") as mock_smtp, \
-             patch("asyncio.create_task", return_value=None):
+             patch("smtplib.SMTP") as mock_smtp:
             mock_smtp.return_value = MagicMock()
 
             result = asyncio.run(adapter.connect())
 
             self.assertTrue(result)
             self.assertEqual(adapter._startup_seen_uid_cutoff, 6)
+            self.assertEqual(adapter._startup_seen_uidvalidity, b"123")
             self.assertEqual(adapter._seen_uids, {b"5", b"6"})
             adapter._running = False
+            if adapter._poll_task:
+                adapter._poll_task.cancel()
 
 class TestFetchNewMessages(unittest.TestCase):
     """Test IMAP message fetching logic."""
@@ -563,6 +567,7 @@ class TestFetchNewMessages(unittest.TestCase):
         raw_email["Message-ID"] = "<msg@test.com>"
 
         mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"123"])
         fetched_uids = []
 
         def uid_handler(command, *args):
@@ -582,6 +587,80 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(results[0]["uid"], b"1002")
         self.assertEqual(fetched_uids, [b"1002"])
         self.assertNotIn(b"999", adapter._seen_uids)
+
+    def test_connect_cutoff_suppresses_startup_uid_on_next_fetch(self):
+        """The startup cutoff protects the first poll even after connect trimming."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._seen_uids_max = 4
+        adapter._poll_loop = AsyncMock()
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        startup_imap = MagicMock()
+        startup_imap.response.return_value = ("UIDVALIDITY", [b"123"])
+        startup_imap.uid.return_value = ("OK", [b"1 2 3 4 5 6"])
+
+        poll_imap = MagicMock()
+        poll_imap.response.return_value = ("UIDVALIDITY", [b"123"])
+        fetched_uids = []
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1 7"])
+            if command == "fetch":
+                fetched_uids.append(args[0])
+                return ("OK", [(args[0], raw_email.as_bytes())])
+            return ("NO", [])
+
+        poll_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", side_effect=[startup_imap, poll_imap]), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            self.assertTrue(asyncio.run(adapter.connect()))
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(fetched_uids, [b"7"])
+        self.assertEqual([msg["uid"] for msg in results], [b"7"])
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
+
+    def test_fetch_clears_startup_cutoff_when_uidvalidity_changes(self):
+        """A UIDVALIDITY reset invalidates the old startup cutoff."""
+        adapter = self._make_adapter()
+        adapter._seen_uids = {b"1001"}
+        adapter._startup_seen_uid_cutoff = 1001
+        adapter._startup_seen_uidvalidity = b"old"
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        mock_imap = MagicMock()
+        mock_imap.response.return_value = ("UIDVALIDITY", [b"new"])
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"999"])
+            if command == "fetch":
+                return ("OK", [(args[0], raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual([msg["uid"] for msg in results], [b"999"])
+        self.assertIsNone(adapter._startup_seen_uid_cutoff)
+        self.assertEqual(adapter._startup_seen_uidvalidity, b"new")
+        self.assertIn(b"999", adapter._seen_uids)
 
 class TestPollLoop(unittest.TestCase):
     """Test the async polling loop."""


### PR DESCRIPTION
## What does this PR do?

Fixes an email gateway startup replay edge case: when the initial `UID SEARCH ALL` result is larger than `_seen_uids_max`, `_trim_seen_uids()` drops older startup UIDs. If one of those old messages is still `UNSEEN`, the next poll can fetch and dispatch it as if it arrived after startup.

The adapter now records the highest numeric UID observed during the startup scan and searches later polls only for `UNSEEN` UIDs above that startup cutoff, while keeping a defensive post-search cutoff guard. `_seen_uids` can still be trimmed for in-process duplicate suppression without storing every historical UID. The cutoff is tied to the selected mailbox UIDVALIDITY; if the INBOX UID namespace changes, Hermes re-establishes a fresh baseline on that poll and does not dispatch the existing unread backlog as new mail. A new connect baseline also clears stale duplicate UID cache entries so UIDVALIDITY-scoped `_seen_uids` state cannot suppress fresh mail after a reconnect baseline.

## Related Issue

Fixes #60637

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/email/adapter.py`: establish a startup UID baseline from `UID SEARCH ALL` without seeding every historical numeric UID into `_seen_uids`.
- `plugins/platforms/email/adapter.py`: narrow poll-time IMAP search to `UNSEEN` UIDs above the startup cutoff, while still skipping any cutoff-or-older UID before fetching message bodies.
- `plugins/platforms/email/adapter.py`: fail closed if the startup UID baseline cannot be established; this intentionally aborts connect instead of starting in an unsafe degraded mode.
- `plugins/platforms/email/adapter.py`: record selected INBOX UIDVALIDITY and re-baseline safely if the mailbox UID namespace changes, keeping old state intact if replacement baseline fails so the next poll retries safely.
- `plugins/platforms/email/adapter.py`: reset stale `_seen_uids` duplicate state whenever a fresh mailbox baseline is established.
- `plugins/platforms/email/adapter.py`: warn explicitly when reconnect creates a fresh baseline, because the gateway currently creates a new adapter instance and cannot preserve an outage-window UID boundary.
- `plugins/platforms/email/adapter.py`: reject malformed `OK` baseline payloads as unsafe instead of treating them as an empty inbox.
- `tests/gateway/test_email.py`: add regressions proving the startup high-water mark replaces historical UID caching, the connect-then-poll path skips old startup UIDs, cutoff-backed polling narrows the IMAP search, dispatch still refuses cutoff-or-older UIDs returned by a server, connect rebaseline clears stale duplicate cache state, baseline failure/exception/malformed payloads stop startup before SMTP, UIDVALIDITY resets re-baseline without dispatch and resumes dispatch on the next poll, failed/raising rebaseline leaves old state intact, unsorted/empty/malformed baseline responses are handled, cutoff equality is skipped, and old unread startup UIDs are not replayed.

### Upgrade semantics for existing users

No config change is required. On the first `connect()` after upgrading, the adapter establishes the baseline from the mailbox's current state exactly as before (`UID SEARCH ALL`), so an existing large inbox sees: no backlog dispatch (including old UNSEEN mail that the previous trim-based tracking would have replayed), and new mail from that point on delivered normally. The only behavioral difference on upgrade is the *absence* of the erroneous replay; there is no persisted state to migrate because UID state was never persisted across adapter instances.

## How to Test

1. Before the implementation, the new regression failed on `origin/main`:
   `scripts/run_tests.sh tests/gateway/test_email.py -- -k 'startup_uid_cutoff or trimmed_startup' -q`
   - `TestConnectDisconnect.test_connect_records_startup_uid_cutoff_before_trimming`: `AttributeError: 'EmailAdapter' object has no attribute '_startup_seen_uid_cutoff'`
   - `TestFetchNewMessages.test_fetch_skips_trimmed_startup_uids`: `AssertionError: 2 != 1`
2. Final focused proof:
   `scripts/run_tests.sh tests/gateway/test_email.py -- -k 'malformed_ok_payload or startup_uid_baseline_raises or searches_only_uids_above_startup_cutoff or check_inbox_does_not_dispatch_startup_cutoff_uid or resumes_dispatch_after_uidvalidity_rebaseline or connect_rebaseline_clears_stale_seen_uids or connect_cutoff or uidvalidity or startup_uid_cutoff or trimmed_startup' -q`
   - 12 passed
3. Broader focused proof:
   `scripts/run_tests.sh tests/gateway/test_email.py`
   - 105 passed
4. Cross-platform/lint proof:
   `.venv/bin/python scripts/check-windows-footguns.py plugins/platforms/email/adapter.py tests/gateway/test_email.py`
   - No Windows footguns found
   `.venv/bin/ruff check plugins/platforms/email/adapter.py tests/gateway/test_email.py`
   - All checks passed
   `git diff --check`
   - clean
   `.venv/bin/python scripts/lint_diff.py --base-ruff /private/tmp/hermes-lint-60637.w29D73/base/ruff.json --head-ruff /private/tmp/hermes-lint-60637.w29D73/head/ruff.json --base-ty /private/tmp/hermes-lint-60637.w29D73/base/ty.json --head-ty /private/tmp/hermes-lint-60637.w29D73/head/ty.json --base-ref origin/main --head-ref fix/email-startup-uid-cutoff`
   - No new ruff issues; no new ty issues

Duplicate-work / cluster check:

- Current exact search for `60637` finds two open PRs: #60652 and this PR (#60677).
- #60652 is earlier and addresses the same root cause with a 1-file watermark-only patch, but currently has no checked-in regression tests and no reported check rollup on its branch.
- This PR is later, but has the stronger proof surface: checked-in red/green regressions, server-side poll narrowing above the cutoff, defensive post-search cutoff guard, UIDVALIDITY rebaseline handling, fail-closed startup baseline behavior, malformed baseline payload hardening, and green required checks.
- Root-cause keyword search for `email uid replay trim seen_uids watermark startup cutoff` did not find additional sibling PRs.

Pre-push review status:

- Normal pushes to `fork/fix/email-startup-uid-cutoff` launched the private cowork pre-push review hook.
- Review feedback raised UIDVALIDITY, reset-poll replay, failed-rebaseline atomicity, logging, edge-case coverage, connect-rebaseline stale-cache, post-rebaseline dispatch, connect-time baseline exception coverage, malformed baseline payloads, dead baseline-reset optionality, large-unread-backlog search-efficiency concerns, and the #60652 duplicate cluster; this branch addresses the actionable code/test items and documents the remaining reconnect/offline-delivery scope below.

Known scope note:

- The email adapter already treats mail present before a fully successful `connect()` as existing backlog, including `connect(is_reconnect=True)` because the gateway creates a fresh adapter without a persisted prior UID boundary. Unread mail arriving while email is disconnected can therefore be included in the reconnect baseline. That reconnect/offline-delivery gap predates this PR and requires persisted state across adapter instances, so it remains separate from #60637's startup-trim replay bug. This PR now emits an explicit reconnect warning instead of leaving the limitation silent, while preserving existing behavior and making the cold-start UID boundary safe for large inboxes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

Not applicable; this is an email gateway polling regression covered by unit tests.

