### PR TITLE
fix(gateway): expand Telegram fallback IP pool, add Quad9 DoH, broaden retryable errors, log connection success

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3346,7 +3346,7 @@ class TelegramAdapter(BasePlatformAdapter):
             
             self._mark_connected()
             mode = "webhook" if self._webhook_mode else "polling"
-            logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
+            logger.warning("[%s] Connected to Telegram (%s mode)", self.name, mode)
 
             # Start the persistent heartbeat loop in polling mode. Webhook mode
             # receives updates via incoming pushes — there is no long-poll

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -37,7 +37,7 @@ _DOH_PROVIDERS: list[dict] = [
         "headers": {"Accept": "application/dns-json"},
     },
     {
-        "url": "https://dns.quad9.net:5053/dns-query",
+        "url": "https://dns.quad9.net/dns-query",
         "params": {"name": _TELEGRAM_API_HOST, "type": "A"},
         "headers": {"Accept": "application/dns-json"},
     },
@@ -272,10 +272,4 @@ def _rewrite_request_for_ip(request: httpx.Request, ip: str) -> httpx.Request:
 
 
 def _is_retryable_connect_error(exc: Exception) -> bool:
-    return isinstance(exc, (
-        httpx.ConnectTimeout,
-        httpx.ConnectError,
-        httpx.ReadTimeout,
-        httpx.ReadError,
-        httpx.RemoteProtocolError,
-    ))
+    return isinstance(exc, (httpx.ConnectTimeout, httpx.ConnectError))

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -36,11 +36,27 @@ _DOH_PROVIDERS: list[dict] = [
         "params": {"name": _TELEGRAM_API_HOST, "type": "A"},
         "headers": {"Accept": "application/dns-json"},
     },
+    {
+        "url": "https://dns.quad9.net:5053/dns-query",
+        "params": {"name": _TELEGRAM_API_HOST, "type": "A"},
+        "headers": {"Accept": "application/dns-json"},
+    },
 ]
 
 # Last-resort IPs when DoH is also blocked.  These are stable Telegram Bot API
-# endpoints in the 149.154.160.0/20 block (same seed used by OpenClaw).
-_SEED_FALLBACK_IPS: list[str] = ["149.154.166.110", "149.154.167.220"]
+# endpoints in the 149.154.160.0/20 block, sampled across multiple subnets to
+# maximise the chance of finding a reachable endpoint when a network-level block
+# affects a subset of the range.
+_SEED_FALLBACK_IPS: list[str] = [
+    "149.154.166.110",   # api.telegram.org canonical
+    "149.154.167.220",   # api.telegram.org alternate
+    "149.154.160.17",    # 149.154.160.0/24
+    "149.154.161.120",   # 149.154.161.0/24
+    "149.154.162.8",     # 149.154.162.0/24
+    "149.154.164.21",    # 149.154.164.0/24
+    "149.154.165.100",   # 149.154.165.0/24
+    "149.154.172.40",    # 149.154.172.0/24
+]
 
 
 def _resolve_proxy_url(target_hosts=None) -> str | None:
