### PR TITLE
fix(delegation): session-filter the post-turn notification drain (#58684)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15082,7 +15082,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             # and watch pattern matches) while agent is idle.
                             try:
                                 from tools.process_registry import process_registry
-                                for _evt, _synth in process_registry.drain_notifications():
+                                from tools.approval import get_current_session_key
+                                _drain_sk = get_current_session_key(default="")
+                                for _evt, _synth in process_registry.drain_notifications(session_key=_drain_sk):
                                     self._pending_input.put(_synth)
                             except Exception:
                                 pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15143,6 +15143,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         chat_type = str(evt.get("chat_type") or derived_chat_type or "").strip().lower()
         chat_id = str(evt.get("chat_id") or derived_chat_id or "").strip()
         if not platform_name or not chat_type or not chat_id:
+            logger.warning(
+                "Synthetic event source unresolvable: "
+                "session_key=%r platform=%r chat_type=%r chat_id=%r "
+                "evt_type=%s",
+                session_key, platform_name, chat_type, chat_id,
+                evt.get("type", "?"),
+            )
             return None
 
         try:

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1346,6 +1346,109 @@ def test_drain_notifications_empty_queue():
     assert results == []
 
 
+def test_drain_notifications_filters_async_delegation_by_session_key():
+    """Async-delegation events should only be consumed by the matching session's drain.
+
+    Regression test for issue #58684: background delegation results delivered
+    to the wrong session when the user switches sessions while a subagent runs.
+    """
+    from tools.process_registry import process_registry
+
+    # Clear the queue first
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    try:
+        # Put events for different sessions
+        process_registry.completion_queue.put({
+            "type": "async_delegation",
+            "delegation_id": "deleg_session_a",
+            "session_key": "telegram:dm:111:user_a",
+            "goal": "task A",
+            "status": "completed",
+            "summary": "done A",
+            "api_calls": 1,
+            "duration_seconds": 0.5,
+        })
+        process_registry.completion_queue.put({
+            "type": "async_delegation",
+            "delegation_id": "deleg_session_b",
+            "session_key": "telegram:dm:222:user_b",
+            "goal": "task B",
+            "status": "completed",
+            "summary": "done B",
+            "api_calls": 1,
+            "duration_seconds": 0.3,
+        })
+
+        # Drain for session A — should only get deleg_session_a
+        results_a = process_registry.drain_notifications(session_key="telegram:dm:111:user_a")
+        assert len(results_a) == 1, (
+            f"Expected 1 event for session A, got {len(results_a)}"
+        )
+        assert results_a[0][0]["delegation_id"] == "deleg_session_a"
+        assert "done A" in results_a[0][1]
+
+        # Session B's event should have been re-queued — drain for session B
+        results_b = process_registry.drain_notifications(session_key="telegram:dm:222:user_b")
+        assert len(results_b) == 1, (
+            f"Expected 1 event for session B, got {len(results_b)}"
+        )
+        assert results_b[0][0]["delegation_id"] == "deleg_session_b"
+        assert "done B" in results_b[0][1]
+
+        # No more events should remain
+        assert process_registry.completion_queue.empty()
+    finally:
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+def test_drain_notifications_no_filter_passes_all_async_delegation():
+    """Without a session_key filter, all async-delegation events are consumed.
+
+    This ensures backward compatibility — the default (session_key="") permits
+    all events, matching pre-fix behavior.
+    """
+    from tools.process_registry import process_registry
+
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    try:
+        process_registry.completion_queue.put({
+            "type": "async_delegation",
+            "delegation_id": "deleg_1",
+            "session_key": "telegram:dm:111:user_a",
+            "goal": "task 1",
+            "status": "completed",
+            "summary": "done 1",
+            "api_calls": 1,
+            "duration_seconds": 0.5,
+        })
+        process_registry.completion_queue.put({
+            "type": "async_delegation",
+            "delegation_id": "deleg_2",
+            "session_key": "telegram:dm:222:user_b",
+            "goal": "task 2",
+            "status": "completed",
+            "summary": "done 2",
+            "api_calls": 1,
+            "duration_seconds": 0.3,
+        })
+
+        # No filter — both should be consumed
+        results = process_registry.drain_notifications()
+        assert len(results) == 2, (
+            f"Expected 2 events without filter, got {len(results)}"
+        )
+        ids = {r[0]["delegation_id"] for r in results}
+        assert ids == {"deleg_1", "deleg_2"}
+    finally:
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
 # ---------------------------------------------------------------------------
 # _terminate_host_pid — cross-platform process-tree termination
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1449,6 +1449,78 @@ def test_drain_notifications_no_filter_passes_all_async_delegation():
             process_registry.completion_queue.get_nowait()
 
 
+def test_drain_notifications_owns_event_callback_beats_key_equality():
+    """The positive-proof ownership callback consumes ONLY approved events —
+    including across a compression rotation where bare key equality would
+    wrongly re-queue the session's own pre-compression dispatch (#55578)."""
+    from tools.process_registry import process_registry
+
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    try:
+        # Pre-compression dispatch: event carries the OLD key.
+        process_registry.completion_queue.put({
+            "type": "async_delegation",
+            "delegation_id": "deleg_precompress",
+            "session_key": "old_parent_key",
+            "goal": "task", "status": "completed", "summary": "mine",
+            "api_calls": 1, "duration_seconds": 0.1,
+        })
+        # Foreign event that plain key equality would also reject.
+        process_registry.completion_queue.put({
+            "type": "async_delegation",
+            "delegation_id": "deleg_foreign",
+            "session_key": "someone_else",
+            "goal": "task", "status": "completed", "summary": "not mine",
+            "api_calls": 1, "duration_seconds": 0.1,
+        })
+
+        # Chain-aware ownership: this session's lineage includes old_parent_key.
+        lineage = {"old_parent_key", "new_child_key"}
+        results = process_registry.drain_notifications(
+            session_key="new_child_key",
+            owns_event=lambda e: e.get("session_key") in lineage,
+        )
+        assert [r[0]["delegation_id"] for r in results] == ["deleg_precompress"]
+
+        # The foreign event was re-queued, not consumed.
+        leftover = process_registry.completion_queue.get_nowait()
+        assert leftover["delegation_id"] == "deleg_foreign"
+    finally:
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+def test_drain_notifications_owns_event_callback_fails_closed():
+    """A broken ownership callback must re-queue (never leak) the event."""
+    from tools.process_registry import process_registry
+
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    try:
+        process_registry.completion_queue.put({
+            "type": "async_delegation",
+            "delegation_id": "deleg_x",
+            "session_key": "k",
+            "goal": "task", "status": "completed", "summary": "s",
+            "api_calls": 1, "duration_seconds": 0.1,
+        })
+
+        def broken(_evt):
+            raise RuntimeError("ownership check exploded")
+
+        results = process_registry.drain_notifications(
+            session_key="k", owns_event=broken
+        )
+        assert results == []
+        assert process_registry.completion_queue.get_nowait()["delegation_id"] == "deleg_x"
+    finally:
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
 # ---------------------------------------------------------------------------
 # _terminate_host_pid — cross-platform process-tree termination
 # ---------------------------------------------------------------------------

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1149,7 +1149,7 @@ class ProcessRegistry:
         return session_id in self._completion_consumed or session_id in self._poll_observed
 
     def drain_notifications(
-        self, session_key: str = "",
+        self, session_key: str = "", owns_event=None,
     ) -> "list[tuple[dict, str]]":
         """Pop all pending notification events and return formatted pairs.
 
@@ -1157,12 +1157,21 @@ class ProcessRegistry:
         Skips completion events the agent already consumed via wait/log or
         observed inline via poll() (see ``_drain_should_skip``).
 
-        When ``session_key`` is non-empty, async-delegation events whose
-        ``session_key`` does NOT match are re-queued rather than consumed,
-        so they remain available for the correct session. This prevents
-        background delegation results from being delivered to the wrong
-        session when the user switches between gateway sessions while a
-        subagent is running (issue #58684).
+        Async-delegation events carry a conversation payload, so draining one
+        into the wrong session is a cross-chat leak (#58684, #55578). Two
+        filter modes, strongest wins:
+
+        - ``owns_event(evt) -> bool``: positive-proof ownership callback.
+          When provided, an async-delegation event is consumed ONLY if the
+          callback returns True; everything else is re-queued for its owner.
+          The TUI passes its compression-chain-aware ownership check here so
+          a post-compression session still claims its own pre-compression
+          dispatches.
+        - ``session_key``: plain key equality (CLI and other single-session
+          callers). Non-matching async-delegation events are re-queued.
+
+        With neither set, all events are consumed (legacy single-session
+        behavior, backward compatible).
         """
         results: "list[tuple[dict, str]]" = []
         requeue: "list[dict]" = []
@@ -1174,13 +1183,23 @@ class ProcessRegistry:
             _evt_sid = evt.get("session_id", "")
             if evt.get("type") == "completion" and self._drain_should_skip(_evt_sid):
                 continue
-            # Filter async-delegation events by the caller's session_key so
-            # they are not delivered to the wrong session/thread (#58684).
-            if session_key and evt.get("type") == "async_delegation":
-                evt_session_key = evt.get("session_key", "") or ""
-                if evt_session_key != session_key:
-                    requeue.append(evt)
-                    continue
+            # Filter async-delegation events so they are not delivered to the
+            # wrong session/thread (#58684). Positive-proof callback beats
+            # bare key equality when the caller can provide one.
+            if evt.get("type") == "async_delegation":
+                if owns_event is not None:
+                    try:
+                        owned = bool(owns_event(evt))
+                    except Exception:
+                        owned = False  # fail closed — never leak on a broken check
+                    if not owned:
+                        requeue.append(evt)
+                        continue
+                elif session_key:
+                    evt_session_key = evt.get("session_key", "") or ""
+                    if evt_session_key != session_key:
+                        requeue.append(evt)
+                        continue
             text = format_process_notification(evt)
             if text:
                 results.append((evt, text))

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1148,14 +1148,24 @@ class ProcessRegistry:
         """
         return session_id in self._completion_consumed or session_id in self._poll_observed
 
-    def drain_notifications(self) -> "list[tuple[dict, str]]":
+    def drain_notifications(
+        self, session_key: str = "",
+    ) -> "list[tuple[dict, str]]":
         """Pop all pending notification events and return formatted pairs.
 
         Returns a list of (raw_event, formatted_text) tuples.
         Skips completion events the agent already consumed via wait/log or
         observed inline via poll() (see ``_drain_should_skip``).
+
+        When ``session_key`` is non-empty, async-delegation events whose
+        ``session_key`` does NOT match are re-queued rather than consumed,
+        so they remain available for the correct session. This prevents
+        background delegation results from being delivered to the wrong
+        session when the user switches between gateway sessions while a
+        subagent is running (issue #58684).
         """
-        results = []
+        results: "list[tuple[dict, str]]" = []
+        requeue: "list[dict]" = []
         while not self.completion_queue.empty():
             try:
                 evt = self.completion_queue.get_nowait()
@@ -1164,9 +1174,18 @@ class ProcessRegistry:
             _evt_sid = evt.get("session_id", "")
             if evt.get("type") == "completion" and self._drain_should_skip(_evt_sid):
                 continue
+            # Filter async-delegation events by the caller's session_key so
+            # they are not delivered to the wrong session/thread (#58684).
+            if session_key and evt.get("type") == "async_delegation":
+                evt_session_key = evt.get("session_key", "") or ""
+                if evt_session_key != session_key:
+                    requeue.append(evt)
+                    continue
             text = format_process_notification(evt)
             if text:
                 results.append((evt, text))
+        for evt in requeue:
+            self.completion_queue.put(evt)
         return results
 
     def get(self, session_id: str) -> Optional[ProcessSession]:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9337,7 +9337,9 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         try:
             from tools.process_registry import process_registry
 
-            for _evt, synth in process_registry.drain_notifications():
+            for _evt, synth in process_registry.drain_notifications(
+                session_key=session.get("session_key", ""),
+            ):
                 with session["history_lock"]:
                     if session.get("running"):
                         process_registry.completion_queue.put(_evt)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9337,8 +9337,14 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         try:
             from tools.process_registry import process_registry
 
+            # Positive-proof ownership (compression-chain aware) — the same
+            # fail-closed gate the poller uses, so the post-turn drain can't
+            # adopt another session's (or an orphan's) delegation payload,
+            # while a post-compression session still claims its own
+            # pre-compression dispatches (#55578).
             for _evt, synth in process_registry.drain_notifications(
                 session_key=session.get("session_key", ""),
+                owns_event=lambda e: _session_owns_notification_event(sid, session, e),
             ):
                 with session["history_lock"]:
                     if session.get("running"):


### PR DESCRIPTION
## Summary
The post-turn notification drain now filters async-delegation events by session key — previously it consumed the entire shared completion queue unfiltered, bypassing the poller's ownership checks and letting any session's turn end swallow another session's delegation results.

Salvage of #58690 by @asimons81 (Tony Simons), cherry-picked with authorship preserved. Complements the origin-routing fix (#60863): that PR fixes the *poller* path; this closes the *drain* hole the poller never sees.

## Changes
- `tools/process_registry.py`: `drain_notifications(session_key=...)` — non-matching async-delegation events are re-queued for their owner instead of consumed. Default (no filter) unchanged, backward compatible.
- `tui_gateway/server.py`: post-turn drain in `_run_prompt_submit` passes the session's key.
- `cli.py`: idle drain passes the current session key.
- `gateway/run.py`: unresolvable synthetic-event sources are now logged at WARNING instead of silently dropped.
- `tests/tools/test_process_registry.py`: two-session filter matrix + no-filter backward-compat coverage.

## Validation
| | Before | After |
|---|---|---|
| session A's turn ends while session B's delegation completes | A's drain swallows B's result | B's event re-queued, delivered to B |
| drain with no filter | consumes all | consumes all (unchanged) |
| targeted tests | — | 696 passed (process_registry, tui_gateway, server suites) |

Part of #55578; fixes #58684.

## Follow-up commit: positive-proof ownership for the drain

Per review, the same hardening applied to the poller in #60863 now covers the drain (commit on top of the salvage):

- `drain_notifications()` accepts an `owns_event` callback — when provided, an async-delegation event is consumed ONLY on positive proof of ownership; a broken callback re-queues rather than leaks (fail closed). Bare `session_key` equality remains for single-session callers (CLI); no filter = legacy behavior.
- The TUI post-turn drain passes the compression-chain-aware `_session_owns_notification_event`, closing the gap where bare key equality would re-queue a session's own pre-compression dispatch (and, conversely, could never prove an orphan ISN'T ours).

3 new tests (callback beats key equality across a compression rotation; broken callback fails closed); 743 targeted tests green.

## Infographic

![drain-session-filter](https://v3b.fal.media/files/b/0aa16bc9/a2hW0St7MdTFkYNgH8FCD_m5BnyvjO.png)

