### PR TITLE
fix(env): remove HASS_TOKEN from unconditional Tier-1 env strip (Fixes #60667)

### DIFF
--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -209,3 +209,24 @@ class TestInternalDynamicSecrets:
         assert {
             "GATEWAY_RELAY_ID", "GATEWAY_RELAY_SECRET", "GATEWAY_RELAY_DELIVERY_KEY",
         } <= _ALWAYS_STRIP_KEYS
+
+
+class TestToolCredentialPassthrough:
+    """Tool credentials should pass through when inherit_credentials=True."""
+
+    def test_hass_token_passes_through_when_inheriting(self):
+        """HASS_TOKEN is a tool secret, not a gateway bot token.
+        It must be passed to TUI/desktop chat subprocesses (#60667)."""
+        assert "HASS_TOKEN" not in _ALWAYS_STRIP_KEYS, (
+            "HASS_TOKEN should not be in _ALWAYS_STRIP_KEYS"
+        )
+        result = _build(
+            {"HASS_TOKEN": "test-hass-token"},
+            inherit_credentials=True,
+        )
+        assert result.get("HASS_TOKEN") == "test-hass-token"
+        result_no = _build(
+            {"HASS_TOKEN": "test-hass-token"},
+            inherit_credentials=False,
+        )
+        assert "HASS_TOKEN" not in result_no

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -421,7 +421,6 @@ _ALWAYS_STRIP_KEYS: frozenset[str] = frozenset({
     "GATEWAY_RELAY_ID",
     "GATEWAY_RELAY_SECRET",
     "GATEWAY_RELAY_DELIVERY_KEY",
-    "HASS_TOKEN",
     "EMAIL_PASSWORD",
     "HERMES_DASHBOARD_SESSION_TOKEN",
     # Remote-compute / infrastructure secrets


### PR DESCRIPTION
## What does this PR do?

HASS_TOKEN was listed in both Tier 1 (`_ALWAYS_STRIP_KEYS`, unconditional) and Tier 2 (`_HERMES_PROVIDER_ENV_BLOCKLIST`, conditional). When `inherit_credentials=True` (TUI/desktop chat sessions), Tier 2 is skipped but Tier 1 still stripped HASS_TOKEN, making ha_* smart-home tools permanently unavailable in TUI/desktop.

## Related Issue

Fixes #60667

## Type of Change

- [x] Bug fix

## Changes Made

- `tools/environments/local.py`: removed HASS_TOKEN from `_ALWAYS_STRIP_KEYS`. It remains protected by Tier 2 blocklist.
- `tests/tools/test_hermes_subprocess_env.py`: added `TestToolCredentialPassthrough` verifying HASS_TOKEN passes through with `inherit_credentials=True` and is stripped without it.

## How to Test

```bash
python -m pytest tests/tools/test_hermes_subprocess_env.py -v
```