### PR TITLE
fix(display): honor indicator config for spinner faces

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -128,6 +128,55 @@ def _get_skin():
         return None
 
 
+_INDICATOR_STYLES = {"ascii", "emoji", "kaomoji", "unicode"}
+
+
+def _normalize_indicator_style(raw, default: str) -> str:
+    value = str(raw or default).strip().lower()
+    return value if value in _INDICATOR_STYLES else default
+
+
+def _default_tui_status_indicator() -> str:
+    try:
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        display = DEFAULT_CONFIG.get("display", {})
+        if isinstance(display, dict):
+            return _normalize_indicator_style(
+                display.get("tui_status_indicator"), "kaomoji"
+            )
+    except Exception:
+        pass
+    return "kaomoji"
+
+
+def _get_tui_status_indicator() -> str:
+    """Return the resolved busy-indicator style.
+
+    ``load_config_readonly`` merges ``DEFAULT_CONFIG`` with the active profile's
+    config, so profile overrides remain authoritative. Historically this
+    module's ``KawaiiSpinner`` had its own kaomoji fallback, separate from the
+    TUI status-bar setting. That meant users could set
+    ``display.tui_status_indicator: emoji`` and still see kaomoji in CLI/tool
+    progress. Treat the same resolved config key as the global indicator-style
+    selector for these spinner faces too.
+    """
+    default = _default_tui_status_indicator()
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+        display = cfg.get("display") if isinstance(cfg, dict) else {}
+        raw = (
+            display.get("tui_status_indicator", default)
+            if isinstance(display, dict)
+            else default
+        )
+        return _normalize_indicator_style(raw, default)
+    except Exception:
+        return default
+
+
 def get_skin_tool_prefix() -> str:
     """Get tool output prefix character from active skin."""
     skin = _get_skin()
@@ -983,6 +1032,18 @@ class KawaiiSpinner:
         "٩(๑❛ᴗ❛๑)۶", "(⊙_⊙)", "(¬_¬)", "( ͡° ͜ʖ ͡°)", "ಠ_ಠ",
     ]
 
