### PR TITLE
fix(kanban): recover done tasks from protocol-violation blocks via task_runs history

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6406,6 +6406,38 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             kind, code = _classify_worker_exit(pid)
             rate_limited_exit = False
             if kind == "clean_exit":
+                # Check if this task already has a completed run in
+                # task_runs history. If so, the worker exited cleanly
+                # because the work was genuinely done in an earlier run
+                # (e.g. the dispatcher restarted and re-dispatched an
+                # already-finished task). Treat this as completed rather
+                # than blocking on a protocol-violation breaker trip.
+                _prior_done = conn.execute(
+                    "SELECT 1 FROM task_runs "
+                    "WHERE task_id = ? AND outcome = 'completed' LIMIT 1",
+                    (row["id"],),
+                ).fetchone()
+                if _prior_done:
+                    conn.execute(
+                        """
+                        UPDATE tasks
+                           SET status       = 'done',
+                               completed_at = ?,
+                               claim_lock   = NULL,
+                               claim_expires = NULL,
+                               worker_pid   = NULL
+                         WHERE id = ?
+                           AND status = 'running'
+                        """,
+                        (int(time.time()), row["id"]),
+                    )
+                    _end_run(
+                        conn, row["id"],
+                        outcome="completed", status="done",
+                        summary="already completed in prior run",
+                        metadata={"recovered_via_task_runs_history": True},
+                    )
+                    continue  # skip the remaining crash/failure path
                 # Worker subprocess returned 0 but its task is still
                 # ``running`` in the DB — it exited without calling
                 # ``kanban_complete`` / ``kanban_block``. Retrying won't


### PR DESCRIPTION
## Summary

When `detect_crashed_workers` encounters a clean-exit (rc=0) protocol violation (worker exited without calling `kanban_complete`/ `kanban_block`), it currently trips the circuit breaker immediately with `failure_limit=1` and moves the task to `blocked`. However, some of these tasks were genuinely completed in an earlier run (recorded in `task_runs` with `outcome='completed'`). The dispatcher restart re-dispatched an already-finished task, the new worker session saw no work left, exited cleanly, and the protocol-violation breaker permanently blocked the card despite valid completed results.

## Fix

Before treating a clean-exit as a protocol violation, query `task_runs` for a prior completed run. If one exists, transition the task to `done` (matching what `kanban_complete` does) and skip the crash/failure path entirely.

## Changes

- `hermes_cli/kanban_db.py` — `detect_crashed_workers`: check `task_runs` history for prior `outcome='completed'`; if found, mark task as `done` and continue.

Fixes #60802