### PR TITLE
fix(windows): force utf8 for detached gateway

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -82,9 +82,10 @@ def _ensure_utf8():
             pass
 
     # Only nudge child processes toward UTF-8 when we actually detected a
-    # non-UTF-8 locale. On a healthy UTF-8 host children inherit UTF-8 from the
-    # locale already, so leave the environment untouched (minimal footprint).
-    if repaired:
+    # non-UTF-8 locale. Windows is the exception: a detached pythonw gateway can
+    # have no stdio streams to repair, yet still inherit a legacy ANSI locale
+    # such as GBK for subprocess pipe decoding unless children get UTF-8 mode.
+    if repaired or sys.platform == "win32":
         os.environ.setdefault("PYTHONUTF8", "1")
         os.environ.setdefault("PYTHONIOENCODING", "utf-8")
 

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -393,7 +393,7 @@ def _build_gateway_cmd_script(
 
     The script:
       - cd's into a stable working directory
-      - exports HERMES_HOME, PYTHONIOENCODING, VIRTUAL_ENV
+      - exports HERMES_HOME, PYTHONIOENCODING, PYTHONUTF8, VIRTUAL_ENV
       - invokes ``python -m hermes_cli.main [--profile X] gateway run``
 
     The .cmd is a compatibility/manual-run artifact: service persistence
@@ -410,6 +410,7 @@ def _build_gateway_cmd_script(
     lines.append(f"cd /d {_quote_cmd_script_arg(working_dir)}")
     lines.append(f'set "HERMES_HOME={hermes_home}"')
     lines.append('set "PYTHONIOENCODING=utf-8"')
+    lines.append('set "PYTHONUTF8=1"')
     lines.append('set "HERMES_GATEWAY_DETACHED=1"')
     python_exe_path, venv_dir, extra_pythonpath = _resolve_detached_python(python_path)
     # VIRTUAL_ENV lets the gateway's own python detection find the venv
@@ -495,6 +496,7 @@ def _build_gateway_vbs_script(
         'Set env = sh.Environment("PROCESS")',
         f"env.Item({_quote_vbs_string('HERMES_HOME')}) = {_quote_vbs_string(hermes_home)}",
         f"env.Item({_quote_vbs_string('PYTHONIOENCODING')}) = {_quote_vbs_string('utf-8')}",
+        f"env.Item({_quote_vbs_string('PYTHONUTF8')}) = {_quote_vbs_string('1')}",
         f"env.Item({_quote_vbs_string('HERMES_GATEWAY_DETACHED')}) = {_quote_vbs_string('1')}",
         f"env.Item({_quote_vbs_string('VIRTUAL_ENV')}) = {_quote_vbs_string(_preserve_hermes_home_path(venv_dir))}",
         # Mirror the cmd wrapper's ``PYTHONPATH=<static>;%PYTHONPATH%``: chain onto
@@ -791,6 +793,7 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
     env_overlay = {
         "HERMES_HOME": hermes_home,
         "PYTHONIOENCODING": "utf-8",
+        "PYTHONUTF8": "1",
         "HERMES_GATEWAY_DETACHED": "1",
         "VIRTUAL_ENV": _preserve_hermes_home_path(venv_dir),
     }
@@ -858,6 +861,7 @@ def windowless_gateway_restart_spec(
 
     env_overlay: dict[str, str] = {
         "PYTHONIOENCODING": "utf-8",
+        "PYTHONUTF8": "1",
         "HERMES_GATEWAY_DETACHED": "1",
         "VIRTUAL_ENV": str(venv_dir),
     }

--- a/tests/hermes_cli/test_ensure_utf8_locale.py
+++ b/tests/hermes_cli/test_ensure_utf8_locale.py
@@ -177,3 +177,17 @@ def test_none_streams_do_not_raise(monkeypatch):
     monkeypatch.setattr(sys, "stdout", None, raising=False)
     monkeypatch.setattr(sys, "stderr", None, raising=False)
     hermes_cli._ensure_utf8()
+
+
+def test_windows_none_streams_still_set_child_utf8_env(monkeypatch):
+    """Detached pythonw has no streams to repair but still needs UTF-8 children."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(sys, "stdout", None, raising=False)
+    monkeypatch.setattr(sys, "stderr", None, raising=False)
+    monkeypatch.delenv("PYTHONUTF8", raising=False)
+    monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+
+    hermes_cli._ensure_utf8()
+
+    assert os.environ.get("PYTHONUTF8") == "1"
+    assert os.environ.get("PYTHONIOENCODING") == "utf-8"

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -109,6 +109,8 @@ def test_build_gateway_argv_keeps_venv_console_python_for_uv_venv(monkeypatch, t
 
     assert argv[:3] == [str(venv_python), "-m", "hermes_cli.main"]
     assert cwd == str(hermes_home.resolve())
+    assert env_overlay["PYTHONIOENCODING"] == "utf-8"
+    assert env_overlay["PYTHONUTF8"] == "1"
     assert env_overlay["VIRTUAL_ENV"] == str(project / "venv")
     assert str(project) in env_overlay["PYTHONPATH"].split(gateway_windows.os.pathsep)
 
@@ -211,6 +213,8 @@ def test_gateway_cmd_script_uses_console_python_without_replace_or_start_churn(m
     assert "gateway run" in content
     assert "--replace" not in content
     assert "start \"\"" not in content
+    assert 'set "PYTHONIOENCODING=utf-8"' in content
+    assert 'set "PYTHONUTF8=1"' in content
     assert "exit /b 0" in content
 
 
@@ -350,7 +354,14 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
     assert "hermes_cli.main" in content
     assert "gateway run" in content
     assert ", 0, False" in content  # hidden window, detached/async
-    for var in ("HERMES_HOME", "PYTHONIOENCODING", "HERMES_GATEWAY_DETACHED", "VIRTUAL_ENV", "PYTHONPATH"):
+    for var in (
+        "HERMES_HOME",
+        "PYTHONIOENCODING",
+        "PYTHONUTF8",
+        "HERMES_GATEWAY_DETACHED",
+        "VIRTUAL_ENV",
+        "PYTHONPATH",
+    ):
         assert var in content
     assert "--profile" in content and "work" in content
     assert content.endswith("\r\n")

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -1137,5 +1137,7 @@ class TestWindowlessGatewayRestartSpec:
         # Everything after the interpreter is byte-for-byte preserved.
         assert new_argv[1:] == argv[1:]
         assert cwd == "C:/hermes"
+        assert env["PYTHONIOENCODING"] == "utf-8"
+        assert env["PYTHONUTF8"] == "1"
         assert env["VIRTUAL_ENV"] == str(Path("C:/venv"))
         assert "PYTHONPATH" in env


### PR DESCRIPTION
Fixes #60760.

## Summary
- force `PYTHONUTF8=1` alongside `PYTHONIOENCODING=utf-8` for detached Windows gateway child environments
- cover Scheduled Task `.cmd` and `.vbs` launchers, direct detached gateway argv, and post-update windowless restart specs
- make `_ensure_utf8()` set UTF-8 child env defaults on Windows even when `pythonw` has no stdio streams to repair

## Root Cause
Detached Windows gateways can run under `pythonw` with `sys.stdout` and `sys.stderr` set to `None`, so `_ensure_utf8()` had no stream to repair and never exported UTF-8 defaults for child processes. When a spawned child emitted UTF-8 text under a legacy ANSI locale such as GBK, Python's subprocess pipe reader could decode with the preferred locale and raise `UnicodeDecodeError`.

## Tests
- `uv run --extra dev pytest tests/hermes_cli/test_ensure_utf8_locale.py tests/hermes_cli/test_gateway_windows.py tests/tools/test_windows_native_support.py::TestWindowlessGatewayRestartSpec -q`
- `uv run --extra dev pytest tests/tools/test_windows_native_support.py -q`

## Safety
- new commit range scanned with `gitleaks git --log-opts='origin/main..HEAD' --redact .`: no leaks found
