### PR TITLE
feat: add native Cline/ClinePass OAuth provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -271,6 +271,9 @@ _PROVIDER_ALIASES = {
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
     "tencentmaas": "tencent-tokenhub",
+    "clinepass": "cline-pass",
+    "cline_pass": "cline-pass",
+    "cline-oauth": "cline-pass",
 }
 
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -221,6 +221,11 @@ class PooledCredential:
                 ):
                     return token.strip()
             return ""
+        if self.provider in ("cline", "cline-pass"):
+            raw = str(self.access_token or "").strip()
+            if not raw:
+                return ""
+            return auth_mod.format_cline_api_key(raw)
         return str(self.access_token or "")
 
     @property

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -83,6 +83,14 @@ NOUS_AUTH_PATH_INVOKE_JWT = "invoke_jwt"
 ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
 NOUS_INVOKE_JWT_MIN_TTL_SECONDS = ACCESS_TOKEN_REFRESH_SKEW_SECONDS
 DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
+DEFAULT_CLINE_API_BASE_URL = "https://api.cline.bot"
+DEFAULT_CLINE_INFERENCE_BASE_URL = f"{DEFAULT_CLINE_API_BASE_URL}/api/v1"
+CLINE_WORKOS_CLIENT_ID = "client_01K3A541FN8TA3EPPHTD2325AR"
+CLINE_WORKOS_DEVICE_CODE_URL = "https://api.workos.com/user_management/authorize/device"
+CLINE_WORKOS_TOKEN_URL = "https://api.workos.com/user_management/authenticate"
+CLINE_WORKOS_DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+CLINE_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 60
+
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_XAI_OAUTH_BASE_URL = "https://api.x.ai/v1"
 MINIMAX_OAUTH_CLIENT_ID = "78257093-7e40-4613-99e0-527b14b39113"
@@ -188,6 +196,22 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="OpenAI Codex",
         auth_type="oauth_external",
         inference_base_url=DEFAULT_CODEX_BASE_URL,
