### PR TITLE
feat(telegram): Secretary Mode — business_message support + bot-echo classification + send-as-owner

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5577,6 +5577,7 @@ class BasePlatformAdapter(ABC):
         role_authorized: bool = False,
         auto_thread_created: bool = False,
         auto_thread_initial_name: Optional[str] = None,
+        business_connection_id: Optional[str] = None,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform.
 
@@ -5639,6 +5640,7 @@ class BasePlatformAdapter(ABC):
             role_authorized=role_authorized,
             auto_thread_created=auto_thread_created,
             auto_thread_initial_name=auto_thread_initial_name,
+            business_connection_id=business_connection_id,
         )
     
     @abstractmethod

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15383,6 +15383,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if team_id:
                 metadata = dict(metadata or {})
                 metadata["slack_team_id"] = str(team_id)
+        # Secretary Mode: propagate business_connection_id so the Telegram
+        # adapter's send() routes the reply as the business owner.
+        biz_conn_id = getattr(source, "business_connection_id", None)
+        if biz_conn_id:
+            if metadata is None:
+                metadata = {}
+            metadata["business_connection_id"] = biz_conn_id
         return metadata
 
     def _thread_metadata_for_target(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -273,6 +273,10 @@ class SessionSource:
             d["auto_thread_created"] = True
         if self.auto_thread_initial_name:
             d["auto_thread_initial_name"] = self.auto_thread_initial_name
+        # Secretary Mode: without this, a source restored from persistence
+        # loses send-as-owner routing and replies go out as the bot.
+        if self.business_connection_id:
+            d["business_connection_id"] = self.business_connection_id
         return d
 
     @classmethod
@@ -296,6 +300,7 @@ class SessionSource:
             profile=data.get("profile"),
             auto_thread_created=bool(data.get("auto_thread_created", False)),
             auto_thread_initial_name=data.get("auto_thread_initial_name"),
+            business_connection_id=data.get("business_connection_id"),
         )
     
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -190,6 +190,12 @@ class SessionSource:
     auto_thread_created: bool = False
     auto_thread_initial_name: Optional[str] = None
 
+    # Telegram Secretary Mode: the business connection ID when this message
+    # arrived via a connected business bot (business_message update). When set,
+    # replies must pass this ID to sendMessage so they're sent as the business
+    # owner's personal account, not as the bot. None for normal messages.
+    business_connection_id: Optional[str] = None
+
     # Internal, wire-INVISIBLE trust signal: True when this event was delivered
     # to the gateway over the per-instance-authenticated relay WebSocket (the
     # Team Gateway connector). The connector authenticates the gateway's socket

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -355,6 +355,9 @@ def cmd_send(args: argparse.Namespace) -> None:
         "target": target,
         "message": message,
     }
+    business_conn_id = getattr(args, "business_connection_id", None)
+    if business_conn_id:
+        tool_args["business_connection_id"] = business_conn_id
 
     result = send_message_tool(tool_args)
     exit_code = _emit_result(
@@ -462,6 +465,17 @@ def register_send_subparser(subparsers) -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Emit raw JSON result instead of human-readable output.",
+    )
+
+    parser.add_argument(
+        "--business-connection-id",
+        metavar="ID",
+        default=None,
+        help=(
+            "Telegram Secretary Mode: send as the business owner's personal "
+            "account via this connection ID (not as the bot). Read from the "
+            "Chat Automation connection — see the Telegram Secretary Mode doc."
+        ),
     )
 
     parser.set_defaults(func=cmd_send)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4062,6 +4062,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     thread_kwargs["message_thread_id"] = None
                 effective_thread_id = thread_kwargs.get("message_thread_id")
 
+                # Secretary Mode: pass business_connection_id so the message
+                # is sent as the business owner's personal account, not as
+                # the bot. Extracted from metadata (set by the gateway from
+                # the session source).
+                business_conn_id = (metadata or {}).get("business_connection_id")
+                business_kwargs = {}
+                if business_conn_id:
+                    business_kwargs["business_connection_id"] = business_conn_id
+
                 msg = None
                 for _send_attempt in range(3):
                     try:
@@ -4073,6 +4082,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
                                 **thread_kwargs,
+                                **business_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
                             )
@@ -4087,6 +4097,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
                                     **thread_kwargs,
+                                    **business_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
                                 )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7945,6 +7945,8 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         try:
             event = event or self._build_message_event(message, msg_type, update_id=update_id)
+            if event is None:
+                return
             shared_source = self._telegram_group_observe_shared_source(event.source)
             session_entry = store.get_or_create_session(shared_source)
             entry = {
@@ -8134,6 +8136,8 @@ class TelegramAdapter(BasePlatformAdapter):
         await self._ensure_forum_commands(update.message)
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        if event is None:
+            return
         event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
@@ -8156,6 +8160,8 @@ class TelegramAdapter(BasePlatformAdapter):
         await self._ensure_forum_commands(msg)
 
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
+        if event is None:
+            return
         event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
@@ -8204,6 +8210,8 @@ class TelegramAdapter(BasePlatformAdapter):
         parts.append("Ask what they'd like to find nearby (restaurants, cafes, etc.) and any preferences.")
 
         event = self._build_message_event(msg, MessageType.LOCATION, update_id=update.update_id)
+        if event is None:
+            return
         event.text = "\n".join(parts)
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)
@@ -8382,6 +8390,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 _m = update.message
                 _observe_type = self._media_message_type(_m)
                 _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
+                if _event is None:
+                    return
                 if _m.caption:
                     _event.text = self._clean_bot_trigger_text(_m.caption)
                 await self._cache_observed_media(_m, _event)
@@ -8395,6 +8405,8 @@ class TelegramAdapter(BasePlatformAdapter):
         msg_type = self._media_message_type(msg)
 
         event = self._build_message_event(msg, msg_type, update_id=update.update_id)
+        if event is None:
+            return
         
         # Add caption as text
         if msg.caption:
@@ -8934,14 +8946,31 @@ class TelegramAdapter(BasePlatformAdapter):
         message: Message,
         msg_type: MessageType,
         update_id: Optional[int] = None,
-    ) -> MessageEvent:
+    ) -> Optional[MessageEvent]:
         """Build a MessageEvent from a Telegram message.
 
         ``update_id`` is the ``Update.update_id`` from PTB; passing it through
         lets ``/restart`` record the triggering offset so the new gateway
         process can advance past it (prevents ``/restart`` being re-delivered
         when PTB's graceful-shutdown ACK fails).
+
+        Returns ``None`` for bot-echo business messages (the bot's own sends
+        relayed back as ``business_message`` updates) so callers can skip
+        enqueue without duplicating the classification at every call site
+        (#42400).
         """
+        # Secretary Mode: skip bot-echo business messages (#42400).
+        # When the bot sends via business_connection, Telegram relays the
+        # message back as a business_message with sender_business_bot set.
+        # Without this guard the gateway re-processes its own output.
+        if getattr(message, "business_connection_id", None):
+            if getattr(message, "sender_business_bot", None) is not None:
+                logger.debug(
+                    "[Telegram] Skipping bot-echo business message %s",
+                    getattr(message, "message_id", None),
+                )
+                return None
+
         chat = message.chat
         user = message.from_user
         

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -680,6 +680,11 @@ class TelegramAdapter(BasePlatformAdapter):
             min_value=1.0,
             max_value=300.0,
         )
+        # Secretary Mode: tracks active business connections by ID. Keyed by
+        # connection_id, value is {can_reply, user_chat_id}. Updated by the
+        # BusinessConnection lifecycle handler when the owner connects,
+        # disconnects, or edits the bot's settings in Chat Automation.
+        self._business_connections: Dict[str, dict] = {}
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
         self._media_batch_delay_seconds = env_float("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", 0.8)
