### PR TITLE
feat(goal): add usage guard for autonomous loops

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -24,6 +24,15 @@ class AccountUsageWindow:
 
 
 @dataclass(frozen=True)
+class AccountUsageVerdict:
+    verdict: str  # safe | caution | stop | unknown
+    reason: str
+    max_used_percent: Optional[float] = None
+    provider: Optional[str] = None
+    window_label: Optional[str] = None
+
+
+@dataclass(frozen=True)
 class AccountUsageSnapshot:
     provider: str
     source: str
@@ -111,6 +120,59 @@ def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, mark
     if snapshot.unavailable_reason:
         lines.append(f"Unavailable: {snapshot.unavailable_reason}")
     return lines
+
+
+def evaluate_account_usage(
+    snapshot: Optional[AccountUsageSnapshot],
+    *,
+    caution_at_percent: float = 80.0,
+    stop_at_percent: float = 95.0,
+) -> AccountUsageVerdict:
+    """Classify an account-usage snapshot for autonomous loop gating.
+
+    This function is intentionally pure and fail-open. Missing snapshots,
+    unavailable providers, and snapshots without numeric quota windows return
+    ``unknown`` rather than ``stop`` so a broken usage API cannot wedge normal
+    work. Callers that need a hard budget can layer stricter policy on top.
+    """
+    if snapshot is None:
+        return AccountUsageVerdict(
+            verdict="unknown",
+            reason="account usage unavailable",
+            max_used_percent=None,
+        )
+    if snapshot.unavailable_reason:
+        return AccountUsageVerdict(
+            verdict="unknown",
+            reason=f"account usage unavailable: {snapshot.unavailable_reason}",
+            max_used_percent=None,
+            provider=snapshot.provider,
+        )
+
+    numeric_windows = [w for w in snapshot.windows if w.used_percent is not None]
+    if not numeric_windows:
+        return AccountUsageVerdict(
+            verdict="unknown",
+            reason="account usage has no numeric quota windows",
+            max_used_percent=None,
+            provider=snapshot.provider,
+        )
+
+    max_window = max(numeric_windows, key=lambda w: float(w.used_percent or 0.0))
+    max_used = float(max_window.used_percent or 0.0)
+    if max_used >= float(stop_at_percent):
+        verdict = "stop"
+    elif max_used >= float(caution_at_percent):
+        verdict = "caution"
+    else:
+        verdict = "safe"
+    return AccountUsageVerdict(
+        verdict=verdict,
+        reason=f"{max_window.label} usage is {max_used:.1f}%",
+        max_used_percent=max_used,
+        provider=snapshot.provider,
+        window_label=max_window.label,
+    )
 
 
 def _resolve_codex_usage_url(base_url: str) -> str:
@@ -312,6 +374,14 @@ def fetch_account_usage(
     api_key: Optional[str] = None,
 ) -> Optional[AccountUsageSnapshot]:
     normalized = str(provider or "").strip().lower()
+    aliases = {
+        "codex": "openai-codex",
+        "openai_codex": "openai-codex",
+        "claude": "anthropic",
+        "claude-code": "anthropic",
+        "claude_code": "anthropic",
+    }
+    normalized = aliases.get(normalized, normalized)
     if normalized in {"", "auto", "custom"}:
         return None
     try:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -29,12 +29,14 @@ Nothing in this module touches the agent's system prompt or toolset.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
 import time
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -66,6 +68,9 @@ _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 # exhausted with every reply shaped like `judge returned empty response` or
 # `judge reply was not JSON`.
 DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES = 3
