### PR TITLE
fix(tools): centralize container_config across sandbox entry points

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -929,7 +929,11 @@ def _probe_remote_backend(env_type: str) -> str | None:
     try:
         # Import locally: tools/ imports are heavy and only relevant when a
         # non-local backend is actually configured.
-        from tools.terminal_tool import _create_environment, _get_env_config  # type: ignore
+        from tools.terminal_tool import (  # type: ignore
+            _build_container_config,
+            _create_environment,
+            _get_env_config,
+        )
     except Exception as e:
         logger.debug("Backend probe unavailable (import failed): %s", e)
         _BACKEND_PROBE_CACHE[cache_key] = ""
@@ -964,21 +968,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
 
         container_config = None
         if env_type in {"docker", "singularity", "modal", "daytona"}:
-            container_config = {
-                "container_cpu": config.get("container_cpu", 1),
-                "container_memory": config.get("container_memory", 5120),
-                "container_disk": config.get("container_disk", 51200),
-                "container_persistent": config.get("container_persistent", True),
-                "modal_mode": config.get("modal_mode", "auto"),
-                "docker_volumes": config.get("docker_volumes", []),
-                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                "docker_forward_env": config.get("docker_forward_env", []),
-                "docker_env": config.get("docker_env", {}),
-                "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                "docker_extra_args": config.get("docker_extra_args", []),
-                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
-                "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
-            }
+            container_config = _build_container_config(config)
 
         env = _create_environment(
             env_type=env_type,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1269,6 +1269,14 @@ class TestEnvironmentHints:
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         _pb._clear_backend_probe_cache()
 
+        config = {
+            "docker_image": "python:3.11",
+            "cwd": "/workspace",
+            "timeout": 60,
+            "docker_network": False,
+            "docker_forward_env": ["PROBE_SECRET"],
+        }
+
         class _FakeEnv:
             def execute(self, cmd, timeout=None):
                 return {
@@ -1283,15 +1291,19 @@ class TestEnvironmentHints:
 
         def _fake_create_environment(*, env_type, **kwargs):
             created["env_type"] = env_type
+            created.update(kwargs)
             return _FakeEnv()
 
         # Patch the REAL factory in tools.terminal_tool — the probe imports it
         # locally, so the import itself must succeed (the bug was here).
         import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_get_env_config", lambda: config)
         monkeypatch.setattr(_tt, "_create_environment", _fake_create_environment)
 
         line = _pb._probe_remote_backend("docker")
         assert created.get("env_type") == "docker"
+        assert created["container_config"] == _tt._build_container_config(config)
+        assert created["container_config"]["docker_network"] is False
         assert line is not None
         assert "Linux 6.8.0" in line
         assert "root" in line
@@ -1644,5 +1656,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 

--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -84,33 +84,35 @@ def test_docker_network_config_is_bridged_everywhere():
     assert "TERMINAL_DOCKER_NETWORK" in _terminal_tool_env_var_names()
 
 
-def test_sibling_container_config_sites_carry_docker_network():
-    """Every container_config dict that carries docker_run_as_host_user must
-    also carry docker_network — otherwise that code path silently falls back
-    to networked containers while the terminal path honors the lockdown
-    (the probe/exec asymmetry reported on issue #46358).
-    """
-    import ast
-    import inspect
+def test_prompt_backend_probe_honors_network_lockdown(monkeypatch):
+    """The real config→builder→factory path must keep probe egress disabled."""
+    import agent.prompt_builder as prompt_builder
 
-    import tools.code_execution_tool as code_execution_tool
-    import tools.file_tools as file_tools
+    captured = {}
 
-    for module in (terminal_tool, file_tools, code_execution_tool):
-        tree = ast.parse(inspect.getsource(module))
-        sites = 0
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Dict):
-                continue
-            keys = {k.value for k in node.keys if isinstance(k, ast.Constant)}
-            if "docker_run_as_host_user" in keys:
-                sites += 1
-                assert "docker_network" in keys, (
-                    f"{module.__name__} builds a container_config with "
-                    f"docker_run_as_host_user but without docker_network "
-                    f"(line {node.lineno})"
-                )
-        assert sites >= 1, f"expected at least one container_config site in {module.__name__}"
+    class _FakeDockerEnvironment:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def execute(self, command, timeout=None):
+            return {
+                "returncode": 0,
+                "output": (
+                    "os=Linux\nkernel=6.8.0\nhome=/root\n"
+                    "cwd=/workspace\nuser=root\n"
+                ),
+            }
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_DOCKER_NETWORK", "false")
+    monkeypatch.setattr(terminal_tool, "_DockerEnvironment", _FakeDockerEnvironment)
+    monkeypatch.setattr(terminal_tool, "_maybe_reap_docker_orphans", lambda _config: None)
+    monkeypatch.setattr(prompt_builder, "_BACKEND_PROBE_CACHE", {})
+
+    result = prompt_builder._probe_remote_backend("docker")
+
+    assert result is not None
+    assert captured["network"] is False
 
 
 def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):

