### PR TITLE
fix(cron): resolve job paths lazily

### DIFF
--- a/cron/__init__.py
+++ b/cron/__init__.py
@@ -24,6 +24,9 @@ from cron.jobs import (
     pause_job,
     resume_job,
     trigger_job,
+    get_cron_dir,
+    get_jobs_file,
+    get_output_dir,
     JOBS_FILE,
 )
 from cron.scheduler import tick
@@ -38,5 +41,8 @@ __all__ = [
     "resume_job",
     "trigger_job",
     "tick",
+    "get_cron_dir",
+    "get_jobs_file",
+    "get_output_dir",
     "JOBS_FILE",
 ]

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -104,6 +104,69 @@ _ONESHOT_RUN_CLAIM_TTL_HEADROOM = 3
 
 _DEFAULT_CRON_INACTIVITY_TIMEOUT = 600.0
 
+_INITIAL_HERMES_DIR = HERMES_DIR
+_INITIAL_CRON_DIR = CRON_DIR
+_INITIAL_JOBS_FILE = JOBS_FILE
+_INITIAL_TICKER_HEARTBEAT_FILE = TICKER_HEARTBEAT_FILE
+_INITIAL_TICKER_SUCCESS_FILE = TICKER_SUCCESS_FILE
+_INITIAL_OUTPUT_DIR = OUTPUT_DIR
+
+
+def _path_value(path: Any) -> Path:
+    """Coerce legacy monkeypatched path globals back to Path."""
+    return path if isinstance(path, Path) else Path(path)
+
+
+def _get_hermes_dir() -> Path:
+    """Return the active cron home, honoring explicit legacy path overrides."""
+    hermes_dir = _path_value(HERMES_DIR)
+    if hermes_dir != _INITIAL_HERMES_DIR:
+        return hermes_dir.resolve()
+    return get_hermes_home().resolve()
+
+
+def get_cron_dir() -> Path:
+    """Return the active cron directory.
+
+    The module-level constants above remain for compatibility, but runtime
+    storage resolves lazily so tests and profile switches that update
+    HERMES_HOME after import cannot write into the previously active home.
+    """
+    cron_dir = _path_value(CRON_DIR)
+    if cron_dir != _INITIAL_CRON_DIR:
+        return cron_dir
+    return _get_hermes_dir() / "cron"
+
+
+def get_jobs_file() -> Path:
+    """Return the active jobs.json path."""
+    jobs_file = _path_value(JOBS_FILE)
+    if jobs_file != _INITIAL_JOBS_FILE:
+        return jobs_file
+    return get_cron_dir() / "jobs.json"
+
+
+def get_output_dir() -> Path:
+    """Return the active cron output directory."""
+    output_dir = _path_value(OUTPUT_DIR)
+    if output_dir != _INITIAL_OUTPUT_DIR:
+        return output_dir
+    return get_cron_dir() / "output"
+
+
+def _get_ticker_heartbeat_file() -> Path:
+    heartbeat_file = _path_value(TICKER_HEARTBEAT_FILE)
+    if heartbeat_file != _INITIAL_TICKER_HEARTBEAT_FILE:
+        return heartbeat_file
+    return get_cron_dir() / "ticker_heartbeat"
+
+
+def _get_ticker_success_file() -> Path:
+    success_file = _path_value(TICKER_SUCCESS_FILE)
+    if success_file != _INITIAL_TICKER_SUCCESS_FILE:
+        return success_file
+    return get_cron_dir() / "ticker_last_success"
+
 
 def _oneshot_run_claim_ttl_seconds() -> float:
     """Resolve the one-shot running-claim stale-recovery TTL.
@@ -136,7 +199,7 @@ def _oneshot_run_claim_ttl_seconds() -> float:
 
 def _jobs_lock_file() -> Path:
     """Return the advisory lock path for the current cron directory."""
-    return CRON_DIR / ".jobs.lock"
+    return get_cron_dir() / ".jobs.lock"
 
 
 @contextlib.contextmanager
@@ -221,7 +284,7 @@ def _job_output_dir(job_id: str) -> Path:
         raise ValueError(f"Invalid cron job id for output path: {job_id!r}")
     if Path(text).is_absolute() or Path(text).drive:
         raise ValueError(f"Invalid cron job id for output path: {job_id!r}")
-    return OUTPUT_DIR / text
+    return get_output_dir() / text
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -328,10 +391,12 @@ def _secure_file(path: Path):
 
 def ensure_dirs():
     """Ensure cron directories exist with secure permissions."""
-    CRON_DIR.mkdir(parents=True, exist_ok=True)
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    _secure_dir(CRON_DIR)
-    _secure_dir(OUTPUT_DIR)
+    cron_dir = get_cron_dir()
+    output_dir = get_output_dir()
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _secure_dir(cron_dir)
+    _secure_dir(output_dir)
 
 
 # =============================================================================
@@ -620,7 +685,7 @@ def _atomic_write_epoch(path: Path) -> None:
     torn/truncated file. Best-effort: failures are swallowed by callers.
     """
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(CRON_DIR), suffix=".tmp", prefix=".hb_")
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".hb_")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(str(time.time()))
@@ -648,12 +713,12 @@ def record_ticker_heartbeat(success: bool = False) -> None:
     Best-effort: a write failure must never disrupt the tick loop.
     """
     try:
-        _atomic_write_epoch(TICKER_HEARTBEAT_FILE)
+        _atomic_write_epoch(_get_ticker_heartbeat_file())
     except Exception:
         pass
     if success:
         try:
-            _atomic_write_epoch(TICKER_SUCCESS_FILE)
+            _atomic_write_epoch(_get_ticker_success_file())
         except Exception:
             pass
 
@@ -672,12 +737,12 @@ def get_ticker_heartbeat_age() -> Optional[float]:
     None = heartbeat file missing/unreadable (older build, never ran, or a
     torn read). Callers treat None as "cannot determine", not "dead".
     """
