### PR TITLE
feat(kanban): materialize worktrees for board-bound repos, not scratch

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2489,6 +2489,50 @@ def create_task(
                 # ``<repo>/.worktrees/<task-id>`` dir keyed on the new task id.
                 project_repo = str(project_obj.primary_path)
 
+    # Board-linked worktree upgrade. When the task has no explicit project
+    # link and would otherwise be an ephemeral ``scratch`` task, but the
+    # target board is bound to a git repo (its ``default_workdir`` — set by
+    # ``hermes project bind-board`` / ``project create --board``), materialize
+    # the work as a real linked git worktree on that repo instead of a
+    # throwaway scratch dir. This keeps board-routed builds on their real
+    # branch/repo instead of evaporating when the scratch workspace is deleted
+    # on completion. ``default_workdir`` lives in the *shared* board metadata,
+    # so this resolves correctly no matter which profile creates the card —
+    # no cross-profile projects.db access is needed.
+    #
+    # goal_mode roots stay scratch: they run coordination loops, produce no
+    # code of their own, and the worktree completion gate (real CI on a code
+    # branch) would block them forever. An explicit ``--workspace worktree``
+    # still wins for the rare goal card that genuinely edits code.
+    board_repo: Optional[str] = None
+    if (
+        project_repo is None
+        and workspace_path is None
+        and workspace_kind == "scratch"
+        and not goal_mode
+    ):
+        try:
+            _board_slug = board if board else get_current_board()
+            _board_default = (
+                read_board_metadata(_board_slug).get("default_workdir") or ""
+            ).strip()
+            if _board_default:
+                _repo_root = _repo_root_for_worktree_target(
+                    Path(_board_default).expanduser()
+                )
+                if _repo_root is not None:
+                    # Upgrade to a linked worktree anchored on the bound repo.
+                    # The concrete ``<repo>/.worktrees/<task-id>`` path is
+                    # deferred to the insert loop (keyed on the new task id),
+                    # mirroring the project-linked path above.
+                    workspace_kind = "worktree"
+                    board_repo = str(_repo_root)
+        except Exception:
+            # Never let board resolution crash task creation — an unmounted
+            # external repo, a torn git dir, or a transient git failure must
+            # degrade gracefully to an ordinary scratch task.
+            board_repo = None
+
     parents = tuple(p for p in parents if p)
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
@@ -2565,6 +2609,7 @@ def create_task(
     if (
         workspace_path is None
         and project_repo is None
+        and board_repo is None
         and workspace_kind in {"dir", "worktree"}
     ):
         board_slug = board if board else get_current_board()
@@ -2610,23 +2655,29 @@ def create_task(
                     if missing:
                         raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
 
-                # Project-linked worktree: a fresh worktree dir under the repo
-                # plus a deterministic branch (project slug + task id). Together
-                # these kill the random ``wt/<task-id>`` worker fallback and the
-                # unanchored ``.worktrees/<id>`` under the dispatcher's cwd.
-                if project_obj is not None and workspace_kind == "worktree":
-                    if project_repo and not workspace_path:
-                        workspace_path = os.path.join(
-                            project_repo, ".worktrees", task_id
+                # Project- or board-linked worktree: a fresh worktree dir under
+                # the anchor repo, ``<repo>/.worktrees/<task-id>``, keyed on the
+                # new task id. This kills the unanchored ``.worktrees/<id>``
+                # under the dispatcher's cwd. A project link additionally gets a
+                # deterministic branch (project slug + task id); a board link
+                # falls back to the worker's ``wt/<task-id>`` branch.
+                anchor_repo = project_repo or board_repo
+                if workspace_kind == "worktree" and anchor_repo and not workspace_path:
+                    workspace_path = os.path.join(
+                        anchor_repo, ".worktrees", task_id
+                    )
+                if (
+                    project_obj is not None
+                    and workspace_kind == "worktree"
+                    and not branch_name
+                ):
+                    # _pdb was imported above when project_obj was resolved.
+                    try:
+                        branch_name = _pdb.branch_name_for(
+                            project_obj, task_id, title=title or ""
                         )
-                    if not branch_name:
-                        # _pdb was imported above when project_obj was resolved.
-                        try:
-                            branch_name = _pdb.branch_name_for(
-                                project_obj, task_id, title=title or ""
-                            )
-                        except Exception:
-                            branch_name = None
+                    except Exception:
+                        branch_name = None
 
                 conn.execute(
                     """

--- a/hermes_cli/projects_cmd.py
+++ b/hermes_cli/projects_cmd.py
@@ -211,6 +211,12 @@ def _cmd_create(args: argparse.Namespace) -> int:
     if proj is None:
         print("project: vanished after create", file=sys.stderr)
         return 2
+    # Creating a project already bound to a board must sync the board's
+    # ``default_workdir`` to the primary repo, exactly as ``bind-board`` does —
+    # otherwise the binding is inert and cards created on the board land in
+    # ephemeral scratch dirs instead of worktrees on the repo.
+    if args.board and args.board.strip():
+        _sync_board_default_workdir(proj, args.board)
     print(f"Created project {proj.slug} ({pid})")
     _print_project(proj)
     return 0

--- a/tests/hermes_cli/test_kanban_board_worktree_autobind.py
+++ b/tests/hermes_cli/test_kanban_board_worktree_autobind.py
@@ -1,0 +1,122 @@
+"""Board-linked worktree autobind: a task created on a board whose
+``default_workdir`` points at a git repo (set by ``hermes project bind-board``
+/ ``project create --board``) is materialized as a real linked worktree on that
+repo instead of an ephemeral scratch dir — even with no explicit ``project_id``
+and even when a *different* profile creates the card (the binding lives in the
+shared board metadata, not the per-profile projects.db).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def _git_repo(path):
+    path.mkdir(parents=True, exist_ok=True)
+    env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
+    for cmd in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@t"],
+        ["git", "config", "user.name", "t"],
+        ["git", "config", "commit.gpgsign", "false"],
+    ):
+        subprocess.run(cmd, cwd=path, env=env, check=True)
+    (path / "README.md").write_text("# repo\n")
+    subprocess.run(["git", "add", "-A"], cwd=path, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, env=env, check=True)
+    return path
+
+
+@pytest.fixture
+def conn():
+    c = kb.connect()
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def test_board_bound_repo_upgrades_scratch_to_worktree(conn, tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    kb.write_board_metadata("default", default_workdir=str(repo))
+
+    tid = kb.create_task(conn, title="Build screen", board="default")
+    task = kb.get_task(conn, tid)
+
+    # No explicit project link, yet the task is upgraded to a worktree anchored
+    # under the bound repo, keyed on the task id.
+    assert task.project_id is None
+    assert task.workspace_kind == "worktree"
+    assert task.workspace_path == os.path.join(str(repo), ".worktrees", tid)
+    # Board links have no deterministic project branch; the worker's wt/<id>
+    # fallback owns the branch (materialized at dispatch).
+    assert task.branch_name is None
+
+
+def test_board_bound_repo_materializes_on_resolve(conn, tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    kb.write_board_metadata("default", default_workdir=str(repo))
+
+    tid = kb.create_task(conn, title="x", board="default")
+    task = kb.get_task(conn, tid)
+    workspace, branch = kb._resolve_worktree_workspace(task, board="default")
+
+    assert workspace == (repo / ".worktrees" / tid)
+    assert branch == f"wt/{tid}"
+    listing = subprocess.run(
+        ["git", "-C", str(repo), "worktree", "list"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert str(repo / ".worktrees" / tid) in listing
+
+
+def test_goal_mode_root_stays_scratch_on_git_backed_board(conn, tmp_path):
+    # goal_mode coordination roots produce no code and must not enter the
+    # worktree completion gate — they stay scratch even on a git-backed board.
+    repo = _git_repo(tmp_path / "repo")
+    kb.write_board_metadata("default", default_workdir=str(repo))
+
+    tid = kb.create_task(conn, title="coordinate", board="default", goal_mode=True)
+    task = kb.get_task(conn, tid)
+    assert task.workspace_kind == "scratch"
+
+
+def test_explicit_workspace_path_is_respected(conn, tmp_path):
+    # An explicit workspace_path must not be overridden by board resolution.
+    repo = _git_repo(tmp_path / "repo")
+    kb.write_board_metadata("default", default_workdir=str(repo))
+
+    explicit = str(tmp_path / "elsewhere")
+    tid = kb.create_task(
+        conn, title="x", board="default",
+        workspace_kind="dir", workspace_path=explicit,
+    )
+    task = kb.get_task(conn, tid)
+    assert task.workspace_kind == "dir"
+    assert task.workspace_path == explicit
+
+
+def test_non_git_board_default_degrades_to_scratch(conn, tmp_path):
+    # default_workdir set to a path that is not inside a git repo (e.g. an
+    # unmounted external drive or a plain dir) must degrade to scratch, not
+    # crash task creation.
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    kb.write_board_metadata("default", default_workdir=str(plain))
+
+    tid = kb.create_task(conn, title="x", board="default")
+    task = kb.get_task(conn, tid)
+    assert task.workspace_kind == "scratch"
+
+
+def test_no_board_default_leaves_scratch(conn):
+    # A board with no default_workdir is unchanged: plain scratch task.
+    tid = kb.create_task(conn, title="plain", board="default")
+    task = kb.get_task(conn, tid)
+    assert task.workspace_kind == "scratch"
+    assert task.project_id is None

--- a/tests/hermes_cli/test_projects_cli.py
+++ b/tests/hermes_cli/test_projects_cli.py
@@ -82,3 +82,25 @@ def test_use_clear(tmp_path):
 def test_unknown_project_returns_error(capsys, tmp_path):
     assert _run(["show", "nope"]) == 1
     assert "no such project" in capsys.readouterr().err
+
+
+def test_create_with_board_syncs_board_default_workdir(tmp_path):
+    # `project create --board <b>` must sync the board's default_workdir to the
+    # primary repo, exactly as `bind-board` does — otherwise the binding is
+    # inert and cards on the board land in scratch dirs instead of worktrees.
+    from hermes_cli import kanban_db as kb
+
+    kb.create_board("appboard")
+    repo = str(tmp_path / "repo")
+    assert _run(["create", "My App", repo, "--primary", repo, "--board", "appboard"]) == 0
+
+    assert kb.read_board_metadata("appboard").get("default_workdir") == repo
+
+
+def test_create_without_board_does_not_touch_board_metadata(tmp_path):
+    from hermes_cli import kanban_db as kb
+
+    kb.create_board("plainboard")
+    repo = str(tmp_path / "repo")
+    assert _run(["create", "P", repo, "--primary", repo]) == 0
+    assert kb.read_board_metadata("plainboard").get("default_workdir") is None


### PR DESCRIPTION
## Problem

A kanban board can be bound to a project's git repo via `hermes project bind-board` (and `hermes project create --board`), which records the repo path in the board's **shared** metadata as `default_workdir`. But a card created on such a board **without an explicit `--project`** was still created as an ephemeral `scratch` task. Its workspace is deleted on completion, so the work never reaches the bound repo — board-routed builds silently "evaporate".

The repo path already lives in shared board metadata (profile-independent), yet nothing at create time consulted it to anchor the work.

## Fix

Two gaps, both in the create path (no dispatcher changes):

1. **`create_task`** — when a task has no project link and would be `scratch`, but the target board's `default_workdir` resolves to a git repo root, upgrade it to a linked worktree anchored at `<repo>/.worktrees/<task-id>`. Because `default_workdir` is shared board metadata, this resolves regardless of which profile creates the card — no cross-profile `projects.db` access is required.
   - `goal_mode` roots stay `scratch` (they run coordination loops, produce no code, and the worktree completion gate would block them forever).
   - A missing/unmounted/non-git `default_workdir` degrades gracefully to `scratch` rather than crashing task creation.
   - An explicit `--project` link or `workspace_path` is untouched.

2. **`project create --board`** — now syncs the board's `default_workdir` to the primary repo, exactly as `bind-board` already does. Previously the binding was inert unless a separate `bind-board` was run.

## Tests

- `tests/hermes_cli/test_kanban_board_worktree_autobind.py` — scratch→worktree upgrade, on-disk worktree materialization, `goal_mode` stays scratch, non-git default_workdir degrades to scratch, no-default_workdir unchanged.
- `tests/hermes_cli/test_projects_cli.py` — `create --board` syncs `default_workdir`; `create` without `--board` leaves board metadata untouched.

## Platforms tested

- **macOS (Darwin 25.5, arm64)** — targeted pytest green (`test_kanban_board_worktree_autobind`, `test_projects_cli`, `test_kanban_project_link`, `test_project_metadata`, `test_kanban_goal_mode`, `test_kanban_db`, `test_kanban_core_functionality`, `test_kanban_cli` — 478 passed / 1 skipped (single combined pytest run)). `scripts/check-windows-footguns.py` clean on both changed files (uses `os.path.join`, no shell/window flags). End-to-end verified on an external **APFS** repo across two profiles (project + binding created under one profile, card created under another) — the worktree materializes on the bound repo in both the `bind-board` and `create --board` paths.
- Windows/Linux: not run locally; change is pure-Python path/metadata logic with no platform-specific branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
