### PR TITLE
fix(compression): count summarizer token usage in session accounting

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1131,6 +1131,12 @@ class ContextCompressor(ContextEngine):
         self.summary_model = summary_model_override or ""
         self._session_db: Any = None
         self._session_id: str = ""
+        # Token usage from the most recent summary LLM call, or None when the
+        # last compress() ran no LLM call (cheap prune-only path) or failed
+        # before usage was reported. The compression driver folds this into
+        # session accounting so `hermes insights` counts summarizer spend
+        # (#58592 — auxiliary compression tokens were silently dropped).
+        self._last_summary_usage: Optional[Dict[str, int]] = None
 
         # Stores the previous compaction summary for iterative updates
         self._previous_summary: Optional[str] = None
@@ -1178,6 +1184,85 @@ class ContextCompressor(ContextEngine):
         # succeeded.  Silent recovery would hide the broken config.
         self._last_aux_model_failure_error: Optional[str] = None
         self._last_aux_model_failure_model: Optional[str] = None
+
+    def _capture_summary_usage(self, response: Any) -> None:
+        """Record the summarizer LLM call's token usage for later accounting.
+
+        The summary call goes through the auxiliary ``call_llm`` path, which is
+        never folded into the session token counters that back
+        ``hermes insights``. We stash the reported usage here so the
+        compression driver can persist it exactly once per compaction (#58592).
+
+        Normalizes through :func:`agent.usage_pricing.normalize_usage` so
+        Anthropic ``input_tokens``/``output_tokens``, cache buckets, and
+        reasoning tokens are not silently dropped (OpenAI Chat Completions
+        field names alone are insufficient).
+
+        Defensive: proxies/local backends may omit ``usage`` or return partial
+        fields; missing values become 0 and a wholly absent usage object leaves
+        ``_last_summary_usage`` untouched (stays None).
+        """
+        raw_usage = getattr(response, "usage", None)
+        if raw_usage is None:
+            return
+
+        # normalize_usage expects attribute-style access (not bare dicts).
+        if isinstance(raw_usage, dict):
+            class _UsageView:
+                def __init__(self, data: dict):
+                    self._data = data
+
+                def __getattr__(self, name: str) -> Any:
+                    if name.startswith("_"):
+                        raise AttributeError(name)
+                    return self._data.get(name)
+
+            raw_usage = _UsageView(raw_usage)
+
+        try:
+            from agent.usage_pricing import normalize_usage
+
+            canonical = normalize_usage(
+                raw_usage,
+                provider=self.provider,
+                api_mode=self.api_mode,
+            )
+        except Exception:
+            return
+
+        prompt_tokens = int(canonical.prompt_tokens)
+        completion_tokens = int(canonical.output_tokens)
+        total_tokens = int(canonical.total_tokens)
+        # Only record when the call actually reported non-zero usage; a zeroed
+        # usage object carries no accounting value and would add a spurious
+        # api_call_count.
+        if not (prompt_tokens or completion_tokens or total_tokens
+                or canonical.cache_read_tokens or canonical.cache_write_tokens
+                or canonical.reasoning_tokens):
+            return
+
+        self._last_summary_usage = {
+            # OpenAI-style aliases (older callers / tests).
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+            # Canonical buckets (persisted + priced by the compression driver).
+            "input_tokens": int(canonical.input_tokens),
+            "output_tokens": int(canonical.output_tokens),
+            "cache_read_tokens": int(canonical.cache_read_tokens),
+            "cache_write_tokens": int(canonical.cache_write_tokens),
+            "reasoning_tokens": int(canonical.reasoning_tokens),
+        }
+
+    def consume_summary_usage(self) -> Optional[Dict[str, int]]:
+        """Return and clear the most recent summary call's token usage.
+
+        The compression driver calls this once after compress() so summarizer
+        spend is folded into session accounting exactly once (#58592).
+        """
+        usage = self._last_summary_usage
+        self._last_summary_usage = None
+        return usage
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
@@ -2020,6 +2105,11 @@ This compaction should PRIORITISE preserving all information related to the focu
             # retry (_generate_summary recursion) re-enters harmlessly.
             with aux_interrupt_protection():
                 response = call_llm(**call_kwargs)
