### PR TITLE
fix: forward profile param in session_search handler calls

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2205,6 +2205,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     sort=next_args.get("sort"),
                     db=session_db,
                     current_session_id=agent.session_id,
+                    profile=next_args.get("profile"),
                 ),
                 next_args,
             )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1200,6 +1200,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     sort=next_args.get("sort"),
                     db=session_db,
                     current_session_id=agent.session_id,
+                    profile=next_args.get("profile"),
                 )
             function_result, function_args = _run_agent_tool_execution_middleware(
                 agent,


### PR DESCRIPTION
## Description

Both `agent_runtime_helpers.py` and `tool_executor.py` intercepted the `session_search` tool call but omitted the `profile` parameter, causing cross-profile searches to silently query the current profile's DB instead of the named one.

**Fixes #60789**

## Changes

- `agent/agent_runtime_helpers.py:2187`: Added `profile=next_args.get("profile")` to the `_session_search()` call
- `agent/tool_executor.py:1203`: Same fix

## Root Cause

The `session_search()` function at `tools/session_search_tool.py:619` correctly swaps to the named profile's DB when `profile` is set — but it never receives the value because both agent-loop handlers drop it.

## Impact

Without this fix, `session_search(query="...", profile="other")` always returns results from the current profile. Two lines total.
