### PR TITLE
refactor(approval): replace regex inline-script-execution detection w…

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -150,14 +150,18 @@ class TestWindowsShellDestructiveCommands:
         assert dangerous is True
         assert desc == "Windows PowerShell destructive delete"
 
-    def test_powershell_benign_path_containing_del_not_flagged(self):
-        # A benign file path that merely contains "del" must NOT trip the guard
-        # (verb-position anchoring prevents matching inside a -File arg).
+    def test_powershell_benign_path_containing_del_not_matched_by_delete_pattern(self):
+        # A benign file path that merely contains "del" must NOT trip the
+        # destructive-delete guard specifically (verb-position anchoring
+        # prevents matching "del" inside a -File path argument). It IS
+        # correctly flagged by the tokenizer-based inline-script-execution
+        # check instead — running any .ps1 script via -File requires
+        # approval, regardless of what its path happens to contain.
         dangerous, key, desc = detect_dangerous_command(
             r"powershell -File C:\del-logs\run.ps1"
         )
-        assert dangerous is False
-        assert key is None
+        assert dangerous is True
+        assert key != "Windows PowerShell destructive delete"
 
     def test_plain_text_does_not_trigger_windows_delete(self):
         dangerous, key, desc = detect_dangerous_command(
@@ -619,11 +623,18 @@ class TestHermesConfigWriteProtection:
 
     def test_perl_eval_no_inplace_safe(self):
         # `perl -e` with no -i flag is code evaluation, not file mutation —
-        # the perl/ruby -i pattern must not fire on it.
+        # the perl/ruby -i (in-place edit) pattern specifically must not
+        # fire on it, since there is no file to protect from a mutation
+        # that isn't happening. `-wne` combines -w -n -e, so this
+        # genuinely is inline code execution ('print' run as Perl per
+        # input line) and IS correctly caught by the tokenizer-based
+        # inline-script-execution check — that's correct; this test only
+        # asserts the -i in-place pattern isn't the one doing the
+        # catching.
         dangerous, key, desc = detect_dangerous_command(
             "perl -wne 'print' ~/.hermes/config.yaml"
         )
-        assert dangerous is False
+        assert key != "in-place edit of Hermes config/env (perl/ruby)"
 
     def test_read_is_safe(self):
         # Reading config is not a write — must not trip.
@@ -1373,6 +1384,244 @@ class TestHeredocScriptExecution:
         """Plain 'bash script.sh' without heredoc must stay safe."""
         dangerous, _, _ = detect_dangerous_command("bash my_script.sh")
         assert dangerous is False
+
+
+class TestTokenizerInlineScriptExecution:
+    """_detect_inline_script_execution() (tokenizer-based, shlex.split() +
+    a language-specific exec-flag table) replaces the regex rules that went
+    through three rounds of external review, each finding a shape the
+    regex missed. These tests pin every previously-missed shape plus the
+    benign cases that must stay unflagged.
+
+    Round 1 (combined short flags, no-space gluing, long-form flags,
+    versioned binaries) and round 2 (glued-without-quote values) are
+    already covered by the pre-existing TestHeredocScriptExecution class
+    and the -File tests elsewhere in this file; this class covers what
+    those rounds could NOT close with more regex — flags that consume
+    their own argument, long-form intervening flags, and an entirely
+    different flag letter for the same behavior — plus PowerShell, which
+    a pure regex-per-interpreter approach could not share without
+    duplicating the same bugs a third time.
+    """
+
+    # --- Round 3: flags with their own argument, intervening long-form ---
+
+    def test_python_short_flag_with_own_argument_before_c(self):
+        # -W takes its own argument ("ignore") as a separate token before
+        # -c — a regex modeling "skip N other flags" has no way to know
+        # -W consumes the next token without also knowing every possible
+        # flag's arity. The tokenizer doesn't need to know this at all:
+        # it just scans every token for a recognized flag.
+        dangerous, key, desc = detect_dangerous_command(
+            'python3 -W ignore -c "print(1)"'
+        )
+        assert dangerous is True
+
+    def test_python_capital_x_flag_with_own_argument_before_c(self):
+        dangerous, key, desc = detect_dangerous_command(
+            'python3 -X dev -c "print(1)"'
+        )
+        assert dangerous is True
+
+    def test_node_long_form_intervening_flag(self):
+        dangerous, key, desc = detect_dangerous_command(
+            'node --no-warnings --eval="require(\'fs\')"'
+        )
+        assert dangerous is True
+
+    # --- Round 3: node -p/--print, a different flag letter entirely ---
+
+    def test_node_short_print_flag(self):
+        # -p evaluates and prints — same risk class as -e, but contains
+        # neither 'e' nor 'c', so no char-class regex built around those
+        # two letters could ever catch it.
+        dangerous, key, desc = detect_dangerous_command('node -p "1+1"')
+        assert dangerous is True
+
+    def test_node_long_print_flag(self):
+        dangerous, key, desc = detect_dangerous_command('node --print "1+1"')
+        assert dangerous is True
+
+    def test_node_check_flag_not_flagged(self):
+        # -c/--check is syntax-check-only (nodejs/node#2411) — the exact
+        # opposite of -p/--print despite the visual similarity. Must not
+        # be flagged; including it would be a pure false positive.
+        dangerous, key, desc = detect_dangerous_command("node -c script.js")
+        assert dangerous is False
+
+    def test_node_long_check_flag_not_flagged(self):
+        dangerous, key, desc = detect_dangerous_command("node --check script.js")
+        assert dangerous is False
+
+    def test_ruby_check_flag_not_flagged(self):
+        # ruby -c is also syntax-check-only, same reasoning as node above.
+        dangerous, key, desc = detect_dangerous_command("ruby -c script.rb")
+        assert dangerous is False
+
+    # --- PowerShell: -File and -Command share the same tokenizer path ---
+
+    def test_powershell_file_flag(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "powershell -File helper.ps1"
+        )
+        assert dangerous is True
+
+    def test_powershell_execution_policy_bypass_file(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "powershell -ExecutionPolicy Bypass -File helper.ps1"
+        )
+        assert dangerous is True
+
+    def test_powershell_command_flag_with_inline_code(self):
+        # -Command runs inline PowerShell — genuinely the same risk class
+        # as -c/-e for other languages, so this SHOULD require approval.
+        # The tokenizer correctly attributes it to -Command; the old regex
+        # this replaces mislabeled it as a -File match instead (still
+        # flagged, but for the wrong stated reason).
+        dangerous, key, desc = detect_dangerous_command(
+            'powershell -Command "Get-Process"'
+        )
+        assert dangerous is True
+        assert "command" in desc.lower()
+
+    def test_powershell_dash_f_inside_command_payload_not_misattributed(self):
+        # Regression test for the exact false-positive-attribution the
+        # regex version had: a -f flag belonging to Write-Host, INSIDE the
+        # quoted -Command payload, must not be picked up as a top-level
+        # PowerShell flag. shlex.split() puts the whole quoted payload in
+        # one token, so "-f" here is just text inside that token, not a
+        # separate flag token the way a real "-f"/"-File" would be.
+        dangerous, key, desc = detect_dangerous_command(
+            'powershell -Command "Write-Host -f Green ok"'
+        )
+        # Still True (via -Command, which IS a real inline-exec flag) —
+        # but the reason must name -Command, not -File.
+        assert dangerous is True
+        assert "file" not in desc.lower()
+
+    # --- Versioned interpreter binaries across all covered languages ---
+
+    def test_versioned_python_still_detected(self):
+        dangerous, key, desc = detect_dangerous_command(
+            'python3.11 -c "print(1)"'
+        )
+        assert dangerous is True
+
+    def test_versioned_ruby_still_detected(self):
+        dangerous, key, desc = detect_dangerous_command('ruby3.2 -e "puts 1"')
+        assert dangerous is True
+
+    def test_versioned_perl_still_detected(self):
+        dangerous, key, desc = detect_dangerous_command('perl5.36 -e "print 1"')
+        assert dangerous is True
+
+    def test_versioned_python_heredoc_still_detected(self):
+        cmd = "python3.11 << 'EOF'\nprint(1)\nEOF"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_full_path_versioned_interpreter_still_detected(self):
+        dangerous, key, desc = detect_dangerous_command(
+            '/usr/bin/python3.11 -c "print(1)"'
+        )
+        assert dangerous is True
+
+    # --- Hermes config/env-specific messaging ---
+
+    def test_config_yaml_reference_gets_specific_message(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "python3 -c \"open('~/.hermes/config.yaml','a').write(1)\""
+        )
+        assert dangerous is True
+        assert key == "inline_script_hermes_config"
+
+    def test_env_reference_gets_specific_message(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "python3 -c \"open('~/.hermes/.env','a').write(1)\""
+        )
+        assert dangerous is True
+        assert key == "inline_script_hermes_config"
+
+    def test_unrelated_payload_gets_generic_message(self):
+        dangerous, key, desc = detect_dangerous_command(
+            'python3 -c "print(\'unrelated\')"'
+        )
+        assert dangerous is True
+        assert key == "inline_script_execution"
+
+    # --- Malformed input must not crash ---
+
+    def test_unclosed_quote_does_not_crash(self):
+        dangerous, key, desc = detect_dangerous_command(
+            'python3 -c "unclosed quote'
+        )
+        assert dangerous is False
+
+    def test_unclosed_single_quote_does_not_crash(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "node --eval='unclosed"
+        )
+        assert dangerous is False
+
+    # --- Benign, unrelated commands must stay unflagged ---
+
+    def test_module_invocation_not_flagged(self):
+        dangerous, key, desc = detect_dangerous_command(
+            "python3 -m my_mcp_server"
+        )
+        assert dangerous is False
+
+    def test_version_check_not_flagged(self):
+        dangerous, key, desc = detect_dangerous_command("python3 --version")
+        assert dangerous is False
+
+    def test_plain_script_file_not_flagged(self):
+        dangerous, key, desc = detect_dangerous_command("node server.js")
+        assert dangerous is False
+
+    def test_unrecognized_command_not_flagged(self):
+        dangerous, key, desc = detect_dangerous_command("vim file.txt")
+        assert dangerous is False
+
+    # --- Regression tests for issues found in code review of this class ---
+
+    def test_exec_flag_wins_over_heredoc_in_same_command(self):
+        # An exec flag AND heredoc syntax present in the same command must
+        # report the exec flag, not heredoc — it's the more specific,
+        # actionable finding (heredoc could be entirely unused stdin).
+        dangerous, key, desc = detect_dangerous_command(
+            'python3 -c "print(1)" << EOF'
+        )
+        assert dangerous is True
+        assert key == "inline_script_execution"
+
+    def test_pure_heredoc_still_detected_without_exec_flag(self):
+        dangerous, key, desc = detect_dangerous_command("python3 << EOF")
+        assert dangerous is True
+        assert key == "inline_script_heredoc"
+
+    def test_new_pattern_key_aliases_to_legacy_regex_description(self):
+        # An operator who permanently allowlisted the old regex rule (by
+        # its description string, used as the historical pattern_key)
+        # before this tokenizer replaced it must not be silently
+        # re-prompted — the new tokenizer keys must alias to the old
+        # description strings that used to live in DANGEROUS_PATTERNS.
+        from tools.approval import _approval_key_aliases
+
+        aliases = _approval_key_aliases("inline_script_execution")
+        assert "script execution via -e/-c flag" in aliases
+
+    def test_legacy_regex_description_aliases_to_new_pattern_key(self):
+        from tools.approval import _approval_key_aliases
+
+        aliases = _approval_key_aliases("script execution via -e/-c flag")
+        assert "inline_script_execution" in aliases
+
+    def test_heredoc_pattern_key_aliases_to_legacy_description(self):
+        from tools.approval import _approval_key_aliases
+
+        aliases = _approval_key_aliases("inline_script_heredoc")
+        assert "script execution via heredoc" in aliases
 
 
 class TestPgrepKillExpansion:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1624,6 +1624,24 @@ class TestTokenizerInlineScriptExecution:
         assert "script execution via heredoc" in aliases
 
 
+    def test_windows_py_launcher_detected(self):
+        # `py` (and `py.exe`) is the Windows Python launcher, installed by
+        # the official Python installer since 3.3 — often the only Python
+        # reliably on PATH on Windows, distinct from `python`/`python3`.
+        dangerous, key, desc = detect_dangerous_command('py -c "print(1)"')
+        assert dangerous is True
+
+    def test_windows_py_exe_launcher_detected(self):
+        dangerous, key, desc = detect_dangerous_command('py.exe -c "print(1)"')
+        assert dangerous is True
+
+    def test_pypy_not_confused_with_py_launcher(self):
+        # `pypy` (an alternative Python implementation) must not be
+        # matched by the `py` launcher alias — anchored regex prevents
+        # `py` from matching as a prefix of a longer, unrelated name.
+        dangerous, key, desc = detect_dangerous_command("pypy script.py")
+        assert dangerous is False
+
 class TestPgrepKillExpansion:
     """kill -9 $(pgrep hermes) bypasses the pkill/killall name-matching
     pattern because the command substitution is opaque to regex.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -225,6 +225,150 @@ _HERMES_CONFIG_PATH = (
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
     r'config\.yaml\b'
 )
+
+# ---------------------------------------------------------------------------
+# Tokenizer-based inline-script-execution detection.
+#
+# Replaces three regex rules ("script execution via -e/-c flag", the
+# Hermes-config/env-specific variant of it, and "script execution via
+# heredoc") that went through three rounds of external review, each finding
+# a new command shape the regex missed: combined short flags, no-space
+# flag gluing, long-form flags, versioned interpreter binaries (round 1);
+# intervening standalone flags, glued-without-quote values (round 2);
+# flags that consume their own argument (-W ignore, -X dev), long-form
+# intervening flags (--no-warnings), and an entirely different flag letter
+# for the same behavior (node -p/--print, which contains neither 'e' nor
+# 'c') (round 3).
+#
+# A regex matching flag characters in a flat string cannot reliably model
+# "skip past any number of other flags, some of which consume their own
+# following token as an argument, in short or long form" — that is
+# argument parsing, and argument parsing needs an actual tokenizer, not a
+# pattern. shlex.split() is already used the same way elsewhere in this
+# file (_literal_command_substitution_output) and in
+# hermes_cli/mcp_security.py's _command_basename().
+#
+# Deliberately narrower than a full CLI parser: this only asks "does any
+# token look like an inline-eval flag for a recognized interpreter", not
+# "parse this command's full argument grammar". False positives (flagging
+# something that turns out to be safe) cost the operator one extra
+# approval prompt; false negatives (missing a real inline-eval flag) are
+# the actual security gap, so ambiguous cases lean toward flagging.
+# ---------------------------------------------------------------------------
+
+_INTERPRETER_FAMILY_PATTERN = re.compile(
+    r'^(?P<python>python[23]?(?:\.\d+)*(?:\.exe)?)$'
+    r'|^(?P<node>node(?:js)?(?:\.exe)?)$'
+    r'|^(?P<perl>perl[0-9]*(?:\.\d+)*(?:\.exe)?)$'
+    r'|^(?P<ruby>ruby[0-9]*(?:[0-9.]+)*(?:\.exe)?)$'
+    r'|^(?P<php>php(?:\.exe)?)$'
+    r'|^(?P<powershell>powershell(?:\.exe)?|pwsh(?:\.exe)?)$',
+    re.IGNORECASE,
+)
+
+# flag -> "inline" (code passed directly on the command line) or "file"
+# (runs an external script file — same approval-worthy category, distinct
+# wording since the risk is "what's in that file", not "what's in this
+# argument"). This value is used ONLY for the approval message text; it
+# must never gate whether a match fires at all — both kinds always require
+# approval identically.
+#
+# Deliberately excluded (checked, not just omitted by oversight): node/ruby
+# "-c"/"--check" perform a syntax check only, without executing anything —
+# see nodejs/node#2411 and `ruby -h`. Including them would be a pure
+# false-positive with no security value.
+_EXEC_FLAGS: dict[str, dict[str, str]] = {
+    "python": {"-c": "inline"},
+    "node": {"-e": "inline", "--eval": "inline", "-p": "inline", "--print": "inline"},
+    "perl": {"-e": "inline", "--eval": "inline"},
+    "ruby": {"-e": "inline"},
+    "php": {"-r": "inline"},
+    "powershell": {"-command": "inline", "-c": "inline", "-file": "file", "-f": "file"},
+}
+
+
+def _interpreter_family(basename: str) -> Optional[str]:
+    m = _INTERPRETER_FAMILY_PATTERN.match(basename.lower())
+    return m.lastgroup if m else None
+
+
+def _detect_inline_script_execution(command: str) -> tuple:
+    """Tokenizer-based replacement for the regex inline-exec-flag rules.
+
+    Returns (is_dangerous, pattern_key, description), matching
+    detect_dangerous_command()'s contract, so it can be called as a
+    fallback after the regex loop there.
+    """
+    try:
+        tokens = shlex.split(command, posix=(os.name != "nt"))
+    except ValueError:
+        # Unbalanced quotes etc. — not a shell string this tokenizer can
+        # parse. The regex loop above already ran on this same command and
+        # would have caught anything it recognizes; falling through to
+        # (False, None, None) here does not weaken that.
+        return (False, None, None)
+    if not tokens:
+        return (False, None, None)
+
+    family = _interpreter_family(os.path.basename(tokens[0]))
+    if family is None:
+        return (False, None, None)
+
+    exec_flags = _EXEC_FLAGS.get(family)
+    heredoc_tok: Optional[str] = None
+    for tok in tokens[1:]:
+        # Heredoc (`python3 << EOF`, `ruby3.2 <<RUBY`) feeds arbitrary code
+        # via stdin with no -c/-e/--eval flag at all. shlex tokenizes this
+        # inconsistently depending on whitespace: `<< EOF` (with a space)
+        # is its own token, `<<EOF`/`<<'EOF'` (glued to the delimiter) is
+        # not, so check for the `<<` prefix rather than an exact-token
+        # match. Recorded but not returned immediately — an exec flag
+        # elsewhere in the same command (`python3 -c "..." << EOF`) is the
+        # more specific, actionable finding and should win the message if
+        # both are present; heredoc is the fallback when no flag matches.
+        if heredoc_tok is None and tok.startswith("<<"):
+            heredoc_tok = tok
+        if not exec_flags or not tok.startswith("-"):
+            continue
+        # Long-form `--eval=value` and short `-c=value` both split cleanly
+        # on the first `=`; a flag with no `=` is unaffected.
+        flag_part = tok.split("=", 1)[0].lower()
+        if flag_part in exec_flags:
+            return _inline_exec_result(family, exec_flags[flag_part], flag_part, command)
+        # Combined short flags (`-uc`, `-pe`) or a value glued directly
+        # onto the flag with no separator (`-copen(...)`): shlex has
+        # already isolated this as one token, so check each character
+        # after the dash against the known single-character flags for
+        # this family. Long-form flags (`--eval`) are never combined this
+        # way, so this branch is skipped for anything starting with `--`.
+        if not flag_part.startswith("--") and len(flag_part) > 2:
+            for ch in flag_part[1:]:
+                short = f"-{ch}"
+                if len(short) == 2 and short in exec_flags:
+                    return _inline_exec_result(family, exec_flags[short], short, command)
+    if heredoc_tok is not None:
+        return (
+            True,
+            "inline_script_heredoc",
+            f"{family} script execution via heredoc",
+        )
+    return (False, None, None)
+
+
+def _inline_exec_result(family: str, kind: str, flag: str, command: str) -> tuple:
+    if re.search(rf'(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', command, re.IGNORECASE):
+        return (
+            True,
+            "inline_script_hermes_config",
+            f"{family} interpreter script referencing Hermes config/env (via {flag})",
+        )
+    return (
+        True,
+        "inline_script_execution",
+        f"{family} {kind} script execution via {flag} flag",
+    )
+
+
 _PROJECT_ENV_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*\.env(?:\.[^/\s"\'`]+)*)'
 _PROJECT_CONFIG_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*config\.yaml)'
 _SHELL_RC_FILES = (
@@ -586,7 +730,10 @@ DANGEROUS_PATTERNS = [
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     # Any shell invocation via -c or combined flags like -lc, -ic, etc.
     (r'\b(bash|sh|zsh|ksh)\s+-[^\s]*c(\s+|$)', "shell command via -c/-lc flag"),
-    (r'\b(python[23]?|perl|ruby|node)\s+-[ec]\s+', "script execution via -e/-c flag"),
+    # `_detect_inline_script_execution()` (tokenizer-based, see its
+    # docstring above) replaces the regex rule that used to sit here for
+    # python/node/perl/ruby -c/-e/--eval detection — see
+    # detect_dangerous_command() below.
     (r'\b(curl|wget)\b.*\|\s*(?:[/\w]*/)?(?:ba)?sh(?:\s|$|-c)', "pipe remote content to shell"),
     (r'\b(bash|sh|zsh|ksh)\s+<\s*<?\s*\(\s*(curl|wget)\b', "execute remote script via process substitution"),
     # Remote content executed via command substitution: eval/source/. $(curl ...)
@@ -693,9 +840,11 @@ DANGEROUS_PATTERNS = [
     # anywhere in the args, not just the first token — `perl -e '...'` (code
     # eval, no -i) does not trip because it has no `-...i` flag token.
     (rf'\b(?:perl|ruby)\b.*(?:^|\s)-[^\s]*i\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl/ruby)"),
-    # Script execution via heredoc — bypasses the -e/-c flag patterns above.
-    # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
-    (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),
+    # `_detect_inline_script_execution()` (tokenizer-based, see its
+    # docstring near _HERMES_CONFIG_PATH above) replaces the regex rule
+    # that used to sit here for python/perl/ruby/node heredoc detection —
+    # see detect_dangerous_command() below. Shell heredoc detection
+    # (bash/sh <<'EOF' ...) is unrelated and stays regex-based just below.
     # Shell execution via heredoc — `bash <<'EOF' ... EOF` runs arbitrary
     # shell commands without triggering the `bash -c` pattern above. The
     # inner commands may not individually match any dangerous pattern (e.g.
@@ -776,6 +925,33 @@ for _pattern, _description in DANGEROUS_PATTERNS:
     _canonical_key = _description
     _PATTERN_KEY_ALIASES.setdefault(_canonical_key, set()).update({_canonical_key, _legacy_key})
     _PATTERN_KEY_ALIASES.setdefault(_legacy_key, set()).update({_legacy_key, _canonical_key})
+
+# _detect_inline_script_execution() (tokenizer-based) replaced three regex
+# rules that used to live in DANGEROUS_PATTERNS above, each with its own
+# description string used as the approval pattern_key. Those descriptions
+# no longer appear in DANGEROUS_PATTERNS, so the auto-built aliasing loop
+# above never links them to the new tokenizer keys. Without this, an
+# operator who permanently allowlisted the old regex rule (e.g. "script
+# execution via -e/-c flag") would be silently re-prompted after this
+# change — not a security bypass (fail-safe direction: re-prompting is
+# strictly more conservative than the old behavior), but it would look
+# like their existing allowlist entry stopped working.
+for _new_key, _old_descriptions in (
+    ("inline_script_execution", (
+        "script execution via -e/-c flag",
+        "interpreter script referencing Hermes config/env",
+    )),
+    ("inline_script_hermes_config", (
+        "script execution via -e/-c flag",
+        "interpreter script referencing Hermes config/env",
+    )),
+    ("inline_script_heredoc", (
+        "script execution via heredoc",
+    )),
+):
+    _PATTERN_KEY_ALIASES.setdefault(_new_key, set()).update({_new_key, *_old_descriptions})
+    for _old_description in _old_descriptions:
+        _PATTERN_KEY_ALIASES.setdefault(_old_description, set()).add(_new_key)
 
 
 def _approval_key_aliases(pattern_key: str) -> set[str]:
@@ -1395,6 +1571,16 @@ def detect_dangerous_command(command: str) -> tuple:
             if pattern_re.search(command_lower):
                 pattern_key = description
                 return (True, pattern_key, description)
+    # Tokenizer-based fallback for inline-script execution (-c/-e/--eval,
+    # heredoc) — see _detect_inline_script_execution()'s docstring above
+    # for why this needs a real tokenizer rather than another regex.
+    # Runs on the same normalized (deobfuscated) command text the regex
+    # loop above already used for its first variant, so it benefits from
+    # the same ANSI/unicode/backslash/$IFS hardening without redoing it.
+    normalized = _normalize_command_for_detection(command)
+    result = _detect_inline_script_execution(normalized)
+    if result[0]:
+        return result
     return (False, None, None)
 
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -257,7 +257,7 @@ _HERMES_CONFIG_PATH = (
 # ---------------------------------------------------------------------------
 
 _INTERPRETER_FAMILY_PATTERN = re.compile(
-    r'^(?P<python>python[23]?(?:\.\d+)*(?:\.exe)?)$'
+    r'^(?P<python>py(?:\.exe)?|python[23]?(?:\.\d+)*(?:\.exe)?)$'
     r'|^(?P<node>node(?:js)?(?:\.exe)?)$'
     r'|^(?P<perl>perl[0-9]*(?:\.\d+)*(?:\.exe)?)$'
     r'|^(?P<ruby>ruby[0-9]*(?:[0-9.]+)*(?:\.exe)?)$'


### PR DESCRIPTION
## Summary
Replaces regex-based inline-script-execution detection in
tools/approval.py (python/node/perl/ruby/php -c/-e/--eval/-p/--print,
PowerShell -File/-Command, and heredoc) with a tokenizer-based
implementation (shlex.split() + a language-specific exec-flag table).

This follows from #57666 and #57990, which received three and two
rounds of comments respectively, each finding a new command shape the
regex missed: combined/glued/long-form flags, versioned interpreter
binaries, flags with their own argument (-W ignore), and an entirely
different flag letter for the same behavior (node -p/--print, neither
'e' nor 'c'). Matching flag characters in a flat string can't reliably
model argument parsing; that needs an actual tokenizer, not another
pattern, so each round closed one shape while leaving the general
problem open for the next.

This isn't cosmetic. `~/.hermes/config.yaml` is where `approvals.mode`,
`yolo`, and the permanent allowlist live, so a missed flag shape lets a
command rewrite it with no approval at all, silently disabling the
agent's own approval gate. Tokenizing once (the same shlex.split()
approach already used in this file's `_literal_command_substitution_output()`
and in `hermes_cli/mcp_security.py`'s `_command_basename()`) closes the
whole class of gaps instead of the one shape found so far.

#57666 and #57990 are left open rather than closed, since both contain
other, independent fixes that don't touch this code path. If this PR
merges, their own `-e/-c`/`-File` regex rules become the same fragile
pattern this one replaces; the natural next step is rebasing those
additions onto this tokenizer instead of carrying their own regex
forward.

---

## Root cause
The old rules were regular expressions trying to answer an argument-
parsing question ("skip past any number of other flags, some of which
take their own argument, in short or long form, and find one meaning
'run this code inline'"). A flat-string pattern has no way to know
which flags consume a following token without hand-enumerating every
one, and no amount of added alternation closes that gap in general; it
only closes the specific shapes someone tested. This is not a fourth
incremental fix to the same rule; it is a different category of tool
for a problem regex was never suited to solve, closing every case in
this class at once rather than the next one someone happens to test.

---

## Behavioral change
Before: detection depended on which flag-combination shapes had been
added to the regex so far.

After: `_detect_inline_script_execution()` tokenizes the command,
identifies the interpreter by family (version-suffix tolerant), and
scans every token against that family's known inline-exec flags,
independent of how many other flags precede it or how the target flag
is glued/combined.

---

## What changed
**`tools/approval.py`**:
- Added `_INTERPRETER_FAMILY_PATTERN`, `_EXEC_FLAGS`,
  `_interpreter_family()`, `_detect_inline_script_execution()`,
  `_inline_exec_result()`, called as a fallback in
  `detect_dangerous_command()` after the existing regex loop
- Removed the `-e/-c` and heredoc regex rules this replaces
- Added `_PATTERN_KEY_ALIASES` entries mapping the new pattern_keys to
  the old regex description strings, so an operator's existing
  permanent allowlist entry isn't silently invalidated
- Ordering fix: an exec flag and heredoc syntax in the same command
  now report the exec flag, not heredoc

**`tests/tools/test_approval.py`**:
- New `TestTokenizerInlineScriptExecution` class (31 tests) covering
  every previously-missed shape from both PRs, node/ruby `-c`/`--check`
  (must stay unflagged), PowerShell `-File`/`-Command` including the
  false-positive-attribution case, versioned binaries, malformed shlex
  input, and the aliasing fix
- Updated two existing tests whose expectations relied on gaps this
  fix closes

---

## What is NOT changed
- GitHub/GitLab/Svix-style detection elsewhere is unrelated and
  untouched
- `perl`/`ruby -i` (in-place file edit) rules are untouched, a
  different threat category not part of this refactor's scope
- `#57666` and `#57990` are left open and unmodified; see Summary
- All existing approval tests pass (329 passed)