### PR TITLE
fix(provider): catch AttributeError on output_tokens in Anthropic stream fallback

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2884,6 +2884,11 @@ def _is_stream_unavailable_error(exc: Exception) -> bool:
         from agent.bedrock_adapter import is_streaming_access_denied_error
 
         return is_streaming_access_denied_error(exc)
+    # MiniMax and other Anthropic-compatible providers may return usage: null
+    # in SSE message_start, causing the SDK's get_final_message() to crash with
+    # AttributeError on output_tokens. Fall back to non-streaming create().
+    if isinstance(exc, AttributeError) and "output_tokens" in str(exc):
+        return True
     return False
 
 

--- a/contributors/emails/AIalliAI@users.noreply.github.com
+++ b/contributors/emails/AIalliAI@users.noreply.github.com
@@ -1,0 +1,1 @@
+AIalliAI

--- a/scripts/tool_search_livetest2.py
+++ b/scripts/tool_search_livetest2.py
@@ -187,7 +187,7 @@ def run_one(scenario: Dict[str, Any], mode: str, rep: int, out_dir: Path) -> Dic
         "final_response": base._redact_secrets(final_response)[:500],
     }
     out_path = out_dir / f"{scenario['id']}__{'enabled' if enabled else 'disabled'}__rep{rep}.json"
-    out_path.write_text(json.dumps(rec, indent=1))
+    out_path.write_text(json.dumps(rec, indent=1), encoding="utf-8")
     shutil.rmtree(Path(os.environ["HERMES_HOME"]).parent, ignore_errors=True)
     return rec
 


### PR DESCRIPTION
## Summary

Fixes a crash in `create_anthropic_message()` when MiniMax (and other Anthropic-compatible providers) return `usage: null` in SSE `message_start` events.

## Problem

When MiniMax's Anthropic-compatible endpoint returns a `message_start` SSE event with `usage: null`, the Anthropic SDK's `stream.get_final_message()` crashes with:

```
AttributeError: 'NoneType' object has no attribute 'output_tokens'
```

This affects:
1. **Context compression** — LLM summary generation fails, triggers 60s cooldown
2. **Main turn streaming** — partial delivery abort, invalid response retry

## Root Cause

The SDK's streaming aggregator in `accumulate_event()` for `message_delta` assigns `event.usage.output_tokens` to `current_snapshot.usage.output_tokens`, but `current_snapshot.usage` is `None` when the provider omitted usage in `message_start`.

## Fix

Extend `_is_stream_unavailable_error()` to recognize this `AttributeError` pattern as a stream-unavailable signal. When caught, the existing fallback path retries via non-streaming `messages.create()`, which is unaffected by the SSE parsing issue.

**Change:** 5 lines added to `agent/anthropic_adapter.py`

## Test Plan

- [ ] MiniMax-M3 with `api_mode: anthropic_messages` no longer crashes during streaming
- [ ] Non-streaming fallback produces valid responses
- [ ] Other providers (Anthropic, Bedrock) unaffected by the new check
- [ ] Context compression with MiniMax no longer triggers 60s cooldown

Closes #60683