### PR TITLE
fix(cron): resolve profile-scoped jobs storage dynamically

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2245,6 +2245,10 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     question=next_args.get("question", ""),
                     choices=next_args.get("choices"),
                     callback=agent.clarify_callback,
+                    multi_select=bool(next_args.get("multi_select", False)),
+                    min_selections=next_args.get("min_selections", 0),
+                    max_selections=next_args.get("max_selections"),
+                    allow_other=bool(next_args.get("allow_other", True)),
                 ),
                 next_args,
             )

--- a/agent/clarify_choice_guard.py
+++ b/agent/clarify_choice_guard.py
@@ -1,0 +1,148 @@
+"""Hard gate for Markdown-only choice prompts that should use clarify.
+
+The model already receives prompt/schema guidance telling it to call the
+``clarify`` tool for final reports and next-action sections that ask the user
+to choose.  This module is the deterministic backstop: if a final text answer
+still contains an inert Markdown choice menu while the live session exposes the
+clarify tool, the conversation loop nudges once for an actual tool call and then
+fails closed instead of delivering dead choices.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Optional, Tuple
+
+_NONINTERACTIVE_PLATFORMS = {
+    "batch",
+    "cron",
+    "curator",
+    "no_agent",
+}
+
+_CHOICE_HEADING_RE = re.compile(
+    r"(?im)^\s{0,3}#{1,6}\s*(?:"
+    r"다음\s*추천\s*작업|"
+    r"다음\s*작업|"
+    r"승인(?:\s*필요|\s*게이트)?|"
+    r"선택(?:\s*필요|\s*항목|\s*지)?|"
+    r"범위(?:\s*선택)?|"
+    r"next\s+(?:recommended\s+)?(?:actions?|steps?)|"
+    r"recommended\s+next\s+(?:actions?|steps?)|"
+    r"approval(?:\s+gate|\s+required)?|"
+    r"choices?|"
+    r"scope(?:\s+selection)?"
+    r")\b.*$"
+)
+
+_ANY_HEADING_RE = re.compile(r"(?m)^\s{0,3}#{1,6}\s+\S")
+
+_CHOICE_LINE_RE = re.compile(
+    r"(?m)^\s{0,6}(?:[-*+]\s+|\d{1,2}[.)]\s+|[A-Ha-h][.)]\s+).+\S"
+)
+
+_SELECT_FENCE_RE = re.compile(r"(?im)^\s*```\s*select\b")
+
+_APPROVAL_KEYWORDS = (
+    "승인 실행",
+    "승인",
+    "수정",
+    "보류",
+    "금지",
+    "approve",
+    "modify",
+    "defer",
+    "forbid",
+    "hold",
+)
+
+
+def _has_clarify(valid_tool_names: Iterable[str] | None) -> bool:
+    return "clarify" in set(valid_tool_names or ())
+
+
+def _is_interactive_platform(platform: str | None) -> bool:
+    normalized = (platform or "").strip().lower()
+    return normalized not in _NONINTERACTIVE_PLATFORMS
+
+
+def _choice_sections(text: str) -> list[str]:
+    sections: list[str] = []
+    for match in _CHOICE_HEADING_RE.finditer(text or ""):
+        start = match.start()
+        next_heading = _ANY_HEADING_RE.search(text, match.end())
+        end = next_heading.start() if next_heading else len(text)
+        sections.append(text[start:end])
+    return sections
+
+
+def _looks_like_choice_menu(text: str) -> bool:
+    if not text:
+        return False
+    if _SELECT_FENCE_RE.search(text):
+        return True
+
+    sections = _choice_sections(text)
+    if not sections:
+        return False
+
+    for section in sections:
+        choice_lines = _CHOICE_LINE_RE.findall(section)
+        if len(choice_lines) >= 2:
+            return True
+
+        lowered = section.casefold()
+        keyword_hits = sum(
+            1 for keyword in _APPROVAL_KEYWORDS if keyword.casefold() in lowered
+        )
+        if keyword_hits >= 2:
+            return True
+
+    return False
+
+
+def clarify_choice_guard_action(
+    final_response: str,
+    *,
+    valid_tool_names: Iterable[str] | None,
+    platform: str | None,
+    attempts: int,
+    max_attempts: int = 1,
+) -> Tuple[str, Optional[str]]:
+    """Return (action, payload) for the final-response clarify hard gate.
+
+    Actions:
+    - ``("allow", None)``: deliver the final text normally.
+    - ``("nudge", message)``: append a synthetic user message and continue so the
+      model can call the actual ``clarify`` tool.
+    - ``("block", message)``: retry budget exhausted; replace the dead menu with
+      a safe failure notice that does not ask the user to click inert Markdown.
+    """
+    if not _has_clarify(valid_tool_names):
+        return "allow", None
+    if not _is_interactive_platform(platform):
+        return "allow", None
+    if not _looks_like_choice_menu(final_response or ""):
+        return "allow", None
+
+    if attempts < max_attempts:
+        return "nudge", (
+            "[System: Your previous answer ended with Markdown-only next-action, "
+            "approval, scope, or fenced select choices. That is not clickable UI. "
+            "Do not send that final text yet. Call the `clarify` tool now, put "
+            "selectable rows only in the `choices` array, and use "
+            "`multi_select=true` when multiple choices can be selected. If no "
+            "choice is genuinely required, answer again without a Markdown choice "
+            "menu.]"
+        )
+
+    return "block", (
+        "Clarify hard gate blocked this response: the model produced "
+        "Markdown-only choice options after being told to call the `clarify` "
+        "tool. No clickable choice UI was shown, and no action was selected. "
+        "Please retry the request or ask for a plain recommendation without a "
+        "choice menu."
+    )
+
+
+__all__ = ["clarify_choice_guard_action"]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4631,16 +4631,23 @@ def run_conversation(
                         if clean:
                             agent._vprint(f"  ┊ 💬 {clean}")
                 
-                # Pop thinking-only prefill message(s) before appending
-                # (tool-call path — same rationale as the final-response path).
+                # Pop internal retry scaffolding before appending tool-call
+                # turns. Clarify choice nudges can legitimately be followed
+                # by a real clarify tool call; once that happens, the dead
+                # Markdown attempt and synthetic nudge must not become durable
+                # transcript context.
                 _had_prefill = False
                 while (
                     messages
                     and isinstance(messages[-1], dict)
-                    and messages[-1].get("_thinking_prefill")
+                    and (
+                        messages[-1].get("_thinking_prefill")
+                        or messages[-1].get("_clarify_choice_guard_synthetic")
+                    )
                 ):
+                    _was_prefill = bool(messages[-1].get("_thinking_prefill"))
                     messages.pop()
-                    _had_prefill = True
+                    _had_prefill = _had_prefill or _was_prefill
 
                 # Reset prefill counter when tool calls follow a prefill
                 # recovery.  Without this, the counter accumulates across
@@ -5121,6 +5128,7 @@ def run_conversation(
                         messages[-1].get("_thinking_prefill")
                         or messages[-1].get("_empty_recovery_synthetic")
                         or messages[-1].get("_empty_terminal_sentinel")
+                        or messages[-1].get("_clarify_choice_guard_synthetic")
                     )
                 ):
                     messages.pop()
@@ -5223,6 +5231,72 @@ def run_conversation(
                                  agent._pre_verify_nudges)
                     continue
 
+                _clarify_guard_valid_tools = getattr(agent, "valid_tool_names", set())
+                try:
+                    from agent.clarify_choice_guard import (
+                        clarify_choice_guard_action,
+                    )
+
+                    _clarify_guard_action, _clarify_guard_payload = (
+                        clarify_choice_guard_action(
+                            final_response,
+                            valid_tool_names=_clarify_guard_valid_tools,
+                            platform=getattr(agent, "platform", "") or "",
+                            attempts=getattr(agent, "_clarify_choice_guard_nudges", 0),
+                        )
+                    )
+                except Exception:
+                    logger.exception("clarify choice hard-gate check failed")
+                    _clarify_raw_text = final_response or ""
+                    _clarify_text = _clarify_raw_text.casefold()
+                    _clarify_maybe_dead_menu = (
+                        "clarify" in set(_clarify_guard_valid_tools or ())
+                        and (
+                            "```select" in _clarify_text
+                            or "## 다음" in _clarify_raw_text
+                            or "## 승인" in _clarify_raw_text
+                            or "## 선택" in _clarify_raw_text
+                            or "## 범위" in _clarify_raw_text
+                            or "## next" in _clarify_text
+                            or "## approval" in _clarify_text
+                            or "## choice" in _clarify_text
+                            or "## scope" in _clarify_text
+                        )
+                    )
+                    if _clarify_maybe_dead_menu:
+                        _clarify_guard_action, _clarify_guard_payload = "block", (
+                            "Clarify hard gate failed while inspecting a possible "
+                            "Markdown-only choice response. To avoid showing dead "
+                            "choice UI, this response was blocked. Please retry."
+                        )
+                    else:
+                        _clarify_guard_action, _clarify_guard_payload = "allow", None
+
+                if _clarify_guard_action == "nudge" and _clarify_guard_payload:
+                    agent._clarify_choice_guard_nudges = (
+                        getattr(agent, "_clarify_choice_guard_nudges", 0) + 1
+                    )
+                    final_msg["finish_reason"] = "clarify_choice_required"
+                    final_msg["_clarify_choice_guard_synthetic"] = True
+                    messages.append(final_msg)
+                    messages.append({
+                        "role": "user",
+                        "content": _clarify_guard_payload,
+                        "_clarify_choice_guard_synthetic": True,
+                    })
+                    agent._session_messages = messages
+                    logger.debug(
+                        "clarify choice hard-gate nudge issued (attempt %d)",
+                        agent._clarify_choice_guard_nudges,
+                    )
+                    continue
+
+                if _clarify_guard_action == "block" and _clarify_guard_payload:
+                    final_response = _clarify_guard_payload
+                    final_msg["content"] = final_response
+                    final_msg["finish_reason"] = "clarify_choice_blocked"
+
+                agent._clarify_choice_guard_nudges = 0
                 messages.append(final_msg)
                 
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1256,6 +1256,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     question=next_args.get("question", ""),
                     choices=next_args.get("choices"),
                     callback=agent.clarify_callback,
+                    multi_select=next_args.get("multi_select", False),
+                    min_selections=next_args.get("min_selections", 0),
+                    max_selections=next_args.get("max_selections"),
+                    allow_other=next_args.get("allow_other", True),
                 )
             function_result, function_args = _run_agent_tool_execution_middleware(
                 agent,

--- a/apps/desktop/electron/update-relaunch.cjs
+++ b/apps/desktop/electron/update-relaunch.cjs
@@ -46,6 +46,10 @@ function unpackedDirName(platform) {
   return 'linux-unpacked'
 }
 
+function pathForPlatform(platform) {
+  return platform === 'win32' ? path.win32 : path.posix
+}
+
 /**
  * If `execPath` lives under `<updateRoot>/apps/desktop/release/<plat>-unpacked`,
  * return that unpacked dir; otherwise null. A null result means the running
@@ -57,12 +61,16 @@ function unpackedDirName(platform) {
  */
 function resolveUnpackedRelease(execPath, updateRoot, platform) {
   if (!execPath || !updateRoot) return null
-  const releaseDir = path.join(updateRoot, 'apps', 'desktop', 'release')
-  const unpacked = path.join(releaseDir, unpackedDirName(platform))
-  const normalizedExec = path.resolve(String(execPath))
+  const pathMod = pathForPlatform(platform)
+  const releaseDir = pathMod.join(updateRoot, 'apps', 'desktop', 'release')
+  const unpacked = pathMod.resolve(pathMod.join(releaseDir, unpackedDirName(platform)))
+  const normalizedExec = pathMod.resolve(String(execPath))
   // execPath must be the unpacked dir itself or a descendant of it.
-  const withSep = unpacked.endsWith(path.sep) ? unpacked : unpacked + path.sep
-  if (normalizedExec === unpacked || normalizedExec.startsWith(withSep)) {
+  const withSep = unpacked.endsWith(pathMod.sep) ? unpacked : unpacked + pathMod.sep
+  const comparableExec = platform === 'win32' ? normalizedExec.toLowerCase() : normalizedExec
+  const comparableUnpacked = platform === 'win32' ? unpacked.toLowerCase() : unpacked
+  const comparableWithSep = platform === 'win32' ? withSep.toLowerCase() : withSep
+  if (comparableExec === comparableUnpacked || comparableExec.startsWith(comparableWithSep)) {
     return unpacked
   }
   return null

--- a/apps/desktop/electron/update-relaunch.test.cjs
+++ b/apps/desktop/electron/update-relaunch.test.cjs
@@ -37,7 +37,7 @@ const {
 } = require('./update-relaunch.cjs')
 
 const ROOT = '/home/u/.hermes/hermes-agent'
-const UNPACKED = path.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked')
+const UNPACKED = path.posix.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked')
 
 // ---------------------------------------------------------------------------
 // 1) The execPath split — the heart of the GUI/backend skew guard.
@@ -49,7 +49,7 @@ test('unpackedDirName maps platform to the electron-builder dir', () => {
 })
 
 test('resolveUnpackedRelease returns the dir for a binary UNDER release/<plat>-unpacked', () => {
-  const exec = path.join(UNPACKED, 'hermes')
+  const exec = path.posix.join(UNPACKED, 'hermes')
   assert.equal(resolveUnpackedRelease(exec, ROOT, 'linux'), UNPACKED)
   // The unpacked dir itself also counts.
   assert.equal(resolveUnpackedRelease(UNPACKED, ROOT, 'linux'), UNPACKED)
@@ -68,12 +68,12 @@ test('resolveUnpackedRelease is null for AppImage / .deb / .rpm / dev / unresolv
   )
   // empty / missing
   assert.equal(resolveUnpackedRelease('', ROOT, 'linux'), null)
-  assert.equal(resolveUnpackedRelease(path.join(UNPACKED, 'hermes'), '', 'linux'), null)
+  assert.equal(resolveUnpackedRelease(path.posix.join(UNPACKED, 'hermes'), '', 'linux'), null)
 })
 
 test('resolveUnpackedRelease is not fooled by a sibling prefix dir', () => {
   // `.../release/linux-unpacked-evil` must NOT match `.../release/linux-unpacked`.
-  const sneaky = path.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked-evil', 'hermes')
+  const sneaky = path.posix.join(ROOT, 'apps', 'desktop', 'release', 'linux-unpacked-evil', 'hermes')
   assert.equal(resolveUnpackedRelease(sneaky, ROOT, 'linux'), null)
 })
 

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -31,8 +31,10 @@ import {
 import { type Translations, useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
 import { asText } from '@/lib/text'
+import { cronJobsProfileForScope } from '@/lib/cron-profile-scope'
 import { $cronFocusJobId, $cronJobs, setCronFocusJobId, setCronJobs, updateCronJobs } from '@/store/cron'
 import { notify, notifyError } from '@/store/notifications'
+import { $profileScope } from '@/store/profile'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import {
@@ -256,6 +258,7 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
   // sidebar and this overlay never drift — a delete here clears the sidebar row
   // immediately. `loading` only gates the first paint before the atom is filled.
   const jobs = useStore($cronJobs)
+  const profileScope = useStore($profileScope)
   const [loading, setLoading] = useState(jobs.length === 0)
   const [query, setQuery] = useState('')
   const [busyJobId, setBusyJobId] = useState<null | string>(null)
@@ -272,13 +275,13 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
 
   const refresh = useCallback(async () => {
     try {
-      setCronJobs(await getCronJobs())
+      setCronJobs(await getCronJobs(cronJobsProfileForScope(profileScope)))
     } catch (err) {
       notifyError(err, c.failedLoad)
     } finally {
       setLoading(false)
     }
-  }, [c])
+  }, [c, profileScope])
 
   useRefreshHotkey(refresh)
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.test.tsx
@@ -1,0 +1,119 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
+import { $activeSessionId } from '@/store/session'
+import type { RpcEvent } from '@/types/hermes'
+
+import type { ClientSessionState } from '../../../types'
+
+import { useGatewayEventHandler } from './gateway-event'
+
+const SESSION_ID = 'session-clarify'
+
+function clientSession(overrides: Partial<ClientSessionState> = {}): ClientSessionState {
+  return {
+    storedSessionId: null,
+    messages: [],
+    branch: '',
+    cwd: '',
+    model: '',
+    provider: '',
+    reasoningEffort: '',
+    serviceTier: '',
+    fast: false,
+    yolo: false,
+    personality: '',
+    busy: false,
+    awaitingResponse: false,
+    streamId: null,
+    sawAssistantPayload: false,
+    pendingBranchGroup: null,
+    interrupted: false,
+    needsInput: true,
+    turnStartedAt: null,
+    ...overrides
+  }
+}
+
+function renderGatewayEventHandler() {
+  const updateSessionState = vi.fn((
+    _sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState
+  ) => updater(clientSession()))
+
+  const { result } = renderHook(() =>
+    useGatewayEventHandler({
+      activeSessionIdRef: { current: SESSION_ID },
+      compactedTurnRef: { current: new Set<string>() },
+      lastCwdInfoSessionRef: { current: null },
+      nativeSubagentSessionsRef: { current: new Set<string>() },
+      appendAssistantDelta: vi.fn(),
+      appendReasoningDelta: vi.fn(),
+      completeAssistantMessage: vi.fn(),
+      failAssistantMessage: vi.fn(),
+      flushQueuedDeltas: vi.fn(),
+      queryClient: new QueryClient(),
+      refreshHermesConfig: vi.fn(async () => undefined),
+      sessionInterrupted: vi.fn(() => false),
+      updateSessionState,
+      upsertToolCall: vi.fn()
+    })
+  )
+
+  return { handleEvent: result.current, updateSessionState }
+}
+
+function toolComplete(name: string): RpcEvent {
+  return {
+    type: 'tool.complete',
+    session_id: SESSION_ID,
+    payload: {
+      tool_id: 'tool-1',
+      name,
+      result: {}
+    }
+  } as RpcEvent
+}
+
+afterEach(() => {
+  clearClarifyRequest()
+  $clarifyRequests.set({})
+  $activeSessionId.set(null)
+  vi.restoreAllMocks()
+})
+
+describe('useGatewayEventHandler clarify completion handling', () => {
+  it('clears the pending clarify request when the clarify tool completes', () => {
+    $activeSessionId.set(SESSION_ID)
+    setClarifyRequest({
+      requestId: 'req-clarify',
+      sessionId: SESSION_ID,
+      question: 'Pick one?',
+      choices: ['A', 'B']
+    })
+
+    const { handleEvent } = renderGatewayEventHandler()
+
+    act(() => handleEvent(toolComplete('clarify')))
+
+    expect($clarifyRequests.get()[SESSION_ID]).toBeUndefined()
+  })
+
+  it('leaves pending clarify requests alone when another tool completes', () => {
+    $activeSessionId.set(SESSION_ID)
+    setClarifyRequest({
+      requestId: 'req-clarify',
+      sessionId: SESSION_ID,
+      question: 'Pick one?',
+      choices: ['A', 'B']
+    })
+
+    const { handleEvent } = renderGatewayEventHandler()
+
+    act(() => handleEvent(toolComplete('terminal')))
+
+    expect($clarifyRequests.get()[SESSION_ID]?.requestId).toBe('req-clarify')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -379,9 +379,13 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           }
 
           // A pending clarify blocks the turn, so the first tool.complete after
-          // one is the clarify resolving — drop the "needs input" flag here so
-          // the sidebar indicator clears as soon as it's answered, not only at
-          // message.complete.
+          // one is the clarify resolving — drop both the request itself and the
+          // "needs input" flag here so stale transcript panels cannot send a
+          // second clarify.respond after the backend has already unblocked.
+          if (payload?.name === 'clarify') {
+            clearClarifyRequest(undefined, sessionId)
+          }
+
           updateSessionState(sessionId, state => (state.needsInput ? { ...state, needsInput: false } : state))
 
           // terminal/process tool calls are the only things that spawn or reap
@@ -428,13 +432,18 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // over; the inline ClarifyTool reads the active session's entry.
         const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
         const question = typeof payload?.question === 'string' ? payload.question : ''
+        const clarifyPayload = payload as Record<string, unknown> | undefined
 
         if (requestId && question) {
           setClarifyRequest({
             requestId,
             question,
-            choices: Array.isArray(payload?.choices) ? payload!.choices!.filter(c => typeof c === 'string') : null,
-            sessionId: sessionId ?? null
+            choices: Array.isArray(payload?.choices) ? payload!.choices!.filter((c): c is string => typeof c === 'string') : null,
+            sessionId: sessionId ?? null,
+            multiSelect: clarifyPayload?.multi_select === true || clarifyPayload?.multiSelect === true,
+            minSelections: typeof clarifyPayload?.min_selections === 'number' ? clarifyPayload.min_selections : null,
+            maxSelections: typeof clarifyPayload?.max_selections === 'number' ? clarifyPayload.max_selections : null,
+            allowOther: clarifyPayload?.allow_other !== false
           })
 
           // The transcript only renders the active session, so a background

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from 'react'
 
 import { getCronJobs, listAllProfileSessions, type SessionInfo } from '@/hermes'
+import { cronJobsProfileForScope } from '@/lib/cron-profile-scope'
 import {
   isMessagingSource,
   LOCAL_SESSION_SOURCE_IDS,
@@ -144,13 +145,13 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // next-run/state fresh as the scheduler advances them.
   const refreshCronJobs = useCallback(async () => {
     try {
-      const jobs = await getCronJobs()
+      const jobs = await getCronJobs(cronJobsProfileForScope(profileScope))
 
       setCronJobs(jobs)
     } catch {
       // Non-fatal: the cron section just keeps its last-known jobs.
     }
-  }, [])
+  }, [profileScope])
 
   const refreshSessions = useCallback(async () => {
     const requestId = refreshSessionsRequestRef.current + 1

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,0 +1,364 @@
+import { type ToolCallMessagePartProps } from '@assistant-ui/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ClarifyTool } from '@/components/assistant-ui/clarify-tool'
+import { I18nProvider } from '@/i18n'
+import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
+import { $gateway } from '@/store/gateway'
+import { $notifications, clearNotifications } from '@/store/notifications'
+import { $activeSessionId } from '@/store/session'
+
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: () => true
+}))
+
+vi.mock('@/lib/haptics', () => ({
+  triggerHaptic: vi.fn()
+}))
+
+type TestClarifyArgs = {
+  allowOther?: boolean
+  choices: string[]
+  maxSelections?: number | null
+  minSelections?: number | null
+  multiSelect?: boolean
+  question: string
+}
+
+function resetClarifyTestState() {
+  clearNotifications()
+  clearClarifyRequest()
+  $clarifyRequests.set({})
+  $activeSessionId.set(null)
+  $gateway.set(null)
+}
+
+function renderClarifyTool(requestMock = vi.fn().mockResolvedValue({ ok: true }), argsOverride: Partial<TestClarifyArgs> = {}) {
+  const args: TestClarifyArgs = {
+    question: 'Which context should Hermes use?',
+    choices: ['Past sessions', 'Local reports', 'Web sources'],
+    ...argsOverride
+  }
+
+  $clarifyRequests.set({})
+  $gateway.set({ request: requestMock } as never)
+  setClarifyRequest({
+    requestId: 'req-1',
+    question: 'Which context should Hermes use?',
+    choices: ['Past sessions', 'Local reports', 'Web sources'],
+    multiSelect: Boolean(args.multiSelect),
+    sessionId: null
+  })
+
+  const props: ToolCallMessagePartProps = {
+    type: 'tool-call',
+    toolCallId: 'tool-1',
+    toolName: 'clarify',
+    args,
+    argsText: '',
+    result: undefined,
+    status: { type: 'running' },
+    addResult: vi.fn(),
+    resume: vi.fn()
+  }
+
+  render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <ClarifyTool {...props} />
+    </I18nProvider>
+  )
+
+  return requestMock
+}
+
+const REQUEST_ID = 'clarify-req-1'
+const SESSION_ID = 'session-1'
+
+function renderPendingClarify(request: { request?: ReturnType<typeof vi.fn> } = {}) {
+  const requestMock = request.request ?? vi.fn(async () => ({ ok: true }))
+
+  $activeSessionId.set(SESSION_ID)
+  setClarifyRequest({
+    requestId: REQUEST_ID,
+    sessionId: SESSION_ID,
+    question: 'Pick one?',
+    choices: ['Continue waiting', 'Stop now']
+  })
+  $gateway.set({ request: requestMock } as never)
+
+  render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <ClarifyTool
+        {...({
+          args: { question: 'Pick one?', choices: ['Continue waiting', 'Stop now'] },
+          result: undefined,
+          status: { type: 'running' }
+        } as unknown as Parameters<typeof ClarifyTool>[0])}
+      />
+    </I18nProvider>
+  )
+
+  return requestMock
+}
+
+beforeEach(() => {
+  resetClarifyTestState()
+})
+
+afterEach(() => {
+  cleanup()
+  resetClarifyTestState()
+  vi.restoreAllMocks()
+})
+
+describe('ClarifyTool selection status UX', () => {
+  it('keeps regular choice clicks as immediate single-choice submit', async () => {
+    const request = renderClarifyTool()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Past sessions' }))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        'clarify.respond',
+        {
+          request_id: 'req-1',
+          answer: 'Past sessions'
+        },
+        120_000
+      )
+    )
+  })
+
+  it('shows the selected single choice while the response is pending', () => {
+    const request = renderClarifyTool(vi.fn(() => new Promise(() => {})))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Past sessions' }))
+
+    expect(request).toHaveBeenCalledWith(
+      'clarify.respond',
+      {
+        request_id: 'req-1',
+        answer: 'Past sessions'
+      },
+      120_000
+    )
+    const status = screen.getByRole('status')
+    expect(status.textContent).toContain('Selected')
+    expect(status.textContent).toContain('Past sessions')
+  })
+
+  it('submits a single-choice answer from its letter shortcut', async () => {
+    const request = renderClarifyTool()
+
+    fireEvent.keyDown(window, { key: 'b' })
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        'clarify.respond',
+        {
+          request_id: 'req-1',
+          answer: 'Local reports'
+        },
+        120_000
+      )
+    )
+  })
+
+  it('focuses Other from the trailing letter shortcut and submits it with Enter', async () => {
+    const request = renderClarifyTool()
+
+    fireEvent.keyDown(window, { key: 'd' })
+
+    const other = screen.getByRole('textbox', { name: 'Other (type your answer)' })
+    expect(document.activeElement).toBe(other)
+
+    fireEvent.change(other, { target: { value: 'Use a custom path' } })
+    fireEvent.keyDown(other, { key: 'Enter' })
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        'clarify.respond',
+        {
+          request_id: 'req-1',
+          answer: 'Use a custom path'
+        },
+        120_000
+      )
+    )
+  })
+
+  it('does not expose staged multi-select controls for single-choice prompts', () => {
+    renderClarifyTool()
+
+    expect(screen.queryByRole('button', { name: 'Toggle Past sessions for multi-select' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Select selected' })).toBeNull()
+  })
+
+  it('keeps the multi-select submit button visible before any choice is staged', () => {
+    renderClarifyTool(vi.fn().mockResolvedValue({ ok: true }), { multiSelect: true })
+
+    expect(screen.getByRole('note').textContent).toContain('Multi-select')
+    const submit = screen.getByRole('button', { name: 'Select selected' })
+    expect(submit.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('hides Skip when a multi-select prompt requires at least one selection', () => {
+    renderClarifyTool(vi.fn().mockResolvedValue({ ok: true }), {
+      allowOther: false,
+      minSelections: 2,
+      multiSelect: true
+    })
+
+    expect(screen.queryByRole('button', { name: 'Skip' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Select selected' })).toBeTruthy()
+  })
+
+  it('hides Skip for constrained single-select prompts that disallow Other', () => {
+    renderClarifyTool(vi.fn().mockResolvedValue({ ok: true }), { allowOther: false })
+
+    expect(screen.queryByRole('button', { name: 'Skip' })).toBeNull()
+  })
+
+  it('uses multi-select rows to stage multiple choices without submitting until Select selected', async () => {
+    const request = renderClarifyTool(vi.fn().mockResolvedValue({ ok: true }), { multiSelect: true })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Past sessions for multi-select' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Web sources for multi-select' }))
+
+    expect(request).not.toHaveBeenCalled()
+    expect(screen.getByText('2 selected')).toBeTruthy()
+    expect(screen.getByText('Selected')).toBeTruthy()
+    expect(screen.getByText('Past sessions, Web sources')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select selected' }))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        'clarify.respond',
+        {
+          request_id: 'req-1',
+          answer: 'Past sessions, Web sources'
+        },
+        120_000
+      )
+    )
+  })
+
+  it('toggles multi-select choices by letter shortcut and submits them with Enter', async () => {
+    const request = renderClarifyTool(vi.fn().mockResolvedValue({ ok: true }), { multiSelect: true })
+
+    fireEvent.keyDown(window, { key: 'a' })
+    fireEvent.keyDown(window, { key: 'c' })
+
+    expect(request).not.toHaveBeenCalled()
+    expect(screen.getByText('2 selected')).toBeTruthy()
+    expect(screen.getByText('Past sessions, Web sources')).toBeTruthy()
+
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        'clarify.respond',
+        {
+          request_id: 'req-1',
+          answer: 'Past sessions, Web sources'
+        },
+        120_000
+      )
+    )
+  })
+
+  it('keeps free-form Other submission available for multi-select prompts', async () => {
+    const request = renderClarifyTool(vi.fn().mockResolvedValue({ ok: true }), { multiSelect: true })
+
+    const other = screen.getByRole('textbox', { name: 'Other (type your answer)' })
+    fireEvent.focus(other)
+    fireEvent.change(other, { target: { value: 'Use a custom path' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        'clarify.respond',
+        {
+          request_id: 'req-1',
+          answer: 'Use a custom path'
+        },
+        120_000
+      )
+    )
+  })
+
+  it('shows the current free-form draft as a custom selection', () => {
+    renderClarifyTool()
+
+    const other = screen.getByRole('textbox', { name: 'Other (type your answer)' })
+
+    fireEvent.focus(other)
+    fireEvent.change(other, {
+      target: { value: 'Use only local reports' }
+    })
+
+    expect(screen.getByText('Selected')).toBeTruthy()
+    expect(screen.getByText('Other (type your answer): Use only local reports')).toBeTruthy()
+  })
+})
+
+describe('ClarifyTool response timeout handling', () => {
+  it('uses a long dedicated timeout for clarify.respond acknowledgements', async () => {
+    const requestMock = renderPendingClarify()
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue waiting/i }))
+
+    await waitFor(() => {
+      expect(requestMock).toHaveBeenCalledWith(
+        'clarify.respond',
+        { request_id: REQUEST_ID, answer: 'Continue waiting' },
+        120_000
+      )
+    })
+  })
+
+  it('warns that a timed-out clarify response may still be processing', async () => {
+    const requestMock = renderPendingClarify({
+      request: vi.fn(async () => {
+        throw new Error('request timed out: clarify.respond')
+      })
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Stop now/i }))
+
+    await waitFor(() => expect(requestMock).toHaveBeenCalled())
+
+    await waitFor(() => {
+      expect($notifications.get()[0]).toMatchObject({
+        kind: 'warning',
+        title: 'Clarify response may still be processing',
+        message: expect.stringContaining('wait a moment before trying again')
+      })
+    })
+  })
+
+  it('clears expired clarify requests when the backend has no pending request', async () => {
+    const requestMock = renderPendingClarify({
+      request: vi.fn(async () => {
+        throw new Error('RPC 4009: no pending answer request')
+      })
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue waiting/i }))
+
+    await waitFor(() => expect(requestMock).toHaveBeenCalled())
+
+    await waitFor(() => {
+      expect($clarifyRequests.get()[SESSION_ID]).toBeUndefined()
+      expect(screen.getByText('Clarify request expired')).toBeTruthy()
+      expect($notifications.get()[0]).toMatchObject({
+        kind: 'warning',
+        title: 'Clarify request expired',
+        message: expect.stringContaining('no longer pending')
+      })
+    })
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ToolCallMessagePartProps, useAuiState } from '@assistant-ui/react'
+import { type ToolCallMessagePartProps } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import {
   type ComponentProps,
@@ -19,17 +19,47 @@ import { Kbd } from '@/components/ui/kbd'
 import { Textarea } from '@/components/ui/textarea'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
-import { Loader2, MessageQuestion } from '@/lib/icons'
+import { Check, Loader2, MessageQuestion } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { $clarifyRequest, clearClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
-import { notifyError } from '@/store/notifications'
+import { notify, notifyError } from '@/store/notifications'
 
 import { selectMessageRunning } from './tool/fallback-model'
 
 interface ClarifyArgs {
-  question?: string
+  allowOther?: boolean
   choices?: string[] | null
+  maxSelections?: number | null
+  minSelections?: number | null
+  multiSelect?: boolean
+  question?: string
+}
+
+function readNumber(row: Record<string, unknown>, camel: string, snake: string): number | null | undefined {
+  const value = row[camel] ?? row[snake]
+
+  return typeof value === 'number' ? value : value === null ? null : undefined
+}
+
+function readBoolean(row: Record<string, unknown>, camel: string, snake: string): boolean | undefined {
+  const value = row[camel] ?? row[snake]
+
+  return typeof value === 'boolean' ? value : undefined
+}
+
+const CLARIFY_RESPOND_TIMEOUT_MS = 120_000
+
+function isClarifyRespondTimeoutError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /request timed out:\s*clarify\.respond/i.test(message)
+}
+
+function isClarifyNoPendingRequestError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /no pending answer request/i.test(message)
 }
 
 function readClarifyArgs(args: unknown): ClarifyArgs {
@@ -41,8 +71,12 @@ function readClarifyArgs(args: unknown): ClarifyArgs {
   const choices = Array.isArray(row.choices) ? row.choices.filter((c): c is string => typeof c === 'string') : null
 
   return {
-    question: typeof row.question === 'string' ? row.question : undefined,
-    choices: choices && choices.length > 0 ? choices : null
+    allowOther: readBoolean(row, 'allowOther', 'allow_other'),
+    choices: choices && choices.length > 0 ? choices : null,
+    maxSelections: readNumber(row, 'maxSelections', 'max_selections'),
+    minSelections: readNumber(row, 'minSelections', 'min_selections'),
+    multiSelect: readBoolean(row, 'multiSelect', 'multi_select'),
+    question: typeof row.question === 'string' ? row.question : undefined
   }
 }
 
@@ -95,14 +129,38 @@ function KeyBadge({ char, preview, selected }: { char: string; preview?: boolean
   )
 }
 
-export const ClarifyTool = (props: ToolCallMessagePartProps) => {
-  const messageRunning = useAuiState(selectMessageRunning)
+function SelectToggle({ selected }: { selected: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'mt-px grid size-4 shrink-0 place-items-center rounded-full border transition-colors',
+        selected ? 'border-primary bg-primary text-white' : 'border-(--ui-stroke-secondary) text-transparent'
+      )}
+    >
+      {selected && <Check className="size-3" />}
+    </span>
+  )
+}
 
-  // Only the live, still-blocked turn shows the interactive panel. Once the
-  // message stops running — answered, the turn ended, or the user hit Stop —
-  // fall back to the standard tool block so the Q/A settles like every other
-  // row instead of stranding a dead prompt the gateway no longer waits on.
-  const isPending = messageRunning && props.result === undefined
+function toggleChoice(choices: string[], choice: string, maxSelections: number | null): string[] {
+  if (choices.includes(choice)) {
+    return choices.filter(item => item !== choice)
+  }
+
+  if (maxSelections !== null && choices.length >= maxSelections) {
+    return choices
+  }
+
+  return [...choices, choice]
+}
+
+export const ClarifyTool = (props: ToolCallMessagePartProps) => {
+  // The clarify request itself is the source of truth for interactivity. Using
+  // assistant-ui's messageRunning flag here can briefly flip false while the
+  // backend is still blocked on clarify.respond, which makes the selection block
+  // disappear even though the request is still live.
+  const isPending = props.result === undefined
 
   if (!isPending) {
     return <ToolFallback {...props} />
@@ -138,11 +196,17 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   )
 
   const hasChoices = choices.length > 0
+  const multiSelect = fromArgs.multiSelect ?? matchingRequest?.multiSelect ?? false
+  const allowOther = fromArgs.allowOther ?? matchingRequest?.allowOther ?? true
+  const minSelections = fromArgs.minSelections ?? matchingRequest?.minSelections ?? 0
+  const maxSelections = fromArgs.maxSelections ?? matchingRequest?.maxSelections ?? null
 
   const [draft, setDraft] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null)
+  const [selectedChoices, setSelectedChoices] = useState<string[]>([])
   const [otherFocused, setOtherFocused] = useState(false)
+  const [expired, setExpired] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
   // Race: tool.start fires a tick before clarify.request, so request_id
@@ -169,45 +233,99 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
       setSubmitting(true)
 
       try {
-        await gateway.request<{ ok?: boolean }>('clarify.respond', {
-          request_id: matchingRequest.requestId,
-          answer
-        })
+        await gateway.request<{ ok?: boolean }>(
+          'clarify.respond',
+          {
+            request_id: matchingRequest.requestId,
+            answer
+          },
+          CLARIFY_RESPOND_TIMEOUT_MS
+        )
         triggerHaptic('submit')
         clearClarifyRequest(matchingRequest.requestId, matchingRequest.sessionId)
         // The matching tool.complete will land shortly after, swapping this
         // panel for the ToolFallback view above.
       } catch (error) {
-        notifyError(error, copy.sendFailed)
+        if (isClarifyRespondTimeoutError(error)) {
+          notify({
+            kind: 'warning',
+            title: copy.responsePendingTitle,
+            message: copy.responsePendingMessage,
+            detail: error instanceof Error ? error.message : String(error),
+            durationMs: 12_000
+          })
+        } else if (isClarifyNoPendingRequestError(error)) {
+          clearClarifyRequest(matchingRequest.requestId, matchingRequest.sessionId)
+          setExpired(true)
+          notify({
+            kind: 'warning',
+            title: copy.responseExpiredTitle,
+            message: copy.responseExpiredMessage,
+            detail: error instanceof Error ? error.message : String(error),
+            durationMs: 12_000
+          })
+        } else {
+          notifyError(error, copy.sendFailed)
+        }
+
         setSubmitting(false)
       }
     },
-    [copy.gatewayDisconnected, copy.notReady, copy.sendFailed, gateway, matchingRequest, ready]
+    [
+      copy.gatewayDisconnected,
+      copy.notReady,
+      copy.responseExpiredMessage,
+      copy.responseExpiredTitle,
+      copy.responsePendingMessage,
+      copy.responsePendingTitle,
+      copy.sendFailed,
+      gateway,
+      matchingRequest,
+      ready
+    ]
   )
 
   const trimmedDraft = draft.trim()
-  // The answer is whichever input is active: a picked choice, or typed text.
-  // Picking a choice no longer fires immediately — it selects, then the user
-  // confirms with Continue (or Enter from the field).
-  const pendingAnswer = selectedChoice ?? (trimmedDraft || null)
+  const selectedSummary = selectedChoices.join(', ')
+  const customSummary = trimmedDraft ? `${copy.other}: ${trimmedDraft}` : ''
+  const selectionSummary = selectedSummary || selectedChoice || customSummary
+  const selectedChoiceCount = selectedChoices.length
+  const canSubmitSelected = multiSelect && selectedChoiceCount > 0 && selectedChoiceCount >= minSelections
+  const canSkip = minSelections <= 0 && (multiSelect || !hasChoices || allowOther)
 
-  const selectChoice = useCallback((choice: string) => {
-    // Picking a choice and typing are mutually exclusive answers.
-    setDraft('')
-    setSelectedChoice(choice)
-  }, [])
+  const selectChoice = useCallback(
+    (choice: string) => {
+      setDraft('')
+      setSelectedChoices([])
+      setSelectedChoice(choice)
+      void respond(choice)
+    },
+    [respond]
+  )
 
-  const submitAnswer = useCallback(() => {
-    if (selectedChoice !== null) {
-      void respond(selectedChoice)
+  const toggleMultiChoice = useCallback(
+    (choice: string) => {
+      if (!multiSelect) {
+        return
+      }
+      setDraft('')
+      setSelectedChoice(null)
+      setSelectedChoices(current => toggleChoice(current, choice, maxSelections))
+    },
+    [maxSelections, multiSelect]
+  )
 
-      return
+  const submitSelected = useCallback(() => {
+    if (canSubmitSelected) {
+      void respond(selectedChoices.join(', '))
     }
+  }, [canSubmitSelected, respond, selectedChoices])
 
+  const submitDraft = useCallback(() => {
     if (trimmedDraft) {
       void respond(trimmedDraft)
     }
-  }, [respond, selectedChoice, trimmedDraft])
+  }, [respond, trimmedDraft])
 
   const handleTextareaKey = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -217,49 +335,55 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
       if (event.key === 'Enter' && !event.shiftKey) {
         event.preventDefault()
-        submitAnswer()
+        submitDraft()
       }
     },
-    [submitAnswer]
+    [submitDraft]
   )
 
-  const handleSubmit = useCallback(
+  const handleSubmitDraft = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault()
-      submitAnswer()
+      submitDraft()
     },
-    [submitAnswer]
+    [submitDraft]
   )
 
-  // Letter shortcuts: A/B/C… pick the matching option, the trailing letter jumps
-  // into "Other", and Enter confirms the current pick. Stands down whenever a
-  // field is focused (you're typing, not navigating) so it never eats keystrokes
-  // meant for the composer or the Other box.
+  // Letter shortcuts: A/B/C… activate the visible key-badged rows, the
+  // trailing letter focuses "Other", and Enter submits staged multi-select
+  // choices. Stand down while a field is focused so normal typing is untouched.
   useEffect(() => {
-    if (!ready || !hasChoices || submitting) {
+    if (!ready || !hasChoices || submitting || expired) {
       return
     }
 
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+    const handleShortcut = (event: globalThis.KeyboardEvent) => {
       if (event.metaKey || event.ctrlKey || event.altKey || event.defaultPrevented) {
         return
       }
 
       const active = document.activeElement as HTMLElement | null
+      const tag = active?.tagName.toLowerCase()
 
-      if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) {
+      if (tag === 'input' || tag === 'textarea' || active?.isContentEditable) {
         return
       }
 
-      const key = event.key.toLowerCase()
+      if (event.key.length === 1) {
+        const index = event.key.toUpperCase().charCodeAt(0) - 65
 
-      if (key.length === 1 && key >= 'a' && key <= 'z') {
-        const index = key.charCodeAt(0) - 97
-
-        if (index < choices.length) {
+        if (index >= 0 && index < choices.length) {
           event.preventDefault()
-          selectChoice(choices[index])
-        } else if (index === choices.length) {
+          if (multiSelect) {
+            toggleMultiChoice(choices[index])
+          } else {
+            selectChoice(choices[index])
+          }
+
+          return
+        }
+
+        if (allowOther && index === choices.length) {
           event.preventDefault()
           textareaRef.current?.focus()
         }
@@ -267,16 +391,38 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
         return
       }
 
-      if (event.key === 'Enter' && pendingAnswer) {
+      if (event.key === 'Enter' && multiSelect && canSubmitSelected && !trimmedDraft) {
         event.preventDefault()
-        submitAnswer()
+        submitSelected()
       }
     }
 
-    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keydown', handleShortcut)
 
-    return () => window.removeEventListener('keydown', onKeyDown)
-  }, [choices, hasChoices, pendingAnswer, ready, selectChoice, submitAnswer, submitting])
+    return () => window.removeEventListener('keydown', handleShortcut)
+  }, [
+    allowOther,
+    canSubmitSelected,
+    choices,
+    expired,
+    hasChoices,
+    multiSelect,
+    ready,
+    selectChoice,
+    submitSelected,
+    submitting,
+    toggleMultiChoice,
+    trimmedDraft
+  ])
+
+  if (expired) {
+    return (
+      <ClarifyShell className="grid gap-1 px-2.5 py-2" role="status">
+        <div className="font-medium text-(--ui-text-primary)">{copy.responseExpiredTitle}</div>
+        <div className="text-xs text-(--ui-text-secondary)">{copy.responseExpiredMessage}</div>
+      </ClarifyShell>
+    )
+  }
 
   if (loading) {
     return (
@@ -293,10 +439,11 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   const onDraftChange = (value: string) => {
     setDraft(value)
 
-    // Typing is its own answer — drop any picked choice so the two inputs can't
-    // both look selected.
+    // Typing is its own answer — drop any picked/staged choice so the inputs
+    // can't both look selected.
     if (value.trim()) {
       setSelectedChoice(null)
+      setSelectedChoices([])
     }
   }
 
@@ -307,11 +454,55 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
         <MessageQuestion aria-hidden className="mt-px size-4 shrink-0 text-(--ui-text-tertiary)" />
       </div>
 
-      <form className="grid gap-2" onSubmit={handleSubmit}>
-        {hasChoices ? (
-          <div className="grid gap-px" role="group">
-            {choices.map((choice, index) => (
+      {selectionSummary && (
+        <div className="rounded-[0.25rem] border border-primary/20 bg-primary/5 px-2 py-1 text-xs" role="status">
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-medium text-primary">{copy.selected}</span>
+            {selectedChoiceCount > 0 && (
+              <span className="text-(--ui-text-tertiary)">{copy.selectedCount(selectedChoiceCount)}</span>
+            )}
+          </div>
+          <div className="mt-0.5 wrap-anywhere text-(--ui-text-secondary)">{selectionSummary}</div>
+        </div>
+      )}
+
+      {hasChoices && multiSelect && (
+        <div className="rounded-[0.25rem] bg-(--chrome-action-hover) px-2 py-1 text-xs text-(--ui-text-secondary)" role="note">
+          {copy.multiSelectHint}
+        </div>
+      )}
+
+      {hasChoices && (
+        <div className="grid gap-px" role="group">
+          {choices.map((choice, index) => {
+            const staged = selectedChoices.includes(choice)
+
+            if (multiSelect) {
+              return (
+                <button
+                  aria-label={`Toggle ${choice} for multi-select`}
+                  aria-pressed={staged}
+                  className={cn(
+                    OPTION_ROW_CLASS,
+                    'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
+                    staged && 'text-(--ui-text-primary)'
+                  )}
+                  data-choice
+                  disabled={submitting}
+                  key={`${index}-${choice}`}
+                  onClick={() => toggleMultiChoice(choice)}
+                  type="button"
+                >
+                  <KeyBadge char={letterFor(index)} selected={staged} />
+                  <span className="flex-1 wrap-anywhere">{choice}</span>
+                  <SelectToggle selected={staged} />
+                </button>
+              )
+            }
+
+            return (
               <button
+                aria-label={choice}
                 className={cn(
                   OPTION_ROW_CLASS,
                   'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
@@ -326,20 +517,20 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 <KeyBadge char={letterFor(index)} selected={selectedChoice === choice} />
                 <span className="flex-1 wrap-anywhere">{choice}</span>
               </button>
-            ))}
-            {/* "Other" is an inline content-sizing field, not a separate view. */}
+            )
+          })}
+          {allowOther && (
             <label className={cn(OPTION_ROW_CLASS, 'focus-within:bg-(--chrome-action-hover)')}>
               <KeyBadge char={letterFor(choices.length)} preview={otherFocused} selected={Boolean(trimmedDraft)} />
               <textarea
+                aria-label={copy.other}
                 className={FREEFORM_INPUT_CLASS}
                 disabled={submitting}
                 onBlur={() => setOtherFocused(false)}
                 onChange={event => onDraftChange(event.target.value)}
-                // Focusing "Other" is a switch to typing your own answer, so it
-                // deselects any picked choice — a chosen option and an active
-                // Other field can never both look selected.
                 onFocus={() => {
                   setSelectedChoice(null)
+                  setSelectedChoices([])
                   setOtherFocused(true)
                 }}
                 onKeyDown={handleTextareaKey}
@@ -349,8 +540,12 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
                 value={draft}
               />
             </label>
-          </div>
-        ) : (
+          )}
+        </div>
+      )}
+
+      {!hasChoices && (
+        <form className="grid gap-2" onSubmit={handleSubmitDraft}>
           <Textarea
             className={FREEFORM_INPUT_CLASS}
             disabled={submitting}
@@ -361,13 +556,21 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
             rows={1}
             value={draft}
           />
-        )}
+        </form>
+      )}
 
-        <div className="flex items-center justify-end gap-1">
+      <div className="flex items-center justify-end gap-1">
+        {canSkip && (
           <Button disabled={submitting} onClick={() => void respond('')} size="xs" type="button" variant="text">
             {copy.skip}
           </Button>
-          <Button disabled={submitting || !pendingAnswer} size="xs" type="submit">
+        )}
+        {multiSelect && !trimmedDraft ? (
+          <Button disabled={submitting || !canSubmitSelected} onClick={submitSelected} size="xs" type="button">
+            {submitting ? <Loader2 className="size-3" /> : copy.selectSelected}
+          </Button>
+        ) : (
+          <Button disabled={submitting || !trimmedDraft} onClick={submitDraft} size="xs" type="button">
             {submitting ? (
               <Loader2 className="size-3 animate-spin" />
             ) : (
@@ -379,8 +582,8 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
               </>
             )}
           </Button>
-        </div>
-      </form>
+        )}
+      </div>
     </ClarifyShell>
   )
 }

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -101,7 +101,7 @@ describe('Hermes REST session helpers', () => {
       [getHermesConfigDefaults, '/api/config/defaults'],
       [getGlobalModelInfo, '/api/model/info'],
       [() => getGlobalModelOptions(), '/api/model/options?explicit_only=1'],
-      [getCronJobs, '/api/cron/jobs']
+      [getCronJobs, '/api/cron/jobs?profile=default']
     ]
 
     for (const [call, path] of bootCalls) {
@@ -109,6 +109,35 @@ describe('Hermes REST session helpers', () => {
       await call()
       expect(api).toHaveBeenCalledWith(expect.objectContaining({ path, timeoutMs: 60_000 }))
     }
+  })
+
+  it('defaults cron job listing to the primary profile instead of aggregating worker profiles', async () => {
+    api.mockResolvedValue([])
+
+    await getCronJobs()
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/cron/jobs?profile=default',
+        timeoutMs: 60_000
+      })
+    )
+  })
+
+  it('can explicitly request named-profile or all-profile cron job lists', async () => {
+    api.mockResolvedValue([])
+
+    await getCronJobs('coder')
+    await getCronJobs('all')
+
+    expect(api).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ path: '/api/cron/jobs?profile=coder', timeoutMs: 60_000 })
+    )
+    expect(api).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ path: '/api/cron/jobs?profile=all', timeoutMs: 60_000 })
+    )
   })
 
   it('keeps the liveness poll on the short default so a dead backend fails fast', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -747,9 +747,9 @@ export function testMessagingPlatform(platformId: string): Promise<MessagingPlat
   })
 }
 
-export function getCronJobs(): Promise<CronJob[]> {
+export function getCronJobs(profile = 'default'): Promise<CronJob[]> {
   return window.hermesDesktop.api<CronJob[]>({
-    path: '/api/cron/jobs',
+    path: `/api/cron/jobs?profile=${encodeURIComponent(profile)}`,
     timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2273,11 +2273,20 @@ export const en: Translations = {
       notReady: 'Clarify request is not ready yet',
       gatewayDisconnected: 'Hermes gateway is not connected',
       sendFailed: 'Could not send clarify response',
+      responsePendingTitle: 'Clarify response may still be processing',
+      responsePendingMessage:
+        'Hermes did not confirm the choice in time. The backend may still receive it, so wait a moment before trying again to avoid duplicate responses.',
+      responseExpiredTitle: 'Clarify request expired',
+      responseExpiredMessage: 'That choice request is no longer pending. Wait for Hermes to ask again, then answer the fresh prompt.',
       loadingQuestion: 'Loading question…',
       other: 'Other (type your answer)',
       placeholder: 'Type your answer…',
       skip: 'Skip',
-      continueLabel: 'Continue'
+      continueLabel: 'Continue',
+      selected: 'Selected',
+      selectedCount: count => `${count} selected`,
+      multiSelectHint: 'Multi-select: use the circle on the right to stage choices, then press Select selected.',
+      selectSelected: 'Select selected'
     },
     tool: {
       code: 'Code',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2249,6 +2249,9 @@ export const ja = defineLocale({
       notReady: '明確化リクエストはまだ準備できていません',
       gatewayDisconnected: 'Hermes ゲートウェイが接続されていません',
       sendFailed: '明確化応答を送信できませんでした',
+      responsePendingTitle: '明確化応答はまだ処理中の可能性があります',
+      responsePendingMessage:
+        'Hermes は選択を時間内に確認できませんでした。バックエンドにはまだ届く可能性があるため、重複応答を避けるため少し待ってから再試行してください。',
       loadingQuestion: '質問を読み込み中…',
       other: 'その他（回答を入力）',
       placeholder: '回答を入力…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1905,11 +1905,19 @@ export interface Translations {
       notReady: string
       gatewayDisconnected: string
       sendFailed: string
+      responsePendingTitle: string
+      responsePendingMessage: string
+      responseExpiredTitle: string
+      responseExpiredMessage: string
       loadingQuestion: string
       other: string
       placeholder: string
       skip: string
       continueLabel: string
+      selected: string
+      selectedCount: (count: number) => string
+      multiSelectHint: string
+      selectSelected: string
     }
     tool: {
       code: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2181,6 +2181,8 @@ export const zhHant = defineLocale({
       notReady: '澄清請求尚未就緒',
       gatewayDisconnected: 'Hermes 閘道未連線',
       sendFailed: '無法傳送澄清回應',
+      responsePendingTitle: '澄清回應可能仍在處理中',
+      responsePendingMessage: 'Hermes 未能及時確認這次選擇。後端可能仍會收到它，請稍等片刻再重試，以避免重複回應。',
       loadingQuestion: '正在載入問題…',
       other: '其他（輸入您的答案）',
       placeholder: '輸入您的答案…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2435,11 +2435,19 @@ export const zh: Translations = {
       notReady: '澄清请求尚未就绪',
       gatewayDisconnected: 'Hermes 网关未连接',
       sendFailed: '无法发送澄清响应',
+      responsePendingTitle: '澄清响应可能仍在处理中',
+      responsePendingMessage: 'Hermes 未能及时确认该选择。后端可能仍会收到它，请稍等片刻再重试，以避免重复响应。',
+      responseExpiredTitle: '澄清请求已过期',
+      responseExpiredMessage: '该选择请求已不再等待回复。请等 Hermes 重新提问后，再回答新的提示。',
       loadingQuestion: '正在加载问题…',
       other: '其他 (输入你的答案)',
       placeholder: '输入你的答案…',
       skip: '跳过',
-      continueLabel: '继续'
+      continueLabel: '继续',
+      selected: '已选择',
+      selectedCount: count => `已选择 ${count} 项`,
+      multiSelectHint: '多选：使用右侧圆点暂存选项，然后点击“提交已选择”。',
+      selectSelected: '提交已选择'
     },
     tool: {
       code: '代码',

--- a/apps/desktop/src/lib/cron-profile-scope.test.ts
+++ b/apps/desktop/src/lib/cron-profile-scope.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { ALL_PROFILES } from '@/store/profile'
+
+import { cronJobsProfileForScope } from './cron-profile-scope'
+
+describe('cronJobsProfileForScope', () => {
+  it('keeps concrete profile cron lists scoped to that profile', () => {
+    expect(cronJobsProfileForScope('default')).toBe('default')
+    expect(cronJobsProfileForScope('coder')).toBe('coder')
+  })
+
+  it('maps the sidebar all-profiles scope to the backend aggregate profile', () => {
+    expect(cronJobsProfileForScope(ALL_PROFILES)).toBe('all')
+  })
+
+  it('falls back to the primary profile for empty scope values', () => {
+    expect(cronJobsProfileForScope(null)).toBe('default')
+    expect(cronJobsProfileForScope('')).toBe('default')
+  })
+})

--- a/apps/desktop/src/lib/cron-profile-scope.ts
+++ b/apps/desktop/src/lib/cron-profile-scope.ts
@@ -1,0 +1,10 @@
+import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
+
+// The desktop sidebar scopes cron jobs like sessions: concrete profile views show
+// only that profile, while the explicit All Profiles view asks the backend for
+// its aggregate list. Empty/null falls back to the primary/default profile.
+export function cronJobsProfileForScope(profileScope: null | string | undefined): string {
+  const normalized = normalizeProfileKey(profileScope)
+
+  return normalized === ALL_PROFILES ? 'all' : normalized
+}

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -7,6 +7,10 @@ export interface ClarifyRequest {
   question: string
   choices: string[] | null
   sessionId: string | null
+  multiSelect?: boolean
+  minSelections?: null | number
+  maxSelections?: null | number
+  allowOther?: boolean
 }
 
 // Pending clarify requests keyed by the runtime session id that raised them.

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -551,11 +551,15 @@ export interface AnalyticsTotals {
 export interface CronJob {
   deliver?: null | string
   enabled: boolean
+  hermes_home?: null | string
   id: string
+  is_default_profile?: boolean
   last_error?: null | string
   last_run_at?: null | string
   name?: null | string
   next_run_at?: null | string
+  profile?: null | string
+  profile_name?: null | string
   prompt?: null | string
   schedule?: CronJobSchedule
   schedule_display?: null | string

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -61,6 +61,12 @@ except ImportError:
 # profiles (the security boundary #4707 was filed for). Do NOT change this to
 # the default root: that re-breaks per-profile isolation. See also the dynamic
 # `_get_hermes_home()` / `_get_lock_paths()` resolution in cron/scheduler.py.
+#
+# These module-level paths are compatibility defaults only. Runtime cron IO uses
+# the dynamic helpers below so a long-lived process that enters a scoped profile
+# via ``set_hermes_home_override`` does not keep writing to an import-time
+# ``JOBS_FILE``. If tests or dashboard code deliberately monkeypatch the public
+# globals, the helpers honor that override for backward compatibility.
 HERMES_DIR = get_hermes_home().resolve()
 CRON_DIR = HERMES_DIR / "cron"
 JOBS_FILE = CRON_DIR / "jobs.json"
@@ -85,6 +91,55 @@ TICKER_INTERVAL_SECONDS = 60
 _jobs_file_lock = threading.RLock()
 _jobs_lock_state = threading.local()
 OUTPUT_DIR = CRON_DIR / "output"
+
+_IMPORT_HERMES_DIR = HERMES_DIR
+_IMPORT_CRON_DIR = CRON_DIR
+_IMPORT_JOBS_FILE = JOBS_FILE
+_IMPORT_OUTPUT_DIR = OUTPUT_DIR
+_IMPORT_TICKER_HEARTBEAT_FILE = TICKER_HEARTBEAT_FILE
+_IMPORT_TICKER_SUCCESS_FILE = TICKER_SUCCESS_FILE
+
+
+def _hermes_dir() -> Path:
+    """Return the active Hermes home for cron IO, honoring legacy monkeypatches."""
+    if HERMES_DIR != _IMPORT_HERMES_DIR:
+        return Path(HERMES_DIR)
+    return get_hermes_home().resolve()
+
+
+def _cron_dir() -> Path:
+    """Return the active cron directory for the current profile/scope."""
+    if CRON_DIR != _IMPORT_CRON_DIR:
+        return Path(CRON_DIR)
+    return _hermes_dir() / "cron"
+
+
+def _jobs_file() -> Path:
+    """Return the active jobs.json path for the current profile/scope."""
+    if JOBS_FILE != _IMPORT_JOBS_FILE:
+        return Path(JOBS_FILE)
+    return _cron_dir() / "jobs.json"
+
+
+def _output_dir() -> Path:
+    """Return the active cron output directory for the current profile/scope."""
+    if OUTPUT_DIR != _IMPORT_OUTPUT_DIR:
+        return Path(OUTPUT_DIR)
+    return _cron_dir() / "output"
+
+
+def _ticker_heartbeat_file() -> Path:
+    if TICKER_HEARTBEAT_FILE != _IMPORT_TICKER_HEARTBEAT_FILE:
+        return Path(TICKER_HEARTBEAT_FILE)
+    return _cron_dir() / "ticker_heartbeat"
+
+
+def _ticker_success_file() -> Path:
+    if TICKER_SUCCESS_FILE != _IMPORT_TICKER_SUCCESS_FILE:
+        return Path(TICKER_SUCCESS_FILE)
+    return _cron_dir() / "ticker_last_success"
+
+
 ONESHOT_GRACE_SECONDS = 120
 
 # Fallback stale-recovery window for a one-shot's running-claim (#59229) when
@@ -136,7 +191,7 @@ def _oneshot_run_claim_ttl_seconds() -> float:
 
 def _jobs_lock_file() -> Path:
     """Return the advisory lock path for the current cron directory."""
-    return CRON_DIR / ".jobs.lock"
+    return _cron_dir() / ".jobs.lock"
 
 
 @contextlib.contextmanager
@@ -221,7 +276,7 @@ def _job_output_dir(job_id: str) -> Path:
         raise ValueError(f"Invalid cron job id for output path: {job_id!r}")
     if Path(text).is_absolute() or Path(text).drive:
         raise ValueError(f"Invalid cron job id for output path: {job_id!r}")
-    return OUTPUT_DIR / text
+    return _output_dir() / text
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -328,10 +383,15 @@ def _secure_file(path: Path):
 
 def ensure_dirs():
     """Ensure cron directories exist with secure permissions."""
-    CRON_DIR.mkdir(parents=True, exist_ok=True)
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    _secure_dir(CRON_DIR)
-    _secure_dir(OUTPUT_DIR)
+    cron_dir = _cron_dir()
+    jobs_parent = _jobs_file().parent
+    output_dir = _output_dir()
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    jobs_parent.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _secure_dir(cron_dir)
+    _secure_dir(jobs_parent)
+    _secure_dir(output_dir)
 
 
 # =============================================================================
@@ -620,7 +680,7 @@ def _atomic_write_epoch(path: Path) -> None:
     torn/truncated file. Best-effort: failures are swallowed by callers.
     """
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(CRON_DIR), suffix=".tmp", prefix=".hb_")
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".hb_")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(str(time.time()))
@@ -648,12 +708,12 @@ def record_ticker_heartbeat(success: bool = False) -> None:
     Best-effort: a write failure must never disrupt the tick loop.
     """
     try:
-        _atomic_write_epoch(TICKER_HEARTBEAT_FILE)
+        _atomic_write_epoch(_ticker_heartbeat_file())
     except Exception:
         pass
     if success:
         try:
-            _atomic_write_epoch(TICKER_SUCCESS_FILE)
+            _atomic_write_epoch(_ticker_success_file())
         except Exception:
             pass
 
@@ -672,12 +732,12 @@ def get_ticker_heartbeat_age() -> Optional[float]:
     None = heartbeat file missing/unreadable (older build, never ran, or a
     torn read). Callers treat None as "cannot determine", not "dead".
     """
