### PR TITLE
fix(tui_gateway): back off notification poller when session is busy (#55578)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "contato@siteup.com.br": "SiteupAgencia",  # PR #57435 salvage (tui_gateway: back off notification poller when session is busy; #55578)
     "164521089+rainbowgits@users.noreply.github.com": "rainbowgore",  # PR #59405 salvage (mcp: bound stdio initialize handshake to stop subprocess/FD leak; #59349)
     "sage@Sages-Mac-mini.local": "thestudionorth",  # PR #60015 salvage (mcp: parent-death watchdog for stdio children; commit under unlinked local identity)
     "4087127+vampyren@users.noreply.github.com": "vampyren",  # PR #59830 salvage (kanban: grab-to-pan board scrolling; original commit under unlinked local identity)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8487,11 +8487,19 @@ def _notification_poller_loop(
             _emit("status.update", sid, {"kind": "process", "text": text})
             _emitted.add(_dedup_key)
 
+        _requeued = False
         with session["history_lock"]:
             if session.get("running"):
                 process_registry.completion_queue.put(evt)
-                continue
-            session["running"] = True
+                _requeued = True
+            else:
+                session["running"] = True
+        if _requeued:
+            # Back off before re-polling: the re-queued event keeps the queue
+            # non-empty, so without a sleep this loop spins at full speed
+            # (100% CPU, GIL churn) for as long as the session stays busy.
+            time.sleep(0.25)
+            continue
 
         rid = f"__notif__{int(time.time() * 1000)}"
         try:


### PR DESCRIPTION
## Summary
The TUI notification poller no longer hot-spins at 100% CPU while its session is busy — the busy-requeue path now sleeps 0.25s before re-polling.

Salvage of #57435 by @SiteupAgencia (Lucas Oliveira), cherry-picked with authorship preserved. The busy path re-queued the event and `continue`d immediately; since the re-queued event keeps the queue non-empty, the loop spun full-speed for the entire duration of any async-injected turn, churning the GIL and starving the asyncio loop. This is the leading suspect for the `session.resume`/`prompt.submit` timeouts reported in #55578 (symptom d). The contributor confirmed the spin in production with py-spy/strace.

First PR of the #55578 async-delegation session-split stack (routing fixes follow separately).

## Changes
- `tui_gateway/server.py` (@SiteupAgencia, cherry-picked): move the requeue decision under the lock, back off 0.25s outside it before re-polling. The foreign-event put-back path already had a sleep; this closes the busy path.
- `scripts/release.py`: AUTHOR_MAP entry.

## Validation
| | Before | After |
|---|---|---|
| poller loop while session busy | tight spin (put → get → put ...) | one wake per 0.25s |
| targeted tests | — | 595 passed (`tests/tui_gateway/` + server suite) |

Part of #55578.

## Infographic

![notif-poller-backoff](https://v3b.fal.media/files/b/0aa16b83/9gFYXSpQv5NtRk0MxBqta_Hf8f2QW4.png)
