### PR TITLE
feat(mcp-catalog): add blockout optional MCP

### DIFF
--- a/optional-mcps/blockout/manifest.yaml
+++ b/optional-mcps/blockout/manifest.yaml
@@ -1,0 +1,59 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: blockout
+description: Drive the Blockout previs desktop app — stage scenes, choreograph cast and camera, export motion-reference packages for AI video generators.
+source: https://github.com/wassermanproductions/blockout-mcp
+
+# Blockout (https://github.com/wassermanproductions/blockout, Apache-2.0) is a
+# desktop previs tool for AI filmmaking. On launch the app starts a
+# localhost-only control server on a random port and writes a discovery file
+# to ~/.config/blockout/control.json (per-launch random bearer token, mode
+# 0600, removed on quit). This bridge is a single zero-dependency Node script
+# that reads the discovery file and forwards MCP tool calls to the running
+# app — nothing listens on a public port and there is nothing to configure.
+transport:
+  type: stdio
+  command: "node"
+  args:
+    - "${INSTALL_DIR}/blockout-mcp.mjs"
+
+# The bridge is zero-dependency (Node >= 18) — clone is the whole install,
+# so no bootstrap commands.
+install:
+  type: git
+  url: https://github.com/wassermanproductions/blockout-mcp.git
+  # Pin to a commit/tag. Required — manifests do not float HEAD.
+  ref: v1.0.0
+
+# The app's control server binds to 127.0.0.1 only and authenticates with a
+# per-launch random token the bridge auto-discovers from the local discovery
+# file. Nothing to prompt for.
+auth:
+  type: none
+
+# Tool selection at install time:
+# The bridge exposes ~30 tools (get_state, add_entity, spawn_sequence,
+# apply_camera_move, screenshot, ...). All of them mutate only the user's
+# local previs project inside the app — there is no external side effect —
+# so nothing is pruned. Leave default_enabled unset; the install-time
+# checklist lists the full surface and users prune per taste.
+
+post_install: |
+  This bridge talks to the Blockout desktop app, which must be RUNNING before
+  Hermes connects:
+
+    1. Get Blockout from https://github.com/wassermanproductions/blockout
+       (build from source, or use a release DMG on macOS).
+    2. Launch the app. It writes its control endpoint + token to
+       ~/.config/blockout/control.json automatically.
+    3. Start a new Hermes session to load the Blockout tools.
+
+  If the app is not running, tool calls return a friendly "launch the app
+  first" error rather than hanging.
+
+  Agent workflow: call get_state first (it carries the scene conventions —
+  meters, +X right, -Z forward), then stage with add_entity/spawn_sequence,
+  frame with apply_framing/apply_camera_move, and use screenshot to see the
+  viewport.

--- a/optional-mcps/blockout/manifest.yaml
+++ b/optional-mcps/blockout/manifest.yaml
@@ -24,8 +24,9 @@ transport:
 install:
   type: git
   url: https://github.com/wassermanproductions/blockout-mcp.git
-  # Pin to a commit/tag. Required — manifests do not float HEAD.
-  ref: v1.0.0
+  # Pinned to an immutable commit SHA (the v1.0.0 release), per the
+  # dependency policy for Git URLs — tags can move, commits cannot.
+  ref: e678f26697a79ad6716e356844fe6e1a6b34c0ce
 
 # The app's control server binds to 127.0.0.1 only and authenticates with a
 # per-launch random token the bridge auto-discovers from the local discovery


### PR DESCRIPTION
## What

Adds an `optional-mcps/blockout/manifest.yaml` catalog entry for **Blockout** (https://github.com/wassermanproductions/blockout) — an open-source (Apache-2.0) desktop previs app for AI filmmaking. With the entry installed, Hermes can stage scenes, place and choreograph characters/crowds, apply classic camera-move presets, take viewport screenshots, and export motion-reference packages for AI video generators (Seedance, Kling, ComfyUI, Blender).

## Why

Previs is a natural agent task ("stage a 5-person dance sequence in a parking lot and orbit the camera 90° left") and the app was built agent-first: it ships a localhost-only control server (127.0.0.1, random port, per-launch random bearer token in `~/.config/blockout/control.json`, mode 0600, removed on quit) plus a zero-dependency Node stdio MCP bridge. `auth: none` — the bridge auto-discovers the token locally, nothing to prompt for (same pattern as the unreal-engine entry). Git install is pinned to https://github.com/wassermanproductions/blockout-mcp tag `v1.0.0`; the bridge has no dependencies, so there are no bootstrap commands.

## Testing instructions

1. Launch the Blockout app (build from the repo or use a release DMG) and create/open a project.
2. `hermes mcp install official/blockout` — clones the pinned tag, no prompts.
3. Start a new Hermes session; ask it to `get_state`, add an entity, and take a screenshot.

## Testing done

- Manifest parses cleanly through `hermes_cli.mcp_catalog._parse_manifest` and `_build_server_config` expands `${INSTALL_DIR}` to the expected `mcp_servers.blockout` block.
- Simulated the exact install path: `git clone --depth 1 --branch v1.0.0` into `~/.hermes/mcp-installs/blockout`, then ran the manifest's literal command against the packaged app with a project open. Verified over raw JSON-RPC: `initialize` (protocol 2024-11-05), `tools/list` (27 tools), `tools/call get_state` (live scene state), `add_entity` (mutation lands in the app), `screenshot` (PNG image content). Invalid params return friendly validation errors; with the app closed, calls return "launch the app first" rather than hanging.

## Platforms tested

- macOS 15 (arm64), Node 22.

## Issues

None — new catalog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)