### PR TITLE
feat(tools): support native Windows shells (PowerShell/cmd) via HERMES_TERMINAL_SHELL

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -911,6 +911,26 @@ _WINDOWS_BASH_SHELL_HINT = (
     "POSIX equivalents (`ls`, `$FOO`, `grep`)."
 )
 
+_WINDOWS_POWERSHELL_HINT = (
+    "Shell: on this Windows host your `terminal` tool runs commands through "
+    "PowerShell (native Windows), NOT bash or cmd.exe. Use PowerShell syntax "
+    "(`Get-ChildItem`, `$env:FOO`, `Select-String`, `&&`, `|`) inside terminal "
+    "calls. Native Windows paths like `C:\\Users\\<user>\\...` are standard. "
+    "POSIX commands (`ls`, `grep`, `cat`) will NOT work — use their PowerShell "
+    "equivalents (`Get-ChildItem` / `dir`, `Select-String`, `Get-Content`). "
+    'For simple file ops, `cmd /c "dir"` style fallbacks also work.'
+)
+
+_WINDOWS_CMD_HINT = (
+    "Shell: on this Windows host your `terminal` tool runs commands through "
+    "cmd.exe (native Windows Command Prompt), NOT bash or PowerShell. "
+    "Use cmd syntax (`dir`, `%VAR%`, `&&`, `|`) inside terminal calls. "
+    "Native Windows paths like `C:\\Users\\<user>\\...` are standard. "
+    "POSIX commands (`ls`, `grep`, `cat`) will NOT work — use their cmd "
+    "equivalents (`dir`, `findstr`, `type`). PowerShell cmdlets also "
+    'won\'t work unless wrapped with `powershell -Command "..."`.'
+)
+
 
 def _probe_remote_backend(env_type: str) -> str | None:
     """Run a tiny introspection command inside the active terminal backend.
@@ -1096,10 +1116,17 @@ def build_environment_hints() -> str:
             )
         hints.append("\n".join(host_lines))
 
-        # Windows-local terminal runs bash, not PowerShell — the model must
-        # know this or it will issue PowerShell syntax and fail.
+        # Windows-local terminal: tell the model which shell is active.
+        # Defaults to bash (Git Bash / WSL bash); HERMES_TERMINAL_SHELL
+        # can be set to "powershell", "pwsh", or "cmd" for native Windows.
         if sys.platform == "win32" and not is_wsl():
-            hints.append(_WINDOWS_BASH_SHELL_HINT)
+            terminal_shell = os.environ.get("HERMES_TERMINAL_SHELL", "").strip().lower()
+            if terminal_shell in ("powershell", "pwsh"):
+                hints.append(_WINDOWS_POWERSHELL_HINT)
+            elif terminal_shell == "cmd":
+                hints.append(_WINDOWS_CMD_HINT)
+            else:
+                hints.append(_WINDOWS_BASH_SHELL_HINT)
     else:
         # --- Remote backend block (host info suppressed) ---
         probe = _probe_remote_backend(backend)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -567,6 +567,52 @@ def _find_bash() -> str:
     )
 
 
+# Shell-type override — set HERMES_TERMINAL_SHELL=powershell|pwsh|cmd to use
+# native Windows shells instead of bash (Git Bash / WSL bash).
+_TERMINAL_SHELL_TYPE: str = "bash"  # "bash", "powershell", "pwsh", "cmd"
+
+
+def _get_terminal_shell() -> tuple:
+    """Return (executable_path, shell_type) for terminal command execution.
+
+    On Windows, honours HERMES_TERMINAL_SHELL to switch away from bash
+    to native PowerShell or cmd.exe.  Defaults to ``_find_bash()`` /
+    ``"bash"`` when the env var is absent or unset.
+    """
+    global _TERMINAL_SHELL_TYPE
+
+    if _IS_WINDOWS:
+        override = os.environ.get("HERMES_TERMINAL_SHELL", "").strip().lower()
+        if override in ("powershell", "pwsh"):
+            exe = (
+                shutil.which("powershell.exe")
+                or shutil.which("pwsh.exe")
+                or os.path.join(
+                    os.environ.get("SystemRoot", r"C:\Windows"),
+                    "System32", "WindowsPowerShell", "v1.0", "powershell.exe",
+                )
+            )
+            _TERMINAL_SHELL_TYPE = "powershell"
+            return exe, "powershell"
+        if override == "cmd":
+            exe = os.environ.get("COMSPEC") or os.path.join(
+                os.environ.get("SystemRoot", r"C:\Windows"),
+                "System32", "cmd.exe",
+            )
+            _TERMINAL_SHELL_TYPE = "cmd"
+            return exe, "cmd"
+
+    _TERMINAL_SHELL_TYPE = "bash"
+    path = _find_bash()
+    if path.lower().endswith(".exe") and not os.path.isfile(path):
+        # _find_bash returned a WSL entry point or stale path
+        raise RuntimeError(
+            f"Shell executable not found: {path}. "
+            f"Set HERMES_TERMINAL_SHELL=powershell for native Windows shell."
+        )
+    return path, "bash"
+
+
 # POSIX-sh-family shells that understand the ``[shell, "-lic", "set +m; …"]``
 # invocation spawn_local uses. $SHELL values outside this set (fish, csh/tcsh,
 # nushell, elvish, xonsh, …) would error on that syntax, so _find_shell falls
@@ -769,8 +815,12 @@ def _apply_windows_msys_bash_env_defaults(env: dict) -> None:
     """
     if not _IS_WINDOWS:
         return
