### PR TITLE
fix(memory): replace partial old_text within entry instead of replacing whole entry (#59184)

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -431,7 +431,8 @@ class MemoryStore:
 
             # Check that replacement doesn't blow the budget
             test_entries = entries.copy()
-            test_entries[idx] = new_content
+            # Replace only the matched portion within the entry, not the whole entry
+            test_entries[idx] = entries[idx].replace(old_text, new_content, 1)
             new_total = len(ENTRY_DELIMITER.join(test_entries))
 
             if new_total > limit:
@@ -448,7 +449,10 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            entries[idx] = new_content
+            # Replace only the matched portion within the entry, not the whole entry.
+            # This preserves other sections in composite entries when old_text
+            # is a partial match. (#59184)
+            entries[idx] = entries[idx].replace(old_text, new_content, 1)
             self._set_entries(target, entries)
             self.save_to_disk(target)
 


### PR DESCRIPTION
## Summary

When using the memory tool's replace action with a partial `old_text` on a composite (multi-section) entry, the replacement previously replaced the **entire entry** with `new_content`. This caused all sections except the matched one to be lost.

## Root Cause

In `tools/memory_tool.py`, the `replace` method used:
```python
entries[idx] = new_content
```

This replaces the entire matched entry with the new content, discarding all other sections/lines in composite entries.

## Fix

Changed to a string replacement within the entry:
```python
entries[idx] = entries[idx].replace(old_text, new_content, 1)
```

This preserves all other sections of the composite entry while only replacing the matched `old_text` portion. The char limit check is also updated to use the same inline replacement for accurate size calculation.

## Test Plan

1. Create a composite memory entry with multiple sections (e.g. Section A, Section B, Section C)
2. Call memory replace with `old_text` matching only Section B
3. Verify that only Section B is replaced and Sections A and C are preserved

Closes #59184