### PR TITLE
fix(cron): close SQLite session store on wake-gate skip paths

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2720,72 +2720,12 @@ def run_job(
     # ---------------------------------------------------------------
     from run_agent import AIAgent
 
-    # Initialize SQLite session store so cron job messages are persisted
-    # and discoverable via session_search (same pattern as gateway/run.py).
-    #
-    # Bounded with its own timeout (separate from HERMES_CRON_TIMEOUT, which
-    # only watches the agent's run_conversation below): SessionDB.__init__
-    # opens/migrates state.db synchronously and has no timeout of its own
-    # against a wedged sqlite3.connect (e.g. a stale flock left by a crashed
-    # sibling process). An unbounded hang here is invisible to every other
-    # cron safeguard, because it happens BEFORE _submit_with_guard's future
-    # exists — the finally block that releases the job from
-    # _running_job_ids never runs, so the job stays wedged "running" until
-    # the whole gateway process is restarted, silently skipping every
-    # scheduled fire in between with "already running — skipping".
+    # The SQLite session store is constructed later, inside the try/finally
+    # below, so its connection is always closed. Constructing it here leaked an
+    # open connection on every wake-gate/skip early return (fd exhaustion ->
+    # EMFILE, the same failure mode as #10200), because those returns fire
+    # before the finally that closes it.
     _session_db = None
-    try:
-        from hermes_state import SessionDB
-
-        # Resolve timeout: env override → config.yaml → default 10s.
-        # Mirrors the script_timeout_seconds resolution pattern.
-        _session_db_timeout: float | None = None
-        _raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
-        if _raw_env_timeout:
-            try:
-                _session_db_timeout = float(_raw_env_timeout)
-            except (ValueError, TypeError):
-                logger.warning(
-                    "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
-                    _raw_env_timeout,
-                )
-        if _session_db_timeout is None:
-            try:
-                from hermes_cli.config import load_config
-                _cfg = load_config() or {}
-                _cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
-                _configured = _cron_cfg.get("session_db_timeout_seconds")
-                if _configured is not None:
-                    _session_db_timeout = float(_configured)
-            except Exception as exc:
-                logger.debug(
-                    "Failed to load cron.session_db_timeout_seconds from config: %s",
-                    exc,
-                )
-        if _session_db_timeout is None:
-            _session_db_timeout = 10.0
-
-        if _session_db_timeout > 0:
-            _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            try:
-                _session_db = _session_db_pool.submit(SessionDB).result(timeout=_session_db_timeout)
-            finally:
-                # Don't wait for a wedged connect() to unwind — abandon the
-                # worker thread (same pattern as the agent inactivity timeout
-                # further down) rather than blocking shutdown on it too.
-                _session_db_pool.shutdown(wait=False)
-        else:
-            # 0 = unlimited (legacy behavior, opt-in for debugging)
-            _session_db = SessionDB()
-    except concurrent.futures.TimeoutError:
-        logger.error(
-            "Job '%s': SessionDB init did not return within %.0fs — proceeding "
-            "without a session store for this run instead of blocking it "
-            "forever",
-            job.get("id", "?"), _session_db_timeout,
-        )
-    except Exception as e:
-        logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
 
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
@@ -2932,6 +2872,74 @@ def run_job(
     # (every future job blocks on acquire_*); a leaked reader blocks all
     # future writers.  Acquire itself can't leak (it either blocks or returns).
     try:
+        # Initialize SQLite session store so cron job messages are persisted
+        # and discoverable via session_search (same pattern as gateway/run.py).
+        # Constructed here, inside the try, so the finally below always closes
+        # it and no early return above can leak the connection.
+        #
+        # Bounded with its own timeout (separate from HERMES_CRON_TIMEOUT, which
+        # only watches the agent's run_conversation below): SessionDB.__init__
+        # opens/migrates state.db synchronously and has no timeout of its own
+        # against a wedged sqlite3.connect (e.g. a stale flock left by a crashed
+        # sibling process). Now that construction lives inside this try/finally,
+        # an unbounded hang here still holds _terminal_cwd_lock until the
+        # process is restarted — bound it the same way _run_job_script_with_
+        # claim_heartbeat bounds script execution.
+        try:
+            from hermes_state import SessionDB
+
+            # Resolve timeout: env override → config.yaml → default 10s.
+            # Mirrors the script_timeout_seconds resolution pattern.
+            _session_db_timeout: float | None = None
+            _raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
+            if _raw_env_timeout:
+                try:
+                    _session_db_timeout = float(_raw_env_timeout)
+                except (ValueError, TypeError):
+                    logger.warning(
+                        "Invalid HERMES_CRON_SESSION_DB_TIMEOUT=%r; using config/default",
+                        _raw_env_timeout,
+                    )
+            if _session_db_timeout is None:
+                try:
+                    from hermes_cli.config import load_config
+                    _cfg = load_config() or {}
+                    _cron_cfg = _cfg.get("cron", {}) if isinstance(_cfg, dict) else {}
+                    _configured = _cron_cfg.get("session_db_timeout_seconds")
+                    if _configured is not None:
+                        _session_db_timeout = float(_configured)
+                except Exception as exc:
+                    logger.debug(
+                        "Failed to load cron.session_db_timeout_seconds from config: %s",
+                        exc,
+                    )
+            if _session_db_timeout is None:
+                _session_db_timeout = 10.0
+
+            if _session_db_timeout > 0:
+                _session_db_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+                try:
+                    _session_db = _session_db_pool.submit(SessionDB).result(timeout=_session_db_timeout)
+                finally:
+                    # Don't wait for a wedged connect() to unwind — abandon the
+                    # worker thread (same pattern as the agent inactivity timeout
+                    # further down) rather than blocking shutdown on it too.
+                    _session_db_pool.shutdown(wait=False)
+            else:
+                # 0 = unlimited (legacy behavior, opt-in for debugging)
+                _session_db = SessionDB()
+        except concurrent.futures.TimeoutError:
+            logger.error(
+                "Job '%s': SessionDB init did not return within %.0fs — proceeding "
+                "without a session store for this run instead of blocking it "
+                "forever",
+                job.get("id", "?"), _session_db_timeout,
+            )
+        except Exception as e:
+            logger.debug(
+                "Job '%s': SQLite session store not available: %s", job.get("id", "?"), e
+            )
+
         if _job_workdir:
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -4982,3 +4982,47 @@ class TestSetCronSessionTitle:
         from cron.scheduler import _set_cron_session_title
         assert _set_cron_session_title(None, "sess-1", "X") is None
         assert _set_cron_session_title(MagicMock(), "", "X") is None
+
+
+class TestRunJobDoesNotLeakSessionDb:
+    """A wake-gated cron tick that skips the agent must not leak a SQLite connection.
+
+    Regression: the SQLite session store used to be constructed before the
+    wake-gate/skip early returns, so every ``wakeAgent=false`` tick leaked an
+    open connection (fd exhaustion -> EMFILE on a gateway that ticks cron
+    frequently).
+    """
+
+    def test_wake_gate_false_does_not_leak_session_db(self):
+        import hermes_state
+
+        created = []
+
+        class _TrackingSessionDB:
+            def __init__(self, *args, **kwargs):
+                self.closed = False
+                created.append(self)
+
+            def close(self):
+                self.closed = True
+
+        job = {
+            "id": "wake_gate_job",
+            "name": "wake-gated job",
+            "prompt": "do something",
+            "script": "/tmp/does-not-run.sh",
+        }
+
+        with patch(
+            "cron.scheduler._run_job_script", return_value=(True, '{"wakeAgent": false}')
+        ), patch.object(hermes_state, "SessionDB", _TrackingSessionDB):
+            success, _doc, final, _err = run_job(job)
+
+        # The tick short-circuited: the agent was skipped.
+        assert success is True
+        assert final == SILENT_MARKER
+        # No SQLite connection may be left open. On the buggy code the store was
+        # constructed before the wake-gate return and its close() never ran.
+        assert all(
+            db.closed for db in created
+        ), "run_job leaked an unclosed SessionDB connection on the wake-gate skip path"


### PR DESCRIPTION
## What does this PR do?

Fixes a file-descriptor leak in the cron scheduler. `run_job()` constructed the SQLite session store (`SessionDB`, whose `__init__` eagerly opens `sqlite3.connect(...)`) **before** the wake-gate and prompt short-circuits. The only `close()` lives in the `finally` of the main `try:` further down, but three early returns fire before that try:

- `wakeAgent=false` gate → `return True, silent_doc, SILENT_MARKER, None`
- prompt-injection block → `return False, blocked_doc, "", str(block_exc)`
- empty script output → `return True, "", SILENT_MARKER, None`

(plus a non-`CronPromptInjectionBlocked` exception from `_build_job_prompt` propagating out). Each exits with the connection open and never closed. On a gateway that ticks cron frequently, a wake-gated job leaks ~1 fd per tick until `EMFILE` ("too many open files") — the same failure mode the teardown comment already calls out (#10200).

The store is only used on the agent path (it's passed to the agent and closed in the `finally`). Moving its construction **inside** that `try` block makes the existing `finally` always close it, and means the skip paths never open a connection at all — which also matches the stated intent of only paying `SessionDB` construction costs when the agent actually runs.

## Related Issue

Fixes #60859

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: move the `SessionDB` construction from before the wake-gate/skip early returns to inside the main `try:` block whose `finally` already closes it. Keep `_session_db = None` before the returns so the skip paths never open a connection.
- `tests/cron/test_scheduler.py`: add `TestRunJobDoesNotLeakSessionDb` — a `wakeAgent=false` tick must leave no unclosed `SessionDB`. It fails on `main` (connection opened then leaked) and passes with this change.

## How to Test

1. `scripts/run_tests.sh tests/cron` — 658 tests pass.
2. New regression test: `pytest tests/cron/test_scheduler.py::TestRunJobDoesNotLeakSessionDb -q`. Reverting the `scheduler.py` change makes it fail with "leaked an unclosed SessionDB connection".
3. `ruff check cron/scheduler.py tests/cron/test_scheduler.py` — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cron):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (ran `scripts/run_tests.sh tests/cron`; full suite green locally)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal bug fix)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure resource-lifetime fix, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