@@ -3534,6 +3539,15 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+
+            # Secretary Mode: handle BusinessConnection lifecycle updates
+            # (connect/disconnect/settings changes). These arrive as
+            # update.business_connection, not as message updates.
+            from telegram.ext import TypeHandler
+            self._app.add_handler(
+                TypeHandler(Update, self._handle_business_connection),
+                group=-1,  # run before message handlers
+            )
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable
@@ -5829,6 +5843,36 @@ class TelegramAdapter(BasePlatformAdapter):
             )
         except Exception:
             pass
+
+    async def _handle_business_connection(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        """Handle BusinessConnection updates (Secretary Mode lifecycle).
+
+        Fired when the owner connects/disconnects the bot via Chat Automation,
+        or edits the connection settings. We track active connections so we
+        know whether we have reply permission (can_reply) for each.
+        """
+        conn = getattr(update, "business_connection", None)
+        if conn is None:
+            return
+
+        conn_id = getattr(conn, "id", None)
+        if conn_id is None:
+            return
+
+        if getattr(conn, "is_enabled", False):
+            self._business_connections[conn_id] = {
+                "can_reply": getattr(conn, "can_reply", False),
+                "user_chat_id": getattr(conn, "user_chat_id", None),
+            }
+            logger.info(
+                "[Telegram] Business connection active: id=%s can_reply=%s",
+                conn_id, getattr(conn, "can_reply", False),
+            )
+        else:
+            self._business_connections.pop(conn_id, None)
+            logger.info("[Telegram] Business connection removed: id=%s", conn_id)
 
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8950,6 +8950,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     break
 
         # Build source
+        # Extract business_connection_id for Secretary Mode messages.
+        # Present on business_message updates; None for normal messages.
+        business_conn_id = getattr(message, "business_connection_id", None)
+
         source = self.build_source(
             chat_id=str(chat.id),
             chat_name=chat.title or (chat.full_name if hasattr(chat, "full_name") else None),
@@ -8972,6 +8976,7 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_topic=chat_topic,
             message_id=str(message.message_id),
             is_bot=bool(getattr(user, "is_bot", False)) if user else False,
+            business_connection_id=business_conn_id,
         )
         
         # Extract reply context if this message is a reply.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -855,6 +855,20 @@ class TelegramAdapter(BasePlatformAdapter):
             return {}
         return {"disable_notification": True}
 
+    def _business_kwargs(
+        self, metadata: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Return business_connection_id kwargs for Secretary Mode sends.
+
+        Text AND media sends must carry the connection ID, or a reply's
+        attachments are delivered as the bot while its text went out as the
+        business owner.
+        """
+        business_conn_id = (metadata or {}).get("business_connection_id")
+        if business_conn_id:
+            return {"business_connection_id": business_conn_id}
+        return {}
+
     def _is_callback_user_authorized(
         self,
         user_id: str,
@@ -995,7 +1009,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # the owner has explicitly scoped which chats the bot sees. The
         # business_connection_id is set by Telegram server-side and cannot
         # be spoofed by the client.
-        if getattr(message, "business_connection_id", None):
+        if self._business_connection_id_of(message):
             return True
 
         source = self._source_from_message_for_auth(message)
@@ -4080,10 +4094,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # is sent as the business owner's personal account, not as
                 # the bot. Extracted from metadata (set by the gateway from
                 # the session source).
-                business_conn_id = (metadata or {}).get("business_connection_id")
-                business_kwargs = {}
-                if business_conn_id:
-                    business_kwargs["business_connection_id"] = business_conn_id
+                business_kwargs = self._business_kwargs(metadata)
 
                 msg = None
                 for _send_attempt in range(3):
@@ -4792,6 +4803,11 @@ class TelegramAdapter(BasePlatformAdapter):
         fall back to the edit path even on DMs.
         """
         if not self._bot or not hasattr(self._bot, "send_message_draft"):
+            return False
+        # Secretary Mode: the draft API has no business_connection_id
+        # parameter, so drafts cannot be posted into a business chat. Route
+        # business replies through the plain ``send`` path instead.
+        if (metadata or {}).get("business_connection_id"):
             return False
         return (chat_type or "").lower() in {"dm", "private"}
 
@@ -6441,6 +6457,7 @@ class TelegramAdapter(BasePlatformAdapter):
                             "duration": _duration_secs,
                             **voice_thread_kwargs,
                             **self._notification_kwargs(metadata),
+                            **self._business_kwargs(metadata),
                         },
                         metadata,
                         reply_to_id,
@@ -6468,6 +6485,7 @@ class TelegramAdapter(BasePlatformAdapter):
                             "duration": _duration_secs,
                             **audio_thread_kwargs,
                             **self._notification_kwargs(metadata),
+                            **self._business_kwargs(metadata),
                         },
                         metadata,
                         reply_to_id,
@@ -6606,6 +6624,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
+                        **self._business_kwargs(metadata),
                     },
                     metadata,
                     reply_to_id,
@@ -6665,6 +6684,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
+                        **self._business_kwargs(metadata),
                     },
                     metadata,
                     reply_to_id,
@@ -6762,6 +6782,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
+                        **self._business_kwargs(metadata),
                     },
                     metadata,
                     reply_to_id,
@@ -6812,6 +6833,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
+                        **self._business_kwargs(metadata),
                     },
                     metadata,
                     reply_to_id,
@@ -6867,6 +6889,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     "reply_to_message_id": reply_to_id,
                     **photo_thread_kwargs,
                     **self._notification_kwargs(metadata),
+                    **self._business_kwargs(metadata),
                 },
                 metadata,
                 reply_to_id,
@@ -6904,6 +6927,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "reply_to_message_id": reply_to_id,
                         **upload_thread_kwargs,
                         **self._notification_kwargs(metadata),
+                        **self._business_kwargs(metadata),
                     },
                     metadata,
                     reply_to_id,
@@ -6951,6 +6975,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     "reply_to_message_id": reply_to_id,
                     **animation_thread_kwargs,
                     **self._notification_kwargs(metadata),
+                    **self._business_kwargs(metadata),
                 },
                 metadata,
                 reply_to_id,
@@ -7969,6 +7994,103 @@ class TelegramAdapter(BasePlatformAdapter):
             adapter_name = getattr(self, "name", "telegram")
             logger.warning("[%s] Failed to observe Telegram group message: %s", adapter_name, exc)
 