-    return _epoch_file_age(TICKER_HEARTBEAT_FILE)
+    return _epoch_file_age(_ticker_heartbeat_file())
 
 
 def get_ticker_success_age() -> Optional[float]:
     """Seconds since the ticker last completed a tick WITHOUT raising, or None."""
-    return _epoch_file_age(TICKER_SUCCESS_FILE)
+    return _epoch_file_age(_ticker_success_file())
 
 
 # =============================================================================
@@ -687,19 +747,20 @@ def get_ticker_success_age() -> Optional[float]:
 def load_jobs() -> List[Dict[str, Any]]:
     """Load all jobs from storage."""
     ensure_dirs()
-    if not JOBS_FILE.exists():
+    jobs_file = _jobs_file()
+    if not jobs_file.exists():
         return []
 
     _strict_retry = False  # track whether we used the strict=False fallback
 
     try:
-        with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+        with open(jobs_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         _strict_retry = True
         try:
-            with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+            with open(jobs_file, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
         except Exception as e:
             logger.error("Failed to auto-repair jobs.json: %s", e)
@@ -735,14 +796,15 @@ def load_jobs() -> List[Dict[str, Any]]:
 def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
     """Save all jobs to storage. Caller must hold _jobs_lock()."""
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
+    jobs_file = _jobs_file()
+    fd, tmp_path = tempfile.mkstemp(dir=str(jobs_file.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
             json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
             f.flush()
             os.fsync(f.fileno())
-        atomic_replace(tmp_path, JOBS_FILE)
-        _secure_file(JOBS_FILE)
+        atomic_replace(tmp_path, jobs_file)
+        _secure_file(jobs_file)
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2213,7 +2213,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     # Inject output from referenced cron jobs as context.
     context_from = job.get("context_from")
     if context_from:
-        from cron.jobs import OUTPUT_DIR
+        from cron.jobs import _job_output_dir
         if isinstance(context_from, str):
             context_from = [context_from]
         for source_job_id in context_from:
@@ -2228,7 +2228,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 )
                 continue
             try:
-                job_output_dir = OUTPUT_DIR / source_job_id
+                job_output_dir = _job_output_dir(source_job_id)
                 if not job_output_dir.exists():
                     continue  # silent skip — no output yet
                 output_files = sorted(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3093,6 +3093,10 @@ class BasePlatformAdapter(ABC):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        multi_select: bool = False,
+        min_selections: int = 0,
+        max_selections: Optional[int] = None,
+        allow_other: bool = True,
     ) -> SendResult:
         """Send a clarify prompt to the user.
 
@@ -3125,10 +3129,27 @@ class BasePlatformAdapter(ABC):
         """
         if choices:
             lines = [f"❓ {question}", ""]
+            if multi_select:
+                suffix = ", or your own answer" if allow_other else ""
+                lines.append(
+                    "Multiple selections allowed: reply with numbers/letters "
+                    f"like `1,3` or `A+C`, or option text{suffix}."
+                )
+                lines.append("")
             for i, choice in enumerate(choices, start=1):
-                lines.append(f"  {i}. {choice}")
+                prefix = f"{i}."
+                if multi_select:
+                    letter = chr(ord("A") + i - 1)
+                    prefix = f"{i}/{letter}."
+                lines.append(f"  {prefix} {choice}")
             lines.append("")
-            lines.append("Reply with the number, the option text, or your own answer.")
+            if multi_select:
+                suffix = ", option text, or your own answer" if allow_other else " or option text"
+                lines.append(f"Reply with one or more numbers/letters{suffix}.")
+            elif allow_other:
+                lines.append("Reply with the number, the option text, or your own answer.")
+            else:
+                lines.append("Reply with the number or the option text.")
             text = "\n".join(lines)
             # Text fallback: enable text-capture so the gateway intercept
             # picks up the user's typed reply (e.g. "2" or choice text).

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -718,13 +718,19 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        multi_select: bool = False,
+        min_selections: int = 0,
+        max_selections: Optional[int] = None,
+        allow_other: bool = True,
     ) -> SendResult:
         """Render a clarify prompt as native WhatsApp interactive buttons.
 
-        - 1–3 choices → ``interactive.type=button`` (inline pill buttons).
-        - 4+ choices → ``interactive.type=list`` (tap-to-open sheet with
-          up to 10 rows). Telegram's "Other (type answer)" escape hatch
-          is appended as the final row, picking it flips the entry into
+        - Multi-select prompts fall back to the base numbered-text renderer
+          because WhatsApp Cloud interactive controls are single-select only.
+        - 1–3 single-select choices → ``interactive.type=button`` (inline pill buttons).
+        - 4+ single-select choices → ``interactive.type=list`` (tap-to-open sheet with
+          up to 10 rows). When ``allow_other`` is true, an "Other (type
+          answer)" row is appended; picking it flips the entry into
           text-capture mode handled by the gateway's text intercept.
         - 0 choices (open-ended) → plain text question; the next message
           in the session is captured by the gateway and resolves clarify.
@@ -741,6 +747,25 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # Open-ended → just send the question, gateway captures next msg.
         if not choices:
             return await self.send(chat_id, f"❓ {question}", reply_to=reply_to)
+
+        # WhatsApp Cloud interactive buttons/lists are single-select. Preserve
+        # multi-select semantics by deliberately degrading to BasePlatformAdapter's
+        # numbered text fallback, where the gateway parser accepts replies like
+        # "1,3" / "A+C" and enforces min/max/allow_other.
+        if multi_select:
+            return await BasePlatformAdapter.send_clarify(
+                self,
+                chat_id=chat_id,
+                question=question,
+                choices=choices,
+                clarify_id=clarify_id,
+                session_key=session_key,
+                metadata=metadata,
+                multi_select=multi_select,
+                min_selections=min_selections,
+                max_selections=max_selections,
+                allow_other=allow_other,
+            )
 
         # Mirror Telegram: render full choice text in body so long
         # options aren't truncated to the 20-char button label cap.
@@ -779,11 +804,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     "title": self._truncate_button_label(f"{idx + 1}", limit=24),
                     "description": self._truncate_button_label(choice_text, limit=72),
                 })
-            rows.append({
-                "id": f"cl:{clarify_id}:other",
-                "title": "✏️ Other",
-                "description": "Type your own answer",
-            })
+            if allow_other:
+                rows.append({
+                    "id": f"cl:{clarify_id}:other",
+                    "title": "✏️ Other",
+                    "description": "Type your own answer",
+                })
             interactive = {
                 "type": "list",
                 "body": {"text": body_text},

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9017,6 +9017,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.
                     return ""
+                logger.info(
+                    "Gateway rejected invalid clarify text response (session=%s, id=%s)",
+                    _quick_key, _pending_clarify.clarify_id,
+                )
+                return _clarify_mod.format_invalid_text_response_message(_pending_clarify)
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are
@@ -18192,7 +18197,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # explaining that no response arrived (so the agent can adapt
             # rather than hang forever).
             # ------------------------------------------------------------------
-            def _clarify_callback_sync(question: str, choices) -> str:
+            def _clarify_callback_sync(
+                question: str,
+                choices,
+                *,
+                multi_select: bool = False,
+                min_selections: int = 0,
+                max_selections = None,
+                allow_other: bool = True,
+            ) -> str:
                 from tools import clarify_gateway as _clarify_mod
                 import uuid as _uuid
 
@@ -18205,6 +18218,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key=session_key or "",
                     question=question,
                     choices=list(choices) if choices else None,
+                    multi_select=multi_select,
+                    min_selections=min_selections,
+                    max_selections=max_selections,
+                    allow_other=allow_other,
                 )
 
                 # Pause typing — like approval, we don't want a "thinking..."
@@ -18225,6 +18242,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         clarify_id=clarify_id,
                         session_key=session_key or "",
                         metadata=_status_thread_metadata,
+                        multi_select=multi_select,
+                        min_selections=min_selections,
+                        max_selections=max_selections,
+                        allow_other=allow_other,
                     ),
                     _loop_for_step,
                     logger=logger,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5713,6 +5713,10 @@ class DiscordAdapter(BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        multi_select: bool = False,
+        min_selections: int = 0,
+        max_selections: Optional[int] = None,
+        allow_other: bool = True,
     ) -> SendResult:
         """Render a clarify prompt with one Discord button per choice.
 
@@ -5794,17 +5798,42 @@ class DiscordAdapter(BasePlatformAdapter):
             clean_choices = clean_choices[:24]
 
             if clean_choices:
-                embed.add_field(
-                    name="Choices",
-                    value="Pick one below, or click ✏️ Other to type a custom answer.",
-                    inline=False,
-                )
-                view = ClarifyChoiceView(
-                    choices=clean_choices,
-                    clarify_id=clarify_id,
-                    allowed_user_ids=self._allowed_user_ids,
-                    allowed_role_ids=self._allowed_role_ids,
-                )
+                if multi_select:
+                    help_text = "Pick one or more below, then submit selected"
+                    if allow_other:
+                        help_text += ", or click ✏️ Other to type a custom answer"
+                    help_text += "."
+                    embed.add_field(
+                        name="Choices",
+                        value=help_text,
+                        inline=False,
+                    )
+                    view = ClarifyMultiSelectView(
+                        choices=clean_choices,
+                        clarify_id=clarify_id,
+                        allowed_user_ids=self._allowed_user_ids,
+                        allowed_role_ids=self._allowed_role_ids,
+                        min_selections=min_selections,
+                        max_selections=max_selections,
+                        allow_other=allow_other,
+                    )
+                else:
+                    help_text = "Pick one below"
+                    if allow_other:
+                        help_text += ", or click ✏️ Other to type a custom answer"
+                    help_text += "."
+                    embed.add_field(
+                        name="Choices",
+                        value=help_text,
+                        inline=False,
+                    )
+                    view = ClarifyChoiceView(
+                        choices=clean_choices,
+                        clarify_id=clarify_id,
+                        allowed_user_ids=self._allowed_user_ids,
+                        allowed_role_ids=self._allowed_role_ids,
+                        allow_other=allow_other,
+                    )
             else:
                 embed.add_field(
                     name="Reply",
@@ -6817,7 +6846,7 @@ def _define_discord_view_classes() -> None:
     lazy install sets DISCORD_AVAILABLE=True but leaves the classes
     undefined, causing NameError on the first button interaction.
     """
-    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView
+    global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView, ClarifyMultiSelectView
 
     class ExecApprovalView(discord.ui.View):
         """
@@ -7507,6 +7536,196 @@ def _define_discord_view_classes() -> None:
                     pass
 
 
+    class ClarifyMultiSelectView(discord.ui.View):
+        """Native Discord multi-select clarify view.
+
+        Stages choices via a select menu and resolves only when the user taps
+        Submit. This preserves true multi-pick semantics instead of forcing a
+        single button click to end the clarify request.
+        """
+
+        def __init__(
+            self,
+            choices: List[str],
+            clarify_id: str,
+            allowed_user_ids: set,
+            allowed_role_ids: Optional[set] = None,
+            min_selections: int = 0,
+            max_selections: Optional[int] = None,
+            allow_other: bool = True,
+        ):
+            super().__init__(timeout=300)
+            self.choices = list(choices)[:24]
+            self.clarify_id = clarify_id
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+            self.min_selections = int(min_selections or 0)
+            self.max_selections = min(int(max_selections), len(self.choices)) if max_selections is not None else len(self.choices)
+            self.allow_other = bool(allow_other)
+            self.selected_indices: set[int] = set()
+            self.resolved = False
+
+            options = [
+                discord.SelectOption(label=str(choice)[:100], value=str(index))
+                for index, choice in enumerate(self.choices)
+            ]
+            select = discord.ui.Select(
+                placeholder="Select one or more choices…",
+                options=options,
+                custom_id=f"clarify:{clarify_id}:multi",
+                min_values=max(1, self.min_selections) if self.choices else 0,
+                max_values=max(1, self.max_selections) if self.choices else 1,
+            )
+            select.callback = self._on_select
+            self.add_item(select)
+
+            submit_btn = discord.ui.Button(
+                label="✅ Submit selected",
+                style=discord.ButtonStyle.success,
+                custom_id=f"clarify:{clarify_id}:multi_submit",
+            )
+            submit_btn.callback = self._on_submit
+            self.add_item(submit_btn)
+
+            if self.allow_other:
+                other_btn = discord.ui.Button(
+                    label="✏️ Other (type answer)",
+                    style=discord.ButtonStyle.secondary,
+                    custom_id=f"clarify:{clarify_id}:other",
+                )
+                other_btn.callback = self._on_other
+                self.add_item(other_btn)
+
+        def _check_auth(self, interaction: "discord.Interaction") -> bool:
+            return _component_check_auth(
+                interaction, self.allowed_user_ids, self.allowed_role_ids,
+            )
+
+        async def _on_select(self, interaction: "discord.Interaction") -> None:
+            if self.resolved:
+                await interaction.response.send_message(
+                    "This prompt has already been answered~", ephemeral=True,
+                )
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to answer this prompt~", ephemeral=True,
+                )
+                return
+            values = getattr(interaction, "data", {}).get("values", [])
+            selected: set[int] = set()
+            for value in values:
+                try:
+                    idx = int(value)
+                except (TypeError, ValueError):
+                    continue
+                if 0 <= idx < len(self.choices):
+                    selected.add(idx)
+            self.selected_indices = selected
+
+            embed = interaction.message.embeds[0] if (
+                interaction.message and interaction.message.embeds
+            ) else None
+            if embed:
+                selected_text = ", ".join(self.choices[i] for i in sorted(selected)) or "none yet"
+                embed.set_footer(text=f"Selected: {selected_text}")
+            await interaction.response.edit_message(embed=embed, view=self)
+
+        async def _on_submit(self, interaction: "discord.Interaction") -> None:
+            if self.resolved:
+                await interaction.response.send_message(
+                    "This prompt has already been answered~", ephemeral=True,
+                )
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to answer this prompt~", ephemeral=True,
+                )
+                return
+            if len(self.selected_indices) < self.min_selections:
+                await interaction.response.send_message(
+                    f"Select at least {self.min_selections} choices~", ephemeral=True,
+                )
+                return
+
+            resolved_text = ", ".join(
+                self.choices[i] for i in sorted(self.selected_indices) if 0 <= i < len(self.choices)
+            )
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+
+            embed = interaction.message.embeds[0] if (
+                interaction.message and interaction.message.embeds
+            ) else None
+            if embed:
+                user = getattr(interaction, "user", None)
+                display_name = getattr(user, "display_name", "user")
+                embed.color = discord.Color.green()
+                embed.set_footer(text=f"Answered by {display_name}: {resolved_text}")
+
+            try:
+                from tools.clarify_gateway import resolve_gateway_clarify
+                resolved = resolve_gateway_clarify(self.clarify_id, resolved_text)
+                logger.info(
+                    "Discord clarify multi-select resolved (id=%s, choices=%r, ok=%s)",
+                    self.clarify_id, resolved_text, resolved,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Discord clarify multi-select resolve failed (id=%s): %s",
+                    self.clarify_id, exc,
+                )
+            await interaction.response.edit_message(embed=embed, view=self)
+
+        async def _on_other(self, interaction: "discord.Interaction") -> None:
+            if self.resolved:
+                await interaction.response.send_message(
+                    "This prompt has already been answered~", ephemeral=True,
+                )
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to answer this prompt~", ephemeral=True,
+                )
+                return
+            try:
+                from tools.clarify_gateway import mark_awaiting_text
+                mark_awaiting_text(self.clarify_id)
+            except Exception as exc:
+                logger.warning(
+                    "Discord clarify multi-select mark_awaiting_text failed (id=%s): %s",
+                    self.clarify_id, exc,
+                )
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+            embed = interaction.message.embeds[0] if (
+                interaction.message and interaction.message.embeds
+            ) else None
+            if embed:
+                user = getattr(interaction, "user", None)
+                display_name = getattr(user, "display_name", "user")
+                embed.color = discord.Color.blue()
+                embed.set_footer(text=f"Awaiting typed response from {display_name}…")
+            await interaction.response.edit_message(embed=embed, view=self)
+
+        async def on_timeout(self):
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+            msg = getattr(self, '_message', None)
+            if msg:
+                try:
+                    embed = msg.embeds[0] if msg.embeds else None
+                    if embed:
+                        embed.color = discord.Color.greyple()
+                        embed.set_footer(text="⏱ Prompt expired — no action taken")
+                    await msg.edit(embed=embed, view=self)
+                except Exception:
+                    pass
+
+
     class ClarifyChoiceView(discord.ui.View):
         """Interactive button view for the clarify tool's multiple-choice prompts.
 
@@ -7528,12 +7747,14 @@ def _define_discord_view_classes() -> None:
             clarify_id: str,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
+            allow_other: bool = True,
         ):
             super().__init__(timeout=_read_discord_prompt_timeout())
             self.choices = list(choices)[:24]
             self.clarify_id = clarify_id
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
+            self.allow_other = bool(allow_other)
             self.resolved = False
 
             for index, choice in enumerate(self.choices):
@@ -7587,13 +7808,14 @@ def _define_discord_view_classes() -> None:
                 button.callback = self._make_choice_callback(index, choice)
                 self.add_item(button)
 
-            other_btn = discord.ui.Button(
-                label="✏️ Other (type answer)",
-                style=discord.ButtonStyle.secondary,
-                custom_id=f"clarify:{clarify_id}:other",
-            )
-            other_btn.callback = self._on_other
-            self.add_item(other_btn)
+            if self.allow_other:
+                other_btn = discord.ui.Button(
+                    label="✏️ Other (type answer)",
+                    style=discord.ButtonStyle.secondary,
+                    custom_id=f"clarify:{clarify_id}:other",
+                )
+                other_btn.callback = self._on_other
+                self.add_item(other_btn)
 
         def _check_auth(self, interaction: "discord.Interaction") -> bool:
             return _component_check_auth(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -643,6 +643,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
+        # Native multi-select clarify state: clarify_id → {choices, selected, ...}.
+        self._clarify_multi_state: Dict[str, dict] = {}
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -4667,6 +4669,10 @@ class TelegramAdapter(BasePlatformAdapter):
         clarify_id: str,
         session_key: str,
         metadata: Optional[Dict[str, Any]] = None,
+        multi_select: bool = False,
+        min_selections: int = 0,
+        max_selections: Optional[int] = None,
+        allow_other: bool = True,
     ) -> SendResult:
         """Render a clarify prompt with one inline button per choice.
 
