### PR TITLE
fix(desktop): keep legacy ready token for desktop serve

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16606,6 +16606,21 @@ def _write_dashboard_ready_file(actual_port: int) -> None:
         _log.warning("Failed to write dashboard ready file %r: %s", target, exc)
 
 
+def _dashboard_ready_lines(actual_port: int, *, headless: bool) -> list[str]:
+    """Return stdout port-discovery sentinels for dashboard/desktop spawns."""
+    if not headless:
+        return [f"HERMES_DASHBOARD_READY port={actual_port}"]
+
+    lines = [f"HERMES_BACKEND_READY port={actual_port}"]
+    if os.environ.get("HERMES_DESKTOP") == "1":
+        # Compatibility for packaged desktop shells whose Electron parser only
+        # knows the legacy dashboard token. They may launch an updated Python
+        # backend via `hermes serve`, so keep the old sentinel as a side-channel
+        # when and only when the backend is desktop-spawned.
+        lines.append(f"HERMES_DASHBOARD_READY port={actual_port}")
+    return lines
+
+
 def _maybe_open_browser(
     host: str, actual_port: int, open_browser: bool, initial_profile: str
 ) -> None:
@@ -16825,9 +16840,10 @@ def start_server(
             _write_dashboard_ready_file(actual_port)
             # Port-discovery sentinel parsed by the desktop spawn. `serve` is a
             # plain backend, not a dashboard, so it announces a neutral token;
-            # `dashboard` keeps the legacy one. The desktop matches either.
-            ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
-            print(f"{ready_token} port={actual_port}", flush=True)
+            # desktop-spawned `serve` also emits the legacy token for older
+            # packaged shells whose parser predates HERMES_BACKEND_READY.
+            for ready_line in _dashboard_ready_lines(actual_port, headless=headless):
+                print(ready_line, flush=True)
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.

--- a/tests/hermes_cli/test_web_server_boot_handshake.py
+++ b/tests/hermes_cli/test_web_server_boot_handshake.py
@@ -53,6 +53,35 @@ def _make_slow_drain(seconds: float):
 
 
 # ---------------------------------------------------------------------------
+# Ready-line compatibility
+# ---------------------------------------------------------------------------
+
+def test_dashboard_ready_lines_use_legacy_token_for_dashboard(monkeypatch):
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+
+    assert web_server_mod._dashboard_ready_lines(54321, headless=False) == [
+        "HERMES_DASHBOARD_READY port=54321"
+    ]
+
+
+def test_dashboard_ready_lines_use_backend_token_for_plain_headless(monkeypatch):
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+
+    assert web_server_mod._dashboard_ready_lines(43210, headless=True) == [
+        "HERMES_BACKEND_READY port=43210"
+    ]
+
+
+def test_dashboard_ready_lines_keep_legacy_token_for_desktop_headless(monkeypatch):
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+
+    assert web_server_mod._dashboard_ready_lines(43210, headless=True) == [
+        "HERMES_BACKEND_READY port=43210",
+        "HERMES_DASHBOARD_READY port=43210",
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Test 1 — _lifespan fire-and-forget does not block the event loop
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- emit the legacy HERMES_DASHBOARD_READY sentinel for desktop-spawned headless serve backends
- keep plain headless serve on the neutral HERMES_BACKEND_READY token only
- add ready-line compatibility tests for dashboard, serve, and desktop serve

Fixes #60772

## Tests
- node --test apps/desktop/electron/backend-ready.test.cjs apps/desktop/electron/backend-command.test.cjs
- ./.venv/bin/python -m pytest tests/hermes_cli/test_web_server_boot_handshake.py -k "dashboard_ready_lines" -vv
- ./.venv/bin/python -m pytest tests/hermes_cli/test_dashboard_unified_launch.py -q

Note: the full tests/hermes_cli/test_web_server_boot_handshake.py run exceeded the expected time with no new output after the first three tests, so I interrupted it and ran the new focused tests separately.