### PR TITLE
fix(compression): raise timeout floor from 300s to 900s for slow local models (#60604)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5981,7 +5981,13 @@ _DEFAULT_AUX_TIMEOUT = 30.0
 # per-call ``timeout=``.  A floor is harmless for fast compression models
 # (they finish before the deadline) and is a minimum, so a higher config value
 # is kept unchanged.
-_COMPRESSION_TIMEOUT_FLOOR_SECONDS = 300.0
+# For slow local models (Ollama, llama.cpp, LM Studio, etc.) on consumer
+# hardware, compressing a large conversation history (~200K tokens) can
+# take well over 5 minutes.  The floor was raised from 300s → 900s to
+# prevent premature timeouts on such setups (#60604).  Users with very
+# slow models can increase further via ``auxiliary.compression.timeout``
+# in config.yaml (the floor is a minimum, so a higher config value wins).
+_COMPRESSION_TIMEOUT_FLOOR_SECONDS = 900.0
 
 
 def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Context

Context compression on slow local models (Ollama, llama.cpp, LM Studio) running on consumer hardware can take well over 5 minutes to summarize large conversation histories (~200K tokens). The compression timeout floor of 300s was causing premature timeouts on such setups.

## Change

Raise `_COMPRESSION_TIMEOUT_FLOOR_SECONDS` from 300 → 900 (15 minutes). This is a floor — users with very slow setups can increase further via `auxiliary.compression.timeout` in config.yaml.

For context: the issue reporter's Ollama endpoint at http://192.168.0.203:11434/v1 was timing out on a ~162K-token context with a Qwen 2.5 27B Q4 model. Before the 300s floor was introduced (for #54915), there was no compression-specific timeout and compression could run indefinitely on local models. The 900s floor balances avoiding hangs vs. accommodating local hardware.

## Testing

- No behavioral change for fast models (they finish well before 900s)
- Config value higher than 900s still wins (floor via max())
- Explicit per-call timeout= overrides the floor
- Only affects the `compression` auxiliary task

Fixes #60604