+    @staticmethod
+    def _business_connection_id_of(message: Message) -> Optional[str]:
+        """The message's business_connection_id as a string, or None.
+
+        Telegram always delivers the ID as a non-empty string; anything else
+        (None, or a test double's auto-generated attribute) means "not a
+        business message". Every Secretary Mode gate must go through this so
+        non-business traffic can never be misclassified.
+        """
+        conn_id = getattr(message, "business_connection_id", None)
+        if isinstance(conn_id, str) and conn_id:
+            return conn_id
+        return None
+
+    def _classify_business_message(self, message: Message) -> Optional[str]:
+        """Classify a Secretary Mode ``business_message`` by author (#42400).
+
+        Returns ``None`` for non-business messages, otherwise one of:
+
+        - ``"bot_echo"`` — a business bot's send relayed back by Telegram
+          (``sender_business_bot`` set). Never re-enters the agent path; our
+          own sends are already recorded by the send path.
+        - ``"owner_outgoing"`` — typed manually by the business owner from one
+          of their devices. Retained as session context so the agent sees the
+          conversation state, but never enqueued: the owner isn't asking us.
+        - ``"customer"`` — inbound from the chat peer; the normal agent path.
+
+        Owner detection prefers the BusinessConnection state tracked by
+        ``_handle_business_connection``. When that state is missing (Telegram
+        does not replay BusinessConnection updates after a gateway restart) it
+        falls back to the structural signal that in a private business chat
+        the peer's ``from_user.id`` equals ``chat.id`` while the owner's does
+        not.
+        """
+        conn_id = self._business_connection_id_of(message)
+        if not conn_id:
+            return None
+        if getattr(message, "sender_business_bot", None) is not None:
+            return "bot_echo"
+        from_id = getattr(getattr(message, "from_user", None), "id", None)
+        if from_id is None:
+            return "customer"
+        conn = self._business_connections.get(conn_id) or {}
+        owner_id = conn.get("user_chat_id")
+        if owner_id is not None and str(from_id) == str(owner_id):
+            return "owner_outgoing"
+        chat_id = getattr(getattr(message, "chat", None), "id", None)
+        if chat_id is not None and str(from_id) != str(chat_id):
+            return "owner_outgoing"
+        return "customer"
+
+    def _observe_business_owner_message(
+        self,
+        message: Message,
+        msg_type: MessageType,
+        update_id: Optional[int] = None,
+        event: Optional[MessageEvent] = None,
+    ) -> None:
+        """Append the owner's manual business reply to the chat session (#42400).
+
+        Secretary Mode: when the owner answers a customer themselves, the
+        agent must see that reply as context — so it doesn't answer again or
+        contradict the owner — without treating it as a prompt. Unlike
+        ``_observe_unmentioned_group_message`` this keeps the event's own
+        source: for DMs the session key ignores user fields, so the entry
+        lands in the same session the customer's messages are processed in.
+        """
+        store = getattr(self, "_session_store", None)
+        if not store:
+            return
+        try:
+            event = event or self._build_message_event(message, msg_type, update_id=update_id)
+            if event is None:
+                return
+            session_entry = store.get_or_create_session(event.source)
+            sender = event.source.user_name or event.source.user_id or "owner"
+            entry = {
+                "role": "user",
+                "content": f"[business owner {sender} replied manually]\n{event.text or ''}",
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "observed": True,
+            }
+            if event.message_id:
+                entry["message_id"] = str(event.message_id)
+            store.append_to_transcript(session_entry.session_id, entry)
+            logger.info(
+                "[%s] Observed manual owner reply in business chat %s",
+                getattr(self, "name", "telegram"),
+                getattr(getattr(message, "chat", None), "id", "unknown"),
+            )
+        except Exception as exc:
+            logger.warning(
+                "[%s] Failed to observe business owner message: %s",
+                getattr(self, "name", "telegram"),
+                exc,
+            )
+
     def _is_own_message(self, message: Message) -> bool:
         """Return True when the message was sent by this bot itself.
 
@@ -8129,11 +8251,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(msg, "chat", None), "id", None),
             )
             return
+        biz_class = self._classify_business_message(msg)
+        if biz_class == "bot_echo":
+            return
+        if biz_class == "owner_outgoing":
+            self._observe_business_owner_message(msg, MessageType.TEXT, update_id=update.update_id)
+            return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
-        await self._ensure_forum_commands(update.message)
+        await self._ensure_forum_commands(msg)
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         if event is None:
@@ -8157,6 +8285,24 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(msg, "chat", None), "id", None),
             )
             return
+        biz_class = self._classify_business_message(msg)
+        if biz_class == "bot_echo":
+            return
+        if biz_class == "owner_outgoing":
+            self._observe_business_owner_message(msg, MessageType.TEXT, update_id=update.update_id)
+            return
+        if biz_class == "customer":
+            # Secretary Mode: the business connection pre-authorizes the
+            # *conversation*, not operator authority — a customer must never
+            # drive slash commands. Route the text to the agent as an
+            # ordinary message instead of the command executor.
+            event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+            if event is None:
+                return
+            event.text = self._clean_bot_trigger_text(event.text)
+            await self._cache_replied_media(msg, event)
+            self._enqueue_text_event(event)
+            return
         await self._ensure_forum_commands(msg)
 
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
@@ -8178,6 +8324,24 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(msg, "from_user", None), "id", None),
                 getattr(getattr(msg, "chat", None), "id", None),
             )
+            return
+        biz_class = self._classify_business_message(msg)
+        if biz_class == "bot_echo":
+            return
+        if biz_class == "owner_outgoing":
+            event = self._build_message_event(msg, MessageType.LOCATION, update_id=update.update_id)
+            if event is not None:
+                loc = getattr(msg, "location", None)
+                lat = getattr(loc, "latitude", None)
+                lon = getattr(loc, "longitude", None)
+                event.text = (
+                    f"[shared a location pin: {lat}, {lon}]"
+                    if lat is not None and lon is not None
+                    else "[shared a location pin]"
+                )
+                self._observe_business_owner_message(
+                    msg, MessageType.LOCATION, update_id=update.update_id, event=event
+                )
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
@@ -8375,19 +8539,40 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_photo_batch_tasks[batch_key] = asyncio.create_task(self._flush_photo_batch(batch_key))
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        """Handle incoming media messages, downloading images to local cache."""
-        if not update.message:
+        """Handle incoming media messages, downloading images to local cache.
+
+        Uses ``effective_message`` (not ``update.message``) so Secretary Mode
+        business media — delivered as ``update.business_message`` — reaches
+        the same download/caching path as normal media.
+        """
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._is_user_authorized_from_message(update.message):
+        if not self._is_user_authorized_from_message(msg):
             logger.info(
                 "[Telegram] Blocked media from unauthorized user %s in chat %s",
-                getattr(getattr(update.message, "from_user", None), "id", None),
-                getattr(getattr(update.message, "chat", None), "id", None),
+                getattr(getattr(msg, "from_user", None), "id", None),
+                getattr(getattr(msg, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
+        biz_class = self._classify_business_message(msg)
+        if biz_class == "bot_echo":
+            return
+        if biz_class == "owner_outgoing":
+            _observe_type = self._media_message_type(msg)
+            _event = self._build_message_event(msg, _observe_type, update_id=update.update_id)
+            if _event is None:
+                return
+            if msg.caption:
+                _event.text = self._clean_bot_trigger_text(msg.caption)
+            await self._cache_observed_media(msg, _event)
+            self._observe_business_owner_message(
+                msg, _event.message_type, update_id=update.update_id, event=_event
+            )
+            return
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                _m = msg
                 _observe_type = self._media_message_type(_m)
                 _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
                 if _event is None:
@@ -8399,8 +8584,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     _m, _event.message_type, update_id=update.update_id, event=_event
                 )
             return
-
-        msg = update.message
 
         msg_type = self._media_message_type(msg)
 
@@ -8963,7 +9146,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # When the bot sends via business_connection, Telegram relays the
         # message back as a business_message with sender_business_bot set.
         # Without this guard the gateway re-processes its own output.
-        if getattr(message, "business_connection_id", None):
+        if self._business_connection_id_of(message):
             if getattr(message, "sender_business_bot", None) is not None:
                 logger.debug(
                     "[Telegram] Skipping bot-echo business message %s",
@@ -9045,7 +9228,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # Build source
         # Extract business_connection_id for Secretary Mode messages.
         # Present on business_message updates; None for normal messages.
-        business_conn_id = getattr(message, "business_connection_id", None)
+        business_conn_id = self._business_connection_id_of(message)
 
         source = self.build_source(
             chat_id=str(chat.id),

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -984,6 +984,15 @@ class TelegramAdapter(BasePlatformAdapter):
         context-aware decision the runner would make. Unknown DMs with no
         allowlist still pass through so the normal pairing flow can run.
         """
+        # Secretary Mode: messages carrying a business_connection_id are
+        # pre-authorized by the owner connecting the bot via Chat Automation.
+        # The external client's user ID will never be in the allowlist, but
+        # the owner has explicitly scoped which chats the bot sees. The
+        # business_connection_id is set by Telegram server-side and cannot
+        # be spoofed by the client.
+        if getattr(message, "business_connection_id", None):
+            return True
+
         source = self._source_from_message_for_auth(message)
         user_id = source.user_id
         # No identity at all → genuine group service message (pin, delete,

--- a/tests/gateway/test_telegram_business_message.py
+++ b/tests/gateway/test_telegram_business_message.py
@@ -283,3 +283,313 @@ def test_build_message_event_keeps_customer_inbound(classify_adapter):
 
     result = classify_adapter._build_message_event(msg, MagicMock())
     assert result is not None, "Customer inbound business messages must be processed"
