### PR TITLE
fix(kanban): recover done tasks from protocol-violation blocks via task_runs history (#60802)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6407,9 +6407,39 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             rate_limited_exit = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
-                # ``running`` in the DB — it exited without calling
-                # ``kanban_complete`` / ``kanban_block``. Retrying won't
-                # help.
+                # ``running`` in the DB. Normally that's a protocol
+                # violation (no kanban_complete/kanban_block call) and
+                # retrying won't help. BUT if task_runs already holds a
+                # *completed* run, the work genuinely finished in an
+                # earlier run — recover to done instead of tripping the
+                # breaker and permanently blocking an already-done card
+                # (which would need manual DB intervention). See #60802.
+                done_run = conn.execute(
+                    "SELECT ended_at FROM task_runs "
+                    "WHERE task_id = ? AND outcome = 'completed' "
+                    "ORDER BY COALESCE(ended_at, 0) DESC LIMIT 1",
+                    (row["id"],),
+                ).fetchone()
+                if done_run is not None:
+                    completed_at = (
+                        int(done_run["ended_at"])
+                        if done_run["ended_at"]
+                        else int(time.time())
+                    )
+                    _end_run(conn, row["id"], outcome="completed", status="done")
+                    conn.execute(
+                        "UPDATE tasks SET status='done', completed_at=?, "
+                        "claim_lock=NULL, claim_expires=NULL, "
+                        "worker_pid=NULL, current_run_id=NULL, "
+                        "block_kind=NULL, block_recurrences=0 "
+                        "WHERE id = ? AND status='running' AND worker_pid = ?",
+                        (completed_at, row["id"], pid),
+                    )
+                    _append_event(
+                        conn, row["id"], "protocol_violation_recovered",
+                        {"pid": pid, "claimer": row["claim_lock"], "exit_code": code},
+                    )
+                    continue
                 protocol_violation = True
                 error_text = (
                     "worker exited cleanly (rc=0) without calling "

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -850,6 +850,82 @@ def test_detect_crashed_workers_grace_period_env_override(
         assert tid in kb.detect_crashed_workers(conn)
 
 
+def test_detect_crashed_workers_recovers_completed_run(kanban_home, monkeypatch):
+    """A clean-exit (rc=0) worker whose task is still ``running`` is normally
+    a protocol violation that trips the breaker. BUT if task_runs already holds
+    a *completed* run, the work genuinely finished earlier — recover the card
+    to ``done`` instead of permanently blocking it. Regression for #60802."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.delenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", raising=False)
+    # Classify our fake dead PID as a clean exit (rc=0).
+    _kb._record_worker_exit(90001, _exited_status(0))
+
+    now = 3_000_000.0
+    monkeypatch.setattr(_kb.time, "time", lambda: now + 60)
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="already done", assignee="a")
+        # Simulate a prior completed run recorded in task_runs.
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'completed', ?, ?)",
+            (tid, int(now) - 100, int(now) - 50),
+        )
+        conn.execute(
+            "UPDATE tasks SET status='running', worker_pid=?, claim_lock=?, "
+            "started_at=? WHERE id=?",
+            (90001, f"{host}:w", int(now), tid),
+        )
+        conn.commit()
+
+        crashed = kb.detect_crashed_workers(conn)
+        # Not a crash — the work was already completed.
+        assert tid not in crashed
+        task = kb.get_task(conn, tid)
+        assert task.status == "done", (
+            f"card with a completed run should recover to done, got {task.status}"
+        )
+        assert task.completed_at is not None
+        events = kb.list_events(conn, tid)
+        assert any(e.kind == "protocol_violation_recovered" for e in events)
+
+
+def test_detect_crashed_workers_protocol_violation_without_prior_run(
+    kanban_home, monkeypatch,
+):
+    """Clean exit with NO prior completed run still trips the breaker as a
+    protocol violation (the auto-block path must be preserved)."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.delenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", raising=False)
+    _kb._record_worker_exit(90002, _exited_status(0))
+
+    now = 4_000_000.0
+    monkeypatch.setattr(_kb.time, "time", lambda: now + 60)
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="never completed", assignee="a")
+        # No completed run in task_runs.
+        conn.execute(
+            "UPDATE tasks SET status='running', worker_pid=?, claim_lock=?, "
+            "started_at=? WHERE id=?",
+            (90002, f"{host}:w", int(now), tid),
+        )
+        conn.commit()
+
+        crashed = kb.detect_crashed_workers(conn)
+        assert tid in crashed, "clean exit without a completed run must crash"
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked", (
+            f"protocol violation with no prior run should auto-block, got {task.status}"
+        )
+
+
 def test_resolve_crash_grace_seconds_handles_bad_env(monkeypatch):
     """Bad env values fall back to DEFAULT_CRASH_GRACE_SECONDS."""
     import hermes_cli.kanban_db as _kb


### PR DESCRIPTION
## Summary
- `detect_crashed_workers` treated **every** clean-exit (rc=0) on a still-`running` task as a protocol violation and tripped the circuit breaker, permanently blocking the card.
- Root cause: the dispatcher checked liveness but never consulted `task_runs` history. A worker may have genuinely completed an earlier run and the terminal transition was simply missed — leaving an already-done card stuck in `blocked` requiring manual DB intervention.
- Fix: before flagging a protocol violation, query `task_runs` for a `completed` run. If one exists, recover the card to `done` (emitting a `protocol_violation_recovered` event) instead of blocking it. Clean exits with **no** prior completed run still trip the breaker as before (behavior preserved).

## Repowise pre-flight (quality gate, now fully active)
- `hermes_cli/kanban_db.py` defect-risk score = **6.62** (aggregate biomarker impact; >5 = high-ROI target). Change is a single bounded SQL check inside the existing `clean_exit` branch — blast radius limited to the recovery path; all sibling callers (`dispatch_once`) route through the same function.
- Gate required fixing the tree-sitter ABI mismatch: `tree-sitter-python 0.25` (ABI 15) was silently dropped by repowise against core `tree-sitter 0.23.2` (ABI 13-14). Pinned `tree-sitter-python==0.23.6` — now 2909 Python files score.

## Test plan
- `test_detect_crashed_workers_recovers_completed_run` — card with a prior completed run recovers to `done`, not blocked.
- `test_detect_crashed_workers_protocol_violation_without_prior_run` — clean exit with no prior run still auto-blocks (regression guard for existing behavior).
- Full `detect_crashed_workers` + rate-limit + classify suites pass (8/8).

Closes #60802