@@ -195,13 +211,13 @@ async def _query_doh_provider(
 async def discover_fallback_ips() -> list[str]:
     """Auto-discover Telegram API IPs via DNS-over-HTTPS.
 
-    Resolves api.telegram.org through Google and Cloudflare DoH and returns all
-    unique A records.  IPs that match the local system resolver are kept rather
-    than excluded: in many networks the system-DNS IP is the most reliable path
-    to api.telegram.org and a transient primary-path failure should be retried
-    against the same address via the IP-rewrite path before the seed list is
-    consulted (#14520).  Falls back to a hardcoded seed list only when DoH
-    yields no usable answers.
+    Resolves api.telegram.org through Google, Cloudflare, and Quad9 DoH and
+    returns all unique A records.  IPs that match the local system resolver are
+    kept rather than excluded: in many networks the system-DNS IP is the most
+    reliable path to api.telegram.org and a transient primary-path failure
+    should be retried against the same address via the IP-rewrite path before
+    the seed list is consulted (#14520).  Falls back to a hardcoded seed list
+    spanning multiple /24 subnets only when DoH yields no usable answers.
     """
     async with httpx.AsyncClient(timeout=httpx.Timeout(_DOH_TIMEOUT)) as client:
         doh_tasks = [_query_doh_provider(client, p) for p in _DOH_PROVIDERS]
@@ -256,4 +272,10 @@ def _rewrite_request_for_ip(request: httpx.Request, ip: str) -> httpx.Request:
 
 
 def _is_retryable_connect_error(exc: Exception) -> bool:
-    return isinstance(exc, (httpx.ConnectTimeout, httpx.ConnectError))
+    return isinstance(exc, (
+        httpx.ConnectTimeout,
+        httpx.ConnectError,
+        httpx.ReadTimeout,
+        httpx.ReadError,
+        httpx.RemoteProtocolError,
+    ))

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -181,54 +181,18 @@ class TestFallbackTransport:
         assert transport._sticky_ip == "149.154.167.220"
 
     @pytest.mark.asyncio
-    async def test_does_not_fallback_on_non_connect_error(self, monkeypatch):
-        """Non-retryable errors like HTTPStatusError should not trigger fallback."""
-        calls = []
-        behavior = {"api.telegram.org": httpx.HTTPStatusError("server error", request=None, response=None), "149.154.167.220": "ok"}
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
-
-        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
-
-        with pytest.raises(httpx.HTTPStatusError):
-            await transport.handle_async_request(_telegram_request())
-
-        assert [c["url_host"] for c in calls] == ["api.telegram.org"]
-
-    @pytest.mark.asyncio
-    async def test_falls_back_on_read_timeout(self, monkeypatch):
-        """ReadTimeout is retryable — should trigger fallback to next IP."""
+    async def test_does_not_fallback_on_read_timeout(self, monkeypatch):
+        """Errors like ReadTimeout are not connection issues — don't retry."""
         calls = []
         behavior = {"api.telegram.org": httpx.ReadTimeout("read timeout"), "149.154.167.220": "ok"}
         monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
-        await transport.handle_async_request(_telegram_request())
 
-        assert [c["url_host"] for c in calls] == ["api.telegram.org", "149.154.167.220"]
+        with pytest.raises(httpx.ReadTimeout):
+            await transport.handle_async_request(_telegram_request())
 
-    @pytest.mark.asyncio
-    async def test_falls_back_on_read_error(self, monkeypatch):
-        """ReadError is retryable — should trigger fallback to next IP."""
-        calls = []
-        behavior = {"api.telegram.org": httpx.ReadError("read error"), "149.154.167.220": "ok"}
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
-
-        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
-        await transport.handle_async_request(_telegram_request())
-
-        assert [c["url_host"] for c in calls] == ["api.telegram.org", "149.154.167.220"]
-
-    @pytest.mark.asyncio
-    async def test_falls_back_on_remote_protocol_error(self, monkeypatch):
-        """RemoteProtocolError is retryable — should trigger fallback to next IP."""
-        calls = []
-        behavior = {"api.telegram.org": httpx.RemoteProtocolError("protocol error"), "149.154.167.220": "ok"}
-        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
-
-        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
-        await transport.handle_async_request(_telegram_request())
-
-        assert [c["url_host"] for c in calls] == ["api.telegram.org", "149.154.167.220"]
+        assert [c["url_host"] for c in calls] == ["api.telegram.org"]
 
     @pytest.mark.asyncio
     async def test_all_ips_fail_raises_last_error(self, monkeypatch):
@@ -659,7 +623,7 @@ class TestDiscoverFallbackIps:
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, {"Status": 0}),  # no Answer key
             "https://cloudflare-dns.com": (200, {"garbage": True}),
-            "https://dns.quad9.net": (200, {"garbage": True}),
+            "https://dns.quad9.net": (200, {"Status": 0}),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
@@ -726,6 +690,36 @@ class TestDiscoverFallbackIps:
         q9_reqs = [r for r in client.requests_made if "quad9" in r["url"]]
         assert q9_reqs
         assert q9_reqs[0]["headers"]["Accept"] == "application/dns-json"
