### PR TITLE
fix(auth): persist Z.AI auto-detected endpoint to disk (#41201 salvage)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -708,7 +708,13 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
             "label": detected.get("label", ""),
             "key_hash": key_hash,
         }
-        _save_provider_state(auth_store, "zai", state)
+        with _auth_store_lock():
+            # Reload auth_store under lock to avoid overwriting concurrent changes
+            auth_store = _load_auth_store()
+            state_under_lock = _load_provider_state(auth_store, "zai") or {}
+            state_under_lock["detected_endpoint"] = state["detected_endpoint"]
+            _save_provider_state(auth_store, "zai", state_under_lock)
+            _save_auth_store(auth_store)
         logger.info("Z.AI: auto-detected endpoint %s (%s)", detected["label"], detected["base_url"])
         return detected["base_url"]
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -701,23 +701,29 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
     if detected and detected.get("base_url"):
         # Persist the detection result keyed on the API key hash.
         key_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
-        state["detected_endpoint"] = {
+        detected_endpoint = {
             "base_url": detected["base_url"],
             "endpoint_id": detected.get("id", ""),
             "model": detected.get("model", ""),
             "label": detected.get("label", ""),
             "key_hash": key_hash,
         }
-        with _auth_store_lock():
-            # Reload auth_store under lock to avoid overwriting concurrent changes
-            auth_store = _load_auth_store()
-            state_under_lock = _load_provider_state(auth_store, "zai") or {}
-            state_under_lock["detected_endpoint"] = state["detected_endpoint"]
-            # set_active=False: this runs from credential-pool env seeding
-            # (agent/credential_pool.py) for ANY user with a Z.AI key in env,
-            # and caching a probe result must not flip their active provider.
-            _store_provider_state(auth_store, "zai", state_under_lock, set_active=False)
-            _save_auth_store(auth_store)
+        # Persist failure (disk full, permissions, lock timeout) must not
+        # break resolution — detection already succeeded; worst case the
+        # next start re-probes.
+        try:
+            with _auth_store_lock():
+                # Reload auth_store under lock to avoid overwriting concurrent changes
+                auth_store = _load_auth_store()
+                state_under_lock = _load_provider_state(auth_store, "zai") or {}
+                state_under_lock["detected_endpoint"] = detected_endpoint
+                # set_active=False: this runs from credential-pool env seeding
+                # (agent/credential_pool.py) for ANY user with a Z.AI key in env,
+                # and caching a probe result must not flip their active provider.
+                _store_provider_state(auth_store, "zai", state_under_lock, set_active=False)
+                _save_auth_store(auth_store)
+        except Exception as exc:
+            logger.warning("Z.AI: could not persist detected endpoint (%s); will re-probe next start", exc)
         logger.info("Z.AI: auto-detected endpoint %s (%s)", detected["label"], detected["base_url"])
         return detected["base_url"]
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -713,7 +713,10 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
             auth_store = _load_auth_store()
             state_under_lock = _load_provider_state(auth_store, "zai") or {}
             state_under_lock["detected_endpoint"] = state["detected_endpoint"]
-            _save_provider_state(auth_store, "zai", state_under_lock)
+            # set_active=False: this runs from credential-pool env seeding
+            # (agent/credential_pool.py) for ANY user with a Z.AI key in env,
+            # and caching a probe result must not flip their active provider.
+            _store_provider_state(auth_store, "zai", state_under_lock, set_active=False)
             _save_auth_store(auth_store)
         logger.info("Z.AI: auto-detected endpoint %s (%s)", detected["label"], detected["base_url"])
         return detected["base_url"]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -890,6 +890,7 @@ AUTHOR_MAP = {
     "kshitijk4poor@gmail.com": "kshitijk4poor",
     "1294707+Tosko4@users.noreply.github.com": "Tosko4",
     "keira.voss94@gmail.com": "keiravoss94",
+    "vadim.veroslavov@mail.ru": "veradim",  # PR #41201 salvage (Z.AI endpoint persist)
     "16443023+stablegenius49@users.noreply.github.com": "stablegenius49",
     "fqsy1416@gmail.com": "EKKOLearnAI",
     "octo-patch@github.com": "octo-patch",


### PR DESCRIPTION
## Summary
`hermes` startup with a Z.AI key no longer re-probes the four Z.AI endpoints on every process start — the auto-detected endpoint now actually persists to `auth.json` (multi-minute worst-case startups drop to <300ms after the first detection).

Root cause: `_resolve_zai_base_url()` called `_save_provider_state()`, which only mutates the in-memory dict — nothing ever called `_save_auth_store()`, so the "cached" detection was lost when the process exited and the sequential HTTPS probes re-fired on every startup.

Salvages #41201 by @veradim (cherry-picked, authorship preserved), stale-base refreshed onto current main.

## Changes
- `hermes_cli/auth.py`: persist the detected endpoint under `_auth_store_lock()` with a reload-under-lock so concurrent auth.json writers aren't clobbered (veradim's commit).
- `hermes_cli/auth.py` (follow-up): use `_store_provider_state(set_active=False)` — `_save_provider_state()` sets `active_provider` as a side effect, and this code path runs from credential-pool env seeding for any user with a Z.AI key in env; caching a probe result must not flip their active provider.
- `scripts/release.py`: AUTHOR_MAP entry for veradim (plain-email contributor).

## Validation
| | Before | After |
|---|---|---|
| 2nd process start w/ ZAI key | re-probes endpoints (up to ~8s each) | disk cache hit, no probe |
| `active_provider` after probe | flipped to `zai` (with the naive persist) | unchanged |

E2E (real imports, temp HERMES_HOME): persist-to-disk verified by module reload simulating a fresh process (probe stubbed to raise — not reached); key-rotation hash mismatch re-probes; `GLM_BASE_URL` override still wins; `active_provider` preserved. `tests/hermes_cli/test_api_key_providers.py`: 166 passed. ruff clean, ty 0 net-new vs base.

Supersedes #41201 — can be closed in favor of this.
