### PR TITLE
fix: add explicit UTF-8 encoding to remaining subprocess text=True calls (#53428)

### DIFF
--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -423,7 +423,7 @@ def _op_whoami(binary: Path, account: str) -> Optional[str]:
     if account:
         cmd += ["--account", account]
     try:
-        res = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        res = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10)
     except (OSError, subprocess.TimeoutExpired):
         return None
     if res.returncode != 0:

--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -408,6 +408,8 @@ def _op_version(binary: Path) -> str:
             [str(binary), "--version"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
         )
         if res.returncode == 0:

--- a/tests/tools/test_subprocess_utf8_encoding.py
+++ b/tests/tools/test_subprocess_utf8_encoding.py
@@ -1,0 +1,52 @@
+"""Regression test for issue #53428 — subprocess.run(text=True) without
+explicit ``encoding=`` triggers ``UnicodeDecodeError`` on Chinese Windows
+(cp936/GBK default encoding).
+
+PR #55339 covers 21 call sites in ``agent/``, ``gateway/``, ``cli.py``,
+``cron/``, plus 5 more in ``tools/`` and ``hermes_cli/`` (main.py,
+setup.py, tts_tool.py, transcription_tools.py). The one call site it
+misses — ``hermes_cli/onepassword_secrets_cli.py::_op_whoami`` — is
+guarded here.
+
+Without ``encoding=``, ``text=True`` decodes child output with
+``locale.getpreferredencoding(False)`` — cp936 on Chinese Windows —
+which crashes on non-GBK bytes (issues #47939, #53428, #57238).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+def _assert_utf8_kwargs(mock_run):
+    """Lift the encoding/errors kwargs out of the mock and assert them."""
+    assert mock_run.called, "subprocess.run was not called"
+    kwargs = mock_run.call_args.kwargs
+    assert kwargs.get("encoding") == "utf-8", (
+        f"subprocess.run called without encoding='utf-8' "
+        f"(got encoding={kwargs.get('encoding')!r}). "
+        f"On Chinese Windows (cp936), text=True without explicit encoding "
+        f"crashes with UnicodeDecodeError on non-GBK bytes. See #53428."
+    )
+    assert kwargs.get("errors") == "replace", (
+        f"subprocess.run called without errors='replace' "
+        f"(got errors={kwargs.get('errors')!r}). encoding='utf-8' alone "
+        f"still raises UnicodeDecodeError on non-UTF-8 bytes emitted by "
+        f"Windows-native CLIs. See #53428."
+    )
+
+
+def test_op_whoami_passes_utf8_encoding(tmp_path):
+    """_op_whoami must pass encoding='utf-8', errors='replace' so op CLI
+    output containing non-ASCII account names doesn't crash on cp936."""
+    from hermes_cli import onepassword_secrets_cli as op_cli
+
+    fake_binary = tmp_path / "op"
+    fake_binary.write_bytes(b"")
+    with patch.object(op_cli.subprocess, "run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="user@example.com", stderr=""
+        )
+        op_cli._op_whoami(fake_binary, account="")
+    _assert_utf8_kwargs(mock_run)

--- a/tests/tools/test_subprocess_utf8_encoding.py
+++ b/tests/tools/test_subprocess_utf8_encoding.py
@@ -4,9 +4,9 @@ explicit ``encoding=`` triggers ``UnicodeDecodeError`` on Chinese Windows
 
 PR #55339 covers 21 call sites in ``agent/``, ``gateway/``, ``cli.py``,
 ``cron/``, plus 5 more in ``tools/`` and ``hermes_cli/`` (main.py,
-setup.py, tts_tool.py, transcription_tools.py). The one call site it
-misses — ``hermes_cli/onepassword_secrets_cli.py::_op_whoami`` — is
-guarded here.
+setup.py, tts_tool.py, transcription_tools.py). The two call sites it
+misses — ``hermes_cli/onepassword_secrets_cli.py::_op_whoami`` and
+``_op_version`` — are guarded here.
 
 Without ``encoding=``, ``text=True`` decodes child output with
 ``locale.getpreferredencoding(False)`` — cp936 on Chinese Windows —
@@ -49,4 +49,20 @@ def test_op_whoami_passes_utf8_encoding(tmp_path):
             returncode=0, stdout="user@example.com", stderr=""
         )
         op_cli._op_whoami(fake_binary, account="")
+    _assert_utf8_kwargs(mock_run)
+
+
+def test_op_version_passes_utf8_encoding(tmp_path):
+    """_op_version must pass encoding='utf-8', errors='replace' so op CLI
+    output containing non-ASCII bytes doesn't crash on cp936. Pairs with
+    _op_whoami — both run in the same setup/status CLI flow."""
+    from hermes_cli import onepassword_secrets_cli as op_cli
+
+    fake_binary = tmp_path / "op"
+    fake_binary.write_bytes(b"")
+    with patch.object(op_cli.subprocess, "run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="2.24.0", stderr=""
+        )
+        op_cli._op_version(fake_binary)
     _assert_utf8_kwargs(mock_run)


### PR DESCRIPTION
## Summary

PR #55339 adds `encoding="utf-8", errors="replace"` to 26 `subprocess.run(text=True)` call sites across the codebase. The triage review (thanks @alt-glitch) diffed this PR against #55339 and found that **5 of the 6 originally-touched call sites are already covered there byte-identically** — this PR has been **narrowed to the one genuinely net-new site**:

- `hermes_cli/onepassword_secrets_cli.py::_op_whoami` (1Password `op` CLI whoami probe)

The other 5 sites should land via #55339:
- `hermes_cli/main.py::_probe_container`
- `hermes_cli/setup.py` SSH probe
- `tools/tts_tool.py::_generate_neutts`
- `tools/transcription_tools.py::_prepare_local_audio`
- `tools/transcription_tools.py::_transcribe_local_command` (both branches)

Without explicit `encoding=`, `text=True` decodes child output with `locale.getpreferredencoding(False)` — cp936 on Chinese Windows — which crashes `_readerthread` on non-GBK bytes, cascading into pipe buffer fills, event loop stalls, and TUI freezes (issues #47939, #53428, #57238).

## Changes

| File | Change |
|---|---|
| `hermes_cli/onepassword_secrets_cli.py` | Add `encoding="utf-8", errors="replace"` to `_op_whoami`'s `subprocess.run` call |
| `tests/tools/test_subprocess_utf8_encoding.py` | Regression test: patches `subprocess.run` and asserts `encoding`/`errors` kwargs are passed at runtime |

## Test Plan
- [x] `pytest tests/tools/test_subprocess_utf8_encoding.py` — 1 passed
- [x] Sensitivity verified: removing `encoding=` from `_op_whoami` fails the test with a clear message referencing #53428

Refs #53428 (together with #55339).