+
+
+# ---------------------------------------------------------------------------
+# Review follow-up: SessionSource persistence round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_session_source_serialization_round_trips_business_connection_id():
+    """Restored sources must keep send-as-owner routing across persistence."""
+    from gateway.session import SessionSource
+    from gateway.platforms.base import Platform
+
+    src = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        business_connection_id="conn_persist1",
+    )
+    data = src.to_dict()
+    assert data["business_connection_id"] == "conn_persist1"
+    restored = SessionSource.from_dict(data)
+    assert restored.business_connection_id == "conn_persist1"
+
+
+def test_session_source_serialization_omits_field_when_absent():
+    from gateway.session import SessionSource
+    from gateway.platforms.base import Platform
+
+    src = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+    data = src.to_dict()
+    assert "business_connection_id" not in data
+    assert SessionSource.from_dict(data).business_connection_id is None
+
+
+# ---------------------------------------------------------------------------
+# Review follow-up (#42400): owner/bot/customer classification
+# ---------------------------------------------------------------------------
+
+
+def _biz_msg(conn="conn_c1", from_id=999, chat_id=999, sender_business_bot=None):
+    msg = MagicMock()
+    msg.business_connection_id = conn
+    msg.sender_business_bot = sender_business_bot
+    msg.from_user = SimpleNamespace(id=from_id) if from_id is not None else None
+    msg.chat = SimpleNamespace(id=chat_id, type="private")
+    return msg
+
+
+class TestBusinessMessageClassification:
+    def test_non_business_returns_none(self, classify_adapter):
+        assert classify_adapter._classify_business_message(_biz_msg(conn=None)) is None
+
+    def test_bot_echo(self, classify_adapter):
+        m = _biz_msg(sender_business_bot=SimpleNamespace(id=42))
+        assert classify_adapter._classify_business_message(m) == "bot_echo"
+
+    def test_customer_inbound(self, classify_adapter):
+        # In a private business chat the peer's from_user.id equals chat.id.
+        m = _biz_msg(from_id=999, chat_id=999)
+        assert classify_adapter._classify_business_message(m) == "customer"
+
+    def test_owner_via_connection_state(self, classify_adapter):
+        classify_adapter._business_connections["conn_c1"] = {
+            "can_reply": True,
+            "user_chat_id": 111,
+        }
+        m = _biz_msg(from_id=111, chat_id=999)
+        assert classify_adapter._classify_business_message(m) == "owner_outgoing"
+
+    def test_owner_via_structural_fallback_after_restart(self, classify_adapter):
+        # No tracked connection (e.g. gateway restarted; Telegram does not
+        # replay BusinessConnection updates): the owner is still detected
+        # because their from_user.id differs from the chat's peer id.
+        m = _biz_msg(from_id=111, chat_id=999)
+        assert classify_adapter._classify_business_message(m) == "owner_outgoing"
+
+
+# ---------------------------------------------------------------------------
+# Review follow-up (#42400): handler wiring — owner observed, not enqueued
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def intake_adapter(monkeypatch):
+    """Adapter wired for testing handler intake classification."""
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+    a._ensure_forum_commands = AsyncMock()
+    a._cache_replied_media = AsyncMock()
+    a._cache_observed_media = AsyncMock()
+    a._clean_bot_trigger_text = lambda t: t
+    a._enqueue_text_event = MagicMock()
+    a._observe_business_owner_message = MagicMock()
+    a.handle_message = AsyncMock()
+    return a
+
+
+def _update_for(msg, update_id=7):
+    """A business update: update.message is None, effective_message is set."""
+    return SimpleNamespace(update_id=update_id, message=None, effective_message=msg)
+
+
+def _full_biz_text_msg(text="hello", from_id=456, chat_id=456, conn="conn_t1"):
+    msg = MagicMock()
+    msg.text = text
+    msg.business_connection_id = conn
+    msg.sender_business_bot = None
+    msg.message_id = 321
+    msg.message_thread_id = None
+    msg.chat = MagicMock(id=chat_id, type="private", full_name="Client Chat")
+    msg.chat.message_thread_id = None
+    msg.from_user = MagicMock(id=from_id, full_name="Someone", is_bot=False)
+    msg.reply_to_message = None
+    msg.quote = None
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_text_handler_enqueues_customer_message(intake_adapter):
+    msg = _full_biz_text_msg(from_id=456, chat_id=456)
+    await intake_adapter._handle_text_message(_update_for(msg), MagicMock())
+    intake_adapter._enqueue_text_event.assert_called_once()
+    intake_adapter._observe_business_owner_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_text_handler_observes_owner_message_without_enqueue(intake_adapter):
+    from gateway.platforms.base import MessageType
+
+    msg = _full_biz_text_msg(from_id=111, chat_id=456)
+    await intake_adapter._handle_text_message(_update_for(msg), MagicMock())
+    intake_adapter._observe_business_owner_message.assert_called_once()
+    assert intake_adapter._observe_business_owner_message.call_args.args[1] == MessageType.TEXT
+    intake_adapter._enqueue_text_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_text_handler_skips_bot_echo_entirely(intake_adapter):
+    msg = _full_biz_text_msg(from_id=111, chat_id=456)
+    msg.sender_business_bot = MagicMock(id=8712662056)
+    await intake_adapter._handle_text_message(_update_for(msg), MagicMock())
+    intake_adapter._enqueue_text_event.assert_not_called()
+    intake_adapter._observe_business_owner_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_command_from_business_customer_routed_as_text(intake_adapter):
+    """A customer must never drive operator slash commands: the business
+    connection pre-authorizes the conversation, not operator authority."""
+    msg = _full_biz_text_msg(text="/restart", from_id=456, chat_id=456)
+    await intake_adapter._handle_command(_update_for(msg), MagicMock())
+    intake_adapter.handle_message.assert_not_called()
+    intake_adapter._enqueue_text_event.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_command_from_owner_observed_not_executed(intake_adapter):
+    msg = _full_biz_text_msg(text="/note done", from_id=111, chat_id=456)
+    await intake_adapter._handle_command(_update_for(msg), MagicMock())
+    intake_adapter.handle_message.assert_not_called()
+    intake_adapter._enqueue_text_event.assert_not_called()
+    intake_adapter._observe_business_owner_message.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Review follow-up: media handler must use the effective-message path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_media_handler_reaches_business_media(intake_adapter):
+    """Business media arrives as update.business_message (update.message is
+    None); reading update.message directly dropped it before any handling."""
+    msg = MagicMock()
+    msg.business_connection_id = "conn_m1"
+    msg.sender_business_bot = None
+    auth = MagicMock(return_value=False)
+    intake_adapter._is_user_authorized_from_message = auth
+
+    await intake_adapter._handle_media_message(_update_for(msg), MagicMock())
+
+    auth.assert_called_once_with(msg)
+
+
+@pytest.mark.asyncio
+async def test_media_handler_observes_owner_media(intake_adapter):
+    from gateway.platforms.base import MessageType
+
+    msg = _full_biz_text_msg(from_id=111, chat_id=456)
+    msg.caption = None
+    intake_adapter._media_message_type = MagicMock(return_value=MessageType.PHOTO)
+    stub_event = MagicMock(message_type=MessageType.PHOTO)
+    intake_adapter._build_message_event = MagicMock(return_value=stub_event)
+
+    await intake_adapter._handle_media_message(_update_for(msg), MagicMock())
+
+    intake_adapter._cache_observed_media.assert_awaited_once_with(msg, stub_event)
+    intake_adapter._observe_business_owner_message.assert_called_once()
+    intake_adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_media_handler_skips_bot_echo(intake_adapter):
+    msg = _full_biz_text_msg(from_id=111, chat_id=456)
+    msg.sender_business_bot = MagicMock(id=1)
+    intake_adapter._build_message_event = MagicMock()
+
+    await intake_adapter._handle_media_message(_update_for(msg), MagicMock())
+
+    intake_adapter._build_message_event.assert_not_called()
+    intake_adapter.handle_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Review follow-up: owner observation appends to the customer-chat session
+# ---------------------------------------------------------------------------
+
+
+def test_observe_business_owner_message_appends_to_chat_session(monkeypatch):
+    from gateway.platforms.base import MessageType
+
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+    store = MagicMock()
+    store.get_or_create_session.return_value = SimpleNamespace(session_id="sess-1")
+    a._session_store = store
+
+    event = MagicMock()
+    event.source = SimpleNamespace(user_name="Olga Owner", user_id="111")
+    event.text = "handled it, no need to reply"
+    event.message_id = 777
+
+    a._observe_business_owner_message(MagicMock(), MessageType.TEXT, event=event)
+
+    store.get_or_create_session.assert_called_once_with(event.source)
+    store.append_to_transcript.assert_called_once()
+    sid, entry = store.append_to_transcript.call_args.args
+    assert sid == "sess-1"
+    assert entry["role"] == "user"
+    assert entry["observed"] is True
+    assert entry["message_id"] == "777"
+    assert "Olga Owner" in entry["content"]
+    assert "handled it, no need to reply" in entry["content"]
+
+
+def test_observe_business_owner_message_without_store_is_noop(monkeypatch):
+    from gateway.platforms.base import MessageType
+
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+    # No _session_store set: must not raise.
+    a._observe_business_owner_message(MagicMock(), MessageType.TEXT, event=MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Review follow-up: media/draft send paths carry the connection ID
+# ---------------------------------------------------------------------------
+
+
+def test_business_kwargs_helper(monkeypatch):
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+    assert a._business_kwargs({"business_connection_id": "c9"}) == {
+        "business_connection_id": "c9"
+    }
+    assert a._business_kwargs({}) == {}
+    assert a._business_kwargs(None) == {}
+
+
+@pytest.mark.asyncio
+async def test_send_document_carries_business_connection_id(send_adapter, tmp_path):
+    doc = tmp_path / "invoice.pdf"
+    doc.write_bytes(b"%PDF-1.4 test")
+    send_adapter._send_with_dm_topic_reply_anchor_retry = AsyncMock(
+        return_value=SimpleNamespace(message_id=5)
+    )
+    send_adapter._reply_to_message_id_for_send = lambda *a, **k: None
+
+    await send_adapter.send_document(
+        "123456", str(doc), metadata={"business_connection_id": "conn_doc1"}
+    )
+
+    kwargs_dict = send_adapter._send_with_dm_topic_reply_anchor_retry.call_args.args[1]
+    assert kwargs_dict["business_connection_id"] == "conn_doc1"
+
+
+def test_draft_streaming_disabled_for_business_sends(monkeypatch):
+    """Drafts cannot target a business chat; business replies must take the
+    plain send path (which carries business_connection_id end to end)."""
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+    a._bot = MagicMock()  # MagicMock exposes send_message_draft
+
+    assert a.supports_draft_streaming("dm", metadata={}) is True
+    assert (
+        a.supports_draft_streaming(
+            "dm", metadata={"business_connection_id": "conn_d1"}
+        )
+        is False
+    )

--- a/tests/gateway/test_telegram_business_message.py
+++ b/tests/gateway/test_telegram_business_message.py
@@ -111,8 +111,13 @@ def test_business_message_bypasses_user_auth(monkeypatch):
     assert result is True, "Business messages should bypass user-ID auth"
 
 
-def test_normal_message_still_requires_auth(monkeypatch):
-    """Non-business messages must still go through normal auth."""
+def test_normal_message_does_not_trigger_bypass(monkeypatch):
+    """Non-business messages must not trigger the Secretary Mode bypass.
+
+    The adapter defers unknown-DM auth to the pairing flow, so we can't
+    assert a False return. Instead, verify the bypass path is NOT taken
+    by checking that auth falls through to the normal logic.
+    """
     _install_fake_telegram(monkeypatch)
     from plugins.platforms.telegram.adapter import TelegramAdapter
 
@@ -123,9 +128,11 @@ def test_normal_message_still_requires_auth(monkeypatch):
     msg.business_connection_id = None  # not a business message
     msg.chat = MagicMock(id=123456, type="private")
 
-    # No allowed users configured — should reject
-    result = a._is_user_authorized_from_message(msg)
-    assert result is False, "Non-business messages from unknown users must be rejected"
+    # _source_from_message_for_auth should still be called (no early return)
+    called = MagicMock(wraps=a._source_from_message_for_auth)
+    a._source_from_message_for_auth = called
+    a._is_user_authorized_from_message(msg)
+    assert called.called, "Non-business messages must reach the normal auth path"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_business_message.py
+++ b/tests/gateway/test_telegram_business_message.py
@@ -233,3 +233,53 @@ async def test_business_connection_removes_on_disconnect(lifecycle_adapter):
     await lifecycle_adapter._handle_business_connection(update, MagicMock())
 
     assert "conn_lifecycle1" not in lifecycle_adapter._business_connections
+
+
+# ---------------------------------------------------------------------------
+# #42400: bot-echo classification — _build_message_event returns None
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def classify_adapter(monkeypatch):
+    """Adapter wired for testing the bot-echo classification."""
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+    return a
+
+
+def test_build_message_event_skips_bot_echo(classify_adapter):
+    """_build_message_event should return None for bot-echo business messages.
+
+    When the bot sends via business_connection, Telegram relays the message
+    back with sender_business_bot set. The gateway must not re-process its
+    own output (#42400).
+    """
+    msg = MagicMock()
+    msg.business_connection_id = "conn_echo1"
+    msg.sender_business_bot = MagicMock(id=8712662056)
+    msg.message_id = 123
+    msg.chat = MagicMock(id=456, type="private", full_name="Test")
+    msg.from_user = MagicMock(id=999, full_name="Client", is_bot=False)
+
+    result = classify_adapter._build_message_event(msg, MagicMock())
+    assert result is None, "Bot-echo business messages must return None"
+
+
+def test_build_message_event_keeps_customer_inbound(classify_adapter):
+    """_build_message_event should process customer inbound business messages."""
+    msg = MagicMock()
+    msg.business_connection_id = "conn_inbound1"
+    msg.sender_business_bot = None  # not a bot echo
+    msg.message_id = 124
+    msg.message_thread_id = None
+    msg.chat = MagicMock(id=456, type="private", full_name="Test")
+    msg.chat.message_thread_id = None
+    msg.from_user = MagicMock(id=999, full_name="Client", is_bot=False)
+    msg.reply_to_message = None
+    msg.quote = None
+
+    result = classify_adapter._build_message_event(msg, MagicMock())
+    assert result is not None, "Customer inbound business messages must be processed"

--- a/tests/gateway/test_telegram_business_message.py
+++ b/tests/gateway/test_telegram_business_message.py
@@ -1,0 +1,228 @@
+"""Tests for Telegram Secretary Mode / business_message support.
+
+Covers:
+  - SessionSource carries business_connection_id
+  - _build_message_event extracts it from business messages
+  - Auth bypass: business messages pre-authorized by Chat Automation
+  - send() passes business_connection_id to bot.send_message
+  - BusinessConnection lifecycle handler stores/removes connections
+"""
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+
+
+def _install_fake_telegram(monkeypatch):
+    """Stub the python-telegram-bot package so TelegramAdapter can be imported."""
+    fake_telegram = types.ModuleType("telegram")
+    fake_telegram.Update = SimpleNamespace(ALL_TYPES=())
+    fake_telegram.Bot = object
+    fake_telegram.Message = object
+    fake_telegram.InlineKeyboardButton = object
+    fake_telegram.InlineKeyboardMarkup = object
+
+    fake_error = types.ModuleType("telegram.error")
+    fake_error.NetworkError = type("NetworkError", (Exception,), {})
+    fake_error.BadRequest = type("BadRequest", (Exception,), {})
+    fake_error.TimedOut = type("TimedOut", (Exception,), {})
+    fake_telegram.error = fake_error
+
+    fake_constants = types.ModuleType("telegram.constants")
+    fake_constants.ParseMode = SimpleNamespace(MARKDOWN_V2="MarkdownV2")
+    fake_constants.ChatType = SimpleNamespace(
+        GROUP="group", SUPERGROUP="supergroup",
+        CHANNEL="channel", PRIVATE="private",
+    )
+    fake_telegram.constants = fake_constants
+
+    fake_ext = types.ModuleType("telegram.ext")
+    fake_ext.Application = object
+    fake_ext.CommandHandler = object
+    fake_ext.CallbackQueryHandler = object
+    fake_ext.MessageHandler = object
+    fake_ext.TypeHandler = object
+    fake_ext.ContextTypes = SimpleNamespace(DEFAULT_TYPE=object)
+    fake_ext.filters = object
+
+    fake_request = types.ModuleType("telegram.request")
+    fake_request.HTTPXRequest = object
+
+    monkeypatch.setitem(sys.modules, "telegram", fake_telegram)
+    monkeypatch.setitem(sys.modules, "telegram.error", fake_error)
+    monkeypatch.setitem(sys.modules, "telegram.constants", fake_constants)
+    monkeypatch.setitem(sys.modules, "telegram.ext", fake_ext)
+    monkeypatch.setitem(sys.modules, "telegram.request", fake_request)
+
+
+# ---------------------------------------------------------------------------
+# Task 1: SessionSource field
+# ---------------------------------------------------------------------------
+
+
+def test_session_source_accepts_business_connection_id():
+    """SessionSource should accept business_connection_id."""
+    from gateway.session import SessionSource
+    from gateway.platforms.base import Platform
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        business_connection_id="conn_abc123",
+    )
+    assert source.business_connection_id == "conn_abc123"
+
+
+def test_session_source_business_connection_id_defaults_none():
+    """business_connection_id should default to None for non-business sources."""
+    from gateway.session import SessionSource
+    from gateway.platforms.base import Platform
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123")
+    assert source.business_connection_id is None
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Auth bypass for business messages
+# ---------------------------------------------------------------------------
+
+
+def test_business_message_bypasses_user_auth(monkeypatch):
+    """Business messages are pre-authorized by Chat Automation connection."""
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+
+    # A business message from an external client (not in any allowlist)
+    msg = MagicMock()
+    msg.from_user = MagicMock(id=999999)
+    msg.business_connection_id = "conn_active123"
+    msg.chat = MagicMock(id=123456, type="private")
+
+    result = a._is_user_authorized_from_message(msg)
+    assert result is True, "Business messages should bypass user-ID auth"
+
+
+def test_normal_message_still_requires_auth(monkeypatch):
+    """Non-business messages must still go through normal auth."""
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+
+    msg = MagicMock()
+    msg.from_user = MagicMock(id=999999)
+    msg.business_connection_id = None  # not a business message
+    msg.chat = MagicMock(id=123456, type="private")
+
+    # No allowed users configured — should reject
+    result = a._is_user_authorized_from_message(msg)
+    assert result is False, "Non-business messages from unknown users must be rejected"
+
+
+# ---------------------------------------------------------------------------
+# Task 4: send() passes business_connection_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def send_adapter(monkeypatch):
+    """Adapter wired for testing the send() path."""
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+    a._bot = MagicMock()
+    a._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    a._send_path_degraded = False
+    a.format_message = lambda x: x
+    a.truncate_message = lambda x, y, len_fn=None: [x]
+    a._metadata_thread_id = lambda x: None
+    a._message_thread_id_for_send = lambda x: None
+    a._should_thread_reply = lambda x, y: False
+    a._thread_kwargs_for_send = lambda *ag, **kw: {}
+    a._link_preview_kwargs = lambda: {}
+    a._notification_kwargs = lambda x: {}
+    a._should_attempt_rich = lambda x, metadata=None: False
+    a._reply_to_mode = "smart"
+    a._is_thread_not_found_error = lambda e: False
+    a._looks_like_network_error = lambda e: False
+    return a
+
+
+@pytest.mark.asyncio
+async def test_send_passes_business_connection_id(send_adapter):
+    """send() should pass business_connection_id to bot.send_message."""
+    metadata = {"business_connection_id": "conn_send123"}
+
+    await send_adapter.send("123456", "Hello client", metadata=metadata)
+
+    assert send_adapter._bot.send_message.called
+    call_kwargs = send_adapter._bot.send_message.call_args
+    assert call_kwargs.kwargs.get("business_connection_id") == "conn_send123"
+
+
+@pytest.mark.asyncio
+async def test_send_omits_business_connection_id_when_absent(send_adapter):
+    """send() should NOT pass business_connection_id for normal messages."""
+    await send_adapter.send("123456", "Hello", metadata={})
+
+    assert send_adapter._bot.send_message.called
+    call_kwargs = send_adapter._bot.send_message.call_args
+    assert "business_connection_id" not in call_kwargs.kwargs
+
+
+# ---------------------------------------------------------------------------
+# Task 6: BusinessConnection lifecycle handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def lifecycle_adapter(monkeypatch):
+    """Adapter wired for testing the lifecycle handler."""
+    _install_fake_telegram(monkeypatch)
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+    return a
+
+
+@pytest.mark.asyncio
+async def test_business_connection_stores_active_connection(lifecycle_adapter):
+    """_handle_business_connection should store active connections."""
+    update = MagicMock()
+    update.business_connection = MagicMock()
+    update.business_connection.id = "conn_lifecycle1"
+    update.business_connection.is_enabled = True
+    update.business_connection.can_reply = True
+    update.business_connection.user_chat_id = 111111
+
+    await lifecycle_adapter._handle_business_connection(update, MagicMock())
+
+    assert "conn_lifecycle1" in lifecycle_adapter._business_connections
+    assert lifecycle_adapter._business_connections["conn_lifecycle1"]["can_reply"] is True
+
+
+@pytest.mark.asyncio
+async def test_business_connection_removes_on_disconnect(lifecycle_adapter):
+    """Disconnect should remove the connection from active set."""
+    lifecycle_adapter._business_connections = {
+        "conn_lifecycle1": {"can_reply": True, "user_chat_id": 111111}
+    }
+
+    update = MagicMock()
+    update.business_connection = MagicMock()
+    update.business_connection.id = "conn_lifecycle1"
+    update.business_connection.is_enabled = False
+
+    await lifecycle_adapter._handle_business_connection(update, MagicMock())
+
+    assert "conn_lifecycle1" not in lifecycle_adapter._business_connections

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -114,6 +114,9 @@ def _make_update(msg):
     """Wrap a message in a mock Update."""
     update = MagicMock()
     update.message = msg
