### PR TITLE
fix(agent): fall back to messages.create on Anthropic stream usage aggregation errors

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2745,6 +2745,15 @@ def _is_stream_unavailable_error(exc: Exception) -> bool:
         from agent.bedrock_adapter import is_streaming_access_denied_error
 
         return is_streaming_access_denied_error(exc)
+    # Anthropic SDK accumulate_event() assumes message_start carried a usage
+    # object; some Anthropic-compatible providers (e.g. MiniMax api.minimaxi.com)
+    # emit usage: null on message_start and only populate it on message_delta,
+    # so get_final_message() raises AttributeError on output_tokens (#60683).
+    if isinstance(exc, AttributeError):
+        if "output_tokens" in err_lower:
+            return True
+        if "nonetype" in err_lower and "usage" in err_lower:
+            return True
     return False
 
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2559,7 +2559,20 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # this return value is discarded anyway.
             if agent._interrupt_requested:
                 return None
-            return stream.get_final_message()
+            try:
+                return stream.get_final_message()
+            except Exception as exc:
+                from agent.anthropic_adapter import _is_stream_unavailable_error
+
+                if not _is_stream_unavailable_error(exc):
+                    raise
+                logger.debug(
+                    "%sAnthropic stream aggregation failed; falling back to "
+                    "messages.create(): %s",
+                    getattr(agent, "log_prefix", ""),
+                    exc,
+                )
+                return agent._anthropic_messages_create(api_kwargs)
 
     def _call():
         import httpx as _httpx

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2482,97 +2482,110 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # that can leak in under an api_mode-flip race. The Anthropic SDK
         # raises a non-retryable TypeError on them, killing the turn. See
         # #31673 / sanitize_anthropic_kwargs().
-        from agent.anthropic_adapter import sanitize_anthropic_kwargs
+        from agent.anthropic_adapter import (
+            _is_stream_unavailable_error,
+            create_anthropic_message,
+            sanitize_anthropic_kwargs,
+        )
         sanitize_anthropic_kwargs(
             api_kwargs, log_prefix=getattr(agent, "log_prefix", "")
         )
-        # Use the Anthropic SDK's streaming context manager
-        with agent._anthropic_client.messages.stream(**api_kwargs) as stream:
-            # The Anthropic SDK exposes the raw httpx response on
-            # ``stream.response``.  Snapshot diagnostic headers
-            # immediately so they survive a stream that dies before the
-            # first event.
-            try:
-                agent._stream_diag_capture_response(
-                    _diag, getattr(stream, "response", None)
-                )
-            except Exception:
-                pass
-            for event in stream:
-                # Update stale-stream timer on every event so the
-                # outer poll loop knows data is flowing.  Without
-                # this, the detector kills healthy long-running
-                # Opus streams after 180 s even when events are
-                # actively arriving (the chat_completions path
-                # already does this at the top of its chunk loop).
-                last_chunk_time["t"] = time.time()
-                agent._touch_activity("receiving stream response")
-
-                # Update per-attempt diagnostic counters (best-effort).
+        # Use the Anthropic SDK's streaming context manager. Wrap the full
+        # stream context + iteration: Anthropic SDK accumulate_event() runs
+        # on every SSE event (including message_delta), so MiniMax-style
+        # ``usage: null`` crashes can raise during ``for event in stream``
+        # — not only at get_final_message() (#60683).
+        try:
+            with agent._anthropic_client.messages.stream(**api_kwargs) as stream:
+                # The Anthropic SDK exposes the raw httpx response on
+                # ``stream.response``.  Snapshot diagnostic headers
+                # immediately so they survive a stream that dies before the
+                # first event.
                 try:
-                    _diag["chunks"] = int(_diag.get("chunks", 0)) + 1
-                    if _diag.get("first_chunk_at") is None:
-                        _diag["first_chunk_at"] = last_chunk_time["t"]
-                    try:
-                        _diag["bytes"] = int(_diag.get("bytes", 0)) + len(repr(event))
-                    except Exception:
-                        pass
+                    agent._stream_diag_capture_response(
+                        _diag, getattr(stream, "response", None)
+                    )
                 except Exception:
                     pass
+                for event in stream:
+                    # Update stale-stream timer on every event so the
+                    # outer poll loop knows data is flowing.  Without
+                    # this, the detector kills healthy long-running
+                    # Opus streams after 180 s even when events are
+                    # actively arriving (the chat_completions path
+                    # already does this at the top of its chunk loop).
+                    last_chunk_time["t"] = time.time()
+                    agent._touch_activity("receiving stream response")
 
