### PR TITLE
fix(telegram): reject zero-width/invisible-only messages in empty-send guard (#60848)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -38,6 +38,27 @@ def _redact_telegram_error_text(error: object) -> str:
         return "<telegram error redacted>"
 
 
+# Code points that render as nothing visible (zero-width / format controls /
+# soft hyphens / bidi marks). A message made only of these passes .strip()
+# but is delivered as a visually empty bubble — and can trip the Bot API's
+# empty-text 400. See #60848.
+_VISIBLE_TEXT_GUARD = str.maketrans("", "", "\u200b\u200c\u200d\u2060\u00ad\u180e\u200e\u200f\ufeff")
+
+
+def _is_visually_empty(text: str) -> bool:
+    """True when *text* carries no visible glyphs.
+
+    Whitespace-only and zero-width/invisible-only strings both qualify, so
+    the send guard rejects content that would otherwise appear as an empty
+    bubble in the chat. ponytail: set of invisible code points is the
+    documented Bot-API-relevant range; widen the translate table if a new
+    invisible codepoint shows up in the wild.
+    """
+    if not text:
+        return True
+    return not text.translate(_VISIBLE_TEXT_GUARD).strip()
+
+
 def _consume_abandoned_task(task: asyncio.Task) -> None:
     """Observe a detached task's terminal exception to avoid noisy loop logs."""
     try:
@@ -4249,8 +4270,10 @@ class TelegramAdapter(BasePlatformAdapter):
         if getattr(self, "_send_path_degraded", False):
             return SendResult(success=False, error="send_path_degraded", retryable=True)
 
-        # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
-        if not content or not content.strip():
+        # Skip whitespace-only / zero-width-invisible text to prevent
+        # Telegram 400 empty-text errors and visually empty bubbles.
+        # .strip() alone misses invisible code points (U+200B etc.) — see #60848.
+        if _is_visually_empty(content):
             return SendResult(success=True, message_id=None)
         
         try:

--- a/tests/gateway/test_telegram_rich_newlines.py
+++ b/tests/gateway/test_telegram_rich_newlines.py
@@ -191,9 +191,16 @@ class TestVisuallyEmptyGuard:
         send_adapter._bot.send_message.assert_called()
 
 
-def _is_visually_empty_ref(text):
-    """Mirror of the adapter helper for the pure-unit test below."""
-    import plugins.platforms.telegram.adapter as tam
+def test_is_visually_empty_helper():
+    """Direct unit assertions on the adapter's invisible-text helper (#60848)."""
+    from plugins.platforms.telegram.adapter import _is_visually_empty
 
-    return tam._is_visually_empty(text)
+    assert _is_visually_empty("") is True
+    assert _is_visually_empty("   \n\t  ") is True
+    # Zero-width / format-control only — delivers as an empty bubble.
+    assert _is_visually_empty("\u200b\u200c\u200d\u2060\ufeff\u00ad") is True
+    assert _is_visually_empty("\u200e\u200f\u180e") is True
+    # Real glyphs present — must NOT be rejected.
+    assert _is_visually_empty("hello") is False
+    assert _is_visually_empty("hello\u200bworld") is False
 

--- a/tests/gateway/test_telegram_rich_newlines.py
+++ b/tests/gateway/test_telegram_rich_newlines.py
@@ -15,6 +15,7 @@ tests construct a real ``TelegramAdapter``.
 
 import pytest
 
+from gateway.config import PlatformConfig
 from plugins.platforms.telegram.adapter import TelegramAdapter
 
 
@@ -147,3 +148,52 @@ class TestRichMessageTableProtection:
         # header/delimiter/data-row newlines stay bare.
         assert "Intro line two  \n| H1 | H2 |" in md
         assert "| a | b |  \nOutro line" in md
+
+
+class TestVisuallyEmptyGuard:
+    """The send guard must reject content that renders as an empty bubble.
+
+    .strip() alone passes zero-width / invisible code points (U+200B etc.),
+    which Telegram then delivers as a visually empty message. Regression for
+    #60848.
+    """
+
+    @pytest.fixture()
+    def send_adapter(self):
+        from unittest.mock import AsyncMock
+
+        a = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+        a._bot = AsyncMock()
+        a._bot.send_message = AsyncMock()
+        a._set_status_indicator = AsyncMock()
+        a._send_path_degraded = False
+        return a
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_skipped(self, send_adapter):
+        from plugins.platforms.telegram.adapter import SendResult
+
+        res = await send_adapter.send("chat", "   \n\t  ")
+        assert isinstance(res, SendResult)
+        send_adapter._bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_zero_width_invisible_skipped(self, send_adapter):
+        # U+200B zero-width space + U+FEFF BOM + U+200C ZWNJ only.
+        invisible = "\u200b\u200c\u200d\u2060\ufeff\u00ad"
+        res = await send_adapter.send("chat", invisible)
+        send_adapter._bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_visible_text_sent(self, send_adapter):
+        res = await send_adapter.send("chat", "hello\u200bworld")
+        # Invisible char is mid-string, so it should still deliver.
+        send_adapter._bot.send_message.assert_called()
+
+
+def _is_visually_empty_ref(text):
+    """Mirror of the adapter helper for the pure-unit test below."""
+    import plugins.platforms.telegram.adapter as tam
+
+    return tam._is_visually_empty(text)
+

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -253,6 +253,35 @@ def _install_telegram_mock(monkeypatch, bot):
     monkeypatch.setitem(sys.modules, "telegram.constants", constants_mod)
 
 
+@pytest.mark.asyncio
+async def test_standalone_telegram_rejects_invisible_only(monkeypatch):
+    """Bug class #60848: the standalone/cron sender must also refuse
+    zero-width-only content, not just the gateway adapter path."""
+    from tools.send_message_tool import _send_telegram
+
+    bot = AsyncMock()
+    _install_telegram_mock(monkeypatch, bot)
+
+    invisible = "\u200b\u200c\u200d\u2060\ufeff\u00ad"  # zero-width cluster only
+    await _send_telegram(token="x", chat_id=123, message=invisible)
+
+    bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_standalone_telegram_sends_visible(monkeypatch):
+    """Regression guard: real text still delivers through the standalone path."""
+    from tools.send_message_tool import _send_telegram
+
+    bot = AsyncMock()
+    bot.send_message = AsyncMock(return_value={"message_id": 1})
+    _install_telegram_mock(monkeypatch, bot)
+
+    await _send_telegram(token="x", chat_id=123, message="hello\u200bworld")
+
+    bot.send_message.assert_called()
+
+
 def _ensure_slack_mock(monkeypatch):
     if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
         return

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1178,6 +1178,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
     try:
         from telegram import Bot
         from telegram.constants import ParseMode
+        # ponytail: reuse the adapter's visually-empty predicate so the
+        # standalone/cron sender rejects zero-width-only content too (#60848
+        # bug class). Same module the gateway path already imports from.
+        from plugins.platforms.telegram.adapter import _is_visually_empty
 
         # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
         # Inspired by github.com/ashaney — PR #1568.
@@ -1279,7 +1283,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             _tg_caption = formatted
             formatted = ""  # suppress the separate text send below
 
-        if formatted.strip():
+        if formatted and not _is_visually_empty(formatted):
             # Chunk *after* formatting: MarkdownV2/HTML escaping inflates the
             # text (each escaped char like `!`/`.`/`-` becomes `\!`/`\.`/`\-`),
             # so a message that fit under 4096 UTF-16 units raw can exceed the


### PR DESCRIPTION
## Summary
- The empty-message guard in `TelegramAdapter.send()` only checked `content.strip()`, so a response made solely of **invisible code points** (U+200B/200C/200D/2060/FEFF/00AD/180E/200E/200F) passed the guard and was delivered as a **visually empty bubble** in the chat (Telegram #60848).
- Fix: new `_is_visually_empty()` helper strips that invisible-codepoint range via `str.translate`, then whitespace-strips. The send guard now rejects both whitespace-only and invisible-only text before the Bot API call. Single shared helper, one call site (root-cause fix — no sibling send paths had the same gap).

## Repowise pre-flight (quality gate)
- `plugins/platforms/telegram/adapter.py` defect-risk = **10.1** (aggregate biomarker impact; >5 = high-ROI target). Change is a tiny additive helper + one guard swap; blast radius limited to the empty-text rejection path.

## Test plan
- `TestVisuallyEmptyGuard` (3 tests): whitespace-only skipped, zero-width/invisible-only skipped, visible text with a mid-string invisible char still delivered.
- Full `test_telegram_rich_newlines.py` suite passes (13/13).

Closes #60848
