### PR TITLE
fix(agent,state): pass profile in session_search handlers + enable FTS in read-only mode

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1820,6 +1820,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     around_message_id=next_args.get("around_message_id"),
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
+                    profile=next_args.get("profile"),
                     db=session_db,
                     current_session_id=agent.session_id,
                 ),

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1082,6 +1082,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     around_message_id=next_args.get("around_message_id"),
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
+                    profile=next_args.get("profile"),
                     db=session_db,
                     current_session_id=agent.session_id,
                 )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -715,6 +715,16 @@ class SessionDB:
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                # Detect pre-existing FTS5 virtual tables read-only (no DDL,
+                # no write lock) so cross-profile session_search — which opens
+                # these handles via _resolve_profile_db() — can actually query
+                # them instead of silently returning 0 results.  The tables
+                # were created by the owning profile's read-write SessionDB;
+                # here we only need to see them.
+                self._fts_enabled = self._fts_table_exists("messages_fts")
+                self._trigram_available = self._fts_table_exists(
+                    "messages_fts_trigram"
+                )
                 return
 
             self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2574,6 +2574,57 @@ class TestConcurrentToolExecution:
             )
             assert result == "result"
 
+    def test_invoke_tool_passes_profile_to_session_search(self, agent, monkeypatch):
+        """The agent-runtime dispatch path must forward session_search.profile."""
+        sentinel_db = object()
+        captured = {}
+        agent._session_db = sentinel_db
+
+        def fake_session_search(**kwargs):
+            captured.update(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.session_search_tool.session_search", fake_session_search)
+
+        result = json.loads(agent._invoke_tool(
+            "session_search",
+            {"query": "koala", "profile": "other"},
+            "task-1",
+        ))
+
+        assert result["success"] is True
+        assert captured["profile"] == "other"
+        assert captured["db"] is sentinel_db
+
+    def test_sequential_dispatch_passes_profile_to_session_search(self, agent, monkeypatch):
+        """The sequential dispatch path must forward session_search.profile."""
+        sentinel_db = object()
+        captured = {}
+        agent._session_db = sentinel_db
+
+        def fake_session_search(**kwargs):
+            captured.update(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.session_search_tool.session_search", fake_session_search)
+        tool_call = _mock_tool_call(
+            name="session_search",
+            arguments='{"query":"koala","profile":"other"}',
+            call_id="session-search-1",
+        )
+        messages = []
+
+        agent._execute_tool_calls_sequential(
+            _mock_assistant_msg(content="", tool_calls=[tool_call]),
+            messages,
+            "task-1",
+        )
+
+        assert len(messages) == 1
+        assert json.loads(messages[0]["content"])["success"] is True
+        assert captured["profile"] == "other"
+        assert captured["db"] is sentinel_db
+
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])

