### PR TITLE
fix(mcp): add timeout to session.list_tools() in _discover_tools and _refresh_tools

### DIFF
--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -378,3 +378,61 @@ class TestKeepaliveProbeFallback:
         assert task._ping_unsupported is False
 
 
+@pytest.mark.asyncio
+class TestStalledListToolsTimeout:
+    """Discovery / refresh must time out when list_tools() never returns."""
+
+    async def _make_tool_capable_task(self):
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(tools=SimpleNamespace())
+        return task
+
+    async def test_discover_tools_times_out_on_stalled_rpc(self):
+        """_discover_tools raises TimeoutError when list_tools hangs."""
+        task = await self._make_tool_capable_task()
+        # Use a short timeout so the test doesn't hang
+        task._config = {"connect_timeout": 0.1}
+
+        async def _hang():
+            await asyncio.sleep(10)
+
+        task.session = SimpleNamespace(
+            list_tools=AsyncMock(side_effect=_hang)
+        )
+
+        with pytest.raises(asyncio.TimeoutError):
+            await task._discover_tools()
+
+    async def test_refresh_tools_times_out_on_stalled_rpc(self):
+        """_refresh_tools raises TimeoutError when list_tools hangs."""
+        task = await self._make_tool_capable_task()
+        task._config = {"connect_timeout": 0.1}
+        # Must populate _registered_tool_names so refresh doesn't short-circuit
+        task._registered_tool_names = set()
+
+        async def _hang():
+            await asyncio.sleep(10)
+
+        task.session = SimpleNamespace(
+            list_tools=AsyncMock(side_effect=_hang)
+        )
+
+        with pytest.raises(asyncio.TimeoutError):
+            await task._refresh_tools()
+
+    async def test_discover_tools_honors_configured_timeout(self):
+        """A longer configured timeout is used instead of the default."""
+        task = await self._make_tool_capable_task()
+        task._config = {"connect_timeout": 30.0}
+        task.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(tools=[])
+            )
+        )
+
+        await task._discover_tools()
+
+        task.session.list_tools.assert_awaited_once()
+        assert task._tools == []
+
+

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1776,7 +1776,15 @@ class MCPServerTask:
 
             # 1. Fetch current tool list from server
             async with self._rpc_lock:
-                tools_result = await self.session.list_tools()
+                connect_timeout = float(
+                    self._config.get(
+                        "connect_timeout", _DEFAULT_CONNECT_TIMEOUT
+                    )
+                )
+                tools_result = await asyncio.wait_for(
+                    self.session.list_tools(),
+                    timeout=connect_timeout,
+                )
             new_mcp_tools = tools_result.tools if hasattr(tools_result, "tools") else []
 
             # 2. Re-register with fresh tool list. Avoid nuke-and-repave for
@@ -2579,7 +2587,15 @@ class MCPServerTask:
             self._register_discovered_tools_if_needed()
             return
         async with self._rpc_lock:
-            tools_result = await self.session.list_tools()
+            connect_timeout = float(
+                self._config.get(
+                    "connect_timeout", _DEFAULT_CONNECT_TIMEOUT
+                )
+            )
+            tools_result = await asyncio.wait_for(
+                self.session.list_tools(),
+                timeout=connect_timeout,
+            )
         self._tools = (
             tools_result.tools
             if hasattr(tools_result, "tools")


### PR DESCRIPTION
## What does this PR do?

Two call sites called `session.list_tools()` without timeout protection, risking indefinite hangs if the MCP server becomes unresponsive. Every other network call in the MCP transport (`session.initialize()`, keepalive probes) already has timeout via `asyncio.wait_for`.

## Type of Change

- [x] Bug fix

## Changes Made

- `tools/mcp_tool.py`: wrapped `self.session.list_tools()` in `asyncio.wait_for(timeout=_DEFAULT_CONNECT_TIMEOUT)` at both `_refresh_tools()` (line 1779) and `_discover_tools()` (line 2582).

## How to Test

```bash
python -m pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_circuit_breaker.py -q
```