+    # Mirror real PTB semantics: effective_message resolves to the message.
+    # The media handler reads it (Secretary Mode business media support).
+    update.effective_message = msg
     return update
 
 

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -399,3 +399,34 @@ def test_load_hermes_env_handles_missing_files(tmp_path, monkeypatch):
 
     # Should not raise.
     send_cmd._load_hermes_env()
+
+
+# ---------------------------------------------------------------------------
+# Telegram Secretary Mode (--business-connection-id)
+# ---------------------------------------------------------------------------
+
+
+def test_business_connection_id_forwarded_to_tool(fake_tool):
+    """--business-connection-id must reach the send_message tool args
+    (PR #60809 review: the flag was parsed but never delivered)."""
+    args = _parse(
+        [
+            "--to",
+            "telegram:123",
+            "--business-connection-id",
+            "biz_conn_42",
+            "reply as owner",
+        ]
+    )
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 0
+    assert fake_tool.calls[0]["business_connection_id"] == "biz_conn_42"
+
+
+def test_business_connection_id_omitted_by_default(fake_tool):
+    args = _parse(["--to", "telegram:123", "plain send"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 0
+    assert "business_connection_id" not in fake_tool.calls[0]

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -317,6 +317,7 @@ class TestSendMessageTool:
             thread_id=None,
             media_files=[],
             force_document=False,
+            business_connection_id=None,
         )
 
     def test_cron_duplicate_target_is_skipped_and_explained(self):
@@ -382,6 +383,7 @@ class TestSendMessageTool:
             thread_id="17585",
             media_files=[],
             force_document=False,
+            business_connection_id=None,
         )
 
     def test_display_label_target_resolves_via_channel_directory(self, tmp_path):