+    ),
+    "cline": ProviderConfig(
+        id="cline",
+        name="Cline",
+        auth_type="oauth_external",
+        inference_base_url=DEFAULT_CLINE_INFERENCE_BASE_URL,
+        api_key_env_vars=("CLINE_API_KEY", "CLINEPASS_TOKEN", "CLINE_ACCESS_TOKEN"),
+        base_url_env_var="CLINE_BASE_URL",
+    ),
+    "cline-pass": ProviderConfig(
+        id="cline-pass",
+        name="ClinePass",
+        auth_type="oauth_external",
+        inference_base_url=DEFAULT_CLINE_INFERENCE_BASE_URL,
+        api_key_env_vars=("CLINEPASS_TOKEN", "CLINE_API_KEY", "CLINE_ACCESS_TOKEN"),
+        base_url_env_var="CLINE_BASE_URL",
     ),
     "openai-api": ProviderConfig(
         id="openai-api",
@@ -8241,6 +8265,350 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
     except Exception as exc:
         print(f"Login failed: {exc}")
         raise SystemExit(1)
+
+
+# =============================================================================
+# Cline / ClinePass — WorkOS device-code OAuth + token refresh
+# =============================================================================
+
+def _strip_cline_api_key_prefix(token: str) -> str:
+    """Strip the 'workos:' prefix from a Cline API key if present."""
+    token = str(token or "").strip()
+    if token.lower().startswith("workos:"):
+        return token[7:]
+    return token
+
+
+def format_cline_api_key(token: str) -> str:
+    """Ensure a Cline access token has the 'workos:' prefix."""
+    token = str(token or "").strip()
+    if not token:
+        return ""
+    if token.lower().startswith("workos:"):
+        return token
+    return f"workos:{token}"
+
+
+def _cline_access_token_is_expiring(
+    access_token: str,
+    expires_at_ms: Optional[int],
+    skew_seconds: int = CLINE_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+) -> bool:
+    if not access_token:
+        return True
+    if expires_at_ms is None:
+        claims = _decode_jwt_claims(access_token)
+        exp = claims.get("exp")
+        if exp is not None:
+            expires_at_ms = int(exp) * 1000
+        else:
+            return False
+    now_ms = int(time.time() * 1000)
+    return expires_at_ms - now_ms <= skew_seconds * 1000
+
+
+def _save_cline_tokens(tokens: dict, provider_id: str = "cline") -> None:
+    """Persist Cline OAuth tokens to auth.json."""
+    store_key = "cline"
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        state = _load_provider_state(auth_store, store_key) or {}
+        access_token = _strip_cline_api_key_prefix(tokens.get("access_token", ""))
+        state["access_token"] = access_token
+        if tokens.get("refresh_token"):
+            state["refresh_token"] = tokens["refresh_token"]
+        if tokens.get("expires_at_ms"):
+            state["expires_at_ms"] = tokens["expires_at_ms"]
+        if tokens.get("inference_base_url"):
+            state["inference_base_url"] = tokens["inference_base_url"]
+        if tokens.get("api_base_url"):
+            state["api_base_url"] = tokens["api_base_url"]
+        if tokens.get("email"):
+            state["email"] = tokens["email"]
+        if tokens.get("account_id"):
+            state["account_id"] = tokens["account_id"]
+        state["last_refresh"] = tokens.get("last_refresh") or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        state["auth_mode"] = "workos"
+        _save_provider_state(auth_store, store_key, state)
+        _save_auth_store(auth_store)
+
+
+def _resolve_cline_api_base_url() -> str:
+    return (
+        os.getenv("CLINE_API_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_CLINE_API_BASE_URL
+    )
+
+
+def _normalize_cline_api_base_url(url: str) -> str:
+    url = (url or "").strip().rstrip("/")
+    return url or DEFAULT_CLINE_API_BASE_URL
+
+
+def _cline_device_code_login(
+    provider_id: str = "cline",
+    open_browser: bool = True,
+    timeout_seconds: float = 15.0,
+) -> dict:
+    """Run the WorkOS device-code OAuth flow for Cline."""
+    import webbrowser
+
+    client_id = CLINE_WORKOS_CLIENT_ID
+    api_base_url = _resolve_cline_api_base_url()
+
+    # Step 1: Request device code
+    try:
+        resp = httpx.post(
+            CLINE_WORKOS_DEVICE_CODE_URL,
+            data={"client_id": client_id},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=httpx.Timeout(timeout_seconds),
+        )
+    except Exception as exc:
+        raise AuthError(
+            f"Cline device-code request failed: {exc}",
+            provider=provider_id,
+            code="cline_device_code_failed",
+        )
+    if resp.status_code != 200:
+        raise AuthError(
+            f"Cline device-code request failed: {resp.status_code} {resp.text[:200]}",
+            provider=provider_id,
+            code="cline_device_code_failed",
+        )
+    device_data = resp.json()
+    device_code = device_data.get("device_code", "")
+    user_code = device_data.get("user_code", "")
+    verification_uri = device_data.get("verification_uri", "")
+    verification_uri_complete = device_data.get("verification_uri_complete", "")
+    expires_in = int(device_data.get("expires_in", 300))
+    interval = int(device_data.get("interval", 5))
+
+    url = verification_uri_complete or verification_uri
+    print(f"\n  Open this URL in your browser: {url}")
+    if user_code:
+        print(f"  Enter code: {user_code}")
+    if open_browser:
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+    # Step 2: Poll for token
+    deadline = time.time() + expires_in
+    poll_interval = min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS)
+    while time.time() < deadline:
+        time.sleep(poll_interval)
+        token_resp = httpx.post(
+            CLINE_WORKOS_TOKEN_URL,
+            data={
+                "grant_type": CLINE_WORKOS_DEVICE_GRANT_TYPE,
+                "device_code": device_code,
+                "client_id": client_id,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=httpx.Timeout(30),
+        )
+        token_data = token_resp.json()
+        if token_resp.status_code == 200:
+            access_token = token_data.get("access_token", "")
+            refresh_token = token_data.get("refresh_token", "")
+            if not access_token:
+                raise AuthError(
+                    "Cline OAuth: no access_token in response",
+                    provider=provider_id,
+                    code="cline_no_access_token",
+                )
+            expires_at_ms = int(time.time() * 1000) + 3600 * 1000
+            email = ""
+            account_id = ""
+
+            # Step 3: Register with Cline API to get Cline-specific tokens
+            try:
+                register_resp = httpx.post(
+                    f"{api_base_url}/api/v1/auth/register",
+                    json={
+                        "accessToken": access_token,
+                        "refreshToken": refresh_token,
+                        "provider": "cline",
+                    },
+                    headers={"Content-Type": "application/json"},
+                    timeout=httpx.Timeout(30),
+                )
+                if register_resp.status_code == 200:
+                    reg_data = register_resp.json()
+                    if reg_data.get("success") and reg_data.get("data"):
+                        d = reg_data["data"]
+                        access_token = d.get("accessToken", access_token)
+                        refresh_token = d.get("refreshToken", refresh_token)
+                        expires_at_str = d.get("expiresAt", "")
+                        if expires_at_str:
+                            try:
+                                expires_at_ms = int(time.mktime(
+                                    time.fromisoformat(expires_at_str.replace("Z", "+00:00"))
+                                ) * 1000)
+                            except Exception:
+                                pass
+                        email = (d.get("userInfo") or {}).get("email", "")
+                        account_id = (d.get("userInfo") or {}).get("clineUserId", "")
+            except Exception:
+                pass
+
+            return {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "expires_at_ms": expires_at_ms,
+                "inference_base_url": DEFAULT_CLINE_INFERENCE_BASE_URL,
+                "api_base_url": api_base_url,
+                "email": email,
+                "account_id": account_id,
+                "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            }
+
+        error = token_data.get("error", "")
+        if error == "authorization_pending":
+            continue
+        elif error == "slow_down":
+            poll_interval = min(poll_interval * 2, 10)
+            continue
+        elif error in ("expired_token", "access_denied"):
+            raise AuthError(
+                f"Cline OAuth {error}: {token_data.get('error_description', '')}",
+                provider=provider_id,
+                code=f"cline_{error}",
+                relogin_required=True,
+            )
+
+    raise AuthError(
+        "Cline OAuth: device code expired",
+        provider=provider_id,
+        code="cline_device_code_expired",
+        relogin_required=True,
+    )
+
+
+def refresh_cline_oauth_pure(
+    access_token: str,
+    refresh_token: str,
+    api_base_url: str = "",
+) -> dict:
+    """Refresh Cline/ClinePass WorkOS tokens through Cline's auth bridge."""
+    del access_token
+    refresh_token = str(refresh_token or "").strip()
+    if not refresh_token:
+        raise AuthError(
+            "Cline auth is missing refresh_token. Re-authenticate.",
+            provider="cline",
+            code="cline_auth_missing_refresh_token",
+            relogin_required=True,
+        )
+    api_base_url = _normalize_cline_api_base_url(api_base_url or _resolve_cline_api_base_url())
+    resp = httpx.post(
+        f"{api_base_url}/api/v1/auth/refresh",
+        json={"refreshToken": refresh_token},
+        headers={"Content-Type": "application/json"},
+        timeout=httpx.Timeout(30),
+    )
+    if resp.status_code != 200:
+        raise AuthError(
+            f"Cline token refresh failed: {resp.status_code} {resp.text[:200]}",
+            provider="cline",
+            code="cline_refresh_failed",
+            relogin_required=True,
+        )
+    data = resp.json()
+    d = data.get("data") if data.get("success") else None
+    if not d:
+        raise AuthError(
+            f"Cline refresh: unexpected response: {str(data)[:200]}",
+            provider="cline",
+            code="cline_refresh_bad_response",
+            relogin_required=True,
+        )
+    new_access = d.get("accessToken", "")
+    new_refresh = d.get("refreshToken", refresh_token)
+    expires_at_str = d.get("expiresAt", "")
+    expires_at_ms = int(time.time() * 1000) + 3600 * 1000
+    if expires_at_str:
+        try:
+            expires_at_ms = int(time.mktime(
+                time.fromisoformat(expires_at_str.replace("Z", "+00:00"))
+            ) * 1000)
+        except Exception:
+            pass
+    return {
+        "access_token": new_access,
+        "refresh_token": new_refresh,
+        "expires_at_ms": expires_at_ms,
+        "inference_base_url": DEFAULT_CLINE_INFERENCE_BASE_URL,
+        "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def resolve_cline_runtime_credentials(
+    provider_id: str = "cline",
+    refresh_if_expiring: bool = True,
+) -> dict:
+    """Resolve Cline runtime credentials from auth store, refreshing if needed."""
+    store_key = "cline"
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        state = _load_provider_state(auth_store, store_key)
+    if not state:
+        raise AuthError(
+            "No Cline credentials stored. Run `hermes auth add cline --type oauth` or `hermes model`.",
+            provider=provider_id,
+            code="cline_auth_missing",
+            relogin_required=True,
+        )
+    access_token = _strip_cline_api_key_prefix(state.get("access_token", ""))
+    refresh_token = str(state.get("refresh_token") or "").strip()
+    if not access_token:
+        raise AuthError(
+            "Cline auth missing access_token. Re-authenticate.",
+            provider=provider_id,
+            code="cline_auth_missing_access_token",
+            relogin_required=True,
+        )
+    if not refresh_token:
+        raise AuthError(
+            "Cline auth missing refresh_token. Re-authenticate.",
+            provider=provider_id,
+            code="cline_auth_missing_refresh_token",
+            relogin_required=True,
+        )
+
+    expires_at_ms = state.get("expires_at_ms")
+    if refresh_if_expiring and _cline_access_token_is_expiring(access_token, expires_at_ms):
+        try:
+            refreshed = refresh_cline_oauth_pure(
+                access_token,
+                refresh_token,
+                api_base_url=state.get("api_base_url", ""),
+            )
+            access_token = refreshed["access_token"]
+            refresh_token = refreshed.get("refresh_token", refresh_token)
+            expires_at_ms = refreshed.get("expires_at_ms")
+            state.update(refreshed)
+            state["access_token"] = access_token
+            state["refresh_token"] = refresh_token
+            with _auth_store_lock():
+                auth_store2 = _load_auth_store()
+                _save_provider_state(auth_store2, store_key, state)
+                _save_auth_store(auth_store2)
+        except AuthError:
+            if state.get("expires_at_ms") and time.time() * 1000 < state["expires_at_ms"]:
+                pass
+            else:
+                raise
+
+    return {
+        "api_key": format_cline_api_key(access_token),
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "base_url": state.get("inference_base_url") or DEFAULT_CLINE_INFERENCE_BASE_URL,
+        "expires_at_ms": expires_at_ms,
+    }
 
 
 def logout_command(args) -> None:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -34,7 +34,7 @@ from hermes_cli.secret_prompt import masked_secret_prompt
 
 
 # Providers that support OAuth login in addition to API keys.
-_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "xai-oauth", "qwen-oauth", "minimax-oauth"}
+_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "cline", "cline-pass", "xai-oauth", "qwen-oauth", "minimax-oauth"}
 
 
 def _get_custom_provider_names() -> list:
@@ -80,6 +80,10 @@ def _normalize_provider(provider: str) -> str:
         return "openrouter"
     if normalized in {"grok-oauth", "xai-oauth", "x-ai-oauth", "xai-grok-oauth"}:
         return "xai-oauth"
+    if normalized in {"clinepass", "cline_pass", "cline-pass", "cline-oauth"}:
+        return "cline-pass"
+    if normalized == "cline":
+        return "cline"
     # Check if it matches a custom provider name
     custom_key = _resolve_custom_provider_input(normalized)
     if custom_key:
@@ -404,6 +408,36 @@ def auth_add_command(args) -> None:
             access_token=creds["access_token"],
             refresh_token=creds.get("refresh_token"),
             base_url=creds.get("inference_base_url"),
+        )
+        pool.add_entry(entry)
+        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        return
+
+    if provider in {"cline", "cline-pass"}:
+        auth_mod.unsuppress_credential_source(provider, "device_code")
+        creds = auth_mod._cline_device_code_login(
+            provider_id=provider,
+            open_browser=not getattr(args, "no_browser", False),
+            timeout_seconds=getattr(args, "timeout", None) or 15.0,
+        )
+        auth_mod._save_cline_tokens(creds, provider_id=provider)
+        label = (getattr(args, "label", None) or "").strip() or (
+            creds.get("email")
+            or creds.get("account_id")
+            or label_from_token(creds.get("access_token", ""), _oauth_default_label(provider, len(pool.entries()) + 1))
+        )
+        entry = PooledCredential(
+            provider=provider,
+            id=uuid.uuid4().hex[:6],
+            label=label,
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source="device_code",
+            access_token=auth_mod.format_cline_api_key(creds.get("access_token", "")),
+            refresh_token=creds.get("refresh_token"),
+            expires_at_ms=creds.get("expires_at_ms"),
+            base_url=creds.get("inference_base_url") or creds.get("base_url"),
+            last_refresh=creds.get("last_refresh"),
         )
         pool.add_entry(entry)
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -609,6 +609,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_xai_oauth,
     _model_flow_qwen_oauth,
     _model_flow_minimax_oauth,
