### PR TITLE
Fix Windows cua-driver autostart paths with spaces

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1140,6 +1140,91 @@ def _clear_stale_cua_install_lock() -> None:
         logger.debug("stale cua install lock check failed: %s", e)
 
 
+def _ps_single_quote(value: str) -> str:
+    """Return a PowerShell single-quoted string literal."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _cua_driver_autostart_registered_windows() -> bool:
+    """Return whether the Windows cua-driver scheduled task is registered."""
+    if sys.platform != "win32":
+        return False
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["schtasks.exe", "/Query", "/TN", "cua-driver-serve"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0
+
+
+def _repair_cua_driver_autostart_windows(driver_cmd: str, *, verbose: bool) -> bool:
+    """Best-effort repair for Windows installer autostart quoting failures.
+
+    Older install.ps1 builds invoked
+    ``& C:\\Users\\Name With Spaces\\...\\cua-driver`` from an elevated
+    PowerShell command string, which PowerShell split at the first space. If
+    the installer left the scheduled task missing, retry by
+    launching the resolved binary through Start-Process's structured
+    ``-FilePath`` / ``-ArgumentList`` parameters instead of interpolating a
+    path into a command string.
+    """
+    if sys.platform != "win32":
+        return True
+    if _cua_driver_autostart_registered_windows():
+        return True
+
+    import subprocess
+
+    binary = shutil.which(driver_cmd)
+    if not binary:
+        return False
+
+    ps = shutil.which("powershell") or shutil.which("powershell.exe") or "powershell"
+    ps_cmd = (
+        f"$exe = {_ps_single_quote(binary)}; "
+        "$proc = Start-Process -FilePath $exe "
+        "-ArgumentList @('autostart','enable') "
+        "-Verb RunAs -Wait -PassThru -ErrorAction Stop; "
+        "exit $proc.ExitCode"
+    )
+
+    if verbose:
+        _print_info("    Registering cua-driver auto-start...")
+    else:
+        _print_info("    Repairing cua-driver auto-start registration...")
+
+    try:
+        result = subprocess.run(
+            [ps, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps_cmd],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env=_cua_driver_env(),
+        )
+    except subprocess.TimeoutExpired:
+        _print_warning("    cua-driver autostart registration timed out.")
+        return False
+    except Exception as exc:
+        _print_warning(f"    cua-driver autostart registration failed: {exc}")
+        return False
+
+    if result.returncode == 0:
+        return True
+
+    tail = (result.stderr or result.stdout or "").strip().splitlines()[-3:]
+    _print_warning("    cua-driver autostart registration failed.")
+    for line in tail:
+        _print_info(f"      {line[:200]}")
+    _print_info("    From an elevated shell, run: cua-driver autostart enable")
+    return False
+
+
 def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -> bool:
     """Run the upstream cua-driver installer for this platform.
 
@@ -1342,6 +1427,12 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -
                 if result.returncode != 0:
                     logger.debug("cua-driver installer output:\n%s", result.stdout)
         if result.returncode == 0 and shutil.which(driver_cmd):
+            if is_windows and not _repair_cua_driver_autostart_windows(
+                driver_cmd, verbose=verbose
+            ):
+                _print_warning(
+                    "    cua-driver installed, but auto-start was not registered."
+                )
             if verbose:
                 _print_success(f"    {driver_cmd} installed.")
                 if is_windows:

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -22,6 +22,7 @@ cleanly on missing-arch assets, and the upgrade path uses
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -712,3 +713,105 @@ class TestInstallerNoShell:
 
         assert "script" in captured
         assert not os.path.exists(captured["script"])