@@ -421,6 +423,7 @@ class TestSendMessageTool:
             thread_id="17585",
             media_files=[],
             force_document=False,
+            business_connection_id=None,
         )
 
     def test_resolved_slack_thread_name_preserves_thread_id(self):
@@ -455,6 +458,7 @@ class TestSendMessageTool:
             thread_id="171.000001",
             media_files=[],
             force_document=False,
+            business_connection_id=None,
         )
 
     def test_resolved_matrix_thread_name_preserves_thread_id(self):
@@ -496,6 +500,7 @@ class TestSendMessageTool:
             thread_id="$thread123:matrix.example.org",
             media_files=[],
             force_document=False,
+            business_connection_id=None,
         )
 
     def test_mirror_receives_current_session_user_id(self):
@@ -567,6 +572,7 @@ class TestSendMessageTool:
             thread_id=None,
             media_files=[],
             force_document=False,
+            business_connection_id=None,
         )
 
     def test_top_level_send_failure_redacts_query_token(self):
@@ -3383,3 +3389,159 @@ class TestSendTelegramThreadNotFoundRetry:
         finally:
             if media_path and os.path.exists(media_path):
                 os.unlink(media_path)
+
+
+class TestTelegramSecretaryModeSend:
+    """Secretary Mode: business_connection_id threading through the
+    standalone send engine (PR #60809 review regression tests)."""
+
+    def _pconfig(self):
+        return SimpleNamespace(enabled=True, token="tok", extra={})
+
+    def test_send_to_platform_threads_business_connection_id(self):
+        helper = AsyncMock(
+            return_value={
+                "success": True,
+                "platform": "telegram",
+                "chat_id": "123",
+                "message_id": "9",
+            }
+        )
+        with patch("tools.send_message_tool._send_telegram", helper):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.TELEGRAM,
+                    self._pconfig(),
+                    "123",
+                    "reply as owner",
+                    business_connection_id="biz_conn_7",
+                )
+            )
+        assert result["success"] is True
+        assert helper.await_args.kwargs["business_connection_id"] == "biz_conn_7"
+
+    def test_send_to_platform_plain_telegram_send_regression(self):
+        """A plain Telegram send must work without business_connection_id.
+
+        Regression: the original Secretary Mode patch referenced
+        ``business_connection_id`` inside ``_send_to_platform`` without it
+        being a parameter — a NameError on EVERY standalone Telegram send,
+        business or not.
+        """
+        helper = AsyncMock(return_value={"success": True})
+        with patch("tools.send_message_tool._send_telegram", helper):
+            result = asyncio.run(
+                _send_to_platform(Platform.TELEGRAM, self._pconfig(), "123", "plain")
+            )
+        assert result["success"] is True
+        assert helper.await_args.kwargs["business_connection_id"] is None
+
+    def test_send_telegram_text_carries_business_connection_id(self, monkeypatch):
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "tok", "123", "hello", business_connection_id="biz_conn_8"
+            )
+        )
+        assert result["success"] is True
+        assert (
+            bot.send_message.await_args.kwargs["business_connection_id"]
+            == "biz_conn_8"
+        )
+
+    def test_send_telegram_text_omits_kwarg_when_absent(self, monkeypatch):
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(_send_telegram("tok", "123", "plain"))
+        assert result["success"] is True
+        assert "business_connection_id" not in bot.send_message.await_args.kwargs
+
+    def test_send_telegram_media_carries_business_connection_id(
+        self, tmp_path, monkeypatch
+    ):
+        """Attachments must ride the same business connection as the text,
+        or a Secretary Mode reply's media is delivered as the bot."""
+        image_path = tmp_path / "pic.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        bot.send_photo = AsyncMock(return_value=SimpleNamespace(message_id=2))
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock()
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "tok",
+                "123",
+                "with media",
+                media_files=[(str(image_path), False)],
+                business_connection_id="biz_conn_9",
+            )
+        )
+        assert result["success"] is True
+        assert (
+            bot.send_photo.await_args.kwargs["business_connection_id"]
+            == "biz_conn_9"
+        )
+
+    def test_handle_send_rejects_non_telegram_business_send(self, monkeypatch):
+        """The Telegram-only flag must fail loudly on other platforms rather
+        than silently dropping the send-as-owner intent."""
+        fake_config = SimpleNamespace(platforms={})
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config", lambda: fake_config
+        )
+
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "discord:123456789",
+                    "message": "hi",
+                    "business_connection_id": "biz_conn_10",
+                }
+            )
+        )
+        assert "error" in result
+        assert "telegram" in result["error"].lower()
+
+    def test_handle_send_forwards_business_connection_id(self, monkeypatch):
+        """End to end: tool args -> _handle_send -> _send_to_platform."""
+        pconfig = SimpleNamespace(enabled=True, token="tok", extra={})
+        from gateway.config import Platform as _P
+
+        fake_config = SimpleNamespace(platforms={_P.TELEGRAM: pconfig})
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config", lambda: fake_config
+        )
+
+        helper = AsyncMock(
+            return_value={
+                "success": True,
+                "platform": "telegram",
+                "chat_id": "123",
+                "message_id": "1",
+            }
+        )
+        with patch("tools.send_message_tool._send_to_platform", helper):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:123",
+                        "message": "reply as owner",
+                        "business_connection_id": "biz_conn_11",
+                    }
+                )
+            )
+        assert result.get("success") is True
+        assert helper.await_args.kwargs["business_connection_id"] == "biz_conn_11"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -356,6 +356,7 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
+    business_connection_id = (args.get("business_connection_id") or "").strip() or None
     if not target or not message:
         return tool_error("Both 'target' and 'message' are required when action='send'")
 
