### PR TITLE
fix(tui): route /compress through command.dispatch with server-side compression

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11339,6 +11339,7 @@ _PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
         "moa",
         "undo",
         "learn",
+        "compress",
     }
 )
 
@@ -11923,6 +11924,49 @@ def _(rid, params: dict) -> dict:
                     ),
                 },
             )
+
+    if name == "compress":
+        if not session:
+            return _err(rid, 4001, "no active session to compress")
+        agent = session.get("agent")
+        if agent is None:
+            return _err(rid, 4001, "no agent built for session — send a message first")
+        try:
+            from agent.conversation_compression import compress_context
+            history = list(session.get("history", []))
+            if not history or len(history) < 4:
+                return _ok(
+                    rid,
+                    {"type": "exec", "output": "Not enough conversation history to compress (need at least 4 messages)."},
+                )
+            sys_msg = session.get("system_message", "")
+            with session.get("history_lock"):
+                compressed, new_sys = compress_context(
+                    agent, history, sys_msg, force=True, focus_topic=arg.strip() or None,
+                )
+            if len(compressed) == len(history):
+                return _ok(
+                    rid,
+                    {"type": "exec", "output": "Compression aborted — the auxiliary model could not produce a summary. Try again later."},
+                )
+            with session["history_lock"]:
+                session["history"] = list(compressed)
+                session["history_version"] = int(session.get("history_version", 0)) + 1
+            if new_sys:
+                session["system_message"] = new_sys
+            compressed_count = len(history) - len(compressed)
+            return _ok(
+                rid,
+                {
+                    "type": "exec",
+                    "output": (
+                        f"Compressed context: removed {compressed_count} message(s), "
+                        f"kept {len(compressed)} message(s)."
+                    ),
+                },
+            )
+        except Exception as e:
+            return _err(rid, 5030, f"compress failed: {e}")
 
     return _err(rid, 4018, f"not a quick/plugin/skill command: {name}")
 


### PR DESCRIPTION
## Summary

When using Hermes Desktop (or TUI), running `/compress` failed with "not a quick/plugin/skill command: compress". The desktop routes `exec`-type slash commands through `slash.exec`, which in the TUI gateway runs them through a `_SlashWorker` subprocess. The slash worker failed for `/compress`, the desktop fell back to `command.dispatch`, which also had no handler — causing the error.

## Fix

1. Added `compress` to `_PENDING_INPUT_COMMANDS` so `slash.exec` routes it directly to `command.dispatch` (bypassing the flaky slash-worker path).
2. Implemented a `compress` handler in `command.dispatch` that uses the agent's `compress_context()` to compress the session history server-side, returning the result as `exec` output.

## Changes

- `tui_gateway/server.py` — add `compress` to `_PENDING_INPUT_COMMANDS` frozenset and add full `compress` handler in `command.dispatch`.

Fixes #60603