### PR TITLE
fix(gateway): avoid false Telegram approval success

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5345,10 +5345,51 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
+                session_key = self._approval_state.get(approval_id)
                 if not session_key:
                     await query.answer(text="This approval has already been resolved.")
                     return
+
+                user_display = getattr(query.from_user, "first_name", "User")
+
+                # Resolve the approval before acknowledging success.  If the
+                # backend queue already timed out or was cleared by /stop, a
+                # stale Telegram button can still be clickable.  Do not pop the
+                # callback state or edit the prompt as approved until the agent
+                # thread was actually unblocked.
+                try:
+                    from tools.approval import resolve_gateway_approval
+                    count = resolve_gateway_approval(session_key, choice)
+                    logger.info(
+                        "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
+                        count, session_key, choice, user_display,
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "Failed to resolve gateway approval from Telegram button: %s",
+                        exc,
+                        exc_info=True,
+                    )
+                    await query.answer(
+                        text="Could not deliver approval. Please tap again."
+                    )
+                    return
+
+                if not count:
+                    self._approval_state.pop(approval_id, None)
+                    expired_text = "⚠️ Approval expired before it could be delivered"
+                    await query.answer(text="This approval is no longer active. Please retry the command.")
+                    try:
+                        await query.edit_message_text(
+                            text=self.format_message(expired_text),
+                            parse_mode=ParseMode.MARKDOWN_V2,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    return
+
+                self._approval_state.pop(approval_id, None)
 
                 # Map choice to human-readable label
                 label_map = {
@@ -5357,7 +5398,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     "always": "✅ Approved permanently",
                     "deny": "❌ Denied",
                 }
-                user_display = getattr(query.from_user, "first_name", "User")
                 label = label_map.get(choice, "Resolved")
 
                 await query.answer(text=label)
@@ -5371,18 +5411,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception:
                     pass  # non-fatal if edit fails
-
-                # Resolve the approval — unblocks the agent thread
-                try:
-                    from tools.approval import resolve_gateway_approval
-                    count = resolve_gateway_approval(session_key, choice)
-                    logger.info(
-                        "Telegram button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                        count, session_key, choice, user_display,
-                    )
-                except Exception as exc:
-                    logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
-                    count = 0
 
                 # Resume the typing indicator — paused when the approval was
                 # sent (gateway/run.py).  The text /approve and /deny paths

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -304,15 +304,21 @@ class TestTelegramApprovalCallback:
         assert "12345" not in adapter._typing_paused
 
     @pytest.mark.asyncio
-    async def test_typing_stays_paused_when_resolve_returns_zero(self):
-        """If resolve_gateway_approval reports 0 resolves, the agent thread
-        was never unblocked, so typing should NOT be force-resumed."""
+    async def test_expired_backend_approval_is_not_marked_approved(self):
+        """A stale inline button must not claim approval if no waiter exists.
+
+        Regression: the Telegram callback used to pop the button state and show
+        "Approved" before calling resolve_gateway_approval(). If the backend
+        queue had already timed out or been cleared, resolve returned 0, the
+        agent thread stayed blocked/denied, and a second tap only showed
+        "already resolved".
+        """
         adapter = _make_adapter()
         adapter._approval_state[6] = "agent:main:telegram:group:12345:99"
         adapter.pause_typing_for_chat("12345")
 
         query = AsyncMock()
-        query.data = "ea:once:6"
+        query.data = "ea:always:6"
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.from_user = MagicMock()
@@ -330,6 +336,44 @@ class TestTelegramApprovalCallback:
                 await adapter._handle_callback_query(update, context)
 
         assert "12345" in adapter._typing_paused
+        assert 6 not in adapter._approval_state
+        assert "no longer active" in query.answer.call_args[1]["text"]
+        edit_kwargs = query.edit_message_text.call_args[1]
+        assert "Approval expired" in edit_kwargs["text"]
+        assert "Approved" not in edit_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_resolver_exception_keeps_approval_available_for_retry(self):
+        """Transient resolver failures should not consume the Telegram button."""
+        adapter = _make_adapter()
+        adapter._approval_state[8] = "agent:main:telegram:group:12345:99"
+        adapter.pause_typing_for_chat("12345")
+
+        query = AsyncMock()
+        query.data = "ea:always:8"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Norbert"
+        query.from_user.id = "12345"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch(
+                "tools.approval.resolve_gateway_approval",
+                side_effect=RuntimeError("temporary resolver failure"),
+            ):
+                await adapter._handle_callback_query(update, context)
+
+        assert "12345" in adapter._typing_paused
+        assert adapter._approval_state[8] == "agent:main:telegram:group:12345:99"
+        assert "tap again" in query.answer.call_args[1]["text"]
+        query.edit_message_text.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_approval_callback_escapes_dynamic_user_name(self):


### PR DESCRIPTION
## Summary
- resolve Telegram inline approval callbacks before acknowledging success to the user
- show an explicit expired/inactive message when the backend approval waiter is gone instead of marking the command approved
- add a regression test for stale `ea:always` callbacks where `resolve_gateway_approval()` returns 0

## Why
A stale Telegram approval button could be clicked after the backend approval wait had timed out or been cleared. The callback popped the button state and edited the message as approved before checking whether `resolve_gateway_approval()` actually unblocked an agent thread, leaving the command denied/timed out while Telegram appeared resolved.

## Tests
- `python -m pytest tests/gateway/test_telegram_approval_buttons.py -q -p no:cacheprovider` → 20 passed
- `scripts/run_tests.sh tests/gateway/test_telegram_approval_buttons.py tests/tools/test_approval_heartbeat.py tests/tools/test_approval_plugin_hooks.py` → 23 passed
- `python scripts/check-windows-footguns.py plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_approval_buttons.py` → no Windows footguns found
- `git diff --check origin/main...HEAD` → passed

## Review
- Codex review verdict: APPROVED.
- Follow-up noted by review: Slack/Discord/Feishu have similar approval-button patterns and may deserve separate cleanup; this PR intentionally scopes the reported Telegram inline callback bug.
