### PR TITLE
fix: parse ISO timestamps in replay cleanup

### DIFF
--- a/agent/replay_cleanup.py
+++ b/agent/replay_cleanup.py
@@ -18,7 +18,8 @@ of the WebUI path silently skipping it.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List
+from datetime import datetime
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -191,6 +192,27 @@ def is_dangerous_confirmation(content: Any) -> bool:
     return any(pattern in text for pattern in _DANGEROUS_CONFIRMATION_PATTERNS)
 
 
+def _timestamp_to_epoch(value: Any) -> Optional[float]:
+    """Best-effort timestamp parser for replay-history timestamps."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    raw = value.strip()
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+
+    try:
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        return datetime.fromisoformat(raw).timestamp()
+    except ValueError:
+        return None
+
+
 def strip_stale_dangerous_confirmations(
     agent_history: List[Dict[str, Any]],
     *,
@@ -219,7 +241,7 @@ def strip_stale_dangerous_confirmations(
     text is replaced by a sentinel that tells the model the confirmation
     has expired.
 
-    Messages without a timestamp are left untouched (backward
+    Messages without a parseable timestamp are left untouched (backward
     compatibility: legacy transcripts and in-memory test scaffolding have
     no timestamps).  User messages that contain dangerous confirmation
     text but are within the expiry window are also left untouched — they
@@ -240,12 +262,12 @@ def strip_stale_dangerous_confirmations(
             and msg.get("role") == "user"
             and is_dangerous_confirmation(msg.get("content", ""))
         ):
-            ts = msg.get("timestamp")
-            if ts is not None and (now - float(ts)) > expiry_seconds:
+            ts_epoch = _timestamp_to_epoch(msg.get("timestamp"))
+            if ts_epoch is not None and (now - ts_epoch) > expiry_seconds:
                 logger.debug(
                     "Redacting stale dangerous-confirmation text in user "
                     "message (age=%.1fs, expiry=%.1fs): %r",
-                    now - float(ts),
+                    now - ts_epoch,
                     expiry_seconds,
                     (msg.get("content") or "")[:80],
                 )

--- a/tests/agent/test_replay_cleanup.py
+++ b/tests/agent/test_replay_cleanup.py
@@ -8,6 +8,8 @@ because the dangling tool-call tail was replayed on every resume).
 
 from agent.replay_cleanup import (
     is_interrupted_tool_result,
+    is_dangerous_confirmation,
+    strip_stale_dangerous_confirmations,
     strip_dangling_tool_call_tail,
     strip_interrupted_tool_tails,
     sanitize_replay_history,
@@ -16,6 +18,10 @@ from agent.replay_cleanup import (
 
 def _user(text):
     return {"role": "user", "content": text}
+
+
+def _user_at(text, timestamp):
+    return {"role": "user", "content": text, "timestamp": timestamp}
 
 
 def _assistant_tc(name):
@@ -38,6 +44,60 @@ def test_is_interrupted_tool_result_markers():
     assert not is_interrupted_tool_result("exit_code: 0\nclean output")
     assert not is_interrupted_tool_result("ordinary tool output")
     assert not is_interrupted_tool_result(None)
+
+
+def test_is_dangerous_confirmation_matches_known_high_risk_phrases():
+    assert is_dangerous_confirmation("confirm forced restart")
+    assert is_dangerous_confirmation("Please CONFIRM shutdown now.")
+    assert is_dangerous_confirmation("確認重啟")
+    assert not is_dangerous_confirmation("confirm")
+    assert not is_dangerous_confirmation("yes")
+    assert not is_dangerous_confirmation("ordinary follow-up")
+
+
+def test_strip_stale_dangerous_confirmations_redacts_old_confirmation_in_place():
+    history = [
+        _user("start"),
+        {"role": "assistant", "content": "ready"},
+        _user_at("confirm forced restart", 100.0),
+        {"role": "assistant", "content": "restarting"},
+    ]
+
+    out = strip_stale_dangerous_confirmations(history, now=500.0)
+
+    assert len(out) == len(history)
+    assert [msg["role"] for msg in out] == ["user", "assistant", "user", "assistant"]
+    assert out[2]["timestamp"] == 100.0
+    assert out[2]["content"] != "confirm forced restart"
+    assert "EXPIRED" in out[2]["content"]
+    assert "confirm forced restart" not in out[2]["content"]
+
+
+def test_strip_stale_dangerous_confirmations_redacts_iso_timestamp():
+    history = [_user_at("confirm forced restart", "1970-01-01T00:01:40+00:00")]
+
+    out = strip_stale_dangerous_confirmations(history, now=500.0)
+
+    assert out[0]["timestamp"] == "1970-01-01T00:01:40+00:00"
+    assert "EXPIRED" in out[0]["content"]
+
+
+def test_strip_stale_dangerous_confirmations_preserves_fresh_confirmation():
+    history = [_user_at("confirm forced restart", 100.0)]
+
+    assert strip_stale_dangerous_confirmations(history, now=150.0) == history
+
+
+def test_strip_stale_dangerous_confirmations_preserves_old_ordinary_text():
+    history = [_user_at("ordinary follow-up", 100.0)]
+
+    assert strip_stale_dangerous_confirmations(history, now=500.0) == history
+
+
+def test_strip_stale_dangerous_confirmations_preserves_untimestamped_messages():
+    history = [_user("confirm forced restart")]
+
+    assert strip_stale_dangerous_confirmations(history, now=500.0) == history
 
 
 def test_strip_dangling_tool_call_tail_removes_unanswered_tail():


### PR DESCRIPTION
## Summary
- Parse numeric and ISO-8601 replay-history timestamps before expiring stale dangerous confirmations.
- Preserve existing redaction-in-place behavior so stale confirmations do not break provider role alternation.
- Add regression coverage for known dangerous phrases, stale redaction, fresh/ordinary/untimestamped preservation, and ISO timestamp handling.

## Verification
- RED: `scripts/run_tests.sh tests/agent/test_replay_cleanup.py -v --tb=short` failed on ISO timestamp `ValueError` before the production fix.
- GREEN: `scripts/run_tests.sh tests/agent/test_replay_cleanup.py -v --tb=short` -> 15 passed.
- `venv/bin/python -m py_compile agent/replay_cleanup.py` -> ok.
- `git diff --check` / `git diff --cached --check` -> ok.
- Static scan of added lines -> 0 hits for secrets, shell injection, eval/exec, pickle, SQL formatting.
- Independent reviewer: passed; no security concerns or logic errors.

## Notes
- This branch intentionally leaves the existing stash entries untouched.