### PR TITLE
fix(qqbot): accept is_reconnect kwarg in connect() to match base class

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Summary

Commit `43b8ba4181` (fix #46621, 2026-06-25) added an `is_reconnect` keyword argument to `BasePlatformAdapter.connect()`, and `GatewayRunner._connect_adapter_with_timeout` now passes it to every adapter. However, `QQAdapter` overrides `connect()` with the old narrow signature:

```python
async def connect(self) -> bool:
````

This causes every cold-boot and reconnect attempt to fail with:

```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

The QQ bot is stuck in an infinite reconnect loop (88+ attempts logged in one session).

## Fix

Accept the `is_reconnect` keyword-only argument with default `False` to match the base class contract:

```python
async def connect(self, *, is_reconnect: bool = False) -> bool:
````

The QQ adapter does not maintain a server-side update queue, so the flag is ignored — same pattern as webhook, signal, whatsapp_cloud, and other adapters that were correctly updated in the original commit.

## Testing

- [x] Gateway reconnect loop no longer throws `TypeError` for qqbot
- [x] No behavioral change — `is_reconnect` is accepted and ignored