+                    # Update per-attempt diagnostic counters (best-effort).
+                    try:
+                        _diag["chunks"] = int(_diag.get("chunks", 0)) + 1
+                        if _diag.get("first_chunk_at") is None:
+                            _diag["first_chunk_at"] = last_chunk_time["t"]
+                        try:
+                            _diag["bytes"] = int(_diag.get("bytes", 0)) + len(repr(event))
+                        except Exception:
+                            pass
+                    except Exception:
+                        pass
+
+                    if agent._interrupt_requested:
+                        break
+
+                    event_type = getattr(event, "type", None)
+
+                    if event_type == "content_block_start":
+                        block = getattr(event, "content_block", None)
+                        if block and getattr(block, "type", None) == "tool_use":
+                            has_tool_use = True
+                            tool_name = getattr(block, "name", None)
+                            if tool_name:
+                                _fire_first_delta()
+                                agent._fire_tool_gen_started(tool_name)
+
+                    elif event_type == "content_block_delta":
+                        delta = getattr(event, "delta", None)
+                        if delta:
+                            delta_type = getattr(delta, "type", None)
+                            if delta_type == "text_delta":
+                                text = getattr(delta, "text", "")
+                                if text and not has_tool_use:
+                                    _fire_first_delta()
+                                    agent._fire_stream_delta(text)
+                                    deltas_were_sent["yes"] = True
+                            elif delta_type == "thinking_delta":
+                                thinking_text = getattr(delta, "thinking", "")
+                                if thinking_text:
+                                    _fire_first_delta()
+                                    agent._fire_reasoning_delta(thinking_text)
+
+                # Return the native Anthropic Message for downstream processing.
+                # If the stream was interrupted (the event loop broke out above on
+                # agent._interrupt_requested), do NOT call get_final_message() — on
+                # a partially-consumed stream the SDK may hang draining remaining
+                # events or return a Message with incomplete tool_use blocks (partial
+                # JSON in `input`). The outer poll loop raises InterruptedError, so
+                # this return value is discarded anyway.
                 if agent._interrupt_requested:
-                    break
-
-                event_type = getattr(event, "type", None)
-
-                if event_type == "content_block_start":
-                    block = getattr(event, "content_block", None)
-                    if block and getattr(block, "type", None) == "tool_use":
-                        has_tool_use = True
-                        tool_name = getattr(block, "name", None)
-                        if tool_name:
-                            _fire_first_delta()
-                            agent._fire_tool_gen_started(tool_name)
-
-                elif event_type == "content_block_delta":
-                    delta = getattr(event, "delta", None)
-                    if delta:
-                        delta_type = getattr(delta, "type", None)
-                        if delta_type == "text_delta":
-                            text = getattr(delta, "text", "")
-                            if text and not has_tool_use:
-                                _fire_first_delta()
-                                agent._fire_stream_delta(text)
-                                deltas_were_sent["yes"] = True
-                        elif delta_type == "thinking_delta":
-                            thinking_text = getattr(delta, "thinking", "")
-                            if thinking_text:
-                                _fire_first_delta()
-                                agent._fire_reasoning_delta(thinking_text)
-
-            # Return the native Anthropic Message for downstream processing.
-            # If the stream was interrupted (the event loop broke out above on
-            # agent._interrupt_requested), do NOT call get_final_message() — on
-            # a partially-consumed stream the SDK may hang draining remaining
-            # events or return a Message with incomplete tool_use blocks (partial
-            # JSON in `input`). The outer poll loop raises InterruptedError, so
-            # this return value is discarded anyway.
-            if agent._interrupt_requested:
-                return None
-            try:
+                    return None
                 return stream.get_final_message()
-            except Exception as exc:
-                from agent.anthropic_adapter import _is_stream_unavailable_error
-
-                if not _is_stream_unavailable_error(exc):
-                    raise
-                logger.debug(
-                    "%sAnthropic stream aggregation failed; falling back to "
-                    "messages.create(): %s",
-                    getattr(agent, "log_prefix", ""),
-                    exc,
-                )
-                return agent._anthropic_messages_create(api_kwargs)
+        except Exception as exc:
+            if not _is_stream_unavailable_error(exc):
+                raise
+            # Force non-streaming create — _anthropic_messages_create() would
+            # pass prefer_stream=True again and re-enter messages.stream().
+            logger.debug(
+                "%sAnthropic stream aggregation failed; falling back to "
+                "messages.create(): %s",
+                getattr(agent, "log_prefix", ""),
+                exc,
+            )
+            return create_anthropic_message(
+                agent._anthropic_client,
+                api_kwargs,
+                log_prefix=getattr(agent, "log_prefix", ""),
+                prefer_stream=False,
+            )
 
     def _call():
         import httpx as _httpx

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6681,6 +6681,61 @@ class TestAnthropicCredentialRefresh:
         agent._anthropic_client.messages.create.assert_called_once_with(model="MiniMax-M3")
         assert result is response
 
