### PR TITLE
fix(qqbot): add is_reconnect parameter to QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Summary

Align `QQAdapter.connect()` signature with `BasePlatformAdapter.connect()`, which accepts an `is_reconnect` keyword argument (defined in `gateway/platforms/base.py` line 2864).

## Problem

When the gateway attempts to reconnect the QQBot WebSocket, it calls `adapter.connect(is_reconnect=True)`. The QQAdapter's `connect()` method did not accept this parameter, causing:

```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

This prevents the QQBot platform from reconnecting after transient network drops.

## Fix

Add `*, is_reconnect: bool = False` to `QQAdapter.connect()` in `gateway/platforms/qqbot/adapter.py`, matching the base class signature.

## Verification

- The fix is a one-line signature change — no behavioral logic modified.
- Other platform adapters (WeChat, WhatsApp Cloud, API Server, BlueBubbles, Relay) already accept `is_reconnect` in their `connect()` methods.
- QQBot was the only adapter missing this parameter.