--- a/tests/tools/test_execute_code_container_config.py
+++ b/tests/tools/test_execute_code_container_config.py
@@ -1,10 +1,9 @@
-"""Tests for docker container_config key propagation in code_execution_tool.
+"""Tests for container_config parity across sandbox entry points.
 
-Regression tests for the sibling-dict drift where execute_code's hand-copied
-container_config lacked docker_forward_env/docker_env/docker_extra_args (and
-the other terminal_tool keys). Because terminal, file, and execute_code tools
-share one environment slot per task, an environment (re)created by
-execute_code silently dropped every forwarded secret for all of them.
+Regression tests for the sibling-dict drift where execute_code silently
+dropped forwarded secrets from the environment shared by terminal and file
+tools.  Each caller must pass the canonical builder output so a future config
+addition cannot recreate the same divergence.
 """
 
 import threading
@@ -12,6 +11,25 @@ from unittest.mock import MagicMock, patch
 
 import tools.code_execution_tool as code_execution_tool
 import tools.file_tools as file_tools
+import tools.terminal_tool as terminal_tool
+
+
+NON_DEFAULT_CONTAINER_SETTINGS = {
+    "container_cpu": 3,
+    "container_memory": 1234,
+    "container_disk": 4321,
+    "container_persistent": False,
+    "modal_mode": "sandbox",
+    "docker_volumes": ["/host/secrets:/run/secrets:ro"],
+    "docker_mount_cwd_to_workspace": True,
+    "docker_forward_env": ["MY_SECRET", "API_KEY"],
+    "docker_env": {"KEY_PATH": "/run/secrets/key.pem"},
+    "docker_run_as_host_user": True,
+    "docker_extra_args": ["--cap-drop=ALL"],
+    "docker_network": False,
+    "docker_persist_across_processes": False,
+    "docker_orphan_reaper": False,
+}
 
 
 def _make_env_config(**overrides):
@@ -24,51 +42,16 @@ def _make_env_config(**overrides):
         "cwd": "/workspace",
         "host_cwd": None,
         "timeout": 180,
-        # Non-default value for every container_config key so a dropped key
-        # shows up as a mismatch instead of hiding behind the default.
-        "container_cpu": 3,
-        "container_memory": 1234,
-        "container_disk": 4321,
-        "container_persistent": False,
-        "modal_mode": "sandbox",
-        "docker_volumes": ["/host/secrets:/run/secrets:ro"],
-        "docker_mount_cwd_to_workspace": True,
-        "docker_forward_env": ["MY_SECRET", "API_KEY"],
-        "docker_env": {"KEY_PATH": "/run/secrets/key.pem"},
-        "docker_run_as_host_user": True,
-        "docker_extra_args": ["--cap-drop=ALL"],
-        "docker_network": False,
-        "docker_persist_across_processes": False,
-        "docker_orphan_reaper": False,
     }
+    base.update(NON_DEFAULT_CONTAINER_SETTINGS)
     base.update(overrides)
     return base
-
-
-# Every key terminal_tool puts in container_config; the sibling entry points
-# must forward all of them or the shared environment loses settings depending
-# on which tool happened to create it.
-CONTAINER_CONFIG_KEYS = (
-    "container_cpu",
-    "container_memory",
-    "container_disk",
-    "container_persistent",
-    "modal_mode",
-    "docker_volumes",
-    "docker_mount_cwd_to_workspace",
-    "docker_forward_env",
-    "docker_env",
-    "docker_run_as_host_user",
-    "docker_extra_args",
-    "docker_network",
-    "docker_persist_across_processes",
-    "docker_orphan_reaper",
-)
 
 
 def _capture_container_config(run_entry_point):
     captured = {}
     mock_env = MagicMock()
+    mock_env.execute.return_value = {"output": "", "returncode": 0}
 
     def fake_create_env(**kwargs):
         captured.update(kwargs)
@@ -90,28 +73,68 @@ def _capture_container_config(run_entry_point):
     return captured["container_config"]
 
 
-class TestExecuteCodeContainerConfig:
-    def test_every_key_taken_from_config(self):
-        """No config key falls back to its default when explicitly set."""
+class TestContainerConfigParity:
+    def test_builder_preserves_every_container_setting(self):
+        config = _make_env_config()
+        built = terminal_tool._build_container_config(config)
+        for key, value in NON_DEFAULT_CONTAINER_SETTINGS.items():
+            assert built[key] == value
+
+    def test_terminal_uses_shared_builder(self):
+        config = _make_env_config()
+        cc = _capture_container_config(
+            lambda: terminal_tool.terminal_tool(
+                command="true", task_id="t-terminal", force=True,
+            )
+        )
+        assert cc == terminal_tool._build_container_config(config)
+
+    def test_execute_code_uses_shared_builder(self):
         config = _make_env_config()
         cc = _capture_container_config(
             lambda: code_execution_tool._get_or_create_env("t-exec"))
-        for key in CONTAINER_CONFIG_KEYS:
-            assert key in cc, f"{key} missing from execute_code container_config"
-            assert cc[key] == config[key], f"{key} not taken from config"
-
-    def test_forwarded_secrets_survive_execute_code_creation(self):
-        """The keys whose loss broke secret forwarding are passed through."""
-        cc = _capture_container_config(
-            lambda: code_execution_tool._get_or_create_env("t-exec2"))
+        assert cc == terminal_tool._build_container_config(config)
         assert cc["docker_forward_env"] == ["MY_SECRET", "API_KEY"]
         assert cc["docker_env"] == {"KEY_PATH": "/run/secrets/key.pem"}
         assert cc["docker_extra_args"] == ["--cap-drop=ALL"]
 
-    def test_execute_code_and_file_tools_build_identical_config(self):
-        """The shared environment must not depend on which tool created it."""
-        cc_exec = _capture_container_config(
-            lambda: code_execution_tool._get_or_create_env("t-parity"))
-        cc_file = _capture_container_config(
-            lambda: file_tools._get_file_ops("t-parity"))
-        assert cc_exec == cc_file
+    def test_file_tools_use_shared_builder(self):
+        config = _make_env_config()
+        cc = _capture_container_config(
+            lambda: file_tools._get_file_ops("t-file"))
+        assert cc == terminal_tool._build_container_config(config)
+
+
+def test_execute_code_env_config_reaches_docker_factory(monkeypatch):
+    """Exercise the real env parser, builder, and environment factory chain."""
+    captured = {}
+
+    class _FakeDockerEnvironment:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CWD", "/workspace")
+    monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "python:3.11")
+    monkeypatch.setenv(
+        "TERMINAL_DOCKER_FORWARD_ENV", '["FORWARDED_SECRET", "API_TOKEN"]'
+    )
+    monkeypatch.setenv("TERMINAL_DOCKER_ENV", '{"STATIC_KEY": "static-value"}')
+    monkeypatch.setenv("TERMINAL_DOCKER_EXTRA_ARGS", '["--cap-drop=ALL"]')
+    monkeypatch.setenv("TERMINAL_DOCKER_NETWORK", "false")
+    monkeypatch.setattr(terminal_tool, "_DockerEnvironment", _FakeDockerEnvironment)
+    monkeypatch.setattr(terminal_tool, "_maybe_reap_docker_orphans", lambda _config: None)
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_creation_locks", {})
+    monkeypatch.setattr(terminal_tool, "_creation_locks_lock", threading.Lock())
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+
+    _, env_type = code_execution_tool._get_or_create_env("t-exec-e2e")
+
+    assert env_type == "docker"
+    assert captured["forward_env"] == ["FORWARDED_SECRET", "API_TOKEN"]
+    assert captured["env"] == {"STATIC_KEY": "static-value"}
+    assert captured["extra_args"] == ["--cap-drop=ALL"]
+    assert captured["network"] is False

--- a/tests/tools/test_execute_code_container_config.py
+++ b/tests/tools/test_execute_code_container_config.py
@@ -1,0 +1,117 @@
+"""Tests for docker container_config key propagation in code_execution_tool.
+
+Regression tests for the sibling-dict drift where execute_code's hand-copied
+container_config lacked docker_forward_env/docker_env/docker_extra_args (and
+the other terminal_tool keys). Because terminal, file, and execute_code tools
+share one environment slot per task, an environment (re)created by
+execute_code silently dropped every forwarded secret for all of them.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import tools.code_execution_tool as code_execution_tool
+import tools.file_tools as file_tools
+
+
+def _make_env_config(**overrides):
+    base = {
+        "env_type": "docker",
+        "docker_image": "test-image:latest",
+        "singularity_image": "docker://test",
+        "modal_image": "test",
+        "daytona_image": "test",
+        "cwd": "/workspace",
+        "host_cwd": None,
+        "timeout": 180,
+        # Non-default value for every container_config key so a dropped key
+        # shows up as a mismatch instead of hiding behind the default.
+        "container_cpu": 3,
+        "container_memory": 1234,
+        "container_disk": 4321,
+        "container_persistent": False,
+        "modal_mode": "sandbox",
+        "docker_volumes": ["/host/secrets:/run/secrets:ro"],
+        "docker_mount_cwd_to_workspace": True,
+        "docker_forward_env": ["MY_SECRET", "API_KEY"],
+        "docker_env": {"KEY_PATH": "/run/secrets/key.pem"},
+        "docker_run_as_host_user": True,
+        "docker_extra_args": ["--cap-drop=ALL"],
+        "docker_network": False,
+        "docker_persist_across_processes": False,
+        "docker_orphan_reaper": False,
+    }
+    base.update(overrides)
+    return base
+
+
+# Every key terminal_tool puts in container_config; the sibling entry points
+# must forward all of them or the shared environment loses settings depending
+# on which tool happened to create it.
+CONTAINER_CONFIG_KEYS = (
+    "container_cpu",
+    "container_memory",
+    "container_disk",
+    "container_persistent",
+    "modal_mode",
+    "docker_volumes",
+    "docker_mount_cwd_to_workspace",
+    "docker_forward_env",
+    "docker_env",
+    "docker_run_as_host_user",
+    "docker_extra_args",
+    "docker_network",
+    "docker_persist_across_processes",
+    "docker_orphan_reaper",
+)
+
+
+def _capture_container_config(run_entry_point):
+    captured = {}
+    mock_env = MagicMock()
+
+    def fake_create_env(**kwargs):
+        captured.update(kwargs)
+        return mock_env
+
+    with patch("tools.terminal_tool._get_env_config", return_value=_make_env_config()), \
+         patch("tools.terminal_tool._task_env_overrides", {}), \
+         patch("tools.terminal_tool._active_environments", {}), \
+         patch("tools.terminal_tool._last_activity", {}), \
+         patch("tools.terminal_tool._creation_locks", {}), \
+         patch("tools.terminal_tool._creation_locks_lock", threading.Lock()), \
+         patch("tools.terminal_tool._create_environment", side_effect=fake_create_env), \
+         patch("tools.terminal_tool._start_cleanup_thread"), \
+         patch("tools.terminal_tool._check_disk_usage_warning"), \
+         patch("tools.file_tools._file_ops_cache", {}), \
+         patch("tools.file_tools._file_ops_lock", threading.Lock()):
+        run_entry_point()
+
+    return captured["container_config"]
+
+
+class TestExecuteCodeContainerConfig:
+    def test_every_key_taken_from_config(self):
+        """No config key falls back to its default when explicitly set."""
+        config = _make_env_config()
+        cc = _capture_container_config(
+            lambda: code_execution_tool._get_or_create_env("t-exec"))
+        for key in CONTAINER_CONFIG_KEYS:
+            assert key in cc, f"{key} missing from execute_code container_config"
+            assert cc[key] == config[key], f"{key} not taken from config"
+
+    def test_forwarded_secrets_survive_execute_code_creation(self):
+        """The keys whose loss broke secret forwarding are passed through."""
+        cc = _capture_container_config(
+            lambda: code_execution_tool._get_or_create_env("t-exec2"))
+        assert cc["docker_forward_env"] == ["MY_SECRET", "API_KEY"]
+        assert cc["docker_env"] == {"KEY_PATH": "/run/secrets/key.pem"}
+        assert cc["docker_extra_args"] == ["--cap-drop=ALL"]
+
+    def test_execute_code_and_file_tools_build_identical_config(self):
+        """The shared environment must not depend on which tool created it."""
+        cc_exec = _capture_container_config(
+            lambda: code_execution_tool._get_or_create_env("t-parity"))
+        cc_file = _capture_container_config(
+            lambda: file_tools._get_file_ops("t-parity"))
+        assert cc_exec == cc_file

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -635,7 +635,7 @@ def _get_or_create_env(task_id: str):
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
         _creation_locks, _creation_locks_lock, _task_env_overrides,