+
+    @pytest.mark.asyncio
+    async def test_quad9_documented_url_used(self, monkeypatch):
+        """Quad9 must use the documented https://dns.quad9.net/dns-query endpoint."""
+        client = self._patch_doh(monkeypatch, {
+            "https://dns.google": (200, _doh_answer("149.154.167.220")),
+            "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.221")),
+            "https://dns.quad9.net": (200, _doh_answer("149.154.167.222")),
+        }, system_dns_ips=["149.154.166.110"])
+
+        await tnet.discover_fallback_ips()
+
+        q9_reqs = [r for r in client.requests_made if "quad9" in r["url"]]
+        assert q9_reqs
+        assert q9_reqs[0]["url"] == "https://dns.quad9.net/dns-query"
+        assert q9_reqs[0]["headers"]["Accept"] == "application/dns-json"
+
+    @pytest.mark.asyncio
+    async def test_quad9_contributing_to_ip_pool(self, monkeypatch):
+        """Quad9 results should be collected alongside Google and Cloudflare."""
+        self._patch_doh(monkeypatch, {
+            "https://dns.google": (200, _doh_answer("149.154.167.220")),
+            "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.221")),
+            "https://dns.quad9.net": (200, _doh_answer("149.154.167.222")),
+        }, system_dns_ips=["149.154.166.110"])
+
+        ips = await tnet.discover_fallback_ips()
+        assert "149.154.167.220" in ips
+        assert "149.154.167.221" in ips
+        assert "149.154.167.222" in ips
 
     @pytest.mark.asyncio
     async def test_non_a_records_ignored(self, monkeypatch):

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -182,17 +182,53 @@ class TestFallbackTransport:
 
     @pytest.mark.asyncio
     async def test_does_not_fallback_on_non_connect_error(self, monkeypatch):
-        """Errors like ReadTimeout are not connection issues — don't retry."""
+        """Non-retryable errors like HTTPStatusError should not trigger fallback."""
+        calls = []
+        behavior = {"api.telegram.org": httpx.HTTPStatusError("server error", request=None, response=None), "149.154.167.220": "ok"}
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await transport.handle_async_request(_telegram_request())
+
+        assert [c["url_host"] for c in calls] == ["api.telegram.org"]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_read_timeout(self, monkeypatch):
+        """ReadTimeout is retryable — should trigger fallback to next IP."""
         calls = []
         behavior = {"api.telegram.org": httpx.ReadTimeout("read timeout"), "149.154.167.220": "ok"}
         monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
 
         transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        await transport.handle_async_request(_telegram_request())
 
-        with pytest.raises(httpx.ReadTimeout):
-            await transport.handle_async_request(_telegram_request())
+        assert [c["url_host"] for c in calls] == ["api.telegram.org", "149.154.167.220"]
 
-        assert [c["url_host"] for c in calls] == ["api.telegram.org"]
+    @pytest.mark.asyncio
+    async def test_falls_back_on_read_error(self, monkeypatch):
+        """ReadError is retryable — should trigger fallback to next IP."""
+        calls = []
+        behavior = {"api.telegram.org": httpx.ReadError("read error"), "149.154.167.220": "ok"}
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        await transport.handle_async_request(_telegram_request())
+
+        assert [c["url_host"] for c in calls] == ["api.telegram.org", "149.154.167.220"]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_remote_protocol_error(self, monkeypatch):
+        """RemoteProtocolError is retryable — should trigger fallback to next IP."""
+        calls = []
+        behavior = {"api.telegram.org": httpx.RemoteProtocolError("protocol error"), "149.154.167.220": "ok"}
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+        await transport.handle_async_request(_telegram_request())
+
+        assert [c["url_host"] for c in calls] == ["api.telegram.org", "149.154.167.220"]
 
     @pytest.mark.asyncio
     async def test_all_ips_fail_raises_last_error(self, monkeypatch):
@@ -556,15 +592,17 @@ class TestDiscoverFallbackIps:
         return client
 
     @pytest.mark.asyncio
-    async def test_google_and_cloudflare_ips_collected(self, monkeypatch):
+    async def test_google_cloudflare_and_quad9_ips_collected(self, monkeypatch):
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, _doh_answer("149.154.167.220")),
             "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.221")),
+            "https://dns.quad9.net": (200, _doh_answer("149.154.167.222")),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
         assert "149.154.167.220" in ips
         assert "149.154.167.221" in ips
+        assert "149.154.167.222" in ips
 
     @pytest.mark.asyncio
     async def test_system_dns_ip_kept_when_doh_confirms(self, monkeypatch):
@@ -577,6 +615,7 @@ class TestDiscoverFallbackIps:
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, _doh_answer("149.154.166.110", "149.154.167.220")),
             "https://cloudflare-dns.com": (200, _doh_answer("149.154.166.110")),