+    STYLE_WAITING = {
+        "ascii": ["*", "+", "-", "~"],
+        "emoji": ["⚕", "🌀", "✨", "🍵", "🔮"],
+        "unicode": ["⠋", "⠙", "⠹", "⠸", "⠼"],
+    }
+
+    STYLE_THINKING = {
+        "ascii": ["?", "*", "+", "~"],
+        "emoji": ["🤔", "🧠", "💭", "💡", "✨"],
+        "unicode": ["⠋", "⠙", "⠹", "⠸", "⠼"],
+    }
+
     THINKING_VERBS = [
         "pondering", "contemplating", "musing", "cogitating", "ruminating",
         "deliberating", "mulling", "reflecting", "processing", "reasoning",
@@ -991,7 +1052,11 @@ class KawaiiSpinner:
 
     @classmethod
     def get_waiting_faces(cls) -> list:
-        """Return waiting faces from the active skin, falling back to KAWAII_WAITING."""
+        """Return waiting faces for the configured indicator style."""
+        style = _get_tui_status_indicator()
+        if style != "kaomoji":
+            return cls.STYLE_WAITING.get(style, cls.STYLE_WAITING["emoji"])
+
         try:
             skin = _get_skin()
             if skin:
@@ -1004,7 +1069,11 @@ class KawaiiSpinner:
 
     @classmethod
     def get_thinking_faces(cls) -> list:
-        """Return thinking faces from the active skin, falling back to KAWAII_THINKING."""
+        """Return thinking faces for the configured indicator style."""
+        style = _get_tui_status_indicator()
+        if style != "kaomoji":
+            return cls.STYLE_THINKING.get(style, cls.STYLE_THINKING["emoji"])
+
         try:
             skin = _get_skin()
             if skin:

--- a/tests/agent/test_display_spinner_faces.py
+++ b/tests/agent/test_display_spinner_faces.py
@@ -1,0 +1,66 @@
+from agent import display
+from agent.display import KawaiiSpinner
+
+
+def _set_indicator(monkeypatch, value):
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config_readonly",
+        lambda: {"display": {"tui_status_indicator": value}},
+    )
+
+
+def test_spinner_faces_follow_emoji_indicator(monkeypatch):
+    _set_indicator(monkeypatch, "emoji")
+
+    assert KawaiiSpinner.get_waiting_faces() == KawaiiSpinner.STYLE_WAITING["emoji"]
+    assert KawaiiSpinner.get_thinking_faces() == KawaiiSpinner.STYLE_THINKING["emoji"]
+    assert not any("(" in face or "◕" in face for face in KawaiiSpinner.get_waiting_faces())
+
+
+def test_spinner_faces_follow_ascii_indicator(monkeypatch):
+    _set_indicator(monkeypatch, "ascii")
+
+    assert KawaiiSpinner.get_waiting_faces() == KawaiiSpinner.STYLE_WAITING["ascii"]
+    assert KawaiiSpinner.get_thinking_faces() == KawaiiSpinner.STYLE_THINKING["ascii"]
+
+
+def test_spinner_faces_use_kaomoji_only_when_explicit(monkeypatch):
+    _set_indicator(monkeypatch, "kaomoji")
+    monkeypatch.setattr(display, "_get_skin", lambda: None)
+
+    assert KawaiiSpinner.get_waiting_faces() == KawaiiSpinner.KAWAII_WAITING
+    assert KawaiiSpinner.get_thinking_faces() == KawaiiSpinner.KAWAII_THINKING
+
+
+def test_spinner_faces_use_default_config_when_unset(monkeypatch):
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "DEFAULT_CONFIG",
+        {"display": {"tui_status_indicator": "emoji"}},
+    )
+    monkeypatch.setattr(config_mod, "load_config_readonly", lambda: {"display": {}})
+
+    assert KawaiiSpinner.get_waiting_faces() == KawaiiSpinner.STYLE_WAITING["emoji"]
+    assert KawaiiSpinner.get_thinking_faces() == KawaiiSpinner.STYLE_THINKING["emoji"]
+
+
+def test_spinner_faces_fall_back_to_default_config_when_config_unavailable(monkeypatch):
+    import hermes_cli.config as config_mod
+
+    def raise_config_error():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        config_mod,
+        "DEFAULT_CONFIG",
+        {"display": {"tui_status_indicator": "unicode"}},
+    )
+    monkeypatch.setattr(config_mod, "load_config_readonly", raise_config_error)
+
+    assert KawaiiSpinner.get_waiting_faces() == KawaiiSpinner.STYLE_WAITING["unicode"]
+    assert KawaiiSpinner.get_thinking_faces() == KawaiiSpinner.STYLE_THINKING["unicode"]


### PR DESCRIPTION
## Summary
- Make `KawaiiSpinner` read the resolved `display.tui_status_indicator` from `load_config_readonly()`.
- Preserve the default configured in `DEFAULT_CONFIG`, while allowing the active profile config to override it.
- Keep kaomoji/skin faces only when the resolved indicator style is `kaomoji`; otherwise use matching emoji/unicode/ascii face sets.

## Why
`display.tui_status_indicator` already controls the TUI status-bar indicator, but CLI/tool progress still used `KawaiiSpinner`'s kaomoji fallback. That means a profile can set `display.tui_status_indicator: emoji` and still see kaomoji during CLI/tool progress.

This makes the config key the single source of truth across both paths without changing the upstream default.

## Test plan
- `uv run --extra dev pytest tests/agent/test_display_spinner_faces.py -q`
- `uv run --extra dev ruff check agent/display.py tests/agent/test_display_spinner_faces.py`
- Manual smoke: patched `load_config_readonly()` to return `emoji` and `kaomoji` values and verified `KawaiiSpinner.get_waiting_faces()` follows the resolved config.