@@ -4695,7 +4701,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     f"{i + 1}. {_html.escape(str(c))}"
                     for i, c in enumerate(choices)
                 )
-                text += f"\n\n{option_lines}"
+                if multi_select:
+                    text += f"\n\nSelect one or more, then tap ✅ Done.\n\n{option_lines}"
+                else:
+                    text += f"\n\n{option_lines}"
 
             kwargs: Dict[str, Any] = {
                 "chat_id": normalize_telegram_chat_id(chat_id),
@@ -4705,22 +4714,49 @@ class TelegramAdapter(BasePlatformAdapter):
             }
 
             if choices:
-                # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>"
-                # short.
+                # Telegram caps callback_data at 64 bytes; keep callback ids short.
                 rows = []
-                for idx in range(len(choices)):
+                if multi_select:
+                    clean_choices = [str(c).strip() for c in choices if str(c).strip()]
+                    self._clarify_multi_state[clarify_id] = {
+                        "choices": clean_choices,
+                        "selected": set(),
+                        "min_selections": int(min_selections or 0),
+                        "max_selections": max_selections,
+                        "allow_other": bool(allow_other),
+                    }
+                    for idx in range(len(clean_choices)):
+                        rows.append([
+                            InlineKeyboardButton(
+                                f"☐ {idx + 1}",
+                                callback_data=f"clms:{clarify_id}:toggle:{idx}",
+                            )
+                        ])
                     rows.append([
-                        InlineKeyboardButton(
-                            str(idx + 1),
-                            callback_data=f"cl:{clarify_id}:{idx}",
-                        )
+                        InlineKeyboardButton("✅ Done", callback_data=f"clms:{clarify_id}:done")
                     ])
