### PR TITLE
fix(honcho): report configured vs reachable status

### DIFF
--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -1058,6 +1058,7 @@ def cmd_status(args) -> None:
 
     api_key = hcfg.api_key or ""
     masked = f"...{api_key[-8:]}" if len(api_key) > 8 else ("set" if api_key else "not set")
+    configured = bool(hcfg.enabled and (hcfg.api_key or hcfg.base_url))
 
     # Auth line distinguishes an OAuth grant (refreshable) from a static API key
     # — the OAuth access token is also stored under apiKey, so masking alone hides it.
@@ -1073,6 +1074,7 @@ def cmd_status(args) -> None:
         print(f"  Profile:        {profile}")
     print(f"  Host:           {hcfg.host}")
     print(f"  Enabled:        {hcfg.enabled}")
+    print(f"  Configured:     {configured}")
     if cred is not None:
         import time as _time
         remaining = int(cred.expires_at - _time.time())
@@ -1107,56 +1109,55 @@ def cmd_status(args) -> None:
     print(f"  Observation:    user(me={hcfg.user_observe_me},others={hcfg.user_observe_others}) ai(me={hcfg.ai_observe_me},others={hcfg.ai_observe_others})")
     print(f"  Write freq:     {hcfg.write_frequency}")
 
-    if hcfg.enabled and (hcfg.api_key or hcfg.base_url):
-        print("\n  Connection... ", end="", flush=True)
+    if configured:
         try:
             client = get_honcho_client(hcfg)
-            _show_peer_cards(hcfg, client)
-            print("OK")
+            card, ai_text = _load_peer_cards(hcfg, client)
+            print("  Reachable:      yes")
+            _print_peer_cards(card, ai_text)
+            print()
         except Exception as e:
-            print(f"FAILED ({e})\n")
+            print(f"  Reachable:      no ({e})\n")
     else:
         reason = "disabled" if not hcfg.enabled else "no API key or base URL"