+# Account-usage checks can involve live provider APIs. Cache verdicts briefly so
+# long /goal loops do not spend a network call on every continuation turn.
+DEFAULT_USAGE_GUARD_TTL_SECONDS = 60.0
 
 
 CONTINUATION_PROMPT_TEMPLATE = (
@@ -463,6 +468,54 @@ def judge_goal(
     return verdict, reason, parse_failed
 
 
+_USAGE_GUARD_CACHE: Dict[Tuple[str, str, str], Tuple[float, Any]] = {}
+
+
+def _usage_guard_cache_fingerprint(value: Any) -> str:
+    text = str(value or "")
+    if not text:
+        return ""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _goal_usage_guard(*, now: Optional[float] = None) -> Any:
+    """Return an account-usage verdict for autonomous goal-loop gating.
+
+    Fail-open by design: missing config, unsupported providers, and API errors
+    all produce an ``unknown`` verdict rather than pausing the loop. A concrete
+    ``stop`` verdict is the only result that callers treat as a hard gate.
+    """
+    try:
+        from agent.account_usage import AccountUsageVerdict, evaluate_account_usage, fetch_account_usage
+        from hermes_cli.config import load_config
+    except Exception as exc:  # pragma: no cover - import failures are environment-specific
+        logger.debug("goal usage guard: import failed: %s", exc)
+        return SimpleNamespace(verdict="unknown", reason="usage guard unavailable")
+
+    try:
+        cfg = load_config()
+        model_cfg_raw = cfg.get("model") or {}
+        model_cfg = model_cfg_raw if isinstance(model_cfg_raw, dict) else {}
+        provider = str(model_cfg.get("provider") or cfg.get("provider") or "").strip()
+        base_url = model_cfg.get("base_url") or cfg.get("base_url")
+        api_key = model_cfg.get("api_key") or cfg.get("api_key")
+        key = (provider.lower(), str(base_url or ""), _usage_guard_cache_fingerprint(api_key))
+        ts = time.time() if now is None else float(now)
+        cached = _USAGE_GUARD_CACHE.get(key)
+        if cached and ts - cached[0] < DEFAULT_USAGE_GUARD_TTL_SECONDS:
+            return cached[1]
+        snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+        verdict = evaluate_account_usage(snapshot)
+        _USAGE_GUARD_CACHE[key] = (ts, verdict)
+        return verdict
+    except Exception as exc:
+        logger.debug("goal usage guard: failed open: %s", exc)
+        return AccountUsageVerdict(
+            verdict="unknown",
+            reason=f"usage guard unavailable: {type(exc).__name__}",
+        )
+
+
 # ──────────────────────────────────────────────────────────────────────
 # GoalManager — the orchestration surface CLI + gateway talk to
 # ──────────────────────────────────────────────────────────────────────
@@ -724,6 +777,24 @@ class GoalManager:
                 ),
             }
 
+        usage_verdict = _goal_usage_guard()
+        if getattr(usage_verdict, "verdict", "unknown") == "stop":
+            state.status = "paused"
+            state.paused_reason = f"usage guard stop: {usage_verdict.reason}"
+            save_goal(self.session_id, state)
+            return {
+                "status": "paused",
+                "should_continue": False,
+                "continuation_prompt": None,
+                "verdict": "continue",
+                "reason": reason,
+                "usage_verdict": usage_verdict.verdict,
+                "message": (
+                    f"⏸ Goal paused by usage guard — {usage_verdict.reason}. "
+                    "Use /goal resume after quota resets or switch to a lower-cost path."
+                ),
+            }
+
         save_goal(self.session_id, state)
         return {
             "status": "active",
@@ -731,6 +802,7 @@ class GoalManager:
             "continuation_prompt": self.next_continuation_prompt(),
             "verdict": "continue",
             "reason": reason,
+            "usage_verdict": getattr(usage_verdict, "verdict", "unknown"),
             "message": (
                 f"↻ Continuing toward goal ({state.turns_used}/{state.max_turns}): {reason}"
             ),

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -286,6 +286,85 @@ class TestGoalManager:
         assert mgr.state.status == "active"
         assert mgr.state.turns_used == 1
 
+    def test_evaluate_after_turn_pauses_on_usage_guard_stop(self, hermes_home):
+        from agent.account_usage import AccountUsageVerdict
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="eval-sid-usage-stop", default_max_turns=5)
+        mgr.set("a long expensive goal")
+
+        with patch.object(goals, "judge_goal", return_value=("continue", "more work", False)), patch.object(
+            goals,
+            "_goal_usage_guard",
+            return_value=AccountUsageVerdict(
+                verdict="stop",
+                reason="Weekly usage is 96.0%",
+                max_used_percent=96.0,
+                provider="openai-codex",
+                window_label="Weekly",
+            ),
+        ):
+            decision = mgr.evaluate_after_turn("made some progress")
+
+        assert decision["status"] == "paused"
+        assert decision["should_continue"] is False
+        assert decision["continuation_prompt"] is None
+        assert decision["usage_verdict"] == "stop"
+        assert "usage guard" in decision["message"].lower()
+        assert mgr.state.status == "paused"
+        assert "usage guard" in (mgr.state.paused_reason or "").lower()
+
+    def test_evaluate_after_turn_continues_when_usage_guard_unknown(self, hermes_home):
+        from agent.account_usage import AccountUsageVerdict
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="eval-sid-usage-unknown", default_max_turns=5)
+        mgr.set("a long goal")
+
+        with patch.object(goals, "judge_goal", return_value=("continue", "more work", False)), patch.object(
+            goals,
+            "_goal_usage_guard",
+            return_value=AccountUsageVerdict(
+                verdict="unknown",
+                reason="account usage unavailable",
+            ),
+        ):
+            decision = mgr.evaluate_after_turn("made some progress")
+
+        assert decision["status"] == "active"
+        assert decision["should_continue"] is True
+        assert decision["usage_verdict"] == "unknown"
+
+    def test_goal_usage_guard_handles_string_model_config_and_caches_by_api_key(self, hermes_home):
+        from datetime import datetime, timezone
+
+        from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+        from hermes_cli import goals
+
+        goals._USAGE_GUARD_CACHE.clear()
+        snapshot = AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime.now(timezone.utc),
+            windows=(AccountUsageWindow(label="Weekly", used_percent=96),),
+        )
+        with patch("hermes_cli.config.load_config", side_effect=[
+            {"model": "gpt-5.5", "provider": "codex", "api_key": "key-a"},
+            {"model": "gpt-5.5", "provider": "codex", "api_key": "key-a"},
+            {"model": "gpt-5.5", "provider": "codex", "api_key": "key-b"},
+        ]), patch("agent.account_usage.fetch_account_usage", return_value=snapshot) as fetch_mock:
+            first = goals._goal_usage_guard(now=1000)
+            second = goals._goal_usage_guard(now=1010)
+            third = goals._goal_usage_guard(now=1020)
+
+        assert first.verdict == "stop"
+        assert second.verdict == "stop"
+        assert third.verdict == "stop"
+        # Same key is cached, but a different credential fingerprint fetches again.
+        assert fetch_mock.call_count == 2
+
     def test_evaluate_after_turn_budget_exhausted(self, hermes_home):
         """When turn budget hits ceiling, auto-pause instead of continuing."""
         from hermes_cli import goals

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -2,7 +2,9 @@ from datetime import datetime, timezone
 
 from agent.account_usage import (
     AccountUsageSnapshot,
+    AccountUsageVerdict,
     AccountUsageWindow,
+    evaluate_account_usage,
     fetch_account_usage,
     render_account_usage_lines,
 )
