### PR TITLE
fix(fallback): trigger immediate failover on overloaded (529) errors

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1555,8 +1555,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _reset_stale_streak(agent)
         return True
     except Exception as e:
-        if fb_provider == "nous":
-            unavailable.add(fb_key)
+        # #60761: Don't permanently suppress on transient errors.
+        # The local_skip_reason + fb_client-is-None checks above already
+        # handle permanent config/auth problems. Suppressing on every
+        # exception (including transient network failures) made fallback
+        # entries permanently unrecoverable within a session.
         logger.error("Failed to activate fallback %s: %s", fb_model, e)
         return agent._try_activate_fallback(reason)  # try next in chain
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3133,19 +3133,22 @@ def run_conversation(
                     # is exhausted or didn't help.
 
                 # Eager fallback for rate-limit errors (429 or quota exhaustion)
-                # and transport errors (connection failure / timeout / provider
-                # overloaded).  Rate limits and billing: switch immediately —
-                # the primary provider won't recover within the retry window.
-                # Transport errors: allow 1 retry first (transient hiccups
-                # recover), then fall back if the provider is truly unreachable.
+                # and provider overload (529).  Rate limits, billing, and
+                # overload: switch immediately — the primary provider won't
+                # recover within the retry window (Anthropic SDK treats 529
+                # as a hard signal to failover).  Z.AI Coding Plan overload
+                # 429s are demoted back to transport-failure below to keep
+                # their existing long-backoff schedule (30/60/90/120s).
+                # Transport errors (timeout / connection): allow 1 retry
+                # first (transient hiccups recover), then fall back.
                 is_rate_limited = classified.reason in {
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                     FailoverReason.upstream_rate_limit,
+                    FailoverReason.overloaded,
                 }
                 _is_transport_failure = classified.reason in {
                     FailoverReason.timeout,
-                    FailoverReason.overloaded,
                 }
                 # Z.AI Coding Plan GLM-5.2 overload 429s classify as
                 # `overloaded` (to spare the credential pool), but `overloaded`
@@ -3159,6 +3162,13 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+                    # Z.AI Coding Plan overload 429s self-heal in minutes —
+                    # preserve the existing long-backoff schedule instead of
+                    # immediate fallback. Demote back to transport failure so
+                    # retries run before fallback is considered.
+                    if classified.reason == FailoverReason.overloaded:
+                        is_rate_limited = False
+                        _is_transport_failure = True
                 _should_fallback = (
                     is_rate_limited
                     or (_is_transport_failure and retry_count >= 2)


### PR DESCRIPTION
## Summary

Two fixes for `fallback_providers` that were broken in real-world conditions:

### Bug 1: Overloaded (529) never triggers fallback
`FailoverReason.overloaded` was in the transport-failure set requiring `retry_count >= 2`, but with default `api_max_retries=3` the retry budget was exhausted before reaching the threshold — fallback never activated.

**Fix:** Move `overloaded` to the rate-limit set (immediate failover, no retry threshold), matching Anthropic SDK behavior. Z.AI Coding Plan overload 429s preserve their existing long-backoff schedule.

### Bug 2: Fallback entries permanently suppressed on transient errors
`_unavailable_fallback_keys` permanently suppressed nous fallback entries on ANY exception, including transient network errors, for the entire session lifetime.

**Fix:** Remove the blanket nous suppression from the except block. The existing `local_skip_reason` and `fb_client-is-None` guards already handle permanent config/auth problems.

## Changes
- `agent/conversation_loop.py`: overloaded → immediate failover (with Z.AI exception)
- `agent/chat_completion_helpers.py`: remove permanent nous suppression

Fixes: #60761