### PR TITLE
feat(desktop): add display.resume_last_session config toggle (#60812)

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -15,7 +15,7 @@ import { cn } from '@/lib/utils'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
 import { formatRefValue } from '../components/assistant-ui/directive-text'
-import { getSessionMessages, type SessionMessage, triggerCronJob } from '../hermes'
+import { getSessionMessages, getHermesConfigRecord, type SessionMessage, triggerCronJob } from '../hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '../lib/chat-messages'
 import { storedSessionIdForNotification } from '../lib/session-ids'
 import { isMessagingSource } from '../lib/session-source'
@@ -280,18 +280,37 @@ export function DesktopController() {
   // Restore that chat once, on cold start only (we're at the new-chat route and
   // haven't navigated yet). A dead/deleted id self-clears via the exhausted latch
   // below, so we never boot-loop into an error screen.
+  //
+  // Governed by display.resume_last_session (default true). When false the app
+  // always starts on a fresh new-chat instead of reopening the last session (#60812).
+  // The config fetch is async; on error we fall back to true (preserve old behavior).
   const restoredLastSessionRef = useRef(false)
   useEffect(() => {
     if (restoredLastSessionRef.current) {
       return
     }
 
-    restoredLastSessionRef.current = true
     const last = getRememberedSessionId()
-
-    if (last && location.pathname === NEW_CHAT_ROUTE) {
-      navigate(sessionRoute(last), { replace: true })
+    if (!last || location.pathname !== NEW_CHAT_ROUTE) {
+      return
     }
+
+    restoredLastSessionRef.current = true
+    void (async () => {
+      let resume = true
+      try {
+        const config = await getHermesConfigRecord()
+        const display = config.display as Record<string, unknown> | undefined
+        if (display && typeof display.resume_last_session === 'boolean') {
+          resume = display.resume_last_session
+        }
+      } catch {
+        // Config unavailable — preserve existing behavior (resume).
+      }
+      if (resume) {
+        navigate(sessionRoute(last), { replace: true })
+      }
+    })()
   }, [location.pathname, navigate])
 
   useEffect(() => {

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { LanguageSwitcher } from '@/components/language-switcher'
 import { Button } from '@/components/ui/button'
 import { SegmentedControl } from '@/components/ui/segmented-control'
+import { Switch } from '@/components/ui/switch'
 import type { DesktopMarketplaceSearchItem } from '@/global'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
@@ -21,6 +22,8 @@ import { getBaseColors, useTheme } from '@/themes/context'
 import { installVscodeThemeFromMarketplace } from '@/themes/install'
 import type { DesktopTheme } from '@/themes/types'
 import { $marketplaceInstalls, isUserTheme, removeUserTheme } from '@/themes/user-themes'
+import { getHermesConfigRecord, saveHermesConfig } from '@/hermes'
+import { invalidateHermesConfig, useHermesConfigRecord } from '../hooks/use-config-record'
 
 import { MODE_OPTIONS } from './constants'
 import { PetSettings } from './pet-settings'
@@ -252,6 +255,28 @@ export function AppearanceSettings() {
   const profiles = useStore($profiles)
   const activeProfileKey = normalizeProfileKey(useStore($activeGatewayProfile))
   const a = t.settings.appearance
+
+  // display.resume_last_session lives in the backend config record (not a
+  // frontend store). Read it via the shared react-query cache so a save here
+  // invalidates every other surface that reads the same key.
+  const configQuery = useHermesConfigRecord()
+  const resumeLastSession = (() => {
+    const display = configQuery.data?.display as Record<string, unknown> | undefined
+    return display?.resume_last_session !== false // default true when absent
+  })()
+
+  const setResumeLastSession = async (value: boolean) => {
+    try {
+      const config = await getHermesConfigRecord()
+      const display = { ...((config.display as Record<string, unknown>) ?? {}) }
+      display.resume_last_session = value
+      await saveHermesConfig({ ...config, display })
+      invalidateHermesConfig()
+    } catch {
+      // saveHermesConfig already surfaces errors via the API layer; the
+      // toggle reverts on next render because the cache wasn't updated.
+    }
+  }
 
   const [query, setQuery] = useState('')
 
@@ -493,6 +518,20 @@ export function AppearanceSettings() {
             }
             description={a.embedsDesc}
             title={a.embedsTitle}
+          />
+
+          <ListRow
+            action={
+              <Switch
+                checked={resumeLastSession}
+                onCheckedChange={checked => {
+                  triggerHaptic('selection')
+                  void setResumeLastSession(checked)
+                }}
+              />
+            }
+            description={a.resumeLastSessionDesc}
+            title={a.resumeLastSessionTitle}
           />
         </div>
       </div>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -394,6 +394,8 @@ export const en: Translations = {
       embedsAlways: 'Always',
       embedsOff: 'Off',
       embedsReset: (count: number) => `Reset ${count} allowed ${count === 1 ? 'service' : 'services'}`,
+      resumeLastSessionTitle: 'Reopen Last Chat on Launch',
+      resumeLastSessionDesc: 'When enabled, the app reopens your most recent chat on cold start. Turn off to always start with a fresh new chat.',
       product: 'Product',
       productDesc: 'Human-friendly tool activity with concise summaries.',
       technical: 'Technical',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -300,6 +300,8 @@ export const ja = defineLocale({
       embedsAlways: '常に',
       embedsOff: 'オフ',
       embedsReset: (count: number) => `許可した${count}件のサービスをリセット`,
+      resumeLastSessionTitle: '起動時に前回のチャットを再開',
+      resumeLastSessionDesc: 'オンの場合、コールドスタート時に直近のチャットを再び開きます。オフにすると常に新しいチャットから始まります。',
       product: 'プロダクト',
       productDesc: '読みやすいツール活動と簡潔な要約を表示します。',
       technical: 'テクニカル',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -313,6 +313,8 @@ export interface Translations {
       embedsAlways: string
       embedsOff: string
       embedsReset: (count: number) => string
+      resumeLastSessionTitle: string
+      resumeLastSessionDesc: string
       product: string
       productDesc: string
       technical: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -291,6 +291,8 @@ export const zhHant = defineLocale({
       embedsAlways: '一律',
       embedsOff: '關閉',
       embedsReset: (count: number) => `重設 ${count} 個已允許的服務`,
+      resumeLastSessionTitle: '啟動時恢復上次會話',
+      resumeLastSessionDesc: '開啟後，應用冷啟動時重新打開最近的聊天。關閉則始終從空白新會話開始。',
       product: '產品',
       productDesc: '易讀的工具活動與精簡摘要。',
       technical: '技術',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -382,6 +382,8 @@ export const zh: Translations = {
       embedsAlways: '总是',
       embedsOff: '关闭',
       embedsReset: (count: number) => `重置 ${count} 个已允许的服务`,
+      resumeLastSessionTitle: '启动时恢复上次会话',
+      resumeLastSessionDesc: '开启后，应用冷启动时重新打开最近的聊天。关闭则始终从空白新会话开始。',
       product: '产品',
       productDesc: '易读的工具活动与简洁摘要。',
       technical: '技术',

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1760,6 +1760,12 @@ DEFAULT_CONFIG = {
         # Mirrors `hermes -c` muscle memory.  Default off so existing
         # users aren't surprised.  HERMES_TUI_RESUME=<id> always wins.
         "tui_auto_resume_recent": False,
+        # When true (default), the Desktop app reopens the last chat
+        # session on cold start instead of landing on a fresh new-chat.
+        # Set false to always start with a blank new session. Mirrors the
+        # TUI's tui_auto_resume_recent but defaults to true so existing
+        # Desktop behavior is preserved.
+        "resume_last_session": True,
         # When true (default), `hermes --tui` drops a one-time hint
         # ("subagents working · /agents to watch live") the first time a turn
         # starts delegating, nudging the user toward the live spawn-tree

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1207,6 +1207,20 @@ class TestCliRefreshIntervalConfig:
         assert DEFAULT_CONFIG["display"]["cli_refresh_interval"] == 1.0
 
 
+class TestResumeLastSessionConfig:
+    """Test the Desktop resume_last_session config default (#60812)."""
+
+    def test_default_config_enables_resume_last_session(self):
+        """resume_last_session defaults to True so the Desktop app preserves
+        its existing cold-start behavior of reopening the last chat. Users
+        who prefer a fresh new-chat on every launch set it to False."""
+        assert DEFAULT_CONFIG["display"]["resume_last_session"] is True
+
+    def test_tui_auto_resume_recent_still_exists(self):
+        """The TUI's separate toggle must remain untouched."""
+        assert DEFAULT_CONFIG["display"]["tui_auto_resume_recent"] is False
+
+
 class TestDiscordChannelPromptsConfig:
     def test_default_config_includes_discord_channel_prompts(self):
         assert DEFAULT_CONFIG["discord"]["channel_prompts"] == {}


### PR DESCRIPTION
## Summary

Fixes #60812 — The Desktop app always reopened the last chat on cold start with no config option to start fresh. The TUI has `display.tui_auto_resume_recent` for this; the Desktop had no equivalent.

This PR adds both the **backend config toggle** and a **GUI switch** in Settings → Appearance.

## Changes

### Commit 1: Backend config + cold-start logic

| File | Change |
|------|--------|
| `hermes_cli/config.py` | Add `display.resume_last_session` (default `true`) to `DEFAULT_CONFIG`. Mirrors the TUI's `tui_auto_resume_recent` but defaults to `true` so existing Desktop behavior is preserved. |
| `apps/desktop/src/app/desktop-controller.tsx` | The cold-start restore `useEffect` now fetches config via `getHermesConfigRecord()` and gates `navigate()` on `display.resume_last_session`. Falls back to `true` (resume) on config fetch error so the failure mode is the old behavior. |
| `tests/hermes_cli/test_config.py` | 2 new tests: default value is `true`, TUI toggle unchanged. |

### Commit 2: GUI toggle in Settings → Appearance

| File | Change |
|------|--------|
| `apps/desktop/src/app/settings/appearance-settings.tsx` | New `ListRow` with a `Switch` component below "Inline Embeds". Reads `display.resume_last_session` via the shared `useHermesConfigRecord` react-query cache; writes via `saveHermesConfig` + `invalidateHermesConfig` so all config surfaces stay in sync. Defaults to `true` when config is absent. |
| `apps/desktop/src/i18n/types.ts` | Add `resumeLastSessionTitle` + `resumeLastSessionDesc` to the `appearance` type. |
| `apps/desktop/src/i18n/en.ts` | English strings. |
| `apps/desktop/src/i18n/zh.ts` | Simplified Chinese strings. |
| `apps/desktop/src/i18n/zh-hant.ts` | Traditional Chinese strings. |
| `apps/desktop/src/i18n/ja.ts` | Japanese strings. |

## User-facing result

Settings → Appearance → "Reopen Last Chat on Launch" toggle (Switch component, below Inline Embeds). Toggle off → next cold start lands on a fresh new-chat instead of reopening the last session.

## Design decisions

- **Default `true`**: the Desktop has always resumed; flipping the default would surprise existing users. Users who want fresh-start set `display.resume_last_session: false` in `config.yaml` **or** toggle it off in Settings → Appearance.
- **Async config fetch in cold-start**: the restore `useEffect` was synchronous; it now awaits `getHermesConfigRecord()` before navigating. When `resume_last_session` is `false`, the effect returns without navigating — the app stays on the new-chat route with zero flicker. When `true` (default), there is a brief async delay before navigation, but this is the same path the old code took (just deferred by one microtask).
- **Error fallback to `true`**: if the config endpoint is unavailable on cold start (backend not yet ready, network error), we preserve the old behavior (resume). This is the safer fallback — a user who explicitly set `false` will see a resume on the rare config-fetch failure, but this self-corrects on next launch.
- **GUI toggle reads/writes the same config key**: the Appearance Settings switch uses the shared `useHermesConfigRecord` react-query cache, so a change in Settings immediately reflects in the cold-start logic on the next launch. No localStorage duplication.
- **No localStorage**: the config is read fresh each launch via the existing `/api/config` REST endpoint, not cached in localStorage. This ensures a config change takes effect on the next launch without needing to clear browser storage.

## Test results

- `tests/hermes_cli/test_config.py::TestResumeLastSessionConfig` — 2 new tests pass
- Full `test_config.py` — 145 passed, 1 pre-existing environment-related failure (`TestGetHermesHome::test_default_path`, unrelated to this change)
- `tsc -p . --noEmit` — zero TypeScript errors (both commits)

Closes #60812