+    _model_flow_cline,
     _model_flow_custom,
     _model_flow_azure_foundry,
     _model_flow_named_custom,
@@ -3074,6 +3075,8 @@ def select_provider_and_model(args=None):
         _model_flow_qwen_oauth(config, current_model)
     elif selected_provider == "minimax-oauth":
         _model_flow_minimax_oauth(config, current_model, args=args)
+    elif selected_provider in ("cline", "cline-pass"):
+        _model_flow_cline(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
     elif selected_provider == "copilot":

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -675,6 +675,45 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
     else:
         print("No change.")
 
+def _model_flow_cline(_config, current_model=""):
+    """Cline OAuth provider: check auth, then pick model."""
+    from hermes_cli.auth import (
+        resolve_cline_runtime_credentials,
+        _prompt_model_selection,
+        _save_model_choice,
+        _update_config_for_provider,
+        DEFAULT_CLINE_INFERENCE_BASE_URL,
+        AuthError,
+        format_auth_error,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    try:
+        resolve_cline_runtime_credentials(refresh_if_expiring=False)
+    except AuthError as exc:
+        print(format_auth_error(exc))
+        print("\nRun: hermes auth add cline --type oauth")
+        return
+
+    models = list(_PROVIDER_MODELS.get("cline", []))
+    if not models:
+        print("No ClinePass models available.")
+        return
+
+    default = current_model or (models[0] if models else "cline-pass/glm-5.2")
+    selected = _prompt_model_selection(
+        models,
+        current_model=default,
+        confirm_provider="cline",
+        confirm_base_url=DEFAULT_CLINE_INFERENCE_BASE_URL,
+    )
+    if selected:
+        _save_model_choice(selected)
+        _update_config_for_provider("cline", DEFAULT_CLINE_INFERENCE_BASE_URL)
+        print(f"Default model set to: {selected} (via ClinePass)")
+    else:
+        print("No change.")
+
 def _model_flow_qwen_oauth(_config, current_model=""):
     """Qwen OAuth provider: reuse local Qwen CLI login, then pick model."""
     from hermes_cli.main import _DEFAULT_QWEN_PORTAL_MODELS

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -244,6 +244,30 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-4o-mini",
     ],
     "openai-codex": _codex_curated_models(),
+    "cline": [
+        "cline-pass/glm-5.2",
+        "cline-pass/kimi-k2.7-code",
+        "cline-pass/kimi-k2.6",
+        "cline-pass/deepseek-v4-pro",
+        "cline-pass/deepseek-v4-flash",
+        "cline-pass/mimo-v2.5",
+        "cline-pass/mimo-v2.5-pro",
+        "cline-pass/minimax-m3",
+        "cline-pass/qwen3.7-max",
+        "cline-pass/qwen3.7-plus",
+    ],
+    "cline-pass": [
+        "cline-pass/glm-5.2",
+        "cline-pass/kimi-k2.7-code",
+        "cline-pass/kimi-k2.6",
+        "cline-pass/deepseek-v4-pro",
+        "cline-pass/deepseek-v4-flash",
+        "cline-pass/mimo-v2.5",
+        "cline-pass/mimo-v2.5-pro",
+        "cline-pass/minimax-m3",
+        "cline-pass/qwen3.7-max",
+        "cline-pass/qwen3.7-plus",
+    ],
     "xai-oauth": _xai_curated_models(),
     "copilot-acp": [
         "copilot-acp",
@@ -1064,6 +1088,8 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek; IAM or API key)"),
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint, your Azure AI deployment)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (Reuses local Qwen CLI login)"),
+    ProviderEntry("cline",          "Cline",                    "Cline Usage-Billing (browser OAuth, OpenAI-compatible API)"),
+    ProviderEntry("cline-pass",     "ClinePass",                "ClinePass (browser OAuth, OpenAI-compatible API)"),
 ]
 
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/
@@ -1804,7 +1830,7 @@ def _model_in_provider_catalog(name_lower: str, providers: set[str]) -> bool:
 
 
 _AGGREGATOR_PROVIDERS = frozenset(
-    {"nous", "openrouter", "copilot", "kilocode"}
+    {"nous", "openrouter", "copilot", "kilocode", "cline", "cline-pass"}
 )
 
 # Subscription/OAuth providers whose catalogs RE-EXPOSE other vendors' models

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -81,6 +81,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://portal.qwen.ai/v1",
         base_url_env_var="HERMES_QWEN_BASE_URL",
     ),
