### PR TITLE
fix(auxiliary): preserve /anthropic base_url for custom vision provider with anthropic_messages api_mode

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4518,7 +4518,15 @@ def resolve_provider_client(
         custom_base = ""
         custom_key = ""
         if explicit_base_url:
-            custom_base = _to_openai_base_url(explicit_base_url).strip()
+            # When api_mode is anthropic_messages, preserve the raw base_url
+            # (e.g. .../apps/anthropic) instead of transforming it with
+            # _to_openai_base_url(). The Anthropic SDK appends /v1/messages
+            # to the base_url it receives, so stripping /anthropic here would
+            # produce a non-existent path like /apps/v1/messages (#fix-aux-vision).
+            if api_mode == "anthropic_messages":
+                custom_base = explicit_base_url.strip().rstrip("/")
+            else:
+                custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()


### PR DESCRIPTION
## Problem

When `auxiliary.vision` is configured with a custom provider and `api_mode: anthropic_messages`, the `_to_openai_base_url()` function transforms the `base_url` by stripping the `/anthropic` path suffix.

For example, with:
```yaml
auxiliary:
  vision:
    provider: custom
    base_url: https://dashscope.aliyuncs.com/apps/anthropic
    api_mode: anthropic_messages
    model: qwen3.6-flash
```

The URL gets rewritten from `.../apps/anthropic` to `.../apps/v1`. This transformed URL is then passed to `build_anthropic_client()`, which appends `/v1/messages`, producing:

```
https://dashscope.aliyuncs.com/apps/v1/messages  (404)
```

Instead of the correct:
```
https://dashscope.aliyuncs.com/apps/anthropic/v1/messages  (200)
```

## Root Cause

`resolve_provider_client()` in the `custom` provider branch (line 4521) unconditionally calls `_to_openai_base_url()` on the `explicit_base_url` before passing it downstream. This function is designed for providers that expose separate `/anthropic` and `/v1` endpoints (e.g., MiniMax), and assumes the URL always needs to be converted to OpenAI-wire format -- even when `api_mode` is explicitly `anthropic_messages` and the URL will be consumed by the Anthropic SDK.

## Fix

Skip the `_to_openai_base_url()` transformation when `api_mode == "anthropic_messages"`, since the Anthropic SDK will construct the correct `/v1/messages` path from the preserved base_url. The URL only needs OpenAI-wire conversion when the client will use `chat.completions` format.

This is a minimal change that fixes the issue without affecting existing behavior for endpoints that genuinely need the URL transformation (MiniMax, Z.AI/GLM, etc.), since those do not set `api_mode: anthropic_messages`.

## Testing

- Qwen3.6-flash via DashScope Anthropic-compatible API: vision requests now return 200 instead of 404
- Existing MiniMax and Z.AI paths are unaffected (they don't pass `api_mode: anthropic_messages`)
