### PR TITLE
feat(bedrock): opt-in 1M context beta for Opus 4.8 / Sonnet 5 (native Converse path)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -37,6 +37,51 @@ from typing import Any, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# 1M context beta (native Bedrock Converse path)
+# ---------------------------------------------------------------------------
+# The AnthropicBedrock (OpenAI-compat) client path already forwards
+# ``context-1m-2025-08-07`` via _CONTEXT_1M_BETA in agent/anthropic_adapter.py
+# (PR #16793). The native boto3 Converse path (this module) is separate and
+# was never wired up — Opus 4.6/4.7/4.8 and Sonnet 4.6 stayed capped at
+# 200K here even on accounts with the 1M entitlement. See issue #31277.
+#
+# Off by default: Anthropic gates the entitlement per-account, and sending
+# the beta header to an account without it can be rejected outright. Users
+# opt in explicitly once they've confirmed AWS/Anthropic granted access.
+_BEDROCK_1M_CONTEXT_ENV = "HERMES_BEDROCK_1M_CONTEXT"
+_BEDROCK_CONTEXT_1M_BETA = "context-1m-2025-08-07"
+
+# Model families verified to support the 1M context beta on Bedrock.
+# Substring-matched against the (lowercased) model id, so cross-region
+# inference profile prefixes (us., global., eu.) and version suffixes
+# (-v1:0, -20250514, etc.) don't break the match.
+_BEDROCK_1M_CAPABLE_SUBSTRINGS = (
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-sonnet-4-6",
+    "claude-sonnet-5",
+)
+
+
+def bedrock_1m_context_enabled() -> bool:
+    """Return True when the user has opted in to 1M-context Bedrock requests.
+
+    Opt-in only — accounts without the Anthropic 1M-context entitlement
+    should not have this beta header sent on their behalf.
+    """
+    return os.environ.get(_BEDROCK_1M_CONTEXT_ENV, "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def is_bedrock_1m_context_capable(model_id: str) -> bool:
+    """Return True if ``model_id`` is a Claude family known to support 1M context."""
+    model_lower = (model_id or "").lower()
+    return any(sub in model_lower for sub in _BEDROCK_1M_CAPABLE_SUBSTRINGS)
+
+
+# ---------------------------------------------------------------------------
 # Ensure boto3/botocore are installed before any code in this module runs.
 # Upstream removed boto3 from [all] extras (PRs #24220, #24515); lazy_deps
 # handles on-demand installation so the Bedrock provider still works in the
@@ -983,6 +1028,12 @@ def build_converse_kwargs(
     if guardrail_config:
         kwargs["guardrailConfig"] = guardrail_config
 
+    if bedrock_1m_context_enabled() and is_bedrock_1m_context_capable(model):
+        additional_fields = kwargs.setdefault("additionalModelRequestFields", {})
+        existing_betas = additional_fields.get("anthropic_beta", [])
+        if _BEDROCK_CONTEXT_1M_BETA not in existing_betas:
+            additional_fields["anthropic_beta"] = [*existing_betas, _BEDROCK_CONTEXT_1M_BETA]
+
     return kwargs
 
 
@@ -1297,7 +1348,9 @@ def classify_bedrock_error(error_message: str) -> str:
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock
+    "anthropic.claude-opus-4-8":     200_000,
     "anthropic.claude-opus-4-6":     200_000,
+    "anthropic.claude-sonnet-5":     200_000,
     "anthropic.claude-sonnet-4-6":   200_000,
     "anthropic.claude-sonnet-4-5":   200_000,
     "anthropic.claude-haiku-4-5":    200_000,
@@ -1331,7 +1384,13 @@ def get_bedrock_context_length(model_id: str) -> int:
 
     Uses substring matching so versioned IDs like
     ``anthropic.claude-sonnet-4-6-20250514-v1:0`` resolve correctly.
+
+    Returns 1M when the user has opted in via ``HERMES_BEDROCK_1M_CONTEXT``
+    and the model is a known 1M-capable Claude family (see issue #31277).
     """
+    if bedrock_1m_context_enabled() and is_bedrock_1m_context_capable(model_id):
+        return 1_000_000
+
     model_lower = model_id.lower()
     best_key = ""
     best_val = BEDROCK_DEFAULT_CONTEXT_LENGTH

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -210,6 +210,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "claude-opus-4.7": 1000000,
     "claude-opus-4-6": 1000000,
     "claude-sonnet-4-6": 1000000,
+    "claude-sonnet-5": 1000000,
     "claude-opus-4.6": 1000000,
     "claude-sonnet-4.6": 1000000,
     # Catch-all for older Claude models (must sort after specific entries)

--- a/tests/agent/test_bedrock_1m_context.py
+++ b/tests/agent/test_bedrock_1m_context.py
@@ -61,3 +61,89 @@ class TestBedrockContext1MBeta:
         # Other common betas still present — no regression.
         assert "interleaved-thinking-2025-05-14" in beta_header
         assert "fine-grained-tool-streaming-2025-05-14" in beta_header
+
+
+class TestBedrockConverse1MContextOptIn:
+    """Native boto3 Converse path (agent/bedrock_adapter.py) — issue #31277.
+
+    Opus 4.8 and Sonnet 5 (and the earlier 4.6/4.7 families) need the
+    ``context-1m-2025-08-07`` beta forwarded via ``additionalModelRequestFields``
+    on the Converse API. Off by default — only active when the user opts in
+    via ``HERMES_BEDROCK_1M_CONTEXT``, since the entitlement is gated
+    per-account and an unentitled account gets a hard rejection otherwise.
+    """
+
+    def test_capability_matrix(self):
+        from agent.bedrock_adapter import is_bedrock_1m_context_capable
+
+        capable = [
+            "anthropic.claude-opus-4-8-v1:0",
+            "us.anthropic.claude-opus-4-8-v1:0",
+            "global.anthropic.claude-sonnet-5-20260201-v1:0",
+            "anthropic.claude-sonnet-4-6-v1:0",
+            "anthropic.claude-opus-4-6-v1:0",
+            "anthropic.claude-opus-4-7-v1:0",
+        ]
+        not_capable = [
+            "anthropic.claude-sonnet-4-5-v1:0",
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "amazon.nova-pro-v1:0",
+        ]
+        for model_id in capable:
+            assert is_bedrock_1m_context_capable(model_id), model_id
+        for model_id in not_capable:
+            assert not is_bedrock_1m_context_capable(model_id), model_id
+
+    def test_opt_in_env_var(self, monkeypatch):
+        from agent.bedrock_adapter import bedrock_1m_context_enabled
+
+        monkeypatch.delenv("HERMES_BEDROCK_1M_CONTEXT", raising=False)
+        assert bedrock_1m_context_enabled() is False
+
+        monkeypatch.setenv("HERMES_BEDROCK_1M_CONTEXT", "true")
+        assert bedrock_1m_context_enabled() is True
+
+        monkeypatch.setenv("HERMES_BEDROCK_1M_CONTEXT", "0")
+        assert bedrock_1m_context_enabled() is False
+
+    def test_build_converse_kwargs_adds_beta_when_opted_in(self, monkeypatch):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        monkeypatch.setenv("HERMES_BEDROCK_1M_CONTEXT", "true")
+        kwargs = build_converse_kwargs(
+            model="anthropic.claude-opus-4-8-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        betas = kwargs["additionalModelRequestFields"]["anthropic_beta"]
+        assert "context-1m-2025-08-07" in betas
+
+    def test_build_converse_kwargs_no_beta_when_not_opted_in(self, monkeypatch):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        monkeypatch.delenv("HERMES_BEDROCK_1M_CONTEXT", raising=False)
+        kwargs = build_converse_kwargs(
+            model="anthropic.claude-opus-4-8-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert "additionalModelRequestFields" not in kwargs
+
+    def test_build_converse_kwargs_no_beta_for_incapable_model(self, monkeypatch):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        monkeypatch.setenv("HERMES_BEDROCK_1M_CONTEXT", "true")
+        kwargs = build_converse_kwargs(
+            model="anthropic.claude-sonnet-4-5-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert "additionalModelRequestFields" not in kwargs
+
+    def test_get_bedrock_context_length_opt_in(self, monkeypatch):
+        from agent.bedrock_adapter import get_bedrock_context_length
+
+        monkeypatch.delenv("HERMES_BEDROCK_1M_CONTEXT", raising=False)
+        assert get_bedrock_context_length("anthropic.claude-opus-4-8-v1:0") == 200_000
+
+        monkeypatch.setenv("HERMES_BEDROCK_1M_CONTEXT", "true")
+        assert get_bedrock_context_length("anthropic.claude-opus-4-8-v1:0") == 1_000_000
+        # Non-capable model is unaffected by opt-in.
+        assert get_bedrock_context_length("amazon.nova-pro-v1:0") == 300_000


### PR DESCRIPTION
Closes #31277.

The AnthropicBedrock OpenAI-compat client path already forwards the `context-1m-2025-08-07` beta header for Opus 4.6/4.7 and Sonnet 4.6 (see PR #16793). The native boto3 Converse API path (`agent/bedrock_adapter.py`) never was wired up, so Opus 4.8 and Sonnet 5 stayed silently capped at 200K context on Bedrock even on accounts with the 1M entitlement.

## Changes
- `is_bedrock_1m_context_capable(model_id)`: substring match against known 1M-capable Claude families (opus-4-6/4-7/4-8, sonnet-4-6/5).
- `bedrock_1m_context_enabled()`: opt-in gate via `HERMES_BEDROCK_1M_CONTEXT` env var. Off by default — Anthropic gates the 1M entitlement per-account, sending the beta header on an unentitled account can be hard-rejected.
- `build_converse_kwargs`: when opted in and model is capable, adds `context-1m-2025-08-07` to `additionalModelRequestFields.anthropic_beta`.
- `get_bedrock_context_length`: returns 1M instead of the 200K default when opted in and capable, so downstream context-window accounting matches reality.
- Added `anthropic.claude-opus-4-8` and `anthropic.claude-sonnet-5` to `BEDROCK_CONTEXT_LENGTHS` (were missing, falling through to the generic default).
- `model_metadata.py`: added `claude-sonnet-5` to `DEFAULT_CONTEXT_LENGTHS`.

## Testing
No pytest binary available in this environment's venv, so I verified behavior with direct assertions run via `python3 -c` importing the module (capability matrix, opt-in env var truthiness, `build_converse_kwargs` beta injection on/off, `get_bedrock_context_length` return values) — all passed. Added `TestBedrockConverse1MContextOptIn` covering the same cases to `tests/agent/test_bedrock_1m_context.py` for CI to run with pytest.