+            "https://dns.quad9.net": (200, _doh_answer("149.154.166.110")),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
@@ -587,6 +626,7 @@ class TestDiscoverFallbackIps:
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, _doh_answer("149.154.167.220")),
             "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.220")),
+            "https://dns.quad9.net": (200, _doh_answer("149.154.167.220")),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
@@ -597,6 +637,7 @@ class TestDiscoverFallbackIps:
         self._patch_doh(monkeypatch, {
             "https://dns.google": httpx.TimeoutException("timeout"),
             "https://cloudflare-dns.com": httpx.TimeoutException("timeout"),
+            "https://dns.quad9.net": httpx.TimeoutException("timeout"),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
@@ -607,6 +648,7 @@ class TestDiscoverFallbackIps:
         self._patch_doh(monkeypatch, {
             "https://dns.google": httpx.ConnectError("refused"),
             "https://cloudflare-dns.com": httpx.ConnectError("refused"),
+            "https://dns.quad9.net": httpx.ConnectError("refused"),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
@@ -617,20 +659,23 @@ class TestDiscoverFallbackIps:
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, {"Status": 0}),  # no Answer key
             "https://cloudflare-dns.com": (200, {"garbage": True}),
+            "https://dns.quad9.net": (200, {"garbage": True}),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
         assert ips == tnet._SEED_FALLBACK_IPS
 
     @pytest.mark.asyncio
-    async def test_one_provider_fails_other_succeeds(self, monkeypatch):
+    async def test_one_provider_fails_others_succeed(self, monkeypatch):
         self._patch_doh(monkeypatch, {
             "https://dns.google": httpx.TimeoutException("timeout"),
             "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.220")),
+            "https://dns.quad9.net": (200, _doh_answer("149.154.167.221")),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
-        assert ips == ["149.154.167.220"]
+        assert "149.154.167.220" in ips
+        assert "149.154.167.221" in ips
 
     @pytest.mark.asyncio
     async def test_system_dns_failure_keeps_all_doh_ips(self, monkeypatch):
@@ -638,11 +683,13 @@ class TestDiscoverFallbackIps:
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, _doh_answer("149.154.166.110", "149.154.167.220")),
             "https://cloudflare-dns.com": (200, _doh_answer()),
+            "https://dns.quad9.net": (200, _doh_answer("149.154.167.221")),
         }, system_dns_ips=None)  # triggers OSError
 
         ips = await tnet.discover_fallback_ips()
         assert "149.154.166.110" in ips
         assert "149.154.167.220" in ips
+        assert "149.154.167.221" in ips
 
     @pytest.mark.asyncio
     async def test_all_doh_ips_same_as_system_dns_kept(self, monkeypatch):
@@ -656,16 +703,18 @@ class TestDiscoverFallbackIps:
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, _doh_answer("149.154.166.110")),
             "https://cloudflare-dns.com": (200, _doh_answer("149.154.166.110")),
+            "https://dns.quad9.net": (200, _doh_answer("149.154.166.110")),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
         assert ips == ["149.154.166.110"]
 
     @pytest.mark.asyncio
-    async def test_cloudflare_gets_accept_header(self, monkeypatch):
+    async def test_cloudflare_and_quad9_get_accept_header(self, monkeypatch):
         client = self._patch_doh(monkeypatch, {
             "https://dns.google": (200, _doh_answer("149.154.167.220")),
             "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.221")),
+            "https://dns.quad9.net": (200, _doh_answer("149.154.167.222")),
         }, system_dns_ips=["149.154.166.110"])
 
         await tnet.discover_fallback_ips()
@@ -673,6 +722,10 @@ class TestDiscoverFallbackIps:
         cf_reqs = [r for r in client.requests_made if "cloudflare" in r["url"]]
         assert cf_reqs
         assert cf_reqs[0]["headers"]["Accept"] == "application/dns-json"
+
+        q9_reqs = [r for r in client.requests_made if "quad9" in r["url"]]
+        assert q9_reqs
+        assert q9_reqs[0]["headers"]["Accept"] == "application/dns-json"
 
     @pytest.mark.asyncio
     async def test_non_a_records_ignored(self, monkeypatch):
@@ -687,6 +740,7 @@ class TestDiscoverFallbackIps:
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, answer),
             "https://cloudflare-dns.com": (200, _doh_answer()),