--- a/tests/tools/test_cross_profile_discovery.py
+++ b/tests/tools/test_cross_profile_discovery.py
@@ -1,0 +1,88 @@
+# =========================================================================
+# Cross-profile discovery — profile param with FTS search
+# =========================================================================
+
+import json
+
+import pytest
+
+from hermes_state import SessionDB
+from tools.session_search_tool import session_search
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+class TestCrossProfileDiscovery:
+    """session_search(query=..., profile=\"other\") must search the named
+    profile's DB, not the current one.  This covers both the SessionDB
+    read-only FTS detection (#49554) and the agent-loop parameter passthrough
+    (#FIXME replace with actual issue number after creation)."""
+
+    @staticmethod
+    def _patch_profiles(monkeypatch, home, exists=True):
+        from hermes_cli import profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+        monkeypatch.setattr(profiles_mod, "validate_profile_name", lambda n: None)
+        monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: exists)
+        monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: home)
+
+    def test_discovery_with_profile_searches_correct_db(self, db, tmp_path, monkeypatch):
+        """Query the other profile's DB — must return hits from that profile only."""
+        # ── Seed "other" profile DB ──
+        other_home = tmp_path / "other_home"
+        other_home.mkdir()
+        other_db = SessionDB(other_home / "state.db")
+        try:
+            other_db.create_session("s_alt", source="cli")
+            other_db.append_message("s_alt", role="user", content="koala conservation plan")
+            other_db.append_message("s_alt", role="assistant", content="Let's protect the koalas.")
+            other_db._conn.commit()
+        finally:
+            other_db.close()
+
+        # ── Seed current profile DB with a DIFFERENT topic ──
+        db.create_session("s_curr", source="cli")
+        db.append_message("s_curr", role="user", content="penguin habitat study")
+        db._conn.commit()
+
+        self._patch_profiles(monkeypatch, other_home)
+
+        # Query the other profile — should find "koala", not "penguin"
+        result = json.loads(
+            session_search(query="koala", profile="other", db=db)
+        )
+        assert result["success"] is True
+        assert result["mode"] == "discover"
+        assert result["count"] >= 1, "should find koala in other profile"
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_alt" in sids, "should include the other profile's session"
+
+    def test_discovery_profile_isolation(self, db, tmp_path, monkeypatch):
+        """A query that only matches the current profile must return empty
+        when searching the other profile."""
+        other_home = tmp_path / "other_home"
+        other_home.mkdir()
+        other_db = SessionDB(other_home / "state.db")
+        try:
+            other_db.create_session("s_alt", source="cli")
+            other_db.append_message("s_alt", role="user", content="koala")
+            other_db._conn.commit()
+        finally:
+            other_db.close()
+
+        # Current profile has "penguin" — not in other profile
+        db.create_session("s_curr", source="cli")
+        db.append_message("s_curr", role="user", content="penguin migration patterns")
+        db._conn.commit()
+
+        self._patch_profiles(monkeypatch, other_home)
+
+        # Search "penguin" in other profile — should be empty
+        result = json.loads(
+            session_search(query="penguin", profile="other", db=db)
+        )
+        assert result["success"] is True
+        assert result["count"] == 0, "penguin is only in current profile, not other"

--- a/tests/tools/test_cross_profile_discovery.py
+++ b/tests/tools/test_cross_profile_discovery.py
@@ -19,7 +19,7 @@ class TestCrossProfileDiscovery:
     """session_search(query=..., profile=\"other\") must search the named
     profile's DB, not the current one.  This covers both the SessionDB
     read-only FTS detection (#49554) and the agent-loop parameter passthrough
-    (#FIXME replace with actual issue number after creation)."""
+    (#60789)."""
 
     @staticmethod
     def _patch_profiles(monkeypatch, home, exists=True):


### PR DESCRIPTION
## Summary

Two bugs prevented cross-profile `session_search(profile=...)` from working:

1. **Agent-loop handlers drop the profile parameter** (#60789): both
   `agent_runtime_helpers.py` and `tool_executor.py` intercept
   `session_search` but omit `profile=` when forwarding to
   `_session_search()`, causing the named profile's DB to never be used.

2. **Read-only SessionDB never enables FTS** (#49554): `SessionDB(read_only=True)`
   returns before detecting pre-existing FTS tables, so every cross-profile
   discovery returns zero results even when the target DB has matches.

Both must be fixed together — either alone still produces broken cross-profile
search (wrong DB with no results, or right DB with FTS disabled).

## Changes

| File | Change |
|------|--------|
| `agent/agent_runtime_helpers.py` | +1 line: `profile=next_args.get("profile")` |
| `agent/tool_executor.py` | +1 line: same |
| `hermes_state.py` | +10 lines: probe FTS tables in read-only constructor |
| `tests/tools/test_cross_profile_discovery.py` | +88 lines: new regression tests |

## Related PRs

- #49577 covers the same `hermes_state.py` fix independently.
  Included here for end-to-end testability; happy to drop the state commit
  if #49577 lands first.

## Verification

```
pytest tests/tools/test_session_search.py -q          → 47 passed
pytest tests/tools/test_cross_profile_discovery.py -q → 2 passed
```

Closes #60789, Closes #49554