### PR TITLE
fix(docker): survive root-owned leftover .gateway-*.tmp staging dirs at boot

### DIFF
--- a/docker/cont-init.d/02-reconcile-profiles
+++ b/docker/cont-init.d/02-reconcile-profiles
@@ -28,6 +28,18 @@ set -e
 # starts root-owned by s6-overlay.
 chown hermes:hermes /run/service 2>/dev/null || true
 
+# Sweep leftover registration staging dirs from an interrupted previous
+# run while we are still root. /run/service is tmpfs and survives
+# `docker restart` (not `docker rm`), so a run interrupted mid-
+# registration leaves a root-owned 0700 `.gateway-<profile>.tmp` that
+# the post-drop reconciler can neither stat, list, nor delete, wedging
+# boot (#60774). Dot-prefixed entries are never supervised by s6-svscan
+# and the atomic publish renames to the dotless live name, so any
+# surviving `.tmp` (or `.tmp.stale-*` set aside by the reconciler) is
+# always garbage. Deliberately NOT a recursive chown of /run/service:
+# the .s6-svscan internals and live supervise/ dirs must stay root-owned.
+find /run/service -maxdepth 1 -name '.gateway-*.tmp*' -exec rm -rf {} + 2>/dev/null || true
+
 # Make the svscan control FIFO hermes-writable so s6-svscanctl -a
 # / -an work for the hermes user. The FIFO is created by s6-svscan
 # at PID-1 startup, so by the time this cont-init.d script runs it

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -415,6 +415,7 @@ def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
 
     from hermes_cli.service_manager import (
         S6ServiceManager,
+        _reset_staging_dir,
         _seed_supervise_skeleton,
         validate_profile_name,
     )
@@ -432,10 +433,9 @@ def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
     # name, so the published slot is unchanged.
     tmp_dir = service_dir.with_name("." + service_dir.name + ".tmp")
 
-    # Wipe any leftover tmp from a previous interrupted run.
-    if tmp_dir.exists():
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-    tmp_dir.mkdir(parents=True)
+    # Wipe any leftover tmp from a previous interrupted run. Robust against
+    # a root-owned leftover this (post-drop) user cannot delete (#60774).
+    _reset_staging_dir(tmp_dir)
 
     try:
         (tmp_dir / "type").write_text("longrun\n")

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -413,6 +413,41 @@ _HERMES_UID = 10000
 _HERMES_GID = 10000
 
 