-                rows.append([
-                    InlineKeyboardButton(
-                        "✏️ Other (type answer)",
-                        callback_data=f"cl:{clarify_id}:other",
-                    )
-                ])
+                    if allow_other:
+                        rows.append([
+                            InlineKeyboardButton(
+                                "✏️ Other (type answer)",
+                                callback_data=f"clms:{clarify_id}:other",
+                            )
+                        ])
+                else:
+                    for idx in range(len(choices)):
+                        rows.append([
+                            InlineKeyboardButton(
+                                str(idx + 1),
+                                callback_data=f"cl:{clarify_id}:{idx}",
+                            )
+                        ])
+                    if allow_other:
+                        rows.append([
+                            InlineKeyboardButton(
+                                "✏️ Other (type answer)",
+                                callback_data=f"cl:{clarify_id}:other",
+                            )
+                        ])
                 kwargs["reply_markup"] = InlineKeyboardMarkup(rows)
 
             reply_to_id = self._reply_to_message_id_for_send(None, metadata)
@@ -5491,6 +5527,132 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Clarify multi-select callbacks (clms:clarify_id:toggle:idx | done | other) ---
+        if data.startswith("clms:"):
+            parts = data.split(":")
+            if len(parts) >= 3:
+                clarify_id = parts[1]
+                action = parts[2]
+
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to answer this prompt.")
+                    return
+
+                session_key = self._clarify_state.get(clarify_id)
+                state = self._clarify_multi_state.get(clarify_id)
+                if not session_key or not state:
+                    await query.answer(text="This prompt has already been resolved.")
+                    return
+
+                user_display = getattr(query.from_user, "first_name", "User")
+                choices = list(state.get("choices") or [])
+                selected = state.setdefault("selected", set())
+
+                if action == "toggle" and len(parts) == 4:
+                    try:
+                        idx = int(parts[3])
+                    except (ValueError, TypeError):
+                        await query.answer(text="Invalid choice.")
+                        return
+                    if not 0 <= idx < len(choices):
+                        await query.answer(text="Invalid choice.")
+                        return
+                    if idx in selected:
+                        selected.remove(idx)
+                    else:
+                        max_sel = state.get("max_selections")
+                        if max_sel is not None and len(selected) >= int(max_sel):
+                            await query.answer(text=f"Select at most {max_sel}.")
+                            return
+                        selected.add(idx)
+                    await query.answer(text=f"{len(selected)} selected")
+                    try:
+                        rows = []
+                        for choice_idx in range(len(choices)):
+                            mark = "☑" if choice_idx in selected else "☐"
+                            rows.append([
+                                InlineKeyboardButton(
+                                    f"{mark} {choice_idx + 1}",
+                                    callback_data=f"clms:{clarify_id}:toggle:{choice_idx}",
+                                )
+                            ])
+                        rows.append([
+                            InlineKeyboardButton("✅ Done", callback_data=f"clms:{clarify_id}:done")
+                        ])
+                        if state.get("allow_other", True):
+                            rows.append([
+                                InlineKeyboardButton(
+                                    "✏️ Other (type answer)",
+                                    callback_data=f"clms:{clarify_id}:other",
+                                )
+                            ])
+                        await query.edit_message_text(
+                            text=query.message.text or "",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=InlineKeyboardMarkup(rows),
+                        )
+                    except Exception:
+                        pass
+                    return
+
+                if action == "other":
+                    try:
+                        from tools.clarify_gateway import mark_awaiting_text
+                        mark_awaiting_text(clarify_id)
+                    except Exception as exc:
+                        logger.warning("[%s] mark_awaiting_text failed: %s", self.name, exc)
+                    await query.answer(text="✏️ Type your answer in the chat.")
+                    try:
+                        await query.edit_message_text(
+                            text=f"❓ {query.message.text or ''}\n\n<i>Awaiting typed response from {_html.escape(user_display)}…</i>",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    return
+
+                if action == "done":
+                    min_sel = int(state.get("min_selections") or 0)
+                    if len(selected) < min_sel:
+                        await query.answer(text=f"Select at least {min_sel}.")
+                        return
+                    resolved_labels = [choices[i] for i in sorted(selected) if 0 <= i < len(choices)]
+                    resolved_text = ", ".join(resolved_labels)
+                    self._clarify_state.pop(clarify_id, None)
+                    self._clarify_multi_state.pop(clarify_id, None)
+                    try:
+                        from tools.clarify_gateway import resolve_gateway_clarify
+                        resolved = resolve_gateway_clarify(clarify_id, resolved_text)
+                    except Exception as exc:
+                        logger.error("[%s] resolve_gateway_clarify failed: %s", self.name, exc)
+                        resolved = False
+                    await query.answer(text=f"✓ {len(resolved_labels)} selected")
+                    try:
+                        await query.edit_message_text(
+                            text=f"❓ {_html.escape(query.message.text or '')}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    if resolved:
+                        logger.info(
+                            "Telegram clarify multi-select resolved (id=%s, choices=%r, user=%s)",
+                            clarify_id, resolved_text, user_display,
+                        )
+                    return
+
+                await query.answer(text="Invalid choice.")
             return
 
         # --- Clarify callbacks (cl:clarify_id:idx | cl:clarify_id:other) ---

--- a/run_agent.py
+++ b/run_agent.py
@@ -1666,14 +1666,16 @@ class AIAgent:
         self._flush_messages_to_session_db(messages, conversation_history)
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
-        """Remove private empty-response retry/failure scaffolding from transcript tails.
+        """Remove private retry/failure scaffolding from transcript tails.
 
         Also rewinds past any trailing tool-result / assistant(tool_calls) pair
         that the failed iteration left hanging. Without this, the tail ends at
         a raw ``tool`` message and the next user turn lands as
         ``...tool, user, user`` — a protocol-invalid sequence that most
         providers silently reject (returns empty content), causing the
-        empty-retry loop to fire forever. (issue number to be backfilled once filed)
+        empty-retry loop to fire forever. Clarify-choice guard nudges are also
+        ephemeral retry scaffolding; they must not be persisted if a guarded
+        retry is interrupted before the normal success/block cleanup path runs.
         """
         # Pass 1: strip the flagged scaffolding messages themselves.
         dropped_scaffolding = False
@@ -1683,6 +1685,7 @@ class AIAgent:
             and (
                 messages[-1].get("_empty_recovery_synthetic")
                 or messages[-1].get("_empty_terminal_sentinel")
+                or messages[-1].get("_clarify_choice_guard_synthetic")
             )
         ):
             messages.pop()

--- a/tests/agent/test_clarify_choice_guard.py
+++ b/tests/agent/test_clarify_choice_guard.py
@@ -1,0 +1,161 @@
+from agent.clarify_choice_guard import clarify_choice_guard_action
+
+
+def test_nudges_markdown_next_action_choices_when_clarify_available():
+    response = """작업 확인됨.
+
+## 결과 요약
+확인했습니다.
+
+## 다음 추천 작업
+- 그대로 두기: 지금 상태를 유지합니다.
+- 소스 하드게이트 구현하기: 재발을 막습니다.
+- 보류: 나중에 합니다.
+"""
+
+    action, payload = clarify_choice_guard_action(
+        response,
+        valid_tool_names={"clarify", "terminal"},
+        platform="desktop",
+        attempts=0,
+    )
+
+    assert action == "nudge"
+    assert payload is not None
+    assert "clarify" in payload
+    assert "choices" in payload
+
+
+def test_nudges_fenced_select_blocks_because_they_are_not_native_ui():
+    response = """## 다음 추천 작업
+
+```select
+A. Continue
+B. Stop
+```
+"""
+
+    action, payload = clarify_choice_guard_action(
+        response,
+        valid_tool_names={"clarify"},
+        platform="desktop",
+        attempts=0,
+    )
+
+    assert action == "nudge"
+    assert payload is not None
+    assert "fenced" in payload
+    assert "clarify" in payload
+
+
+def test_nudges_approval_choice_headings_too():
+    response = """## 승인 필요
+- 승인 실행
+- 수정
+- 보류
+- 금지
+"""
+
+    action, payload = clarify_choice_guard_action(
+        response,
+        valid_tool_names={"clarify"},
+        platform="desktop",
+        attempts=0,
+    )
+
+    assert action == "nudge"
+    assert payload is not None
+    assert "clarify" in payload
+
+
+def test_nudges_english_next_action_choice_headings_too():
+    response = """## Recommended next actions
+A. Keep current local state
+B. Apply runtime restart
+"""
+
+    action, payload = clarify_choice_guard_action(
+        response,
+        valid_tool_names={"clarify"},
+        platform="desktop",
+        attempts=0,
+    )
+
+    assert action == "nudge"
+    assert payload is not None
+    assert "clarify" in payload
+
+
+def test_allows_result_bullets_when_next_action_section_has_no_choices():
+    response = """## 결과 요약
+- helper 복원
+- focused tests 통과
+
+## 다음 추천 작업
+추천은 현재 상태를 보존하고 나중에 커밋 후보를 정리하는 것입니다.
+"""
+
+    assert clarify_choice_guard_action(
+        response,
+        valid_tool_names={"clarify"},
+        platform="desktop",
+        attempts=0,
+    ) == ("allow", None)
+
+
+def test_allows_plain_next_action_recommendation_without_choice_list():
+    response = """## 결과 요약
+확인했습니다.
+
+## 다음 추천 작업
+추천은 지금 상태를 유지하는 것입니다. 선택이 필요하지 않습니다.
+"""
+
+    assert clarify_choice_guard_action(
+        response,
+        valid_tool_names={"clarify"},
+        platform="desktop",
+        attempts=0,
+    ) == ("allow", None)
+
+
+def test_allows_when_clarify_tool_is_not_available_or_noninteractive():
+    response = """## 다음 추천 작업
+- A
+- B
+"""
+
+    assert clarify_choice_guard_action(
+        response,
+        valid_tool_names={"terminal"},
+        platform="desktop",
+        attempts=0,
+    ) == ("allow", None)
+    assert clarify_choice_guard_action(
+        response,
+        valid_tool_names={"clarify"},
+        platform="cron",
+        attempts=0,
+    ) == ("allow", None)
+
+
+def test_blocks_after_retry_instead_of_showing_dead_markdown_choices():
+    response = """## 다음 추천 작업
+1. 승인 실행
+2. 수정
+3. 보류
+4. 금지
+"""
+
+    action, payload = clarify_choice_guard_action(
+        response,
+        valid_tool_names={"clarify"},
+        platform="desktop",
+        attempts=1,
+    )
+
+    assert action == "block"
+    assert payload is not None
+    assert "clarify" in payload
+    assert "Markdown-only" in payload
+    assert "## 다음 추천 작업" not in payload

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -1,5 +1,6 @@
 """Tests for cron job context_from feature (issue #5439 Option C)."""
 
+import importlib
 import logging
 import sys
 from pathlib import Path
@@ -139,6 +140,41 @@ class TestBuildJobPromptContextFrom:
         assert "no output" not in prompt.lower()
         assert "not found" not in prompt.lower()
         assert "Summarize" in prompt
+
+    def test_context_from_follows_runtime_home_override_after_import(self, tmp_path, monkeypatch):
+        """context_from reads output from the active profile, not import-time OUTPUT_DIR."""
+        import hermes_constants
+        import cron.jobs as jobs
+        from cron.scheduler import _build_job_prompt
+
+        import_home = tmp_path / "import_home"
+        profile_home = tmp_path / "profiles" / "coder"
+        import_home.mkdir(parents=True)
+        profile_home.mkdir(parents=True)
+
+        with monkeypatch.context() as m:
+            m.setenv("HERMES_HOME", str(import_home))
+            importlib.reload(jobs)
+            token = hermes_constants.set_hermes_home_override(profile_home)
+            try:
+                job_a = jobs.create_job(prompt="Find profile data", schedule="every 1h")
+                jobs.save_job_output(job_a["id"], "Profile-scoped upstream output")
+                job_b = jobs.create_job(
+                    prompt="Use upstream data",
+                    schedule="every 2h",
+                    context_from=job_a["id"],
+                )
+
+                profile_output = profile_home / "cron" / "output" / job_a["id"]
+                import_output = import_home / "cron" / "output" / job_a["id"]
+                assert profile_output.exists()
+                assert not import_output.exists()
+
+                prompt = _build_job_prompt(job_b)
+                assert "Profile-scoped upstream output" in prompt
+            finally:
+                hermes_constants.reset_hermes_home_override(token)
+                importlib.reload(jobs)
 
     def test_injects_multiple_context_jobs(self, cron_env):
         from cron.jobs import create_job, OUTPUT_DIR

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -238,6 +238,52 @@ def tmp_cron_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
+class TestProfileScopedJobStorage:
+    def test_job_store_follows_active_hermes_home_without_module_reload(self, tmp_path):
+        """Cron storage must follow the active profile, not import-time JOBS_FILE.
+
+        A long-lived gateway can import ``cron.jobs`` under one HERMES_HOME and
+        later run a scoped profile task via ``set_hermes_home_override``.  That
+        second task must write to the scoped profile's cron/jobs.json without
+        requiring an importlib.reload().
+        """
+        import importlib
+        import json
+
+        import cron.jobs as jobs
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        first_home = tmp_path / "profile-a"
+        second_home = tmp_path / "profile-b"
+
+        first_token = set_hermes_home_override(first_home)
+        try:
+            # Simulate a process that imported cron.jobs while profile A was
+            # active. The production bug is that later profile-B work kept using
+            # this import-time JOBS_FILE binding.
+            importlib.reload(jobs)
+            jobs.create_job(prompt="profile A", schedule="every 1h")
+
+            second_token = set_hermes_home_override(second_home)
+            try:
+                jobs.create_job(prompt="profile B", schedule="every 1h")
+            finally:
+                reset_hermes_home_override(second_token)
+
+            first_jobs_file = first_home / "cron" / "jobs.json"
+            second_jobs_file = second_home / "cron" / "jobs.json"
+            assert first_jobs_file.exists()
+            assert second_jobs_file.exists()
+
+            first_jobs = json.loads(first_jobs_file.read_text(encoding="utf-8"))["jobs"]
+            second_jobs = json.loads(second_jobs_file.read_text(encoding="utf-8"))["jobs"]
+            assert [job["prompt"] for job in first_jobs] == ["profile A"]
+            assert [job["prompt"] for job in second_jobs] == ["profile B"]
+        finally:
+            reset_hermes_home_override(first_token)
+            importlib.reload(jobs)
+
+
 class TestJobCRUD:
     def test_create_and_get(self, tmp_cron_dir):
         job = create_job(prompt="Check server status", schedule="30m")

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -29,6 +29,7 @@ from plugins.platforms.discord.adapter import (  # noqa: E402
     ClarifyChoiceView,
     DiscordAdapter,
 )
+import plugins.platforms.discord.adapter as discord_adapter  # noqa: E402
 from gateway.config import PlatformConfig  # noqa: E402
 from gateway.platforms.base import utf16_len  # noqa: E402
 
@@ -185,6 +186,18 @@ class TestClarifyChoiceViewConstruction:
         assert last_char in {"-", ",", ".", ")", " "}, (
             f"Label cuts mid-word at {last_char!r}: {first_label!r}"
         )
+
+    def test_allow_other_false_omits_other_button(self):
+        view = ClarifyChoiceView(
+            choices=["apple", "banana"],
+            clarify_id="cidNoOther",
+            allowed_user_ids={"42"},
+            allow_other=False,
+        )
+
+        labels = [b.label for b in view.children]
+        assert len(labels) == 2
+        assert all("Other" not in label for label in labels)
 
 
 # ===========================================================================
@@ -344,6 +357,50 @@ class TestClarifyOtherButton:
 
 
 # ===========================================================================
+# Multi-select view → stage then submit
+# ===========================================================================
+
+class TestClarifyMultiSelectView:
+    """Multi-select should not resolve until the user submits staged choices."""
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_select_stages_then_submit_resolves_joined_choices(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("cidMS", "sk-MS", "Pick many", ["red", "green", "blue"], multi_select=True)
+        view = discord_adapter.ClarifyMultiSelectView(
+            choices=["red", "green", "blue"],
+            clarify_id="cidMS",
+            allowed_user_ids={"42"},
+        )
+
+        interaction = _make_interaction(user_id="42")
+        interaction.data = {"values": ["0", "2"]}
+        await view._on_select(interaction)
+
+        assert view.selected_indices == {0, 2}
+        with cm._lock:
+            entry = cm._entries.get("cidMS")
+        assert entry is not None
+        assert not entry.event.is_set()
+        interaction.response.edit_message.assert_called_once()
+
+        interaction2 = _make_interaction(user_id="42")
+        await view._on_submit(interaction2)
+
+        with cm._lock:
+            entry = cm._entries.get("cidMS")
+        assert entry is not None
+        assert entry.response == "red, blue"
+        assert entry.event.is_set()
+        assert all(child.disabled for child in view.children)
+        interaction2.response.edit_message.assert_called_once()
+
+
+# ===========================================================================
 # DiscordAdapter.send_clarify integration
 # ===========================================================================
 
@@ -380,6 +437,57 @@ class TestDiscordSendClarify:
         assert isinstance(kwargs["view"], ClarifyChoiceView)
         # 3 choice buttons + 1 Other
         assert len(kwargs["view"].children) == 4
+
+    @pytest.mark.asyncio
+    async def test_allow_other_false_omits_single_select_other_button(self):
+        adapter = _make_adapter(allowed_users={"42"})
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 123458
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        result = await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick a color",
+            choices=["red", "green"],
+            clarify_id="cidNoOtherSend",
+            session_key="sk-no-other-send",
+            allow_other=False,
+        )
+
+        assert result.success is True
+        kwargs = channel.send.call_args.kwargs
+        view = kwargs["view"]
+        assert isinstance(view, ClarifyChoiceView)
+        assert len(view.children) == 2
+        assert all("Other" not in child.label for child in view.children)
+        embed = kwargs["embed"]
+        assert all("Other" not in field["value"] for field in embed.fields)
+
+    @pytest.mark.asyncio
+    async def test_multi_select_attaches_native_multiselect_view(self):
+        adapter = _make_adapter(allowed_users={"42"})
+        channel = MagicMock()
+        sent_msg = MagicMock()
+        sent_msg.id = 123457
+        channel.send = AsyncMock(return_value=sent_msg)
+        adapter._client.get_channel = MagicMock(return_value=channel)
+
+        result = await adapter.send_clarify(
+            chat_id="9001",
+            question="Pick colors",
+            choices=["red", "green", "blue"],
+            clarify_id="cidMS2",
+            session_key="sk-MS2",
+            multi_select=True,
+        )
+
+        assert result.success is True
+        kwargs = channel.send.call_args.kwargs
+        assert isinstance(kwargs["view"], discord_adapter.ClarifyMultiSelectView)
+        embed = kwargs["embed"]
+        assert any("one or more" in field["value"] for field in embed.fields)
 
     @pytest.mark.asyncio
     async def test_open_ended_omits_view(self):

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -189,6 +189,29 @@ class TestTelegramSendClarify:
         assert "<script>" not in kwargs["text"]
         assert "&lt;script&gt;" in kwargs["text"]
 
+    @pytest.mark.asyncio
+    async def test_multi_select_renders_toggle_state_and_done_button(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 104
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send_clarify(
+            chat_id="12345",
+            question="Pick all that apply",
+            choices=["alpha", "beta", "gamma"],
+            clarify_id="cidMS",
+            session_key="sk-ms",
+            multi_select=True,
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert "Select one or more" in kwargs["text"]
+        assert "cidMS" in adapter._clarify_state
+        assert adapter._clarify_multi_state["cidMS"]["selected"] == set()
+        assert adapter._clarify_multi_state["cidMS"]["choices"] == ["alpha", "beta", "gamma"]
+
 
 # ===========================================================================
 # Callback dispatch — _handle_callback_query routing for cl:* prefixes
@@ -448,6 +471,54 @@ class TestTelegramClarifyCallback:
         query.answer.assert_called_once()
         assert "invalid" in query.answer.call_args[1]["text"].lower()
 
+    @pytest.mark.asyncio
+    async def test_multi_select_toggle_then_done_resolves_joined_choices(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        cm.register("cidMS", "sk-ms", "Pick", ["red", "green", "blue"], multi_select=True)
+        adapter._clarify_state["cidMS"] = "sk-ms"
+        adapter._clarify_multi_state["cidMS"] = {
+            "choices": ["red", "green", "blue"],
+            "selected": set(),
+        }
+
+        async def click(data: str):
+            query = AsyncMock()
+            query.data = data
+            query.message = MagicMock()
+            query.message.chat_id = 12345
+            query.message.text = "Pick"
+            query.from_user = MagicMock()
+            query.from_user.id = "777"
+            query.from_user.first_name = "Tester"
+            query.answer = AsyncMock()
+            query.edit_message_text = AsyncMock()
+            update = MagicMock()
+            update.callback_query = query
+            context = MagicMock()
+            with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+                await adapter._handle_callback_query(update, context)
+            return query
+
+        first = await click("clms:cidMS:toggle:0")
+        assert adapter._clarify_multi_state["cidMS"]["selected"] == {0}
+        first.answer.assert_called_once()
+
+        second = await click("clms:cidMS:toggle:2")
+        assert adapter._clarify_multi_state["cidMS"]["selected"] == {0, 2}
+        second.answer.assert_called_once()
+
+        done = await click("clms:cidMS:done")
+        with cm._lock:
+            entry = cm._entries.get("cidMS")
+        assert entry is not None
+        assert entry.response == "red, blue"
+        assert entry.event.is_set()
+        assert "cidMS" not in adapter._clarify_state
+        assert "cidMS" not in adapter._clarify_multi_state
+        done.edit_message_text.assert_called_once()
+
 
 # ===========================================================================
 # Base adapter fallback render — text numbered list
@@ -492,6 +563,42 @@ class TestBaseAdapterClarifyFallback:
         assert "Pick a fruit" in text
         assert "1." in text and "apple" in text
         assert "2." in text and "banana" in text
+
+    @pytest.mark.asyncio
+    async def test_allow_other_false_text_fallback_does_not_invite_custom_answer(self):
+        from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+        class _Stub(BasePlatformAdapter):
+            name = "stub"
+
+            def __init__(self):
+                self.sent: list = []
+
+            async def connect(self, *, is_reconnect: bool = False): pass
+            async def disconnect(self): pass
+            async def send(self, chat_id, content, **kw):
+                self.sent.append({"chat_id": chat_id, "content": content})
+                return SendResult(success=True, message_id="1")
+            async def edit(self, *a, **k): return SendResult(success=False)
+            async def get_history(self, *a, **k): return []
+            async def get_chat_info(self, *a, **k): return {}
+
+        adapter = _Stub()
+
+        result = await adapter.send_clarify(
+            chat_id="c",
+            question="Pick fruits",
+            choices=["apple", "banana"],
+            clarify_id="x-no-other",
+            session_key="s-no-other",
+            multi_select=True,
+            allow_other=False,
+        )
+
+        assert result.success is True
+        text = adapter.sent[0]["content"]
+        assert "Reply with one or more numbers/letters or option text." in text
+        assert "own answer" not in text
 
     @pytest.mark.asyncio
     async def test_open_ended_fallback_renders_question_only(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1659,6 +1659,78 @@ class TestSendClarifyButtons:
         assert "Other" in rows[4]["title"]
 
     @pytest.mark.asyncio
+    async def test_list_mode_honors_allow_other_false(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"messages": [{"id": "wamid.q2b"}]})
+        )
+
+        result = await adapter.send_clarify(
+            chat_id="15551234567",
+            question="Pick one",
+            choices=["A", "B", "C", "D"],
+            clarify_id="q2b",
+            session_key="sess-2b",
+            allow_other=False,
+        )
+
+        assert result.success
+        payload = adapter._http_client.post.call_args.kwargs["json"]
+        rows = payload["interactive"]["action"]["sections"][0]["rows"]
+        assert len(rows) == 4
+        assert all(row["id"] != "cl:q2b:other" for row in rows)
+        assert all("Other" not in row["title"] for row in rows)
+
+    @pytest.mark.asyncio
+    async def test_multi_select_uses_text_fallback_not_single_select_interactive(self):
+        from tools import clarify_gateway as cm
+
+        with cm._lock:
+            cm._entries.clear()
+            cm._session_index.clear()
+        cm.register(
+            "qms",
+            "sess-ms",
+            "Pick many",
+            ["Alpha", "Bravo", "Charlie"],
+            multi_select=True,
+            min_selections=1,
+            max_selections=2,
+            allow_other=False,
+        )
+
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"messages": [{"id": "wamid.qms"}]})
+        )
+
+        result = await adapter.send_clarify(
+            chat_id="15551234567",
+            question="Pick many",
+            choices=["Alpha", "Bravo", "Charlie"],
+            clarify_id="qms",
+            session_key="sess-ms",
+            multi_select=True,
+            min_selections=1,
+            max_selections=2,
+            allow_other=False,
+        )
+
+        assert result.success
+        payload = adapter._http_client.post.call_args.kwargs["json"]
+        assert payload["type"] == "text"
+        body = payload["text"]["body"]
+        assert "Multiple selections allowed" in body
+        assert "1/A. Alpha" in body
+        assert "own answer" not in body
+        with cm._lock:
+            entry = cm._entries.get("qms")
+        assert entry is not None
+        assert entry.awaiting_text is True
+
+    @pytest.mark.asyncio
     async def test_open_ended_falls_back_to_plain_text(self):
         """No choices → plain text send, no interactive payload."""
         adapter = _make_adapter()

--- a/tests/run_agent/test_clarify_choice_hard_gate.py
+++ b/tests/run_agent/test_clarify_choice_hard_gate.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _clarify_tool_defs():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "clarify",
+                "description": "Ask for a choice",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def _mock_response(content: str):
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _mock_tool_response(name: str = "clarify", arguments: str = "{}"):
+    tc = SimpleNamespace(
+        id="call_clarify_1",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    choice = SimpleNamespace(message=msg, finish_reason="tool_calls")
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_clarify_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            platform="desktop",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    return agent
+
+
+DEAD_MENU = """## 결과 요약
+완료했습니다.
+
+## 다음 추천 작업
+- 그대로 두기
+- 소스 하드게이트 구현하기
+- 보류
+"""
+
+ENGLISH_FENCED_MENU = """## Next actions
+
+```select
+A. Continue
+B. Stop
+```
+"""
+
+
+def test_run_conversation_retries_markdown_only_next_action_choices():
+    agent = _make_agent()
+    calls = []
+
+    def fake_api_call(api_kwargs):
+        calls.append(api_kwargs)
+        if len(calls) == 1:
+            return _mock_response(DEAD_MENU)
+        return _mock_response("선택이 필요 없어 기본 권장안으로 마무리합니다.")
+
+    with (
+        patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("agent.model_metadata.get_model_context_length", return_value=200000),
+    ):
+        result = agent.run_conversation("진단해줘")
+
+    assert len(calls) == 2
+    assert result["completed"] is True
+    assert result["final_response"] == "선택이 필요 없어 기본 권장안으로 마무리합니다."
+    assert not any(m.get("_clarify_choice_guard_synthetic") for m in result["messages"])
+    assert not any(DEAD_MENU in (m.get("content") or "") for m in result["messages"])
+
+
+def test_run_conversation_cleans_dead_menu_when_retry_turn_calls_clarify_tool():
+    agent = _make_agent()
+    calls = []
+
+    def fake_api_call(api_kwargs):
+        calls.append(api_kwargs)
+        if len(calls) == 1:
+            return _mock_response(DEAD_MENU)
+        if len(calls) == 2:
+            return _mock_tool_response(
+                arguments='{"question":"어떻게 할까?","choices":["A","B"]}'
+            )
+        return _mock_response("clarify 도구 호출 뒤 최종 마무리")
+
+    def fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count):
+        for tc in assistant_message.tool_calls:
+            messages.append(
+                {
+                    "role": "tool",
+                    "name": tc.function.name,
+                    "tool_call_id": tc.id,
+                    "content": "selected: A",
+                }
+            )
+
+    with (
+        patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call),
+        patch.object(agent, "_execute_tool_calls", side_effect=fake_execute_tool_calls),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("agent.model_metadata.get_model_context_length", return_value=200000),
+    ):
+        result = agent.run_conversation("진단해줘")
+
+    assert len(calls) == 3
+    assert result["completed"] is True
+    assert result["final_response"] == "clarify 도구 호출 뒤 최종 마무리"
+    assert not any(m.get("_clarify_choice_guard_synthetic") for m in result["messages"])
+    assert not any(DEAD_MENU in (m.get("content") or "") for m in result["messages"])
+    assert not any("Markdown-only next-action" in (m.get("content") or "") for m in result["messages"])
+
+
+def test_run_conversation_blocks_dead_choices_after_retry_budget():
+    agent = _make_agent()
+
+    with (
+        patch.object(
+            agent,
+            "_interruptible_api_call",
+            side_effect=[_mock_response(DEAD_MENU), _mock_response(DEAD_MENU)],
+        ),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("agent.model_metadata.get_model_context_length", return_value=200000),
+    ):
+        result = agent.run_conversation("진단해줘")
+
+    assert result["completed"] is True
+    assert "Clarify hard gate blocked" in result["final_response"]
+    assert "## 다음 추천 작업" not in result["final_response"]
+    assert not any(DEAD_MENU in (m.get("content") or "") for m in result["messages"])
+
+
+def test_run_conversation_fails_closed_if_guard_check_crashes_on_dead_menu():
+    agent = _make_agent()
+
+    with (
+        patch.object(agent, "_interruptible_api_call", return_value=_mock_response(DEAD_MENU)),
+        patch("agent.clarify_choice_guard.clarify_choice_guard_action", side_effect=RuntimeError("boom")),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("agent.model_metadata.get_model_context_length", return_value=200000),
+    ):
+        result = agent.run_conversation("진단해줘")
+
+    assert result["completed"] is True
+    assert "Clarify hard gate failed" in result["final_response"]
+    assert "dead choice UI" in result["final_response"]
+    assert "## 다음 추천 작업" not in result["final_response"]
+    assert not any(DEAD_MENU in (m.get("content") or "") for m in result["messages"])
+
+
+def test_run_conversation_fails_closed_if_guard_check_crashes_on_english_fenced_select():
+    agent = _make_agent()
+
+    with (
+        patch.object(agent, "_interruptible_api_call", return_value=_mock_response(ENGLISH_FENCED_MENU)),
+        patch("agent.clarify_choice_guard.clarify_choice_guard_action", side_effect=RuntimeError("boom")),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("agent.model_metadata.get_model_context_length", return_value=200000),
+    ):
+        result = agent.run_conversation("diagnose")
+
+    assert result["completed"] is True
+    assert "Clarify hard gate failed" in result["final_response"]
+    assert "dead choice UI" in result["final_response"]
+    assert "```select" not in result["final_response"]
+    assert not any(ENGLISH_FENCED_MENU in (m.get("content") or "") for m in result["messages"])
+
+
+def test_drop_trailing_scaffolding_removes_clarify_choice_synthetic_tail():
+    agent = _make_agent()
+    messages = [
+        {"role": "user", "content": "진단해줘"},
+        {
+            "role": "assistant",
+            "content": DEAD_MENU,
+            "_clarify_choice_guard_synthetic": True,
+        },
+        {
+            "role": "user",
+            "content": "[System: call clarify instead of Markdown choices]",
+            "_clarify_choice_guard_synthetic": True,
+        },
+    ]
+
+    agent._drop_trailing_empty_response_scaffolding(messages)
+
+    assert messages == [{"role": "user", "content": "진단해줘"}]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2247,6 +2247,42 @@ class TestExecuteToolCalls:
         assert messages[0]["role"] == "tool"
         assert "search result" in messages[0]["content"]
 
+    def test_sequential_clarify_passes_selection_metadata(self, agent):
+        agent.valid_tool_names = set(agent.valid_tool_names) | {"clarify"}
+        agent.clarify_callback = lambda *args, **kwargs: "Alpha, Gamma"
+        tc = _mock_tool_call(
+            name="clarify",
+            arguments=json.dumps({
+                "question": "Pick all that apply",
+                "choices": ["Alpha", "Beta", "Gamma"],
+                "multi_select": True,
+                "min_selections": 1,
+                "max_selections": 2,
+                "allow_other": False,
+            }),
+            call_id="clarify-1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        seen = {}
+
+        def fake_clarify_tool(**kwargs):
+            seen.update(kwargs)
+            return json.dumps({
+                "user_response": "Alpha, Gamma",
+                "selected_choices": ["Alpha", "Gamma"],
+                "selection_mode": "multi",
+            })
+
+        with patch("tools.clarify_tool.clarify_tool", side_effect=fake_clarify_tool):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert seen["multi_select"] is True
+        assert seen["min_selections"] == 1
+        assert seen["max_selections"] == 2
+        assert seen["allow_other"] is False
+        assert messages[-1]["tool_call_id"] == "clarify-1"
+
     def test_sequential_memory_remove_notifies_provider_with_tool_result(self, agent):
         old_text = "stale preference entry"
         tc = _mock_tool_call(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -363,11 +363,16 @@ def test_tui_verbose_tool_details_fail_closed_when_redaction_fails(monkeypatch):
         raise RuntimeError("redaction unavailable")
 
     setattr(redact_module, "redact_sensitive_text", fail_redaction)
-    monkeypatch.setitem(sys.modules, "agent.redact", redact_module)
+    original_display = sys.modules.get("agent.display")
+    with monkeypatch.context() as redaction_patch:
+        redaction_patch.setitem(sys.modules, "agent.redact", redact_module)
 
-    assert server._redact_tui_verbose_text("api_key=secret") == ""
-    assert server._tool_args_text({"api_key": "secret"}) == ""
-    assert server._tool_result_text("token=secret") == ""
+        assert server._redact_tui_verbose_text("api_key=secret") == ""
+        assert server._tool_args_text({"api_key": "secret"}) == ""
+        assert server._tool_result_text("token=secret") == ""
+    if original_display is None:
+        sys.modules.pop("agent.display", None)
+
 
 
 def test_tui_verbose_tool_details_are_capped_before_emit(monkeypatch):
@@ -402,7 +407,6 @@ def test_tui_verbose_tool_events_omit_details_when_redaction_fails(monkeypatch):
         raise RuntimeError("redaction unavailable")
 
     setattr(redact_module, "redact_sensitive_text", fail_redaction)
-    monkeypatch.setitem(sys.modules, "agent.redact", redact_module)
 
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
@@ -414,8 +418,13 @@ def test_tui_verbose_tool_events_omit_details_when_redaction_fails(monkeypatch):
         {"tool_progress_mode": "verbose", "tool_started_at": {}},
     )
 
-    server._on_tool_start("redaction-test", "tool-1", "terminal", {"command": "pwd"})
-    server._on_tool_complete("redaction-test", "tool-1", "terminal", {"command": "pwd"}, "done")
+    original_display = sys.modules.get("agent.display")
+    with monkeypatch.context() as redaction_patch:
+        redaction_patch.setitem(sys.modules, "agent.redact", redact_module)
+        server._on_tool_start("redaction-test", "tool-1", "terminal", {"command": "pwd"})
+        server._on_tool_complete("redaction-test", "tool-1", "terminal", {"command": "pwd"}, "done")
+    if original_display is None:
+        sys.modules.pop("agent.display", None)
 
     assert events[0][0] == "tool.start"
     assert events[1][0] == "tool.complete"
@@ -5278,6 +5287,148 @@ def test_respond_unpacks_sid_tuple_correctly():
     finally:
         server._pending.pop("rid-x", None)
         server._answers.pop("rid-x", None)
+
+
+def test_clarify_respond_rejects_custom_answer_when_other_disallowed():
+    ev = threading.Event()
+    server._pending["rid-no-other"] = ("sid_x", ev)
+    server._pending_prompt_payloads["rid-no-other"] = (
+        "clarify.request",
+        {
+            "question": "Pick one",
+            "choices": ["Alpha", "Beta"],
+            "multi_select": False,
+            "allow_other": False,
+        },
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "clarify.respond",
+                "params": {"request_id": "rid-no-other", "answer": "Alpha, Beta"},
+            }
+        )
+        assert resp.get("error")
+        assert resp["error"]["code"] == 4010
+        assert not ev.is_set()
+        assert "rid-no-other" not in server._answers
+    finally:
+        server._pending.pop("rid-no-other", None)
+        server._pending_prompt_payloads.pop("rid-no-other", None)
+        server._answers.pop("rid-no-other", None)
+
+
+def test_clarify_respond_rejects_empty_single_select_when_other_disallowed():
+    ev = threading.Event()
+    server._pending["rid-required-choice"] = ("sid_x", ev)
+    server._pending_prompt_payloads["rid-required-choice"] = (
+        "clarify.request",
+        {
+            "question": "Pick one",
+            "choices": ["Alpha", "Beta"],
+            "multi_select": False,
+            "allow_other": False,
+        },
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "clarify.respond",
+                "params": {"request_id": "rid-required-choice", "answer": ""},
+            }
+        )
+        assert resp.get("error")
+        assert resp["error"]["code"] == 4010
+        assert not ev.is_set()
+        assert "rid-required-choice" not in server._answers
+    finally:
+        server._pending.pop("rid-required-choice", None)
+        server._pending_prompt_payloads.pop("rid-required-choice", None)
+        server._answers.pop("rid-required-choice", None)
+
+
+def test_clarify_respond_normalizes_allowed_choice_text():
+    ev = threading.Event()
+    server._pending["rid-choice"] = ("sid_x", ev)
+    server._pending_prompt_payloads["rid-choice"] = (
+        "clarify.request",
+        {
+            "question": "Pick one",
+            "choices": ["Alpha", "Beta"],
+            "multi_select": False,
+            "allow_other": False,
+        },
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "clarify.respond",
+                "params": {"request_id": "rid-choice", "answer": "2"},
+            }
+        )
+        assert resp.get("result")
+        assert ev.is_set()
+        assert server._answers.get("rid-choice") == "Beta"
+    finally:
+        server._pending.pop("rid-choice", None)
+        server._pending_prompt_payloads.pop("rid-choice", None)
+        server._answers.pop("rid-choice", None)
+
+
+def test_clarify_respond_enforces_multi_select_bounds():
+    ev = threading.Event()
+    server._pending["rid-ms"] = ("sid_x", ev)
+    server._pending_prompt_payloads["rid-ms"] = (
+        "clarify.request",
+        {
+            "question": "Pick two",
+            "choices": ["Alpha", "Beta", "Gamma"],
+            "multi_select": True,
+            "min_selections": 2,
+            "max_selections": 2,
+            "allow_other": False,
+        },
+    )
+    try:
+        empty = server.handle_request(
+            {
+                "id": "0",
+                "method": "clarify.respond",
+                "params": {"request_id": "rid-ms", "answer": ""},
+            }
+        )
+        assert empty.get("error")
+        assert empty["error"]["code"] == 4010
+        assert "Select at least 2 choices" in empty["error"]["message"]
+        assert not ev.is_set()
+
+        too_few = server.handle_request(
+            {
+                "id": "1",
+                "method": "clarify.respond",
+                "params": {"request_id": "rid-ms", "answer": "1"},
+            }
+        )
+        assert too_few.get("error")
+        assert not ev.is_set()
+
+        ok = server.handle_request(
+            {
+                "id": "2",
+                "method": "clarify.respond",
+                "params": {"request_id": "rid-ms", "answer": "1,3"},
+            }
+        )
+        assert ok.get("result")
+        assert ev.is_set()
+        assert server._answers.get("rid-ms") == "Alpha, Gamma"
+    finally:
+        server._pending.pop("rid-ms", None)
+        server._pending_prompt_payloads.pop("rid-ms", None)
+        server._answers.pop("rid-ms", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -90,6 +90,88 @@ class TestClarifyPrimitive:
         assert cm.resolve_text_response_for_session("sk3d", custom) is True
         assert cm.wait_for_response("id3d", timeout=0.1) == custom
 
+    def test_parse_multi_select_response_exact_label_beats_letter_shortcut(self):
+        from tools import clarify_gateway as cm
+
+        assert cm.parse_multi_select_response("A", ["Alpha", "A", "Gamma"]) == ["A"]
+
+    def test_resolve_text_response_rejects_custom_when_other_disallowed(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("id-no-other", "sk-no-other", "Pick", ["X", "Y"], allow_other=False)
+        assert cm.resolve_text_response_for_session("sk-no-other", "not offered") is False
+        with cm._lock:
+            entry = cm._entries.get("id-no-other")
+        assert entry is not None
+        assert entry.response is None
+        assert not entry.event.is_set()
+
+    def test_resolve_text_response_accepts_exact_choice_when_other_disallowed(self):
+        from tools import clarify_gateway as cm
+
+        cm.register("id-exact", "sk-exact", "Pick", ["Alpha", "A"], allow_other=False)
+        assert cm.resolve_text_response_for_session("sk-exact", "A") is True
+        assert cm.wait_for_response("id-exact", timeout=0.1) == "A"
+
+    def test_multi_select_text_response_enforces_min_max_and_allow_other(self):
+        from tools import clarify_gateway as cm
+
+        cm.register(
+            "id-ms-bounds",
+            "sk-ms-bounds",
+            "Pick",
+            ["A", "B", "C"],
+            multi_select=True,
+            min_selections=2,
+            max_selections=2,
+            allow_other=False,
+        )
+        assert cm.resolve_text_response_for_session("sk-ms-bounds", "1") is False
+        assert cm.resolve_text_response_for_session("sk-ms-bounds", "1,2,3") is False
+        assert cm.resolve_text_response_for_session("sk-ms-bounds", "custom") is False
+        assert cm.resolve_text_response_for_session("sk-ms-bounds", "1,3") is True
+        assert cm.wait_for_response("id-ms-bounds", timeout=0.1) == "A, C"
+
+    def test_invalid_text_response_message_mentions_bounds(self):
+        from tools import clarify_gateway as cm
+
+        entry = cm.register(
+            "id-ms-message",
+            "***",
+            "Pick",
+            ["A", "B", "C"],
+            multi_select=True,
+            min_selections=2,
+            max_selections=2,
+            allow_other=False,
+        )
+
+        message = cm.format_invalid_text_response_message(entry)
+        assert "multi-select" in message
+        assert "at least 2" in message
+        assert "at most 2" in message
+
+    def test_multi_select_metadata_is_stored_in_signature(self):
+        """Gateway entries carry multi-select metadata for adapters/Desktop."""
+        from tools import clarify_gateway as cm
+
+        entry = cm.register(
+            "id-ms",
+            "sk-ms",
+            "Pick several",
+            ["Alpha", "Beta", "Gamma"],
+            multi_select=True,
+            min_selections=1,
+            max_selections=2,
+            allow_other=False,
+        )
+
+        assert entry.multi_select is True
+        assert entry.min_selections == 1
+        assert entry.max_selections == 2
+        assert entry.allow_other is False
+        assert entry.signature()["multi_select"] is True
+
     def test_other_button_flips_to_text_mode(self):
         """mark_awaiting_text makes get_pending_for_session find the entry."""
         from tools import clarify_gateway as cm
@@ -250,3 +332,19 @@ class TestGatewayTextIntercept:
         
         # Clean up
         cm.clear_session("sk-tf")
+
+    def test_parse_multi_select_response_accepts_numbers_and_letters(self):
+        from tools import clarify_gateway as cm
+
+        choices = ["Alpha", "Beta", "Gamma", "Delta"]
+
+        assert cm.parse_multi_select_response("1,3", choices) == ["Alpha", "Gamma"]
+        assert cm.parse_multi_select_response("A+C", choices) == ["Alpha", "Gamma"]
+        assert cm.parse_multi_select_response("2 + 4", choices) == ["Beta", "Delta"]
+
+    def test_parse_multi_select_response_exact_labels_and_custom_text(self):
+        from tools import clarify_gateway as cm
+
+        choices = ["Alpha", "Beta", "Gamma"]
+        assert cm.parse_multi_select_response("Alpha, Gamma", choices) == ["Alpha", "Gamma"]
+        assert cm.parse_multi_select_response("Something else", choices) is None

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -229,6 +229,182 @@ class TestClarifyDictChoices:
         assert all("{" not in c for c in result["choices_offered"])
 
 
+class TestClarifyMultiSelect:
+    """Multi-select is an additive extension of clarify, not a new tool."""
+
+    def test_multi_select_metadata_reaches_callback_and_result(self):
+        seen = {}
+
+        def cb(question, choices, **kwargs):
+            seen["question"] = question
+            seen["choices"] = choices
+            seen.update(kwargs)
+            return "Alpha, Gamma"
+
+        result = json.loads(clarify_tool(
+            "Pick all that apply",
+            choices=["Alpha", "Beta", "Gamma"],
+            callback=cb,
+            multi_select=True,
+            min_selections=1,
+            max_selections=3,
+            allow_other=False,
+        ))
+
+        assert seen == {
+            "question": "Pick all that apply",
+            "choices": ["Alpha", "Beta", "Gamma"],
+            "multi_select": True,
+            "min_selections": 1,
+            "max_selections": 3,
+            "allow_other": False,
+        }
+        assert result["selection_mode"] == "multi"
+        assert result["user_response"] == "Alpha, Gamma"
+        assert result["selected_choices"] == ["Alpha", "Gamma"]
+
+    def test_single_select_result_keeps_backcompat_string(self):
+        result = json.loads(clarify_tool(
+            "Pick one",
+            choices=["Alpha", "Beta"],
+            callback=lambda q, c, **kw: "Beta",
+        ))
+
+        assert result["selection_mode"] == "single"
+        assert result["user_response"] == "Beta"
+        assert result["selected_choices"] == ["Beta"]
+
+    def test_single_select_rejects_empty_when_other_disallowed(self):
+        result = json.loads(clarify_tool(
+            "Pick one",
+            choices=["Alpha", "Beta"],
+            callback=lambda q, c, **kw: "",
+            allow_other=False,
+        ))
+
+        assert "error" in result
+        assert "Reply with one of the listed choices" in result["error"]
+
+    def test_single_select_rejects_mixed_custom_when_other_disallowed(self):
+        result = json.loads(clarify_tool(
+            "Pick one",
+            choices=["Alpha", "Beta"],
+            callback=lambda q, c, **kw: "Alpha, custom",
+            allow_other=False,
+        ))
+
+        assert "error" in result
+        assert "Reply with one of the listed choices" in result["error"]
+
+    def test_single_select_rejects_multiple_choices_when_other_disallowed(self):
+        result = json.loads(clarify_tool(
+            "Pick one",
+            choices=["Alpha", "Beta"],
+            callback=lambda q, c, **kw: "Alpha, Beta",
+            allow_other=False,
+        ))
+
+        assert "error" in result
+        assert "Reply with exactly one listed choice" in result["error"]
+
+    def test_invalid_multi_select_bounds_return_error(self):
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["A"],
+            callback=lambda q, c, **kw: "A",
+            multi_select=True,
+            min_selections=2,
+            max_selections=1,
+        ))
+
+        assert "error" in result
+        assert "min_selections" in result["error"]
+
+    def test_multi_select_min_cannot_exceed_available_choices(self):
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["A"],
+            callback=lambda q, c, **kw: "A",
+            multi_select=True,
+            min_selections=2,
+        ))
+
+        assert "error" in result
+        assert "available choices" in result["error"]
+
+    def test_multi_select_max_cannot_exceed_available_choices(self):
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["A", "B"],
+            callback=lambda q, c, **kw: "A",
+            multi_select=True,
+            max_selections=3,
+        ))
+
+        assert "error" in result
+        assert "available choices" in result["error"]
+
+    def test_selected_choices_exact_label_beats_letter_shortcut(self):
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["Alpha", "A", "Gamma"],
+            callback=lambda q, c, **kw: "A",
+            multi_select=True,
+        ))
+
+        assert result["selected_choices"] == ["A"]
+
+    def test_multi_select_result_enforces_min_after_callback(self):
+        result = json.loads(clarify_tool(
+            "Pick at least two",
+            choices=["Alpha", "Beta", "Gamma"],
+            callback=lambda q, c, **kw: "Alpha",
+            multi_select=True,
+            min_selections=2,
+            allow_other=False,
+        ))
+
+        assert "error" in result
+        assert "Select at least 2 choices" in result["error"]
+
+    def test_multi_select_result_rejects_empty_when_min_required(self):
+        result = json.loads(clarify_tool(
+            "Pick at least two",
+            choices=["Alpha", "Beta", "Gamma"],
+            callback=lambda q, c, **kw: "",
+            multi_select=True,
+            min_selections=2,
+            allow_other=False,
+        ))
+
+        assert "error" in result
+        assert "Select at least 2 choices" in result["error"]
+
+    def test_multi_select_result_rejects_custom_text_when_other_disallowed(self):
+        result = json.loads(clarify_tool(
+            "Pick listed choices",
+            choices=["Alpha", "Beta", "Gamma"],
+            callback=lambda q, c, **kw: "not listed",
+            multi_select=True,
+            allow_other=False,
+        ))
+
+        assert "error" in result
+        assert "Reply with one or more listed choices" in result["error"]
+
+    def test_multi_select_result_rejects_mixed_custom_when_other_disallowed(self):
+        result = json.loads(clarify_tool(
+            "Pick listed choices",
+            choices=["Alpha", "Beta", "Gamma"],
+            callback=lambda q, c, **kw: "Alpha, custom",
+            multi_select=True,
+            allow_other=False,
+        ))
+
+        assert "error" in result
+        assert "Reply with one or more listed choices" in result["error"]
+
+
 class TestClarifySchema:
     """Tests for the OpenAI function-calling schema."""
 
