### PR TITLE
fix: /update now drains active agents before gateway exit

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4620,5 +4620,22 @@ class GatewaySlashCommandsMixin:
             exit_code_path.unlink(missing_ok=True)
             return t("gateway.update.start_failed", error=e)
 
+        # Trigger the same drain-then-stop path as /restart so in-flight
+        # cron jobs and agent tool work get a graceful drain window
+        # before the gateway process exits.  Without this, /update exits
+        # immediately after spawning the detached update helper, killing
+        # active tool subprocesses mid-work (#60432).
+        active_agents = self._running_agent_count()
+        _under_service = bool(os.environ.get("INVOCATION_ID")) or os.environ.get(
+            "XPC_SERVICE_NAME", "0"
+        ) not in ("", "0")
+        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+        if _under_service or _in_container:
+            self.request_restart(detached=False, via_service=True)
+        else:
+            self.request_restart(detached=True, via_service=False)
+
         self._schedule_update_notification_watch()
+        if active_agents:
+            return t("gateway.draining", count=active_agents)
         return t("gateway.update.starting")


### PR DESCRIPTION
## Summary

`/update` spawned the update helper via `setsid` but did NOT call `request_restart()`, so the gateway exited without running the drain phase (`active_at_start=0, drain took 0.00s`). This killed active cron jobs and tool subprocesses mid-work.

A production incident with the Daily family briefing during `/update` showed the more severe failure mode: the cron job started, then never logged completion or delivery.

## Fix

Call `request_restart()` after spawning the update helper, same as `/restart` does. This triggers `stop() -> _drain_active_agents()` with the configured `restart_drain_timeout`, giving in-flight work a graceful drain window before the gateway process exits.

## Comparison: /restart vs /update (before fix)

| | /restart | /update (before) | /update (after) |
|---|---|---|---|
| Spawn detached helper | yes | yes | yes |
| `request_restart()` | yes | **no** | **yes** |
| `stop() -> _drain_active_agents()` | yes | **no** | **yes** |
| Drain timeout | `restart_drain_timeout` | none | `restart_drain_timeout` |

Closes #60432