### PR TITLE
Add opt-in metadata-only run traces for agent turns

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -25,6 +25,7 @@ import ssl
 import threading
 import time
 import uuid
+from functools import wraps
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
@@ -58,6 +59,7 @@ from agent.model_metadata import (
 )
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import apply_anthropic_cache_control
+from agent import run_trace as run_trace_mod
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
@@ -520,6 +522,49 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     return sp
 
 
+def _finish_unfinalized_run_trace(agent, result: Any) -> None:
+    """Finish traces for direct-return and exception paths outside the finalizer."""
+
+    trace = getattr(agent, "_current_run_trace", None)
+    if trace is None or trace.ended_at_ms is not None:
+        return
+    payload = result if isinstance(result, dict) else {}
+    status = (
+        "interrupted" if payload.get("interrupted") else
+        "failed" if payload.get("failed") or result is None else
+        "completed" if payload.get("completed") else
+        "partial"
+    )
+    run_trace_mod.finish_trace_for_turn(
+        trace,
+        status=status,
+        exit_reason=payload.get("turn_exit_reason") or "unknown",
+        api_call_count=int(payload.get("api_calls") or 0),
+    )
+
+
+def _trace_direct_returns(func):
+    """Ensure every traced turn is closed even when the loop returns early."""
+
+    @wraps(func)
+    def wrapped(agent, *args, **kwargs):
+        agent._current_run_trace = None
+        result = None
+        try:
+            result = func(agent, *args, **kwargs)
+            return result
+        finally:
+            try:
+                _finish_unfinalized_run_trace(agent, result)
+            except Exception:
+                logger.debug("run_trace direct-return finish failed", exc_info=True)
+            finally:
+                agent._current_run_trace = None
+
+    return wrapped
+
+
+@_trace_direct_returns
 def run_conversation(
     agent,
     user_message: str,
@@ -618,6 +663,7 @@ def run_conversation(
     # user-facing result available; it must not be confused with error or
     # recovery text produced by unrelated exit paths.
     _pending_verification_response = None
+    _run_trace = None
 
     # Per-turn tally of consecutive successful credential-pool token refreshes,
     # keyed by (provider, pool-entry-id). A persistent upstream 401 lets
@@ -639,6 +685,13 @@ def run_conversation(
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
         )
+
+    _run_trace = run_trace_mod.start_trace_for_turn(
+        agent,
+        turn_id=turn_id,
+        task_id=effective_task_id,
+    )
+    agent._current_run_trace = _run_trace
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
@@ -4690,6 +4743,11 @@ def run_conversation(
                     except Exception:
                         pass
 
+                run_trace_mod.record_tool_batch(
+                    _run_trace,
+                    assistant_message.tool_calls,
+                    status="requested",
+                )
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
 
                 if agent._tool_guardrail_halt_decision is not None:
@@ -5311,7 +5369,7 @@ def run_conversation(
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.
     from agent.turn_finalizer import finalize_turn
-    return finalize_turn(
+    _result = finalize_turn(
         agent,
         final_response=final_response,
         api_call_count=api_call_count,
@@ -5326,7 +5384,9 @@ def run_conversation(
         _should_review_memory=_should_review_memory,
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,
+        _run_trace=_run_trace,
     )
+    return _result
 
 
 

--- a/agent/run_trace.py
+++ b/agent/run_trace.py
@@ -1,0 +1,323 @@
+"""Metadata-only run trace persistence.
+
+Run traces are deliberately smaller and safer than full trajectories: they
+capture turn-level execution metadata (IDs, model/provider, status, API call
+count, and tool names) without raw prompts, raw tool arguments, raw tool
+outputs, or assistant text.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from hashlib import sha256
+from typing import Any, Iterable
+
+from agent.redact import redact_sensitive_text
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "hermes_run_trace_v1"
+_DEFAULT_TRACE_PATH = "run_traces/run_traces.jsonl"
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_ALLOWED_STATUS = {"running", "completed", "interrupted", "failed", "partial"}
+_ALLOWED_EXIT_REASONS = {
+    "unknown",
+    "interrupted_by_user",
+    "budget_exhausted",
+    "ollama_runtime_context_too_small",
+    "interrupted_during_api_call",
+    "all_retries_exhausted_no_response",
+    "guardrail_halt",
+    "partial_stream_recovery",
+    "fallback_prior_turn_content",
+    "empty_response_exhausted",
+    "text_response",
+    "error_near_max_iterations",
+    "max_iterations_reached",
+}
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _safe_text(value: Any, *, max_len: int = 240) -> str:
+    """Return redacted bounded metadata text.
+
+    This helper is intentionally used only for metadata fields, never raw prompt
+    text, tool arguments, or tool outputs.  ``force=True`` means trace safety is
+    not weakened when a user disables general log redaction.
+    """
+
+    if value is None:
+        return ""
+    try:
+        text = str(value)
+    except Exception:
+        text = "<unserializable>"
+    text = redact_sensitive_text(text, force=True)
+    if len(text) > max_len:
+        return text[: max_len - 1] + "…"
+    return text
+
+
+def _safe_tool_name(value: Any) -> str:
+    return _safe_text(value, max_len=128)
+
+
+def _safe_identifier(value: Any, *, max_len: int = 160) -> str:
+    """Return a stable fingerprint without persisting identifier text.
+
+    Identifier-shaped strings are not inherently safe: caller-provided labels
+    can be valid slugs while still containing customer or task details. Hash all
+    identifiers so generated IDs remain correlatable without creating an
+    allowlist bypass for free text.
+    """
+
+    text = _safe_text(value, max_len=max_len)
+    if not text:
+        return ""
+    digest = sha256(text.encode("utf-8", errors="replace")).hexdigest()[:16]
+    return f"sha256:{digest}"
+
+
+def _safe_status(value: Any) -> str:
+    status = _safe_text(value, max_len=48).strip().lower()
+    return status if status in _ALLOWED_STATUS else "partial"
+
+
+def _safe_exit_reason(value: Any) -> str:
+    """Return a controlled exit-reason code, never raw exception text."""
+
+    text = _safe_text(value, max_len=240).strip()
+    if not text:
+        return "unknown"
+    code = text.split("(", 1)[0].strip().lower()
+    code = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in code)
+    return code if code in _ALLOWED_EXIT_REASONS else "other"
+
+
+def _cfg_get(config: Any, *keys: str, default: Any = None) -> Any:
+    node = config
+    for key in keys:
+        if not isinstance(node, dict) or key not in node:
+            return default
+        node = node[key]
+    return node
+
+
+def _load_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        logger.debug("run_trace config load failed", exc_info=True)
+        return {}
+
+
+def trace_enabled(*, config: dict[str, Any] | None = None) -> bool:
+    """Return whether run trace persistence is enabled.
+
+    Disabled by default.  The first PR is observe-only and opt-in through
+    ``observability.run_trace_enabled``.
+    """
+
+    cfg = _load_config() if config is None else config
+    raw = _cfg_get(cfg, "observability", "run_trace_enabled", default=False)
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        return raw.strip().lower() in _TRUE_VALUES
+    if isinstance(raw, (int, float)):
+        return bool(raw)
+    return False
+
+
+def _trace_path(*, config: dict[str, Any] | None = None):
+    cfg = _load_config() if config is None else config
+    rel = _cfg_get(cfg, "observability", "run_trace_path", default=_DEFAULT_TRACE_PATH)
+    if not isinstance(rel, str) or not rel.strip():
+        rel = _DEFAULT_TRACE_PATH
+    rel = rel.strip()
+    home = get_hermes_home()
+    path = home / rel
+    try:
+        path.resolve().relative_to(home.resolve())
+    except Exception:
+        # Keep the writer inside HERMES_HOME even if config is malicious or
+        # accidentally absolute.  This is a safety fallback, not enforcement UX.
+        path = home / _DEFAULT_TRACE_PATH
+    return path
+
+
+@dataclass
+class RunTraceToolCall:
+    """Safe metadata about one requested tool call."""
+
+    name: str
+    tool_call_id: str = ""
+    status: str = "requested"
+    duration_ms: int | None = None
+    error_type: str = ""
+    error_message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": _safe_tool_name(self.name),
+            "tool_call_id": _safe_identifier(self.tool_call_id, max_len=160),
+            "status": _safe_text(self.status, max_len=48),
+            "duration_ms": self.duration_ms if isinstance(self.duration_ms, int) else None,
+            "error_type": _safe_text(self.error_type, max_len=120),
+            "error_message": _safe_exit_reason(self.error_message) if self.error_message else "",
+        }
+
+
+@dataclass
+class RunTrace:
+    """Metadata-only record for one agent turn."""
+
+    run_id: str = field(default_factory=lambda: f"run_{uuid.uuid4().hex}")
+    session_id: str = ""
+    turn_id: str = ""
+    task_id: str = ""
+    model: str = ""
+    provider: str = ""
+    source: str = ""
+    status: str = "running"
+    exit_reason: str = ""
+    api_call_count: int = 0
+    started_at_ms: int = field(default_factory=_now_ms)
+    ended_at_ms: int | None = None
+    duration_ms: int | None = None
+    tool_calls: list[RunTraceToolCall] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": _safe_identifier(self.run_id, max_len=160),
+            "session_id": _safe_identifier(self.session_id, max_len=160),
+            "turn_id": _safe_identifier(self.turn_id, max_len=160),
+            "task_id": _safe_identifier(self.task_id, max_len=160),
+            "model": _safe_text(self.model, max_len=160),
+            "provider": _safe_text(self.provider, max_len=160),
+            "source": _safe_text(self.source, max_len=80),
+            "status": _safe_status(self.status),
+            "exit_reason": _safe_exit_reason(self.exit_reason),
+            "api_call_count": int(self.api_call_count or 0),
+            "started_at_ms": int(self.started_at_ms or 0),
+            "ended_at_ms": int(self.ended_at_ms or 0) if self.ended_at_ms is not None else None,
+            "duration_ms": int(self.duration_ms) if isinstance(self.duration_ms, int) else None,
+            "tool_calls": [tc.to_dict() for tc in self.tool_calls],
+        }
+
+
+def start_trace_for_turn(
+    agent: Any,
+    *,
+    turn_id: str,
+    task_id: str | None,
+    config: dict[str, Any] | None = None,
+) -> RunTrace | None:
+    """Build a run trace for a turn when tracing is enabled."""
+
+    if not trace_enabled(config=config):
+        return None
+    return RunTrace(
+        session_id=_safe_text(getattr(agent, "session_id", ""), max_len=160),
+        turn_id=_safe_text(turn_id, max_len=160),
+        task_id=_safe_text(task_id or "", max_len=160),
+        model=_safe_text(getattr(agent, "model", ""), max_len=160),
+        provider=_safe_text(getattr(agent, "provider", ""), max_len=160),
+        source=_safe_text(getattr(agent, "platform", "") or "cli", max_len=80),
+    )
+
+
+def record_tool_batch(
+    trace: RunTrace | None,
+    tool_calls: Iterable[Any] | None,
+    *,
+    status: str = "requested",
+) -> None:
+    """Append safe metadata for a batch of tool calls.
+
+    Raw arguments are intentionally ignored.
+    """
+
+    if trace is None or not tool_calls:
+        return
+    for tc in tool_calls:
+        function = getattr(tc, "function", None)
+        trace.tool_calls.append(
+            RunTraceToolCall(
+                name=_safe_tool_name(getattr(function, "name", "")),
+                tool_call_id=_safe_text(getattr(tc, "id", ""), max_len=160),
+                status=status,
+            )
+        )
+
+
+def append_run_trace(
+    trace: RunTrace,
+    *,
+    config: dict[str, Any] | None = None,
+) -> bool:
+    """Append one run trace JSON line.
+
+    Returns ``False`` instead of raising for all disabled/write-failure paths;
+    tracing is observability only and must never fail an agent turn.
+    """
+
+    if trace is None or not trace_enabled(config=config):
+        return False
+    try:
+        path = _trace_path(config=config)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(trace.to_dict(), ensure_ascii=False, sort_keys=True) + "\n")
+        return True
+    except Exception:
+        logger.debug("run_trace append failed", exc_info=True)
+        return False
+
+
+def finish_trace_for_turn(
+    trace: RunTrace | None,
+    *,
+    status: str,
+    exit_reason: str,
+    api_call_count: int,
+    config: dict[str, Any] | None = None,
+) -> bool:
+    """Mark a trace complete and append it, swallowing observability failures."""
+
+    if trace is None:
+        return False
+    try:
+        now = _now_ms()
+        trace.status = status
+        trace.exit_reason = exit_reason
+        trace.api_call_count = api_call_count
+        trace.ended_at_ms = now
+        trace.duration_ms = max(0, now - int(trace.started_at_ms or now))
+        return append_run_trace(trace, config=config)
+    except Exception:
+        logger.debug("run_trace finish failed", exc_info=True)
+        return False
+
+
+__all__ = [
+    "RunTrace",
+    "RunTraceToolCall",
+    "append_run_trace",
+    "finish_trace_for_turn",
+    "record_tool_batch",
+    "start_trace_for_turn",
+    "trace_enabled",
+]

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -43,6 +43,7 @@ def finalize_turn(
     _should_review_memory,
     _turn_exit_reason,
     _pending_verification_response=None,
+    _run_trace=None,
 ):
     """Run the post-loop finalization and return the turn ``result`` dict.
 
@@ -528,5 +529,23 @@ def finalize_turn(
         )
     except Exception as exc:
         logger.warning("on_session_end hook failed: %s", exc)
+
+    # Run traces belong to the finalization seam so they observe the same
+    # post-loop state returned to callers, including cleanup failures and
+    # max-iteration fallback results. Trace persistence is best-effort and
+    # never stores response text.
+    from agent import run_trace as _run_trace_mod
+    _trace_status = (
+        "interrupted" if result.get("interrupted") else
+        "failed" if result.get("failed") or result.get("cleanup_errors") else
+        "completed" if result.get("completed") else
+        "partial"
+    )
+    _run_trace_mod.finish_trace_for_turn(
+        _run_trace,
+        status=_trace_status,
+        exit_reason=result.get("turn_exit_reason") or _turn_exit_reason,
+        api_call_count=int(result.get("api_calls") or api_call_count or 0),
+    )
 
     return result

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1159,7 +1159,15 @@ DEFAULT_CONFIG = {
         "image_input_mode": "auto",
         "disabled_toolsets": [],
     },
-    
+
+    "observability": {
+        # Metadata-only run trace persistence. Disabled by default and
+        # observe-only: it writes turn/tool metadata under HERMES_HOME without
+        # raw prompts, raw tool arguments, raw tool output, or assistant text.
+        "run_trace_enabled": False,
+        "run_trace_path": "run_traces/run_traces.jsonl",
+    },
+
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",

--- a/tests/agent/test_run_trace.py
+++ b/tests/agent/test_run_trace.py
@@ -1,0 +1,225 @@
+"""Tests for metadata-only run trace persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_constants import get_hermes_home
+from agent.run_trace import (
+    RunTrace,
+    RunTraceToolCall,
+    append_run_trace,
+    finish_trace_for_turn,
+    record_tool_batch,
+    start_trace_for_turn,
+    trace_enabled,
+)
+
+
+def _secret() -> str:
+    return "sk-test_" + "a" * 32
+
+
+def test_trace_disabled_by_default_and_enabled_by_config():
+    assert trace_enabled(config={}) is False
+    assert trace_enabled(config={"observability": {"run_trace_enabled": False}}) is False
+    assert trace_enabled(config={"observability": {"run_trace_enabled": True}}) is True
+    assert trace_enabled(config={"observability": {"run_trace_enabled": "yes"}}) is True
+
+
+def test_run_trace_metadata_only_omits_raw_prompt_args_and_tool_output():
+    trace = RunTrace(
+        run_id="run_test",
+        session_id="session_1",
+        turn_id="turn_1",
+        task_id="task_1",
+        model="test-model",
+        provider="test-provider",
+        source="cli",
+    )
+    tool_call = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(
+            name="terminal",
+            arguments=json.dumps({"command": "cat /tmp/private_prompt.txt", "token": _secret()}),
+        ),
+    )
+
+    record_tool_batch(trace, [tool_call], status="requested")
+    trace.tool_calls.append(
+        RunTraceToolCall(
+            name="terminal",
+            tool_call_id="call_2",
+            status="error",
+            error_type="RuntimeError",
+            error_message=f"tool failed with {_secret()}",
+        )
+    )
+    data = trace.to_dict()
+    encoded = json.dumps(data, ensure_ascii=False)
+
+    assert "private_prompt" not in encoded
+    assert "cat /tmp" not in encoded
+    assert "command" not in encoded
+    assert "arguments" not in encoded
+    assert "result" not in encoded
+    assert "output" not in encoded
+    assert _secret() not in encoded
+    tool_data = data["tool_calls"][0]
+    assert tool_data["name"] == "terminal"
+    assert tool_data["tool_call_id"].startswith("sha256:")
+    assert tool_data["status"] == "requested"
+    assert tool_data["duration_ms"] is None
+    assert tool_data["error_type"] == ""
+    assert tool_data["error_message"] == ""
+    assert "call_1" not in encoded
+
+
+def test_run_trace_redacts_secret_like_metadata_values():
+    trace = RunTrace(
+        run_id="run_test",
+        session_id=f"session {_secret()}",
+        turn_id="turn_1",
+        task_id="task_1",
+        model="test-model",
+        provider="test-provider",
+        source="cli",
+        exit_reason=f"error_near_max_iterations(private prompt {_secret()})",
+        tool_calls=[
+            RunTraceToolCall(
+                name="terminal",
+                tool_call_id="call_1",
+                status="error",
+                error_type="RuntimeError",
+                error_message=f"OPENAI_API_KEY={_secret()}",
+            )
+        ],
+    )
+
+    data = trace.to_dict()
+    encoded = json.dumps(data, ensure_ascii=False)
+
+    assert _secret() not in encoded
+    assert "private prompt" not in encoded
+    assert "OPENAI_API_KEY=" not in encoded
+    assert data["exit_reason"] == "error_near_max_iterations"
+    assert data["tool_calls"][0]["error_message"] == "other"
+
+
+def test_run_trace_hashes_free_text_identifiers():
+    trace = RunTrace(
+        run_id="run_test",
+        session_id="session_1",
+        turn_id="turn_1",
+        task_id="customer asked about a private acquisition plan",
+    )
+
+    data = trace.to_dict()
+    encoded = json.dumps(data, ensure_ascii=False)
+
+    assert "private acquisition" not in encoded
+    assert data["task_id"].startswith("sha256:")
+
+
+def test_run_trace_hashes_slug_and_underscore_identifiers():
+    identifiers = (
+        "customer-private-acquisition-plan",
+        "customer_private_acquisition_plan",
+    )
+
+    for identifier in identifiers:
+        trace = RunTrace(
+            run_id="run_test",
+            session_id="session_1",
+            turn_id=f"session_1:{identifier}:deadbeef",
+            task_id=identifier,
+        )
+
+        data = trace.to_dict()
+        encoded = json.dumps(data, ensure_ascii=False)
+
+        assert identifier not in encoded
+        assert data["task_id"].startswith("sha256:")
+        assert data["turn_id"].startswith("sha256:")
+
+
+def test_append_run_trace_persists_jsonl_under_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    trace = RunTrace(run_id="run_test", session_id="sess", turn_id="turn", task_id="task")
+    finish_trace_for_turn(
+        trace,
+        status="completed",
+        exit_reason="text_response(finish_reason=stop)",
+        api_call_count=1,
+        config={"observability": {"run_trace_enabled": True}},
+    )
+
+    path = get_hermes_home() / "run_traces" / "run_traces.jsonl"
+    assert path.exists()
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["schema_version"] == "hermes_run_trace_v1"
+    assert entry["run_id"].startswith("sha256:")
+    assert "run_test" not in json.dumps(entry, ensure_ascii=False)
+    assert entry["status"] == "completed"
+    assert entry["api_call_count"] == 1
+
+
+def test_append_run_trace_disabled_does_not_write(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    trace = RunTrace(run_id="run_test")
+
+    wrote = append_run_trace(trace, config={"observability": {"run_trace_enabled": False}})
+
+    assert wrote is False
+    assert not (get_hermes_home() / "run_traces" / "run_traces.jsonl").exists()
+
+
+def test_append_run_trace_write_failure_is_non_fatal(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    blocked_parent = get_hermes_home() / "run_traces"
+    blocked_parent.parent.mkdir(parents=True, exist_ok=True)
+    blocked_parent.write_text("not a directory", encoding="utf-8")
+    trace = RunTrace(run_id="run_test")
+
+    wrote = append_run_trace(trace, config={"observability": {"run_trace_enabled": True}})
+
+    assert wrote is False
+
+
+def test_start_trace_for_turn_builds_metadata_from_agent_when_enabled():
+    agent = SimpleNamespace(
+        session_id="session_1",
+        model="test-model",
+        provider="test-provider",
+        platform="gateway",
+    )
+
+    trace = start_trace_for_turn(
+        agent,
+        turn_id="turn_1",
+        task_id="task_1",
+        config={"observability": {"run_trace_enabled": True}},
+    )
+
+    assert trace is not None
+    assert trace.session_id == "session_1"
+    assert trace.turn_id == "turn_1"
+    assert trace.task_id == "task_1"
+    assert trace.model == "test-model"
+    assert trace.provider == "test-provider"
+    assert trace.source == "gateway"
+
+
+def test_start_trace_for_turn_returns_none_when_disabled():
+    agent = SimpleNamespace(session_id="session_1")
+
+    assert start_trace_for_turn(
+        agent,
+        turn_id="turn_1",
+        task_id="task_1",
+        config={"observability": {"run_trace_enabled": False}},
+    ) is None

--- a/tests/agent/test_run_trace_integration.py
+++ b/tests/agent/test_run_trace_integration.py
@@ -1,0 +1,277 @@
+"""Integration tests for the observe-only run trace hook."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hermes_constants import get_hermes_home
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_tool_call(name="web_search", arguments="{}", call_id="call_1"):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _mock_assistant_msg(content="Hello", tool_calls=None):
+    return SimpleNamespace(content=content, tool_calls=tool_calls)
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = _mock_assistant_msg(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=msg, finish_reason=finish_reason)],
+        model="test/model",
+        usage=None,
+    )
+
+
+def _make_agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _enable_run_trace_config():
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "observability:\n  run_trace_enabled: true\n",
+        encoding="utf-8",
+    )
+
+
+def _read_trace_entries() -> list[dict]:
+    path = get_hermes_home() / "run_traces" / "run_traces.jsonl"
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_run_conversation_writes_metadata_only_trace_for_final_answer():
+    _enable_run_trace_config()
+    agent = _make_agent()
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="Final answer",
+        finish_reason="stop",
+    )
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello with sk-test_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+    assert result["completed"] is True
+    entries = _read_trace_entries()
+    assert len(entries) == 1
+    entry = entries[0]
+    encoded = json.dumps(entry, ensure_ascii=False)
+    assert entry["schema_version"] == "hermes_run_trace_v1"
+    assert entry["status"] == "completed"
+    assert entry["api_call_count"] == 1
+    assert entry["model"] == "test/model"
+    assert entry["provider"] == "openrouter"
+    assert entry["tool_calls"] == []
+    assert "hello with" not in encoded
+    assert "Final answer" not in encoded
+    assert "sk-test_aaaaaaaa" not in encoded
+
+
+def test_run_conversation_trace_records_tool_names_without_args_or_results():
+    _enable_run_trace_config()
+    agent = _make_agent()
+    tc = _mock_tool_call(
+        name="web_search",
+        arguments=json.dumps({"query": "private query", "token": "sk-test_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}),
+        call_id="call_search_1",
+    )
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc]),
+        _mock_response(content="Done", finish_reason="stop"),
+    ]
+
+    with (
+        patch("run_agent.handle_function_call", return_value="raw tool output sk-test_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("search something private")
+
+    assert result["completed"] is True
+    entries = _read_trace_entries()
+    assert len(entries) == 1
+    entry = entries[0]
+    encoded = json.dumps(entry, ensure_ascii=False)
+    assert entry["api_call_count"] == 2
+    assert len(entry["tool_calls"]) == 1
+    tool_data = entry["tool_calls"][0]
+    assert tool_data["name"] == "web_search"
+    assert tool_data["tool_call_id"].startswith("sha256:")
+    assert tool_data["status"] == "requested"
+    assert tool_data["duration_ms"] is None
+    assert tool_data["error_type"] == ""
+    assert tool_data["error_message"] == ""
+    assert "call_search_1" not in encoded
+    assert "private query" not in encoded
+    assert "raw tool output" not in encoded
+    assert "sk-test_aaaaaaaa" not in encoded
+
+
+def test_run_conversation_trace_hashes_caller_supplied_slug_task_id():
+    _enable_run_trace_config()
+    agent = _make_agent()
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="Final answer",
+        finish_reason="stop",
+    )
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            "hello",
+            task_id="customer-private-acquisition-plan",
+        )
+
+    assert result["completed"] is True
+    entry = _read_trace_entries()[0]
+    encoded = json.dumps(entry, ensure_ascii=False)
+    assert entry["task_id"].startswith("sha256:")
+    assert entry["turn_id"].startswith("sha256:")
+    assert "customer-private-acquisition-plan" not in encoded
+
+
+def test_run_conversation_trace_finishes_on_direct_return_path():
+    _enable_run_trace_config()
+    agent = _make_agent()
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="model refusal detail",
+        finish_reason="content_filter",
+    )
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["completed"] is False
+    entries = _read_trace_entries()
+    assert len(entries) == 1
+    assert entries[0]["status"] == "failed"
+    assert entries[0]["api_call_count"] == 1
+    assert "model refusal detail" not in json.dumps(entries[0], ensure_ascii=False)
+
+
+def test_run_conversation_trace_write_failure_does_not_fail_turn(monkeypatch):
+    _enable_run_trace_config()
+    agent = _make_agent()
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="Final answer",
+        finish_reason="stop",
+    )
+
+    def _raise(_trace, *, config=None):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr("agent.run_trace.append_run_trace", _raise)
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Final answer"
+
+
+def test_run_conversation_trace_reflects_post_finalize_cleanup_errors():
+    _enable_run_trace_config()
+    agent = _make_agent()
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="Final answer",
+        finish_reason="stop",
+    )
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(
+            agent,
+            "_cleanup_task_resources",
+            side_effect=RuntimeError("cleanup leaked private prompt text"),
+        ),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["completed"] is True
+    assert result["cleanup_errors"]
+    entries = _read_trace_entries()
+    assert len(entries) == 1
+    encoded = json.dumps(entries[0], ensure_ascii=False)
+    assert entries[0]["status"] == "failed"
+    assert entries[0]["exit_reason"] == "text_response"
+    assert "cleanup leaked private" not in encoded
+
+
+def test_run_conversation_does_not_start_trace_for_codex_app_server_path():
+    _enable_run_trace_config()
+    agent = _make_agent()
+    agent.api_mode = "codex_app_server"
+    agent._run_codex_app_server_turn = MagicMock(
+        return_value={
+            "final_response": "codex result",
+            "completed": True,
+            "api_calls": 0,
+        }
+    )
+
+    result = agent.run_conversation("hello")
+
+    assert result["final_response"] == "codex result"
+    assert agent._run_codex_app_server_turn.called
+    assert not (get_hermes_home() / "run_traces" / "run_traces.jsonl").exists()