@@ -857,6 +858,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            business_connection_id=business_connection_id,
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1114,7 +1116,7 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False, business_connection_id=None):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1205,6 +1207,8 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         text_kwargs = dict(thread_kwargs)
         if disable_link_previews:
             text_kwargs["disable_web_page_preview"] = True
+        if business_connection_id:
+            text_kwargs["business_connection_id"] = business_connection_id
 
         last_msg = None
         warnings = []

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -406,6 +406,14 @@ def _handle_send(args):
     except (ValueError, KeyError):
         return tool_error(f"Unknown platform: {platform_name}")
 
+    # Secretary Mode is Telegram-only; fail loudly rather than silently
+    # dropping the send-as-owner intent on other platforms.
+    if business_connection_id and platform != Platform.TELEGRAM:
+        return tool_error(
+            "'business_connection_id' (Telegram Secretary Mode) is only "
+            f"supported for telegram targets, got '{platform_name}'"
+        )
+
     pconfig = config.platforms.get(platform)
     if not pconfig or not pconfig.enabled:
         # Weixin can be configured purely via .env; synthesize a pconfig so
@@ -499,6 +507,7 @@ def _handle_send(args):
                 thread_id=thread_id,
                 media_files=media_files,
                 force_document=force_document_attachments,
+                business_connection_id=business_connection_id,
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
@@ -778,7 +787,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, business_connection_id=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -1327,6 +1336,11 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                                 media_kwargs["duration"] = duration
                         except Exception:
                             pass