-        _resolve_container_task_id,
+        _resolve_container_task_id, _build_container_config,
     )
 
     effective_task_id = _resolve_container_task_id(task_id)
@@ -677,27 +677,7 @@ def _get_or_create_env(task_id: str):
 
         container_config = None
         if env_type in {"docker", "singularity", "modal", "daytona"}:
-            # Keep in lockstep with the terminal_tool container_config: this
-            # dict seeds the shared "default" environment slot, so a key
-            # missing here (docker_forward_env, docker_env, ...) silently
-            # strips that setting from every tool sharing the container
-            # whenever execute_code is the one that (re)creates it.
-            container_config = {
-                "container_cpu": config.get("container_cpu", 1),
-                "container_memory": config.get("container_memory", 5120),
-                "container_disk": config.get("container_disk", 51200),
-                "container_persistent": config.get("container_persistent", True),
-                "modal_mode": config.get("modal_mode", "auto"),
-                "docker_volumes": config.get("docker_volumes", []),
-                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                "docker_forward_env": config.get("docker_forward_env", []),
-                "docker_env": config.get("docker_env", {}),
-                "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                "docker_extra_args": config.get("docker_extra_args", []),
-                "docker_network": config.get("docker_network", True),
-                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
-                "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
-            }
+            container_config = _build_container_config(config)
 
         ssh_config = None
         if env_type == "ssh":

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -677,14 +677,26 @@ def _get_or_create_env(task_id: str):
 
         container_config = None
         if env_type in {"docker", "singularity", "modal", "daytona"}:
+            # Keep in lockstep with the terminal_tool container_config: this
+            # dict seeds the shared "default" environment slot, so a key
+            # missing here (docker_forward_env, docker_env, ...) silently
+            # strips that setting from every tool sharing the container
+            # whenever execute_code is the one that (re)creates it.
             container_config = {
                 "container_cpu": config.get("container_cpu", 1),
                 "container_memory": config.get("container_memory", 5120),
                 "container_disk": config.get("container_disk", 51200),
                 "container_persistent": config.get("container_persistent", True),
+                "modal_mode": config.get("modal_mode", "auto"),
                 "docker_volumes": config.get("docker_volumes", []),
+                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                "docker_forward_env": config.get("docker_forward_env", []),
+                "docker_env": config.get("docker_env", {}),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                "docker_extra_args": config.get("docker_extra_args", []),
                 "docker_network": config.get("docker_network", True),
+                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
             }
 
         ssh_config = None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1024,6 +1024,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _resolve_container_task_id,
         _is_unusable_container_cwd,
         _CONTAINER_BACKENDS,
+        _build_container_config,
     )
     import time
 
@@ -1109,27 +1110,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
 
             container_config = None
             if env_type in {"docker", "singularity", "modal", "daytona"}:
-                # Keep in lockstep with the terminal_tool container_config:
-                # this dict seeds the shared "default" environment slot, so a
-                # key missing here silently strips that setting from every
-                # tool sharing the container whenever the file tools are the
-                # ones that (re)create it.
-                container_config = {
-                    "container_cpu": config.get("container_cpu", 1),
-                    "container_memory": config.get("container_memory", 5120),
-                    "container_disk": config.get("container_disk", 51200),
-                    "container_persistent": config.get("container_persistent", True),
-                    "modal_mode": config.get("modal_mode", "auto"),
-                    "docker_volumes": config.get("docker_volumes", []),
-                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                    "docker_forward_env": config.get("docker_forward_env", []),
-                    "docker_env": config.get("docker_env", {}),
-                    "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                    "docker_extra_args": config.get("docker_extra_args", []),
-                    "docker_network": config.get("docker_network", True),
-                    "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
-                    "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
-                }
+                container_config = _build_container_config(config)
 
             ssh_config = None
             if env_type == "ssh":

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1109,16 +1109,26 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
 
             container_config = None
             if env_type in {"docker", "singularity", "modal", "daytona"}:
+                # Keep in lockstep with the terminal_tool container_config:
+                # this dict seeds the shared "default" environment slot, so a
+                # key missing here silently strips that setting from every
+                # tool sharing the container whenever the file tools are the
+                # ones that (re)create it.
                 container_config = {
                     "container_cpu": config.get("container_cpu", 1),
                     "container_memory": config.get("container_memory", 5120),
                     "container_disk": config.get("container_disk", 51200),
                     "container_persistent": config.get("container_persistent", True),
+                    "modal_mode": config.get("modal_mode", "auto"),
                     "docker_volumes": config.get("docker_volumes", []),
                     "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                     "docker_forward_env": config.get("docker_forward_env", []),
+                    "docker_env": config.get("docker_env", {}),
                     "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                    "docker_extra_args": config.get("docker_extra_args", []),
                     "docker_network": config.get("docker_network", True),
+                    "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                    "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
                 }
 
             ssh_config = None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1387,6 +1387,31 @@ def _get_modal_backend_state(modal_mode: object | None) -> Dict[str, Any]:
     )
 
 
+def _build_container_config(config: dict) -> dict:
+    """Project terminal settings into the canonical container config.
+
+    Terminal, execute_code, file tools, and the prompt backend probe all call
+    ``_create_environment``.  Keeping their configuration in one place avoids
+    silently dropping a setting based on which path creates the environment.
+    """
+    return {
+        "container_cpu": config.get("container_cpu", 1),
+        "container_memory": config.get("container_memory", 5120),
+        "container_disk": config.get("container_disk", 51200),
+        "container_persistent": config.get("container_persistent", True),
+        "modal_mode": config.get("modal_mode", "auto"),
+        "docker_volumes": config.get("docker_volumes", []),
+        "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+        "docker_forward_env": config.get("docker_forward_env", []),
+        "docker_env": config.get("docker_env", {}),
+        "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+        "docker_extra_args": config.get("docker_extra_args", []),
+        "docker_network": config.get("docker_network", True),
+        "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+        "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+    }
+
+
 def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
                         ssh_config: dict = None, container_config: dict = None,
                         local_config: dict = None,
