### PR TITLE
fix(lazy_deps): unpin huggingface-hub to a range so refresh stops breaking Hindsight

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -294,6 +294,53 @@ class TestIsSatisfiedVersionAware:
         assert ld._is_satisfied("mautrix[encryption]==0.21.0") is False
 
 
+class TestSharedDependencyPins:
+    """Pins on packages other Hermes features install transitively must be
+    ranges, not == pins: active_features() flags a feature "active" from mere
+    package presence, so a hard pin makes the post-update lazy refresh
+    downgrade the shared package underneath its other consumers (#60783)."""
+
+    # transformers (via sentence-transformers, the Hindsight local-embedding
+    # provider) requires this range of huggingface-hub.
+    _TRANSFORMERS_HF_HUB_REQ = ">=1.5.0,<2.0"
+
+    def _hub_spec_tail(self):
+        (spec,) = ld.LAZY_DEPS["tool.trace_upload"]
+        assert ld._pkg_name_from_spec(spec) == "huggingface-hub"
+        return ld._specifier_from_spec(spec)
+
+    def test_trace_upload_hub_pin_admits_transformers_range(self):
+        """A version satisfying transformers' floor must satisfy our spec too,
+        so the refresh pass never downgrades it out from under transformers."""
+        from packaging.specifiers import SpecifierSet
+        from packaging.version import Version
+
+        ours = SpecifierSet(self._hub_spec_tail())
+        # Representative versions across transformers' accepted range.
+        for v in ("1.5.0", "1.22.0", "1.99.0"):
+            assert Version(v) in SpecifierSet(self._TRANSFORMERS_HF_HUB_REQ)
+            assert Version(v) in ours, (
+                f"tool.trace_upload huggingface-hub spec {ours!r} rejects "
+                f"{v}, which transformers accepts — the lazy refresh would "
+                f"downgrade the shared package and break Hindsight (#60783)"
+            )
+
+    def test_transformers_compatible_hub_version_is_satisfied(self, monkeypatch):
+        """hermes update must treat an already-compatible newer hub version
+        as current instead of reinstalling the old pin."""
+        from importlib.metadata import PackageNotFoundError
+
+        def _version(pkg):
+            if pkg == "huggingface-hub":
+                return "1.22.0"
+            raise PackageNotFoundError(pkg)
+
+        import importlib.metadata as _md
+        monkeypatch.setattr(_md, "version", _version)
+
+        assert ld.feature_missing("tool.trace_upload") == ()
+
+
 # ---------------------------------------------------------------------------
 # active_features + refresh_active_features (Piece A — hermes update wiring)
 # ---------------------------------------------------------------------------

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -239,7 +239,15 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "starlette==1.0.1",  # CVE-2026-48710 — keep in sync with pyproject [computer-use]
     ),
     # HF Agent Trace Viewer upload (hermes trace upload / /upload-trace).
-    "tool.trace_upload": ("huggingface-hub==1.2.3",),
+    # RANGE, not an == pin: huggingface-hub is shared with transformers /
+    # sentence-transformers (Hindsight local embeddings), which require
+    # huggingface-hub>=1.5.0,<2.0. A hard pin makes the post-update lazy
+    # refresh downgrade the shared package underneath them and break their
+    # import (#60783) — active_features() flags this feature "active" from
+    # mere package presence, so the downgrade fires even for users who never
+    # ran a trace upload. The HfApi surface used here (whoami / create_repo /
+    # upload_file) is stable across the whole 1.x line.
+    "tool.trace_upload": ("huggingface-hub>=1.2.3,<2.0",),
 }
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #60783: `hermes update` downgrades `huggingface-hub` to a stale `==1.2.3` pin, breaking Hindsight local embeddings (`transformers`, via `sentence-transformers`, requires `huggingface-hub>=1.5.0,<2.0`).

**Mechanism:** `huggingface-hub` is a *shared* dependency. `active_features()` marks a lazy feature "active" from mere package presence, so having `sentence-transformers` installed flags `tool.trace_upload` as active even for users who never ran a trace upload. On the next `hermes update`, `_refresh_active_lazy_features()` sees the `==1.2.3` pin unsatisfied and force-downgrades the shared package underneath transformers → Hindsight fails on startup with `ImportError`.

**Fix:** widen the pin to `huggingface-hub>=1.2.3,<2.0`. Ranges are the norm in `LAZY_DEPS` (`mistralai>=2.3.0,<3`, `slack-bolt>=1.18.0,<2`, …) — the hard pin here was the outlier, introduced with the trace-upload feature a day ago. With the range:

- every transformers-compatible version satisfies the spec, so the refresh pass reports **current** instead of downgrading;
- a fresh lazy install resolves to a current 1.x;
- a lone trace-upload user already on 1.2.3 stays put (no churn);
- the `<2.0` cap preserves the pin's ability to carry a future CVE/major-break response.

The `HfApi` surface trace upload uses (`whoami` / `create_repo` / `upload_file`, see `agent/trace_upload.py`) is stable across the whole 1.x line, so the widened range is safe for the feature itself.

The deeper mechanism — presence-based `active_features()` false-positively activating features whose packages arrived transitively (#44404) — is intentionally left out of scope; this fixes the user-breaking conflict without redesigning activation tracking.

## Related Issue

Fixes #60783 (same mechanism noted in #44404)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/lazy_deps.py` — `tool.trace_upload` spec `huggingface-hub==1.2.3` → `huggingface-hub>=1.2.3,<2.0`, with a comment explaining why this one must stay a range
- `tests/tools/test_lazy_deps.py` — new `TestSharedDependencyPins`: (1) the trace_upload spec must admit every version transformers accepts — fails loudly if someone re-pins it into conflict; (2) `feature_missing()` treats a newer in-range installed hub as satisfied (the exact `hermes update` no-downgrade path)

## How to Test

1. `pytest tests/tools/test_lazy_deps.py tests/tools/test_lazy_deps_durable_target.py tests/test_package_json_lazy_deps.py -q` → 85 passed, 1 skipped (3 new)
2. Repro from the issue: with `sentence-transformers` installed and `huggingface-hub` at e.g. 1.22.0, run the refresh pass — `tool.trace_upload` now reports `current`; previously it reinstalled `==1.2.3` and broke the transformers import.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (also checked the issue timeline for fork PRs)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the test suites listed above and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (CachyOS, Python 3.12)

### Documentation & Housekeeping

- [x] Relevant documentation — rationale documented at the pin site; N/A otherwise
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — pure version-spec change; reporter is on Windows 10, nothing platform-specific