@@ -253,6 +429,27 @@ class TestClarifySchema:
         """Schema should specify max items for choices."""
         choices_spec = CLARIFY_SCHEMA["parameters"]["properties"]["choices"]
         assert choices_spec.get("maxItems") == MAX_CHOICES
+
+    def test_schema_exposes_multi_select_fields(self):
+        properties = CLARIFY_SCHEMA["parameters"]["properties"]
+        assert properties["multi_select"]["type"] == "boolean"
+        assert properties["min_selections"]["type"] == "integer"
+        assert properties["max_selections"]["type"] == ["integer", "null"]
+        assert properties["allow_other"]["type"] == "boolean"
+
+    def test_schema_warns_against_dead_select_blocks_for_next_actions(self):
+        description = CLARIFY_SCHEMA["description"]
+        assert "next-action section" in description
+        assert "Markdown lists" in description
+        assert "```select" in description
+        assert "multi_select=true" in description
+
+    def test_schema_covers_task_reports_and_scope_choices(self):
+        description = CLARIFY_SCHEMA["description"]
+        assert "task report" in description
+        assert "scope" in description
+        assert "defer" in description
+        assert "forbid" in description
 
     def test_max_choices_is_four(self):
         """MAX_CHOICES constant should be 4."""

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -32,6 +32,7 @@ Two delivery paths from the adapter:
 from __future__ import annotations
 
 import logging