+    "cline": HermesOverlay(
+        transport="openai_chat",
+        auth_type="oauth_external",
+        base_url_override="https://api.cline.bot/api/v1",
+        base_url_env_var="CLINE_BASE_URL",
+        is_aggregator=True,
+    ),
     "lmstudio": HermesOverlay(
         transport="openai_chat",
         auth_type="api_key",
@@ -342,6 +349,12 @@ ALIASES: Dict[str, str] = {
     # gmi
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
+
+    # cline / clinepass
+    "clinepass": "cline",
+    "cline_pass": "cline",
+    "cline-pass": "cline",
+    "cline-oauth": "cline",
 
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -16,17 +16,20 @@ from agent.secret_scope import get_secret as _get_secret
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
+    DEFAULT_CLINE_INFERENCE_BASE_URL,
     DEFAULT_QWEN_BASE_URL,
     DEFAULT_XAI_OAUTH_BASE_URL,
     PROVIDER_REGISTRY,
     _agent_key_is_usable,
     _nous_inference_env_override,
     format_auth_error,
+    format_cline_api_key,
     resolve_provider,
     resolve_nous_runtime_credentials,
     resolve_codex_runtime_credentials,
     resolve_xai_oauth_runtime_credentials,
     resolve_qwen_runtime_credentials,
+    resolve_cline_runtime_credentials,
     resolve_api_key_provider_credentials,
     resolve_external_process_provider_credentials,
     has_usable_secret,
@@ -418,6 +421,11 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "qwen-oauth":
         api_mode = "chat_completions"
         base_url = base_url or DEFAULT_QWEN_BASE_URL
+    elif provider in ("cline", "cline-pass"):
+        api_mode = "chat_completions"
+        base_url = base_url or _getenv("CLINE_BASE_URL", "").strip().rstrip("/") or DEFAULT_CLINE_INFERENCE_BASE_URL
+        if api_key and not str(api_key).lower().startswith("workos:"):
+            api_key = format_cline_api_key(api_key)
     elif provider == "minimax-oauth":
         # MiniMax OAuth tokens are valid only against the Anthropic Messages
         # compatible endpoint. Do not honor stale model.api_mode values from a
@@ -1817,6 +1825,24 @@ def resolve_runtime_provider(
             if requested_provider != "auto":
                 raise
             logger.info("Qwen OAuth credentials failed; "
+                        "falling through to next provider.")
+
+    if provider in ("cline", "cline-pass"):
+        try:
+            creds = resolve_cline_runtime_credentials(provider_id=provider)
+            return {
+                "provider": provider,
+                "api_mode": "chat_completions",
+                "base_url": creds.get("base_url", "").rstrip("/"),
+                "api_key": creds.get("api_key", ""),
+                "source": creds.get("source", "oauth"),
+                "expires_at_ms": creds.get("expires_at_ms"),
+                "requested_provider": requested_provider,
+            }
+        except AuthError:
+            if requested_provider != "auto":
+                raise
+            logger.info("Cline OAuth credentials failed; "
                         "falling through to next provider.")
 
     if provider == "minimax-oauth":

--- a/tests/hermes_cli/test_auth_cline_provider.py
+++ b/tests/hermes_cli/test_auth_cline_provider.py
@@ -1,0 +1,126 @@
+"""Tests for native Cline/ClinePass OAuth support."""
+
+import json
+import time
+from pathlib import Path
+
+from hermes_cli.auth import (
+    DEFAULT_CLINE_INFERENCE_BASE_URL,
+    _save_cline_tokens,
+    format_cline_api_key,
+    resolve_cline_runtime_credentials,
+    resolve_provider,
+)
+from hermes_cli.runtime_provider import resolve_runtime_provider
+
+
+def _clear_cline_env(monkeypatch):
+    for key in (
+        "CLINE_API_KEY",
+        "CLINEPASS_TOKEN",
+        "CLINE_ACCESS_TOKEN",
+        "CLINE_BASE_URL",
+        "CLINE_API_BASE_URL",
+        "HERMES_CLINE_API_BASE_URL",
+        "HERMES_CLINE_INFERENCE_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_format_cline_api_key_accepts_raw_workos_and_bearer():
+    assert format_cline_api_key("abc.def.ghi") == "workos:abc.def.ghi"
+    assert format_cline_api_key("workos:abc.def.ghi") == "workos:abc.def.ghi"
+    assert format_cline_api_key("Bearer workos:abc.def.ghi") == "workos:abc.def.ghi"
+
+
+def test_resolve_cline_pass_uses_shared_cline_auth_store(tmp_path, monkeypatch):
+    _clear_cline_env(monkeypatch)
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_cline_tokens(
+        {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "expires_at_ms": int((time.time() + 3600) * 1000),
+            "email": "user@example.com",
+        },
+        provider_id="cline-pass",
+    )
+
+    creds = resolve_cline_runtime_credentials("cline-pass")
+    assert creds["provider"] == "cline-pass"
+    assert creds["api_key"] == "workos:access-token"
+    assert creds["base_url"] == DEFAULT_CLINE_INFERENCE_BASE_URL
+
+    auth_store = json.loads((hermes_home / "auth.json").read_text())
+    assert "cline" in auth_store["providers"]
+    assert "cline-pass" not in auth_store["providers"]
+
+
+def test_resolve_cline_runtime_refreshes_expired_token(tmp_path, monkeypatch):
+    _clear_cline_env(monkeypatch)
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_cline_tokens(
+        {
+            "access_token": "old-access",
+            "refresh_token": "old-refresh",
+            "expires_at_ms": int((time.time() - 60) * 1000),
+        },
+        provider_id="cline",
+    )
+
+    called = {"count": 0}
+
+    def _fake_refresh(state, timeout_seconds, *, provider_id="cline"):
+        called["count"] += 1
+        updated = dict(state)
+        updated.update(
+            {
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "expires_at_ms": int((time.time() + 3600) * 1000),
+                "last_refresh": "2026-01-01T00:00:00Z",
+            }
+        )
+        return updated
+
+    monkeypatch.setattr("hermes_cli.auth._refresh_cline_auth_tokens", _fake_refresh)
+
+    creds = resolve_cline_runtime_credentials("cline")
+    assert called["count"] == 1
+    assert creds["api_key"] == "workos:new-access"
+
+
+def test_runtime_provider_uses_cline_env_token_from_pool(tmp_path, monkeypatch):
+    _clear_cline_env(monkeypatch)
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CLINE_API_KEY", "raw-browser-token")
+
+    runtime = resolve_runtime_provider(requested="cline")
+    assert runtime["provider"] == "cline"
+    assert runtime["api_mode"] == "chat_completions"
+    assert runtime["api_key"] == "workos:raw-browser-token"
+    assert runtime["base_url"] == DEFAULT_CLINE_INFERENCE_BASE_URL
+
+
+def test_auto_provider_detects_cline_env_tokens(tmp_path, monkeypatch):
+    _clear_cline_env(monkeypatch)
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    monkeypatch.setenv("CLINE_API_KEY", "raw-browser-token")
+    assert resolve_provider("auto") == "cline"
+
+    monkeypatch.delenv("CLINE_API_KEY", raising=False)
+    monkeypatch.setenv("CLINEPASS_TOKEN", "raw-browser-token")
+    assert resolve_provider("auto") == "cline-pass"


### PR DESCRIPTION
## Summary

Adds native Cline (usage-billing) and ClinePass ($9.99/month subscription) as OAuth providers in Hermes, using the WorkOS device-code flow. Follows existing patterns from Codex, xAI, and Qwen OAuth providers.

## Changes (9 files + 1 test)

- **hermes_cli/auth.py** — Cline constants, PROVIDER_REGISTRY entries, WorkOS device-code login, token refresh, credential resolution, format_cline_api_key() for workos: prefix
- **hermes_cli/auth_commands.py** — _OAUTH_CAPABLE_PROVIDERS, _normalize_provider (native cline before custom_providers), auth_add_command Cline OAuth branch
- **hermes_cli/providers.py** — ALIASES for cline/clinepass/cline_pass/cline-pass/cline-oauth, HERMES_OVERLAYS cline entry
- **hermes_cli/runtime_provider.py** — Cline provider resolution: chat_completions API mode, credential injection
- **hermes_cli/models.py** — _PROVIDER_MODELS with ClinePass model slugs (cline-pass/glm-5.2 etc.), CANONICAL_PROVIDERS entries, _AGGREGATOR_PROVIDERS
- **hermes_cli/model_setup_flows.py** — _model_flow_cline for hermes model picker
- **hermes_cli/main.py** — Import _model_flow_cline, add cline/cline-pass branch in select_provider_and_model
- **agent/credential_pool.py** — Cline runtime_api_key property returns workos:-prefixed token
- **agent/auxiliary_client.py** — Cline alias mappings
- **tests/hermes_cli/test_auth_cline_provider.py** — Unit tests for Cline auth

## Key design decisions

1. **WorkOS device-code flow** — Cline uses WorkOS for auth. The device-code flow matches the Cline VS Code extension's browser login.
2. **Native before custom** — _normalize_provider checks cline/clinepasbefore custom_providers lookup to prevent a user's custom_providers entry named 'cline' from hijacking the native provider.
3. **ClinePass model slugs** — ClinePass subscription uses prefixed model IDs (cline-pass/glm-5.2, cline-pass/kimi-k2.7-code, etc.) that route through the subscription quota, not pay-per-use credits.
4. **workos: token prefix** — Cline's API gateway expects access tokens with a workos: prefix, handled by format_cline_api_key().
5. **Disk persistence** — _save_cline_tokens calls _save_auth_store() after _save_provider_state() to ensure tokens are written to auth.json (not just in-memory).

## API details

- Inference: https://api.cline.bot/api/v1 (OpenAI-compatible chat completions)
- OAuth: WorkOS device-code flow (https://api.workos.com/user_management/authorize/device)
- Token refresh: Cline auth bridge at https://api.cline.bot/api/v1/auth/refresh
- Client ID: client_01K3A541FN8TA3EPPHTD2325ly auth

## Testing

- All 9 files compile successfully
- _normalize_provider('cline') returns 'cline' (not custom:cline)
- 'cline' and 'cline-pass' in PROVIDER_REGISTRY
- resolve_provider_full('cline') returns ProviderDef with id='cline'
- _PROVIDER_MODELS['cline'] contains ClinePass model slugs
- Existing OAuth tokens in auth.json resolve correctly
- Unit tests pass

## Reference

- ClinePass docs: https://docs.cline.bot/getting-started/clinepass
- Cline API docs: https://docs.cline.bot/api/getting-started