### PR TITLE
fix(tui): stop ws_orphan_reap from ending gateway-owned sessions (#60609)

### DIFF
--- a/tests/tui_gateway/test_finalize_session_persist.py
+++ b/tests/tui_gateway/test_finalize_session_persist.py
@@ -174,6 +174,8 @@ class TestFinalizeSessionPersist:
         from tui_gateway.server import _finalize_session
 
         mock_db = MagicMock()
+        # TUI-owned session — end_session must still fire (#60609 guard).
+        mock_db.get_session.return_value = {"source": "tui"}
         mock_get_db.return_value = mock_db
 
         agent = _make_agent(session_id="sess_123")

--- a/tests/tui_gateway/test_ws_orphan_reap_ownership.py
+++ b/tests/tui_gateway/test_ws_orphan_reap_ownership.py
@@ -1,0 +1,135 @@
+"""Regression tests for #60609 — ws_orphan_reap must not end sessions the
+TUI does not own.
+
+``_finalize_session`` marks a session ended in state.db so it doesn't linger
+as a ghost row in /resume.  But the TUI can also *view* sessions it does not
+own — gateway-originated sessions (telegram, bluebubbles, ...) opened via
+``session.resume``.  The messaging gateway is the lifecycle owner of those
+and still routes inbound messages to them; ending one in state.db triggers
+the Groundhog Day routing loop described in #60609 (the gateway's #54878
+self-heal drops the "ended" routing entry, recovers to the pre-compression
+parent, compression splits back to the reaped child, repeat on every
+message).
+
+The guard is a fail-closed ALLOW-list (``_TUI_OWNED_SESSION_SOURCES``):
+only sources this process creates (tui/cli/desktop/webui/local/codex) are
+ever ended; unknown/plugin/gateway/tool sources are left alone.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tui_gateway.server import _TUI_OWNED_SESSION_SOURCES, _finalize_session
+
+
+def _make_agent(session_id="sess_60609"):
+    agent = MagicMock()
+    agent._persist_session = MagicMock()
+    agent.commit_memory_session = MagicMock()
+    agent.session_id = session_id
+    agent.model = "test-model"
+    agent.platform = "tui"
+    agent._session_messages = None
+    return agent
+
+
+def _make_session(agent, session_key="key_60609"):
+    return {
+        "agent": agent,
+        "history": [{"role": "user", "content": "x"}],
+        "history_lock": threading.Lock(),
+        "session_key": session_key,
+        "_finalized": False,
+    }
+
+
+def _finalize_with_source(source):
+    """Run _finalize_session against a mock DB whose session row has *source*.
+
+    Returns the mock db so callers can assert on end_session.
+    """
+    mock_db = MagicMock()
+    row = {"source": source} if source is not None else None
+    mock_db.get_session.return_value = row
+    with patch("tui_gateway.server._get_db", return_value=mock_db):
+        _finalize_session(_make_session(_make_agent()), end_reason="ws_orphan_reap")
+    return mock_db
+
+
+class TestGatewaySessionsNeverEnded:
+    """Sources owned by the messaging gateway must never be end_session()'d."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "telegram",
+            "bluebubbles",
+            "discord",
+            "signal",
+            "whatsapp",
+            "slack",
+            "sms",
+            "matrix",
+            "mattermost",
+            # Platforms the original deny-list proposal MISSED — the reason
+            # the guard is an allow-list:
+            "qqbot",
+            "dingtalk",
+            "wecom",
+            "feishu",
+            "yuanbao",
+            "email",
+            "webhook",
+            "homeassistant",
+            "irc",  # plugin platform
+        ],
+    )
+    def test_gateway_source_not_ended(self, source):
+        db = _finalize_with_source(source)
+        db.end_session.assert_not_called()
+
+    def test_tool_subagent_row_not_ended(self):
+        """Sub-agent rows are owned by their parent run, not the viewer."""
+        db = _finalize_with_source("tool")
+        db.end_session.assert_not_called()
+
+    def test_unknown_source_not_ended(self):
+        """The gateway can stamp source="unknown" — fail closed."""
+        db = _finalize_with_source("unknown")
+        db.end_session.assert_not_called()
+
+    def test_missing_row_not_ended(self):
+        """No DB row at all → cannot prove ownership → don't end."""
+        db = _finalize_with_source(None)
+        db.end_session.assert_not_called()
+
+    def test_empty_source_not_ended(self):
+        db = _finalize_with_source("")
+        db.end_session.assert_not_called()
+
+
+class TestTuiOwnedSessionsStillEnded:
+    """TUI-owned sessions keep the #20001 ghost-row cleanup behavior."""
+
+    @pytest.mark.parametrize("source", sorted(_TUI_OWNED_SESSION_SOURCES))
+    def test_owned_source_ended(self, source):
+        db = _finalize_with_source(source)
+        db.end_session.assert_called_once_with("sess_60609", "ws_orphan_reap")
+
+    def test_source_matching_is_case_and_whitespace_insensitive(self):
+        db = _finalize_with_source("  TUI ")
+        db.end_session.assert_called_once()
+
+
+class TestAllowListShape:
+    def test_no_gateway_platform_in_allow_list(self):
+        """Invariant: no gateway Platform enum value may ever be TUI-owned."""
+        from gateway.config import Platform
+
+        gateway_values = {p.value for p in Platform}
+        assert not (_TUI_OWNED_SESSION_SOURCES & gateway_values)
+
+    def test_tool_not_in_allow_list(self):
+        assert "tool" not in _TUI_OWNED_SESSION_SOURCES

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -586,7 +586,23 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
         try:
             db = _get_db()
             if db is not None:
