### PR TITLE
fix(desktop): surface generated file artifacts

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-preview-routing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.test.tsx
@@ -9,6 +9,7 @@ import {
   type PreviewTarget,
   registerSessionPreview
 } from '@/store/preview'
+import { $previewStatusBySession } from '@/store/preview-status'
 import { $currentCwd, $messages } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -62,6 +63,7 @@ describe('usePreviewRouting', () => {
     $currentCwd.set('/work')
     $messages.set([])
     $previewTarget.set(null)
+    $previewStatusBySession.set({})
     window.localStorage.clear()
     clearSessionPreviewRegistry()
     handleEvent = () => undefined
@@ -78,6 +80,7 @@ describe('usePreviewRouting', () => {
     cleanup()
     $messages.set([])
     $previewTarget.set(null)
+    $previewStatusBySession.set({})
     window.localStorage.clear()
     clearSessionPreviewRegistry()
     vi.restoreAllMocks()
@@ -120,7 +123,7 @@ describe('usePreviewRouting', () => {
     expect(window.hermesDesktop.normalizePreviewTarget).not.toHaveBeenCalled()
   })
 
-  it('does not auto-open a preview from tool results', async () => {
+  it('auto-opens and records generated artifacts from tool results', async () => {
     render(
       <PreviewRoutingHarness
         onEvent={handler => {
@@ -131,14 +134,35 @@ describe('usePreviewRouting', () => {
 
     act(() =>
       handleEvent({
-        payload: { inline_diff: '\u001b[38;2;218;165;32ma/preview-demo.html -> b/preview-demo.html\u001b[0m\n' },
+        payload: { result: { path: './dist/index.html' } },
         session_id: 'session-1',
         type: 'tool.complete'
       })
     )
-    act(() => handleEvent({ payload: { path: './dist/index.html' }, session_id: 'session-1', type: 'tool.complete' }))
+
+    await waitFor(() => {
+      expect($previewTarget.get()).toEqual({ ...previewTarget('./dist/index.html'), renderMode: 'preview' })
+    })
+    expect($previewStatusBySession.get()['session-1']).toMatchObject([{ cwd: '/work', target: './dist/index.html' }])
+  })
+
+  it('does not infer previews from non-artifact tool results', async () => {
+    render(
+      <PreviewRoutingHarness
+        onEvent={handler => {
+          handleEvent = handler
+        }}
+      />
+    )
+
+    act(() =>
+      handleEvent({
+        payload: { result: { url: 'https://example.com/docs' } },
+        session_id: 'session-1',
+        type: 'tool.complete'
+      })
+    )
 
     expect($previewTarget.get()).toBeNull()
-    expect(window.localStorage.getItem('hermes.desktop.sessionPreviews.v1')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.ts
@@ -2,6 +2,8 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect } from 'react'
 
 import { gatewayEventCompletedFileDiff } from '@/lib/gateway-events'
+import { extractGeneratedArtifactTargetsFromToolPayload } from '@/lib/generated-artifacts'
+import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import {
   $previewTarget,
   $sessionPreviewRegistry,
@@ -10,8 +12,10 @@ import {
   getSessionPreviewRecord,
   progressPreviewServerRestart,
   requestPreviewReload,
+  setCurrentSessionPreviewTarget,
   setPreviewTarget
 } from '@/store/preview'
+import { recordPreviewArtifact } from '@/store/preview-status'
 import { $currentCwd } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -29,6 +33,35 @@ interface PreviewRoutingOptions {
 
 function asRecord(payload: unknown): Record<string, unknown> {
   return payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {}
+}
+
+function generatedToolTargets(payload: Record<string, unknown>): string[] {
+  const resultTargets = extractGeneratedArtifactTargetsFromToolPayload(payload.result)
+
+  if (resultTargets.length > 0) {
+    return resultTargets
+  }
+
+  const topLevelTargets = extractGeneratedArtifactTargetsFromToolPayload({
+    file: payload.file,
+    filepath: payload.filepath,
+    path: payload.path,
+    preview: payload.preview,
+    result_text: payload.result_text,
+    summary: payload.summary,
+    target: payload.target,
+    url: payload.url
+  })
+
+  if (topLevelTargets.length > 0) {
+    return topLevelTargets
+  }
+
+  const name = typeof payload.name === 'string' ? payload.name : ''
+
+  return name === 'write_file' || name === 'edit_file' || name === 'patch'
+    ? extractGeneratedArtifactTargetsFromToolPayload(payload.args)
+    : []
 }
 
 function activePreviewSessionId(
@@ -51,10 +84,7 @@ export function usePreviewRouting({
   const previewRegistry = useStore($sessionPreviewRegistry)
   const previewSessionId = activePreviewSessionId(activeSessionIdRef, routedSessionId, selectedStoredSessionId)
 
-  // Restore a *user-opened* preview when its session becomes active. Tool
-  // results no longer auto-register/open a preview — the inline preview card in
-  // the tool row is the only entry point, so HTML artifacts never pop the rail
-  // open on their own.
+  // Restore the session preview when its session becomes active.
   useEffect(() => {
     if (currentView !== 'chat' || !previewSessionId) {
       setPreviewTarget(null)
@@ -119,14 +149,31 @@ export function usePreviewRouting({
         return
       }
 
-      // Only refresh an already-open live preview when a file changes; never
-      // open one unprompted. (Preview links are surfaced from the tool row into
-      // the status stack — see tool-fallback.tsx.)
+      // Refresh an already-open live preview when a file changes; generated
+      // artifacts detected below may also open the preview rail for the turn.
       if ($previewTarget.get()?.kind === 'url' && gatewayEventCompletedFileDiff(event)) {
         requestPreviewReload()
       }
+
+      if (event.type === 'tool.complete') {
+        const targets = generatedToolTargets(asRecord(event.payload))
+        const target = targets[0]
+
+        if (target) {
+          const sessionId = activePreviewSessionId(activeSessionIdRef, routedSessionId, selectedStoredSessionId)
+          const cwd = $currentCwd.get() || currentCwd || ''
+
+          recordPreviewArtifact(sessionId, target, cwd)
+
+          void normalizeOrLocalPreviewTarget(target, cwd || undefined).then(preview => {
+            if (preview && (!event.session_id || event.session_id === activeSessionIdRef.current)) {
+              setCurrentSessionPreviewTarget(preview, 'tool-result', target)
+            }
+          })
+        }
+      }
     },
-    [activeSessionIdRef, baseHandleGatewayEvent]
+    [activeSessionIdRef, baseHandleGatewayEvent, currentCwd, routedSessionId, selectedStoredSessionId]
   )
 
   return { handleDesktopGatewayEvent, restartPreviewServer }

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { useI18n } from '@/i18n'
+import { extractGeneratedArtifactTargetsFromText } from '@/lib/generated-artifacts'
 import { triggerHaptic } from '@/lib/haptics'
 import { GitBranchIcon, Loader2Icon, Volume2Icon, VolumeXIcon, XIcon } from '@/lib/icons'
 import { extractPreviewTargets } from '@/lib/preview-targets'
@@ -74,11 +75,13 @@ export const AssistantMessage: FC<{
   )
 
   const previewTargets = useMemo(() => {
-    if (!completedText || !/(https?:\/\/|file:\/\/)/i.test(completedText)) {
+    if (!completedText) {
       return []
     }
 
-    return pickPrimaryPreviewTarget(extractPreviewTargets(completedText))
+    const targets = [...extractPreviewTargets(completedText), ...extractGeneratedArtifactTargetsFromText(completedText)]
+
+    return pickPrimaryPreviewTarget([...new Set(targets)])
   }, [completedText])
 
   const getMessageText = useCallback(() => messageContentText(messageRuntime.getState().content), [messageRuntime])

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -145,6 +145,29 @@ describe('buildToolView file edit diffs', () => {
     expect(view.subtitle).toBe('src/demo.ts')
     expect(view.detail).toBe('')
   })
+
+  it('surfaces generated file artifacts beyond html diffs', () => {
+    expect(
+      buildToolView(
+        part({
+          args: { path: '/tmp/report.pdf' },
+          result: { success: true },
+          toolName: 'write_file'
+        }),
+        ''
+      ).previewTarget
+    ).toBe('/tmp/report.pdf')
+
+    expect(
+      buildToolView(
+        part({
+          result: { output: 'ZIP created: /tmp/test-backup.zip' },
+          toolName: 'terminal'
+        }),
+        ''
+      ).previewTarget
+    ).toBe('/tmp/test-backup.zip')
+  })
 })
 
 describe('buildToolView title actions', () => {

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -1,5 +1,6 @@
 import { type ToolTitleKey, translateNow } from '@/i18n'
 import { normalizeExternalUrl } from '@/lib/external-link'
+import { extractGeneratedArtifactTargetsFromToolPayload } from '@/lib/generated-artifacts'
 import { summarizeShellCommand } from '@/lib/summarize-command'
 import { capitalize, normalize } from '@/lib/text'
 import { extractToolErrorMessage, formatToolResultSummary } from '@/lib/tool-result-summary'
@@ -697,6 +698,20 @@ function durationLabel(resultRecord: Record<string, unknown>): string | undefine
 }
 
 function toolPreviewTarget(toolName: string, args: Record<string, unknown>, result: Record<string, unknown>): string {
+  const generated = extractGeneratedArtifactTargetsFromToolPayload(result)
+
+  if (generated.length > 0) {
+    return generated[0]
+  }
+
+  if (isFileEditTool(toolName)) {
+    const generatedFromArgs = extractGeneratedArtifactTargetsFromToolPayload(args)
+
+    if (generatedFromArgs.length > 0) {
+      return generatedFromArgs[0]
+    }
+  }
+
   const direct =
     firstStringField(result, ['preview', 'url', 'target']) ||
     firstStringField(args, ['preview', 'url', 'target', 'path', 'file', 'filepath']) ||

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/targets.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/targets.ts
@@ -1,3 +1,5 @@
+import { isGeneratedArtifactTarget, looksLikeLocalArtifactPath } from '@/lib/generated-artifacts'
+
 import type { ToolPart } from './types'
 
 export function looksLikeUrl(value: string): boolean {
@@ -5,16 +7,11 @@ export function looksLikeUrl(value: string): boolean {
 }
 
 export function looksLikePath(value: string): boolean {
-  return /^file:\/\//i.test(value) || /^(?:\/|\.{1,2}\/|~\/).+/.test(value)
+  return looksLikeLocalArtifactPath(value)
 }
 
 export function isPreviewableTarget(target: string): boolean {
-  return Boolean(
-    target &&
-    (/^file:\/\//i.test(target) ||
-      /^(?:\/|\.{1,2}\/|~\/).+\.html?$/i.test(target) ||
-      /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/i.test(target))
-  )
+  return isGeneratedArtifactTarget(target)
 }
 
 export function stableHash(value: string): string {

--- a/apps/desktop/src/lib/generated-artifacts.test.ts
+++ b/apps/desktop/src/lib/generated-artifacts.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  extractGeneratedArtifactTargetsFromText,
+  extractGeneratedArtifactTargetsFromToolPayload,
+  isGeneratedArtifactTarget
+} from './generated-artifacts'
+
+describe('generated artifact detection', () => {
+  it('extracts generated file paths from assistant text', () => {
+    expect(
+      extractGeneratedArtifactTargetsFromText(
+        'ZIP created: /tmp/test-backup.zip\nPDF: C:\\Users\\me\\Documents\\report.pdf\nSee https://example.com/docs'
+      )
+    ).toEqual(['/tmp/test-backup.zip', 'C:\\Users\\me\\Documents\\report.pdf'])
+  })
+
+  it('extracts nested tool result paths and JSON-encoded tool output', () => {
+    expect(
+      extractGeneratedArtifactTargetsFromToolPayload({
+        args: { path: './dist/index.html' },
+        result: {
+          message: '{"download_path":"/tmp/report.pdf","ignored":"plain text"}',
+          output_file: '/tmp/archive.zip'
+        }
+      })
+    ).toEqual(['./dist/index.html', '/tmp/report.pdf', '/tmp/archive.zip'])
+  })
+
+  it('keeps localhost previews but rejects ordinary non-artifact links', () => {
+    expect(isGeneratedArtifactTarget('http://localhost:5173/')).toBe(true)
+    expect(isGeneratedArtifactTarget('https://example.com/report.pdf')).toBe(true)
+    expect(isGeneratedArtifactTarget('https://example.com/docs')).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/generated-artifacts.ts
+++ b/apps/desktop/src/lib/generated-artifacts.ts
@@ -1,0 +1,205 @@
+const MARKDOWN_IMAGE_RE = /!\[[^\]]*]\(([^)\s]+)\)/g
+const MARKDOWN_LINK_RE = /\[[^\]]+]\(([^)\s]+)\)/g
+const URL_RE = /https?:\/\/[^\s<>"')]+/g
+const POSIX_PATH_RE = /(^|[\s("'`])((?:\/|~\/|\.\.?\/)[^\s"'`<>]+(?:\.[a-z0-9]{1,10})?)/gi
+const WINDOWS_PATH_RE = /(^|[\s("'`])([A-Za-z]:[\\/][^\s"'`<>]+(?:\.[a-z0-9]{1,10})?)/gi
+const FILE_URL_RE = /file:\/\/[^\s<>"')]+/gi
+const DATA_IMAGE_RE = /data:image\/[a-z0-9.+-]+;base64,[a-z0-9+/=]+/gi
+const KEY_HINT_RE = /(path|file|url|image|artifact|output|download|result|target|preview|href|link)/i
+
+export const GENERATED_ARTIFACT_EXTENSIONS = new Set([
+  '.bmp',
+  '.csv',
+  '.doc',
+  '.docx',
+  '.gif',
+  '.gz',
+  '.htm',
+  '.html',
+  '.jpeg',
+  '.jpg',
+  '.json',
+  '.md',
+  '.mov',
+  '.mp3',
+  '.mp4',
+  '.pdf',
+  '.png',
+  '.svg',
+  '.tar',
+  '.txt',
+  '.wav',
+  '.webp',
+  '.xls',
+  '.xlsx',
+  '.zip'
+])
+
+function normalizeArtifactValue(value: string): string {
+  return value.trim().replace(/[),.;]+$/, '')
+}
+
+export function artifactExtension(value: string): string {
+  const clean = value.split(/[?#]/, 1)[0] || value
+  const idx = clean.lastIndexOf('.')
+
+  return idx >= 0 ? clean.slice(idx).toLowerCase() : ''
+}
+
+export function looksLikeLocalArtifactPath(value: string): boolean {
+  return (
+    /^file:\/\//i.test(value) ||
+    /^(?:\/|~\/|\.{1,2}\/).+/i.test(value) ||
+    /^[A-Za-z]:[\\/].+/.test(value)
+  )
+}
+
+function looksLikePreviewUrl(value: string): boolean {
+  return (
+    /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/i.test(value) ||
+    GENERATED_ARTIFACT_EXTENSIONS.has(artifactExtension(value))
+  )
+}
+
+export function isGeneratedArtifactTarget(value: string): boolean {
+  const normalized = normalizeArtifactValue(value)
+
+  if (!normalized) {
+    return false
+  }
+
+  if (/^data:image\//i.test(normalized)) {
+    return true
+  }
+
+  if (/^https?:\/\//i.test(normalized)) {
+    return looksLikePreviewUrl(normalized)
+  }
+
+  if (!looksLikeLocalArtifactPath(normalized)) {
+    return false
+  }
+
+  return GENERATED_ARTIFACT_EXTENSIONS.has(artifactExtension(normalized))
+}
+
+function collectStringValues(
+  value: unknown,
+  keyPath: string,
+  collector: (value: string, keyPath: string) => void
+): void {
+  if (typeof value === 'string') {
+    collector(value, keyPath)
+
+    return
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => collectStringValues(entry, `${keyPath}.${index}`, collector))
+
+    return
+  }
+
+  if (!value || typeof value !== 'object') {
+    return
+  }
+
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    collectStringValues(child, keyPath ? `${keyPath}.${key}` : key, collector)
+  }
+}
+
+function parseMaybeJson(value: string): unknown {
+  if (!value.trim()) {
+    return null
+  }
+
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}
+
+function pushUnique(targets: string[], seen: Set<string>, value: string): void {
+  const normalized = normalizeArtifactValue(value)
+
+  if (!isGeneratedArtifactTarget(normalized) || seen.has(normalized)) {
+    return
+  }
+
+  seen.add(normalized)
+  targets.push(normalized)
+}
+
+export function extractGeneratedArtifactTargetsFromText(text: string): string[] {
+  const targets: string[] = []
+  const seen = new Set<string>()
+
+  for (const match of text.matchAll(MARKDOWN_IMAGE_RE)) {
+    pushUnique(targets, seen, match[1] || '')
+  }
+
+  for (const match of text.matchAll(MARKDOWN_LINK_RE)) {
+    const start = match.index ?? 0
+
+    if (start > 0 && text[start - 1] === '!') {
+      continue
+    }
+
+    pushUnique(targets, seen, match[1] || '')
+  }
+
+  for (const match of text.matchAll(URL_RE)) {
+    pushUnique(targets, seen, match[0] || '')
+  }
+
+  for (const match of text.matchAll(FILE_URL_RE)) {
+    pushUnique(targets, seen, match[0] || '')
+  }
+
+  for (const match of text.matchAll(DATA_IMAGE_RE)) {
+    pushUnique(targets, seen, match[0] || '')
+  }
+
+  for (const match of text.matchAll(POSIX_PATH_RE)) {
+    pushUnique(targets, seen, match[2] || '')
+  }
+
+  for (const match of text.matchAll(WINDOWS_PATH_RE)) {
+    pushUnique(targets, seen, match[2] || '')
+  }
+
+  return targets
+}
+
+export function extractGeneratedArtifactTargetsFromToolPayload(payload: unknown): string[] {
+  const targets: string[] = []
+  const seen = new Set<string>()
+
+  collectStringValues(payload, '', (value, keyPath) => {
+    const normalized = normalizeArtifactValue(value)
+
+    if (!normalized) {
+      return
+    }
+
+    if (KEY_HINT_RE.test(keyPath) || looksLikeLocalArtifactPath(normalized) || /^https?:\/\//i.test(normalized)) {
+      pushUnique(targets, seen, normalized)
+    }
+
+    for (const target of extractGeneratedArtifactTargetsFromText(normalized)) {
+      pushUnique(targets, seen, target)
+    }
+
+    const parsed = parseMaybeJson(normalized)
+
+    if (parsed !== null) {
+      for (const target of extractGeneratedArtifactTargetsFromToolPayload(parsed)) {
+        pushUnique(targets, seen, target)
+      }
+    }
+  })
+
+  return targets
+}

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { localPreviewTarget } from './local-preview'
+
+describe('localPreviewTarget', () => {
+  it('resolves relative artifact paths against cwd', () => {
+    expect(localPreviewTarget('./dist/index.html', '/work/app')).toMatchObject({
+      path: '/work/app/dist/index.html',
+      previewKind: 'html',
+      url: 'file:///work/app/dist/index.html'
+    })
+  })
+
+  it('classifies PDFs as binary file previews', () => {
+    expect(localPreviewTarget('/tmp/report.pdf')).toMatchObject({
+      binary: true,
+      path: '/tmp/report.pdf',
+      previewKind: 'binary'
+    })
+  })
+
+  it('keeps Windows absolute paths absolute', () => {
+    expect(localPreviewTarget('C:\\Users\\me\\Documents\\report.pdf', '/work')).toMatchObject({
+      path: 'C:\\Users\\me\\Documents\\report.pdf',
+      url: 'file:///C:/Users/me/Documents/report.pdf'
+    })
+  })
+})

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -1,8 +1,23 @@
 import { isDesktopFsRemoteMode, readDesktopFileText } from '@/lib/desktop-fs'
+import { artifactExtension } from '@/lib/generated-artifacts'
 import type { PreviewTarget } from '@/store/preview'
 
 const HTML_EXTENSIONS = new Set(['.htm', '.html'])
 const IMAGE_EXTENSIONS = new Set(['.bmp', '.gif', '.jpeg', '.jpg', '.png', '.svg', '.webp'])
+const BINARY_EXTENSIONS = new Set([
+  '.doc',
+  '.docx',
+  '.gz',
+  '.mov',
+  '.mp3',
+  '.mp4',
+  '.pdf',
+  '.tar',
+  '.wav',
+  '.xls',
+  '.xlsx',
+  '.zip'
+])
 
 const LANGUAGE_BY_EXT: Record<string, string> = {
   '.c': 'c',
@@ -43,13 +58,6 @@ function basename(value: string) {
   return value.split(/[\\/]/).filter(Boolean).pop() || value
 }
 
-function extension(value: string) {
-  const clean = value.split(/[?#]/, 1)[0] || value
-  const idx = clean.lastIndexOf('.')
-
-  return idx >= 0 ? clean.slice(idx).toLowerCase() : ''
-}
-
 function joinPath(base: string, rel: string) {
   if (!base) {
     return rel
@@ -58,10 +66,15 @@ function joinPath(base: string, rel: string) {
   return `${base.replace(/\/+$/, '')}/${rel.replace(/^\.?\//, '')}`
 }
 
+function isAbsoluteFileTarget(value: string): boolean {
+  return /^file:\/\//i.test(value) || value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)
+}
+
 function pathToFileUrl(path: string) {
-  const encoded = path
+  const normalizedPath = path.replace(/\\/g, '/')
+  const encoded = normalizedPath
     .split('/')
-    .map(part => encodeURIComponent(part))
+    .map(part => (part.endsWith(':') ? part : encodeURIComponent(part)))
     .join('/')
 
   return `file://${encoded.startsWith('/') ? encoded : `/${encoded}`}`
@@ -86,23 +99,22 @@ export function localPreviewTarget(rawTarget: string, cwd?: string | null): Prev
     } catch {
       path = raw.replace(/^file:\/\//i, '')
     }
-  } else if (!raw.startsWith('/') && cwd) {
+  } else if (!isAbsoluteFileTarget(raw) && cwd) {
     path = joinPath(cwd, raw)
   }
 
-  const ext = extension(path)
+  const ext = artifactExtension(path)
   const isHtml = HTML_EXTENSIONS.has(ext)
   const isImage = IMAGE_EXTENSIONS.has(ext)
+  const isBinary = BINARY_EXTENSIONS.has(ext)
 
   return {
+    binary: isBinary || undefined,
     kind: 'file',
     label: basename(path),
     language: LANGUAGE_BY_EXT[ext] || 'text',
     path,
-    // Renderer fallback can't stat/sniff without reading; assume text unless
-    // image/html extension says otherwise. LocalFilePreview still guards
-    // binary/large files when readFileText/readFileDataUrl returns metadata.
-    previewKind: isHtml ? 'html' : isImage ? 'image' : 'text',
+    previewKind: isHtml ? 'html' : isImage ? 'image' : isBinary ? 'binary' : 'text',
     source: raw,
     url: pathToFileUrl(path)
   }


### PR DESCRIPTION
## What does this PR do?

Adds shared desktop generated-artifact detection so files produced by agent/tool output are attached in chat/status UI and can auto-open in the preview rail.

## Shared root cause

Desktop had multiple narrow artifact detectors: assistant messages only recognized explicit `#preview` links, tool rows only treated HTML/local dev URLs as previewable, and preview routing only checked a few top-level event fields. Generated files commonly arrive as nested tool results, JSON-encoded result text, terminal output, or Windows/POSIX paths, so PDFs/ZIPs/images and other deliverables were missed.

## Related Issue

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `apps/desktop/src/lib/generated-artifacts.ts` to extract artifact targets from assistant prose, nested tool payloads, JSON-encoded results, POSIX paths, Windows paths, file URLs, data images, and known deliverable extensions.
- Reused that detector from desktop tool fallback rendering, assistant messages, and `usePreviewRouting` so generated artifacts are recorded in the status stack and tool-complete artifacts open the preview rail.
- Expanded local preview classification for binary deliverables like PDF/DOCX/XLSX/ZIP and preserved Windows absolute paths when building file URLs.
- Added focused desktop regression tests for artifact extraction, local preview classification, tool fallback detection, and tool-event preview routing.

## How this fixes each issue

- #46444: generated file paths in assistant/tool output now produce desktop preview attachment chips/status artifacts instead of remaining plain text only, including ZIP/PDF/image-style deliverables.
- #47481: tool completions now scan nested result/top-level payload fields and JSON/text output for generated file targets, record them, and auto-open the right preview rail for the active session.

## How to Test

1. Ask the desktop agent to create `/tmp/report.pdf` or `/tmp/test-backup.zip`; the generated file should appear as an artifact chip/status row instead of only a raw path.
2. Trigger a tool completion that returns `{ result: { path: "./dist/index.html" } }`; the preview rail should open for the active session.
3. Verify Windows-style output such as `C:\\Users\\me\\Documents\\report.pdf` is detected and normalized as a file preview target.

Local checks run:

- `git diff --check` passed.
- `python scripts/check-windows-footguns.py --diff origin/main` passed; the scanner reported 0 scanned files because this diff only changes TypeScript.
- `pytest tests/ -q -x --timeout=60` was attempted with the required timeout wrapper, but collection aborted before tests ran because `fastapi`/dashboard dependencies are missing and Python package installation is blocked by the externally-managed Homebrew Python environment.
- `npm --workspace apps/desktop run test:ui -- src/lib/generated-artifacts.test.ts src/lib/local-preview.test.ts src/components/assistant-ui/tool/fallback-model.test.ts src/app/session/hooks/use-preview-routing.test.tsx` was attempted, but the workspace has no installed node dependencies (`vitest: command not found`).

## Checklist

### Code

- [x] I've read the Contributing Guide and AGENTS.md instructions
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass locally; blocked by missing dashboard dependencies in this environment
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS on darwin-arm64 (static/local command checks)

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered: preserves Windows absolute generated-file paths
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

Not captured locally; desktop Vitest/UI execution is blocked by missing node dependencies in this worktree.

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #46444
Refs #47481

<!-- autocontrib:worker-id=pr-spanning-c264006c kind=pr-open -->