-        print(f"\n  Not connected ({reason})\n")
+        print(f"  Reachable:      not checked ({reason})\n")
 
 
-def _show_peer_cards(hcfg, client) -> None:
-    """Fetch and display peer cards for the active profile.
+def _load_peer_cards(hcfg, client):
+    """Return user-card facts and AI representation for status display.
 
     Uses get_or_create to ensure the session exists with peers configured.
     This is idempotent -- if the session already exists on the server it's
     just retrieved, not duplicated.
     """
-    try:
-        from plugins.memory.honcho.session import HonchoSessionManager
-        mgr = HonchoSessionManager(honcho=client, config=hcfg)
-        session_key = hcfg.resolve_session_name()
-        mgr.get_or_create(session_key)
+    from plugins.memory.honcho.session import HonchoSessionManager
 
-        # User peer card
-        card = mgr.get_peer_card(session_key)
-        if card:
-            print(f"\n  User peer card ({len(card)} facts):")
-            for fact in card[:10]:
-                print(f"    - {fact}")
-            if len(card) > 10:
-                print(f"    ... and {len(card) - 10} more")
+    mgr = HonchoSessionManager(honcho=client, config=hcfg)
+    session_key = hcfg.resolve_session_name()
+    mgr.get_or_create(session_key)
+    card = mgr.get_peer_card(session_key)
+    ai_rep = mgr.get_ai_representation(session_key)
+    ai_text = ai_rep.get("representation", "")
+    return card, ai_text
 
-        # AI peer representation
-        ai_rep = mgr.get_ai_representation(session_key)
-        ai_text = ai_rep.get("representation", "")
-        if ai_text:
-            # Truncate to first 200 chars
-            display = ai_text[:200] + ("..." if len(ai_text) > 200 else "")
-            print("\n  AI peer representation:")
-            print(f"    {display}")
 
-        if not card and not ai_text:
-            print("\n  No peer data yet (accumulates after first conversation)")
+def _print_peer_cards(card, ai_text: str) -> None:
+    """Render status-only peer-card diagnostics after reachability succeeds."""
+    if card:
+        print(f"\n  User peer card ({len(card)} facts):")
+        for fact in card[:10]:
+            print(f"    - {fact}")
+        if len(card) > 10:
+            print(f"    ... and {len(card) - 10} more")
 
-        print()
-    except Exception as e:
-        print(f"\n  Peer data unavailable: {e}\n")
+    if ai_text:
+        # Truncate to first 200 chars
+        display = ai_text[:200] + ("..." if len(ai_text) > 200 else "")
+        print("\n  AI peer representation:")
+        print(f"    {display}")
+
+    if not card and not ai_text:
+        print("\n  No peer data yet (accumulates after first conversation)")
 
 
 def _cmd_status_all() -> None:

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -180,18 +180,31 @@ class TestCmdSetupLocalJwt:
 
 
 class TestCmdStatus:
-    def test_reports_connection_failure_when_session_setup_fails(self, monkeypatch, capsys, tmp_path):
+    def _install_base_status_stubs(self, monkeypatch, tmp_path, fake_config):
         import plugins.memory.honcho.cli as honcho_cli
 
         cfg_path = tmp_path / "honcho.json"
         cfg_path.write_text("{}")
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: {"apiKey": "***"})
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_active_profile_name", lambda: "default")
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            lambda host=None: fake_config,
+        )
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.get_honcho_client",
+            lambda cfg: object(),
+        )
+        monkeypatch.setitem(__import__("sys").modules, "honcho", SimpleNamespace())
+        return honcho_cli
 
+    @staticmethod
+    def _fake_config(*, enabled=True, api_key="root-key", base_url=None):
         class FakeConfig:
-            enabled = True
-            api_key = "root-key"
             workspace_id = "hermes"
             host = "hermes"
-            base_url = None
             ai_peer = "hermes"
             peer_name = "eri"
             recall_mode = "hybrid"
@@ -205,34 +218,57 @@ class TestCmdStatus:
             dialectic_reasoning_level = "low"
             reasoning_level_cap = "high"
             reasoning_heuristic = True
+            raw = {}
+
+            def __init__(self):
+                self.enabled = enabled
+                self.api_key = api_key
+                self.base_url = base_url
 
             def resolve_session_name(self):
                 return "hermes"
 
-        monkeypatch.setattr(honcho_cli, "_read_config", lambda: {"apiKey": "***"})
-        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
-        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
-        monkeypatch.setattr(honcho_cli, "_active_profile_name", lambda: "default")
-        monkeypatch.setattr(
-            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
-            lambda host=None: FakeConfig(),
-        )
-        monkeypatch.setattr(
-            "plugins.memory.honcho.client.get_honcho_client",
-            lambda cfg: object(),
-        )
+        return FakeConfig()
+
+    def test_reports_unreachable_when_session_setup_fails(self, monkeypatch, capsys, tmp_path):
+        fake_config = self._fake_config()
+        honcho_cli = self._install_base_status_stubs(monkeypatch, tmp_path, fake_config)
 
         def _boom(hcfg, client):
             raise RuntimeError("Invalid API key")
 
-        monkeypatch.setattr(honcho_cli, "_show_peer_cards", _boom)
-        monkeypatch.setitem(__import__("sys").modules, "honcho", SimpleNamespace())
+        monkeypatch.setattr(honcho_cli, "_load_peer_cards", _boom)
 
         honcho_cli.cmd_status(SimpleNamespace(all=False))
 
         out = capsys.readouterr().out
-        assert "FAILED (Invalid API key)" in out
+        assert "Configured:     True" in out
+        assert "Reachable:      no (Invalid API key)" in out
+        assert "Reachable:      yes" not in out
         assert "Connection... OK" not in out
+
+    def test_reports_reachable_when_peer_probe_succeeds(self, monkeypatch, capsys, tmp_path):
+        fake_config = self._fake_config()
+        honcho_cli = self._install_base_status_stubs(monkeypatch, tmp_path, fake_config)
+        monkeypatch.setattr(honcho_cli, "_load_peer_cards", lambda hcfg, client: (["Fact 1"], "AI summary"))
+
+        honcho_cli.cmd_status(SimpleNamespace(all=False))
+
+        out = capsys.readouterr().out
+        assert "Configured:     True" in out
+        assert "Reachable:      yes" in out
+        assert "User peer card (1 facts):" in out
+        assert "AI peer representation:" in out
+
+    def test_reports_not_checked_when_not_configured(self, monkeypatch, capsys, tmp_path):
+        fake_config = self._fake_config(enabled=False, api_key="")
+        honcho_cli = self._install_base_status_stubs(monkeypatch, tmp_path, fake_config)
+
+        honcho_cli.cmd_status(SimpleNamespace(all=False))
+
+        out = capsys.readouterr().out
+        assert "Configured:     False" in out
+        assert "Reachable:      not checked (disabled)" in out
 
     def test_auth_line_detects_oauth_grant(self, monkeypatch, capsys, tmp_path):
         import plugins.memory.honcho.cli as honcho_cli
@@ -285,7 +321,7 @@ class TestCmdStatus:
             lambda host=None: FakeConfig(),
         )
         monkeypatch.setattr("plugins.memory.honcho.client.get_honcho_client", lambda cfg: object())
-        monkeypatch.setattr(honcho_cli, "_show_peer_cards", lambda hcfg, client: None)
+        monkeypatch.setattr(honcho_cli, "_load_peer_cards", lambda hcfg, client: ([], ""))
         monkeypatch.setitem(__import__("sys").modules, "honcho", SimpleNamespace())
 
         honcho_cli.cmd_status(SimpleNamespace(all=False))


### PR DESCRIPTION
Summary
- make `hermes honcho status` distinguish configured state from runtime reachability
- stop reporting a successful connection when the status probe fails during session setup / peer loading
- keep `MemoryProvider.is_available()` unchanged and config/dependency-only

Why
- Honcho could previously print peer-data errors and still end with `Connection... OK`, which made configured-but-unreachable backends look healthy
- upstream research for this task says shared provider availability must stay cheap/config-only, but provider-local diagnostics are an approved path

What changed
- `plugins/memory/honcho/cli.py`
  - add a `Configured:` line based on enabled + credentials/base URL
  - replace the old optimistic connection print path with explicit `Reachable:` reporting
  - split status probing from peer-card rendering so probe failures surface as unreachable instead of being swallowed
- `tests/honcho_plugin/test_cli.py`
  - add coverage for configured+unreachable, configured+reachable, and not-configured cases
  - update OAuth status test to use the new status helper

How to test
- `python -m pytest tests/honcho_plugin/test_cli.py -q`
- `python -m pytest tests/honcho_plugin/test_cli.py::TestCmdStatus -q`
- `python3 scripts/check-windows-footguns.py plugins/memory/honcho/cli.py tests/honcho_plugin/test_cli.py`

Validation notes
- I also started `./scripts/run_tests.sh` for upstream parity. It timed out after 600s on unrelated existing failures outside this change, including:
  - `tests/agent/test_anthropic_adapter.py`
  - `tests/agent/test_credential_pool.py`
  - `tests/hermes_cli/test_model_switch_custom_providers.py`
  - `tests/test_live_system_guard_self_test.py`
  - `tests/test_pty_session.py`
- This PR is therefore opened as draft pending broader suite health, but the Honcho-targeted coverage added here passes locally.

Platforms tested
- macOS 26.5.1

Security
- no security-sensitive behavior changed; status output now avoids overstating backend reachability