### PR TITLE
fix(mcp-oauth): preserve tokens on disk during re-auth probe

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10596,7 +10596,13 @@ async def auth_mcp_server(name: str, profile: Optional[str] = None):
             try:
                 from tools.mcp_oauth_manager import get_manager
 
-                get_manager().remove(name)
+                # #60694: keep tokens on disk during re-auth probe —
+                # only evict the in-memory cache. If the OAuth server is
+                # transiently unreachable (not invalid credentials), the
+                # SDK reloads the still-valid tokens from disk on next
+                # connect. If the tokens ARE invalid, the SDK's normal
+                # auth flow will refresh or re-prompt.
+                get_manager().remove(name, keep_tokens=True)
             except Exception:
                 pass  # No cached state to clear — fine.
             try:

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -556,14 +556,28 @@ class MCPOAuthManager:
             timeout=float(cfg.get("timeout", 300)),
         )
 
-    def remove(self, server_name: str) -> None:
-        """Evict the provider from cache AND delete tokens from disk.
+    def remove(self, server_name: str, *, keep_tokens: bool = False) -> None:
+        """Evict the provider from cache and (by default) delete tokens from disk.
 
         Called by ``hermes mcp remove <name>`` and (indirectly) by
         ``hermes mcp login <name>`` during forced re-auth.
+
+        When *keep_tokens* is True (used by re-auth flows during transient
+        outages), only the in-memory provider cache is evicted — tokens on
+        disk survive so the SDK can reload them on next connect. This
+        prevents permanent credential loss when a probe fails due to a
+        transient network issue rather than invalid credentials (#60694).
         """
         with self._entries_lock:
             self._entries.pop(server_name, None)
+
+        if keep_tokens:
+            logger.info(
+                "MCP OAuth '%s': evicted from cache "
+                "(tokens preserved on disk — transient reconnect)",
+                server_name,
+            )
+            return
 
         from tools.mcp_oauth import remove_oauth_tokens
         remove_oauth_tokens(server_name)


### PR DESCRIPTION
## Summary

When the web-server re-auth flow (dashboard "Test Server" or re-authentication) probes the MCP server, it previously deleted OAuth tokens from disk before attempting connection. If the server was transiently unreachable (network hiccup, not invalid credentials), valid tokens were permanently lost.

## Fix

Added a `keep_tokens` parameter to `MCPOAuthManager.remove()`. The web-server re-auth path now uses `keep_tokens=True`, which only evicts the in-memory provider cache while preserving tokens on disk. The SDK reloads them on next connect and either uses valid ones or goes through normal refresh.

CLI paths (`hermes mcp remove`, `hermes mcp login`) still fully delete tokens.

## Changes

- `tools/mcp_oauth_manager.py`: Add `keep_tokens` parameter to `remove()`
- `hermes_cli/web_server.py`: Use `keep_tokens=True` in re-auth flow

Fixes: #60694