@@ -2199,22 +2224,7 @@ def terminal_tool(
 
                         container_config = None
                         if env_type in {"docker", "singularity", "modal", "daytona"}:
-                            container_config = {
-                                "container_cpu": config.get("container_cpu", 1),
-                                "container_memory": config.get("container_memory", 5120),
-                                "container_disk": config.get("container_disk", 51200),
-                                "container_persistent": config.get("container_persistent", True),
-                                "modal_mode": config.get("modal_mode", "auto"),
-                                "docker_volumes": config.get("docker_volumes", []),
-                                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                                "docker_forward_env": config.get("docker_forward_env", []),
-                                "docker_env": config.get("docker_env", {}),
-                                "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                                "docker_extra_args": config.get("docker_extra_args", []),
-                                "docker_network": config.get("docker_network", True),
-                                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
-                                "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
-                            }
+                            container_config = _build_container_config(config)
 
                         local_config = None
                         if env_type == "local":


### PR DESCRIPTION
## What does this PR do?

Fixes container environment settings being silently dropped depending on which production path calls `_create_environment()`.

There are four callers that need the same `container_config`:

1. `terminal_tool`
2. `execute_code`
3. file tools
4. the system-prompt remote-backend probe

The first three share one collapsed environment slot per task, so whichever path creates or recreates the sandbox determines the configuration reused by all three. The prompt probe uses a separate slot, but it also creates a real container.

Before this PR:

- `execute_code` omitted `docker_forward_env`, `docker_env`, `docker_extra_args`, `modal_mode`, mount, persistence, and orphan-reaper settings.
- file tools omitted `docker_env`, `docker_extra_args`, `modal_mode`, persistence, and orphan-reaper settings.
- the prompt backend probe omitted `docker_network`, so `terminal.docker_network: false` silently fell back to a network-enabled probe container.

This PR adds one private `_build_container_config(config)` projection in `tools/terminal_tool.py` and routes all four callers through it. That fixes the current losses and removes the hand-copied dictionaries that repeatedly drifted.

## Why this is not already fixed

Earlier fixes covered only subsets of the call paths. #14235 fixed the terminal dictionary, and #12900 partially fixed file tools; the execute-code path remained incomplete. The prompt-probe `docker_network` omission was a fourth sibling path not covered by the existing three-module regression guard.

## Related work and contributor credit

This patch builds on prior reports and implementations:

- #8320 by Michel Belleau (`malaiwah`) identified the shared-slot `docker_forward_env` loss across tool paths.
- #30097 by `elozadaf` supplied the execute-code Docker env/extra-args fix.
- #35660 by Ted Malone (`temalo`) supplied full tool-path parity tests and explicitly proposed a shared helper as the follow-up.

`elozadaf` and Ted Malone are preserved as co-authors on follow-up commit `2a7daf1d4`. Related historical reports/attempts include #12534, #17620, #16214, and #5722.

## Changes made

- `tools/terminal_tool.py` — add the canonical container-config builder and use it in the terminal path.
- `tools/code_execution_tool.py` — use the shared builder.
- `tools/file_tools.py` — use the shared builder.
- `agent/prompt_builder.py` — use the shared builder so the probe honors `docker_network` and every other container setting.
- Regression tests now verify:
  - all 14 existing settings preserve non-default sentinel values;
  - terminal, execute-code, and file-tool callers pass the canonical builder output;
  - real `TERMINAL_*` parsing reaches the real environment factory and final Docker constructor for `forward_env`, static env, extra args, and network lockdown;
  - the prompt probe carries `docker_network: false` through the real parser/builder/factory chain.

## How to test

```bash
python -m pytest \
  tests/tools/test_execute_code_container_config.py \
  tests/tools/test_file_tools_container_config.py \
  tests/tools/test_docker_network_config.py \
  tests/tools/test_docker_environment.py \
  tests/tools/test_parse_env_var.py \
  tests/tools/test_docker_orphan_reaper_integration.py \
  tests/tools/test_modal_sandbox_fixes.py \
  tests/tools/test_terminal_config_env_sync.py \
  tests/tools/test_container_cwd_sanitize.py \
  tests/agent/test_prompt_builder.py -q
```

Result on the PR branch: **321 passed, 1 skipped**.

The complete two-commit PR was also replayed onto current `origin/main` (`e4ea0a0ed`) in a temporary worktree: clean rebase, **321 passed, 1 skipped**. Ruff, Python compilation, the Windows-footgun check, and `git diff --check` also pass.

## Scope

- Bug fix only; no new tool, schema, config key, environment variable, or user-facing documentation surface.
- Local and SSH behavior is unchanged (`container_config=None`).
- No system-prompt text or conversation state changes; prompt-cache stability is unaffected.

## Checklist

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] Conventional commit messages.
- [x] Searched and credited related issues/PRs.
- [x] Focused change with behavior-level regression coverage.
- [x] Tested on macOS (Apple Silicon) and replayed on latest `main`.
- [x] No documentation/config example update required because no public setting changed.