### PR TITLE
fix(api-server): honour model_routes on native session chat endpoints

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1894,6 +1894,9 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        # Per-client model routing: honour a model_routes alias sent in the
+        # request body (mirrors /v1/chat/completions). None → global default.
+        route = self._resolve_route(body.get("model"))
         history = self._conversation_history_for_session(session_id)
         result, usage = await self._run_agent(
             user_message=user_message,
@@ -1901,6 +1904,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ephemeral_system_prompt=system_prompt,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
+            route=route,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
@@ -1983,6 +1987,9 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": user_message}}))
                 await queue.put(_event_payload("message.started", {"message": {"id": message_id, "role": "assistant"}}))
+                # Per-client model routing: honour a model_routes alias sent in
+                # the request body (mirrors /v1/chat/completions). None → default.
+                route = self._resolve_route(body.get("model"))
                 history = self._conversation_history_for_session(session_id)
                 result, usage = await self._run_agent(
                     user_message=user_message,
@@ -1992,6 +1999,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
                     gateway_session_key=gateway_session_key,
+                    route=route,
                 )
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3963,6 +3963,84 @@ class TestModelRoutesHandlers:
                     "model": "minimax/minimax-m1", "provider": "openrouter",
                 }
 
+    @pytest.mark.asyncio
+    async def test_session_chat_passes_route_to_run_agent(self, monkeypatch):
+        """POST /api/sessions/{id}/chat honours a model_routes alias sent in the
+        request body, mirroring /v1/chat/completions."""
+        routes = {"minimax-m2": {"model": "minimax/minimax-m1", "provider": "openrouter"}}
+        adapter = _make_routing_adapter(routes)
+        # Session existence + history are storage concerns; stub them so this
+        # stays a pure routing unit test (the /v1 handler tests need no session).
+        monkeypatch.setattr(adapter, "_get_existing_session_or_404", lambda sid: ({"id": sid}, None))
+        monkeypatch.setattr(adapter, "_conversation_history_for_session", lambda sid: [])
+        app = web.Application()
+        app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "hi", "session_id": "s1", "messages": [], "api_calls": 1},
+                    {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10},
+                )
+                resp = await cli.post("/api/sessions/s1/chat", json={
+                    "model": "minimax-m2",
+                    "message": "hello",
+                })
+                assert resp.status == 200
+                assert mock_run.call_args.kwargs.get("route") == {
+                    "model": "minimax/minimax-m1", "provider": "openrouter",
+                }
+
+    @pytest.mark.asyncio
+    async def test_session_chat_stream_passes_route_to_run_agent(self, monkeypatch):
+        """POST /api/sessions/{id}/chat/stream honours a model_routes alias sent
+        in the request body (the endpoint the mobile client actually uses)."""
+        routes = {"minimax-m2": {"model": "minimax/minimax-m1", "provider": "openrouter"}}
+        adapter = _make_routing_adapter(routes)
+        monkeypatch.setattr(adapter, "_get_existing_session_or_404", lambda sid: ({"id": sid}, None))
+        monkeypatch.setattr(adapter, "_conversation_history_for_session", lambda sid: [])
+        monkeypatch.setattr(adapter, "_turn_transcript_messages", lambda *a, **k: [])
+        app = web.Application()
+        app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "hi", "session_id": "s1", "messages": [], "api_calls": 1},
+                    {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10},
+                )
+                resp = await cli.post("/api/sessions/s1/chat/stream", json={
+                    "model": "minimax-m2",
+                    "message": "hello",
+                })
+                assert resp.status == 200
+                await resp.read()  # drain SSE so the background run completes
+                assert mock_run.call_args.kwargs.get("route") == {
+                    "model": "minimax/minimax-m1", "provider": "openrouter",
+                }
+
+    @pytest.mark.asyncio
+    async def test_session_chat_stream_no_route_for_unknown_model(self, monkeypatch):
+        """An unrecognised model on the stream endpoint resolves to no route,
+        leaving the gateway's global default in effect."""
+        adapter = _make_routing_adapter({"minimax-m2": {"model": "minimax/minimax-m1"}})
+        monkeypatch.setattr(adapter, "_get_existing_session_or_404", lambda sid: ({"id": sid}, None))
+        monkeypatch.setattr(adapter, "_conversation_history_for_session", lambda sid: [])
+        monkeypatch.setattr(adapter, "_turn_transcript_messages", lambda *a, **k: [])
+        app = web.Application()
+        app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "hi", "session_id": "s1", "messages": [], "api_calls": 1},
+                    {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10},
+                )
+                resp = await cli.post("/api/sessions/s1/chat/stream", json={
+                    "model": "unknown-model",
+                    "message": "hello",
+                })
+                assert resp.status == 200
+                await resp.read()
+                assert mock_run.call_args.kwargs.get("route") is None
+
 
 class TestModelRoutesAgentCreation:
     def test_route_overrides_model_and_credentials(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

The API server's **native session chat** endpoints — `POST /api/sessions/{id}/chat` and `POST /api/sessions/{id}/chat/stream` — ignored the request-body `model` field. A configured `model_routes` alias therefore only took effect on `/v1/chat/completions`, `/v1/responses`, and `/v1/runs`.

Clients that drive the native session API (e.g. mobile apps, which stream over `/api/sessions/{id}/chat/stream`) could **discover** a route via `GET /v1/models` but selecting it did nothing — every turn ran on the gateway's global default model.

This wires the two native handlers into the same routing path the `/v1/*` handlers already use: resolve the alias from `body["model"]` with `_resolve_route()` and pass the result to `_run_agent()`.

## Related Issue

No existing issue — happy to open one if preferred. Reproduction and proof are below.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`
  - `_handle_session_chat`: resolve `route = self._resolve_route(body.get("model"))` and pass `route=route` to `_run_agent()`.
  - `_handle_session_chat_stream`: same, inside `_run_and_signal()`.
- `tests/gateway/test_api_server.py` — add three cases to `TestModelRoutesHandlers`:
  - `test_session_chat_passes_route_to_run_agent`
  - `test_session_chat_stream_passes_route_to_run_agent`
  - `test_session_chat_stream_no_route_for_unknown_model`

A `None` result (no `model` field, or an unknown alias) preserves the global default, so existing behaviour is unchanged. Per-route provider credentials continue to resolve exactly as they do for the `/v1/*` handlers (`_resolve_route` → `_run_agent` → `_create_agent`).

## How to Test

Repro (before the fix): with a `model_routes` alias configured under `gateway.platforms.api_server.extra.model_routes`, e.g. `glm-5.2 → {provider: zai, model: glm-5.2}`:

```bash
# /v1 path already honoured the route:
curl -s .../v1/chat/completions -H "Authorization: Bearer $KEY" \
  -d '{"model":"glm-5.2","messages":[{"role":"user","content":"name your model"}]}'
# → routed to GLM ✅

# native session path ignored it:
curl -s .../api/sessions/$SID/chat/stream -H "Authorization: Bearer $KEY" \
  -d '{"model":"glm-5.2","message":"name your model"}'
# → answered as the gateway default model ❌ (fixed → GLM ✅)
```

Automated:

```bash
pytest tests/gateway/test_api_server.py -k "ModelRoutes" -q   # 20 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(api-server): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation — N/A (behaviour now matches the documented `/v1/*` routing; no config keys added)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure request-handling change)
