### PR TITLE
fix(kanban): restore done tasks after protocol violations

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6378,8 +6378,8 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # write_txn so can't nest). ``protocol_violation`` flags the
     # clean-exit-but-still-running case so we can trip the breaker
     # immediately instead of incrementing by 1.
-    crash_details: list[tuple[str, int, str, bool, str]] = []
-    # (task_id, pid, claimer, protocol_violation, error_text)
+    crash_details: list[tuple[str, int, str, bool, str, Optional[int]]] = []
+    # (task_id, pid, claimer, protocol_violation, error_text, run_id)
     with write_txn(conn):
         rows = conn.execute(
             "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
@@ -6493,7 +6493,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     crashed.append(row["id"])
                     crash_details.append(
                         (row["id"], pid, row["claim_lock"],
-                         protocol_violation, error_text)
+                         protocol_violation, error_text, run_id)
                     )
     # Outside the main txn: increment the unified failure counter for
     # each crashed task. If the breaker trips, the task transitions
@@ -6509,15 +6509,40 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     if crash_details:
         # Fingerprint errors to detect systemic failures.
         _fp_counts: dict[str, int] = {}
-        for _, _, _, _, err_text in crash_details:
+        for _, _, _, _, err_text, _ in crash_details:
             fp = _error_fingerprint(err_text)
             _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
-        for tid, pid, claimer, protocol_violation, error_text in crash_details:
+        for tid, pid, claimer, protocol_violation, error_text, run_id in crash_details:
             fp = _error_fingerprint(error_text)
             is_systemic = (
                 not protocol_violation
                 and _fp_counts.get(fp, 0) >= 3
             )
+            if protocol_violation:
+                prior_done = conn.execute(
+                    "SELECT ended_at FROM task_runs "
+                    "WHERE task_id = ? AND status = 'done' "
+                    "ORDER BY id DESC LIMIT 1",
+                    (tid,),
+                ).fetchone()
+                if prior_done:
+                    completed_at = prior_done["ended_at"] or int(time.time())
+                    with write_txn(conn):
+                        conn.execute(
+                            "UPDATE tasks SET status = 'done', "
+                            "completed_at = COALESCE(completed_at, ?), "
+                            "consecutive_failures = 0, "
+                            "last_failure_error = NULL, "
+                            "block_kind = NULL, "
+                            "block_recurrences = 0 WHERE id = ?",
+                            (completed_at, tid),
+                        )
+                        conn.execute(
+                            "UPDATE task_runs SET status = 'blocked', "
+                            "error = 'Worker restored — task already completed in prior run' "
+                            "WHERE id = ?", (run_id,),
+                        )
+                    continue
             tripped = _record_task_failure(
                 conn, tid,
                 error=error_text,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6519,6 +6519,14 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 and _fp_counts.get(fp, 0) >= 3
             )
             if protocol_violation:
+                # A prior completed run is only evidence of *accidental*
+                # re-entry when nobody deliberately re-queued the task after
+                # that success. Explicit re-queues (dashboard drag done→ready
+                # emits ``status``; promote/unblock/reclaim emit their own
+                # kinds) are new work — if that attempt clean-exits without
+                # kanban_complete, still trip the breaker. Matches the
+                # re-queue bypass in ``check_respawn_guard`` (status /
+                # promoted / unblocked / reclaimed after completion).
                 prior_done = conn.execute(
                     "SELECT ended_at FROM task_runs "
                     "WHERE task_id = ? AND status = 'done' "
@@ -6526,23 +6534,46 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     (tid,),
                 ).fetchone()
                 if prior_done:
