### PR TITLE
fix(gateway): add HTTP error handling to OIDC client_credentials token request

### DIFF
--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -502,8 +502,20 @@ def _resolve_relay_identity_token() -> str:
             "Accept": "application/json",
         },
     )
-    with urllib.request.urlopen(req, timeout=15.0) as resp:
-        payload = json.loads(resp.read().decode())
+    try:
+        with urllib.request.urlopen(req, timeout=15.0) as resp:
+            payload = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = (json.loads(exc.read().decode()) or {}).get("error", "")
+        except Exception:
+            pass
+        raise RuntimeError(
+            f"IdP client_credentials HTTP {exc.code}" + (f": {detail}" if detail else "")
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"could not reach IdP: {exc.reason}") from exc
     access_token = (payload or {}).get("access_token")
     if not isinstance(access_token, str) or not access_token.strip():
         raise RuntimeError("IdP client_credentials response had no access_token")


### PR DESCRIPTION
## Description

`_resolve_relay_identity_token()` in `gateway/relay/__init__.py` is the only `urllib.request.urlopen()` call in the file without proper HTTP error handling.

The two sibling functions:
- `_post_connector()` (line 420) — catches `HTTPError` and `URLError`
- `_post_policy()` (line 675) — catches `HTTPError` and `URLError`

Both re-raise as `RuntimeError` with actionable context (HTTP status code, error detail from response body, URL reason).

`_resolve_relay_identity_token()` (line 505) lets raw exceptions propagate. When the IdP returns HTTP 400/401/500 or is unreachable, the caller gets a cryptic `urllib.error.HTTPError` traceback instead of a clear error message.

## Changes

`gateway/relay/__init__.py`:
- Wrapped the `urlopen` call in try/except matching the sibling functions
- `HTTPError`: extracts error detail from response body, raises `RuntimeError` with HTTP code
- `URLError`: raises `RuntimeError` with connection failure reason

## Why This Matters

This function is called during gateway boot (self-provision) and `hermes gateway enroll`. A misconfigured IdP (wrong client_id, expired secret, unreachable URL) currently produces an unhelpful traceback. With this fix, the error message directly tells the operator what went wrong.
