### PR TITLE
fix(update): resolve npm before deterministic install

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4816,10 +4816,11 @@ def _run_npm_install_deterministic(
     # --silent/capture_output). It no-ops when CI is set — same as the TUI
     # install path and nix/lib.nix npm ci hooks.
     run_env = {**os.environ, **(env or {}), "CI": "1"}
+    from hermes_cli._subprocess_compat import resolve_node_command
 
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():
-        ci_cmd = [npm, "ci", *extra_args]
+        ci_cmd = resolve_node_command(npm, ("ci", *extra_args))
         ci_result = subprocess.run(
             ci_cmd,
             cwd=cwd,
@@ -4834,7 +4835,7 @@ def _run_npm_install_deterministic(
             return ci_result
         # Fall through to `npm install` — lockfile may be out of sync on a
         # WIP fork/branch, or `npm ci` may not be available on very old npm.
-    install_cmd = [npm, "install", *extra_args]
+    install_cmd = resolve_node_command(npm, ("install", *extra_args))
     return subprocess.run(
         install_cmd,
         cwd=cwd,

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -156,6 +156,19 @@ class TestBuildWebUISkipsWhenFresh:
         assert kwargs["env"]["CI"] == "1"
         assert kwargs["env"]["PYTHON"] == "/nix/store/python"
 
+    def test_npm_install_resolves_bare_npm_command_before_subprocess(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        npm_cmd = r"C:\nodejs\npm.cmd"
+        with patch("hermes_cli._subprocess_compat.shutil.which", return_value=npm_cmd), \
+             patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run:
+            result = _run_npm_install_deterministic("npm", web_dir)
+
+        assert result.returncode == 0
+        assert mock_run.call_args[0][0] == [npm_cmd, "ci"]
+
     def test_npm_install_uses_workspace_web_scope(self, tmp_path):
         web_dir, _ = _make_web_dir(tmp_path)
         # Real workspace checkout: the single lockfile lives at the root, so


### PR DESCRIPTION
## Summary

- Resolve the npm executable through `resolve_node_command` inside `_run_npm_install_deterministic` before `npm ci` / `npm install`.
- Keep the existing CI env, capture mode, and `npm ci` fallback behavior intact.
- Add regression coverage for a bare `npm` resolving to `npm.cmd` before `subprocess.run`.

Fixes #60742.

## Validation

- `uv sync --frozen --extra dev`
- `uv run --extra dev pytest tests/hermes_cli/test_web_ui_build.py tests/test_hermes_constants.py -q` (107 passed)
- `uv run --extra dev pytest tests/hermes_cli/test_cmd_update.py -q` (27 passed)
- `git diff --check origin/main..HEAD`
- `gitleaks git --log-opts origin/main..HEAD --redact` (no leaks found)

## Notes

This complements the existing Windows PATH ordering in `find_node_executable()` by hardening the lower-level deterministic npm install helper too. That matches the failing frame and proposed fix in #60742 when a bare `npm` reaches this helper.