### PR TITLE
fix(codex): normalize legacy gpt55 alias

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -115,6 +115,12 @@ _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
     "xiaomi",
 })
 
+_OPENAI_CODEX_MODEL_ALIASES: dict[str, str] = {
+    # Legacy OpenAI API / proxy shorthand. The ChatGPT Codex backend rejects
+    # this slug, but accepts the dotted model id.
+    "gpt55": "gpt-5.5",
+}
+
 # ---------------------------------------------------------------------------
 # DeepSeek special handling
 # ---------------------------------------------------------------------------
@@ -440,7 +446,9 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         stripped = _strip_matching_provider_prefix(name, provider)
         if stripped == name and name.startswith("openai/"):
             # openai-codex maps openai/gpt-5.4 -> gpt-5.4
-            return name.split("/", 1)[1]
+            stripped = name.split("/", 1)[1]
+        if provider == "openai-codex":
+            return _OPENAI_CODEX_MODEL_ALIASES.get(stripped.lower(), stripped)
         return stripped
 
     # --- DeepSeek: map to one of two canonical names ---
@@ -470,4 +478,3 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 # ---------------------------------------------------------------------------
 # Batch / convenience helpers
 # ---------------------------------------------------------------------------
-

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -145,6 +145,11 @@ class TestCopilotModelNormalization:
         """Regression: openai-codex must still strip the openai/ prefix."""
         assert normalize_model_for_provider("openai/gpt-5.4", "openai-codex") == "gpt-5.4"
 
+    @pytest.mark.parametrize("model", ["gpt55", "openai/gpt55"])
+    def test_openai_codex_normalizes_legacy_gpt55_alias(self, model):
+        """Regression: ChatGPT Codex rejects the legacy gpt55 proxy slug."""
+        assert normalize_model_for_provider(model, "openai-codex") == "gpt-5.5"
+
 
 # ── Aggregator providers (regression) ──────────────────────────────────
 


### PR DESCRIPTION
## Summary
- normalize legacy `gpt55` / `openai/gpt55` selections to `gpt-5.5` for `openai-codex`
- keep the alias scoped to `openai-codex` so OpenAI API/proxy model IDs are unaffected
- add regression coverage for both raw and prefixed legacy aliases

## Test
- `uv run --python 3.11 --extra dev python -m pytest tests/hermes_cli/test_model_normalize.py -q`

## Context
A Desktop/TUI session can carry a stale `gpt55` selection from the OpenAI API/proxy provider while switching to `openai-codex`. The ChatGPT Codex backend rejects that model slug with HTTP 400, before the first response token. The dotted `gpt-5.5` model ID is accepted.