### PR TITLE
fix(daytona): forward env_passthrough variables to sandbox processes (#59286)

### DIFF
--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -235,8 +235,27 @@ class DaytonaEnvironment(BaseEnvironment):
         else:
             shell_cmd = f"bash -c {shlex.quote(cmd_string)}"
 
+        # Forward allowlisted env vars to the remote sandbox.  Only
+        # variables registered via terminal.env_passthrough or a skill's
+        # required_environment_variables are forwarded — Hermes-managed
+        # provider credentials (OPENAI_API_KEY, ANTHROPIC_TOKEN, etc.)
+        # are blocked by is_env_passthrough.
+        try:
+            from tools.env_passthrough import is_env_passthrough as _is_passthrough
+        except Exception:
+            _is_passthrough = lambda _: False  # noqa: E731
+
+        passthrough_env = {
+            k: v for k, v in os.environ.items()
+            if _is_passthrough(k)
+        }
+
         def exec_fn() -> tuple[str, int]:
-            response = sandbox.process.exec(shell_cmd, timeout=timeout)
+            response = sandbox.process.exec(
+                shell_cmd,
+                timeout=timeout,
+                env=passthrough_env if passthrough_env else None,
+            )
             return (response.result or "", response.exit_code)
 
         return _ThreadedProcessHandle(exec_fn, cancel_fn=cancel)


### PR DESCRIPTION
## Summary

Fixes #59286: when using `terminal.backend: daytona`, environment variables registered via `terminal.env_passthrough` or a skill's `required_environment_variables` were never forwarded to the remote sandbox, because the Daytona backend's `_run_bash` method never passed an `env` parameter to `sandbox.process.exec()`.

## Root Cause

The local backend (`tools/environments/local.py`) uses `is_env_passthrough()` to filter `os.environ` and pass the allowlisted variables to the subprocess. The Daytona backend (`tools/environments/daytona.py`) was calling `sandbox.process.exec(shell_cmd, timeout=timeout)` without any `env` parameter.

## Fix

1. In `tools/environments/daytona.py`, import `is_env_passthrough` and build a filtered environment dict from `os.environ` — only variables the user has registed via `terminal.env_passthrough` config or a skill's `required_environment_variables` are forwarded (Hermes-managed provider credentials like `OPENAI_API_KEY` are still blocked by `is_env_passthrough`).

2. Pass this dict as `env` to the SDK's `sandbox.process.exec()` call, which already supports the `env` parameter (Daytona SDK v0.155.0 — line 100 of `_sync/process.py`: `env: dict[str, str] | None = None`). The SDK exports them safely using base64-encoded shell commands.

## Verification

- All 27 existing Daytona environment tests pass
- All 20 `env_passthrough` tests pass
- Tested against the Daytona SDK v0.155.0 which accepts `env=` in `process.exec()`