### PR TITLE
Fix Telegram clarify numeric choice rendering

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -300,11 +300,34 @@ def check_telegram_requirements() -> bool:
 # Matches every character that MarkdownV2 requires to be backslash-escaped
 # when it appears outside a code span or fenced code block.
 _MDV2_ESCAPE_RE = re.compile(r'([_*\[\]()~`>#\+\-=|{}.!\\])')
+_CLARIFY_FENCE_RE = re.compile(r"```[^\n`]*\n(?P<code>.*?)```", re.DOTALL)
 
 
 def _escape_mdv2(text: str) -> str:
     """Escape Telegram MarkdownV2 special characters with a preceding backslash."""
     return _MDV2_ESCAPE_RE.sub(r'\\\1', text)
+
+
+def _format_clarify_question_html(question: str) -> str:
+    """Escape clarify text for Telegram HTML while preserving fenced code blocks."""
+    parts: list[str] = []
+    start = 0
+    for match in _CLARIFY_FENCE_RE.finditer(question):
+        parts.append(_html.escape(question[start:match.start()]))
+        code = match.group("code")
+        if code.endswith("\n"):
+            code = code[:-1]
+        parts.append(f"<pre>{_html.escape(code)}</pre>")
+        start = match.end()
+    parts.append(_html.escape(question[start:]))
+    return "".join(parts)
+
+
+def _clarify_choices_are_numeric_buttons(choices: Optional[list]) -> bool:
+    if not choices:
+        return False
+    normalized = [str(choice).strip() for choice in choices]
+    return normalized == [str(index) for index in range(1, len(normalized) + 1)]
 
 
 def _strip_mdv2(text: str) -> str:
@@ -4683,10 +4706,11 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            text = f"❓ {_html.escape(question)}"
+            text = f"❓ {_format_clarify_question_html(question)}"
             thread_id = self._metadata_thread_id(metadata)
+            numeric_button_choices = _clarify_choices_are_numeric_buttons(choices)
 
-            if choices:
+            if choices and not numeric_button_choices:
                 # Render full option text in the message body so mobile
                 # users can read long choices that would be truncated in
                 # inline button labels.  Buttons keep short numeric labels
@@ -4708,13 +4732,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>"
                 # short.
                 rows = []
-                for idx in range(len(choices)):
+                if numeric_button_choices:
                     rows.append([
                         InlineKeyboardButton(
                             str(idx + 1),
                             callback_data=f"cl:{clarify_id}:{idx}",
                         )
+                        for idx in range(len(choices))
                     ])