-                    completed_at = prior_done["ended_at"] or int(time.time())
-                    with write_txn(conn):
-                        conn.execute(
-                            "UPDATE tasks SET status = 'done', "
-                            "completed_at = COALESCE(completed_at, ?), "
-                            "consecutive_failures = 0, "
-                            "last_failure_error = NULL, "
-                            "block_kind = NULL, "
-                            "block_recurrences = 0 WHERE id = ?",
-                            (completed_at, tid),
-                        )
-                        conn.execute(
-                            "UPDATE task_runs SET status = 'blocked', "
-                            "error = 'Worker restored — task already completed in prior run' "
-                            "WHERE id = ?", (run_id,),
-                        )
-                    continue
+                    completed_at = int(prior_done["ended_at"] or 0)
+                    requeued_after = conn.execute(
+                        "SELECT 1 FROM task_events "
+                        "WHERE task_id = ? AND created_at >= ? "
+                        "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+                        "LIMIT 1",
+                        (tid, completed_at),
+                    ).fetchone()
+                    if not requeued_after:
+                        restore_at = prior_done["ended_at"] or int(time.time())
+                        with write_txn(conn):
+                            # CAS: only restore while this is still the
+                            # released crashed attempt. The crash path
+                            # already flipped running→ready and cleared
+                            # claim/run; if another claimer raced in,
+                            # leave their attempt alone.
+                            cur = conn.execute(
+                                "UPDATE tasks SET status = 'done', "
+                                "completed_at = COALESCE(completed_at, ?), "
+                                "consecutive_failures = 0, "
+                                "last_failure_error = NULL, "
+                                "block_kind = NULL, "
+                                "block_recurrences = 0 "
+                                "WHERE id = ? AND status = 'ready' "
+                                "AND claim_lock IS NULL "
+                                "AND current_run_id IS NULL",
+                                (restore_at, tid),
+                            )
+                            if cur.rowcount == 1 and run_id is not None:
+                                conn.execute(
+                                    "UPDATE task_runs SET status = 'blocked', "
+                                    "error = 'Worker restored — task already "
+                                    "completed in prior run' "
+                                    "WHERE id = ?",
+                                    (run_id,),
+                                )
+                        # Restore hit or CAS miss: do not record a failure.
+                        # On hit the completed history owns the task; on miss
+                        # a concurrent claimer already owns it.
+                        continue
             tripped = _record_task_failure(
                 conn, tid,
                 error=error_text,

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4457,6 +4457,90 @@ def test_detect_crashed_workers_protocol_violation_auto_blocks(kanban_home):
         conn.close()
 
 
+def test_protocol_violation_restores_task_with_prior_completed_run(kanban_home):
+    """A duplicate clean-exit worker must not block a task already completed
+    by an earlier run.
+    """
+    import hermes_cli.kanban_db as _kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="already shipped", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        lock = f"{host_prefix}:mock"
+
+        kb.claim_task(conn, tid, claimer=lock)
+        assert kb.complete_task(
+            conn,
+            tid,
+            result="shipped",
+            summary="implemented and verified",
+        )
+
+        # Preserve a separate historical crash row to prove the recovery only
+        # annotates the current protocol-violation run.
+        old_started = int(time.time()) - 120
+        old_ended = old_started + 5
+        old_crash_id = conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at, error) "
+            "VALUES (?, 'crashed', 'crashed', ?, ?, 'old crash')",
+            (tid, old_started, old_ended),
+        ).lastrowid
+
+        # Simulate the stale duplicate/retry shape from #60802: the task has
+        # a completed run in history, but a later dispatcher attempt put it
+        # back into running state.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'ready', completed_at = NULL WHERE id = ?",
+                (tid,),
+            )
+        kb.claim_task(conn, tid, claimer=lock)
+        fake_pid = 999997
+        kb._set_worker_pid(conn, tid, fake_pid)
+
+        _kb._record_worker_exit(fake_pid, 0)
+        original_alive = _kb._pid_alive
+        _kb._pid_alive = lambda p: False
+        try:
+            result_crashed = kb.detect_crashed_workers(conn)
+        finally:
+            _kb._pid_alive = original_alive
+
+        assert tid in result_crashed
+        task = kb.get_task(conn, tid)
+        assert task.status == "done"
+        assert task.completed_at is not None
+        assert task.consecutive_failures == 0
+        assert task.last_failure_error is None
+        assert task.current_run_id is None
+
+        old_crash = conn.execute(
+            "SELECT status, outcome, error FROM task_runs WHERE id = ?",
+            (old_crash_id,),
+        ).fetchone()
+        assert dict(old_crash) == {
+            "status": "crashed",
+            "outcome": "crashed",
+            "error": "old crash",
+        }
+
+        runs = kb.list_runs(conn, tid)
+        assert [(r.status, r.outcome) for r in runs].count(("done", "completed")) == 1
+        assert any(
+            r.status == "blocked"
+            and r.outcome == "crashed"
+            and r.error == "Worker restored — task already completed in prior run"
+            for r in runs
+        )
+
+        events = kb.list_events(conn, tid)
+        kinds = [e.kind for e in events]
+        assert "protocol_violation" in kinds
+        assert "gave_up" not in kinds
+    finally:
+        conn.close()
+
+
 def test_detect_crashed_workers_nonzero_exit_uses_default_limit(kanban_home):
     """A worker that exited non-zero (real error / crash) uses the
     normal counter path — one failure doesn't trip the breaker.

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4458,8 +4458,12 @@ def test_detect_crashed_workers_protocol_violation_auto_blocks(kanban_home):
 
 
 def test_protocol_violation_restores_task_with_prior_completed_run(kanban_home):
-    """A duplicate clean-exit worker must not block a task already completed
-    by an earlier run.
+    """Accidental re-entry after a prior completed run restores to done.
+
+    Models #60802: a completed task is put back to ready *without* an
+    explicit re-queue audit event (status/promoted/unblocked/reclaimed),
+    then a duplicate worker clean-exits. History still proves the work
+    shipped, so restore rather than trip the breaker.
     """
     import hermes_cli.kanban_db as _kb
     conn = kb.connect()
