### PR TITLE
fix(api): include final reasoning in runs SSE

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6071,6 +6071,47 @@ class APIServerAdapter(BasePlatformAdapter):
         return out
 
     @staticmethod
+    def _reasoning_events_from_messages(
+        messages: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Build final reasoning events from persisted assistant messages.
+
+        Provider-native reasoning often lands only on the completed assistant
+        message, after live callback previews have already fired. Returning a
+        final reasoning event lets /v1/runs SSE clients reconcile with the same
+        reasoning fields that session/history readers see after refresh.
+        """
+        events: List[Dict[str, Any]] = []
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+
+            reasoning = msg.get("reasoning")
+            reasoning_content = msg.get("reasoning_content")
+            if not reasoning and reasoning_content is None:
+                continue
+
+            text = ""
+            if isinstance(reasoning_content, str) and reasoning_content:
+                text = reasoning_content
+            elif isinstance(reasoning, str):
+                text = reasoning
+
+            payload: Dict[str, Any] = {
+                "text": text,
+                "final": True,
+                "source": "messages",
+            }
+            if msg.get("id"):
+                payload["message_id"] = msg.get("id")
+            if reasoning:
+                payload["reasoning"] = reasoning
+            if reasoning_content is not None:
+                payload["reasoning_content"] = reasoning_content
+            events.append(payload)
+        return events
+
+    @staticmethod
     def _extract_output_items(result: Dict[str, Any], start_index: int = 0) -> List[Dict[str, Any]]:
         """
         Build the output item array from the agent's messages.
@@ -6859,6 +6900,24 @@ class APIServerAdapter(BasePlatformAdapter):
                     # see turn_finalizer) rides on the terminal event/status so
                     # the client can replay it as the next user turn.
                     pending_steer = result.get("pending_steer") if isinstance(result, dict) else None
+                    turn_messages = (
+                        self._turn_transcript_messages(
+                            conversation_history,
+                            user_message,
+                            result,
+                        )
+                        if isinstance(result, dict)
+                        else []
+                    )
+                    reasoning_events = self._reasoning_events_from_messages(turn_messages)
+                    for payload in reasoning_events:
+                        _put_event_if_active({
+                            "event": "reasoning.available",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            **payload,
+                        })
+
                     completed_event = {
                         "event": "run.completed",
                         "run_id": run_id,
@@ -6868,6 +6927,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     }
                     if pending_steer:
                         completed_event["pending_steer"] = pending_steer
+                    if turn_messages:
+                        completed_event["messages"] = turn_messages
                     _put_event_if_active(completed_event)
                     self._set_run_status(
                         run_id,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5637,6 +5637,47 @@ class APIServerAdapter(BasePlatformAdapter):
         return out
 
     @staticmethod
+    def _reasoning_events_from_messages(
+        messages: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Build final reasoning events from persisted assistant messages.
+
+        Provider-native reasoning often lands only on the completed assistant
+        message, after live callback previews have already fired. Returning a
+        final reasoning event lets /v1/runs SSE clients reconcile with the same
+        reasoning fields that session/history readers see after refresh.
+        """
+        events: List[Dict[str, Any]] = []
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+
+            reasoning = msg.get("reasoning")
+            reasoning_content = msg.get("reasoning_content")
+            if not reasoning and reasoning_content is None:
+                continue
+
+            text = ""
+            if isinstance(reasoning_content, str) and reasoning_content:
+                text = reasoning_content
+            elif isinstance(reasoning, str):
+                text = reasoning
+
+            payload: Dict[str, Any] = {
+                "text": text,
+                "final": True,
+                "source": "messages",
+            }
+            if msg.get("id"):
+                payload["message_id"] = msg.get("id")
+            if reasoning:
+                payload["reasoning"] = reasoning
+            if reasoning_content is not None:
+                payload["reasoning_content"] = reasoning_content
+            events.append(payload)
+        return events
+
+    @staticmethod
     def _extract_output_items(result: Dict[str, Any], start_index: int = 0) -> List[Dict[str, Any]]:
         """
         Build the output item array from the agent's messages.
@@ -6365,13 +6406,34 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                    _put_event_if_active({
+                    turn_messages = (
+                        self._turn_transcript_messages(
+                            conversation_history,
+                            user_message,
+                            result,
+                        )
+                        if isinstance(result, dict)
+                        else []
+                    )
+                    reasoning_events = self._reasoning_events_from_messages(turn_messages)
+                    for payload in reasoning_events:
+                        _put_event_if_active({
+                            "event": "reasoning.available",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            **payload,
+                        })
+
+                    completed_event = {
                         "event": "run.completed",
                         "run_id": run_id,
                         "timestamp": time.time(),
                         "output": final_response,
                         "usage": usage,
-                    })
+                    }
+                    if turn_messages:
+                        completed_event["messages"] = turn_messages
+                    _put_event_if_active(completed_event)
                     self._set_run_status(
                         run_id,
                         "completed",

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -73,6 +74,14 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/runs/{run_id}/steer", adapter._handle_steer_run)
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
+
+
+def _sse_events(body: str) -> list[dict]:
+    events = []
+    for line in body.splitlines():
+        if line.startswith("data: "):
+            events.append(json.loads(line[len("data: ") :]))
+    return events
 
 
 def _make_slow_agent(**kwargs):
@@ -333,6 +342,58 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_events_stream_replays_final_message_reasoning(self, adapter):
+        """Completed runs should expose reasoning fields that history will show."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "Final answer",
+                    "messages": [
+                        {"role": "user", "content": "hello"},
+                        {
+                            "role": "assistant",
+                            "content": "Final answer",
+                            "reasoning": "short summary",
+                            "reasoning_content": "provider-native chain",
+                        },
+                    ],
+                }
+                mock_agent.session_prompt_tokens = 10
+                mock_agent.session_completion_tokens = 5
+                mock_agent.session_total_tokens = 15
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                data = await resp.json()
+
+                events_resp = await cli.get(f"/v1/runs/{data['run_id']}/events")
+                assert events_resp.status == 200
+                events = _sse_events(await events_resp.text())
+
+        reasoning = [
+            event for event in events if event.get("event") == "reasoning.available"
+        ]
+        assert reasoning
+        assert reasoning[-1]["final"] is True
+        assert reasoning[-1]["source"] == "messages"
+        assert reasoning[-1]["text"] == "provider-native chain"
+        assert reasoning[-1]["reasoning"] == "short summary"
+        assert reasoning[-1]["reasoning_content"] == "provider-native chain"
+
+        completed = [event for event in events if event.get("event") == "run.completed"]
+        assert completed
+        assert completed[-1]["messages"] == [
+            {
+                "role": "assistant",
+                "content": "Final answer",
+                "reasoning": "short summary",
+                "reasoning_content": "provider-native chain",
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -71,6 +72,14 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
+
+
+def _sse_events(body: str) -> list[dict]:
+    events = []
+    for line in body.splitlines():
+        if line.startswith("data: "):
+            events.append(json.loads(line[len("data: ") :]))
+    return events
 
 
 def _make_slow_agent(**kwargs):
@@ -331,6 +340,58 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_events_stream_replays_final_message_reasoning(self, adapter):
+        """Completed runs should expose reasoning fields that history will show."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "Final answer",
+                    "messages": [
+                        {"role": "user", "content": "hello"},
+                        {
+                            "role": "assistant",
+                            "content": "Final answer",
+                            "reasoning": "short summary",
+                            "reasoning_content": "provider-native chain",
+                        },
+                    ],
+                }
+                mock_agent.session_prompt_tokens = 10
+                mock_agent.session_completion_tokens = 5
+                mock_agent.session_total_tokens = 15
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                data = await resp.json()
+
+                events_resp = await cli.get(f"/v1/runs/{data['run_id']}/events")
+                assert events_resp.status == 200
+                events = _sse_events(await events_resp.text())
+
+        reasoning = [
+            event for event in events if event.get("event") == "reasoning.available"
+        ]
+        assert reasoning
+        assert reasoning[-1]["final"] is True
+        assert reasoning[-1]["source"] == "messages"
+        assert reasoning[-1]["text"] == "provider-native chain"
+        assert reasoning[-1]["reasoning"] == "short summary"
+        assert reasoning[-1]["reasoning_content"] == "provider-native chain"
+
+        completed = [event for event in events if event.get("event") == "run.completed"]
+        assert completed
+        assert completed[-1]["messages"] == [
+            {
+                "role": "assistant",
+                "content": "Final answer",
+                "reasoning": "short summary",
+                "reasoning_content": "provider-native chain",
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):


### PR DESCRIPTION
Fixes #60634.

## Summary
- emit a final `reasoning.available` SSE event for `/v1/runs` from the authoritative completed assistant message when it carries `reasoning` or `reasoning_content`
- include the safe per-turn assistant/tool transcript on `run.completed`, matching the reconciliation pattern already used by session chat streaming
- add a regression proving provider-native `reasoning_content` appears in the live SSE stream and in the completed event messages

## Why
Live `/v1/runs/{run_id}/events` only forwarded callback previews during the run, while richer reasoning fields were preserved on the completed assistant message and only visible later through session/history reloads. That made embedded clients render different reasoning before and after refresh.

## Tests
- `uv run --extra dev pytest tests/gateway/test_api_server_runs.py::TestRunEvents::test_events_stream_replays_final_message_reasoning -q`
- `uv run --extra dev pytest tests/gateway/test_api_server_runs.py -q`
- `python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py`
- `git diff --check`
- `gitleaks git --log-opts='origin/main..HEAD' --redact .`
