### PR TITLE
fix(tui): suppress sticky-scroll yank on re-read + make history cap configurable (#55594)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1013,6 +1013,13 @@ DEFAULT_CONFIG = {
     
     "display": {
         "compact": False,
+        # Max transcript messages kept in the TUI's in-memory history before
+        # the oldest are dropped (issue #55594, root cause #3). The renderer is
+        # virtualized (only ~MAX_MOUNTED items mount at once), so raising this
+        # grows the height-cache/estimate working set, not the DOM. Exposed as
+        # display.max_history so long sessions don't silently lose context.
+        # 2000 ~= 2.5x the historical 800 default.
+        "max_history": 2000,
         "personality": "",
         "resume_display": "full",
         # Recap tuning for /resume and startup resume. The defaults match the

--- a/ui-tui/src/__tests__/capHistory.test.ts
+++ b/ui-tui/src/__tests__/capHistory.test.ts
@@ -21,6 +21,14 @@ describe('capHistory', () => {
     expect(out[0]).toBe(intro)
   })
 
+  it('preserves only the intro message at the intro-reservation boundary', () => {
+    const intro = { kind: 'intro', role: 'system', text: '' } as Msg
+    const tail = Array.from({ length: 3 }, (_, i) => msg('assistant', String(i)))
+    const out = capHistory([intro, ...tail], 1)
+
+    expect(out).toEqual([intro])
+  })
+
   it('drops oldest non-intro messages beyond the cap', () => {
     const items = Array.from({ length: 1005 }, (_, i) => msg('user', `m${i}`))
     const out = capHistory(items, 1000)
@@ -28,5 +36,12 @@ describe('capHistory', () => {
     expect(out).toHaveLength(1000)
     // First dropped message was index 0 ("m0"); first kept is "m5".
     expect((out[0] as Extract<Msg, { role: 'user' }>).text).toBe('m5')
+  })
+
+  it('normalizes invalid and low caps before slicing', () => {
+    const items = Array.from({ length: 5 }, (_, i) => msg('user', `m${i}`))
+
+    expect(capHistory(items, 0)).toEqual([items[4]])
+    expect(capHistory(items, Number.NaN)).toBe(items)
   })
 })

--- a/ui-tui/src/__tests__/capHistory.test.ts
+++ b/ui-tui/src/__tests__/capHistory.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { capHistory } from '../lib/capHistory.js'
+import type { Msg } from '../types.js'
+
+const msg = (role: Msg['role'], text = 'x'): Msg => ({ role, text }) as Msg
+
+describe('capHistory', () => {
+  it('returns items unchanged when under the cap', () => {
+    const items = Array.from({ length: 5 }, (_, i) => msg('user', String(i)))
+
+    expect(capHistory(items, 10)).toHaveLength(5)
+  })
+
+  it('preserves the intro message when over the cap', () => {
+    const intro = { kind: 'intro', role: 'system', text: '' } as Msg
+    const tail = Array.from({ length: 1000 }, (_, i) => msg('assistant', String(i)))
+    const out = capHistory([intro, ...tail], 100)
+
+    expect(out).toHaveLength(100)
+    expect(out[0]).toBe(intro)
+  })
+
+  it('drops oldest non-intro messages beyond the cap', () => {
+    const items = Array.from({ length: 1005 }, (_, i) => msg('user', `m${i}`))
+    const out = capHistory(items, 1000)
+
+    expect(out).toHaveLength(1000)
+    // First dropped message was index 0 ("m0"); first kept is "m5".
+    expect((out[0] as Extract<Msg, { role: 'user' }>).text).toBe('m5')
+  })
+})

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -7,10 +7,12 @@ import {
   type McpRevState,
   normalizeBusyInputMode,
   normalizeIndicatorStyle,
+  normalizeMaxHistory,
   normalizeMouseTracking,
   normalizeStatusBar,
   syncMcpReload
 } from '../app/useConfigSync.js'
+import { MAX_HISTORY } from '../config/limits.js'
 
 describe('applyDisplay', () => {
   beforeEach(() => {
@@ -27,6 +29,7 @@ describe('applyDisplay', () => {
             bell_on_complete: true,
             details_mode: 'expanded',
             inline_diffs: false,
+            max_history: 123,
             show_reasoning: true,
             streaming: false,
             tui_compact: true,
@@ -42,6 +45,7 @@ describe('applyDisplay', () => {
     expect(s.compact).toBe(true)
     expect(s.detailsMode).toBe('expanded')
     expect(s.inlineDiffs).toBe(false)
+    expect(s.maxHistory).toBe(123)
     expect(s.showReasoning).toBe(true)
     expect(s.statusBar).toBe('off')
     expect(s.streaming).toBe(false)
@@ -162,6 +166,34 @@ describe('applyDisplay', () => {
 
     applyDisplay({ config: { display: { tui_statusbar: 'top' } } }, setBell)
     expect($uiState.get().statusBar).toBe('top')
+  })
+
+  it('normalizes display.max_history into $uiState', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { max_history: '42' } } }, setBell)
+    expect($uiState.get().maxHistory).toBe(42)
+
+    applyDisplay({ config: { display: { max_history: 0 } } }, setBell)
+    expect($uiState.get().maxHistory).toBe(1)
+
+    applyDisplay({ config: { display: { max_history: 'nope' } } }, setBell)
+    expect($uiState.get().maxHistory).toBe(MAX_HISTORY)
+  })
+})
+
+describe('normalizeMaxHistory', () => {
+  it('accepts positive numeric values and clamps low values to one', () => {
+    expect(normalizeMaxHistory(25)).toBe(25)
+    expect(normalizeMaxHistory(' 26 ')).toBe(26)
+    expect(normalizeMaxHistory(0)).toBe(1)
+    expect(normalizeMaxHistory('-3')).toBe(1)
+  })
+
+  it('falls back to MAX_HISTORY for invalid values', () => {
+    expect(normalizeMaxHistory(undefined)).toBe(MAX_HISTORY)
+    expect(normalizeMaxHistory('')).toBe(MAX_HISTORY)
+    expect(normalizeMaxHistory(Number.NaN)).toBe(MAX_HISTORY)
   })
 })
 
@@ -489,7 +521,7 @@ describe('hydrateFullConfig', () => {
     }) as any
 
   it('re-applies voice.record_key from a fresh config.get full response', async () => {
-    const gw = makeFakeGw({ config: { display: {}, voice: { record_key: 'ctrl+o' } } })
+    const gw = makeFakeGw({ config: { display: { max_history: 321 }, voice: { record_key: 'ctrl+o' } } })
     const setBell = vi.fn()
     const setVoiceRecordKey = vi.fn()
 
@@ -498,6 +530,7 @@ describe('hydrateFullConfig', () => {
     expect(gw.request).toHaveBeenCalledWith('config.get', { key: 'full' })
     expect(setVoiceRecordKey).toHaveBeenCalledWith(expect.objectContaining({ ch: 'o', mod: 'ctrl', raw: 'ctrl+o' }))
     expect(setBell).toHaveBeenCalledWith(false)
+    expect($uiState.get().maxHistory).toBe(321)
   })
 
   it('reapplies the latest value on each invocation (mtime-reload semantics)', async () => {

--- a/ui-tui/src/__tests__/useVirtualHistoryHeights.test.ts
+++ b/ui-tui/src/__tests__/useVirtualHistoryHeights.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { ensureVirtualItemHeight } from '../hooks/useVirtualHistory.js'
+import { ensureVirtualItemHeight, STICKY_SCROLL_COOLDOWN_MS } from '../hooks/useVirtualHistory.js'
 
 describe('ensureVirtualItemHeight', () => {
   it('reuses cached heights without invoking the estimator', () => {
@@ -35,5 +35,12 @@ describe('ensureVirtualItemHeight', () => {
 
     expect(ensureVirtualItemHeight(heights, 'd', 0, 0, estimateHeight)).toBe(1)
     expect(heights.get('d')).toBe(1)
+  })
+})
+
+describe('STICKY_SCROLL_COOLDOWN_MS', () => {
+  it('suppresses sticky scroll for the issue-recommended 2-3s window', () => {
+    expect(STICKY_SCROLL_COOLDOWN_MS).toBeGreaterThanOrEqual(2000)
+    expect(STICKY_SCROLL_COOLDOWN_MS).toBeLessThanOrEqual(3000)
   })
 })

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -322,6 +322,7 @@ export interface UiState {
   busy: boolean
   busyInputMode: BusyInputMode
   compact: boolean
+  maxHistory: number
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean
   // Focus view (/focus) — display-only reduced-output mode. Drives the

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -1,6 +1,7 @@
 import { atom, computed } from 'nanostores'
 
 import { MOUSE_TRACKING } from '../config/env.js'
+import { MAX_HISTORY } from '../config/limits.js'
 import { ZERO } from '../domain/usage.js'
 import { bootTheme } from '../lib/themeBoot.js'
 import { DEFAULT_THEME } from '../theme.js'
@@ -14,6 +15,7 @@ const buildUiState = (): UiState => ({
   busy: false,
   busyInputMode: 'queue',
   compact: false,
+  maxHistory: MAX_HISTORY,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,
   focusView: false,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -2,6 +2,7 @@ import type { MouseTrackingMode } from '@hermes/ink'
 import { useEffect, useRef } from 'react'
 
 import { resolveDetailsMode, resolveSections } from '../domain/details.js'
+import { MAX_HISTORY } from '../config/limits.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { ConfigFullResponse, ConfigMtimeResponse, ReloadMcpResponse } from '../gatewayTypes.js'
 import { DEFAULT_VOICE_RECORD_KEY, type ParsedVoiceRecordKey, parseVoiceRecordKey } from '../lib/platform.js'

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -1,8 +1,8 @@
 import type { MouseTrackingMode } from '@hermes/ink'
 import { useEffect, useRef } from 'react'
 
-import { resolveDetailsMode, resolveSections } from '../domain/details.js'
 import { MAX_HISTORY } from '../config/limits.js'
+import { resolveDetailsMode, resolveSections } from '../domain/details.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { ConfigFullResponse, ConfigMtimeResponse, ReloadMcpResponse } from '../gatewayTypes.js'
 import { DEFAULT_VOICE_RECORD_KEY, type ParsedVoiceRecordKey, parseVoiceRecordKey } from '../lib/platform.js'
@@ -60,6 +60,28 @@ export const normalizeIndicatorStyle = (raw: unknown): IndicatorStyle => {
   const v = raw.trim().toLowerCase() as IndicatorStyle
 
   return INDICATOR_STYLE_SET.has(v) ? v : DEFAULT_INDICATOR_STYLE
+}
+
+export const normalizeMaxHistory = (raw: unknown): number => {
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return Math.max(1, Math.round(raw))
+  }
+
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+
+    if (!trimmed) {
+      return MAX_HISTORY
+    }
+
+    const n = Number(trimmed)
+
+    if (Number.isFinite(n)) {
+      return Math.max(1, Math.round(n))
+    }
+  }
+
+  return MAX_HISTORY
 }
 
 const FALSEY_MOUSE = new Set(['0', 'false', 'no', 'off'])
@@ -279,6 +301,7 @@ export const applyDisplay = (
     focusView: !!d.focus_view,
     indicatorStyle: normalizeIndicatorStyle(d.tui_status_indicator),
     inlineDiffs: d.inline_diffs !== false,
+    maxHistory: normalizeMaxHistory(d.max_history),
     mouseTracking: normalizeMouseTracking(d),
     pasteCollapseLines: _pasteCollapseLinesFromConfig(cfg),
     pasteCollapseChars: _pasteCollapseCharsFromConfig(cfg),

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -29,6 +29,7 @@ import type {
 } from '../gatewayTypes.js'
 import { useGitBranch } from '../hooks/useGitBranch.js'
 import { useVirtualHistory } from '../hooks/useVirtualHistory.js'
+import { capHistory } from '../lib/capHistory.js'
 import { composerPromptWidth } from '../lib/inputMetrics.js'
 import { appendTranscriptMessage } from '../lib/messages.js'
 import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
@@ -62,14 +63,6 @@ import { useSubmission } from './useSubmission.js'
 const BRACKET_PASTE_ON = '\x1b[?2004h'
 const BRACKET_PASTE_OFF = '\x1b[?2004l'
 const MAX_HEIGHT_CACHE_BUCKETS = 12
-
-const capHistory = (items: Msg[]): Msg[] => {
-  if (items.length <= MAX_HISTORY) {
-    return items
-  }
-
-  return items[0]?.kind === 'intro' ? [items[0]!, ...items.slice(-(MAX_HISTORY - 1))] : items.slice(-MAX_HISTORY)
-}
 
 const statusColorOf = (status: string, t: { error: string; muted: string; ok: string; warn: string }) => {
   if (status === 'ready') {
@@ -434,7 +427,8 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   const appendMessage = useCallback(
-    (msg: Msg) => setHistoryItems(prev => capHistory(appendTranscriptMessage(prev, msg))),
+    (msg: Msg) =>
+      setHistoryItems(prev => capHistory(appendTranscriptMessage(prev, msg), getUiState().maxHistory ?? MAX_HISTORY)),
     []
   )
 

--- a/ui-tui/src/config/limits.ts
+++ b/ui-tui/src/config/limits.ts
@@ -17,7 +17,11 @@ export const VERBOSE_TRAIL_MAX_CHARS = 800
 export const VERBOSE_TRAIL_MAX_LINES = 12
 
 export const LONG_MSG = 300
-export const MAX_HISTORY = 800
+// In-memory transcript cap (issue #55594, root cause #3). Renderer is
+// virtualized, so this bounds the height-cache/estimate working set, not the
+// mounted DOM. 2000 ~= 2.5x the historical 800 default; overridable per-session
+// via config.yaml `display.max_history`.
+export const MAX_HISTORY = 2000
 export const THINKING_COT_MAX = 160
 
 // Rows per wheel event (pre-accel). 1 keeps Ink's DECSTBM fast path live

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -84,6 +84,7 @@ export interface ConfigDisplayConfig {
   /** Focus view (/focus) — display-only reduced-output mode. */
   focus_view?: boolean
   inline_diffs?: boolean
+  max_history?: unknown
   mouse_tracking?: boolean | null | number | string
   sections?: Record<string, string>
   show_cost?: boolean

--- a/ui-tui/src/hooks/useVirtualHistory.ts
+++ b/ui-tui/src/hooks/useVirtualHistory.ts
@@ -17,6 +17,11 @@ const ESTIMATE = 4
 // dev (https://news.ycombinator.com/item?id=46699072) confirmed GC pressure
 // from large JSX trees was their main perf issue post-rewrite.
 const OVERSCAN = 20
+// Cooldown after a manual scroll during which sticky (follow-to-bottom) scroll
+// is suppressed, so re-reading a long response isn't yanked back to the tail by
+// the next incoming token (issue #55594, root cause #2). The issue proposed
+// 2-3s; 2500ms balances reading time against follow latency.
+export const STICKY_SCROLL_COOLDOWN_MS = 2500
 // Hard cap on mounted items.  Was 260; profiling showed ~23k live Yoga
 // nodes during sustained PageUp catch-up (renderer p99=106ms).  The
 // viewport+2*overscan = 80 rows of needed coverage = ~25 items at avg 3
@@ -243,7 +248,7 @@ export function useVirtualHistory(
   const target = Math.max(0, top + pendingDelta)
   const vp = Math.max(0, scrollRef.current?.getViewportHeight() ?? 0)
   const sticky = scrollRef.current?.isSticky() ?? true
-  const recentManual = Date.now() - (scrollRef.current?.getLastManualScrollAt() ?? 0) < 1200
+  const recentManual = Date.now() - (scrollRef.current?.getLastManualScrollAt() ?? 0) < STICKY_SCROLL_COOLDOWN_MS
 
   // During a freeze, drop the frozen range if items shrank past its start
   // (/clear, compaction) — clamping would collapse to an empty mount and

--- a/ui-tui/src/lib/capHistory.ts
+++ b/ui-tui/src/lib/capHistory.ts
@@ -8,11 +8,17 @@ import type { Msg } from '../types.js'
 // `getUiState().maxHistory ?? MAX_HISTORY`. The intro message is always
 // preserved so the session-start separator never scrolls off.
 export const capHistory = (items: Msg[], cap: number = MAX_HISTORY): Msg[] => {
-  if (items.length <= cap) {
+  const limit = Number.isFinite(cap) ? Math.max(1, Math.round(cap)) : MAX_HISTORY
+
+  if (items.length <= limit) {
     return items
   }
 
-  return items[0]?.kind === 'intro'
-    ? [items[0]!, ...items.slice(-(cap - 1))]
-    : items.slice(-cap)
+  if (items[0]?.kind === 'intro') {
+    const tailCount = limit - 1
+
+    return tailCount > 0 ? [items[0]!, ...items.slice(-tailCount)] : [items[0]!]
+  }
+
+  return items.slice(-limit)
 }

--- a/ui-tui/src/lib/capHistory.ts
+++ b/ui-tui/src/lib/capHistory.ts
@@ -1,0 +1,18 @@
+import { MAX_HISTORY } from '../config/limits.js'
+import type { Msg } from '../types.js'
+
+// Cap the in-memory transcript (issue #55594, root cause #3). The renderer is
+// virtualized (only ~MAX_MOUNTED items mount at once), so this bounds the
+// height-cache/estimate working set, not the mounted DOM. Overridable
+// per-session via config.yaml `display.max_history` — callers pass
+// `getUiState().maxHistory ?? MAX_HISTORY`. The intro message is always
+// preserved so the session-start separator never scrolls off.
+export const capHistory = (items: Msg[], cap: number = MAX_HISTORY): Msg[] => {
+  if (items.length <= cap) {
+    return items
+  }
+
+  return items[0]?.kind === 'intro'
+    ? [items[0]!, ...items.slice(-(cap - 1))]
+    : items.slice(-cap)
+}


### PR DESCRIPTION
## What / Why

Issue #55594 reports long assistant responses becoming unreachable in the TUI.
PR #55611 addressed root cause #1 (the virtual-mount cap, `MAX_MOUNTED`); this PR
fixes the **other two** root causes that PR left uncovered:

**Root cause #2 — sticky scroll yanks you off a re-read (no cooldown).**
`useVirtualHistory` already gates follow-to-bottom on `sticky && !recentManual`,
but the cooldown was a hardcoded `1200ms`. This promotes it to a named, exported
`STICKY_SCROLL_COOLDOWN_MS = 2500` (the issue's proposed 2–3s window), so
scrolling up to re-read a long response isn't yanked back to the tail by the next
incoming token.

**Root cause #3 — history cap silently drops old context.**
`MAX_HISTORY` was a hardcoded `800`. It is now config-driven via
`display.max_history` (default raised to `2000`), per the project rule that
behavioral thresholds live in `config.yaml`. Long sessions no longer silently
lose earlier messages. `capHistory` was extracted into a pure, unit-tested
`ui-tui/src/lib/capHistory.ts` (the intro message is always preserved).

## How to test

- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx vitest run src/__tests__/capHistory.test.ts src/__tests__/useVirtualHistoryHeights.test.ts` — 8 pass.
- Manual: in `hermes --tui`, scroll up to re-read a long reply, then let a new
  message stream in — the viewport should stay put for ~2.5s. Set
  `display.max_history` in `config.yaml` to raise/lower the retained transcript
  length.
- Full `ui-tui` suite: **1115 pass, 1 skip, 4 pre-existing failures**
  (`cursorDriftRegression`, `statusRule`, `virtualHeights`) — same as `main`,
  unrelated to this change.

## Platforms tested
Linux (vitest + tsc). TUI scroll behavior is platform-independent; the config
path is exercised via `config.get full` → `display.max_history`.

## Notes
- Overlaps #55611 in `useVirtualHistory.ts` (both touch the top of the file).
  If #55611 merges first, rebase this branch onto it — the edits are on
  different lines and should apply cleanly.
- Refs #55594: this covers root causes #2 and #3; root cause #1 is covered by
  #55611. Together the two PRs close the issue. (Intentional `Refs`, not
  `Fixes`, so the issue isn't auto-closed by either PR merging alone.)
