### PR TITLE
feat(cli): add /set_compression command to configure threshold

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8635,6 +8635,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._handle_fast_command(cmd_original)
         elif canonical == "compress":
             self._manual_compress(cmd_original)
+        elif canonical == "set_compression":
+            # /set_compression <1-100> — set auto-compression threshold
+            parts = cmd_original.strip().split()
+            if len(parts) < 2:
+                cfg = self.config.get("compression", {})
+                cur = cfg.get("threshold", 0.50)
+                print(f"  Current compression threshold: {cur * 100:.0f}%")
+                print("  Usage: /set_compression <1-100>")
+            else:
+                try:
+                    pct = int(parts[1])
+                    if not 1 <= pct <= 100:
+                        print("  Threshold must be between 1 and 100")
+                    else:
+                        from hermes_cli.config import save_config_value
+                        save_config_value("compression.threshold", pct / 100.0)
+                        print(f"  Compression threshold set to {pct}%")
+                        print("  Takes effect on next session (/reset).")
+                except ValueError:
+                    print("  Invalid value. Usage: /set_compression <1-100>")
         elif canonical == "usage":
             self._show_usage()
         elif canonical == "credits":

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -90,6 +90,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("fork",), args_hint="[name]"),
     CommandDef("compress", "Compress conversation context (add 'here [N]' to keep recent N turns; --preview shows what would happen)", "Session",
                aliases=("compact",), args_hint="[here [N] | focus topic | --preview|--dry-run]"),
+    CommandDef("set_compression", "Set auto-compression threshold (e.g. 70 = compress at 70% context usage)", "Configuration",
+               args_hint="<1-100>"),
     CommandDef("rollback", "List or restore filesystem checkpoints", "Session",
                args_hint="[number]"),
     CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",


### PR DESCRIPTION
## Summary

Adds `/set_compression` command to set the auto-compression threshold from inside the CLI. Previously only `/compress` (force compress now) existed — no way to configure when automatic compression triggers.

## Usage

```
/set_compression 70    # compress at 70% context usage
/set_compression       # show current threshold
```

## Changes

- **hermes_cli/commands.py**: New `CommandDef` for `set_compression`
- **cli.py**: Handler reads/writes `compression.threshold` via `save_config_value`

## Backward Compatibility

No config changes. Default threshold (0.50) unchanged. Command is purely additive.

Closes #60582