### PR TITLE
fix(telegram): allow local opt-in for CJK rich messages

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2422,8 +2422,9 @@ DEFAULT_CONFIG = {
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
         "extra": {
-            "rich_messages": False,     # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
-            "rich_drafts": False,       # Experimental Bot API 10.1 rich draft previews during Telegram DM streaming. Default off because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws.
+            "rich_messages": False,            # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
+            "rich_drafts": False,              # Experimental Bot API 10.1 rich draft previews during Telegram DM streaming. Default off because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws.
+            "allow_cjk_rich_messages": False,  # Keep the upstream Desktop/macOS CJK safety default unless you know your Telegram clients render CJK rich messages correctly.
         },
     },
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -525,8 +525,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # can leave Bot API 10.1 rich draft frames visually overlaid until the
         # chat is redrawn, while final rich messages remain useful.
         self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
+        # Current Telegram Desktop/macOS rich rendering can garble CJK text.
+        # Keep the upstream safety default, but allow an explicit local opt-in
+        # when the operator knows their own clients are unaffected.
+        self._allow_cjk_rich_messages: bool = self._coerce_bool_extra("allow_cjk_rich_messages", False)
         # Latched off after a capability failure on sendRichMessage /
-        # sendRichMessageDraft (e.g. older python-telegram-bot without the
+
         # endpoint) so later sends skip the doomed rich attempt entirely.
         self._rich_send_disabled: bool = False
         self._rich_draft_disabled: bool = False
@@ -1362,13 +1366,15 @@ class TelegramAdapter(BasePlatformAdapter):
         return False
 
     def _has_telegram_desktop_cjk_rich_garble_shape(self, content: str) -> bool:
-        """Return True for CJK content that current TDesktop rich drafts garble.
+        """Return True when the upstream CJK rich-rendering safety guard applies.
 
