### PR TITLE
fix: keep Codex autoraise notices out of gateway replay

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2048,16 +2048,17 @@ def init_agent(
     # Gateway status_callback is not yet wired, so any warning is stored
     # in _compression_warning and replayed in the first run_conversation().
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.x autoraise notice: the startup print
-    # above only reaches the CLI, so stash the same text here to be replayed
-    # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    if _show_autoraise_notice:
+    # Keep the Codex autoraise lifecycle hint out of gateway replay. Compression
+    # feasibility warnings still use this slot, but an informational threshold
+    # banner would otherwise arrive as a Telegram/Discord status message during
+    # agent construction instead of when the user can act on it.
+    _platform = agent.platform or "cli"
+    if _show_autoraise_notice and _platform == "cli":
         agent._compression_warning = _build_codex_gpt5_autoraise_notice(_autoraise)
 
-    # Mark shown so repeated inits in this profile (e.g. every gateway message)
-    # stay silent. Recorded once, whether the notice went to the CLI print or
-    # the gateway replay slot.
-    if _show_autoraise_notice:
+    # Mark shown only when a surface actually received it. Gateway sessions stay
+    # silent and do not consume the CLI's one-time profile notice.
+    if _show_autoraise_notice and (_platform == "cli" or not agent.quiet_mode):
         _record_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network

--- a/tests/agent/test_codex_gpt55_autoraise_notice.py
+++ b/tests/agent/test_codex_gpt55_autoraise_notice.py
@@ -108,8 +108,7 @@ def test_codex_gpt55_autoraise_notice_can_be_suppressed_without_disabling_autora
 
 
 def test_codex_gpt55_autoraise_notice_deduped_across_agent_inits(monkeypatch, tmp_path):
-    # Gateway spam scenario (#54432): the gateway rebuilds the agent per
-    # inbound message. The first init shows the notice; the second stays
+    # CLI/local startup shows the notice once; subsequent agent inits stay
     # silent because the per-profile marker was recorded.
     agent1, stdout1 = _make_codex_agent(monkeypatch, tmp_path, show_notice=True)
     assert "auto-compaction was raised" in stdout1
@@ -119,6 +118,34 @@ def test_codex_gpt55_autoraise_notice_deduped_across_agent_inits(monkeypatch, tm
     assert _threshold_ratio(agent2) == 0.85  # autoraise still applies
     assert "auto-compaction was raised" not in stdout2
     assert getattr(agent2, "_compression_warning") is None
+
+
+def test_codex_gpt55_autoraise_notice_not_replayed_as_gateway_status(monkeypatch, tmp_path):
+    # Gateway spam scenario: lifecycle hints must not be stashed in
+    # _compression_warning, because run_conversation replays that slot through
+    # status_callback as a Telegram/Discord/etc. message.
+    from hermes_cli import config as config_mod
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: _config(show_notice=True))
+    db = SessionDB(db_path=tmp_path / "gateway-state.db")
+
+    agent = AIAgent(
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="test-key",
+        provider="openai-codex",
+        model="gpt-5.5",
+        enabled_toolsets=[],
+        disabled_toolsets=[],
+        quiet_mode=True,
+        platform="telegram",
+        skip_memory=True,
+        session_db=db,
+        session_id="codex-gateway-notice-test",
+    )
+
+    assert _threshold_ratio(agent) == 0.85
+    assert getattr(agent, "_compression_threshold_autoraised") == AUTORAISE
+    assert getattr(agent, "_compression_warning") is None
 
 
 # ── per-profile dedupe marker (#54432) ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- keep the informational Codex gpt-5.x compaction autoraise banner out of gateway status replay
- preserve the CLI/local one-time notice path and real compression feasibility warning replay
- add a regression test proving Telegram/gateway agents do not stash the lifecycle hint in _compression_warning

## Test Plan
- scripts/run_tests.sh tests/agent/test_codex_gpt55_autoraise_notice.py -v --tb=short
- scripts/run_tests.sh tests/agent/test_codex_gpt55_autoraise_notice.py tests/run_agent/test_compression_feasibility.py tests/agent/test_compression_count_warning_36908.py -q