-    env.setdefault("MSYS_NO_PATHCONV", "1")
-    env.setdefault("MSYS2_ARG_CONV_EXCL", "*")
+    # Only set MSYS path-conversion opt-outs when the shell is bash-family.
+    # Native Windows shells (PowerShell, cmd) don't need these and setting
+    # MSYS2_ARG_CONV_EXCL on them is harmless but misleading.
+    if _TERMINAL_SHELL_TYPE == "bash":
+        env.setdefault("MSYS_NO_PATHCONV", "1")
+        env.setdefault("MSYS2_ARG_CONV_EXCL", "*")
 
 
 def _path_env_key(run_env: dict) -> str | None:
@@ -989,18 +1039,26 @@ class LocalEnvironment(BaseEnvironment):
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
-        bash = _find_bash()
+        shell_exe, shell_type = _get_terminal_shell()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
         # custom init files so tools registered outside bash_profile
         # (nvm, asdf, pyenv, …) end up on PATH in the captured snapshot.
         # Non-login invocations are already sourcing the snapshot and
-        # don't need this.
-        if login:
+        # don't need this.  Login mode only applies to bash-family shells.
+        if login and shell_type == "bash":
             init_files = _resolve_shell_init_files()
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
-        args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
+
+        # Build invocation args per shell type
+        if shell_type in ("powershell", "pwsh"):
+            args = [shell_exe, "-NoProfile", "-NonInteractive", "-Command", cmd_string]
+        elif shell_type == "cmd":
+            args = [shell_exe, "/c", cmd_string]
+        else:
+            # bash, zsh, sh, etc.
+            args = [shell_exe, "-l", "-c", cmd_string] if login else [shell_exe, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
         # Recover when the cwd has been deleted out from under us — usually by


### PR DESCRIPTION
## Summary

Add `HERMES_TERMINAL_SHELL` env var to switch terminal shell on Windows, allowing native PowerShell or cmd.exe instead of requiring Git Bash / WSL bash.

## Problem

On Windows, Hermes terminal tool hardcodes bash execution via `_find_bash()` — which finds WSL's bash or Git Bash. This means:
- All terminal commands run through WSL2 bash, not native Windows
- WSL interop (binfmt_misc) must be working for Windows .exe access
- Users who prefer PowerShell/cmd have no option

## Solution

A new env var `HERMES_TERMINAL_SHELL` controls which shell the terminal tool uses:

| Value | Shell | Invocation |
|-------|-------|-----------|
| `powershell` / `pwsh` | PowerShell | `powershell.exe -NoProfile -NonInteractive -Command "..."` |
| `cmd` | Command Prompt | `cmd.exe /c "..."` |
| unset / empty | bash | current default behavior |

### Changes

- **`tools/environments/local.py`**: Add `_get_terminal_shell()` that reads `HERMES_TERMINAL_SHELL` and returns `(executable, shell_type)`. Modify `_run_bash()` to build correct invocation args per shell type. Skip MSYS env defaults for non-bash shells.

- **`agent/prompt_builder.py`**: Add `_WINDOWS_POWERSHELL_HINT` and `_WINDOWS_CMD_HINT` constants. Emit dynamic shell hint based on `HERMES_TERMINAL_SHELL` instead of hardcoding the bash-only hint.

## How to test

1. Set `HERMES_TERMINAL_SHELL=powershell` in `.env`
2. Start a new Hermes session
3. Verify terminal commands use PowerShell: `$PSVersionTable` or `Get-Date`
4. System prompt should show the PowerShell hint, not the bash hint

## Platform

Tested on Windows 10 with PowerShell 5.1 and PowerShell 7.
Backward compatible — when env var is not set, behavior is identical to current.