### PR TITLE
feat(slack): add CaitSith work item tracking helpers

### DIFF
--- a/agent/jarvis_notification_queue.py
+++ b/agent/jarvis_notification_queue.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+TERMINAL_STATUSES = {"sent", "failed", "dead_letter"}
+NON_TERMINAL_STATUSES = {"pending", "retry_wait"}
+ALLOWED_STATUSES = TERMINAL_STATUSES | NON_TERMINAL_STATUSES
+
+
+@contextmanager
+def _locked_file(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            handle.seek(0)
+            yield handle
+        finally:
+            handle.flush()
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _parse_jsonl_lines(lines: list[str]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def make_notification_id(now: datetime | None = None, seed: str = "") -> str:
+    dt = now or datetime.now(timezone.utc)
+    stamp = dt.strftime("%Y%m%d_%H%M%S")
+    digest = hashlib.sha256(f"{dt.isoformat()}:{seed}".encode("utf-8")).hexdigest()[:12]
+    return f"jn_{stamp}_{digest}"
+
+
+def load_notifications(path: Path) -> list[dict[str, Any]]:
+    try:
+        return _parse_jsonl_lines(path.read_text(encoding="utf-8").splitlines())
+    except FileNotFoundError:
+        return []
+
+
+def latest_notifications(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_key: dict[str, dict[str, Any]] = {}
+    for item in items:
+        key = item.get("handoff_id") or item.get("notification_id")
+        if isinstance(key, str) and key:
+            by_key[key] = item
+    return list(by_key.values())
+
+
+def append_notification(path: Path, notification: dict[str, Any]) -> dict[str, Any]:
+    record = dict(notification)
+    if record.get("status") not in ALLOWED_STATUSES:
+        raise ValueError(f"invalid notification status: {record.get('status')}")
+    with _locked_file(path) as handle:
+        handle.seek(0, 2)
+        handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+    return record
+
+
+def mark_notification(path: Path, notification_id: str, status: str, **fields: Any) -> dict[str, Any]:
+    if status not in ALLOWED_STATUSES:
+        raise ValueError(f"invalid notification status: {status}")
+    current = None
+    for item in reversed(load_notifications(path)):
+        if item.get("notification_id") == notification_id:
+            current = item
+            break
+    if current is None:
+        raise KeyError(notification_id)
+    marked = dict(current)
+    marked.update(fields)
+    marked["status"] = status
+    marked["updated_at"] = datetime.now(timezone.utc).isoformat()
+    return append_notification(path, marked)
+
+
+def pending_notifications(path: Path) -> list[dict[str, Any]]:
+    return [item for item in latest_notifications(load_notifications(path)) if item.get("status") == "pending"]

--- a/agent/slack_work_items.py
+++ b/agent/slack_work_items.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import parse_qs, unquote, urlparse
+
+SourceType = Literal["thread", "canvas", "list", "file", "unknown"]
+
+_SLACK_LINK_RE = re.compile(r"<(?P<url>https?://[^>|]+)(?:\|[^>]+)?>")
+_ARCHIVE_RE = re.compile(r"/archives/(?P<channel>[A-Z0-9]+)/p(?P<pstamp>\d{16})")
+_FILE_ID_RE = re.compile(r"\bF[A-Z0-9]{8,}\b")
+
+
+@dataclass(frozen=True)
+class SlackSourceRef:
+    source_type: SourceType
+    permalink: str
+    channel_id: str | None
+    message_ts: str | None
+    thread_ts: str | None
+    file_id: str | None
+
+
+def _clean_link(text: str) -> str:
+    raw = str(text or "").strip()
+    match = _SLACK_LINK_RE.search(raw)
+    if match:
+        return unquote(match.group("url").replace("&amp;", "&"))
+    return unquote(raw.replace("&amp;", "&"))
+
+
+def _pstamp_to_ts(pstamp: str) -> str:
+    return f"{pstamp[:10]}.{pstamp[10:]}"
+
+
+def parse_slack_source_ref(text: str) -> SlackSourceRef | None:
+    link = _clean_link(text)
+    file_match = _FILE_ID_RE.search(link)
+    archive_match = _ARCHIVE_RE.search(link)
+
+    if archive_match:
+        parsed = urlparse(link)
+        query = parse_qs(parsed.query)
+        channel_id = archive_match.group("channel")
+        message_ts = _pstamp_to_ts(archive_match.group("pstamp"))
+        thread_ts = (query.get("thread_ts") or [message_ts])[0]
+        return SlackSourceRef(
+            source_type="thread",
+            permalink=link,
+            channel_id=channel_id,
+            message_ts=message_ts,
+            thread_ts=thread_ts,
+            file_id=file_match.group(0) if file_match else None,
+        )
+
+    if file_match:
+        return SlackSourceRef(
+            source_type="file",
+            permalink=link if link.startswith("http") else "",
+            channel_id=None,
+            message_ts=None,
+            thread_ts=None,
+            file_id=file_match.group(0),
+        )
+
+    return None
+
+
+def make_work_id(now: datetime | None = None, seed: str = "") -> str:
+    dt = now or datetime.now(timezone.utc)
+    stamp = dt.strftime("%Y%m%d_%H%M%S")
+    digest = hashlib.sha256(f"{dt.isoformat()}:{seed}".encode("utf-8")).hexdigest()[:12]
+    return f"sw_{stamp}_{digest}"
+
+
+@contextmanager
+def _locked_file(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            handle.seek(0)
+            yield handle
+        finally:
+            handle.flush()
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _parse_jsonl_lines(lines: list[str]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            items.append(item)
+    return items
+
+
+def load_work_items(path: Path) -> list[dict[str, Any]]:
+    try:
+        return _parse_jsonl_lines(path.read_text(encoding="utf-8").splitlines())
+    except FileNotFoundError:
+        return []
+
+
+def latest_work_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_id: dict[str, dict[str, Any]] = {}
+    for item in items:
+        work_id = item.get("work_id")
+        if isinstance(work_id, str) and work_id:
+            by_id[work_id] = item
+    return list(by_id.values())
+
+
+def append_work_item(path: Path, item: dict[str, Any]) -> dict[str, Any]:
+    record = dict(item)
+    with _locked_file(path) as handle:
+        handle.seek(0, 2)
+        handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+    return record
+
+
+def find_work_item(items: list[dict[str, Any]], ref: SlackSourceRef) -> dict[str, Any] | None:
+    for item in reversed(latest_work_items(items)):
+        if ref.file_id and item.get("file_id") == ref.file_id:
+            return item
+        if ref.channel_id and ref.thread_ts:
+            if item.get("channel_id") == ref.channel_id and item.get("thread_ts") == ref.thread_ts:
+                return item
+        if ref.permalink and item.get("source_permalink") == ref.permalink:
+            return item
+    return None
+
+
+def update_work_item(path: Path, work_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+    current = None
+    for item in reversed(latest_work_items(load_work_items(path))):
+        if item.get("work_id") == work_id:
+            current = item
+            break
+    if current is None:
+        raise KeyError(work_id)
+    merged = dict(current)
+    merged.update(updates)
+    return append_work_item(path, merged)

--- a/agent/slack_work_items.py
+++ b/agent/slack_work_items.py
@@ -44,6 +44,16 @@ def _pstamp_to_ts(pstamp: str) -> str:
     return f"{pstamp[:10]}.{pstamp[10:]}"
 
 
+def _classify_file_link_source_type(link: str) -> SourceType:
+    parsed = urlparse(link if link.startswith("http") else "")
+    path = parsed.path.lower()
+    if "/lists/" in path or "/list/" in path:
+        return "list"
+    if "/docs/" in path or "/canvas/" in path or "/canvases/" in path:
+        return "canvas"
+    return "file"
+
+
 def parse_slack_source_ref(text: str) -> SlackSourceRef | None:
     link = _clean_link(text)
     file_match = _FILE_ID_RE.search(link)
@@ -66,7 +76,7 @@ def parse_slack_source_ref(text: str) -> SlackSourceRef | None:
 
     if file_match:
         return SlackSourceRef(
-            source_type="file",
+            source_type=_classify_file_link_source_type(link),
             permalink=link if link.startswith("http") else "",
             channel_id=None,
             message_ts=None,

--- a/agent/slack_work_items.py
+++ b/agent/slack_work_items.py
@@ -14,6 +14,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 SourceType = Literal["thread", "canvas", "list", "file", "unknown"]
 
 _SLACK_LINK_RE = re.compile(r"<(?P<url>https?://[^>|]+)(?:\|[^>]+)?>")
+_URL_RE = re.compile(r"https?://\S+")
 _ARCHIVE_RE = re.compile(r"/archives/(?P<channel>[A-Z0-9]+)/p(?P<pstamp>\d{16})")
 _FILE_ID_RE = re.compile(r"\bF[A-Z0-9]{8,}\b")
 
@@ -33,6 +34,9 @@ def _clean_link(text: str) -> str:
     match = _SLACK_LINK_RE.search(raw)
     if match:
         return unquote(match.group("url").replace("&amp;", "&"))
+    url_match = _URL_RE.search(raw)
+    if url_match:
+        return unquote(url_match.group(0).rstrip(">).,]").replace("&amp;", "&"))
     return unquote(raw.replace("&amp;", "&"))
 
 

--- a/scripts/jarvis_handoff_notification_check.py
+++ b/scripts/jarvis_handoff_notification_check.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from agent.jarvis_notification_queue import mark_notification, pending_notifications
+
+DEFAULT_QUEUE = Path.home() / ".hermes" / "handoffs" / "jarvis" / "notifications.jsonl"
+
+
+def _send_discord(message: str, target: str, timeout: int) -> tuple[bool, str]:
+    try:
+        proc = subprocess.run(
+            ["hermes", "send", "--to", target, message],
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except Exception as exc:
+        return False, exc.__class__.__name__
+    detail = (proc.stdout or proc.stderr or "").strip()[:500]
+    return proc.returncode == 0, detail
+
+
+def process_queue(*, queue: Path, target: str, dry_run: bool, timeout: int) -> int:
+    processed = 0
+    for item in pending_notifications(queue):
+        notification_id = str(item.get("notification_id") or "")
+        message = str(item.get("message") or "").strip()
+        if not notification_id:
+            continue
+        if not message:
+            mark_notification(queue, notification_id, "failed", delivery_result="empty message")
+            processed += 1
+            continue
+        if dry_run:
+            mark_notification(queue, notification_id, "sent", delivery_result=f"dry-run:{target}")
+            processed += 1
+            continue
+        ok, detail = _send_discord(message, target, timeout)
+        mark_notification(queue, notification_id, "sent" if ok else "failed", delivery_result=detail)
+        processed += 1
+    return processed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Send pending Jarvis handoff notifications via the default profile.")
+    parser.add_argument("--queue", default=os.getenv("JARVIS_NOTIFICATION_QUEUE", str(DEFAULT_QUEUE)))
+    parser.add_argument("--target", default=os.getenv("JARVIS_NOTIFICATION_TARGET", "discord"))
+    parser.add_argument("--timeout", type=int, default=int(os.getenv("JARVIS_NOTIFICATION_SEND_TIMEOUT", "60")))
+    parser.add_argument("--dry-run", action="store_true", default=os.getenv("JARVIS_NOTIFICATION_DRY_RUN", "") == "1")
+    args = parser.parse_args()
+    processed = process_queue(queue=Path(args.queue), target=args.target, dry_run=args.dry_run, timeout=args.timeout)
+    print(f"processed={processed} queue={args.queue} target={args.target} dry_run={args.dry_run}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_jarvis_notification_queue.py
+++ b/tests/agent/test_jarvis_notification_queue.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timezone
+
+from agent.jarvis_notification_queue import (
+    append_notification,
+    latest_notifications,
+    load_notifications,
+    make_notification_id,
+    mark_notification,
+    pending_notifications,
+)
+
+
+def test_notification_queue_append_and_mark(tmp_path):
+    path = tmp_path / "notifications.jsonl"
+    appended = append_notification(
+        path,
+        {
+            "notification_id": "jn_test",
+            "handoff_id": "handoff-test",
+            "source_profile": "caitsith",
+            "target_profile": "default",
+            "target_platform": "discord",
+            "status": "pending",
+            "message": "Jarvis 알림: 등록했습니다.",
+            "created_at": "2026-07-08T00:00:00+00:00",
+        },
+    )
+    assert appended["status"] == "pending"
+    assert load_notifications(path)[0]["notification_id"] == "jn_test"
+
+    marked = mark_notification(path, "jn_test", "sent", delivery_result="discord:ok")
+
+    records = load_notifications(path)
+    assert len(records) == 2
+    assert marked["status"] == "sent"
+    assert marked["delivery_result"] == "discord:ok"
+    assert pending_notifications(path) == []
+
+
+def test_latest_notifications_are_last_wins_by_handoff_id(tmp_path):
+    path = tmp_path / "notifications.jsonl"
+    append_notification(
+        path,
+        {
+            "notification_id": "jn_old",
+            "handoff_id": "handoff-same",
+            "source_profile": "caitsith",
+            "target_profile": "default",
+            "target_platform": "discord",
+            "status": "pending",
+            "message": "old",
+            "created_at": "2026-07-08T00:00:00+00:00",
+        },
+    )
+    append_notification(
+        path,
+        {
+            "notification_id": "jn_new",
+            "handoff_id": "handoff-same",
+            "source_profile": "caitsith",
+            "target_profile": "default",
+            "target_platform": "discord",
+            "status": "failed",
+            "message": "new",
+            "created_at": "2026-07-08T00:01:00+00:00",
+        },
+    )
+
+    latest = latest_notifications(load_notifications(path))
+
+    assert len(latest) == 1
+    assert latest[0]["notification_id"] == "jn_new"
+    assert latest[0]["status"] == "failed"
+
+
+def test_make_notification_id_is_stable_for_seed_and_time():
+    notification_id = make_notification_id(
+        datetime(2026, 7, 8, tzinfo=timezone.utc),
+        seed="handoff-test",
+    )
+
+    assert notification_id.startswith("jn_20260708_000000_")
+    assert notification_id == make_notification_id(
+        datetime(2026, 7, 8, tzinfo=timezone.utc),
+        seed="handoff-test",
+    )

--- a/tests/agent/test_slack_work_items.py
+++ b/tests/agent/test_slack_work_items.py
@@ -59,6 +59,30 @@ def test_parse_bare_file_id_as_file_ref():
     )
 
 
+def test_parse_slack_canvas_doc_link_as_canvas_ref():
+    ref = parse_slack_source_ref("https://ffxivkr.slack.com/docs/T01234567/F0AC9G3PYE9/project-canvas")
+    assert ref == SlackSourceRef(
+        source_type="canvas",
+        permalink="https://ffxivkr.slack.com/docs/T01234567/F0AC9G3PYE9/project-canvas",
+        channel_id=None,
+        message_ts=None,
+        thread_ts=None,
+        file_id="F0AC9G3PYE9",
+    )
+
+
+def test_parse_slack_list_link_as_list_ref():
+    ref = parse_slack_source_ref("이 리스트 봐줘 https://ffxivkr.slack.com/lists/T01234567/F0LIST3PYE9/tasks")
+    assert ref == SlackSourceRef(
+        source_type="list",
+        permalink="https://ffxivkr.slack.com/lists/T01234567/F0LIST3PYE9/tasks",
+        channel_id=None,
+        message_ts=None,
+        thread_ts=None,
+        file_id="F0LIST3PYE9",
+    )
+
+
 def test_work_item_append_lookup_and_update(tmp_path):
     path = tmp_path / "slack_work_items.jsonl"
     ref = parse_slack_source_ref(

--- a/tests/agent/test_slack_work_items.py
+++ b/tests/agent/test_slack_work_items.py
@@ -1,0 +1,114 @@
+from datetime import datetime, timezone
+
+from agent.slack_work_items import (
+    SlackSourceRef,
+    append_work_item,
+    find_work_item,
+    latest_work_items,
+    load_work_items,
+    make_work_id,
+    parse_slack_source_ref,
+    update_work_item,
+)
+
+
+def test_parse_thread_permalink_with_thread_ts():
+    ref = parse_slack_source_ref(
+        "<https://ffxivkr.slack.com/archives/C0B7QVCLQF9/p1783498191737439?thread_ts=1783489727.804269&cid=C0B7QVCLQF9|link>"
+    )
+    assert ref == SlackSourceRef(
+        source_type="thread",
+        permalink="https://ffxivkr.slack.com/archives/C0B7QVCLQF9/p1783498191737439?thread_ts=1783489727.804269&cid=C0B7QVCLQF9",
+        channel_id="C0B7QVCLQF9",
+        message_ts="1783498191.737439",
+        thread_ts="1783489727.804269",
+        file_id=None,
+    )
+
+
+def test_parse_thread_permalink_without_thread_ts_uses_message_ts():
+    ref = parse_slack_source_ref(
+        "https://ffxivkr.slack.com/archives/C0B7QVCLQF9/p1783498191737439"
+    )
+    assert ref is not None
+    assert ref.channel_id == "C0B7QVCLQF9"
+    assert ref.message_ts == "1783498191.737439"
+    assert ref.thread_ts == "1783498191.737439"
+
+
+def test_parse_bare_file_id_as_file_ref():
+    ref = parse_slack_source_ref("F0AC9G3PYE9")
+    assert ref == SlackSourceRef(
+        source_type="file",
+        permalink="",
+        channel_id=None,
+        message_ts=None,
+        thread_ts=None,
+        file_id="F0AC9G3PYE9",
+    )
+
+
+def test_work_item_append_lookup_and_update(tmp_path):
+    path = tmp_path / "slack_work_items.jsonl"
+    ref = parse_slack_source_ref(
+        "https://ffxivkr.slack.com/archives/C0B7QVCLQF9/p1783498191737439?thread_ts=1783489727.804269&cid=C0B7QVCLQF9"
+    )
+    assert ref is not None
+    work_id = make_work_id(
+        datetime(2026, 7, 8, tzinfo=timezone.utc),
+        seed="C0B7QVCLQF9:1783489727.804269",
+    )
+    item = append_work_item(
+        path,
+        {
+            "work_id": work_id,
+            "source_type": ref.source_type,
+            "source_permalink": ref.permalink,
+            "channel_id": ref.channel_id,
+            "thread_ts": ref.thread_ts,
+            "message_ts": ref.message_ts,
+            "file_id": ref.file_id,
+            "requested_by_user_id": "U05NZ8WD30C",
+            "request_text": "@캐트시 인제스트해",
+            "intent": "ingest",
+            "status": "received",
+            "result_summary": "",
+            "artifact_paths": [],
+            "jarvis_handoff_id": None,
+            "jarvis_notification_status": "read_from_jarvis_queue",
+            "created_at": "2026-07-08T00:00:00+00:00",
+            "updated_at": "2026-07-08T00:00:00+00:00",
+        },
+    )
+    assert item["work_id"] == work_id
+    items = load_work_items(path)
+    assert find_work_item(items, ref)["work_id"] == work_id
+    updated = update_work_item(
+        path, work_id, {"status": "completed", "result_summary": "처리 완료"}
+    )
+    assert updated["status"] == "completed"
+    records = load_work_items(path)
+    assert len(records) == 2
+    assert latest_work_items(records)[0]["result_summary"] == "처리 완료"
+
+
+def test_find_work_item_prefers_canonical_thread_key_over_permalink(tmp_path):
+    path = tmp_path / "slack_work_items.jsonl"
+    append_work_item(
+        path,
+        {
+            "work_id": "sw_test",
+            "source_type": "thread",
+            "source_permalink": "https://old.example/archives/C0B7QVCLQF9/p1783498191737439",
+            "channel_id": "C0B7QVCLQF9",
+            "thread_ts": "1783489727.804269",
+            "message_ts": "1783498191.737439",
+            "file_id": None,
+            "status": "received",
+        },
+    )
+    ref = parse_slack_source_ref(
+        "https://ffxivkr.slack.com/archives/C0B7QVCLQF9/p1783498191737439?thread_ts=1783489727.804269&cid=C0B7QVCLQF9"
+    )
+    assert ref is not None
+    assert find_work_item(load_work_items(path), ref)["work_id"] == "sw_test"

--- a/tests/agent/test_slack_work_items.py
+++ b/tests/agent/test_slack_work_items.py
@@ -36,6 +36,17 @@ def test_parse_thread_permalink_without_thread_ts_uses_message_ts():
     assert ref.thread_ts == "1783498191.737439"
 
 
+def test_parse_thread_permalink_embedded_in_natural_text():
+    ref = parse_slack_source_ref(
+        "이거 처리됐어? https://ffxivkr.slack.com/archives/C0B7QVCLQF9/p1783498191737439?thread_ts=1783489727.804269&cid=C0B7QVCLQF9"
+    )
+    assert ref is not None
+    assert ref.permalink == "https://ffxivkr.slack.com/archives/C0B7QVCLQF9/p1783498191737439?thread_ts=1783489727.804269&cid=C0B7QVCLQF9"
+    assert ref.channel_id == "C0B7QVCLQF9"
+    assert ref.message_ts == "1783498191.737439"
+    assert ref.thread_ts == "1783489727.804269"
+
+
 def test_parse_bare_file_id_as_file_ref():
     ref = parse_slack_source_ref("F0AC9G3PYE9")
     assert ref == SlackSourceRef(


### PR DESCRIPTION
## Summary

This PR adds the first release-candidate slice of CaitSith/Jarvis Slack work-item tracking:

- Add append-only Slack work item ledger helpers with file locking.
- Parse Slack thread permalinks embedded in natural text.
- Classify Slack Canvas/List/docs-style links and preserve canonical `file_id` provenance.
- Add append-only Jarvis notification queue helpers.
- Add a default-profile notification consumer script that sends pending handoff notifications via `hermes send --to discord`.

## Scope boundary

Included:
- Slack source identity/provenance tracking.
- Canonical lookup by `(channel_id, thread_ts)` for threads and `file_id` for Canvas/List/file links.
- Jarvis/default notification queue ownership and consumer script.

Explicitly deferred:
- Slack Canvas/List body fetch.
- Canvas/List mutation/write support.
- Share-thread comment harvesting.

Those document body reads need a separate Slack workspace-document read feature because they require `files.info`, authenticated `url_private` fetch, and body-vs-share-thread permission handling.

## Verification

Fresh local verification:

- `scripts/run_tests.sh tests/agent/test_slack_work_items.py tests/agent/test_jarvis_notification_queue.py -v --tb=short`
  - 11 passed
- `PYTHONPATH=/Users/dukho/.hermes/hermes-agent /Users/dukho/.hermes/hermes-agent/venv/bin/python -m pytest /Users/dukho/.hermes/profiles/caitsith/plugins/slack-chatmode/test_chatmode_security.py -q`
  - 12 passed

Live smoke already completed outside this PR's tracked files:

- CaitSith Slack outbound DM smoke: passed.
- CaitSith owner inbound DM smoke: passed.
- CaitSith DM source-link lookup smoke: passed.
- Jarvis/default real Discord notification smoke through temp queue: passed.
- Default-profile cron wrapper for the notification consumer: registered and observed `ok`.

## Notes for reviewers

The CaitSith profile-local Slack plugin changes and default-profile cron wrapper are operational runtime artifacts outside this repository's tracked files. They are captured separately in the user's local release-candidate packet for recovery/review. This PR contains the reusable repo-level helpers, tests, and notification consumer script.
