### PR TITLE
fix(approval): gate remote repository mutations

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch as mock_patch
 
+import pytest
+
 import tools.approval as approval_module
 from hermes_constants import get_hermes_home
 from tools.approval import (
@@ -1533,11 +1535,12 @@ class TestGitDestructiveOps:
         dangerous, _, _ = detect_dangerous_command(cmd)
         assert dangerous is False
 
-    def test_safe_git_push_not_flagged(self):
-        """Normal push without --force must not be flagged."""
+    def test_git_push_requires_approval(self):
+        """Normal push mutates remote repository state and must be approved."""
         cmd = "git push origin main"
-        dangerous, _, _ = detect_dangerous_command(cmd)
-        assert dangerous is False
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "remote repository" in desc.lower()
 
     def test_git_branch_lowercase_d_also_flagged(self):
         """git branch -d triggers approval too — IGNORECASE is global.
@@ -1576,6 +1579,79 @@ class TestGitDestructiveOps:
         cmd = "git branch --delete feature-branch"
         dangerous, _, _ = detect_dangerous_command(cmd)
         assert dangerous is False
+
+
+class TestRemoteMutationApproval:
+    @pytest.mark.parametrize(
+        ("command", "needle"),
+        [
+            ("gh pr merge 60 --squash --delete-branch", "pr merge"),
+            ("gh api -X DELETE repos/o/r/git/refs/heads/main", "api mutating"),
+            ("gh api --method PATCH repos/o/r/issues/1 -f title=x", "api mutating"),
+            (
+                "gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:\"x\"}) { clientMutationId } }'",
+                "graphql mutation",
+            ),
+            ("gh release create v1.2.3 dist/app.zip", "release mutation"),
+            ("gh repo delete owner/repo --yes", "repository mutation"),
+            ("git push origin main", "remote repository"),
+            ("git push --force-with-lease origin main", "force"),
+            ("git push origin --delete feature", "delete remote ref"),
+            ("git push origin :feature", "delete remote ref"),
+        ],
+    )
+    def test_remote_mutation_commands_require_approval(self, command, needle):
+        dangerous, key, desc = detect_dangerous_command(command)
+        assert dangerous is True
+        assert key is not None
+        assert needle in desc.lower()
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh pr view 60 --json title",
+            "gh api repos/o/r",
+            "gh api -X GET repos/o/r",
+            "git status",
+            "git fetch origin main",
+            "git push --dry-run origin main",
+        ],
+    )
+    def test_read_only_or_dry_run_repository_commands_stay_safe(self, command):
+        dangerous, key, desc = detect_dangerous_command(command)
+        assert dangerous is False
+        assert key is None
+        assert desc is None
+
+    def test_git_push_comment_dry_run_does_not_bypass_detection(self):
+        dangerous, _, desc = detect_dangerous_command(
+            "git push origin main # --dry-run appears only in a comment"
+        )
+        assert dangerous is True
+        assert "remote repository" in desc.lower()
+
+    def test_remote_mutation_fails_closed_without_approval_surface(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
+
+        session_key = "remote-mutation-no-surface-test"
+        token = approval_module.set_current_session_key(session_key)
+        try:
+            approval_module.disable_session_yolo(session_key)
+            result = approval_module.check_all_command_guards(
+                "gh pr merge 60 --squash --delete-branch",
+                "local",
+            )
+        finally:
+            approval_module.reset_current_session_key(token)
+
+        assert result["approved"] is False
+        assert result["outcome"] == "blocked"
+        assert result["user_consent"] is False
+        assert "Remote repository mutation" in result["message"]
 
 
 class TestChmodExecuteCombo:

--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -157,6 +157,44 @@ def test_guard_headless_local_approved(monkeypatch):
     assert A.check_execute_code_guard("import os", "local")["approved"] is True
 
 
+def test_guard_headless_local_blocks_embedded_remote_mutation(monkeypatch):
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+
+    res = A.check_execute_code_guard(
+        'from hermes_tools import terminal\n'
+        'terminal("gh pr merge 60 --squash --delete-branch")',
+        "local",
+    )
+
+    assert res["approved"] is False
+    assert res["outcome"] == "blocked"
+    assert res["user_consent"] is False
+    assert "Remote repository mutation" in res["message"]
+
+
+def test_guard_execute_code_session_approval_does_not_cover_remote_mutation(gw_session):
+    A.approve_session(gw_session, "execute_code")
+    try:
+        _register_resolver(gw_session, "deny")
+        res = A.check_execute_code_guard(
+            'import subprocess\n'
+            'subprocess.run("gh pr merge 60 --squash --delete-branch", shell=True)',
+            "local",
+        )
+    finally:
+        with A._lock:
+            A._session_approved.get(gw_session, set()).discard("execute_code")
+
+    assert res["approved"] is False
+    assert res["outcome"] == "denied"
+    assert res["user_consent"] is False
+    assert "remote repository mutation" in res["description"].lower()
+
+
 def test_guard_cron_deny_blocks(monkeypatch):
     monkeypatch.setenv("HERMES_CRON_SESSION", "1")
     monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -3,12 +3,22 @@
 import tools.terminal_tool as terminal_tool
 
 
-def setup_function():
+def _reset_test_state():
     terminal_tool._reset_cached_sudo_passwords()
+    try:
+        from gateway.session_context import reset_session_vars
+
+        reset_session_vars()
+    except Exception:
+        pass
+
+
+def setup_function():
+    _reset_test_state()
 
 
 def teardown_function():
-    terminal_tool._reset_cached_sudo_passwords()
+    _reset_test_state()
 
 
 def test_searching_for_sudo_does_not_trigger_rewrite(monkeypatch):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -584,6 +584,17 @@ DANGEROUS_PATTERNS = [
     (r'\bkillall\s+(-[^\s]*\s+)*-s\s+(KILL|SIGKILL|9)\b', "force kill processes (killall -s KILL)"),
     (r'\bkillall\s+(-[^\s]*\s+)*-r\b', "kill processes by regex (killall -r)"),
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
+    # Remote repository mutations: these change shared GitHub/git state outside
+    # the local workspace, so an autonomous agent must obtain human approval
+    # before running them. Keep these before the generic shell/script execution
+    # patterns so embedded `bash -c 'gh pr merge ...'` reports the remote action.
+    (r'\bgh\s+pr\s+merge\b', "GitHub PR merge (remote repository mutation)"),
+    (r'\bgh\s+repo\s+(?:delete|archive|transfer|rename|edit)\b', "GitHub repository mutation"),
+    (r'\bgh\s+release\s+(?:create|delete|upload|edit)\b', "GitHub release mutation"),
+    (r'\bgh\s+api\b[^;|&\n#]*?(?:-X|--method)(?:=|\s+)?(?:POST|PUT|PATCH|DELETE)\b',
+     "GitHub API mutating request"),
+    (r'\bgh\s+api\b[^;|&\n#]*?\bgraphql\b[^;|&\n#]*?\bmutation\b',
+     "GitHub API GraphQL mutation"),
     # Any shell invocation via -c or combined flags like -lc, -ic, etc.
     (r'\b(bash|sh|zsh|ksh)\s+-[^\s]*c(\s+|$)', "shell command via -c/-lc flag"),
     (r'\b(python[23]?|perl|ruby|node)\s+-[ec]\s+', "script execution via -e/-c flag"),
@@ -713,6 +724,10 @@ DANGEROUS_PATTERNS = [
     (r'\bgit\s+reset\s+--h(?:a(?:r(?:d)?)?)?\b', "git reset --hard (destroys uncommitted changes)"),
     (r'\bgit\s+push\b.*--forc[a-z]*\b', "git force push (rewrites remote history)"),
     (r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
+    (r'\bgit\s+push\b(?![^;|&\n#]*--dry-run\b)[^;|&\n]*(?:--delete\b|\s:[^\s;|&\n]+)',
+     "git push delete remote ref"),
+    (r'\bgit\s+push\b(?![^;|&\n#]*--dry-run\b)',
+     "git push (remote repository mutation)"),
     (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
     (r'\bgit\s+branch\s+-D\b', "git branch force delete"),
     # `-D` is shorthand for `-d --force`; the long-flag spellings
@@ -756,6 +771,33 @@ DANGEROUS_PATTERNS = [
     (r'\bsudo\b[^;|&\n]*?\s+-[a-z]*[sa][a-z]*\b',
      "sudo with combined-flag privilege escalation"),
 ]
+
+
+REMOTE_REPOSITORY_MUTATION_PATTERN_KEYS = frozenset({
+    "GitHub PR merge (remote repository mutation)",
+    "GitHub repository mutation",
+    "GitHub release mutation",
+    "GitHub API mutating request",
+    "GitHub API GraphQL mutation",
+    "git push (remote repository mutation)",
+    "git push delete remote ref",
+    "git force push (rewrites remote history)",
+    "git force push short flag (rewrites remote history)",
+})
+
+
+def _requires_human_for_remote_repository_mutation(pattern_key: str | None) -> bool:
+    """Return True for command patterns that mutate shared repository state."""
+    return bool(pattern_key in REMOTE_REPOSITORY_MUTATION_PATTERN_KEYS)
+
+
+def _remote_repository_mutation_no_human_message(description: str | None) -> str:
+    return (
+        f"BLOCKED: Remote repository mutation requires human approval ({description}) "
+        "but no interactive user or gateway is present to approve it. "
+        "Do not merge pull requests, push refs, mutate releases, or call mutating "
+        "GitHub APIs from an unattended session."
+    )
 
 
 # Pre-compiled variant (same rationale as HARDLINE_PATTERNS_COMPILED above).
@@ -2280,6 +2322,7 @@ def check_dangerous_command(command: str, env_type: str,
     if not is_dangerous:
         return {"approved": True, "message": None}
 
+    requires_human = _requires_human_for_remote_repository_mutation(pattern_key)
     return _run_approval_gate(
         pattern_key=pattern_key,
         description=description,
@@ -2294,6 +2337,11 @@ def check_dangerous_command(command: str, env_type: str,
         ),
         autoapprove_log_prefix=(
             "AUTO-APPROVED dangerous command in non-interactive non-gateway context"
+        ),
+        fail_closed_when_no_human=requires_human,
+        no_human_block_message=(
+            _remote_repository_mutation_no_human_message(description)
+            if requires_human else ""
         ),
     )
 
@@ -2594,15 +2642,16 @@ def check_all_command_guards(command: str, env_type: str,
     is_cli = _is_interactive_cli()
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
+    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    requires_human = _requires_human_for_remote_repository_mutation(pattern_key)
 
     # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
-    # flows, we do not block on approvals and we skip external guard work.
+    # flows, we do not block on approvals and we skip external guard work,
+    # except for remote repository mutations where silence cannot be consent.
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
         if env_var_enabled("HERMES_CRON_SESSION"):
             if _get_cron_approval_mode() == "deny":
-                # Run detection to get a description for the block message
-                is_dangerous, _pk, description = detect_dangerous_command(command)
                 if is_dangerous:
                     return {
                         "approved": False,
@@ -2661,6 +2710,20 @@ def check_all_command_guards(command: str, env_type: str,
                             ),
                         }
                     # else: tirith_fail_open is True — allow as before
+        elif requires_human:
+            logger.warning(
+                "BLOCKED remote repository mutation in non-interactive "
+                "non-gateway context (pattern: %s): %s",
+                pattern_key, command[:200],
+            )
+            return {
+                "approved": False,
+                "message": _remote_repository_mutation_no_human_message(description),
+                "pattern_key": pattern_key,
+                "description": description,
+                "outcome": "blocked",
+                "user_consent": False,
+            }
         return {"approved": True, "message": None}
 
     # --- Phase 1: Gather findings from both checks ---
@@ -2707,9 +2770,6 @@ def check_all_command_guards(command: str, env_type: str,
             }
         # else: tirith_fail_open is True — allow as before (tirith_result stays "allow")
 
-    # Dangerous command check (detection only, no approval)
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
-
     # --- Phase 2: Decide ---
 
     # Collect warnings that need approval
@@ -2741,7 +2801,11 @@ def check_all_command_guards(command: str, env_type: str,
     # When approvals.mode=smart, ask the aux LLM before prompting the user.
     # Inspired by OpenAI Codex's Smart Approvals guardian subagent
     # (openai/codex#13860).
-    if approval_mode == "smart":
+    requires_explicit_human = any(
+        _requires_human_for_remote_repository_mutation(key)
+        for key, _, _ in warnings
+    )
+    if approval_mode == "smart" and not requires_explicit_human:
         combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
         verdict = _smart_approve(command, combined_desc_for_llm)
         if verdict == "approve":
@@ -2962,19 +3026,32 @@ def check_execute_code_guard(code: str, env_type: str,
     contract as ``check_all_command_guards``.
 
     Scope (documented limitation, #30882): in a purely local non-interactive
-    non-gateway session (no TTY, not gateway, not cron-deny) this returns
-    approved — matching the existing terminal auto-approve contract. The
-    hardline floor still blocks catastrophic ``terminal()`` commands the script
-    issues; running arbitrary code headlessly without any approval surface is
-    trusted-by-config (set a gateway/ask surface or ``approvals.cron_mode`` to
-    require approval).
+    non-gateway session (no TTY, not gateway, not cron-deny) benign scripts
+    return approved — matching the existing terminal auto-approve contract.
+    Remote repository mutations are the exception: they fail closed without a
+    human approval surface because they alter shared state outside the local
+    workspace. The hardline floor still blocks catastrophic ``terminal()``
+    commands the script issues; running arbitrary code headlessly without any
+    approval surface is otherwise trusted-by-config (set a gateway/ask surface
+    or ``approvals.cron_mode`` to require approval).
     """
-    pattern_key = "execute_code"
-    description = (
+    execute_code_pattern_key = "execute_code"
+    execute_code_description = (
         "execute_code script execution. The script can spawn subprocesses or "
         "mutate files without passing through terminal command approval; "
         "approval is one-shot for this run."
     )
+    _script_is_dangerous, script_pattern_key, script_description = detect_dangerous_command(code)
+    script_requires_human = _requires_human_for_remote_repository_mutation(script_pattern_key)
+    if script_requires_human:
+        pattern_key = script_pattern_key
+        description = (
+            f"{script_description} embedded in execute_code script. "
+            f"{execute_code_description}"
+        )
+    else:
+        pattern_key = execute_code_pattern_key
+        description = execute_code_description
 
     # Isolated backends already sandbox the child — matches the container skip
     # in check_all_command_guards / check_dangerous_command. Docker stops
@@ -3019,6 +3096,15 @@ def check_execute_code_guard(code: str, env_type: str,
     #     prompt would fire on every execute_code call.
     #   * Local non-interactive non-gateway: documented limitation above.
     if not is_gateway and not is_ask:
+        if script_requires_human:
+            return {
+                "approved": False,
+                "message": _remote_repository_mutation_no_human_message(description),
+                "pattern_key": pattern_key,
+                "description": description,
+                "outcome": "blocked",
+                "user_consent": False,
+            }
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
@@ -3046,7 +3132,7 @@ def check_execute_code_guard(code: str, env_type: str,
     # Smart mode: ask the aux LLM about the whole script. An APPROVE here only
     # suppresses the redundant whole-script prompt; the per-call terminal()
     # guards (restored by context propagation) still run independently.
-    if approval_mode == "smart":
+    if approval_mode == "smart" and not script_requires_human:
         verdict = _smart_approve(command, description)
         if verdict == "approve":
             logger.debug("Smart approval: auto-approved execute_code for session %s",


### PR DESCRIPTION
## Summary
- add dangerous-command patterns for remote repository mutations including `gh pr merge`, mutating `gh api`, GitHub repo/release mutations, and `git push`
- fail closed for those mutations when no interactive or gateway approval surface is available
- make `execute_code` use the embedded remote-mutation approval key so generic session approval for `execute_code` cannot cover a later push or PR merge
- reset session context in terminal-tool sudo tests so combined approval/terminal runs remain deterministic

## Why
Autonomous agents can otherwise mutate shared GitHub/git state without an explicit human approval step. These operations are outside the local workspace and include irreversible or externally visible actions, so they need stronger consent handling than ordinary local risky commands.

Refs #60056

## Tests
- `uv run --extra dev pytest tests/tools/test_approval.py::TestGitDestructiveOps tests/tools/test_approval.py::TestRemoteMutationApproval tests/tools/test_execute_code_approval_cluster.py -q`
- `uv run --extra dev pytest tests/tools/test_approval.py tests/tools/test_execute_code_approval_cluster.py tests/tools/test_cron_approval_mode.py tests/tools/test_terminal_tool.py -q`
- `git diff --check`
- `gitleaks git --log-opts='origin/main..HEAD' --redact .`