### PR TITLE
fix(tools): surface new syntax errors so write_file/patch don't report invalid writes as success

### DIFF
--- a/tests/tools/test_file_tools_syntax_regression.py
+++ b/tests/tools/test_file_tools_syntax_regression.py
@@ -1,0 +1,98 @@
+import json
+import os
+import shutil
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def isolated_hermes_home(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    yield hermes_home
+
+    from tools.file_tools import clear_file_ops_cache, _patch_failure_lock, _patch_failure_tracker
+    from tools.file_tools import _read_tracker_lock, _read_tracker
+    from tools.terminal_tool import _active_environments, _env_lock
+
+    clear_file_ops_cache()
+    with _read_tracker_lock:
+        _read_tracker.clear()
+    with _patch_failure_lock:
+        _patch_failure_tracker.clear()
+    with _env_lock:
+        _active_environments.clear()
+
+
+@pytest.fixture
+def safe_temp_path():
+    base = tempfile.mkdtemp(prefix="hermes-file-tools-regression-", dir="/tmp")
+    try:
+        yield base
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+def test_write_file_invalid_json_is_reported_as_failure(isolated_hermes_home, safe_temp_path):
+    from tools.file_tools import write_file_tool
+
+    target = os.path.join(safe_temp_path, "bad.json")
+    result = json.loads(write_file_tool(str(target), '{"a":'))
+
+    assert result.get("error"), result
+    assert "files_modified" not in result, result
+
+
+def test_patch_tool_replace_invalidates_file_with_syntax_regression(
+    isolated_hermes_home, safe_temp_path
+):
+    from tools.file_tools import patch_tool
+
+    target = os.path.join(safe_temp_path, "valid.json")
+    with open(target, "w", encoding="utf-8") as fp:
+        fp.write('{"a": 1}')
+
+    result = json.loads(
+        patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string='"a": 1',
+            new_string='"a":',
+        )
+    )
+
+    assert result.get("error"), result
+    assert "files_modified" not in result, result
+
+
+def test_write_file_valid_json_still_reports_success(isolated_hermes_home, safe_temp_path):
+    from tools.file_tools import write_file_tool
+
+    target = os.path.join(safe_temp_path, "good.json")
+    resolved_target = os.path.realpath(target)
+    with open(target, "w", encoding="utf-8") as fp:
+        fp.write('{"a": 1}')
+
+    result = json.loads(write_file_tool(str(target), '{"a": 1, "b": 2}'))
+
+    assert not result.get("error"), result
+    assert result.get("files_modified") == [resolved_target], result
+
+
+def test_pre_existing_syntax_error_is_not_recast_as_new_regression(
+    isolated_hermes_home, safe_temp_path
+):
+    from tools.file_tools import write_file_tool
+
+    target = os.path.join(safe_temp_path, "broken.json")
+    payload = '{"a":\n'
+    resolved_target = os.path.realpath(target)
+    with open(target, "w", encoding="utf-8") as fp:
+        fp.write(payload)
+
+    result = json.loads(write_file_tool(str(target), payload))
+
+    assert not result.get("error"), result
+    assert result.get("files_modified") == [resolved_target], result

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -317,6 +317,7 @@ class LintResult:
     skipped: bool = False
     output: str = ""
     message: str = ""
+    introduced_errors: Optional[bool] = None
     
     def to_dict(self) -> dict:
         if self.skipped:
@@ -324,6 +325,8 @@ class LintResult:
         result = {"status": "ok" if self.success else "error", "output": self.output}
         if self.message:
             result["message"] = self.message
+        if self.introduced_errors is not None and not self.success:
+            result["introduced_errors"] = self.introduced_errors
         return result
 
 
@@ -1745,17 +1748,20 @@ class ShellFileOperations(FileOperations):
 
         # Hot path: clean post-write syntactically.
         if post.success or post.skipped:
+            post.introduced_errors = False
             return post
 
         # Post-write has syntax errors.  If we have pre-content, run the
         # delta refinement to filter out pre-existing errors.
         if pre_content is None:
+            post.introduced_errors = True
             return post
 
         pre = self._check_lint(path, content=pre_content)
         if pre.success or pre.skipped or not pre.output:
             # Pre-write was clean (or we couldn't lint it) — post errors
             # are all new.  Return the full post output.
+            post.introduced_errors = True
             return post
 
         # Both pre- and post-write had errors.  Compute the set-difference
@@ -1778,6 +1784,7 @@ class ShellFileOperations(FileOperations):
                 success=False,
                 output=post.output,
                 message="Pre-existing lint errors — this edit didn't introduce new ones but the file is still broken.",
+                introduced_errors=False,
             )
 
         return LintResult(
@@ -1785,7 +1792,8 @@ class ShellFileOperations(FileOperations):
             output=(
                 "New lint errors introduced by this edit "
                 "(pre-existing errors filtered out):\n" + "\n".join(post_lines)
-            )
+            ),
+            introduced_errors=True,
         )
 
     def _lsp_local_only(self) -> bool:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1675,6 +1675,16 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             result_dict = result.to_dict()
             if stale_warning:
                 result_dict["_warning"] = stale_warning
