### PR TITLE
fix(process): reconcile status-bar background count

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -331,6 +331,24 @@ class TestOrphanedPipeReconciliation:
         proc.kill()
         proc.wait()
 
+    def test_count_running_reconciles_exited_local_process(self, registry):
+        """Status-bar counts should not stay stale after a child exits."""
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.stdout = None
+        s = _make_session(sid="proc_status_bar_stale")
+        s.process = proc
+        s.pid = 12345
+        registry._running[s.id] = s
+
+        with patch.object(registry, "_write_checkpoint"):
+            assert registry.count_running() == 0
+
+        assert s.exited is True
+        assert s.exit_code == 0
+        assert s.id in registry._finished
+        assert s.id not in registry._running
+
     def test_reconcile_noop_on_already_exited(self, registry):
         """Reconcile is a no-op when session.exited is already True."""
         s = _make_session(sid="proc_already_exited", exited=True, exit_code=7)

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -477,6 +477,24 @@ class TestOrphanedPipeReconciliation:
         except (ProcessLookupError, PermissionError):
             pass
 
+    def test_count_running_reconciles_exited_local_process(self, registry):
+        """Status-bar counts should not stay stale after a child exits."""
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.stdout = None
+        s = _make_session(sid="proc_status_bar_stale")
+        s.process = proc
+        s.pid = 12345
+        registry._running[s.id] = s
+
+        with patch.object(registry, "_write_checkpoint"):
+            assert registry.count_running() == 0
+
+        assert s.exited is True
+        assert s.exit_code == 0
+        assert s.id in registry._finished
+        assert s.id not in registry._running
+
     def test_wait_returns_when_reader_blocked(self, registry):
         """wait() must also reconcile — not just poll()."""
         proc = subprocess.Popen(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1569,13 +1569,20 @@ class ProcessRegistry:
     def count_running(self) -> int:
         """Return the count of currently-running background processes.
 
-        Cheap O(1) read of the running dict, suitable for status-bar polling
-        on every render tick. CPython dict ``len()`` is atomic; callers do not
-        need to hold ``self._lock``. Reflects ``_running`` only: sessions are
-        moved to ``_finished`` when their subprocess exits.
+        Status-bar polling can be the only process-registry touchpoint after a
+        child exits, so reconcile stale local/detached sessions before reading
+        the count.
         """
         try:
-            return len(self._running)
+            with self._lock:
+                sessions = list(self._running.values())
+
+            for session in sessions:
+                self._refresh_detached_session(session)
+                self._reconcile_local_exit(session)
+
+            with self._lock:
+                return len(self._running)
         except Exception:
             return 0
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2544,13 +2544,20 @@ class ProcessRegistry:
     def count_running(self) -> int:
         """Return the count of currently-running background processes.
 
-        Cheap O(1) read of the running dict, suitable for status-bar polling
-        on every render tick. CPython dict ``len()`` is atomic; callers do not
-        need to hold ``self._lock``. Reflects ``_running`` only: sessions are
-        moved to ``_finished`` when their subprocess exits.
+        Status-bar polling can be the only process-registry touchpoint after a
+        child exits, so reconcile stale local/detached sessions before reading
+        the count.
         """
         try:
-            return len(self._running)
+            with self._lock:
+                sessions = list(self._running.values())
+
+            for session in sessions:
+                self._refresh_detached_session(session)
+                self._reconcile_local_exit(session)
+
+            with self._lock:
+                return len(self._running)
         except Exception:
             return 0
 


### PR DESCRIPTION
Closes #60853

## Summary
- Reconcile exited local/detached background sessions before reading the status-bar process count.
- Keep the count path lock-safe by snapshotting running sessions before reconciliation.
- Add regression coverage for stale `_running` entries after the child process has already exited.

## Tests
- `python3 -m pytest tests/tools/test_process_registry.py -q -k count_running_reconciles_exited_local_process`
- `python3 -m pytest tests/tools/test_process_registry.py -q -k "reconcile and not child_still_running"`
- `python3 -m ruff check tools/process_registry.py tests/tools/test_process_registry.py`