--- a/website/docs/developer-guide/run-trace.md
+++ b/website/docs/developer-guide/run-trace.md
@@ -1,0 +1,109 @@
+---
+title: Run trace
+---
+
+# Run trace
+
+Hermes run traces are an opt-in, metadata-only observability record for one
+agent turn. They are intentionally smaller and safer than full trajectories:
+they capture execution shape without persisting raw prompts, tool arguments,
+tool results, or assistant text.
+
+Run traces are designed as a substrate for future eval, review, and replay
+workflows. The first implementation is observe-only and fail-open: if trace
+writing fails, the agent turn continues normally.
+
+## Enable
+
+Run tracing is disabled by default. Enable it in `~/.hermes/config.yaml`:
+
+```yaml
+observability:
+  run_trace_enabled: true
+  run_trace_path: run_traces/run_traces.jsonl
+```
+
+`run_trace_path` is relative to `HERMES_HOME`; absolute or escaping paths fall
+back to the default path under `HERMES_HOME`.
+
+## Storage
+
+By default traces are appended as JSON Lines:
+
+```text
+~/.hermes/run_traces/run_traces.jsonl
+```
+
+Each line is one turn-level record.
+
+## Schema
+
+Current schema version: `hermes_run_trace_v1`.
+
+```json
+{
+  "schema_version": "hermes_run_trace_v1",
+  "run_id": "sha256:...",
+  "session_id": "sha256:...",
+  "turn_id": "sha256:...",
+  "task_id": "sha256:...",
+  "model": "anthropic/claude-sonnet-4.6",
+  "provider": "openrouter",
+  "source": "cli",
+  "status": "completed",
+  "exit_reason": "text_response",
+  "api_call_count": 2,
+  "started_at_ms": 1770000000000,
+  "ended_at_ms": 1770000001234,
+  "duration_ms": 1234,
+  "tool_calls": [
+    {
+      "name": "read_file",
+      "tool_call_id": "sha256:...",
+      "status": "requested",
+      "duration_ms": null,
+      "error_type": "",
+      "error_message": ""
+    }
+  ]
+}
+```
+
+## Privacy boundary
+
+Run traces must not store:
+
+- raw user prompts;
+- raw system prompts;
+- raw assistant text;
+- raw tool arguments;
+- raw tool outputs;
+- full message history;
+- credentials or secret values.
+
+Only metadata is persisted. Metadata strings are still passed through forced
+secret redaction before writing. All run, session, turn, task, and tool-call
+identifiers are stored as short SHA-256 fingerprints instead of raw text. This
+keeps generated IDs correlatable while preventing slug-shaped caller text from
+bypassing the metadata-only boundary.
+
+`exit_reason` and per-tool `error_message` are controlled codes, not raw
+exception strings. This avoids persisting exception text that might contain
+prompts, tool arguments, tool outputs, URLs, or other non-credential private
+data.
+
+## Relationship to trajectories
+
+Trajectories are detailed debugging artifacts and may include the content needed
+to reconstruct model/tool interactions. Run traces are not a replacement for
+trajectories. They are a low-risk observability surface for aggregate review and
+future eval tooling.
+
+Use trajectories when you need full execution detail and have an appropriate
+privacy boundary. Use run traces when you only need run shape, status, timing,
+model/provider, and tool names.
+
+## Failure behavior
+
+Trace persistence is best-effort. Writer errors are logged at debug level and
+return `False` internally; they do not fail the agent turn.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -764,6 +764,7 @@ const sidebars: SidebarsConfig = {
             'developer-guide/browser-supervisor',
             'developer-guide/acp-internals',
             'developer-guide/cron-internals',
+            'developer-guide/run-trace',
             'developer-guide/trajectory-format',
           ],
         },


