### PR TITLE
Fix gateway 429 provider error classification

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -355,11 +355,6 @@ def _redact_approval_command(cmd: "str | None") -> str:
 
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
-    if _GATEWAY_AUTH_ERROR_RE.search(text):
-        return (
-            "⚠️ Provider authentication failed. Check the configured credentials; "
-            "raw provider details are in the gateway logs."
-        )
     if _GATEWAY_PROVIDER_POLICY_RE.search(text):
         return (
             "⚠️ The model provider rejected the request. I kept the raw provider "
@@ -367,6 +362,11 @@ def _gateway_provider_error_reply(text: str) -> str:
         )
     if _GATEWAY_RATE_LIMIT_RE.search(text):
         return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    if _GATEWAY_AUTH_ERROR_RE.search(text):
+        return (
+            "⚠️ Provider authentication failed. Check the configured credentials; "
+            "raw provider details are in the gateway logs."
+        )
     return (
         "⚠️ The model provider failed after retries. I kept raw provider details "
         "out of chat; check gateway logs for diagnostics."

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -707,11 +707,6 @@ def _format_exec_approval_fallback(
 
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
-    if _GATEWAY_AUTH_ERROR_RE.search(text):
-        return (
-            "⚠️ Provider authentication failed. Check the configured credentials; "
-            "raw provider details are in the gateway logs."
-        )
     if _GATEWAY_PROVIDER_POLICY_RE.search(text):
         return (
             "⚠️ The model provider rejected the request. I kept the raw provider "
@@ -719,6 +714,11 @@ def _gateway_provider_error_reply(text: str) -> str:
         )
     if _GATEWAY_RATE_LIMIT_RE.search(text):
         return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    if _GATEWAY_AUTH_ERROR_RE.search(text):
+        return (
+            "⚠️ Provider authentication failed. Check the configured credentials; "
+            "raw provider details are in the gateway logs."
+        )
     if _GATEWAY_CONNECTION_ERROR_RE.search(text):
         return (
             "⚠️ The model server is not responding — it looks like the configured "

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -198,6 +198,35 @@ def test_telegram_final_response_redacts_auth_secrets():
     assert "sk-live" not in sanitized
 
 
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_prefer_rate_limit_over_auth_wrapper(platform):
+    """A provider auth wrapper can carry the real 429/rate-limit cause (#60846)."""
+    raw = (
+        "⚠️ Provider authentication failed: API call failed after 3 retries: "
+        "HTTP 429 Rate limit reached for requests."
+    )
+
+    sanitized = _sanitize_gateway_final_response(platform, raw)
+
+    assert "rate-limiting" in sanitized.lower()
+    assert "authentication failed" not in sanitized.lower()
+    assert "check the configured credentials" not in sanitized.lower()
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_keep_policy_precedence_over_http_429(platform):
+    raw = (
+        "API call failed after 3 retries: HTTP 429: request blocked under "
+        "the provider security policy."
+    )
+
+    sanitized = _sanitize_gateway_final_response(platform, raw)
+
+    assert "provider rejected" in sanitized.lower()
+    assert "rate-limiting" not in sanitized.lower()
+    assert "security policy" not in sanitized.lower()
+
+
 def test_telegram_final_response_keeps_normal_answers():
     """Normal assistant content should not be rewritten."""
     answer = "Here is the clean summary you asked for."

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -300,6 +300,35 @@ def test_telegram_final_response_redacts_auth_secrets():
     assert "sk-live" not in sanitized
 
 
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_prefer_rate_limit_over_auth_wrapper(platform):
+    """A provider auth wrapper can carry the real 429/rate-limit cause (#60846)."""
+    raw = (
+        "⚠️ Provider authentication failed: API call failed after 3 retries: "
+        "HTTP 429 Rate limit reached for requests."
+    )
+
+    sanitized = _sanitize_gateway_final_response(platform, raw)
+
+    assert "rate-limiting" in sanitized.lower()
+    assert "authentication failed" not in sanitized.lower()
+    assert "check the configured credentials" not in sanitized.lower()
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_keep_policy_precedence_over_http_429(platform):
+    raw = (
+        "API call failed after 3 retries: HTTP 429: request blocked under "
+        "the provider security policy."
+    )
+
+    sanitized = _sanitize_gateway_final_response(platform, raw)
+
+    assert "provider rejected" in sanitized.lower()
+    assert "rate-limiting" not in sanitized.lower()
+    assert "security policy" not in sanitized.lower()
+
+
 def test_telegram_final_response_keeps_normal_answers():
     """Normal assistant content should not be rewritten."""
     answer = "Here is the clean summary you asked for."


### PR DESCRIPTION
Fixes #60846.

## Summary
- classify 429/rate-limit provider errors before generic auth wrappers
- add chat-gateway regression coverage for auth-wrapper text that contains HTTP 429 details

## Tests
- python -m py_compile gateway/run.py tests/gateway/test_telegram_noise_filter.py
- uv run --extra dev pytest tests/gateway/test_telegram_noise_filter.py -q
- git diff --check origin/main..HEAD
- gitleaks git --log-opts='origin/main..HEAD' --redact .