-                db.end_session(session_id, end_reason)
+                # Don't end gateway-originated sessions — the gateway owns their
+                # lifecycle.  The TUI is a viewer, not the owner.  Ending a
+                # gateway session in state.db triggers a Groundhog Day routing
+                # loop: the gateway's #54878 self-heal detects the stale entry,
+                # recovers to the parent session, context compression splits
+                # back to the reaped child, and the cycle repeats on every
+                # inbound message.  (#60609)
+                _GATEWAY_SOURCES = frozenset({
+                    "bluebubbles", "telegram", "discord", "signal",
+                    "whatsapp", "sms", "slack", "mattermost",
+                    "matrix", "line", "wechat", "facebook",
+                    "imessage", "googlechat",
+                })
+                row = db.get_session(session_id)
+                source = (row or {}).get("source", "")
+                if source not in _GATEWAY_SOURCES:
+                    db.end_session(session_id, end_reason)
         except Exception:
             pass
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -586,22 +586,27 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
         try:
             db = _get_db()
             if db is not None:
-                # Don't end gateway-originated sessions — the gateway owns their
-                # lifecycle.  The TUI is a viewer, not the owner.  Ending a
-                # gateway session in state.db triggers a Groundhog Day routing
-                # loop: the gateway's #54878 self-heal detects the stale entry,
-                # recovers to the parent session, context compression splits
-                # back to the reaped child, and the cycle repeats on every
-                # inbound message.  (#60609)
-                _GATEWAY_SOURCES = frozenset({
-                    "bluebubbles", "telegram", "discord", "signal",
-                    "whatsapp", "sms", "slack", "mattermost",
-                    "matrix", "line", "wechat", "facebook",
-                    "imessage", "googlechat",
-                })
+                # Only end sessions the TUI actually OWNS (created via
+                # session.create — source "tui"/"cli"/etc.). Gateway-originated
+                # sessions (telegram, bluebubbles, ...) are merely *viewed*
+                # here via session.resume; the messaging gateway is their
+                # lifecycle owner and still routes inbound messages to them.
+                # Ending one in state.db triggers a Groundhog Day routing
+                # loop: the gateway's #54878 self-heal detects the stale
+                # entry, recovers to the pre-compression parent, compression
+                # splits back to the reaped child, and the cycle repeats on
+                # every inbound message.  (#60609)
+                #
+                # Fail-closed allow-list, NOT a platform deny-list: platform
+                # names drift (plugins, new adapters), and the gateway can
+                # even stamp source="unknown". Sub-agent rows (source="tool")
+                # are owned by their parent run — a watch window closing must
+                # not end them either. Anything not provably TUI-owned is
+                # left alone; worst case is a ghost row in /resume, never
+                # context amnesia.
                 row = db.get_session(session_id)