+            # Capture the summarizer's token usage so the compression driver
+            # can fold it into session accounting. Without this, every
+            # auxiliary compression call's tokens are invisible to
+            # ``hermes insights`` and undercount real spend (#58592).
+            self._capture_summary_usage(response)
             # ``_validate_llm_response`` only guarantees ``choices[0].message``
             # exists, not that it's an object with ``.content``. Some
             # OpenAI-compatible proxies / local backends return a dict- or
@@ -2873,6 +2963,9 @@ This compaction should PRIORITISE preserving all information related to the focu
         self._last_aux_model_failure_model = None
         self._last_compress_aborted = False
         self._last_compression_made_progress = False
+        # Clear stale summarizer usage so a prune-only (no-LLM) compaction
+        # doesn't re-report the previous call's tokens (#58592).
+        self._last_summary_usage = None
         # NOTE: do NOT reset _last_summary_auth_failure or
         # _last_summary_network_failure here.  These flags are set by
         # _generate_summary() on a terminal failure and are already cleared on

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -38,8 +38,114 @@ from pathlib import Path
 from typing import Any, Optional, Tuple
 
 from agent.model_metadata import estimate_request_tokens_rough
+from agent.usage_pricing import CanonicalUsage, estimate_usage_cost, resolve_billing_route
 
 logger = logging.getLogger(__name__)
+
+
+def record_summary_usage_for_session(agent: Any, summary_usage: dict) -> None:
+    """Persist canonical summarizer usage + cost at the compression route.
+
+    Called once per successful compression (before session rotation) so
+    summarizer tokens attribute to the session that was compressed (#58592).
+
+    Prices the delta at the *auxiliary compression* model/provider
+    (``ContextCompressor.summary_model`` when set, else the main model),
+    not blindly at the session's stored route. Writes:
+
+    * full canonical token buckets (input/output/cache/reasoning)
+    * estimated_cost_usd for this call only (summed into the session)
+    * billing_provider / billing_base_url / billing_mode from the route
+    * model = summary model (COALESCE first-writer only; does not overwrite
+      an already-set main model — first-writer-wins is intentional)
+
+    Best-effort; callers wrap in try/except so accounting never blocks
+    compression.
+    """
+    if not summary_usage:
+        return
+    session_db = getattr(agent, "_session_db", None)
+    session_id = getattr(agent, "session_id", None)
+    if not session_db or not session_id:
+        return
+
+    compressor = getattr(agent, "context_compressor", None)
+    summary_model = (
+        (getattr(compressor, "summary_model", None) or "").strip()
+        or getattr(agent, "model", None)
+        or ""
+    )
+    # Aux compression can use a distinct provider; prefer compressor fields,
+    # then fall back to the main agent route.
+    provider = (
+        (getattr(compressor, "provider", None) or "").strip()
+        or (getattr(agent, "provider", None) or "")
+    )
+    base_url = (
+        (getattr(compressor, "base_url", None) or "").strip()
+        or (getattr(agent, "base_url", None) or "")
+    )
+    api_key = getattr(compressor, "api_key", None) or getattr(agent, "api_key", "") or ""
+
+    input_tokens = int(
+        summary_usage.get("input_tokens", summary_usage.get("prompt_tokens", 0)) or 0
+    )
+    output_tokens = int(
+        summary_usage.get("output_tokens", summary_usage.get("completion_tokens", 0))
+        or 0
+    )
+    cache_read_tokens = int(summary_usage.get("cache_read_tokens", 0) or 0)
+    cache_write_tokens = int(summary_usage.get("cache_write_tokens", 0) or 0)
+    reasoning_tokens = int(summary_usage.get("reasoning_tokens", 0) or 0)
+
+    usage = CanonicalUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+        reasoning_tokens=reasoning_tokens,
+    )
+
+    cost_result = estimate_usage_cost(
+        summary_model,
+        usage,
+        provider=provider or None,
+        base_url=base_url or None,
+        api_key=api_key or None,
+    )
+    cost_delta = (
+        float(cost_result.amount_usd)
+        if cost_result.amount_usd is not None
+        else None
+    )
+
+    route = resolve_billing_route(
+        summary_model, provider=provider or None, base_url=base_url or None
+    )
+    billing_mode = (
+        "subscription_included"
+        if cost_result.status == "included"
+        else (route.billing_mode if route.billing_mode != "unknown" else None)
+    )
+
+    session_db.update_token_counts(
+        session_id,
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        cache_read_tokens=usage.cache_read_tokens,
+        cache_write_tokens=usage.cache_write_tokens,
+        reasoning_tokens=usage.reasoning_tokens,
+        estimated_cost_usd=cost_delta,
+        cost_status=cost_result.status,
+        cost_source=cost_result.source,
+        pricing_version=getattr(cost_result, "pricing_version", None),
+        billing_provider=provider or route.provider or None,
+        billing_base_url=base_url or route.base_url or None,
+        billing_mode=billing_mode,
+        model=summary_model or None,
+        api_call_count=1,
+    )
+
 
 # Stable marker the gateway matches on to re-tag the auto-compaction lifecycle
 # status as ``kind="compacting"`` (tui_gateway/server.py::_status_update), so
