### PR TITLE
fix(gateway): fall back to default home when a routed profile does not exist

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16658,10 +16658,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Prefers the profile the source was routed to (``source.profile`` — set
         by the /p/<profile>/ URL prefix or a per-credential adapter), falling
         back to the active profile (the multiplexer's own home).
+
+        A routed profile whose directory does not exist (e.g. a relay binding
+        or URL prefix that names a profile the operator has since deleted) must
+        NOT scope the turn into a missing HERMES_HOME — config, skills, and the
+        secret scope would all resolve against a nonexistent dir. In that case
+        we log and fall back to the active/default home, the same clean fallback
+        an empty routed profile already gets. ``get_profile_dir`` returns a path
+        regardless of existence and does not raise for a valid-but-absent name,
+        so an explicit ``profile_exists`` check is required here.
         """
-        from hermes_cli.profiles import get_active_profile_name, get_profile_dir
+        from hermes_cli.profiles import (
+            get_active_profile_name,
+            get_profile_dir,
+            profile_exists,
+        )
         try:
-            name = (source.profile or "").strip() or get_active_profile_name() or "default"
+            routed = (source.profile or "").strip()
+            if routed and not profile_exists(routed):
+                logger.warning(
+                    "Routed profile %r has no profile directory; falling back "
+                    "to the active/default home. (Stale relay/URL routing to a "
+                    "deleted profile?)",
+                    routed,
+                )
+                routed = ""
+            name = routed or get_active_profile_name() or "default"
             return get_profile_dir(name)
         except Exception:
             from hermes_constants import get_hermes_home

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -156,3 +156,55 @@ class TestProfilePathResolutionUnderMultiplexScope:
             t.join()
 
         assert seen["home"] == str(prof_b)
+
+
+class TestResolveProfileHomeMissingProfileFallback:
+    """_resolve_profile_home_for_source must not scope a turn into a missing home.
+
+    A routed source.profile that names a profile whose directory has been
+    deleted (stale relay binding / URL prefix) must fall back to the active/
+    default home rather than returning <root>/profiles/<ghost> — a nonexistent
+    HERMES_HOME that would make config/skills/secret-scope resolve against a
+    missing dir. get_profile_dir returns a path regardless of existence and does
+    NOT raise for a valid-but-absent name, so the resolver needs an explicit
+    profile_exists() check.
+    """
+
+    def _runner(self):
+        from gateway.run import GatewayRunner
+        return GatewayRunner.__new__(GatewayRunner)
+
+    def _source(self, profile):
+        from types import SimpleNamespace
+        return SimpleNamespace(profile=profile)
+
+    def test_existing_routed_profile_resolves_to_its_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "profiles" / "coder").mkdir(parents=True)
+        runner = self._runner()
+        home = runner._resolve_profile_home_for_source(self._source("coder"))
+        assert home == tmp_path / "profiles" / "coder"
+
+    def test_missing_routed_profile_falls_back_to_default(self, tmp_path, monkeypatch):
+        # HERMES_HOME is the default (pre-profile) home; no profiles/ghost dir.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runner = self._runner()
+        home = runner._resolve_profile_home_for_source(self._source("ghost"))
+        # Falls back to the active/default home, NOT tmp_path/profiles/ghost.
+        assert home != tmp_path / "profiles" / "ghost"
+        assert home == tmp_path
+
+    def test_empty_routed_profile_uses_active_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runner = self._runner()
+        for empty in (None, "", "   "):
+            home = runner._resolve_profile_home_for_source(self._source(empty))
+            assert home == tmp_path
+
+    def test_missing_profile_does_not_raise(self, tmp_path, monkeypatch):
+        # The whole resolver is wrapped in try/except → get_hermes_home; the
+        # fallback must land on a real dir, never propagate an exception.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        runner = self._runner()
+        home = runner._resolve_profile_home_for_source(self._source("nope"))
+        assert home.exists()


### PR DESCRIPTION
## Summary

`_resolve_profile_home_for_source` (the multiplexer's per-turn "which profile's `HERMES_HOME` serves this inbound source" resolver) called `get_profile_dir(source.profile)` **without checking the profile directory exists**. `get_profile_dir()` returns a path regardless of existence and does **not** raise for a valid-but-absent name — so a routed profile naming a **deleted** profile silently scoped the whole turn into `<root>/profiles/<ghost>`, a nonexistent `HERMES_HOME`. Config, skills, SOUL, and the fail-closed secret scope then all resolve against a missing directory instead of cleanly falling back.

The `try/except` around the resolver only catches a **malformed** name (`normalize_profile_name` raises); a well-formed-but-deleted name sails through.

## Fix

Add an explicit `profile_exists()` check on the **routed name only**: if the routed profile has no directory, log a warning and fall back to the active/default home — the same clean fallback an empty routed profile already gets. The active/default fallback name is trusted and not existence-checked.

```python
routed = (source.profile or "").strip()
if routed and not profile_exists(routed):
    logger.warning("Routed profile %r has no profile directory; falling back …", routed)
    routed = ""
name = routed or get_active_profile_name() or "default"
return get_profile_dir(name)
```

## Why this is worth fixing independently

This is a latent bug independent of any one caller:
- It affects the existing **`/p/<profile>/` URL prefix** today — route to a deleted profile and the turn runs in a broken home.
- It hardens the path ahead of **per-scope profile routing (Team Gateway)**, where the connector will populate `source.profile` from stored state that can drift from the agent's live profile list (a user deletes a profile the Portal still has a routing row for). NAS-side write validation catches the common case, but only this agent-side check closes the delete-after-write race — and it belongs here regardless.

## Validation

| | Result |
|---|---|
| `test_multiplex_credential_isolation.py` | 14/14 pass |
| New cases | existing routed → its dir; **missing routed → active/default (not `profiles/ghost`)**; empty/None/whitespace → active/default; never raises |
| Fail-without-fix | reverting the `profile_exists` check fails **exactly** the two missing-profile tests; existing/empty paths stay green |

## Infographic

![ghost-profile-fallback](https://v3b.fal.media/files/b/0aa16292/q-b0AIiC9hrhoX3mofQkS_ONQfJANI.png)
