### PR TITLE
fix(config): secure direct YAML writes

### DIFF
--- a/tests/hermes_cli/test_atomic_yaml_write.py
+++ b/tests/hermes_cli/test_atomic_yaml_write.py
@@ -1,11 +1,13 @@
 """Tests for utils.atomic_yaml_write — crash-safe YAML file writes."""
 
+import os
+import stat
 from unittest.mock import patch
 
 import pytest
 import yaml
 
-from utils import atomic_yaml_write
+from utils import atomic_roundtrip_yaml_update, atomic_yaml_write
 
 
 class TestAtomicYamlWrite:
@@ -16,6 +18,60 @@ class TestAtomicYamlWrite:
         atomic_yaml_write(target, data)
 
         assert yaml.safe_load(target.read_text(encoding="utf-8")) == data
+
+    def test_config_yaml_write_forces_owner_only_permissions(self, tmp_path):
+        if os.name != "posix":
+            pytest.skip("POSIX-only")
+
+        target = tmp_path / "config.yaml"
+        target.write_text("old: true\n", encoding="utf-8")
+        target.chmod(0o666)
+
+        atomic_yaml_write(target, {"new": True})
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    def test_config_yaml_write_secures_symlink_target(self, tmp_path):
+        if os.name != "posix":
+            pytest.skip("POSIX-only")
+
+        real = tmp_path / "real.yaml"
+        link = tmp_path / "config.yaml"
+        real.write_text("old: true\n", encoding="utf-8")
+        real.chmod(0o666)
+        link.symlink_to(real)
+
+        atomic_yaml_write(link, {"new": True})
+
+        assert link.is_symlink()
+        assert stat.S_IMODE(real.stat().st_mode) == 0o600
+
+    def test_roundtrip_config_yaml_update_forces_owner_only_permissions(self, tmp_path):
+        if os.name != "posix":
+            pytest.skip("POSIX-only")
+
+        target = tmp_path / "config.yaml"
+        target.write_text("model:\n  provider: openrouter\n", encoding="utf-8")
+        target.chmod(0o666)
+
+        atomic_roundtrip_yaml_update(target, "model.provider", "nvidia")
+
+        assert yaml.safe_load(target.read_text(encoding="utf-8")) == {
+            "model": {"provider": "nvidia"}
+        }
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    def test_non_config_yaml_preserves_existing_permissions(self, tmp_path):
+        if os.name != "posix":
+            pytest.skip("POSIX-only")
+
+        target = tmp_path / "state.yaml"
+        target.write_text("old: true\n", encoding="utf-8")
+        target.chmod(0o664)
+
+        atomic_yaml_write(target, {"new": True})
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o664
 
     def test_cleans_up_temp_file_on_baseexception(self, tmp_path):
         class SimulatedAbort(BaseException):

--- a/utils.py
+++ b/utils.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
+_CONFIG_YAML_MODE = 0o600
 
 
 def is_truthy_value(value: Any, default: bool = False) -> bool:
@@ -86,6 +87,15 @@ def _restore_file_mode(path: Path, mode: "int | None") -> None:
         os.chmod(path, mode)
     except OSError:
         pass
+
+
+def _yaml_write_restore_mode(
+    requested_path: Path, resolved_path: Path, original_mode: "int | None"
+) -> "int | None":
+    """Return the final mode for YAML atomic writes."""
+    if requested_path.name == "config.yaml" or resolved_path.name == "config.yaml":
+        return _CONFIG_YAML_MODE
+    return original_mode
 
 
 def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
@@ -282,7 +292,9 @@ def atomic_yaml_write(
         real_path = atomic_replace(tmp_path, path)
         real_path_obj = Path(real_path)
         _restore_file_owner(real_path_obj, original_owner)
-        _restore_file_mode(real_path_obj, original_mode)
+        _restore_file_mode(
+            real_path_obj, _yaml_write_restore_mode(path, real_path_obj, original_mode)
+        )
     except BaseException:
         # Match atomic_json_write: cleanup must also happen for process-level
         # interruptions before we re-raise them.
@@ -351,7 +363,9 @@ def atomic_roundtrip_yaml_update(
         real_path = atomic_replace(tmp_path, path)
         real_path_obj = Path(real_path)
         _restore_file_owner(real_path_obj, original_owner)
-        _restore_file_mode(real_path_obj, original_mode)
+        _restore_file_mode(
+            real_path_obj, _yaml_write_restore_mode(path, real_path_obj, original_mode)
+        )
     except BaseException:
         try:
             os.unlink(tmp_path)


### PR DESCRIPTION
Fixes #59726.

## Summary
- Force YAML atomic writes to leave `config.yaml` at owner-only `0600`, including symlink-resolved config targets.
- Keep existing mode preservation for non-config YAML files so Docker/NAS-style deployments retain their chosen permissions.
- Cover direct `atomic_yaml_write`, `atomic_roundtrip_yaml_update`, symlinked config writes, and the non-config preservation path.

## Tests
- `uv run --extra dev pytest tests/hermes_cli/test_atomic_yaml_write.py tests/test_atomic_replace_symlinks.py tests/cron/test_file_permissions.py::TestConfigFilePermissions::test_save_config_sets_0600 tests/hermes_cli/test_config.py::TestSaveConfigAtomicity -q`
- `git diff --check`
- `gitleaks git --log-opts='origin/main..HEAD' --redact .`
