### PR TITLE
feat(mcp-catalog): add motion-previs-studio optional MCP

### DIFF
--- a/optional-mcps/motion-previs-studio/manifest.yaml
+++ b/optional-mcps/motion-previs-studio/manifest.yaml
@@ -1,0 +1,64 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: motion-previs-studio
+description: Drive Motion Previs Studio — turn reference footage into AI-generator control packs (camera path, depth passes, OpenPose skeletons) and send layers to Blockout.
+source: https://github.com/wassermanproductions/motion-previs-mcp
+
+# Motion Previs Studio (https://github.com/wassermanproductions/motion-previs-studio,
+# Apache-2.0) is a desktop app that analyzes real footage and extracts the
+# camera move and actor performance for AI video generation workflows
+# (Seedance, Kling, ComfyUI, Blender). On launch the app starts a
+# localhost-only control server on a random port and writes a discovery file
+# to ~/.config/motion-previs/control.json (per-launch random bearer token,
+# mode 0600, removed on quit). This bridge is a single zero-dependency Node
+# script that reads the discovery file and forwards MCP tool calls to the
+# running app — nothing listens on a public port, nothing to configure.
+transport:
+  type: stdio
+  command: "node"
+  args:
+    - "${INSTALL_DIR}/motion-previs-mcp.mjs"
+
+# The bridge is zero-dependency (Node >= 18) — clone is the whole install,
+# so no bootstrap commands.
+install:
+  type: git
+  url: https://github.com/wassermanproductions/motion-previs-mcp.git
+  # Pin to a commit/tag. Required — manifests do not float HEAD.
+  ref: v1.0.0
+
+# The app's control server binds to 127.0.0.1 only and authenticates with a
+# per-launch random token the bridge auto-discovers from the local discovery
+# file. Nothing to prompt for.
+auth:
+  type: none
+
+# Tool selection at install time:
+# 11 tools covering the whole pipeline (import_file/import_url, set_range,
+# set_mode, set_settings, run_analysis, get_state progress polling,
+# export_pack, list_bundle, send_to_blockout, screenshot). Everything acts
+# only on the user's local analysis session inside the app — no external
+# side effects — so nothing is pruned. Leave default_enabled unset; the
+# install-time checklist shows the full surface.
+
+post_install: |
+  This bridge talks to the Motion Previs Studio desktop app (v4.1+), which
+  must be RUNNING before Hermes connects:
+
+    1. Get the app from
+       https://github.com/wassermanproductions/motion-previs-studio
+       (build from source, or use a release DMG on macOS).
+    2. Launch it. It writes its control endpoint + token to
+       ~/.config/motion-previs/control.json automatically.
+    3. Start a new Hermes session to load the tools.
+
+  If the app is not running, tool calls return a friendly "launch the app
+  first" error rather than hanging.
+
+  Agent workflow: import_file or import_url → set_range + set_mode
+  (camera_only | actor_motion | object_motion | full_scene) → run_analysis →
+  poll get_state until analysis.status is "done" (long shots take minutes) →
+  export_pack → optionally send_to_blockout to hand a layer to the Blockout
+  previs app.

--- a/optional-mcps/motion-previs-studio/manifest.yaml
+++ b/optional-mcps/motion-previs-studio/manifest.yaml
@@ -26,8 +26,9 @@ transport:
 install:
   type: git
   url: https://github.com/wassermanproductions/motion-previs-mcp.git
-  # Pin to a commit/tag. Required — manifests do not float HEAD.
-  ref: v1.0.0
+  # Pinned to an immutable commit SHA (the v1.0.0 release), per the
+  # dependency policy for Git URLs — tags can move, commits cannot.
+  ref: 693881823dee7e4ad7cbb8fc24c9b023562462c0
 
 # The app's control server binds to 127.0.0.1 only and authenticates with a
 # per-launch random token the bridge auto-discovers from the local discovery


### PR DESCRIPTION
## What

Adds an `optional-mcps/motion-previs-studio/manifest.yaml` catalog entry for **Motion Previs Studio** (https://github.com/wassermanproductions/motion-previs-studio) — an open-source (Apache-2.0) desktop app that analyzes real reference footage and extracts the camera move and actor performance into AI-generator control packs (depth passes, OpenPose skeleton video + keypoints, camera path, prompts) for Seedance, Kling, ComfyUI, and Blender workflows.

## Why

The full pipeline is agent-drivable end to end: import a shot (local file or URL), trim the range, choose what to preserve (`camera_only | actor_motion | object_motion | full_scene`), run the analysis, poll progress, export the bundle, and optionally hand layers to the Blockout previs app (companion entry proposed in #60706 — the two entries are independent; neither requires the other). The app ships a localhost-only control server (127.0.0.1, random port, per-launch random bearer token in `~/.config/motion-previs/control.json`, mode 0600, removed on quit) and a zero-dependency Node stdio MCP bridge. `auth: none` — the bridge auto-discovers the token locally (same pattern as the unreal-engine entry). Git install pinned to https://github.com/wassermanproductions/motion-previs-mcp tag `v1.0.0`; no dependencies, so no bootstrap commands.

## Testing instructions

1. Launch Motion Previs Studio v4.1+ (build from the repo or use a release DMG).
2. `hermes mcp install official/motion-previs-studio` — clones the pinned tag, no prompts.
3. Start a new Hermes session; ask it to import a clip, run the analysis, and report the result.

## Testing done

- Manifest parses cleanly through `hermes_cli.mcp_catalog._parse_manifest`; `_build_server_config` expands `${INSTALL_DIR}` to the expected `mcp_servers.motion-previs-studio` block.
- Simulated the exact install path: `git clone --depth 1 --branch v1.0.0` into `~/.hermes/mcp-installs/`, then ran the manifest's literal command against the running app. Verified over raw JSON-RPC: `initialize` (protocol 2024-11-05), `tools/list` (11 tools), then the full workflow — `import_file` of a generated test clip, `set_range`, `set_mode`, `run_analysis`, `get_state` progress polling, `screenshot` (PNG image content). The app repo's e2e suite additionally covers analysis-to-done polling, `export_pack` producing a real 25-file bundle, `list_bundle`, and bearer-token 401 rejection over the same HTTP control surface.
- With the app closed, tool calls return "launch the app first" rather than hanging.

## Platforms tested

- macOS 15 (arm64), Node 22.

## Issues

None — new catalog entry. Companion PR: #60706 (blockout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)