### PR TITLE
fix(desktop): add a visible reveal grip to the collapsed left sidebar

### DIFF
--- a/apps/desktop/src/components/pane-shell/pane-shell.test.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.test.tsx
@@ -305,6 +305,33 @@ describe('PaneShell composition', () => {
     expect($paneStates.get().files?.widthOverride).toBe(300)
   })
 
+  it('shows a wider grip-bearing reveal trigger on a collapsed left pane, and a plain narrow one on the right', () => {
+    const rendered = render(
+      <PaneShell>
+        <Pane defaultOpen={false} hoverReveal id="sidebar" side="left" width="240px">
+          sidebar
+        </Pane>
+        <PaneMain>main</PaneMain>
+        <Pane defaultOpen={false} hoverReveal id="inspector" side="right" width="320px">
+          inspector
+        </Pane>
+      </PaneShell>
+    )
+
+    const leftTrigger = rendered.container.querySelector('[data-pane-id="sidebar"] [data-pane-reveal-trigger]')
+    const rightTrigger = rendered.container.querySelector('[data-pane-id="inspector"] [data-pane-reveal-trigger]')
+
+    if (!(leftTrigger instanceof HTMLElement) || !(rightTrigger instanceof HTMLElement)) {
+      throw new Error('Expected both collapsed panes to render a reveal trigger')
+    }
+
+    expect(leftTrigger.style.width).toBe('20px')
+    expect(leftTrigger.querySelector('span')).not.toBeNull()
+
+    expect(rightTrigger.style.width).toBe('14px')
+    expect(rightTrigger.querySelector('span')).toBeNull()
+  })
+
   it('dragging a right-pane separator clamps to max width', () => {
     const rendered = render(
       <PaneShell>

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -120,6 +120,10 @@ const HOVER_REVEAL_SHADOW = '0px -18px 18px -5px #00000012'
 // pane on hover and swallow its clicks (#44140).
 const HOVER_REVEAL_TRIGGER_WIDTH = 14
 const HOVER_REVEAL_EDGE_GUTTER = 'calc(0.5rem + 2px)'
+// Wider strip on the LEFT, where the visible reveal grip lives, so the grip
+// sits comfortably inside the hit zone. Gutter is unchanged → #44140 stays
+// fixed. (The right edge is handled separately — see follow-up.)
+const HOVER_REVEAL_GRIP_TRIGGER_WIDTH = 20
 
 // Fired (window CustomEvent<{ id }>) to toggle a force-collapsed pane's reveal
 // from the keyboard, since its store-open toggle is a no-op while collapsed.
@@ -502,10 +506,28 @@ export function Pane({
       >
         <div
           aria-hidden="true"
-          className="pointer-events-auto absolute inset-y-0 z-30 [-webkit-app-region:no-drag]"
+          className="pointer-events-auto absolute inset-y-0 z-30 flex items-center [-webkit-app-region:no-drag]"
           data-pane-reveal-trigger=""
-          style={{ [edge]: HOVER_REVEAL_EDGE_GUTTER, width: HOVER_REVEAL_TRIGGER_WIDTH }}
-        />
+          style={{
+            [edge]: HOVER_REVEAL_EDGE_GUTTER,
+            width: side === 'left' ? HOVER_REVEAL_GRIP_TRIGGER_WIDTH : HOVER_REVEAL_TRIGGER_WIDTH
+          }}
+        >
+          {/* Visible grip marking the collapsed LEFT pane's reveal edge, so
+              users can see where to hover instead of hunting a blind strip.
+              Styled with the same token as the resize sash so it reads as
+              native. Fades out once the pane slides in on hover or is pinned
+              open (data-forced). The right edge is handled separately. */}
+          {side === 'left' && (
+            <span
+              className={cn(
+                'absolute left-1 top-1/2 h-9 w-1 -translate-y-1/2 rounded-full bg-(--ui-stroke-secondary)',
+                'opacity-90 transition-opacity duration-150',
+                'group-hover/reveal:opacity-0 group-data-[forced]/reveal:opacity-0'
+              )}
+            />
+          )}
+        </div>
 
         {/* Keyed on side so flipping panes remounts off-screen on the new edge
             instead of transitioning the transform across the viewport. */}


### PR DESCRIPTION
## Summary

When the left sidebar is collapsed, revealing it depends on hovering an **invisible** 14px trigger strip near the window edge. There's no visual cue that the strip exists, and the hit zone is easy to miss — so the reveal feels unreliable and undiscoverable (see #60659).

This PR adds a **visible reveal grip** on the collapsed **left** edge: a small rounded pill, styled with the same token as the resize sash, that marks exactly where to hover. It fades out once the pane slides in on hover or is pinned open. The right edge is intentionally left unchanged and will be handled in a separate PR.

Closes #60659 (left edge).

## Before / After

**Before** — invisible strip, nothing indicates where to hover:

https://github.com/user-attachments/assets/ff04dfd3-ede8-492e-b8b5-518a1d50ba04


**After** — a clear grip marks the reveal edge; hovering it slides the sidebar in:


https://github.com/user-attachments/assets/3f9117d0-4509-4507-871e-e3a0eb5f9a0a



## The problem

The collapsed-pane hover-reveal (`apps/desktop/src/components/pane-shell/pane-shell.tsx`) works entirely through CSS: a zero-width grid cell holds an absolutely-positioned trigger strip; hovering it drives `group-hover/reveal:translate-x-0` on the panel. Two things make that unreliable:

1. **The trigger is invisible.** Nothing on screen tells the user the reveal edge is there, so discovering it is trial-and-error.
2. **The hit zone is small and offset.** The strip is only `HOVER_REVEAL_TRIGGER_WIDTH = 14px`, inset `HOVER_REVEAL_EDGE_GUTTER ≈ 10px` from the window edge, and gated behind a 130ms dwell delay. A cursor thrown at the far edge lands in the inset dead zone, and a fast sweep exits the 14px band before the dwell elapses — so nothing reveals.

## Why the gutter can't just be removed (and #44140)

The obvious "fix" — zero out `HOVER_REVEAL_EDGE_GUTTER` so the whole edge registers — **reintroduces a previously-fixed bug**. The inset is deliberate (see the comment at `pane-shell.tsx:117-120`): it keeps the trigger off (a) the OS window-resize grab band and (b) the adjacent pane's scrollbar (`.scrollbar-dt`).

If the trigger reaches `0`, the `pointer-events-auto` strip sits on top of the scrollbar: moving the cursor to scroll pops the sidebar out, and the revealed panel — clickable while hovered — swallows the scrollbar's clicks/drags. That's exactly the regression **#44140** the gutter was added to fix. So any solution has to keep the inset intact.

## Alternatives considered

- **Zero the gutter to widen the hit zone.** ❌ Rejected — reintroduces #44140 (and collides with the OS resize edge), and doesn't address the dwell delay, so fast sweeps still miss.
- **Widen the strip inward + trim the dwell delay** (grow `HOVER_REVEAL_TRIGGER_WIDTH`, leave the gutter alone). ✅ Safe and helps, but it's still an *invisible* target — it improves the odds of hitting the strip without solving discoverability.
- **JS pointer-intent detection** (velocity/proximity via `mousemove`). ❌ Rejected — the block is explicitly "No JS pointer math," and this is heavier than the problem warrants.
- **A visible grip affordance (this PR).** ✅ Chosen — see below.

## Why a visible indicator is the right fix

The core complaint is really *discoverability + aim*, not just hit-area size. A visible grip solves both at once:

- **You can see the target.** The reveal edge stops being a hidden strip you have to learn about — the grip announces it.
- **You aim instead of sweep.** A visible target invites the cursor to it (Fitts's law), which sidesteps the "fast sweep exits before the dwell" failure mode far more naturally than nudging pixel constants.
- **It stays #44140-safe.** The grip lives *inside* the existing inset trigger, so the scrollbar and OS resize band are untouched. The strip is widened slightly (`20px`) **only on the left**, on the safe/inward side, so the gutter is unchanged.
- **It reads as native.** The grip uses the same `--ui-stroke-secondary` token as the resize sash, so it looks like part of the existing edge vocabulary rather than a new element bolted on.

## Scope

- **Left edge only.** The right edge resolves to the original `HOVER_REVEAL_TRIGGER_WIDTH = 14` with no grip, so it's behaviorally unchanged and can be addressed in a follow-up.
- **Hover-only, decorative** (`aria-hidden`), matching the current interaction model. A natural follow-up is to make the grip click-to-pin and keyboard/screen-reader accessible via the existing `PANE_TOGGLE_REVEAL_EVENT`.

## Testing

- `npm run typecheck` — clean
- `npm run lint` (target file) — clean

## See attached (before and after)