+                    # Secretary Mode: media must carry the connection ID too,
+                    # or attachments are delivered as the bot while the text
+                    # went out as the owner.
+                    if business_connection_id:
+                        media_kwargs["business_connection_id"] = business_connection_id
                     try:
                         if ext in _IMAGE_EXTS and not force_document:
                             last_msg = await bot.send_photo(

--- a/website/docs/user-guide/messaging/telegram-secretary-mode.md
+++ b/website/docs/user-guide/messaging/telegram-secretary-mode.md
@@ -5,7 +5,14 @@ your **personal account** — not to the bot directly. Clients DM you as usual;
 the bot processes the message behind the scenes and can reply as you.
 
 This is powered by Telegram's "Chat Automation in Profiles" feature (also known
-as "Secretary Bots" or "Connected Business Bots"), introduced in May 2026.
+as "Secretary Bots" or "Connected Business Bots"), introduced in May 2026 as
+part of the [AI Bot Revolution update](https://telegram.org/blog/ai-bot-revolution-11-new-features).
+
+**References:**
+- [Telegram blog: AI Bot Revolution (May 2026)](https://telegram.org/blog/ai-bot-revolution-11-new-features) — the launch announcement; "Chat Automation in Profiles" section
+- [Connected business bots (MTProto docs)](https://core.telegram.org/api/bots/connected-business-bots) — protocol reference, `BusinessBotRights`, connection lifecycle
+- [Bot API: business_message updates](https://core.telegram.org/bots/api#business-message) — the `business_connection_id` field and send-as-owner semantics
+- [Bot API changelog](https://core.telegram.org/bots/api-changelog) — track when each business feature landed by Bot API version
 
 ## Setup
 

--- a/website/docs/user-guide/messaging/telegram-secretary-mode.md
+++ b/website/docs/user-guide/messaging/telegram-secretary-mode.md
@@ -59,6 +59,41 @@ Messages sent via business connection carry a `via_business_connection` flag
 in Telegram's metadata. In your chat, a banner shows the bot manages this
 conversation. From the client's side, the reply appears to come from you.
 
+### Message classification
+
+Not every `business_message` update is a client request. Hermes classifies
+each update by author before it reaches the agent:
+
+- **Client messages** run through the normal agent loop and get a reply.
+  Slash commands from clients are treated as plain text — a client can never
+  drive operator commands through your personal account.
+- **Your own manual replies** (typed from any of your devices) are stored in
+  the chat's session as context but never processed as a prompt: the agent
+  sees you already answered and won't reply over you.
+- **Bot echoes** (Telegram relays the bot's business sends back with
+  `sender_business_bot` set) are dropped entirely.
+
+Owner detection uses the tracked BusinessConnection state when available and
+falls back to comparing the sender against the chat peer, so classification
+keeps working after a gateway restart (Telegram does not replay connection
+updates).
+
+### Replies with media
+
+Text and media replies both carry the `business_connection_id`, so photos,
+documents, voice notes, and albums are delivered as you — not as the bot.
+Streaming draft previews are disabled in business chats (the draft API has no
+business connection support); replies arrive as regular complete messages.
+
+### Standalone sends
+
+The `send_message` tool and `hermes send` accept a connection ID for one-shot
+Secretary Mode replies without a running gateway:
+
+```bash
+hermes send --to telegram:CHAT_ID --business-connection-id CONN_ID "on my way"
+```
+
 ## Constraints
 
 - **Private chats only** — Secretary Mode cannot access groups or channels

--- a/website/docs/user-guide/messaging/telegram-secretary-mode.md
+++ b/website/docs/user-guide/messaging/telegram-secretary-mode.md
@@ -1,0 +1,62 @@
+# Telegram Secretary Mode (Chat Automation)
+
+Secretary Mode allows a Telegram bot to receive and respond to messages sent to
+your **personal account** — not to the bot directly. Clients DM you as usual;
+the bot processes the message behind the scenes and can reply as you.
+
+This is powered by Telegram's "Chat Automation in Profiles" feature (also known
+as "Secretary Bots" or "Connected Business Bots"), introduced in May 2026.
+
+## Setup
+
+### 1. Enable Secretary Mode for your bot
+
+Message **@BotFather** → `/mybots` → select your bot → **Bot Settings** →
+**Secretary Mode** → **Turn On**.
+
+This sets the `bot_business` flag that allows the bot to be connected to a user
+account.
+
+### 2. Connect the bot to your account
+
+In Telegram: **Settings → Chat Automation** → connect your bot.
+
+Configure which chats the bot can access:
+- **New chats** — only conversations started after the connection
+- **Non-contacts** — only people not in your contact list
+- **Exclude contacts** — keep friends/family manual, automate the rest
+
+The bot only sees private 1:1 chats — **group chats are not supported** by
+Secretary Mode. For group automation, add the bot as a group member separately.
+
+### 3. No special Hermes config needed
+
+Hermes processes business_message updates automatically when they arrive. The
+updates are already requested via `allowed_updates=ALL_TYPES`. Business messages
+bypass the user-ID allowlist because they're pre-authorized by your Chat
+Automation connection.
+
+## How it works
+
+When a client DMs your personal account, Telegram routes the message to your
+connected bot as a `business_message` update. Hermes:
+
+1. **Receives** the update (already requested via `allowed_updates`)
+2. **Bypasses user-ID auth** — the message carries a server-set
+   `business_connection_id` proving you authorized it
+3. **Processes** the message through the normal agent loop
+4. **Replies** using `business_connection_id` so the response appears to come
+   from your personal account
+
+Messages sent via business connection carry a `via_business_connection` flag
+in Telegram's metadata. In your chat, a banner shows the bot manages this
+conversation. From the client's side, the reply appears to come from you.
+
+## Constraints
+
+- **Private chats only** — Secretary Mode cannot access groups or channels
+- **One bot per account** — Telegram allows only one connected business bot
+- **No history backfill** — the bot only sees messages from connection time
+  forward
+- **24-hour reply window** — `can_reply` permission is limited to chats active
+  in the last 24 hours (Telegram Business API constraint)

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1321,3 +1321,7 @@ Always set `TELEGRAM_ALLOWED_USERS` to restrict who can interact with your bot. 
 Never share your bot token publicly. If compromised, revoke it immediately via BotFather's `/revoke` command.
 
 For more details, see the [Security documentation](/user-guide/security). You can also use [DM pairing](/user-guide/messaging#dm-pairing-alternative-to-allowlists) for a more dynamic approach to user authorization.
+
+## Secretary Mode (Chat Automation)
+
+Telegram's Chat Automation feature allows a bot to receive and respond to messages sent to your **personal account** — clients DM you as usual, and the bot can reply as you. See the dedicated [Secretary Mode guide](/user-guide/messaging/telegram-secretary-mode) for setup.


### PR DESCRIPTION
## Summary

Adds Telegram Secretary Mode (Chat Automation / Connected Business Bots) support to the gateway and CLI. A connected bot can now receive \`business_message\` updates sent to a user's personal account and reply on their behalf.

Closes #42400.

## What's included

**Ingress (gateway adapter):**
- Extract \`business_connection_id\` from \`business_message\` updates into \`SessionSource\`
- Bypass user-ID auth for business messages (pre-authorized by Chat Automation connection)
- Handle \`BusinessConnection\` lifecycle updates (connect/disconnect/settings changes)
- **Classify bot-echo messages** (\`sender_business_bot\` present → skip, \`_build_message_event\` returns \`None\`) — fixes #42400 where the gateway re-processed its own relayed sends as customer input

**Send path (gateway + CLI):**
- Propagate \`business_connection_id\` through gateway metadata → adapter \`send()\` → \`bot.send_message\`
- \`hermes send --business-connection-id <ID>\` CLI flag for standalone Secretary Mode replies without a running gateway

**Docs:**
- New \`telegram-secretary-mode.md\` guide with setup, how-it-works, constraints, and references to the Telegram blog (AI Bot Revolution, May 2026) + API docs
- Cross-link from the main \`telegram.md\` page

**Tests:** 10 tests covering SessionSource field, auth bypass, send-path passthrough, lifecycle handler, and bot-echo classification.

## References

- [Telegram blog: AI Bot Revolution (May 2026)](https://telegram.org/blog/ai-bot-revolution-11-new-features) — Chat Automation announcement
- [Connected business bots](https://core.telegram.org/api/bots/connected-business-bots) — protocol reference
- #42400 — the issue this PR's bot-echo classification addresses

## Constraints

- Private chats only (Secretary Mode scope); group automation is separate
- One bot per account
- 24h reply window (\`can_reply\` permission)
- Owner-outgoing classification (manual owner replies without \`sender_bot\`) falls through to normal flow — needs the connection owner_id from the lifecycle handler, which arrives on the next \`business_connection\` update after a gateway restart