+
+
+class TestWindowsAutostartRepair:
+    def test_existing_task_skips_elevated_powershell_repair(self):
+        from hermes_cli import tools_config
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return SimpleNamespace(returncode=0)
+
+        with patch.object(tools_config.sys, "platform", "win32"), \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch.object(tools_config.shutil, "which") as which:
+            ok = tools_config._repair_cua_driver_autostart_windows(
+                "cua-driver", verbose=False
+            )
+
+        assert ok is True
+        assert [cmd for cmd, _kwargs in calls] == [
+            ["schtasks.exe", "/Query", "/TN", "cua-driver-serve"]
+        ]
+        which.assert_not_called()
+
+    def test_windows_installer_runs_autostart_repair_after_success(self):
+        from unittest.mock import MagicMock
+        from hermes_cli import tools_config
+
+        captured = {}
+        fake_proc = MagicMock()
+        fake_proc.pid = 1
+        fake_proc.returncode = 0
+        fake_proc.communicate.return_value = ("", None)
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return fake_proc
+
+        def fake_which(name: str):
+            if name == "cua-driver":
+                return r"C:\Users\Ha Trung\AppData\Local\Programs\Cua\cua-driver\bin\cua-driver.exe"
+            return None
+
+        with patch("platform.system", return_value="Windows"), \
+             patch.object(tools_config.shutil, "which", side_effect=fake_which), \
+             patch("subprocess.Popen", side_effect=fake_popen), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_repair_cua_driver_autostart_windows", return_value=True) as repair, \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"), \
+             patch.object(tools_config, "_print_success"):
+            ok = tools_config._run_cua_driver_installer(label="Refreshing", verbose=False)
+
+        assert ok is True
+        assert captured["kwargs"].get("shell") is False
+        assert isinstance(captured["cmd"], list)
+        assert captured["cmd"][:4] == [
+            "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
+        ]
+        repair.assert_called_once_with("cua-driver", verbose=False)
+
+    def test_autostart_repair_quotes_username_space_path_via_file_path(self):
+        from hermes_cli import tools_config
+
+        calls = []
+        driver = (
+            r"C:\Users\Ha Trung\AppData\Local\Programs\Cua"
+            r"\cua-driver\bin\cua-driver.exe"
+        )
+
+        def fake_which(name: str):
+            if name == "cua-driver":
+                return driver
+            if name == "powershell":
+                return r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+            return None
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            if cmd[0] == "schtasks.exe":
+                return SimpleNamespace(returncode=1)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch.object(tools_config.sys, "platform", "win32"), \
+             patch.object(tools_config.shutil, "which", side_effect=fake_which), \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info"):
+            ok = tools_config._repair_cua_driver_autostart_windows(
+                "cua-driver", verbose=False
+            )
+
+        assert ok is True
+        ps_calls = [cmd for cmd, _kwargs in calls if cmd[0].endswith("powershell.exe")]
+        assert len(ps_calls) == 1
+        ps_command = ps_calls[0][-1]
+        assert "-FilePath $exe" in ps_command
+        assert "-ArgumentList @('autostart','enable')" in ps_command
+        assert f"$exe = '{driver}'" in ps_command
+        assert f"& {driver}" not in ps_command


### PR DESCRIPTION
## Summary
- Detect whether the Windows `cua-driver-serve` scheduled task exists after the cua-driver installer runs.
- If the task is missing, retry autostart registration by launching the resolved `cua-driver.exe` through PowerShell `Start-Process -FilePath ... -ArgumentList @('autostart','enable') -Verb RunAs` instead of interpolating the path into an `& C:\Users\...` command string.
- Preserve the existing installer behavior when the task is already registered, so successful installs do not trigger an extra UAC prompt.
- Add Windows regression coverage for username-space paths and the post-installer repair hook.

Fixes #60808

## Tests
- `python -m py_compile hermes_cli/tools_config.py tests/hermes_cli/test_install_cua_driver.py`
- `uv run --extra dev pytest tests/hermes_cli/test_install_cua_driver.py -q` — 24 passed
- `uv run --extra dev pytest tests/hermes_cli/test_tools_config.py -k 'cua_driver or computer_use' -q` — 6 passed, 109 deselected
- `uv run --extra dev pytest tests/hermes_cli/test_cmd_update.py -k 'cua or refresh' -q` — 1 passed, 26 deselected
- `uv run --extra dev pytest tests/hermes_cli/test_post_setup_gating.py -q` — 5 passed
- `git diff --cached --check`
- `gitleaks git --log-opts='origin/main..HEAD' --redact .` — no leaks