-    return _epoch_file_age(TICKER_HEARTBEAT_FILE)
+    return _epoch_file_age(_get_ticker_heartbeat_file())
 
 
 def get_ticker_success_age() -> Optional[float]:
     """Seconds since the ticker last completed a tick WITHOUT raising, or None."""
-    return _epoch_file_age(TICKER_SUCCESS_FILE)
+    return _epoch_file_age(_get_ticker_success_file())
 
 
 # =============================================================================
@@ -687,19 +752,20 @@ def get_ticker_success_age() -> Optional[float]:
 def load_jobs() -> List[Dict[str, Any]]:
     """Load all jobs from storage."""
     ensure_dirs()
-    if not JOBS_FILE.exists():
+    jobs_file = get_jobs_file()
+    if not jobs_file.exists():
         return []
 
     _strict_retry = False  # track whether we used the strict=False fallback
 
     try:
-        with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+        with open(jobs_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         _strict_retry = True
         try:
-            with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+            with open(jobs_file, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
         except Exception as e:
             logger.error("Failed to auto-repair jobs.json: %s", e)
@@ -735,14 +801,17 @@ def load_jobs() -> List[Dict[str, Any]]:
 def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
     """Save all jobs to storage. Caller must hold _jobs_lock()."""
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
+    jobs_file = get_jobs_file()
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(jobs_file.parent), suffix='.tmp', prefix='.jobs_'
+    )
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
             json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
             f.flush()
             os.fsync(f.fileno())
-        atomic_replace(tmp_path, JOBS_FILE)
-        _secure_file(JOBS_FILE)
+        atomic_replace(tmp_path, jobs_file)
+        _secure_file(jobs_file)
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2213,7 +2213,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     # Inject output from referenced cron jobs as context.
     context_from = job.get("context_from")
     if context_from:
-        from cron.jobs import OUTPUT_DIR
+        from cron.jobs import get_output_dir
         if isinstance(context_from, str):
             context_from = [context_from]
         for source_job_id in context_from:
@@ -2228,7 +2228,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 )
                 continue
             try:
