### PR TITLE
fix(schema): drop null required from tool schemas

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -189,6 +189,32 @@ def test_required_all_missing_is_dropped():
     assert "required" not in out[0]["function"]["parameters"]
 
 
+def test_required_null_is_dropped():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": None,
+    })]
+    out = sanitize_tool_schemas(tools)
+    assert "required" not in out[0]["function"]["parameters"]
+
+
+def test_nested_required_null_is_dropped():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "payload": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": None,
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    payload = out[0]["function"]["parameters"]["properties"]["payload"]
+    assert "required" not in payload
+
+
 def test_well_formed_schema_unchanged():
     schema = {
         "type": "object",

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -340,16 +340,21 @@ def _sanitize_node(node: Any, path: str) -> Any:
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
 
-    # Prune ``required`` entries that don't exist in properties (defense
-    # against malformed MCP schemas; also caught upstream for MCP tools, but
-    # built-in tools or plugin tools may not have been through that path).
-    if out.get("type") == "object" and isinstance(out.get("required"), list):
-        props = out.get("properties") or {}
-        valid = [r for r in out["required"] if isinstance(r, str) and r in props]
-        if not valid:
+    # Prune invalid ``required`` declarations (defense against malformed MCP
+    # schemas; also caught upstream for MCP tools, but built-in tools or plugin
+    # tools may not have been through that path). JSON Schema requires an array
+    # of property-name strings; strict OpenAI-compatible backends reject
+    # ``required: null`` with HTTP 400 before the model can answer.
+    if out.get("type") == "object" and "required" in out:
+        if isinstance(out.get("required"), list):
+            props = out.get("properties") or {}
+            valid = [r for r in out["required"] if isinstance(r, str) and r in props]
+            if not valid:
+                out.pop("required", None)
+            elif len(valid) != len(out["required"]):
+                out["required"] = valid
+        else:
             out.pop("required", None)
-        elif len(valid) != len(out["required"]):
-            out["required"] = valid
 
     return out
 


### PR DESCRIPTION
## Summary
- Drop malformed `required: null` declarations from sanitized object schemas.
- Keep existing behavior for valid `required` arrays by pruning entries that do not exist in `properties`.
- Add regression coverage for top-level and nested `required: null` schemas.

Fixes #60752.

## Validation
- `uv run pytest tests/tools/test_schema_sanitizer.py`
- `uv run python - <<'PY' ...` checked `get_tool_definitions(enabled_toolsets=['hermes-cli'], quiet_mode=True, skip_tool_search_assembly=True)` and found no `required: null`.

## Notes
- Full-history `gitleaks detect --source . --redact` reports pre-existing leaks in upstream/fork history. The two-file branch diff scanned clean with `gitleaks`.