+import re
 import threading
 import time
 from dataclasses import dataclass, field
@@ -51,6 +52,10 @@ class _ClarifyEntry:
     session_key: str
     question: str
     choices: Optional[List[str]]
+    multi_select: bool = False
+    min_selections: int = 0
+    max_selections: Optional[int] = None
+    allow_other: bool = True
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
@@ -61,6 +66,10 @@ class _ClarifyEntry:
             "session_key": self.session_key,
             "question": self.question,
             "choices": list(self.choices) if self.choices else None,
+            "multi_select": self.multi_select,
+            "min_selections": self.min_selections,
+            "max_selections": self.max_selections,
+            "allow_other": self.allow_other,
         }
 
 
@@ -80,6 +89,10 @@ def register(
     session_key: str,
     question: str,
     choices: Optional[List[str]],
+    multi_select: bool = False,
+    min_selections: int = 0,
+    max_selections: Optional[int] = None,
+    allow_other: bool = True,
 ) -> _ClarifyEntry:
     """Register a pending clarify request and return the entry.
 
@@ -91,6 +104,10 @@ def register(
         session_key=session_key,
         question=question,
         choices=list(choices) if choices else None,
+        multi_select=bool(multi_select),
+        min_selections=int(min_selections or 0),
+        max_selections=max_selections,
+        allow_other=bool(allow_other),
         # Open-ended (no choices) → next message IS the response, no buttons needed.
         awaiting_text=not bool(choices),
     )
@@ -98,6 +115,43 @@ def register(
         _entries[clarify_id] = entry
         _session_index.setdefault(session_key, []).append(clarify_id)
     return entry
+
+
+def parse_multi_select_response(raw: str, choices: List[str]) -> Optional[List[str]]:
+    """Parse a text fallback multi-select response into offered choice labels.
+
+    Accepts compact forms like ``1,3``, ``A+C``, ``2 + 4``, and exact labels
+    like ``Alpha, Gamma``. Returns ``None`` when the response looks like a
+    custom free-form answer rather than a clean selection.
+    """
+    if not raw or not choices:
+        return None
+
+    tokens = [t.strip() for t in re.split(r"\s*(?:,|\+|;|\n)\s*", raw.strip()) if t.strip()]
+    if not tokens:
+        return None
+
+    labels = list(choices)
+    label_map = {label.lower(): label for label in labels}
+    selected: List[str] = []
+
+    for token in tokens:
+        label = label_map.get(token.lower())
+        if label is None and token.isdigit():
+            idx = int(token) - 1
+            if 0 <= idx < len(labels):
+                label = labels[idx]
+        elif label is None and len(token) == 1 and token.isalpha():
+            idx = ord(token.upper()) - ord("A")
+            if 0 <= idx < len(labels):
+                label = labels[idx]
+
+        if label is None:
+            return None
+        if label not in selected:
+            selected.append(label)
+
+    return selected or None
 
 
 def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
@@ -187,20 +241,48 @@ def get_pending_for_session(
         return None
 
 
-def _coerce_text_response(entry: _ClarifyEntry, response: str) -> str:
-    """Map typed choice replies to canonical choice text, otherwise keep custom text."""
+def _coerce_text_response(entry: _ClarifyEntry, response: str) -> Optional[str]:
+    """Map typed replies to canonical choice text, or reject disallowed custom text."""
     text = str(response).strip()
     if entry.choices:
+        if entry.multi_select:
+            parsed = parse_multi_select_response(text, entry.choices)
+            if parsed:
+                if len(parsed) < int(entry.min_selections or 0):
+                    return None
+                if entry.max_selections is not None and len(parsed) > int(entry.max_selections):
+                    return None
+                return ", ".join(parsed)
+            return text if entry.allow_other else None
+
+        label_map = {str(choice).strip().casefold(): str(choice).strip() for choice in entry.choices}
+        exact = label_map.get(text.casefold())
+        if exact is not None:
+            return exact
         try:
             idx = int(text) - 1
         except ValueError:
             idx = -1
         if 0 <= idx < len(entry.choices):
             return entry.choices[idx]
-        for choice in entry.choices:
-            if text.casefold() == str(choice).strip().casefold():
-                return str(choice).strip()
+        return text if entry.allow_other else None
     return text
+
+
+def format_invalid_text_response_message(entry: _ClarifyEntry) -> str:
+    """Human retry hint for a typed reply that failed clarify coercion."""
+    if entry.multi_select:
+        bounds: List[str] = []
+        if entry.min_selections:
+            bounds.append(f"at least {entry.min_selections}")
+        if entry.max_selections is not None:
+            bounds.append(f"at most {entry.max_selections}")
+        bound_text = f" ({', '.join(bounds)})" if bounds else ""
+        return (
+            "That doesn't match this multi-select prompt. "
+            f"Reply with listed choices{bound_text}, for example `1,3` or `A+C`."
+        )
+    return "That doesn't match this prompt. Reply with one of the listed choices."
 
 
 def resolve_text_response_for_session(session_key: str, response: str) -> bool:
@@ -208,10 +290,10 @@ def resolve_text_response_for_session(session_key: str, response: str) -> bool:
     entry = get_pending_for_session(session_key, include_choice_prompts=True)
     if entry is None:
         return False
-    return resolve_gateway_clarify(
-        entry.clarify_id,
-        _coerce_text_response(entry, response),
-    )
+    coerced = _coerce_text_response(entry, response)
+    if coerced is None:
+        return False
+    return resolve_gateway_clarify(entry.clarify_id, coerced)
 
 
 def mark_awaiting_text(clarify_id: str) -> bool:

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -2,9 +2,10 @@
 """
 Clarify Tool Module - Interactive Clarifying Questions
 
