### PR TITLE
feat(xai): add grok-4.5 (GA) to model catalog, context lengths, and reasoning-effort allowlist

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -349,10 +349,10 @@ _GROK_EFFORT_CAPABLE_PREFIXES = (
     "grok-3-mini",
     "grok-4.20-multi-agent",
     "grok-4.3",
-    # grok-4.5 (early access): verified live against /v1/responses 2026-07-08 —
-    # accepts effort low/medium/high (default: high when omitted) but REJECTS
+    # grok-4.5: verified live against /v1/responses 2026-07-08 — accepts
+    # effort low/medium/high (default: high when omitted) but REJECTS
     # "none" ("This model does not support `reasoning_effort` value `none`"),
-    # unlike grok-4.3.
+    # unlike grok-4.3. models.dev agrees: effort values [low, medium, high].
     "grok-4.5",
 )
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -289,11 +289,13 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Premium+); /v1/responses additionally enforces a ~262144 input+output
     # budget, but the usable context (what we track here) is 200k.
     "grok-composer": 200000,    # grok-composer-2.5-fast (Grok Build CLI)
+    "grok-build-latest": 500000,  # alias of grok-4.5 (early access)
     "grok-build": 256000,       # grok-build-0.1
     "grok-code-fast": 256000,   # grok-code-fast-1
     "grok-2-vision": 8192,      # grok-2-vision, -1212, -latest
     "grok-4-fast": 2000000,     # grok-4-fast-(non-)reasoning, also matches -reasoning
     "grok-4.20": 2000000,       # grok-4.20-0309-(non-)reasoning, -multi-agent-0309
+    "grok-4.5": 500000,         # grok-4.5, grok-4.5-latest — 500K context per docs.x.ai
     "grok-4.3": 1000000,        # grok-4.3, grok-4.3-latest — 1M context per docs.x.ai
     "grok-4": 256000,           # grok-4, grok-4-0709
     "grok-3": 131072,           # grok-3, grok-3-mini, grok-3-fast, grok-3-mini-fast
@@ -347,6 +349,11 @@ _GROK_EFFORT_CAPABLE_PREFIXES = (
     "grok-3-mini",
     "grok-4.20-multi-agent",
     "grok-4.3",
+    # grok-4.5 (early access): verified live against /v1/responses 2026-07-08 —
+    # accepts effort low/medium/high (default: high when omitted) but REJECTS
+    # "none" ("This model does not support `reasoning_effort` value `none`"),
+    # unlike grok-4.3.
+    "grok-4.5",
 )
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -113,6 +113,7 @@ def _codex_curated_models() -> list[str]:
 #  grok-4-1-fast{,-reasoning,-non-reasoning}, grok-code-fast-1 → grok-4.3).
 _XAI_STATIC_FALLBACK: list[str] = [
     "grok-build-0.1",
+    "grok-4.5",
     "grok-4.3",
     "grok-4.20-0309-reasoning",
     "grok-4.20-0309-non-reasoning",
@@ -121,6 +122,7 @@ _XAI_STATIC_FALLBACK: list[str] = [
 
 # Callable via xAI OAuth but omitted from models.dev and /v1/models listings.
 _XAI_CURATED_EXTRAS: list[str] = [
+    "grok-4.5",  # early access — not yet in models.dev / public listings
     "grok-composer-2.5-fast",
 ]
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -48,6 +48,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("google/gemini-3.1-pro-preview",          ""),
     ("google/gemini-3.5-flash",                ""),
     # xAI
+    ("x-ai/grok-4.5",                          ""),
     ("x-ai/grok-4.3",                          ""),
     # DeepSeek
     ("deepseek/deepseek-v4-pro",               ""),
@@ -122,7 +123,7 @@ _XAI_STATIC_FALLBACK: list[str] = [
 
 # Callable via xAI OAuth but omitted from models.dev and /v1/models listings.
 _XAI_CURATED_EXTRAS: list[str] = [
-    "grok-4.5",  # early access — not yet in models.dev / public listings
+    "grok-4.5",  # GA 2026-07 — kept until the models.dev disk cache refreshes
     "grok-composer-2.5-fast",
 ]
 
@@ -193,6 +194,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemini-3.1-pro-preview",
         "google/gemini-3.5-flash",
         # xAI
+        "x-ai/grok-4.5",
         "x-ai/grok-4.3",
         # DeepSeek
         "deepseek/deepseek-v4-pro",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-08T13:38:17Z",
+  "updated_at": "2026-07-08T18:59:16Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -54,6 +54,10 @@
         },
         {
           "id": "google/gemini-3.5-flash",
+          "description": ""
+        },
+        {
+          "id": "x-ai/grok-4.5",
           "description": ""
         },
         {
@@ -185,6 +189,9 @@
         },
         {
           "id": "google/gemini-3.5-flash"
+        },
+        {
+          "id": "x-ai/grok-4.5"
         },
         {
           "id": "x-ai/grok-4.3"


### PR DESCRIPTION
## Summary
Hermes now recognizes xAI's `grok-4.5` (GA as of 2026-07-08): it appears in the `/model` picker for both `xai` and `xai-oauth`, resolves the correct 500K context window, and sends the `reasoning.effort` dial it accepts.

Without these entries the model substring-matched the generic `grok-4` fallbacks: 256K context and no effort parameter.

## Changes
- `hermes_cli/models.py`: `grok-4.5` added to `_XAI_CURATED_EXTRAS` (callable but absent from models.dev / public listings) and `_XAI_STATIC_FALLBACK`.
- `agent/model_metadata.py`: context lengths `grok-4.5` → 500,000 and `grok-build-latest` → 500,000 (published alias); `grok-4.5` added to `_GROK_EFFORT_CAPABLE_PREFIXES`.

### GA follow-up (second commit)
- models.dev now lists grok-4.5 (500K context, effort low/medium/high) — confirms the shipped values; curated-extras entry retained until user disk caches refresh.
- `x-ai/grok-4.5` added to the OpenRouter fallback snapshot and Nous static list (verified live on both aggregators).

## Validation
Live against `api.x.ai` (2026-07-08) with a real key:

| Check | Result |
|---|---|
| `GET /v1/models` | lists `grok-4.5` |
| `reasoning.effort` low/medium/high | accepted (server default: high) |
| `reasoning.effort: none` | rejected by xAI (unlike grok-4.3) — allowlist only ever sends low/medium/high, so no impact |
| Function calling | emits `function_call` items correctly |
| Full `AIAgent` turn (codex_responses, terminal toolset) | tool call + correct final response |
| Context resolution E2E (temp HERMES_HOME) | `grok-4.5` / `grok-4.5-latest` → 500K; `grok-build-0.1` still 256K |

Targeted tests green: `test_model_metadata`, `test_xai_curated_models`, `test_xai_model_flow`, `test_model_validation`, `test_xai_retirement`, `test_codex_transport`.

## Infographic

![grok-4.5-ga](https://v3b.fal.media/files/b/0aa17718/MemmgezCKPTFsYRs58Hoq_ryWHDUq7.png)