-        Telegram Mac/Desktop Bot API 10.1 rich-message rendering currently
-        leaves overlapping draft/overlay glyph artifacts for CJK text (#47653).
-        The legacy MarkdownV2 path renders the same text cleanly, so skip rich
-        delivery up front until affected clients age out.
+        Upstream defaults to skipping CJK rich delivery because Telegram
+        Desktop/macOS can render overlapping glyph artifacts. Operators who do
+        not use those clients can opt back in with
+        ``telegram.extra.allow_cjk_rich_messages: true``.
         """
+        if getattr(self, "_allow_cjk_rich_messages", False):
+            return False
         return bool(content and self._RICH_CJK_RE.search(content))
 
     def _needs_rich_rendering(self, content: str) -> bool:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1113,6 +1113,25 @@ class TestLoadGatewayConfig:
 
         assert config.platforms[Platform.TELEGRAM].extra["rich_drafts"] is True
 
+    def test_loads_telegram_allow_cjk_rich_messages_from_gateway_platform_extra(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      extra:\n"
+            "        allow_cjk_rich_messages: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["allow_cjk_rich_messages"] is True
+
     def test_load_config_default_keeps_telegram_rich_messages_opt_in(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
@@ -1125,6 +1144,7 @@ class TestLoadGatewayConfig:
 
         assert config["telegram"]["extra"]["rich_messages"] is False
         assert config["telegram"]["extra"]["rich_drafts"] is False
+        assert config["telegram"]["extra"]["allow_cjk_rich_messages"] is False
 
     def test_bridges_telegram_extra_base_url_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -180,6 +180,17 @@ async def test_cjk_rich_content_skips_rich_send_to_avoid_tdesktop_garble():
 
 
 @pytest.mark.asyncio
+async def test_cjk_rich_content_can_be_opted_back_in():
+    adapter = _make_adapter(extra={"allow_cjk_rich_messages": True})
+
+    result = await adapter.send("12345", CJK_RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_awaited_once()
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_astral_cjk_rich_content_skips_rich_send_to_avoid_tdesktop_garble():
     adapter = _make_adapter()
 
@@ -188,6 +199,17 @@ async def test_astral_cjk_rich_content_skips_rich_send_to_avoid_tdesktop_garble(
     assert result.success is True
     adapter._bot.do_api_request.assert_not_called()
     adapter._bot.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_astral_cjk_rich_content_can_be_opted_back_in():
+    adapter = _make_adapter(extra={"allow_cjk_rich_messages": True})
+
+    result = await adapter.send("12345", ASTRAL_CJK_RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_awaited_once()
+    adapter._bot.send_message.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -976,7 +976,20 @@ gateway:
         rich_drafts: false
 ```
 
-This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. `rich_drafts` controls the experimental rich draft preview path during Telegram DM streaming and stays off by default because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
+This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. `rich_drafts` controls the experimental rich draft preview path during Telegram DM streaming and stays off by default because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws.
+
+CJK rich delivery (Chinese/Japanese/Korean) stays **separately disabled by default** even when `rich_messages: true`, because Telegram Desktop/macOS can render overlapping glyph artifacts for CJK rich messages. If you know your own Telegram clients are unaffected, you can opt back in explicitly:
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      extra:
+        rich_messages: true
+        allow_cjk_rich_messages: true
+```
+
+If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
 
 **Link previews.** Telegram auto-generates link previews for URLs in bot messages. If you'd rather suppress those (long `/tools` output, agent reply that mentions ten links, etc.):
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
@@ -896,7 +896,20 @@ gateway:
         rich_messages: true
 ```
 
-这个设置用于客户端渲染/复制兼容性；当 Telegram 拒绝富消息 API 调用时，Hermes 已经会自动回退。如果你只是想在保持富消息启用的同时恢复旧版「始终使用代码块」表格行为，可在 `config.yaml` 中设置 `telegram.pretty_tables: false` 禁用表格规范化（默认：`true`）。
+这个设置用于客户端渲染/复制兼容性；当 Telegram 拒绝富消息 API 调用时，Hermes 已经会自动回退。
+
+即使 `rich_messages: true` 已开启，CJK 富消息（中文 / 日文 / 韩文）默认仍会**单独保持关闭**，因为 Telegram Desktop/macOS 可能会把 CJK 富消息渲染成重叠字形。如果你确定自己使用的 Telegram 客户端不受影响，可以显式重新开启：
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      extra:
+        rich_messages: true
+        allow_cjk_rich_messages: true
+```
+
+如果你只是想在保持富消息启用的同时恢复旧版「始终使用代码块」表格行为，可在 `config.yaml` 中设置 `telegram.pretty_tables: false` 禁用表格规范化（默认：`true`）。
 
 **链接预览。** Telegram 会为机器人消息中的 URL 自动生成链接预览。如果你希望抑制这些预览（长 `/tools` 输出、提及十个链接的 Agent 回复等）：
 


### PR DESCRIPTION
## Summary
- add `telegram.extra.allow_cjk_rich_messages` as a separate opt-in that preserves the current Desktop/macOS safety default
- allow operators who do not use affected Telegram clients to re-enable native rich rendering for CJK content
- document the new config in the English and zh-Hans Telegram messaging docs and cover it with config/rich-message tests

## Motivation
Hermes currently skips Telegram rich delivery for all CJK content because some Telegram Desktop/macOS clients can render overlapping glyph artifacts. That default is reasonable, but it is broader than necessary for operators who do not use those clients.

This keeps the upstream default unchanged while adding an explicit opt-in:

```yaml
gateway:
  platforms:
    telegram:
      extra:
        rich_messages: true
        allow_cjk_rich_messages: true
```

## Testing
- `pytest -q tests/gateway/test_config.py -k 'telegram_rich_messages or telegram_rich_drafts or allow_cjk_rich_messages'`
- `pytest -q tests/gateway/test_telegram_rich_messages.py -k 'cjk or rich_messages_can_be_opted_in or rich_messages_default_is_legacy_copyable_path'`
- manually verified from a Telegram DM that Chinese rich messages render correctly after opting in