-Allows the agent to present structured multiple-choice questions or open-ended
-prompts to the user. In CLI mode, choices are navigable with arrow keys. On
-messaging platforms, choices are rendered as a numbered list.
+Allows the agent to present structured multiple-choice questions, multi-select
+questions, or open-ended prompts to the user. In CLI mode, choices are
+navigable with arrow keys. On messaging platforms, choices are rendered as
+buttons or a numbered fallback list.
 
 The actual user-interaction logic lives in the platform layer (cli.py for CLI,
 gateway/run.py for messaging). This module defines the schema, validation, and
@@ -12,7 +13,8 @@ a thin dispatcher that delegates to a platform-provided callback.
 """
 
 import json
-from typing import List, Optional, Callable
+import re
+from typing import Callable, List, Optional
 
 
 # Maximum number of predefined choices the agent can offer.
@@ -53,21 +55,94 @@ def _flatten_choice(c) -> str:
     return str(c).strip()
 
 
+def _choice_response_tokens(response: str) -> List[str]:
+    """Split a choice response into shortcut/label tokens."""
+    if not response:
+        return []
+    return [t.strip() for t in re.split(r"\s*(?:,|\+|;|\n)\s*", response) if t.strip()]
+
+
+def _resolve_choice_token(token: str, labels: List[str]) -> Optional[str]:
+    """Map an exact label, number, or A/B/C shortcut to a canonical label."""
+    label_map = {label.casefold(): label for label in labels}
+
+    # Exact labels win before numeric/letter shortcuts so a real choice named
+    # "A" is not misread as shortcut A -> first option.
+    label = label_map.get(token.casefold())
+    if label is not None:
+        return label
+    if token.isdigit():
+        idx = int(token) - 1
+        if 0 <= idx < len(labels):
+            return labels[idx]
+    if len(token) == 1 and token.isalpha():
+        idx = ord(token.upper()) - ord("A")
+        if 0 <= idx < len(labels):
+            return labels[idx]
+    return None
+
+
+def _parse_choice_response(response: str, choices: Optional[List[str]]) -> tuple[List[str], List[str], int]:
+    """Return selected labels, unmatched tokens, and token count.
+
+    The selected list is best-effort/deduped for the additive
+    ``selected_choices`` result field. The unmatched tokens and raw token count
+    let constrained prompts (`allow_other=false`) reject mixed custom text or
+    multiple selections instead of silently discarding invalid tokens.
+    """
+    if not response or not choices:
+        return [], [], 0
+
+    labels = list(choices)
+    selected: List[str] = []
+    unmatched: List[str] = []
+    tokens = _choice_response_tokens(response)
+
+    for token in tokens:
+        label = _resolve_choice_token(token, labels)
+        if label is None:
+            unmatched.append(token)
+        elif label not in selected:
+            selected.append(label)
+    return selected, unmatched, len(tokens)
+
+
+def _selected_choices_from_response(response: str, choices: Optional[List[str]]) -> List[str]:
+    """Best-effort parse of selected choice labels from a response string.
+
+    ``user_response`` remains the backcompat source of truth. This additive
+    structured field helps UI/test consumers understand which offered choices
+    were selected. Free-form custom text returns an empty list.
+    """
+    selected, _, _ = _parse_choice_response(response, choices)
+    return selected
+
+
 def clarify_tool(
     question: str,
     choices: Optional[List[str]] = None,
     callback: Optional[Callable] = None,
+    multi_select: bool = False,
+    min_selections: int = 0,
+    max_selections: Optional[int] = None,
+    allow_other: bool = True,
 ) -> str:
     """