+                else:
+                    for idx in range(len(choices)):
+                        rows.append([
+                            InlineKeyboardButton(
+                                str(idx + 1),
+                                callback_data=f"cl:{clarify_id}:{idx}",
+                            )
+                        ])
                 rows.append([
                     InlineKeyboardButton(
                         "✏️ Other (type answer)",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -323,6 +323,19 @@ def _format_clarify_question_html(question: str) -> str:
     return "".join(parts)
 
 
+def _telegram_message_text_html(message: Any) -> str:
+    """Return existing Telegram text with its formatting entities preserved."""
+    if message is None:
+        return ""
+    try:
+        formatted = message.text_html
+    except Exception:
+        formatted = None
+    if isinstance(formatted, str):
+        return formatted
+    return _html.escape(getattr(message, "text", "") or "")
+
+
 def _clarify_choices_are_numeric_buttons(choices: Optional[list]) -> bool:
     if not choices:
         return False
@@ -5312,7 +5325,7 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             await query.edit_message_text(
                 text=(
-                    f"❓ {_html.escape(query.message.text or '')}\n\n"
+                    f"{_telegram_message_text_html(query.message)}\n\n"
                     "<i>⚠️ This question expired or the session reset — please /retry.</i>"
                 ),
                 parse_mode=ParseMode.HTML,
@@ -5575,7 +5588,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="✏️ Type your answer in the chat.")
                     try:
                         await query.edit_message_text(
-                            text=f"❓ {query.message.text or ''}\n\n<i>Awaiting typed response from {_html.escape(user_display)}…</i>",
+                            text=(
+                                f"{_telegram_message_text_html(query.message)}\n\n"
+                                f"<i>Awaiting typed response from {_html.escape(user_display)}…</i>"
+                            ),
                             parse_mode=ParseMode.HTML,
                             reply_markup=None,
                         )
@@ -5621,7 +5637,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text=f"✓ {resolved_text[:60]}")
                     try:
                         await query.edit_message_text(
-                            text=f"❓ {_html.escape(query.message.text or '')}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}",
+                            text=(
+                                f"{_telegram_message_text_html(query.message)}\n\n"
+                                f"<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}"
+                            ),
                             parse_mode=ParseMode.HTML,
                             reply_markup=None,
                         )

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -273,7 +273,8 @@ class TestTelegramClarifyCallback:
         query.data = "cl:cidA:1"  # green
         query.message = MagicMock()
         query.message.chat_id = 12345
-        query.message.text = "Pick"
+        query.message.text = "❓ Pick\n\n1.  BluRay  H.264\n2.  HDTV"
+        query.message.text_html = "❓ Pick\n\n<pre>1.  BluRay  H.264\n2.  HDTV</pre>"
         query.from_user = MagicMock()
         query.from_user.id = "777"
         query.from_user.first_name = "Tester"
@@ -301,6 +302,12 @@ class TestTelegramClarifyCallback:
         assert entry.event.is_set()
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
+        edited = query.edit_message_text.call_args.kwargs
+        assert "<pre>1.  BluRay  H.264\n2.  HDTV</pre>" in edited["text"]
+        assert "&lt;pre&gt;" not in edited["text"]
+        assert edited["text"].count("❓") == 1
+        assert edited["parse_mode"] == telegram_adapter_module.ParseMode.HTML
+        assert edited["reply_markup"] is None
 
     @pytest.mark.asyncio
     async def test_other_button_flips_to_text_mode(self):
@@ -314,7 +321,8 @@ class TestTelegramClarifyCallback:
         query.data = "cl:cidB:other"
         query.message = MagicMock()
         query.message.chat_id = 12345
-        query.message.text = "Pick"
+        query.message.text = "❓ Pick\n\n1.  x\n2.  y"
+        query.message.text_html = "❓ Pick\n\n<pre>1.  x\n2.  y</pre>"
         query.from_user = MagicMock()
         query.from_user.id = "777"
         query.from_user.first_name = "Tester"
@@ -340,6 +348,10 @@ class TestTelegramClarifyCallback:
             entry = cm._entries.get("cidB")
         assert entry is not None
         assert not entry.event.is_set()
+        edited = query.edit_message_text.call_args.kwargs
+        assert "<pre>1.  x\n2.  y</pre>" in edited["text"]
+        assert edited["text"].count("❓") == 1
+        assert edited["parse_mode"] == telegram_adapter_module.ParseMode.HTML
 
     @pytest.mark.asyncio
     async def test_already_resolved(self):
@@ -424,7 +436,8 @@ class TestTelegramClarifyCallback:
         query.data = "cl:cidExpired:0"
         query.message = MagicMock()
         query.message.chat_id = 12345
-        query.message.text = "Pick"
+        query.message.text = "❓ Pick\n\n1.  x\n2.  y"
+        query.message.text_html = "❓ Pick\n\n<pre>1.  x\n2.  y</pre>"
         query.from_user = MagicMock()
         query.from_user.id = "777"
         query.from_user.first_name = "Tester"
@@ -444,6 +457,8 @@ class TestTelegramClarifyCallback:
         edit_text = query.edit_message_text.call_args[1]["text"].lower()
         assert "expired" in edit_text or "session reset" in edit_text
         assert "/retry" in edit_text
+        assert "<pre>1.  x\n2.  y</pre>" in edit_text
+        assert edit_text.count("❓") == 1
 
     @pytest.mark.asyncio
     async def test_other_button_expired_notifies_user(self):

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -47,6 +47,7 @@ def _ensure_telegram_mock():
 
 _ensure_telegram_mock()
 
+from plugins.platforms.telegram import adapter as telegram_adapter_module
 from plugins.platforms.telegram.adapter import TelegramAdapter
 from gateway.config import PlatformConfig
 
@@ -188,6 +189,65 @@ class TestTelegramSendClarify:
         # Must NOT contain raw <script> — html.escape should have neutralized
         assert "<script>" not in kwargs["text"]
         assert "&lt;script&gt;" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_open_ended_fenced_table_renders_as_pre_block(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 104
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        await adapter.send_clarify(
+            chat_id="12345",
+            question=(
+                "请选择要下载的版本：\n\n"
+                "```text\n"
+                "1.  BluRay  H.264  🧲 42  💾 1.5GB\n"
+                "2.  HDTV      —    🧲  1  💾 3.2GB\n"
+                "```"
+            ),
+            choices=None,
+            clarify_id="cid6",
+            session_key="sk6",
+        )
+
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert "reply_markup" not in kwargs
+        assert "请选择要下载的版本：" in kwargs["text"]
+        assert "```text" not in kwargs["text"]
+        assert "<pre>1.  BluRay  H.264  🧲 42  💾 1.5GB\n2.  HDTV" in kwargs["text"]
+        assert "</pre>" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_numeric_choices_render_inline_buttons_without_duplicate_body_list(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 105
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        await adapter.send_clarify(
+            chat_id="12345",
+            question=(
+                "请选择要下载的版本：\n\n"
+                "```text\n"
+                "1.  BluRay  H.264  🧲 42  💾 1.5GB\n"
+                "2.  HDTV      —    🧲  1  💾 3.2GB\n"
+                "```"
+            ),
+            choices=["1", "2", "3", "4"],
+            clarify_id="cid7",
+            session_key="sk7",
+        )
+
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert "请选择要下载的版本：" in kwargs["text"]
+        assert "<pre>1.  BluRay  H.264  🧲 42  💾 1.5GB\n2.  HDTV" in kwargs["text"]
+        assert "1. 1" not in kwargs["text"]
+        assert "2. 2" not in kwargs["text"]
+        assert kwargs["reply_markup"] is not None
+
+        rows = telegram_adapter_module.InlineKeyboardMarkup.call_args.args[0]
+        assert [len(row) for row in rows] == [4, 1]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Preserve fenced code blocks in Telegram clarify prompts by rendering them as HTML `<pre>` blocks.
- Treat consecutive numeric clarify choices as compact button labels, keeping them in one inline row and avoiding duplicate `1. 1` option text in the message body.
- Add Telegram clarify regression coverage for fenced-table rendering and numeric choice buttons.

## Root cause
Telegram `send_clarify` escaped the whole question as plain HTML text, so fenced code blocks were displayed literally instead of as copyable preformatted content. The same path also appended every choice into the message body and rendered each button vertically, which duplicated numeric labels already present in table-style prompts.

## Tests
- `venv/bin/python -m pytest -q tests/gateway/test_telegram_clarify_buttons.py`
- `venv/bin/python -m py_compile plugins/platforms/telegram/adapter.py && git diff --check`