### PR TITLE
fix(model): expand NVIDIA catalog fallback

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2826,6 +2826,15 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                                 merged_lower.add(_model_dedup_key(m))
                         return merged
                     return live
+            # For models.dev-preferred providers, keep the richer picker
+            # catalog even when no API key is configured. Profile fallback
+            # lists are a last-resort floor and can lag the curated catalog.
+            curated = list(_PROVIDER_MODELS.get(normalized, []))
+            if normalized in _MODELS_DEV_PREFERRED:
+                preferred_floor = curated or list(_p.fallback_models or [])
+                if preferred_floor:
+                    return _merge_with_models_dev(normalized, preferred_floor)
+
             # Use profile's fallback_models if defined
             if _p.fallback_models:
                 return list(_p.fallback_models)

--- a/tests/hermes_cli/test_nvidia_catalog_fallback.py
+++ b/tests/hermes_cli/test_nvidia_catalog_fallback.py
@@ -1,0 +1,55 @@
+"""Behavior regressions for NVIDIA's offline model-picker catalog."""
+
+from unittest.mock import patch
+
+from providers import get_provider_profile
+
+from hermes_cli.models import (
+    _MODELS_DEV_PREFERRED,
+    _PROVIDER_MODELS,
+    provider_model_ids,
+)
+
+
+def test_nvidia_offline_catalog_uses_curated_models_before_profile_fallback():
+    """NVIDIA's small profile fallback must not hide its curated catalog."""
+    profile = get_provider_profile("nvidia")
+    assert profile is not None
+    assert "nvidia" in _MODELS_DEV_PREFERRED
+    assert len(profile.fallback_models) < len(_PROVIDER_MODELS["nvidia"])
+    assert list(profile.fallback_models) != _PROVIDER_MODELS["nvidia"]
+
+    with (
+        patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": "", "base_url": ""},
+        ),
+        patch("agent.models_dev.list_agentic_models", return_value=[]),
+    ):
+        models = provider_model_ids("nvidia")
+
+    assert models == _PROVIDER_MODELS["nvidia"]
+
+
+def test_nvidia_unavailable_live_catalog_merges_fresh_models_dev_entries():
+    """An empty NVIDIA API response still uses the models.dev-preferred path."""
+    profile = get_provider_profile("nvidia")
+    assert profile is not None
+    fresh_model = "nvidia/new-model-from-models-dev"
+
+    with (
+        patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={
+                "api_key": "nvapi-test",
+                "base_url": "https://integrate.api.nvidia.com/v1",
+            },
+        ),
+        patch.object(profile, "fetch_models", return_value=[]) as fetch_models,
+        patch("agent.models_dev.list_agentic_models", return_value=[fresh_model]),
+    ):
+        models = provider_model_ids("nvidia")
+
+    fetch_models.assert_called_once()
+    assert models[0] == fresh_model
+    assert set(_PROVIDER_MODELS["nvidia"]) <= set(models)


### PR DESCRIPTION
## Summary
- use the models.dev-preferred curated catalog for NVIDIA before falling back to the profile's stale two-model fallback
- add a regression test for the no-API-key NVIDIA catalog path

Fixes #59211

## Tests
- uv run --extra dev pytest tests/hermes_cli/test_models_dev_preferred_merge.py tests/hermes_cli/test_provider_live_curated_merge.py -q
- uv run --extra dev python - <<'PY'
from unittest.mock import patch
from hermes_cli.models import provider_model_ids
with patch('agent.models_dev.list_agentic_models', return_value=[]):
    ids = provider_model_ids('nvidia')
print(len(ids))
print(ids[:20])
PY
- git diff --check
- gitleaks git --log-opts='origin/main..HEAD' --redact .