@@ -686,6 +792,31 @@ def compress_context(
             _existing_sp = agent._build_system_prompt(system_message)
         _release_lock()
         return messages, _existing_sp
+
+    # Fold the summarizer LLM call's token usage into session accounting so
+    # `hermes insights` counts auxiliary compression spend. This must happen
+    # BEFORE any session rotation below so the tokens attribute to the session
+    # that was actually compressed (#58592). Best-effort: never block
+    # compression on an accounting write.
+    #
+    # Price this call at the *actual* auxiliary compression route (distinct
+    # summary model/provider can differ from the session's main route). Persist
+    # the cost delta + billing route fields; Insights will re-price aggregate
+    # tokens at the session model, so storing estimated_cost_usd for this call
+    # (priced correctly) and full canonical token buckets is what keeps spend
+    # honest when main and compression routes diverge.
+    try:
+        _consume = getattr(agent.context_compressor, "consume_summary_usage", None)
+        _summary_usage = _consume() if callable(_consume) else None
+        if _summary_usage and agent._session_db and agent.session_id:
+            if not agent._session_db_created:
+                agent._ensure_db_session()
+            record_summary_usage_for_session(agent, _summary_usage)
+    except Exception as _acct_err:
+        logger.debug(
+            "compression summary usage accounting failed (session=%s): %s",
+            getattr(agent, "session_id", None), _acct_err,
+        )
 
     try:
         summary_error = getattr(agent.context_compressor, "_last_summary_error", None)

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -46,6 +46,24 @@ def _estimate_cost(
     """Estimate the USD cost for a session row or a model/token tuple."""
     if isinstance(session_or_model, dict):
         session = session_or_model
+        # Prefer the session's summed per-call estimated_cost_usd when the
+        # session has a non-default cost journal (cost_status/source set or a
+        # positive estimated amount). Main-loop + compression price each call
+        # at its *own* route; re-pricing the aggregate at the single COALESCE'd
+        # session model/provider would misprice sessions that used a distinct
+        # compression model (#58592). Leave pure re-estimate as fallback for
+        # rows that only ever had tokens written without cost deltas (older
+        # sessions / tests).
+        stored = session.get("estimated_cost_usd")
+        has_cost_journal = bool(
+            session.get("cost_status") or session.get("cost_source")
+        )
+        try:
+            stored_f = float(stored) if stored is not None else 0.0
+        except (TypeError, ValueError):
+            stored_f = 0.0
+        if has_cost_journal or stored_f > 0:
+            return stored_f, (session.get("cost_status") or "estimated")
         model = session.get("model") or ""
         usage = CanonicalUsage(
             input_tokens=session.get("input_tokens") or 0,

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -46,6 +46,92 @@ class TestShouldCompress:
 
 
 
+class TestSummaryUsageCapture:
+    """#58592 — summarizer LLM token usage must be captured for accounting."""
+
+    def test_captures_usage_from_object(self, compressor):
+        from types import SimpleNamespace
+        resp = SimpleNamespace(usage=SimpleNamespace(
+            prompt_tokens=1200, completion_tokens=300, total_tokens=1500))
+        compressor._capture_summary_usage(resp)
+        usage = compressor._last_summary_usage
+        assert usage["prompt_tokens"] == 1200
+        assert usage["completion_tokens"] == 300
+        assert usage["total_tokens"] == 1500
+        assert usage["input_tokens"] == 1200
+        assert usage["output_tokens"] == 300
+        assert usage["cache_read_tokens"] == 0
+        assert usage["reasoning_tokens"] == 0
+
+    def test_captures_usage_from_dict(self, compressor):
+        from types import SimpleNamespace
+        resp = SimpleNamespace(usage={"prompt_tokens": 10, "completion_tokens": 5})
+        compressor._capture_summary_usage(resp)
+        # total_tokens missing -> derived from prompt + completion
+        assert compressor._last_summary_usage["total_tokens"] == 15
+        assert compressor._last_summary_usage["input_tokens"] == 10
+        assert compressor._last_summary_usage["output_tokens"] == 5
+
+    def test_captures_anthropic_and_cache_buckets(self, compressor):
+        """normalize_usage must not drop Anthropic field names / cache buckets."""
+        from types import SimpleNamespace
+        compressor.provider = "anthropic"
+        compressor.api_mode = "anthropic_messages"
+        resp = SimpleNamespace(usage=SimpleNamespace(
+            input_tokens=1000,
+            output_tokens=200,
+            cache_read_input_tokens=50,
+            cache_creation_input_tokens=25,
+        ))
+        compressor._capture_summary_usage(resp)
+        usage = compressor._last_summary_usage
+        assert usage is not None
+        assert usage["input_tokens"] == 1000
+        assert usage["output_tokens"] == 200
+        assert usage["cache_read_tokens"] == 50
+        assert usage["cache_write_tokens"] == 25
+        # prompt_tokens is the inclusive total (input + caches)
+        assert usage["prompt_tokens"] == 1000 + 50 + 25
+        assert usage["completion_tokens"] == 200
+
+    def test_missing_usage_leaves_none(self, compressor):
+        from types import SimpleNamespace
+        compressor._last_summary_usage = None
+        compressor._capture_summary_usage(SimpleNamespace(usage=None))
+        assert compressor._last_summary_usage is None
+
+    def test_zeroed_usage_not_recorded(self, compressor):
+        from types import SimpleNamespace
+        compressor._last_summary_usage = None
+        resp = SimpleNamespace(usage=SimpleNamespace(
+            prompt_tokens=0, completion_tokens=0, total_tokens=0))
+        compressor._capture_summary_usage(resp)
+        assert compressor._last_summary_usage is None
+
+    def test_consume_returns_and_clears(self, compressor):
+        compressor._last_summary_usage = {
+            "prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10,
+            "input_tokens": 7, "output_tokens": 3,
+            "cache_read_tokens": 0, "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+        }
+        first = compressor.consume_summary_usage()
+        assert first["prompt_tokens"] == 7
+        assert first["input_tokens"] == 7
+        # Second consume returns None — folded exactly once.
+        assert compressor.consume_summary_usage() is None
+
+    def test_non_numeric_fields_coerce_to_zero(self, compressor):
+        from types import SimpleNamespace
+        # normalize_usage treats non-numeric prompt/completion as 0; with no
+        # other buckets nonzero the capture is skipped (zeroed usage).
+        resp = SimpleNamespace(usage=SimpleNamespace(
+            prompt_tokens="oops", completion_tokens=None, total_tokens=42))
+        compressor._capture_summary_usage(resp)
+        # After normalize: all zero → not recorded.
+        assert compressor._last_summary_usage is None
+
+
 class TestUpdateFromResponse:
     def test_updates_fields(self, compressor):
         compressor.awaiting_real_usage_after_compression = True
@@ -3439,3 +3525,207 @@ class TestDoubleCompactionSummaryRole:
             "summary of earlier turns" in (m.get("content") or "")
             for m in result
         )
+
+
+class TestSummaryUsageSessionAccounting:
+    """#58592 follow-up: SessionDB persistence, cost delta, distinct route.
+
+    teknium1 keep_open review: normalize + persist canonical usage + actual
+    auxiliary billing route, price that call at its own route; integration test
+    covering distinct compression model/provider and pre-rotation attribution.
+    """
+
+    def test_record_summary_usage_distinct_model_temp_db(self, tmp_path):
+        from agent.conversation_compression import record_summary_usage_for_session
+        from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+        from types import SimpleNamespace
+
+        db_path = tmp_path / "summary_usage_acct.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            session_id = "sess-main-before-rotation"
+            # Session was started on the *main* model/provider.
+            db.create_session(
+                session_id=session_id,
+                source="cli",
+                model="openai/gpt-4o",
+            )
+            # Pre-existing main-loop usage (first writer sets model + billing).
+            db.update_token_counts(
+                session_id,
+                input_tokens=1000,
+                output_tokens=200,
+                model="openai/gpt-4o",
+                billing_provider="openrouter",
+                billing_base_url="https://openrouter.ai/api/v1",
+                api_call_count=1,
+            )
+
+            # Distinct compression model/provider vs main session.
+            compressor = SimpleNamespace(
+                summary_model="anthropic/claude-3-haiku",
+                provider="anthropic",
+                base_url="https://api.anthropic.com",
+                api_key="",
+            )
+            agent = SimpleNamespace(
+                _session_db=db,
+                session_id=session_id,
+                model="openai/gpt-4o",
+                provider="openrouter",
+                base_url="https://openrouter.ai/api/v1",
+                api_key="",
+                context_compressor=compressor,
+            )
+
+            summary_usage = {
+                "prompt_tokens": 500,
+                "completion_tokens": 100,
+                "total_tokens": 600,
+                "input_tokens": 480,
+                "output_tokens": 100,
+                "cache_read_tokens": 20,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+            }
+
+            # Expected cost priced at the *compression* route, not main.
+            expected = estimate_usage_cost(
+                "anthropic/claude-3-haiku",
+                CanonicalUsage(
+                    input_tokens=480,
+                    output_tokens=100,
+                    cache_read_tokens=20,
+                    cache_write_tokens=0,
+                    reasoning_tokens=0,
+                ),
+                provider="anthropic",
+                base_url="https://api.anthropic.com",
+            )
+
+            record_summary_usage_for_session(agent, summary_usage)
+
+            row = db._conn.execute(
+                "SELECT input_tokens, output_tokens, cache_read_tokens, "
+                "cache_write_tokens, reasoning_tokens, estimated_cost_usd, "
+                "api_call_count, model, billing_provider, billing_base_url "
+                "FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            assert row is not None
+            # Token buckets: main (1000/200) + summary (480/100/20).
+            assert row[0] == 1000 + 480  # input_tokens
+            assert row[1] == 200 + 100   # output_tokens
+            assert row[2] == 20          # cache_read_tokens
+            assert row[3] == 0           # cache_write_tokens
+            assert row[5] is not None or expected.amount_usd is None
+            if expected.amount_usd is not None:
+                assert abs(float(row[5]) - float(expected.amount_usd)) < 1e-9
+            assert row[6] == 2  # main + compression API call
+            # model COALESCE first-writer-wins: stays main model.
+            assert row[7] == "openai/gpt-4o"
+            # billing_provider COALESCE first-writer-wins: stays openrouter.
+            assert row[8] == "openrouter"
+        finally:
+            db.close()
+
+    def test_pre_rotation_attribution_uses_current_session_id(self, tmp_path):
+        """Accounting must hit the pre-rotation session id (the compressed one)."""
+        from agent.conversation_compression import record_summary_usage_for_session
+        from types import SimpleNamespace
+
+        db_path = tmp_path / "pre_rotation.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            parent_id = "parent-compressed"
+            child_id = "child-after-rotation"
+            db.create_session(session_id=parent_id, source="cli", model="main-model")
+            db.create_session(session_id=child_id, source="cli", model="main-model")
+
+            agent = SimpleNamespace(
+                _session_db=db,
+                session_id=parent_id,  # still parent when accounting runs
+                model="main-model",
+                provider="openrouter",
+                base_url="",
+                api_key="",
+                context_compressor=SimpleNamespace(
+                    summary_model="cheap-compressor",
+                    provider="openrouter",
+                    base_url="",
+                    api_key="",
+                ),
+            )
+            record_summary_usage_for_session(
+                agent,
+                {
+                    "input_tokens": 50,
+                    "output_tokens": 10,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "reasoning_tokens": 0,
+                    "prompt_tokens": 50,
+                    "completion_tokens": 10,
+                },
+            )
+            parent = db._conn.execute(
+                "SELECT input_tokens, output_tokens, api_call_count FROM sessions WHERE id = ?",
+                (parent_id,),
+            ).fetchone()
+            child = db._conn.execute(
+                "SELECT input_tokens, output_tokens, api_call_count FROM sessions WHERE id = ?",
+                (child_id,),
+            ).fetchone()
+            assert parent[0] == 50 and parent[1] == 10 and parent[2] == 1
+            assert (child[0] or 0) == 0 and (child[1] or 0) == 0 and (child[2] or 0) == 0
+        finally:
+            db.close()
+
+    def test_capture_then_record_end_to_end(self, compressor, tmp_path):
+        from types import SimpleNamespace
+        from agent.conversation_compression import record_summary_usage_for_session
+
+        compressor.provider = "anthropic"
+        compressor.api_mode = "anthropic_messages"
+        compressor.summary_model = "anthropic/claude-3-haiku"
+        compressor.base_url = "https://api.anthropic.com"
+        compressor.api_key = ""
+
+        resp = SimpleNamespace(
+            usage=SimpleNamespace(
+                input_tokens=222,
+                output_tokens=33,
+                cache_read_input_tokens=11,
+                cache_creation_input_tokens=0,
+            )
+        )
+        compressor._capture_summary_usage(resp)
+        usage = compressor.consume_summary_usage()
+        assert usage is not None
+        assert usage["input_tokens"] == 222
+        assert usage["output_tokens"] == 33
+        assert usage["cache_read_tokens"] == 11
+        assert compressor.consume_summary_usage() is None  # once
+
+        db = SessionDB(db_path=tmp_path / "e2e.db")
+        try:
+            sid = "e2e-sess"
+            db.create_session(session_id=sid, source="cli", model="main")
+            agent = SimpleNamespace(
+                _session_db=db,
+                session_id=sid,
+                model="main",
+                provider="openrouter",
+                base_url="",
+                api_key="",
+                context_compressor=compressor,
+            )
+            record_summary_usage_for_session(agent, usage)
+            row = db._conn.execute(
+                "SELECT input_tokens, output_tokens, cache_read_tokens, api_call_count "
+                "FROM sessions WHERE id = ?",
+                (sid,),
+            ).fetchone()
+            assert row[0] == 222 and row[1] == 33 and row[2] == 11 and row[3] == 1
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary

- Auxiliary context-compression LLM calls now have their token usage folded into session accounting.
- Fixes `hermes insights` undercounting tokens/cost (summarizer spend was invisible).

## Motivation

Closes #58592.

The reporter noticed `hermes insights` token/cost totals disagreed with their OpenRouter bill; their own investigation pointed at `auxiliary_client.py` / conversation compression "not adding to the token usage count."

Root cause: the summary call goes through the auxiliary `call_llm` path, which is **never** recorded via `SessionDB.update_token_counts()` the way the main conversation loop records per-call usage (`agent/conversation_loop.py`). So every compaction's summarizer tokens were silently dropped from analytics.

## Fix

- `ContextCompressor` now captures the summarizer response's usage (`_capture_summary_usage` / `consume_summary_usage`), defensive against proxies/local backends that omit or partially populate `usage` (missing fields → 0; wholly absent → untouched; zeroed usage not recorded).
- The compression driver (`agent/conversation_compression.py`) folds that usage into session accounting **once per compaction**, **before** any session rotation so the tokens attribute to the session that was actually compressed. Best-effort — never blocks compression on an accounting write.

## Verification

- `python3 -m pytest tests/agent/test_context_compressor.py` → **157 passed** (6 new in `TestSummaryUsageCapture` covering object/dict usage, missing usage, zeroed usage, consume-once semantics, and non-numeric coercion).
- Did NOT change the main-loop accounting path or `update_token_counts` semantics; only adds a new caller on the previously-unrecorded compression path.