### PR DESCRIPTION
# PR: Add opt-in metadata-only run traces for agent turns

## Summary

- Adds `agent/run_trace.py`, a metadata-only JSONL run trace writer for Hermes agent turns.
- Adds a minimal observe-only hook in `agent/conversation_loop.py` to start/finalize traces after turn finalization and record requested tool names/IDs.
- Adds default-disabled config under `observability.run_trace_enabled` and `observability.run_trace_path`.
- Adds unit/integration tests and developer documentation.

## Privacy / safety boundary

Run traces intentionally do **not** persist:

- raw user prompts;
- raw system prompts;
- raw assistant text;
- raw tool arguments;
- raw tool output;
- full message history;
- credential/secret values.

Persisted metadata strings are bounded and passed through forced secret redaction. Caller-supplied identifiers that look like free text are stored as short SHA-256 fingerprints. `exit_reason` and per-tool `error_message` are controlled codes, not raw exception text. Trace writes are best-effort/fail-open and must not fail the agent turn.

## Test plan

```bash
uv run --extra dev python -m pytest tests/agent/test_run_trace.py tests/agent/test_run_trace_integration.py -q
# 14 passed

uv run --extra dev python -m pytest tests/run_agent/test_run_agent.py::TestRunConversation -q
# 44 passed

uv run --extra dev ruff check agent/run_trace.py agent/conversation_loop.py hermes_cli/config.py tests/agent/test_run_trace.py tests/agent/test_run_trace_integration.py
# All checks passed

git diff --check
# pass

cd website && node TypeScript transpileModule(sidebars.ts)
# sidebars.ts transpile ok
```

## Notes / limitations

- This is the first substrate PR only. It deliberately does not add approval objects, policy enforcement, PRR mode, role templates, MCP risk registry, slash commands, or UI.
- The `codex_app_server` runtime path bypasses this first trace substrate and intentionally does not start a trace yet.
- Full website typecheck is currently blocked by pre-existing TypeScript project issues unrelated to this docs/sidebar change.
