### PR TITLE
fix(delegate): raise in-tool heartbeat stale threshold from 20min to 40min

### DIFF
--- a/tests/tools/test_heartbeat_stale_thresholds.py
+++ b/tests/tools/test_heartbeat_stale_thresholds.py
@@ -11,9 +11,9 @@ class TestHeartbeatStaleThresholds:
         assert _HEARTBEAT_STALE_CYCLES_IDLE == 15
 
     def test_in_tool_cycles_value(self):
-        """IN_TOOL stale cycles should be 40 (40 * 30s = 1200s)."""
+        """IN_TOOL stale cycles should be 80 (80 * 30s = 2400s / 40 min)."""
         from tools.delegate_tool import _HEARTBEAT_STALE_CYCLES_IN_TOOL
-        assert _HEARTBEAT_STALE_CYCLES_IN_TOOL == 40
+        assert _HEARTBEAT_STALE_CYCLES_IN_TOOL == 80
 
     def test_idle_timeout_seconds(self):
         """Effective idle stale timeout: 15 * 30 = 450s (> typical LLM response time)."""
@@ -23,10 +23,10 @@ class TestHeartbeatStaleThresholds:
         assert effective > 300  # Must be > 5 minutes for slow LLM responses
 
     def test_in_tool_timeout_seconds(self):
-        """Effective in-tool stale timeout: 40 * 30 = 1200s (= 20 minutes)."""
+        """Effective in-tool stale timeout: 80 * 30 = 2400s (= 40 minutes)."""
         from tools.delegate_tool import _HEARTBEAT_STALE_CYCLES_IN_TOOL, _HEARTBEAT_INTERVAL
         effective = _HEARTBEAT_STALE_CYCLES_IN_TOOL * _HEARTBEAT_INTERVAL
-        assert effective == 1200
+        assert effective == 2400
 
     def test_interval_unchanged(self):
         """Heartbeat interval should remain 30s."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -629,7 +629,7 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 # time to finish; delegation.child_timeout_seconds (off by default) remains an
 # optional hard cap for users who want one.
 _HEARTBEAT_STALE_CYCLES_IDLE = 15  # 15 * 30s = 450s idle between turns → stale
-_HEARTBEAT_STALE_CYCLES_IN_TOOL = 40  # 40 * 30s = 1200s stuck on same tool → stale
+_HEARTBEAT_STALE_CYCLES_IN_TOOL = 80  # 80 * 30s = 2400s (40 min) stuck on same tool → stale
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
 
 


### PR DESCRIPTION
## Problem

Subagents doing legitimate long-running work inside a single tool call (large builds, slow terminal commands, big file scans, heavy code review) were being flagged as stale/stuck and killed by `delegate_task`'s heartbeat monitor once they crossed **1200s (20 minutes)** stuck on the same tool. This is the source of the '20 minute limit' users hit even though `delegation.child_timeout_seconds` is already unset/unbounded by default.

## Fix

Raise `_HEARTBEAT_STALE_CYCLES_IN_TOOL` in `tools/delegate_tool.py` from 40 to 80 cycles (`80 * 30s = 2400s` / 40 minutes). This gives legitimate long-running tool calls more headroom before the stuck-child detector fires, while leaving the idle-between-turns ceiling (`_HEARTBEAT_STALE_CYCLES_IDLE`, 450s) unchanged since that one is meant to catch genuinely stuck children fast.

Updated `tests/tools/test_heartbeat_stale_thresholds.py` to assert the new constant/effective timeout.

## Testing

- Verified constants directly via import (`pytest` unavailable in this venv):
  ```
  _HEARTBEAT_STALE_CYCLES_IN_TOOL == 80
  _HEARTBEAT_STALE_CYCLES_IN_TOOL * _HEARTBEAT_INTERVAL == 2400
  _HEARTBEAT_STALE_CYCLES_IDLE == 15  (unchanged)
  ```
