### PR TITLE
fix: resolve deferred platform-plugin loaders before building plugin CLI subparsers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13123,6 +13123,23 @@ def main():
                 seen_plugin_commands.add(cmd_info["name"])
 
             discover_plugins()
+            # Bundled *platform* plugins (photon, raft, ...) register their
+            # CLI subcommand lazily via platform_registry.register_deferred()
+            # to avoid importing every channel adapter (grpc, aiohttp, etc.)
+            # on every invocation. That means their entry in
+            # PluginManager._cli_commands is only populated once the
+            # deferred loader actually runs. Nothing upstream of this point
+            # ever asks platform_registry for a platform, so without this
+            # resolve, `hermes photon ...` / `hermes raft ...` never appear
+            # as subcommands no matter how the plugin is enabled. Resolve
+            # every pending loader now — cheap because we're already inside
+            # the `_plugin_cli_discovery_needed()` branch, so this cost is
+            # only paid on invocations that already need plugin discovery.
+            try:
+                from gateway.platform_registry import platform_registry as _plat_registry
+                _plat_registry._resolve_all()
+            except Exception:
+                pass
             for cmd_info in get_plugin_manager()._cli_commands.values():
                 if cmd_info["name"] in seen_plugin_commands:
                     continue


### PR DESCRIPTION
## Problem

Bundled platform plugins (e.g. `photon-platform`, `raft-platform`) register their `hermes <name> ...` CLI subcommand lazily via `platform_registry.register_deferred()` — this avoids importing every channel adapter (grpc, aiohttp, spectrum-ts sidecar deps, etc.) on every single CLI invocation, which would cost 500-650ms per call.

The deferred loader is only resolved the first time something asks `platform_registry.get(<name>)` — e.g. gateway startup, cron delivery, `send_message`. Nothing in `main.py`'s argparse setup does this before reading `PluginManager._cli_commands` when building the plugin CLI subparsers (see the `_plugin_cli_discovery_needed()` branch).

Result: **`hermes photon setup` (and any bundled platform plugin that ships a CLI command) always fails** with:

```
hermes: error: argument command: invalid choice: 'photon' (choose from ...)
```

...no matter how the plugin is enabled (`hermes plugins enable photon-platform`, config.yaml, etc.) — there is no code path that reaches it through the normal CLI. Confirmed via `hermes plugins list` showing the plugin as `enabled` while `PluginManager()._cli_commands` remains `{}` until something explicitly calls `platform_registry.get('photon')` / `_resolve_all()`.

## Fix

Call `platform_registry._resolve_all()` right after `discover_plugins()`, inside the existing `_plugin_cli_discovery_needed()` branch. This resolves every pending deferred platform loader before the subparsers are built, so their registered CLI commands (via `ctx.register_cli_command()`) actually show up.

Cost is zero on fast-path invocations (`hermes --version`, `hermes chat -q ...` without a plugin-looking first token) since `_plugin_cli_discovery_needed()` already short-circuits those. Only invocations that were already paying the plugin-discovery cost pay this additional (cheap) resolve.

## Verification

Tested locally against a 0.18.1 → 0.18.2 install with `photon-platform` enabled:

```
$ hermes photon --help
# before: hermes: error: argument command: invalid choice: 'photon' (...)
# after:
usage: hermes photon [-h] {setup,status,install-sidecar,telemetry} ...
  setup               First-time setup (device login + project + user + sidecar)
  status              Show login + project + sidecar dep state
  install-sidecar     Run npm install inside the sidecar directory
  telemetry           Show or toggle Spectrum SDK telemetry (on/off)
```

Regression checks (all pass):
- `hermes --help` still lists all built-in subcommands
- `hermes --version` (fast path, discovery skipped) unaffected
- `raft-platform` correctly shows no CLI command (it never calls `ctx.register_cli_command()` — confirmed by source inspection, this fix doesn't fabricate commands for plugins that don't register any)

## Related

While testing Photon setup on a fresh install I also found the PyPI wheel for 0.18.1/0.18.2 ships an incomplete `plugins/platforms/photon/sidecar/` directory (missing `package.json`, `index.mjs`, `patch-spectrum-mixed-attachments.mjs` — only `README.md` and an empty `package-lock.json` are present), which breaks `hermes photon install-sidecar` with `ENOENT`. That looks like a separate packaging/MANIFEST issue (missing package-data glob for the sidecar dir) — happy to file a separate issue/PR for it if useful, this PR is scoped to the CLI discovery bug only.