+            "https://dns.quad9.net": (200, _doh_answer()),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
@@ -701,7 +755,22 @@ class TestDiscoverFallbackIps:
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, answer),
             "https://cloudflare-dns.com": (200, _doh_answer()),
+            "https://dns.quad9.net": (200, _doh_answer()),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
         assert ips == ["149.154.167.220"]
+
+    @pytest.mark.asyncio
+    async def test_quad9_provider_queried(self, monkeypatch):
+        client = self._patch_doh(monkeypatch, {
+            "https://dns.google": (200, _doh_answer("149.154.167.220")),
+            "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.221")),
+            "https://dns.quad9.net": (200, _doh_answer("149.154.167.222")),
+        }, system_dns_ips=["149.154.166.110"])
+
+        await tnet.discover_fallback_ips()
+
+        q9_reqs = [r for r in client.requests_made if "quad9" in r["url"]]
+        assert len(q9_reqs) == 1
+        assert q9_reqs[0]["url"] == "https://dns.quad9.net:5053/dns-query"

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -755,16 +755,3 @@ class TestDiscoverFallbackIps:
         ips = await tnet.discover_fallback_ips()
         assert ips == ["149.154.167.220"]
 
-    @pytest.mark.asyncio
-    async def test_quad9_provider_queried(self, monkeypatch):
-        client = self._patch_doh(monkeypatch, {
-            "https://dns.google": (200, _doh_answer("149.154.167.220")),
-            "https://cloudflare-dns.com": (200, _doh_answer("149.154.167.221")),
-            "https://dns.quad9.net": (200, _doh_answer("149.154.167.222")),
-        }, system_dns_ips=["149.154.166.110"])
-
-        await tnet.discover_fallback_ips()
-
-        q9_reqs = [r for r in client.requests_made if "quad9" in r["url"]]
-        assert len(q9_reqs) == 1
-        assert q9_reqs[0]["url"] == "https://dns.quad9.net:5053/dns-query"


### PR DESCRIPTION
## Summary

Three improvements for Telegram gateway connectivity resilience and observability on networks with **partial** ISP-level blocks of Telegram's IP ranges.

## Changes

### 1. Expand `_SEED_FALLBACK_IPS` (2 → 8 IPs across 6 /24 subnets)
The hardcoded seed list now spans 8 IPs across different subnets in the `149.154.160.0/20` range. When system DNS and all DoH providers are unreachable, having IPs across different subnets significantly increases the chance of finding a reachable endpoint — especially when an ISP-level block affects a subset of the range.

### 2. Add Quad9 as third DoH provider
Added `https://dns.quad9.net/dns-query` (the documented endpoint) alongside Google and Cloudflare. Quad9 uses independent infrastructure, providing an additional discovery path when both Google and Cloudflare DNS are blocked simultaneously.

### 3. Upgrade connection success log level
Changed `Connected to Telegram` from `INFO` to `WARNING` so it always appears in default journal output. Previously users saw `Connecting to Telegram...` but never a success confirmation, making it impossible to distinguish "still trying" from "connected successfully."

## Testing

- All existing + new tests pass
- New tests: `test_quad9_documented_url_used`, `test_quad9_contributing_to_ip_pool`, `test_google_cloudflare_and_quad9_ips_collected`, `test_one_provider_fails_others_succeed`, `test_cloudflare_and_quad9_get_accept_header`, `test_does_not_fallback_on_read_timeout`
- Verified on a server where `api.telegram.org` is blocked: gateway successfully connects through expanded fallback IP pool

## Scope note

This PR addresses **partial** ISP blocks (a subset of Telegram's IP range is unreachable). It does **not** close #47146, which describes a **full** block of the entire `149.154.160.0/20` range — that requires `TELEGRAM_PROXY` documentation and an exhausted-fallback hint, which will be handled in a separate PR.

## Review history

- Initial submission broadened retryable errors to `ReadTimeout`/`ReadError`/`RemoteProtocolError`. Per @teknium1's review, this was **reverted** — those errors may occur after a request has already reached Telegram, and replaying through the next IP would duplicate Bot API writes. Only connect-phase failures (`ConnectTimeout`/`ConnectError`) remain retryable.
- The Quad9 URL was initially `https://dns.quad9.net:5053/dns-query`; corrected to the documented `https://dns.quad9.net/dns-query` and the contradictory test asserting the old `:5053` URL has been removed.
