### PR TITLE
fix(i18n): resolve locale catalogs for pip install --user layouts

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import logging
 import os
+import site
 import sysconfig
 import threading
 from functools import lru_cache
@@ -94,7 +95,11 @@ def _locales_dir() -> Path:
        sealed-packaging system) to point at the installed catalog directory.
     2. ``<repo-root>/locales`` -- source checkouts and ``pip install -e .``,
        where the working tree sits next to ``agent/``.
-    3. ``<sysconfig data|purelib|platlib>/locales`` -- pip wheel installs.
+    3. ``site.getuserbase()/locales`` -- active ``pip install --user`` layouts.
+       This path is only considered when this module itself is imported from
+       ``site.getusersitepackages()`` so a stale user catalog cannot override
+       a venv/system installation.
+    4. ``<sysconfig data|purelib|platlib>/locales`` -- pip wheel installs.
        setuptools ``data-files`` extracts ``locales/*.yaml`` under the
        interpreter's ``data`` scheme; the other schemes are checked as a
        safety net for nonstandard layouts.
@@ -119,12 +124,33 @@ def _locales_dir() -> Path:
     if source_dir.is_dir():
         return source_dir
 
+    # ``pip install --user`` puts package modules under
+    # ``~/.local/lib/pythonX.Y/site-packages`` but setuptools data-files under
+    # the user *base* (``~/.local/locales``) -- a path none of the sysconfig
+    # schemes below return. Check it explicitly, otherwise a --user install
+    # returns raw i18n keys (e.g. ``gateway.model.switched``) for every
+    # localized slash-command reply, approval prompt, /reset, /goal, etc.
+    try:
+        user_base = site.getuserbase()
+        user_site = site.getusersitepackages()
+        package_path = Path(__file__).resolve()
+        user_site_path = Path(user_site).resolve() if user_site else None
+        is_user_site_package = bool(
+            user_site_path and package_path.is_relative_to(user_site_path)
+        )
+    except (OSError, RuntimeError, TypeError, ValueError):
+        user_base = ""
+        is_user_site_package = False
+    if user_base and is_user_site_package:
+        candidate = Path(user_base) / "locales"
+        if candidate.is_dir():
+            return candidate
+
     # pip wheel install: data-files lands under the interpreter data scheme.
     # ``data`` (== sys.prefix in a venv) is where setuptools data-files extract
     # and is checked first. ``purelib``/``platlib`` (site-packages) are a safety
-    # net for nonstandard layouts. NOTE: this does NOT cover ``pip install
-    # --user`` (user scheme, ~/.local/locales) or ``pip install --target`` --
-    # both are out of scope; see the plan header.
+    # net for nonstandard layouts. NOTE: ``pip install --target`` (custom target
+    # dir) is still out of scope; see the plan header.
     for scheme in ("data", "purelib", "platlib"):
         raw = sysconfig.get_path(scheme)
         if not raw:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,6 +361,7 @@ testpaths = ["tests"]
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
+    "timeout(seconds): per-test timeout consumed by pytest-timeout when installed",
 ]
 # integration tests take way too long to run in the normal CI environments
 addopts = "-m 'not integration'"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -206,7 +206,140 @@ def test_locales_dir_falls_back_to_data_scheme(tmp_path, monkeypatch):
     fake_pkg.mkdir(parents=True)
     monkeypatch.setattr(i18n, "__file__", str(fake_pkg / "i18n.py"))
 
+    # Neutralize the user-base branch (checked before the data scheme) so this
+    # test pins the data-scheme fallback specifically -- otherwise a real
+    # ``pip install --user`` host resolves ~/.local/locales first.
+    user_base_no_locales = tmp_path / "user-base"
+    user_base_no_locales.mkdir()
+    monkeypatch.setattr(i18n.site, "getuserbase", lambda: str(user_base_no_locales))
+
     # Stand up a fake data scheme containing locales/.
+    data_root = tmp_path / "data-scheme"
+    (data_root / "locales").mkdir(parents=True)
+    real_get_path = sysconfig.get_path
+
+    def fake_get_path(name, *args, **kwargs):
+        if name == "data":
+            return str(data_root)
+        return real_get_path(name, *args, **kwargs)
+
+    monkeypatch.setattr(i18n.sysconfig, "get_path", fake_get_path)
+
+    assert i18n._locales_dir() == data_root / "locales"
+
+
+def test_locales_dir_resolves_pip_user_base(tmp_path, monkeypatch):
+    """``pip install --user`` puts data-files under ``site.getuserbase()/locales``
+    (e.g. ~/.local/locales), which none of the sysconfig schemes return. Without
+    an explicit user-base check, every catalog lookup misses and t() returns raw
+    keys for all localized replies. Regression for the --user layout."""
+    import sysconfig
+
+    # No env override.
+    monkeypatch.delenv("HERMES_BUNDLED_LOCALES", raising=False)
+
+    # Force the source-adjacent path to a location with no locales/ dir.
+    fake_pkg = tmp_path / "site-packages" / "agent"
+    fake_pkg.mkdir(parents=True)
+    monkeypatch.setattr(i18n, "__file__", str(fake_pkg / "i18n.py"))
+
+    # Stand up a fake user base containing locales/ (the --user data-files spot).
+    user_base = tmp_path / "user-base"
+    (user_base / "locales").mkdir(parents=True)
+    monkeypatch.setattr(i18n.site, "getuserbase", lambda: str(user_base))
+    monkeypatch.setattr(
+        i18n.site,
+        "getusersitepackages",
+        lambda: str(fake_pkg.parent),
+    )
+
+    # Ensure the sysconfig data-scheme fallback does NOT accidentally resolve,
+    # so this test pins the user-base branch specifically.
+    empty_scheme = tmp_path / "empty-scheme"
+    empty_scheme.mkdir()
+    real_get_path = sysconfig.get_path
+    monkeypatch.setattr(
+        i18n.sysconfig,
+        "get_path",
+        lambda name, *a, **k: str(empty_scheme),
+    )
+
+    assert i18n._locales_dir() == user_base / "locales"
+
+
+def test_locales_dir_user_base_precedes_data_scheme(tmp_path, monkeypatch):
+    """When both the user base and a sysconfig data scheme carry locales/, the
+    user base wins -- it is checked first in the resolution ladder."""
+    monkeypatch.delenv("HERMES_BUNDLED_LOCALES", raising=False)
+
+    fake_pkg = tmp_path / "site-packages" / "agent"
+    fake_pkg.mkdir(parents=True)
+    monkeypatch.setattr(i18n, "__file__", str(fake_pkg / "i18n.py"))
+
+    user_base = tmp_path / "user-base"
+    (user_base / "locales").mkdir(parents=True)
+    monkeypatch.setattr(i18n.site, "getuserbase", lambda: str(user_base))
+    monkeypatch.setattr(
+        i18n.site,
+        "getusersitepackages",
+        lambda: str(fake_pkg.parent),
+    )
+
+    data_root = tmp_path / "data-scheme"
+    (data_root / "locales").mkdir(parents=True)
+    monkeypatch.setattr(
+        i18n.sysconfig,
+        "get_path",
+        lambda name, *a, **k: str(data_root) if name == "data" else "",
+    )
+
+    assert i18n._locales_dir() == user_base / "locales"
+
+
+def test_locales_dir_non_user_install_ignores_stale_user_base(tmp_path, monkeypatch):
+    """A venv/system install must not read catalogs left by a user install."""
+    monkeypatch.delenv("HERMES_BUNDLED_LOCALES", raising=False)
+
+    active_pkg = tmp_path / "venv" / "site-packages" / "agent"
+    active_pkg.mkdir(parents=True)
+    monkeypatch.setattr(i18n, "__file__", str(active_pkg / "i18n.py"))
+
+    stale_user_base = tmp_path / "user-base"
+    (stale_user_base / "locales").mkdir(parents=True)
+    monkeypatch.setattr(i18n.site, "getuserbase", lambda: str(stale_user_base))
+    monkeypatch.setattr(
+        i18n.site,
+        "getusersitepackages",
+        lambda: str(tmp_path / "user-site"),
+    )
+
+    active_data = tmp_path / "active-data"
+    (active_data / "locales").mkdir(parents=True)
+    monkeypatch.setattr(
+        i18n.sysconfig,
+        "get_path",
+        lambda name, *a, **k: str(active_data) if name == "data" else "",
+    )
+
+    assert i18n._locales_dir() == active_data / "locales"
+
+
+def test_locales_dir_user_base_error_is_non_fatal(tmp_path, monkeypatch):
+    """If site.getuserbase() raises (unusual embedded/frozen interpreters),
+    resolution must fall through to the sysconfig data scheme, not crash."""
+    import sysconfig
+
+    monkeypatch.delenv("HERMES_BUNDLED_LOCALES", raising=False)
+
+    fake_pkg = tmp_path / "site-packages" / "agent"
+    fake_pkg.mkdir(parents=True)
+    monkeypatch.setattr(i18n, "__file__", str(fake_pkg / "i18n.py"))
+
+    def _boom():
+        raise RuntimeError("no user base")
+
+    monkeypatch.setattr(i18n.site, "getuserbase", _boom)
+
     data_root = tmp_path / "data-scheme"
     (data_root / "locales").mkdir(parents=True)
     real_get_path = sysconfig.get_path

--- a/tests/test_wheel_locales_e2e.py
+++ b/tests/test_wheel_locales_e2e.py
@@ -92,6 +92,99 @@ def test_installed_wheel_renders_i18n_strings(tmp_path):
 
 
 @pytest.mark.integration
+@pytest.mark.timeout(300)
+def test_user_scheme_wheel_resolves_user_base_locales(tmp_path):
+    """A real ``pip install --user`` must resolve ``$PYTHONUSERBASE/locales``."""
+    wheel_dir = tmp_path / "wheel"
+    base_python = getattr(sys, "_base_executable", None) or sys.executable
+    build_env = {**os.environ, "PIP_DISABLE_PIP_VERSION_CHECK": "1"}
+    build = subprocess.run(
+        [
+            base_python,
+            "-m",
+            "pip",
+            "wheel",
+            "--no-deps",
+            "--no-build-isolation",
+            "-q",
+            "-w",
+            str(wheel_dir),
+            ".",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env=build_env,
+        timeout=600,
+    )
+    assert build.returncode == 0, f"pip wheel failed:\n{build.stderr}"
+    wheels = glob.glob(str(wheel_dir / "*.whl"))
+    assert wheels, "no wheel produced"
+
+    user_base = tmp_path / "user-base"
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k
+        not in (
+            "PYTHONPATH",
+            "HERMES_BUNDLED_LOCALES",
+            "PYTHONNOUSERSITE",
+            "VIRTUAL_ENV",
+        )
+    }
+    env["PYTHONUSERBASE"] = str(user_base)
+    env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+
+    install = subprocess.run(
+        [
+            base_python,
+            "-m",
+            "pip",
+            "install",
+            "-q",
+            "--user",
+            "--no-deps",
+            "--force-reinstall",
+            wheels[0],
+        ],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+    assert install.returncode == 0, (
+        "pip install --user failed:\n"
+        f"stdout: {install.stdout}\nstderr: {install.stderr}"
+    )
+
+    probe = (
+        "from agent import i18n;"
+        "from pathlib import Path;"
+        "import site, sys;"
+        "resolved = i18n._locales_dir();"
+        "expected = Path(site.getuserbase()) / 'locales';"
+        "rendered = i18n.t('gateway.reset.header_default', lang='en');"
+        "print(resolved); print(repr(rendered));"
+        "sys.exit(0 if resolved == expected and rendered != "
+        "'gateway.reset.header_default' else 1)"
+    )
+    run = subprocess.run(
+        [base_python, "-c", probe],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+    assert run.returncode == 0, (
+        "user-scheme wheel failed to resolve its installed locale catalogs:\n"
+        f"stdout: {run.stdout}\nstderr: {run.stderr}"
+    )
+
+
+@pytest.mark.integration
 @pytest.mark.timeout(300)  # overrides the global --timeout=30; cold-CI sdist build can exceed it
 def test_built_sdist_ships_locale_catalogs(tmp_path):
     """The sdist must carry locales/ too.


### PR DESCRIPTION
## What does this PR do?

Fixes locale-catalog resolution for `pip install --user` installs. On a `--user` install, package modules land under `~/.local/lib/pythonX.Y/site-packages/` but setuptools `data-files` (the locale catalogs) land under the user *base*, `~/.local/locales/` — a path none of `sysconfig.get_path("data"|"purelib"|"platlib")` returns.

`agent/i18n._locales_dir()` never checked the user base, so on a `--user` install every catalog lookup missed and `t()` silently returned the raw dotted key. The existing code comment even flagged `--user` as explicitly out of scope:

```python
# NOTE: this does NOT cover ``pip install --user`` (user scheme,
# ~/.local/locales) or ``pip install --target`` -- both are out of scope
```

This closes the `--user` half of that gap by checking `site.getuserbase()/locales` before the generic sysconfig schemes.

## Related Issue

Related to #39105 (and the #27632 / #35374 family) — those track the *packaging* side (shipping `locales/` in the wheel). This PR is the complementary *resolution* fix: even when the catalogs are correctly installed on disk, a `--user` layout puts them at `~/.local/locales`, which the resolver never consulted. Not a duplicate of #54557 (that adds a separate `~/.hermes/locale-overrides/` merge layer).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/i18n.py`: add a `site.getuserbase()/locales` probe in `_locales_dir()`, checked after the source-adjacent path and before the sysconfig `data|purelib|platlib` schemes. `site.getuserbase()` failures are caught so resolution still falls through to the data scheme on unusual (embedded/frozen) interpreters. `import site` added; docstring resolution ladder updated to document the new step.
- `tests/agent/test_i18n.py`: three new cases — the `--user` branch resolving to `userbase/locales`, its precedence over the data scheme, and the non-fatal fall-through when `site.getuserbase()` raises. One existing test (`test_locales_dir_falls_back_to_data_scheme`) updated to neutralize the new branch so it still pins the wheel-layout fallback specifically.

## How to Test

Symptom (before): on a `pip install --user` install, `/model`, `/reset`, `/goal`, `/compress`, `/help`, and approval prompts all print raw keys like `gateway.model.switched` instead of text.

1. `python -m pytest tests/agent/test_i18n.py -q` → **50 passed**.
2. Functional proof of the failure mode + fix (forces source-miss + empty sysconfig schemes, points the user base at a temp catalog):
   ```python
   # with the failure mode forced, _locales_dir() now returns userbase/locales
   # and t("gateway.model.switched", model="opus") -> "Model switched to `opus`"
   # (real text, not the raw key)
   ```
   Verified on a live `pip install --user` host: `t()` renders real strings across `gateway.model.*`, `approval.*`, `gateway.reset.*`, `gateway.goal.*`, `gateway.compress.*`, `gateway.help.*`.
3. `ruff check agent/i18n.py tests/agent/test_i18n.py` → clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(i18n):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/agent/test_i18n.py -q` and all tests pass (50 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.8), Python 3.12, `pip install --user`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (the `_locales_dir()` docstring resolution ladder)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — `site.getuserbase()` is stdlib and cross-platform; on Windows/macOS the `--user` base differs but the same probe applies. No Unix-only assumptions.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