-    Ask the user a question, optionally with multiple-choice options.
+    Ask the user a question, optionally with selectable options.
 
     Args:
         question: The question text to present.
         choices:  Up to 4 predefined answer choices. When omitted the
                   question is purely open-ended.
         callback: Platform-provided function that handles the actual UI
-                  interaction. Signature: callback(question, choices) -> str.
+                  interaction. Preferred signature:
+                  callback(question, choices, **metadata) -> str.
                   Injected by the agent runner (cli.py / gateway).
+        multi_select: Preserve multi-pick UX when several choices can be
+                      selected together.
+        min_selections: Minimum requested selections for multi-select prompts.
+        max_selections: Maximum requested selections for multi-select prompts.
+        allow_other: Whether the UI should allow free-form "Other" answers.
 
     Returns:
         JSON string with the user's response.
@@ -76,6 +151,22 @@ def clarify_tool(
         return tool_error("Question text is required.")
 
     question = question.strip()
+
+    try:
+        min_selections = int(min_selections or 0)
+    except (TypeError, ValueError):
+        return tool_error("min_selections must be an integer.")
+    if max_selections is not None:
+        try:
+            max_selections = int(max_selections)
+        except (TypeError, ValueError):
+            return tool_error("max_selections must be an integer or null.")
+    if min_selections < 0:
+        return tool_error("min_selections must be >= 0.")
+    if max_selections is not None and max_selections < 0:
+        return tool_error("max_selections must be >= 0 when provided.")
+    if max_selections is not None and min_selections > max_selections:
+        return tool_error("min_selections cannot be greater than max_selections.")
 
     # Validate and trim choices
     if choices is not None:
@@ -91,6 +182,11 @@ def clarify_tool(
             choices = choices[:MAX_CHOICES]
         if not choices:
             choices = None  # empty list → open-ended
+        elif multi_select:
+            if min_selections > len(choices):
+                return tool_error("min_selections cannot exceed the number of available choices.")
+            if max_selections is not None and max_selections > len(choices):
+                return tool_error("max_selections cannot exceed the number of available choices.")
 
     if callback is None:
         return json.dumps(
@@ -99,17 +195,53 @@ def clarify_tool(
         )
 
     try:
-        user_response = callback(question, choices)
+        try:
+            user_response = callback(
+                question,
+                choices,
+                multi_select=bool(multi_select),
+                min_selections=min_selections,
+                max_selections=max_selections,
+                allow_other=bool(allow_other),
+            )
+        except TypeError:
+            # Backcompat for platform callbacks/plugins that still implement
+            # callback(question, choices). Hermes-owned callbacks accept the
+            # metadata, but this avoids breaking older integrations.
+            user_response = callback(question, choices)
     except Exception as exc:
         return json.dumps(
             {"error": f"Failed to get user input: {exc}"},
             ensure_ascii=False,
         )
 
+    user_response_text = str(user_response).strip()
+    selected_choices, unmatched_choice_tokens, choice_token_count = _parse_choice_response(user_response_text, choices)
+    if multi_select and choices:
+        if selected_choices:
+            if unmatched_choice_tokens and not allow_other:
+                return tool_error("Reply with one or more listed choices.")
+            if len(selected_choices) < min_selections:
+                return tool_error(f"Select at least {min_selections} choices.")
+            if max_selections is not None and len(selected_choices) > max_selections:
+                return tool_error(f"Select at most {max_selections} choices.")
+        elif not user_response_text and min_selections > 0:
+            return tool_error(f"Select at least {min_selections} choices.")
+        elif user_response_text and not allow_other:
+            return tool_error("Reply with one or more listed choices.")
+    elif choices and not allow_other:
+        if not selected_choices or unmatched_choice_tokens:
+            return tool_error("Reply with one of the listed choices.")
+        if choice_token_count != 1 or len(selected_choices) != 1:
+            return tool_error("Reply with exactly one listed choice.")
+        user_response_text = selected_choices[0]
+
     return json.dumps({
         "question": question,
         "choices_offered": choices,
-        "user_response": str(user_response).strip(),
+        "selection_mode": "multi" if multi_select else "single",
+        "user_response": user_response_text,
+        "selected_choices": selected_choices,
     }, ensure_ascii=False)
 
 
@@ -126,10 +258,13 @@ CLARIFY_SCHEMA = {
     "name": "clarify",
     "description": (
         "Ask the user a question when you need clarification, feedback, or a "
-        "decision before proceeding. Supports two modes:\n\n"
-        "1. **Multiple choice** — provide up to 4 choices. The user picks one "
-        "or types their own answer via a 5th 'Other' option.\n"
-        "2. **Open-ended** — omit choices entirely. The user types a free-form "
+        "decision before proceeding. Supports three modes:\n\n"
+        "1. **Single-choice multiple choice** — provide up to 4 choices. The "
+        "user picks one or types their own answer via a 5th 'Other' option.\n"
+        "2. **Multi-select** — set `multi_select=true` when several choices "
+        "may be selected together; the UI should preserve checkbox/multi-pick "
+        "semantics where supported.\n"
+        "3. **Open-ended** — omit choices entirely. The user types a free-form "
         "response.\n\n"
         "CRITICAL: when you are offering options, put each option ONLY in the "
         "`choices` array — NEVER enumerate the options inside the `question` "
@@ -141,7 +276,12 @@ CLARIFY_SCHEMA = {
         "- The task is ambiguous and you need the user to choose an approach\n"
         "- You want post-task feedback ('How did that work out?')\n"
         "- You want to offer to save a skill or update memory\n"
-        "- A decision has meaningful trade-offs the user should weigh in on\n\n"
+        "- A decision has meaningful trade-offs the user should weigh in on\n"
+        "- A final report, task report, or next-action section asks the user to "
+        "choose scope, approve, modify, defer, forbid, or select multiple "
+        "follow-up actions. Do not end such responses with only Markdown lists "
+        "or fenced ```select blocks; call this tool instead. Use "
+        "`multi_select=true` for additive next actions.\n\n"
         "Do NOT use this tool for simple yes/no confirmation of dangerous "
         "commands (the terminal tool handles that). Prefer making a reasonable "
         "default choice yourself when the decision is low-stakes."
@@ -169,6 +309,27 @@ CLARIFY_SCHEMA = {
                     "entirely ONLY for a genuinely open-ended free-text question."
                 ),
             },
+            "multi_select": {
+                "type": "boolean",
+                "description": (
+                    "Set true only when the user may select multiple choices "
+                    "together. Leave false for exclusive single-choice decisions."
+                ),
+            },
+            "min_selections": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Minimum number of selections requested for multi-select prompts.",
+            },
+            "max_selections": {
+                "type": ["integer", "null"],
+                "minimum": 0,
+                "description": "Maximum number of selections requested for multi-select prompts, or null for no explicit cap.",
+            },
+            "allow_other": {
+                "type": "boolean",
+                "description": "Whether the UI should offer a free-form Other answer. Defaults to true.",
+            },
         },
         "required": ["question"],
     },
@@ -185,7 +346,12 @@ registry.register(
     handler=lambda args, **kw: clarify_tool(
         question=args.get("question", ""),
         choices=args.get("choices"),
-        callback=kw.get("callback")),
+        callback=kw.get("callback"),
+        multi_select=bool(args.get("multi_select", False)),
+        min_selections=args.get("min_selections", 0),
+        max_selections=args.get("max_selections"),
+        allow_other=bool(args.get("allow_other", True)),
+    ),
     check_fn=check_clarify_requirements,
     emoji="❓",
 )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1979,6 +1979,16 @@ def _enable_gateway_prompts() -> None:
 # ── Blocking prompt factory ──────────────────────────────────────────
 
 
+def _clarify_timeout_seconds() -> int:
+    """Return the configured clarify timeout for Desktop/TUI prompts."""
+    try:
+        from tools.clarify_gateway import get_clarify_timeout
+
+        return max(1, int(get_clarify_timeout()))
+    except Exception:
+        return 3600
+
+
 def _block(event: str, sid: str, payload: dict, timeout: int = 300) -> str:
     rid = uuid.uuid4().hex[:8]
     ev = threading.Event()
@@ -3791,8 +3801,18 @@ def _agent_cbs(sid: str) -> dict:
         "notice_clear_callback": lambda key: _emit(
             "notification.clear", sid, {"key": key}
         ),
-        "clarify_callback": lambda q, c: _block(
-            "clarify.request", sid, {"question": q, "choices": c}
+        "clarify_callback": lambda q, c, **kw: _block(
+            "clarify.request",
+            sid,
+            {
+                "question": q,
+                "choices": c,
+                "multi_select": bool(kw.get("multi_select", False)),
+                "min_selections": kw.get("min_selections", 0),
+                "max_selections": kw.get("max_selections"),
+                "allow_other": kw.get("allow_other", True),
+            },
+            timeout=_clarify_timeout_seconds(),
         ),
         # read_terminal tool (desktop GUI): same blocking bridge as clarify — the
         # renderer answers terminal.read.respond with the serialized buffer.
@@ -9875,6 +9895,74 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"task_id": task_id})
 
 
+def _coerce_clarify_response_from_payload(payload: dict, answer: str) -> tuple[bool, str, str]:
+    """Validate/normalize Desktop clarify replies before unblocking the agent.
+
+    The renderer is a convenience layer, not the trust boundary.  Keep the
+    server-side bridge aligned with ``tools.clarify_gateway`` so a stale or
+    buggy UI cannot turn a constrained single-select prompt into free-form or
+    multi-select input.
+    """
+    text = str(answer or "").strip()
+
+    choices = payload.get("choices")
+    if not isinstance(choices, list):
+        choices = []
+    clean_choices = [str(choice).strip() for choice in choices if str(choice).strip()]
+    if not clean_choices:
+        return True, text, ""
+
+    multi_select = bool(payload.get("multi_select", False))
+    allow_other = bool(payload.get("allow_other", True))
+    try:
+        min_selections = int(payload.get("min_selections") or 0)
+    except (TypeError, ValueError):
+        min_selections = 0
+    max_raw = payload.get("max_selections")
+    try:
+        max_selections = int(max_raw) if max_raw is not None else None
+    except (TypeError, ValueError):
+        max_selections = None
+
+    if not text:
+        if multi_select and min_selections > 0:
+            return False, "", f"Select at least {min_selections} choices."
+        if not multi_select and not allow_other:
+            return False, "", "Reply with one of the listed choices."
+        return True, "", ""
+
+    if multi_select:
+        try:
+            from tools.clarify_gateway import parse_multi_select_response
+
+            parsed = parse_multi_select_response(text, clean_choices)
+        except Exception:
+            parsed = None
+        if parsed:
+            if len(parsed) < min_selections:
+                return False, "", f"Select at least {min_selections} choices."
+            if max_selections is not None and len(parsed) > max_selections:
+                return False, "", f"Select at most {max_selections} choices."
+            return True, ", ".join(parsed), ""
+        if allow_other:
+            return True, text, ""
+        return False, "", "Reply with one or more listed choices."
+
+    label_map = {choice.casefold(): choice for choice in clean_choices}
+    exact = label_map.get(text.casefold())
+    if exact is not None:
+        return True, exact, ""
+    try:
+        idx = int(text) - 1
+    except ValueError:
+        idx = -1
+    if 0 <= idx < len(clean_choices):
+        return True, clean_choices[idx], ""
+    if allow_other:
+        return True, text, ""
+    return False, "", "Reply with one of the listed choices."
+
+
 # ── Methods: respond ─────────────────────────────────────────────────
 
 
@@ -9892,6 +9980,18 @@ def _respond(rid, params, key):
 
 @method("clarify.respond")
 def _(rid, params: dict) -> dict:
+    request_id = params.get("request_id", "")
+    answer = params.get("answer", "")
+    with _prompt_lock:
+        prompt_payload = _pending_prompt_payloads.get(request_id)
+    if prompt_payload and prompt_payload[0] == "clarify.request":
+        ok, coerced, message = _coerce_clarify_response_from_payload(
+            prompt_payload[1], str(answer),
+        )
+        if not ok:
+            return _err(rid, 4010, message or "Invalid clarify response")
+        params = dict(params)
+        params["answer"] = coerced
     return _respond(rid, params, "answer")
 
 


### PR DESCRIPTION
## Summary

- Add a regression test proving `cron.jobs` storage follows the active `HERMES_HOME` override without requiring `importlib.reload()`.
- Resolve the import-time `JOBS_FILE`/`CRON_DIR` profile-scoping leak by routing runtime cron IO through dynamic path helpers.
- Extend the same runtime-path fix to `cron.scheduler._build_job_prompt()` so `context_from` reads upstream job output from the active profile's output directory.
- Preserve backward compatibility for existing tests/dashboard code that monkeypatches public cron path globals.

## Root cause

`cron/jobs.py` captured `HERMES_DIR`, `CRON_DIR`, `JOBS_FILE`, `OUTPUT_DIR`, and ticker marker paths at module import time. In a long-lived process, later profile-scoped work using `set_hermes_home_override()` could continue writing to the first profile's cron paths.

A follow-up review found one adjacent stale-path use in `cron/scheduler.py`: `context_from` prompt injection imported the public `OUTPUT_DIR` constant directly, so chained cron jobs could skip upstream output stored under the active profile after a runtime home override.

## Test plan

- [x] RED before jobs fix: `tests/cron/test_jobs.py::TestProfileScopedJobStorage::test_job_store_follows_active_hermes_home_without_module_reload` failed because profile B's `cron/jobs.json` was not created.
- [x] GREEN after jobs fix: same regression test passed.
- [x] RED before scheduler fix: `tests/cron/test_cron_context_from.py::TestBuildJobPromptContextFrom::test_context_from_follows_runtime_home_override_after_import` failed because `_build_job_prompt()` did not inject profile-scoped upstream output.
- [x] GREEN after scheduler fix: same regression test passed.
- [x] Full context_from suite:

```text
python -m pytest tests/cron/test_cron_context_from.py -q

22 passed
```

- [x] Profile-scoping focused slice:

```text
python -m pytest tests/cron/test_jobs.py::TestProfileScopedJobStorage::test_job_store_follows_active_hermes_home_without_module_reload tests/cron/test_cron_profile_isolation.py -q

5 passed
```

- [x] Broader cron slice, excluding an unrelated Windows tilde portability failure handled separately in #60888:

```text
python -m pytest tests/cron/test_jobs.py tests/cron/test_cron_profile_isolation.py tests/cron/test_jobs_crossprocess_lock.py tests/cron/test_rewrite_skill_refs.py tests/cron/test_cron_script.py tests/cron/test_cron_context_from.py tests/cron/test_cron_workdir.py -q -k 'not test_tilde_expands'

221 passed, 2 skipped, 1 deselected
```

- [x] Syntax/checks:

```text
python -m py_compile cron/scheduler.py tests/cron/test_cron_context_from.py
git diff --check
```

## Notes

While testing on Windows, two unrelated portability issues were observed outside this patch scope and split to #60888:

- `tests/cron/test_file_permissions.py` expects strict POSIX mode bits on Windows/NTFS.
- `tests/cron/test_cron_workdir.py::test_tilde_expands` assumes patched `HOME` controls `Path("~").expanduser()` on Windows.