+    def test_anthropic_streaming_falls_back_on_iterator_usage_aggregation_error(self):
+        """Main-turn path: SDK crash during stream iteration must use create().
+
+        #60683 fails inside accumulate_event() on message_delta while the
+        event loop is iterating — outside get_final_message(). Fallback must
+        call messages.create() directly (prefer_stream=False), not
+        _anthropic_messages_create() which would re-enter messages.stream().
+        """
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        ):
+            agent = AIAgent(
+                api_key="sk-ant-oat01-current-token",
+                base_url="https://api.minimaxi.com/anthropic",
+                api_mode="anthropic_messages",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        response = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="ok")],
+            stop_reason="end_turn",
+            usage=None,
+        )
+
+        class _BoomStream:
+            def __iter__(self):
+                raise AttributeError(
+                    "'NoneType' object has no attribute 'output_tokens'"
+                )
+
+            def get_final_message(self):
+                raise AssertionError("get_final_message should not be reached")
+
+        stream_cm = MagicMock()
+        stream_cm.__enter__.return_value = _BoomStream()
+        stream_cm.__exit__.return_value = False
+
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.stream.return_value = stream_cm
+        agent._anthropic_client.messages.create.return_value = response
+        agent._interrupt_requested = False
+
+        with patch.object(agent, "_try_refresh_anthropic_client_credentials", return_value=False):
+            result = agent._interruptible_streaming_api_call(
+                {"model": "MiniMax-M3", "messages": []}
+            )
+
+        agent._anthropic_client.messages.stream.assert_called_once()
+        agent._anthropic_client.messages.create.assert_called_once()
+        assert result is response
+
     def test_anthropic_messages_create_honors_disable_streaming(self):
         with (
             patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6648,6 +6648,39 @@ class TestAnthropicCredentialRefresh:
         agent._anthropic_client.messages.create.assert_called_once_with(model="claude-sonnet-4-20250514")
         assert result is response
 
+    def test_anthropic_messages_create_falls_back_on_sdk_usage_aggregation_error(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        ):
+            agent = AIAgent(
+                api_key="sk-ant-oat01-current-token",
+                base_url="https://api.minimaxi.com/anthropic",
+                api_mode="anthropic_messages",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        response = SimpleNamespace(content=[])
+        agent._anthropic_client = MagicMock()
+        stream_cm = MagicMock()
+        inner = MagicMock()
+        inner.get_final_message.side_effect = AttributeError(
+            "'NoneType' object has no attribute 'output_tokens'"
+        )
+        stream_cm.__enter__.return_value = inner
+        agent._anthropic_client.messages.stream.return_value = stream_cm
+        agent._anthropic_client.messages.create.return_value = response
+
+        with patch.object(agent, "_try_refresh_anthropic_client_credentials", return_value=False):
+            result = agent._anthropic_messages_create({"model": "MiniMax-M3"})
+
+        agent._anthropic_client.messages.stream.assert_called_once_with(model="MiniMax-M3")
+        agent._anthropic_client.messages.create.assert_called_once_with(model="MiniMax-M3")
+        assert result is response
+
     def test_anthropic_messages_create_honors_disable_streaming(self):
         with (
             patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),


### PR DESCRIPTION
## Summary

- Extend `_is_stream_unavailable_error()` to treat Anthropic SDK `AttributeError` on `output_tokens` / `usage` as a stream aggregation failure (MiniMax and other Anthropic-compatible providers can emit `usage: null` on `message_start`, then populate usage on `message_delta`).
- Reuse the existing `messages.create()` fallback in `create_anthropic_message()` (compression/auxiliary path).
- Apply the same fallback at the end of `_call_anthropic()` when `get_final_message()` fails after the streaming event loop (main gateway turn path).
- Add regression test mirroring the existing stream-unavailable fallback tests.

Fixes #60683

## Root cause

Anthropic Python SDK `accumulate_event()` assigns `current_snapshot.usage.output_tokens` on `message_delta` without guarding `usage is None`. Some providers (observed: MiniMax-M3 via `api.minimaxi.com/anthropic`) return `message_start` without a usage object, causing:

```
'NoneType' object has no attribute 'output_tokens'
```

## Test plan

- [x] `pytest tests/run_agent/test_run_agent.py -k anthropic_messages_create_falls_back` (3 passed)
- [x] `pytest tests/run_agent/test_run_agent.py -k anthropic_messages_create_does_not_mask_bedrock` (1 passed)
- [ ] Manual: long MiniMax-M3 session through preflight compression and a streaming tool-call turn; confirm no `output_tokens` AttributeError and successful fallback to non-streaming create when triggered

Made with [Cursor](https://cursor.com)