-                source = (row or {}).get("source", "")
-                if source not in _GATEWAY_SOURCES:
+                source = str((row or {}).get("source") or "").strip().lower()
+                if source in _TUI_OWNED_SESSION_SOURCES:
                     db.end_session(session_id, end_reason)
         except Exception:
             pass
@@ -1574,6 +1579,18 @@ def _session_source(session: dict | None) -> str:
         if source:
             return source
     return "tui"
+
+
+# Session sources whose lifecycle THIS process owns. ``_finalize_session``
+# only writes ``end_session()`` for these; anything else (gateway platforms
+# like telegram/bluebubbles, sub-agent ``tool`` rows, plugin platforms,
+# ``unknown``) is merely viewed here via session.resume and must never be
+# marked ended by a TUI/desktop teardown (#60609). Strictly the sources this
+# server's session.create can stamp — note "local" is a gateway Platform
+# value (Platform.LOCAL) and deliberately NOT in this set.
+_TUI_OWNED_SESSION_SOURCES = frozenset({
+    "tui", "cli", "desktop", "webui",
+})
 
 
 def _register_session_cwd(session: dict | None) -> None:


### PR DESCRIPTION
## Summary
The TUI orphan reaper no longer marks gateway-originated sessions as ended in state.db — killing the "Groundhog Day" routing loop where every inbound gateway message reloaded hours-old pre-compression context.

Root cause: `_finalize_session` in `tui_gateway/server.py` unconditionally called `db.end_session()` for any session it tore down — including gateway sessions (BlueBubbles/Telegram/...) it had merely *viewed* via `session.resume`. Once the WS transport dropped and the 20s orphan grace expired, the live gateway session was marked ended; the gateway's #54878 self-heal then dropped its routing entry, recovered to the pre-compression parent, compression split back to the reaped child, and the cycle repeated on every message.

Salvage of #60619 by @AIalliAI, cherry-picked with authorship preserved, plus a follow-up that hardens the guard.

## Changes
- `tui_gateway/server.py` (@AIalliAI, cherry-picked): ownership guard in `_finalize_session` before `db.end_session()` — the single chokepoint every TUI teardown path (including ws_orphan_reap) goes through.
- `tui_gateway/server.py` (follow-up): guard inverted from a 14-name platform **deny-list** to a fail-closed **allow-list** (`_TUI_OWNED_SESSION_SOURCES` = tui/cli/desktop/webui). The deny-list missed qqbot, dingtalk, wecom, feishu, yuanbao, email, webhook, homeassistant, and every plugin platform (irc, ...) — the bug would have persisted on all of them, and platform names drift. Sub-agent `tool` rows, `source="unknown"`, and missing rows are also left alone: worst case is a ghost row in /resume, never context amnesia.
- `tests/tui_gateway/test_ws_orphan_reap_ownership.py`: 27 regression tests — 18 gateway/plugin sources never ended, tool/unknown/missing-row fail closed, TUI-owned sources keep the #20001 ghost-row cleanup, plus an invariant that no gateway `Platform` enum value can ever enter the allow-list (this test caught `"local"` == `Platform.LOCAL` during development).

## Validation
| | Before | After |
|---|---|---|
| reap viewed bluebubbles session (real SessionDB E2E) | `end_reason=ws_orphan_reap` → routing loop | row untouched, gateway routing intact |
| reap TUI-owned session | ended | still ended (ghost-row cleanup preserved) |
| targeted tests | — | 372 passed across tui_gateway server/ws/lazy/finalize suites |

Fixes #60609.

## Infographic

![ws-orphan-reap-ownership](https://v3b.fal.media/files/b/0aa161e4/ieaD3_UsaNpyQLzAyTsKq_XVE5b0ZX.png)
