### PR TITLE
fix: ws_orphan_reap no longer ends gateway-originated sessions

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -586,7 +586,21 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
         try:
             db = _get_db()
             if db is not None:
-                db.end_session(session_id, end_reason)
+                # Don't end sessions the TUI doesn't own. Gateway-originated
+                # sessions (Telegram, Discord, etc.) are resumed in the TUI
+                # for viewing only — the gateway owns their lifecycle. If
+                # ws_orphan_reap ends them in state.db, the gateway's
+                # SessionStore still routes to the ended session, causing a
+                # Groundhog Day loop on every subsequent inbound message
+                # (#60609).
+                row = db.get_session(session_id) if hasattr(db, "get_session") else None
+                source = (row or {}).get("source", "") if row else ""
+                _GATEWAY_SOURCES = frozenset({
+                    "bluebubbles", "telegram", "discord",
+                    "signal", "whatsapp", "sms",
+                })
+                if source not in _GATEWAY_SOURCES:
+                    db.end_session(session_id, end_reason)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary

`_finalize_session` unconditionally calls `db.end_session()` for all sessions, including gateway-originated ones (Telegram, Discord, etc.) that the TUI merely resumed for viewing. When the TUI WebSocket disconnects, `ws_orphan_reap` marks these sessions as ended in `state.db`, but the gateway's SessionStore still routes to them — creating a Groundhog Day loop where every inbound message reverts to stale pre-compression context.

## Fix

In `_finalize_session`, before calling `db.end_session()`, check the session's source. If source is a gateway platform (bluebubbles, telegram, discord, signal, whatsapp, sms), skip `end_session()` — the TUI is just a viewer, not the lifecycle owner.

## Impact

Prevents the catastrophic routing loop observed in production:
```
17:55:10 WARNING: routing key -> 99fe5aea is ended in state.db but still live in sessions.json
17:55:23 INFO: Session split detected: 081628 → 99fe5aea (compression)
17:57:52 INFO: Session split detected: 081628 → 99fe5aea (compression)
17:58:27 INFO: Session split detected: 081628 → 99fe5aea (compression)
... (repeats on every message)
```

Closes #60609