### PR TITLE
fix(qqbot): add return_exceptions to asyncio.gather in chunk upload

### DIFF
--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -599,4 +599,7 @@ async def _run_with_concurrency(
         async with sem:
             await thunk()
 
-    await asyncio.gather(*(_wrap(t) for t in tasks))
+    results = await asyncio.gather(*(_wrap(t) for t in tasks), return_exceptions=True)
+    for r in results:
+        if isinstance(r, BaseException):
+            raise r


### PR DESCRIPTION
## Summary

Add  to  in  and re-raise the first exception after all tasks complete.

## Problem

 in  calls  without . If one part upload fails, the entire gather raises immediately, abandoning all other in-flight concurrent uploads. This is especially wasteful for large multi-part files where other parts may still be transferring successfully.

## Fix

- Added  to the gather call so all tasks are allowed to complete
- After gather, iterate results and re-raise the first  to preserve error semantics for the caller
- Minimal diff: 4 lines added, 1 line removed

## Testing
- Syntax check passed (py_compile + AST parse)
- Logic verified: same error-raising behavior, but no premature cancellation of sibling tasks