-                job_output_dir = OUTPUT_DIR / source_job_id
+                job_output_dir = get_output_dir() / source_job_id
                 if not job_output_dir.exists():
                     continue  # silent skip — no output yet
                 output_files = sorted(

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -238,6 +238,45 @@ def tmp_cron_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
+def test_storage_re_resolves_hermes_home_after_import(tmp_path, monkeypatch):
+    """Changing HERMES_HOME after import must not write to the old jobs file."""
+    import importlib
+    import cron.jobs as jobs_module
+
+    old_home = tmp_path / "old-home"
+    new_home = tmp_path / "new-home"
+
+    with monkeypatch.context() as m:
+        m.setenv("HERMES_HOME", str(old_home))
+        jobs_module = importlib.reload(jobs_module)
+
+        m.setenv("HERMES_HOME", str(new_home))
+        jobs_module.create_job(prompt="echo hi", schedule="every 5m", name="w")
+
+        assert (new_home / "cron" / "jobs.json").exists()
+        assert not (old_home / "cron" / "jobs.json").exists()
+        assert jobs_module.get_jobs_file() == new_home / "cron" / "jobs.json"
+
+    importlib.reload(jobs_module)
+
+
+def test_explicit_jobs_file_override_still_wins_over_env(tmp_path, monkeypatch):
+    """Existing tests and callers can still pin cron paths explicitly."""
+    import cron.jobs as jobs_module
+
+    env_home = tmp_path / "env-home"
+    override_cron = tmp_path / "override" / "cron"
+    monkeypatch.setenv("HERMES_HOME", str(env_home))
+    monkeypatch.setattr(jobs_module, "CRON_DIR", override_cron)
+    monkeypatch.setattr(jobs_module, "JOBS_FILE", override_cron / "jobs.json")
+    monkeypatch.setattr(jobs_module, "OUTPUT_DIR", override_cron / "output")
+
+    jobs_module.create_job(prompt="say hello", schedule="every 1h", name="alpha")
+
+    assert (override_cron / "jobs.json").exists()
+    assert not (env_home / "cron" / "jobs.json").exists()
+
+
 class TestJobCRUD:
     def test_create_and_get(self, tmp_cron_dir):
         job = create_job(prompt="Check server status", schedule="30m")


### PR DESCRIPTION
Fixes #60014.

## Summary
- Resolve cron storage paths lazily from the current `HERMES_HOME` for runtime reads/writes, instead of relying on import-time `JOBS_FILE` / `CRON_DIR` values.
- Keep the legacy path constants as compatibility override points for existing tests/callers that monkeypatch them directly.
- Apply the same lazy path lookup to cron lock files, heartbeat files, output directories, and scheduler `context_from` output reads.
- Add regression coverage for the import-before-`HERMES_HOME`-change leak and for explicit `JOBS_FILE` override compatibility.

## Root cause
`cron.jobs` computed `HERMES_DIR`, `CRON_DIR`, `JOBS_FILE`, and `OUTPUT_DIR` once at import time. In a long-lived pytest process, a later test could set `HERMES_HOME` to a temp directory but `create_job()` / `save_jobs()` would still write to the previously imported jobs file, including a real user profile.

## Tests
- `uv run --extra dev pytest tests/cron/test_jobs.py::test_storage_re_resolves_hermes_home_after_import tests/cron/test_jobs.py::test_explicit_jobs_file_override_still_wins_over_env tests/cron/test_jobs_changed_notify.py::test_tool_create_notifies_provider tests/hermes_cli/test_console_engine.py::test_cron_pause_resume_and_run_require_confirmation -q`
- `uv run --extra dev pytest tests/cron/test_jobs.py tests/cron/test_jobs_changed_notify.py tests/cron/test_cron_profile_isolation.py tests/hermes_cli/test_console_engine.py -q`
- `uv run --extra dev pytest tests/cron tests/tools/test_cronjob_tools.py tests/hermes_cli/test_cron.py -q` (`752 passed`, 2 existing warnings)
- `uv run --extra dev pytest tests/hermes_cli/test_web_server_cron_profiles.py tests/cron/test_cron_script.py tests/cron/test_rewrite_skill_refs.py tests/agent/test_curator_reports.py -q`
- `git diff --check`
- `gitleaks git --log-opts='origin/main..HEAD' --redact .`
