### PR TITLE
test(tools): add unit tests for skill_gist (salvage #60588)

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -439,3 +439,54 @@ def test_memory_invalid_params_rejected_before_staging(hermes_home):
     r = json.loads(memory_tool("add", "memory", None, store=store))
     assert r["success"] is False
     assert wa.pending_count("memory") == 0
+
+
+class TestSkillGist:
+    """skill_gist builds a heuristic one-line summary for a pending skill write.
+
+    Pure, no model call — every branch is verifiable from the function source.
+    """
+
+    def test_create_with_frontmatter_description(self):
+        from tools import write_approval as wa
+        content = "---\ndescription: My cool skill\n---\nprint('hi')\n"
+        assert (
+            wa.skill_gist("create", "demo", content=content)
+            == f"create 'demo' — My cool skill ({len(content)} chars)"
+        )
+
+    def test_edit_without_description_uses_size_only(self):
+        from tools import write_approval as wa
+        content = "no frontmatter here"
+        assert (
+            wa.skill_gist("edit", "demo", content=content)
+            == f"rewrite 'demo' ({len(content)} chars)"
+        )
+
+    def test_large_content_reports_kb(self):
+        from tools import write_approval as wa
+        content = "x" * 2048  # >= 1024 bytes -> KB rounding
+        assert wa.skill_gist("create", "big", content=content) == "create 'big' (3 KB)"
+
+    def test_create_without_content_falls_through(self):
+        from tools import write_approval as wa
+        assert wa.skill_gist("create", "demo") == "create 'demo'"
+
+    def test_patch_counts_lines(self):
+        from tools import write_approval as wa
+        assert (
+            wa.skill_gist("patch", "demo", file_path="SKILL.md",
+                          old_string="a\nb", new_string="x\ny\nz")
+            == "patch 'demo' SKILL.md (+3/-2 lines)"
+        )
+
+    def test_patch_defaults_target_and_empty_strings(self):
+        from tools import write_approval as wa
+        assert wa.skill_gist("patch", "demo") == "patch 'demo' SKILL.md (+0/-0 lines)"
+
+    def test_file_actions_and_unknown_fallback(self):
+        from tools import write_approval as wa
+        assert wa.skill_gist("write_file", "demo", file_path="a.py") == "write a.py in 'demo'"
+        assert wa.skill_gist("remove_file", "demo", file_path="a.py") == "remove a.py from 'demo'"
+        assert wa.skill_gist("delete", "demo") == "delete skill 'demo'"
+        assert wa.skill_gist("unknown", "demo") == "unknown 'demo'"


### PR DESCRIPTION
## Summary
Salvage of #60588 by @waroffchange — adds unit test coverage for `skill_gist` (tools/write_approval.py), the pure heuristic formatter that builds the one-line summary shown in the skill write-approval chat bubble. It previously had zero direct tests.

## Changes
- `tests/tools/test_write_approval.py`: new `TestSkillGist` class (+51 lines) pinning every branch of the formatter — frontmatter description + char/KB size suffix, `edit` → `rewrite` verb, empty-content fallback, patch line-count delta with `SKILL.md` default target, and the write_file / remove_file / delete / unknown-action one-liners.

Pure input→output assertions: no mocks, no network, no filesystem, zero production code touched. All assertions verified line-by-line against the source on current main.

## Validation
| | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_write_approval.py` | pass |
| Production code changed | none |

Contributor commit cherry-picked with authorship preserved (rebase-merge).

## Infographic

![skill-gist-tests](https://v3b.fal.media/files/b/0aa16cc5/kyjIUGUjuTk4sj-ft0Xqf_r5lhX4Fn.png)