+            lint = result_dict.get("lint")
+            if (
+                not result_dict.get("error")
+                and isinstance(lint, dict)
+                and lint.get("status") == "error"
+                and lint.get("introduced_errors")
+            ):
+                result_dict["error"] = (
+                    lint.get("message") or f"Invalid syntax introduced while writing {path}"
+                )
             if not result_dict.get("error"):
                 _mark_verification_stale(task_id, [path], session_id=session_id)
             _update_read_timestamp(path, task_id)
@@ -1701,6 +1711,17 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # mismatch is visible in the response instead of silently routing
             # the edit to the wrong checkout.
             result_dict["resolved_path"] = _resolved
+            lint = result_dict.get("lint")
+            if (
+                not result_dict.get("error")
+                and isinstance(lint, dict)
+                and lint.get("status") == "error"
+                and lint.get("introduced_errors")
+            ):
+                result_dict["error"] = (
+                    lint.get("message")
+                    or f"Invalid syntax introduced while writing {_resolved}"
+                )
             if not result_dict.get("error"):
                 result_dict["files_modified"] = [_resolved]
                 _mark_verification_stale(task_id, [_resolved], session_id=session_id)
@@ -1854,8 +1875,21 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             _resolved_modified = [
                 _path_to_resolved.get(_p) or _p for _p in _paths_to_check
             ]
-            # Refresh stored timestamps for all successfully-patched paths so
-            # consecutive edits by this task don't trigger false warnings.
+            lint = result_dict.get("lint")
+            lint_regression = (
+                not result_dict.get("error")
+                and isinstance(lint, dict)
+                and lint.get("status") == "error"
+                and lint.get("introduced_errors")
+            )
+            if lint_regression:
+                result_dict["error"] = (
+                    lint.get("message")
+                    or f"Invalid syntax introduced while patching {(_resolved_modified[0] if _resolved_modified else path)}"
+                )
+                result_dict.pop("files_modified", None)
+                result_dict.pop("files_created", None)
+                result_dict.pop("files_deleted", None)
             if not result_dict.get("error"):
                 result_dict["files_modified"] = _resolved_modified
                 if len(_resolved_modified) == 1:
@@ -1872,6 +1906,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 _reset_patch_failures(task_id, [
                     _r for _r in (_path_to_resolved.get(_p) for _p in _paths_to_check) if _r
                 ])
+            else:
+                if _resolved_modified:
+                    result_dict["resolved_path"] = _resolved_modified[0]
         # Hint when old_string not found — saves iterations where the agent
         # retries with stale content instead of re-reading the file.
         # Suppressed when patch_replace already attached a rich "Did you mean?"


### PR DESCRIPTION
_[Bob] — automated contribution prepared and verified by Bob (Minseo Choi's autonomous assistant)._

## Summary

Fixes #60525. `write_file()` and `patch()` write to disk **before** their own
JSON/YAML/TOML syntax check runs, and the syntax result is only attached to the
response — it never sets the top-level `error` key. The `file_tools.py` wrappers gate
`files_modified` reporting on `not result_dict.get("error")`, so a write that produced
syntactically-invalid content is reported as a **successful modification**. On a
self-hosted deployment this silently corrupts config files: the agent writes invalid
JSON, is told it succeeded, and moves on.

## Root cause

`tools/file_operations.py`: `_atomic_write(path, content)` runs first, then
`_check_lint_delta()` afterward with its result merely attached. A *newly introduced*
syntax error (a lint delta regression) does not propagate as an error signal, so the
wrapper's success gate in `tools/file_tools.py` stays clean.

## Fix

Surface a syntax error introduced by *this* write so the wrapper stops reporting a clean
success and omits the file from `files_modified`. Applied to **both** `write_file_tool()`
and `patch_tool()` — the sibling path has the identical write-then-attach pattern, so the
whole bug class is fixed, not just the reported site.

Delta semantics preserved: pre-existing syntax errors that this write did not introduce
are **not** newly flagged; only errors this write introduced are surfaced.

## Verification

- New regression test (`tests/tools/test_file_tools_syntax_regression.py`): writing
  invalid JSON is NOT reported as success and the file is NOT in `files_modified`; a valid
  write still succeeds; a write into a file with a pre-existing error is not falsely flagged.
- Sibling coverage for `patch`.
- `python -m pytest tests/tools/test_file_tools_syntax_regression.py -q` → 4 passed.
- Manual runtime proof with real tool calls against a temporary `HERMES_HOME`: invalid
  write → `error` present + `introduced_errors: True`, no successful `files_modified`;
  valid write → `files_modified` present, no `error`; invalid replace-patch → `error`
  present, no successful `files_modified`.

