### PR TITLE
fix(web_server): preserve user-configured custom providers in model picker (#50944)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1013,6 +1013,15 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
     2. Model-format normalization for the resolved provider via
        ``normalize_model_for_provider`` (e.g. ``anthropic/claude-opus-4.6``
        on native anthropic → ``claude-opus-4-6``).
+
+   修复：在执行 vendor-prefix fallback 逻辑之前，检查传入的 provider 是否存在于
+    用户的配置（providers: 或 custom_providers）中。如果存在，说明是用户显式配置的
+    自定义 provider，应保留不进行 fallback。
+
+    Case: 用户配置了 providers.litellm-proxy.base_url，通过 Desktop model picker
+    选择 litellm-proxy + nvidia/nim/deepseek-v4-pro。litellm-proxy 不在
+    _KNOWN_PROVIDER_NAMES 中，但它是用户配置的合法 provider，不应被 fallback 到
+    openrouter。(#50944)
     """
     from hermes_cli.models import _KNOWN_PROVIDER_NAMES, normalize_provider
     from hermes_cli.model_normalize import normalize_model_for_provider
@@ -1022,6 +1031,22 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
     canonical = normalize_provider(prov_in)
 
     if canonical not in _KNOWN_PROVIDER_NAMES and "/" in model_in:
+        # 检查 provider 是否在用户的 providers: 或 custom_providers 配置中
+        # 如果是，说明是用户显式配置的自定义 provider，保留不进行 fallback
+        try:
+            cfg = load_config()
+            user_providers = set(cfg.get("providers", {}).keys())
+            # 兼容 legacy custom_providers 格式（检查 name 或 id 字段）
+            for cp in cfg.get("custom_providers", []):
+                if isinstance(cp, dict):
+                    user_providers.add(cp.get("name", cp.get("id", "")))
+            if canonical in user_providers:
+                # 用户显式配置的 provider，保留原值
+                return prov_in, model_in
+        except Exception:
+            # 配置读取失败时，继续使用原有逻辑
+            pass
+
         # Vendor prefix posing as a provider (analytics fallback). Resolve
         # against the user's current provider when it's an aggregator that
         # serves vendor-prefixed slugs; otherwise default to openrouter.

--- a/tests/hermes_cli/test_normalize_main_model_assignment_custom_provider.py
+++ b/tests/hermes_cli/test_normalize_main_model_assignment_custom_provider.py
@@ -1,0 +1,132 @@
+"""Test for _normalize_main_model_assignment custom provider preservation (#50944)."""
+import pytest
+from unittest.mock import patch
+
+from hermes_cli.web_server import _normalize_main_model_assignment
+
+
+class TestNormalizeMainModelAssignmentCustomProvider:
+    """Test that user-configured custom providers are preserved during normalization.
+
+    Regression test for #50944: When a user configures a custom provider in the
+    providers: block (e.g., litellm-proxy), and then selects it + a model with a slash
+    (e.g., nvidia/nim/deepseek-v4-pro) via the Desktop model picker, the provider should
+    NOT be fallback-ed to openrouter just because it's not in _KNOWN_PROVIDER_NAMES.
+    """
+
+    @pytest.fixture
+    def mock_config_with_custom_provider(self):
+        """Mock config with a custom provider in providers: block."""
+        return {
+            "model": {"provider": "litellm-proxy", "default": "nvidia/nim/deepseek-v4-pro"},
+            "providers": {
+                "litellm-proxy": {"base_url": "http://localhost:4000"},
+                "ollama": {"base_url": "http://localhost:11434"},
+            },
+        }
+
+    @pytest.fixture
+    def mock_config_with_legacy_custom_provider(self):
+        """Mock config with legacy custom_providers format."""
+        return {
+            "model": {"provider": "my-proxy", "default": "custom-model"},
+            "custom_providers": [
+                {"id": "my-proxy", "base_url": "http://localhost:8080"},
+                {"name": "another-proxy", "base_url": "http://localhost:9090"},
+            ],
+        }
+
+    @pytest.fixture
+    def mock_config_without_custom_provider(self):
+        """Mock config without the provider in question."""
+        return {
+            "model": {"provider": "openrouter", "default": "anthropic/claude-3-5-sonnet"},
+            "providers": {
+                "openrouter": {"api_key_env": "OPENROUTER_API_KEY"},
+            },
+        }
+
+    def test_custom_provider_with_slashed_model_preserved(self, mock_config_with_custom_provider):
+        """Custom provider + model with slash should be preserved, not fallback to openrouter."""
+        with patch("hermes_cli.web_server.load_config", return_value=mock_config_with_custom_provider):
+            provider, model = _normalize_main_model_assignment(
+                "litellm-proxy", "nvidia/nim/deepseek-v4-pro"
+            )
+
+            # Should preserve the custom provider, NOT fallback to openrouter
+            assert provider == "litellm-proxy", f"Expected 'litellm-proxy', got '{provider}'"
+            assert model == "nvidia/nim/deepseek-v4-pro", f"Expected model unchanged, got '{model}'"
+
+    def test_legacy_custom_provider_preserved(self, mock_config_with_legacy_custom_provider):
+        """Legacy custom_providers format should also be recognized."""
+        with patch("hermes_cli.web_server.load_config", return_value=mock_config_with_legacy_custom_provider):
+            provider, model = _normalize_main_model_assignment(
+                "my-proxy", "custom-model"
+            )
+
+            # Should preserve the legacy custom provider
+            assert provider == "my-proxy", f"Expected 'my-proxy', got '{provider}'"
+            assert model == "custom-model", f"Expected model unchanged, got '{model}'"
+
+    def test_legacy_custom_provider_with_name_field(self, mock_config_with_legacy_custom_provider):
+        """Legacy custom_providers with 'name' field should be recognized."""
+        with patch("hermes_cli.web_server.load_config", return_value=mock_config_with_legacy_custom_provider):
+            provider, model = _normalize_main_model_assignment(
+                "another-proxy", "vendor/model"
+            )
+
+            # Should preserve the custom provider with 'name' field
+            assert provider == "another-proxy", f"Expected 'another-proxy', got '{provider}'"
+            assert model == "vendor/model", f"Expected model unchanged, got '{model}'"
+
+    def test_unknown_provider_fallback_to_openrouter(self, mock_config_without_custom_provider):
+        """Unknown provider NOT in config should still fallback to openrouter (analytics fallback).
+
+        Note: 'anthropic' is in _KNOWN_PROVIDER_NAMES, so we use 'poolside' which is NOT.
+        """
+        with patch("hermes_cli.web_server.load_config", return_value=mock_config_without_custom_provider):
+            # Simulate analytics fallback: unknown vendor name as provider
+            provider, model = _normalize_main_model_assignment(
+                "poolside", "poolside/model"
+            )
+
+            # Should fallback to openrouter (current provider is an aggregator)
+            assert provider == "openrouter", f"Expected 'openrouter', got '{provider}'"
+            # Model should be preserved
+            assert model == "poolside/model", f"Expected model unchanged, got '{model}'"
+
+    def test_known_provider_unaffected(self, mock_config_with_custom_provider):
+        """Known providers should not be affected by this fix."""
+        with patch("hermes_cli.web_server.load_config", return_value=mock_config_with_custom_provider):
+            provider, model = _normalize_main_model_assignment(
+                "openrouter", "anthropic/claude-3-5-sonnet"
+            )
+
+            # openrouter is in _KNOWN_PROVIDER_NAMES, should work normally
+            assert provider == "openrouter", f"Expected 'openrouter', got '{provider}'"
+            assert model == "anthropic/claude-3-5-sonnet", f"Expected model unchanged, got '{model}'"
+
+    def test_custom_provider_without_slash(self, mock_config_with_custom_provider):
+        """Custom provider with model without slash should also be preserved."""
+        with patch("hermes_cli.web_server.load_config", return_value=mock_config_with_custom_provider):
+            provider, model = _normalize_main_model_assignment(
+                "litellm-proxy", "deepseek-v4-pro"
+            )
+
+            # Should preserve the custom provider
+            assert provider == "litellm-proxy", f"Expected 'litellm-proxy', got '{provider}'"
+            assert model == "deepseek-v4-pro", f"Expected model unchanged, got '{model}'"
+
+    def test_empty_config_continues_with_fallback(self):
+        """When config load fails, should continue with existing fallback logic.
+
+        Note: 'anthropic' is in _KNOWN_PROVIDER_NAMES, so we use 'unknown-provider' which is NOT.
+        """
+        with patch("hermes_cli.web_server.load_config", side_effect=Exception("Config read failed")):
+            # Even with empty config, the original logic should still work
+            provider, model = _normalize_main_model_assignment(
+                "unknown-provider", "unknown-provider/model"
+            )
+
+            # Should fallback to openrouter (current provider is empty)
+            assert provider == "openrouter", f"Expected 'openrouter', got '{provider}'"


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where the Desktop model picker incorrectly replaced user-configured custom providers with `openrouter` when persisting model selections.

**Problem**: When a user configured a custom provider in the `providers:` block (e.g., `litellm-proxy` with a local LiteLLM pool), and then selected it via the Desktop model picker with a model containing a slash (e.g., `nvidia/nim/deepseek-v4-pro`), the provider name was silently replaced with `openrouter` in the saved `config.yaml`. New sessions then failed with HTTP 400 because `openrouter` was not configured.

**Root cause**: `_normalize_main_model_assignment()` in `web_server.py` assumed that any provider NOT in `_KNOWN_PROVIDER_NAMES` + a model with `/` was a "vendor prefix posing as a provider" (from analytics fallback), and would fallback to the current aggregator or `openrouter`. This assumption was incorrect for user-configured custom providers.

**Fix**: Before executing the vendor-prefix fallback logic, check if the provider exists in the user's config (`providers:` block or `custom_providers` array). If it does, it's a legitimate custom provider — preserve it as-is without fallback.

## Related Issue

Fixes #50944

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Modified `_normalize_main_model_assignment()` to check for user-configured providers before fallback (+16 lines)
- `tests/hermes_cli/test_normalize_main_model_assignment_custom_provider.py`: Added 7 regression tests

## How to Test

### Automated tests
```bash
pytest tests/hermes_cli/test_normalize_main_model_assignment_custom_provider.py -v
# All 7 tests pass
```

### Manual reproduction (from issue)
1. Configure a custom provider in `config.yaml`:
   ```yaml
   providers:
     litellm-proxy:
       base_url: http://localhost:4000
   ```
2. Open Desktop → Settings → Model
3. Select provider `litellm-proxy` and model `nvidia/nim/deepseek-v4-pro`
4. Click "Apply" (or use "Make global default")
5. Inspect `config.yaml` — `model.provider` should be `litellm-proxy`, NOT `openrouter`

**Before this fix**: `model.provider` became `openrouter` (wrong) → HTTP 400 on new sessions
**After this fix**: `model.provider` stays `litellm-proxy` (correct) → requests go to the local LiteLLM pool

### Test coverage
- Custom provider in `providers:` block (new format)
- Legacy `custom_providers` format (both `id` and `name` fields)
- Unknown providers still fallback to `openrouter` (analytics fallback preserved)
- Known providers (e.g., `openrouter`, `anthropic`) unaffected
- Config load failures handled gracefully

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