+def _reset_staging_dir(tmp_dir: Path) -> None:
+    """Clear a leftover registration staging dir and create it fresh.
+
+    A previous interrupted run can leave ``tmp_dir`` behind. Usually a
+    plain rmtree suffices, but when the leftover is owned by another user
+    — a root-owned ``0700`` dir from a run interrupted before the
+    cont-init privilege drop (issue #60774) — this process can neither
+    list nor delete it, ``rmtree(ignore_errors=True)`` silently does
+    nothing, and the subsequent ``mkdir`` crashes registration.
+    ``Path.exists()`` itself can also raise ``PermissionError`` (EACCES is
+    not in pathlib's ignored-errno set).
+
+    In that case, rename the leftover aside instead: rename only needs
+    write+search permission on the scandir, which the reconciler user
+    always has. The renamed entry keeps its dot prefix so s6-svscan keeps
+    ignoring it, and the cont-init boot script sweeps ``.gateway-*.tmp*``
+    entries as root on the next container start.
+    """
+    import os
+    import shutil
+    import time
+
+    try:
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+    except OSError:
+        pass
+    try:
+        tmp_dir.mkdir(parents=True)
+    except OSError:
+        stale = tmp_dir.with_name(f"{tmp_dir.name}.stale-{time.time_ns()}")
+        os.replace(tmp_dir, stale)
+        tmp_dir.mkdir(parents=True)
+
+
 def _seed_supervise_skeleton(svc_dir: Path) -> None:
     """Pre-create the ``supervise/`` and top-level ``event/`` skeleton
     inside a service directory, owned by the hermes user.
@@ -982,9 +1017,7 @@ class S6ServiceManager:
         # rescan land inside the ~ms seed window). The atomic rename to
         # the dotless live name below is unaffected.
         tmp_dir = svc_dir.with_name("." + svc_dir.name + ".tmp")
-        if tmp_dir.exists():
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-        tmp_dir.mkdir(parents=True)
+        _reset_staging_dir(tmp_dir)
 
         try:
             (tmp_dir / "type").write_text("longrun\n")

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -1136,3 +1136,82 @@ def test_s6_log_run_chowns_gateways_parent(s6_scandir, fake_subprocess_run) -> N
     # The parent path must be a runtime env expansion, never a baked-in
     # absolute path (same contract as the log_dir itself).
     assert '/opt/data/logs/gateways"' not in log_text
+
+
+# ---------------------------------------------------------------------------
+# _reset_staging_dir (#60774)
+# ---------------------------------------------------------------------------
+
+
+def test_reset_staging_dir_wipes_normal_leftover(tmp_path) -> None:
+    from hermes_cli.service_manager import _reset_staging_dir
+
+    staging = tmp_path / ".gateway-default.tmp"
+    staging.mkdir()
+    (staging / "run").write_text("#!/bin/sh\n")
+
+    _reset_staging_dir(staging)
+
+    assert staging.is_dir()
+    assert list(staging.iterdir()) == []
+
+
+def test_reset_staging_dir_creates_missing_dir(tmp_path) -> None:
+    from hermes_cli.service_manager import _reset_staging_dir
+
+    staging = tmp_path / ".gateway-default.tmp"
+    _reset_staging_dir(staging)
+    assert staging.is_dir()
+
+
+def test_reset_staging_dir_renames_undeletable_leftover_aside(tmp_path, monkeypatch) -> None:
+    """A leftover owned by another user (root-owned 0700 from a run
+    interrupted before the cont-init privilege drop) can't be listed or
+    removed by this process — rmtree(ignore_errors=True) silently does
+    nothing. The helper must move it aside and still produce a fresh dir."""
+    import shutil as shutil_mod
+
+    from hermes_cli.service_manager import _reset_staging_dir
+
+    staging = tmp_path / ".gateway-default.tmp"
+    staging.mkdir()
+    (staging / "marker").write_text("stale")
+
+    # Simulate the undeletable-foreign-dir case: rmtree silently no-ops
+    # (exactly what ignore_errors=True does on EACCES).
+    monkeypatch.setattr(shutil_mod, "rmtree", lambda *a, **k: None)
+
+    _reset_staging_dir(staging)
+
+    assert staging.is_dir()
+    assert list(staging.iterdir()) == []
+    stale = [p for p in tmp_path.iterdir() if ".tmp.stale-" in p.name]
+    assert len(stale) == 1
+    assert (stale[0] / "marker").read_text() == "stale"
+
+
+def test_reset_staging_dir_survives_permissionerror_on_exists(tmp_path, monkeypatch) -> None:
+    """Path.exists() raises PermissionError when stat is denied (EACCES is
+    not in pathlib's ignored-errno set) — the helper must not crash."""
+    import shutil as shutil_mod
+    from pathlib import Path
+
+    from hermes_cli.service_manager import _reset_staging_dir
+
+    staging = tmp_path / ".gateway-default.tmp"
+    staging.mkdir()
+
+    real_exists = Path.exists
+
+    def fake_exists(self, **kwargs):
+        if self == staging:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_exists(self, **kwargs)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(shutil_mod, "rmtree", lambda *a, **k: None)
+
+    _reset_staging_dir(staging)
+
+    assert real_exists(staging)
+    assert list(staging.iterdir()) == []


### PR DESCRIPTION
## What does this PR do?

Fixes #60774: container boot wedges with a `PermissionError` when an interrupted previous run leaves a root-owned `0700` `.gateway-<profile>.tmp` staging dir in `/run/service` (tmpfs — survives `docker restart`). The `02-reconcile-profiles` chown of `/run/service` is non-recursive, so after the privilege drop the hermes-run reconciler can neither stat, list, nor delete the leftover: `rmtree(ignore_errors=True)` silently no-ops and the subsequent `mkdir` crashes registration.

**Two-layer fix:**

1. **Boot script (root side, the real fix):** `02-reconcile-profiles` sweeps `.gateway-*.tmp*` entries as root before dropping privileges. Dot-prefixed entries are never supervised by s6-svscan and the atomic publish renames to the dotless live name, so any surviving staging dir is by definition garbage. This is deliberately **not** the recursive `chown` of `/run/service` proposed in the issue — the `.s6-svscan` internals and live `supervise/` dirs must stay root-owned (the script's own comments document that invariant, and handing them to the hermes user would let a compromised gateway tamper with root-run service supervision).

2. **Python (defense in depth):** new `_reset_staging_dir()` — shared by `S6ServiceManager.register_profile_gateway` and `container_boot._register_service`, replacing their duplicated wipe blocks — tolerates a leftover the current user cannot delete: it renames the dir aside (rename needs only write+search on the scandir, which the reconciler user always has) and creates a fresh one. It also guards `Path.exists()` raising `PermissionError` (EACCES is not in pathlib's ignored-errno set). Set-aside `.tmp.stale-*` entries keep the dot prefix (s6 ignores them) and are swept by the boot script on the next start.

This kills the failure class at both layers: the boot path can't hit it anymore, and the runtime registration path (profile create at runtime, which never passes through cont-init) recovers instead of crashing.

## Related Issue

Fixes #60774

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `docker/cont-init.d/02-reconcile-profiles` — root-side sweep of `.gateway-*.tmp*` before the privilege drop, with a comment documenting why not `chown -R`
- `hermes_cli/service_manager.py` — new `_reset_staging_dir()` helper; `register_profile_gateway` uses it
- `hermes_cli/container_boot.py` — `_register_service` uses the shared helper (removes the duplicated fragile wipe)
- `tests/hermes_cli/test_service_manager.py` — 4 new tests: normal leftover wiped, missing dir created, undeletable leftover renamed aside with content preserved, `PermissionError` on `exists()` survived

## How to Test

1. `pytest tests/hermes_cli/test_service_manager.py -q` → 70 passed (4 new)
2. `pytest tests/hermes_cli/test_container_boot.py -q` → 55 passed
3. `sh -n docker/cont-init.d/02-reconcile-profiles` → clean
4. Manual repro per the issue: interrupt the container during `02-reconcile-profiles` while `_register_service` is staging, `docker restart` — boot now completes; the stale dir is removed by the root-side sweep.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (also checked the issue's timeline for fork PRs)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the test suites listed above and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (CachyOS, Python 3.12)

### Documentation & Housekeeping

- [x] Relevant documentation — behavior + invariants documented in the script comment and helper docstring; N/A otherwise
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — container-only code path (s6-overlay Linux); host platforms untouched
