### PR TITLE
test(cron): handle Windows path and permission semantics

### DIFF
--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -13,6 +13,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -48,6 +49,13 @@ class TestNormalizeWorkdir:
     def test_tilde_expands(self, tmp_path, monkeypatch):
         from cron.jobs import _normalize_workdir
         monkeypatch.setenv("HOME", str(tmp_path))
+        if os.name == "nt":
+            # Windows pathlib expands "~" from USERPROFILE/HOMEDRIVE+HOMEPATH,
+            # not HOME alone. Patch the platform-native home vars too so the
+            # test exercises the intended temp home on every platform.
+            monkeypatch.setenv("USERPROFILE", str(tmp_path))
+            monkeypatch.delenv("HOMEDRIVE", raising=False)
+            monkeypatch.delenv("HOMEPATH", raising=False)
         result = _normalize_workdir("~")
         assert result == str(tmp_path.resolve())
 

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -8,6 +8,20 @@ from pathlib import Path
 from unittest.mock import patch
 
 
+def assert_secure_mode(testcase: unittest.TestCase, path: Path, expected_mode: int) -> None:
+    """Assert POSIX mode bits where the platform can represent them.
+
+    Windows/NTFS does not round-trip chmod(0600/0700) through st_mode the same
+    way POSIX filesystems do. On Windows, keep the important creation/existence
+    assertion and reserve strict bit checks for POSIX.
+    """
+    testcase.assertTrue(path.exists(), f"{path} should exist")
+    if os.name == "nt":
+        return
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    testcase.assertEqual(mode, expected_mode)
+
+
 class TestCronFilePermissions(unittest.TestCase):
     """Verify cron files get secure permissions."""
 
@@ -34,10 +48,8 @@ class TestCronFilePermissions(unittest.TestCase):
             from cron.jobs import ensure_dirs
             ensure_dirs()
 
-            cron_mode = stat.S_IMODE(os.stat(cron_dir).st_mode)
-            output_mode = stat.S_IMODE(os.stat(output_dir).st_mode)
-            self.assertEqual(cron_mode, 0o700)
-            self.assertEqual(output_mode, 0o700)
+            assert_secure_mode(self, cron_dir, 0o700)
+            assert_secure_mode(self, output_dir, 0o700)
 
     @patch("cron.jobs.CRON_DIR")
     @patch("cron.jobs.OUTPUT_DIR")
@@ -53,8 +65,7 @@ class TestCronFilePermissions(unittest.TestCase):
             from cron.jobs import save_jobs
             save_jobs([{"id": "test", "prompt": "hello"}])
 
-            file_mode = stat.S_IMODE(os.stat(jobs_file).st_mode)
-            self.assertEqual(file_mode, 0o600)
+            assert_secure_mode(self, jobs_file, 0o600)
 
     def test_save_job_output_sets_0600(self):
         output_dir = Path(self.tmpdir) / "output"
@@ -65,13 +76,11 @@ class TestCronFilePermissions(unittest.TestCase):
             from cron.jobs import save_job_output
             output_file = save_job_output("test-job", "test output content")
 
-            file_mode = stat.S_IMODE(os.stat(output_file).st_mode)
-            self.assertEqual(file_mode, 0o600)
+            assert_secure_mode(self, output_file, 0o600)
 
-            # Job output dir should also be 0700
+            # Job output dir should also be 0700 on POSIX.
             job_dir = output_dir / "test-job"
-            dir_mode = stat.S_IMODE(os.stat(job_dir).st_mode)
-            self.assertEqual(dir_mode, 0o700)
+            assert_secure_mode(self, job_dir, 0o700)
 
 
 class TestConfigFilePermissions(unittest.TestCase):
@@ -91,8 +100,7 @@ class TestConfigFilePermissions(unittest.TestCase):
             from hermes_cli.config import save_config
             save_config({"model": "test/model"})
 
-            file_mode = stat.S_IMODE(os.stat(config_path).st_mode)
-            self.assertEqual(file_mode, 0o600)
+            assert_secure_mode(self, config_path, 0o600)
 
     def test_save_env_value_sets_0600(self):
         env_path = Path(self.tmpdir) / ".env"
@@ -101,8 +109,7 @@ class TestConfigFilePermissions(unittest.TestCase):
             from hermes_cli.config import save_env_value
             save_env_value("TEST_KEY", "test_value")
 
-            file_mode = stat.S_IMODE(os.stat(env_path).st_mode)
-            self.assertEqual(file_mode, 0o600)
+            assert_secure_mode(self, env_path, 0o600)
 
     def test_ensure_hermes_home_sets_0700(self):
         home = Path(self.tmpdir) / ".hermes"
@@ -110,12 +117,10 @@ class TestConfigFilePermissions(unittest.TestCase):
             from hermes_cli.config import ensure_hermes_home
             ensure_hermes_home()
 
-            home_mode = stat.S_IMODE(os.stat(home).st_mode)
-            self.assertEqual(home_mode, 0o700)
+            assert_secure_mode(self, home, 0o700)
 
             for subdir in ("cron", "sessions", "logs", "memories"):
-                subdir_mode = stat.S_IMODE(os.stat(home / subdir).st_mode)
-                self.assertEqual(subdir_mode, 0o700, f"{subdir} should be 0700")
+                assert_secure_mode(self, home / subdir, 0o700)
 
 
 class TestSecureHelpers(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Make cron/config permission tests portable on Windows by keeping strict POSIX mode-bit assertions on POSIX only.
- Keep Windows coverage meaningful by still asserting that sensitive files/directories are created.
- Make the `~` workdir normalization test patch Windows-native home variables (`USERPROFILE`, `HOMEDRIVE`, `HOMEPATH`) in addition to `HOME`.

## Root cause

Two tests encoded POSIX-only assumptions:

1. Windows/NTFS does not round-trip `chmod(0600/0700)` through `stat().st_mode` as strict POSIX mode bits.
2. `Path("~").expanduser()` on Windows uses `USERPROFILE`/`HOMEDRIVE`+`HOMEPATH`, not `HOME` alone.

## Test plan

- [x] Reproduced the Windows failures before the patch:
  - `tests/cron/test_file_permissions.py` strict `0600/0700` assertions failed as `0666/0777`.
  - `tests/cron/test_cron_workdir.py::TestNormalizeWorkdir::test_tilde_expands` resolved to `C:\Users\82109` instead of patched `HOME`.
- [x] Focused verification:

```text
python -m pytest tests/cron/test_file_permissions.py tests/cron/test_cron_workdir.py -q

29 passed
```

- [x] Syntax/checks:

```text
python -m py_compile tests/cron/test_file_permissions.py tests/cron/test_cron_workdir.py
git diff --check
```

## Scope note

This is intentionally separate from the cron profile-scoped jobs storage fix in #60882.
