### PR TITLE
fix(schema): preserve empty required array in sanitizer and add additionalProperties to delegate_task (#59386)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3335,6 +3335,7 @@ DELEGATE_TASK_SCHEMA = {
     ),
     "parameters": {
         "type": "object",
+        "additionalProperties": False,
         "properties": {
             "goal": {
                 "type": "string",
@@ -3356,6 +3357,7 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "array",
                 "items": {
                     "type": "object",
+                    "additionalProperties": False,
                     "properties": {
                         "goal": {"type": "string", "description": "Task goal"},
                         "context": {

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -340,14 +340,29 @@ def _sanitize_node(node: Any, path: str) -> Any:
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
 
+    # Guard against ``required: null`` — some strict OpenAI-compatible
+    # backends (e.g., Copilot proxying to Gemini, AWS Bedrock) reject
+    # ``null`` in place of an array with HTTP 400:
+    #   "null is not of type \"array\""
+    # JSON Schema treats absent ``required`` as ``[]``, so remove it.
+    if out.get("type") == "object" and "required" in out:
+        if not isinstance(out["required"], list):
+            out.pop("required", None)
+
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but
     # built-in tools or plugin tools may not have been through that path).
+    # Preserve an empty ``required: []`` — some strict OpenAI-compatible
+    # backends reject a missing/absent ``required`` field as ``null is not of
+    # type 'array'``. (issue #59386)
     if out.get("type") == "object" and isinstance(out.get("required"), list):
         props = out.get("properties") or {}
         valid = [r for r in out["required"] if isinstance(r, str) and r in props]
         if not valid:
-            out.pop("required", None)
+            # Only pop if required was non-empty (malformed entries).
+            # An empty required list is valid and must be preserved.
+            if out["required"]:
+                out.pop("required", None)
         elif len(valid) != len(out["required"]):
             out["required"] = valid
 


### PR DESCRIPTION
## Summary

Fixes HTTP 400 on strict OpenAI-compatible backends when using delegate_task:
`Invalid schema for function 'delegate_task': null is not of type "array"`

## Root Cause & Fix

Two fixes in `tools/schema_sanitizer.py`:

1. **Guard against `required: null`** — Added a type check so non-list `required` values are removed (JSON Schema treats absent required as `[]`).

2. **Preserve empty `required: []`** — The pruning logic incorrectly stripped empty `required` arrays, causing strict backends to see a missing `required` field (interpreted as null).

Additionally added `"additionalProperties": false` to the `delegate_task` parameter schema objects in `tools/delegate_tool.py` for strict backend compatibility.

Closes #59386