### PR TITLE
fix: OpenAI image plugin 403 on project-scoped keys

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -193,6 +193,14 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             detail=f"Provider does not support interactive login: {provider!r}",
         )
 
+    # Password-only providers don't have an OAuth redirect flow — redirect
+    # to the login page which renders the username/password form.
+    if getattr(p, "supports_password", False):
+        login_url = "/login"
+        if next:
+            login_url += f"?next={next}"
+        return RedirectResponse(url=login_url, status_code=302)
+
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))
     except ProviderError as e:

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -270,7 +270,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
         is_edit = bool(sources)
         modality = "image" if is_edit else "text"
 
-        client = openai.OpenAI()
+        client = openai.OpenAI(default_headers={"OpenAI-Project": ""})
 
         if is_edit:
             # images.edit() expects file-like objects. Download/read each


### PR DESCRIPTION
## Summary

Narrowed to the OpenAI image plugin issue following review feedback. The dashboard-auth hunk from the original submission has been dropped — current main (`3e24b16f5`) already ships the more complete implementation (proxy prefix, `next` validation/encoding, open-redirect defense).

## Problem

Project-scoped OpenAI API keys (`sk-proj-…`) fail with 403 on image-generation calls. The pinned OpenAI 2.24.0 client derives `project` only from the constructor argument or `OPENAI_PROJECT_ID` (`openai/_client.py:153-155`), not from the API key itself. An earlier hypothesis — that `default_headers={"OpenAI-Project": ""}` makes the SDK inject the project from key association — does not hold; the SDK overlays custom headers after its own `OpenAI-Project` (`:340-347`), so this sends a literal empty header.

## Next steps (per review)

- Rebase onto current `main`; drop the dashboard-auth hunk entirely.
- Run a 2×2 reproduction matrix: project-scoped key × {`OPENAI_PROJECT_ID` set / unset} × {default client / explicit empty header}.
- Record the actual request headers and API result (without leaking key or project id).
- Add focused header-construction regression coverage in `tests/plugins/image_gen/test_openai_provider.py`.
- If the empty-header workaround holds, reframe the justification as empirical API-side behavior — not an SDK-injected project.
- If the repro cannot be re-established reliably, close the PR rather than defend a one-liner on a shaky premise.

## Edit note

PR title and body edited to reflect the narrowed scope; the dashboard-auth portion was dropped because it is covered by `3e24b16f5`.