@@ -201,3 +203,92 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+
+def test_evaluate_account_usage_unknown_when_snapshot_missing_or_unavailable():
+    missing = evaluate_account_usage(None)
+    assert missing == AccountUsageVerdict(
+        verdict="unknown",
+        reason="account usage unavailable",
+        max_used_percent=None,
+    )
+
+    unavailable = evaluate_account_usage(
+        AccountUsageSnapshot(
+            provider="anthropic",
+            source="oauth_usage_api",
+            fetched_at=datetime.now(timezone.utc),
+            unavailable_reason="OAuth required",
+        )
+    )
+    assert unavailable.verdict == "unknown"
+    assert "OAuth required" in unavailable.reason
+
+
+def test_evaluate_account_usage_safe_caution_and_stop_thresholds():
+    fetched_at = datetime.now(timezone.utc)
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=fetched_at,
+        windows=(AccountUsageWindow(label="Session", used_percent=79.9),),
+    )
+    verdict = evaluate_account_usage(snapshot)
+    assert verdict.verdict == "safe"
+    assert verdict.max_used_percent == 79.9
+
+    caution = evaluate_account_usage(
+        AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=fetched_at,
+            windows=(AccountUsageWindow(label="Weekly", used_percent=80),),
+        )
+    )
+    assert caution.verdict == "caution"
+    assert "Weekly" in caution.reason
+
+    stop = evaluate_account_usage(
+        AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=fetched_at,
+            windows=(
+                AccountUsageWindow(label="Session", used_percent=50),
+                AccountUsageWindow(label="Weekly", used_percent=95),
+            ),
+        )
+    )
+    assert stop.verdict == "stop"
+    assert "Weekly" in stop.reason
+
+
+def test_evaluate_account_usage_windows_without_percent_are_unknown():
+    verdict = evaluate_account_usage(
+        AccountUsageSnapshot(
+            provider="openrouter",
+            source="credits_api",
+            fetched_at=datetime.now(timezone.utc),
+            details=("Credits balance: $9.00",),
+        )
+    )
+    assert verdict.verdict == "unknown"
+    assert verdict.max_used_percent is None
+
+
+def test_fetch_account_usage_accepts_provider_aliases(monkeypatch):
+    codex_snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+    )
+    anthropic_snapshot = AccountUsageSnapshot(
+        provider="anthropic",
+        source="oauth_usage_api",
+        fetched_at=datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr("agent.account_usage._fetch_codex_account_usage", lambda: codex_snapshot)
+    monkeypatch.setattr("agent.account_usage._fetch_anthropic_account_usage", lambda: anthropic_snapshot)
+
+    assert fetch_account_usage("codex") is codex_snapshot
+    assert fetch_account_usage("claude-code") is anthropic_snapshot


### PR DESCRIPTION
## Summary
- add AccountUsageVerdict and evaluate_account_usage() for safe/caution/stop/unknown usage gating
- add a fail-open Usage Guard before /goal continuation, with a 60s provider/account cache
- pause autonomous goal loops only on concrete stop verdicts and keep unknown usage fail-open
- add tests for account usage verdicts, provider aliases, cache keys, and /goal stop/unknown behavior

## Test Plan
- python -m pytest tests/test_account_usage.py tests/hermes_cli/test_goals.py tests/gateway/test_goal_verdict_send.py tests/gateway/test_goal_status_notice.py tests/gateway/test_goal_max_turns_config.py tests/tui_gateway/test_goal_command.py tests/cli/test_cli_goal_interrupt.py -q -o 'addopts='
