### PR TITLE
fix(bounded-read): populate response._content after draining streaming error body (#60597)

### DIFF
--- a/agent/bounded_response.py
+++ b/agent/bounded_response.py
@@ -122,6 +122,23 @@ def read_streaming_error_body(
             sum(len(c) for c in chunks),
             max_bytes,
         )
+
+    # Populate the internal _content buffer so that callers who access
+    # response.text (e.g. agent_runtime_helpers._write_request_dump) from
+    # a gemini_http_error / GeminiAPIError that carries the streaming
+    # response as .response do NOT raise httpx's
+    # "Attempted to access streaming response content, without having
+    #  called read()" — the stream was consumed via iter_bytes() above,
+    # but httpx's text/content property checks _content, which is only
+    # set by read(), not by iter_bytes().  Setting _content here makes
+    # the response appear fully consumed to every downstream consumer.
+    if chunks:
+        try:
+            response._content = b"".join(chunks)
+            response._text = None
+        except Exception:  # noqa: BLE001 — error path must not raise
+            pass
+
     return b"".join(chunks).decode("utf-8", errors="replace")
 
 


### PR DESCRIPTION
## Summary

When `read_streaming_error_body()` drains a streaming `httpx.Response` body via `iter_bytes()` and closes it, the response's internal `_content` buffer remains `None`. Any downstream code that later accesses `response.text` — for example `agent_runtime_helpers._write_request_dump()` reading the `.response` attribute from a `GeminiAPIError` — triggers httpx's

> Attempted to access streaming response content, without having called `read()`

because httpx only sets `_content` on explicit `read()`, not on `iter_bytes()`.

## Fix

After draining and closing the response, set `_content` to the collected bytes so the response presents as fully consumed. This allows downstream error handlers to safely access `response.text`.

The fix is itself wrapped in `try/except` because this runs on the error path and must not mask the original HTTP failure.

## Testing

- All 6 existing `test_bounded_response.py` tests pass unchanged.
- Manual verification: the response's `.text` and `.content` properties now work after `read_streaming_error_body` returns.

Closes #60597
