### PR TITLE
fix(gateway): offload sync DB queries in build_channel_directory to thread

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -7,6 +7,7 @@ action="list" and for resolving human-friendly channel names to numeric IDs.
 """
 
 import json
+import asyncio
 import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -121,7 +122,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     for platform, adapter in adapters.items():
         try:
             if platform == Platform.DISCORD:
-                platforms["discord"] = _build_discord(adapter)
+                platforms["discord"] = await asyncio.to_thread(_build_discord, adapter)
             elif platform == Platform.SLACK:
                 platforms["slack"] = await _build_slack(adapter)
         except Exception as e:
@@ -142,7 +143,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
             or plat_name not in adapter_platform_names
         ):
             continue
-        platforms[plat_name] = _build_from_sessions(plat_name)
+        platforms[plat_name] = await asyncio.to_thread(_build_from_sessions, plat_name)
 
     # Include plugin-registered platforms (dynamic enum members aren't in
     # Platform.__members__, so the loop above misses them). Same
@@ -156,7 +157,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
                 and entry.name not in platforms
                 and entry.name in adapter_platform_names
             ):
-                platforms[entry.name] = _build_from_sessions(entry.name)
+                platforms[entry.name] = await asyncio.to_thread(_build_from_sessions, entry.name)
     except Exception:
         pass
 


### PR DESCRIPTION
## Description

`build_channel_directory()` is an `async def` invoked on gateway startup and every 5 minutes for refresh. It calls synchronous `_build_discord()` and `_build_from_sessions()` directly on the event loop thread. On large `state.db` files (3.7GB+ observed), these blocking DB queries take 10-40s and starve the Discord heartbeat task, causing:

```
discord.gateway: Shard ID None heartbeat blocked for more than 10 seconds
```

In worst cases, this triggers gateway disconnect/reconnect cycles.

**Fixes #60794**

## Changes

`gateway/channel_directory.py`:
- Added `import asyncio`
- Wrapped `_build_discord(adapter)` with `await asyncio.to_thread()`
- Wrapped `_build_from_sessions(plat_name)` with `await asyncio.to_thread()` (2 call sites: Platform enum loop + plugin-registered platforms loop)

## Why This Works

`asyncio.to_thread()` offloads the synchronous function to a thread pool executor, returning control to the event loop while the DB queries run. The Discord heartbeat task (and other async I/O) can proceed unblocked.

All three call sites are independent — they don't share mutable state, so thread-safety is not a concern.
