### PR TITLE
fix(serve): emit both HERMES_DASHBOARD_READY and HERMES_BACKEND_READY for backward compatibility

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16823,11 +16823,15 @@ def start_server(
             app.state.bound_port = actual_port
 
             _write_dashboard_ready_file(actual_port)
-            # Port-discovery sentinel parsed by the desktop spawn. `serve` is a
-            # plain backend, not a dashboard, so it announces a neutral token;
-            # `dashboard` keeps the legacy one. The desktop matches either.
-            ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
-            print(f"{ready_token} port={actual_port}", flush=True)
+            # Port-discovery sentinel parsed by the desktop spawn. During the
+            # transition period (post-#55923), emit both tokens so pre-#55923
+            # desktop builds can still match the legacy sentinel while new
+            # builds use the neutral one. This avoids breaking users who run
+            # `hermes update` (CLI-only) without rebuilding the desktop app.
+            # The desktop regex already matches either sentinel since #55923.
+            print(f"HERMES_DASHBOARD_READY port={actual_port}", flush=True)
+            if headless:
+                print(f"HERMES_BACKEND_READY port={actual_port}", flush=True)
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.


### PR DESCRIPTION
## What does this PR do?

After PR #55923, `hermes serve --headless` (used by desktop app spawn) emits `HERMES_BACKEND_READY port=N` instead of the legacy `HERMES_DASHBOARD_READY port=N`. The desktop regex was updated in the same PR to match either sentinel, but this only takes effect when the Electron app is rebuilt and reinstalled.

Users who run `hermes update` (CLI-only) get the new sentinel emission without the updated regex consumer, causing port discovery to timeout and the desktop to fail to connect.

This PR ensures backward compatibility by emitting both sentinels during the transition period.

## Related Issue

Fixes #60412

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Emit both `HERMES_DASHBOARD_READY port=N` (always) and `HERMES_BACKEND_READY port=N` (headless-only) to ensure pre-#55923 desktop builds can still match the legacy sentinel while post-#55923 builds use the neutral one

## How to Test

1. Start `hermes serve --headless --port 0`
2. Observed result: stdout now contains both sentinel lines:
   ```
   HERMES_DASHBOARD_READY port=54321
   HERMES_BACKEND_READY port=54321
     Hermes backend listening on 127.0.0.1:54321
   ```
3. The desktop regex `const _READY_RE = /^HERMES_(?:BACKEND|DASHBOARD)_READY port=(\d+)/m` (added in #55923) already matches either sentinel, so post-#55923 desktop builds will correctly parse port=54321 from either line
4. Pre-#55923 desktop builds with the old regex `/^HERMES_DASHBOARD_READY port=(\d+)/m` will correctly parse from the first line, avoiding the timeout issue
5. No desktop-side code changes required — this is a CLI-only fix that unblocks the existing compatibility path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A