@@ -4486,9 +4490,8 @@ def test_protocol_violation_restores_task_with_prior_completed_run(kanban_home):
             (tid, old_started, old_ended),
         ).lastrowid
 
-        # Simulate the stale duplicate/retry shape from #60802: the task has
-        # a completed run in history, but a later dispatcher attempt put it
-        # back into running state.
+        # Accidental flap: status flipped ready with no re-queue audit event.
+        # (A deliberate dashboard done→ready would emit kind='status'.)
         with kb.write_txn(conn):
             conn.execute(
                 "UPDATE tasks SET status = 'ready', completed_at = NULL WHERE id = ?",
@@ -4532,6 +4535,177 @@ def test_protocol_violation_restores_task_with_prior_completed_run(kanban_home):
             and r.error == "Worker restored — task already completed in prior run"
             for r in runs
         )
+
+        events = kb.list_events(conn, tid)
+        kinds = [e.kind for e in events]
+        assert "protocol_violation" in kinds
+        assert "gave_up" not in kinds
+    finally:
+        conn.close()
+
+
+def test_protocol_violation_blocks_after_explicit_requeue(kanban_home):
+    """Explicit done→ready is deliberate new work; protocol violation blocks.
+
+    A dashboard (or CLI) re-queue after completion emits a ``status`` event
+    after the completed run. That attempt must not be restored from the
+    earlier success — clean-exit without kanban_complete still trips the
+    breaker on the first occurrence.
+    """
+    import hermes_cli.kanban_db as _kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="rerun me", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        lock = f"{host_prefix}:mock"
+
+        kb.claim_task(conn, tid, claimer=lock)
+        assert kb.complete_task(
+            conn,
+            tid,
+            result="v1 shipped",
+            summary="first pass done",
+        )
+
+        now = int(time.time())
+        # Operator re-queue: audit event after the completion (same signal
+        # check_respawn_guard uses to bypass recent_success).
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events (task_id, kind, created_at) "
+                "VALUES (?, 'status', ?)",
+                (tid, now),
+            )
+            conn.execute(
+                "UPDATE tasks SET status = 'ready', completed_at = NULL WHERE id = ?",
+                (tid,),
+            )
+
+        kb.claim_task(conn, tid, claimer=lock)
+        fake_pid = 999996
+        kb._set_worker_pid(conn, tid, fake_pid)
+
+        _kb._record_worker_exit(fake_pid, 0)
+        original_alive = _kb._pid_alive
+        _kb._pid_alive = lambda p: False
+        try:
+            result_crashed = kb.detect_crashed_workers(conn)
+        finally:
+            _kb._pid_alive = original_alive
+
+        assert tid in result_crashed
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked", (
+            f"explicit requeue protocol violation must auto-block, "
+            f"got status={task.status}"
+        )
+        assert "kanban_complete" in (task.last_failure_error or "")
+
+        events = kb.list_events(conn, tid)
+        kinds = [e.kind for e in events]
+        assert "protocol_violation" in kinds
+        assert "gave_up" in kinds
+        # Prior completed run must remain intact (not rewritten as blocked).
+        runs = kb.list_runs(conn, tid)
+        assert any(r.status == "done" and r.outcome == "completed" for r in runs)
+        assert not any(
+            r.error == "Worker restored — task already completed in prior run"
+            for r in runs
+        )
+    finally:
+        conn.close()
+
+
+def test_protocol_violation_restore_cas_skips_concurrent_claim(kanban_home):
+    """Restore CAS must not overwrite a task already claimed again.
+
+    After the crash path releases running→ready, another claimer can race
+    in before the outer restore txn. A failed status/run-id guard must
+    leave that attempt alone (no silent done overwrite, no failure stamp
+    on the concurrent claimer's task).
+    """
+    import hermes_cli.kanban_db as _kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="race restore", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        lock = f"{host_prefix}:mock"
+
+        kb.claim_task(conn, tid, claimer=lock)
+        assert kb.complete_task(
+            conn,
+            tid,
+            result="shipped",
+            summary="done once",
+        )
+
+        # Accidental ready flap (no re-queue event) + second running claim
+        # with a clean-exit dead pid — same shape as the restore path.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'ready', completed_at = NULL WHERE id = ?",
+                (tid,),
+            )
+        kb.claim_task(conn, tid, claimer=lock)
+        fake_pid = 999995
+        kb._set_worker_pid(conn, tid, fake_pid)
+        _kb._record_worker_exit(fake_pid, 0)
+
+        original_alive = _kb._pid_alive
+        _kb._pid_alive = lambda p: False
+        # After release, steal the ready task before the outer restore
+        # txn runs by wrapping write_txn so the second (restore) txn sees
+        # a concurrent claimer.
+        real_write_txn = _kb.write_txn
+        call_count = {"n": 0}
+
+        class _TxnCM:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def __enter__(self):
+                return self._inner.__enter__()
+
+            def __exit__(self, *a):
+                return self._inner.__exit__(*a)
+
+        def _racing_write_txn(c):
+            cm = real_write_txn(c)
+            call_count["n"] += 1
+            # First write_txn is the crash release; subsequent ones include
+            # the restore attempt. After the release commits, claim again
+            # so restore's CAS (status=ready AND claim_lock IS NULL) fails.
+            class _Racing:
+                def __enter__(self_inner):
+                    return cm.__enter__()
+
+                def __exit__(self_inner, *a):
+                    result = cm.__exit__(*a)
+                    if call_count["n"] == 1:
+                        # Crash release just committed — concurrent claimer.
+                        kb.claim_task(conn, tid, claimer=f"{host_prefix}:racer")
+                    return result
+
+            return _Racing()
+
+        try:
+            _kb.write_txn = _racing_write_txn
+            result_crashed = kb.detect_crashed_workers(conn)
+        finally:
+            _kb._pid_alive = original_alive
+            _kb.write_txn = real_write_txn
+
+        assert tid in result_crashed
+        task = kb.get_task(conn, tid)
+        # Concurrent claimer still owns the task — not restored to done,
+        # not auto-blocked by the restore path's failure counter.
+        assert task.status == "running", (
+            f"CAS miss must leave concurrent claimer in place, got {task.status}"
+        )
+        assert task.claim_lock == f"{host_prefix}:racer"
+        assert task.current_run_id is not None
+        assert task.consecutive_failures == 0
+        assert task.last_failure_error is None
 
         events = kb.list_events(conn, tid)
         kinds = [e.kind for e in events]


### PR DESCRIPTION
## Summary
- restore tasks to done when detect_crashed_workers sees a protocol-violation exit but task_runs already contains a prior completed run
- keep the existing immediate auto-block behavior for fresh protocol violations without a completed history
- add coverage for both the regression fix and the original blocking path

Fixes #60802

## Verification
- .venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py