### PR TITLE
fix(slack): normalize bang commands before parsing

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2620,6 +2620,25 @@ class SlackAdapter(BasePlatformAdapter):
             return
 
         original_text = event.get("text", "")
+        raw_original_text = original_text
+
+        # Slack app_mention/message events include the literal leading bot
+        # mention in text (e.g. "<@U_BOT> !status").  Strip that addressing
+        # prefix before command detection so mentioned commands behave like
+        # the same command typed directly in an addressed thread/channel.
+        team_id_for_mention = event.get("team") or event.get("team_id") or ""
+        bot_uid_for_mention = self._team_bot_user_ids.get(
+            team_id_for_mention,
+            self._bot_user_id,
+        )
+        if bot_uid_for_mention:
+            original_text = re.sub(
+                rf"^\s*<@{re.escape(bot_uid_for_mention)}>\s*",
+                "",
+                original_text,
+                count=1,
+            )
+        mention_stripped_original_text = original_text
 
         # Slack blocks native slash commands inside threads ("/queue is not
         # supported in threads. Sorry!").  As a workaround, recognise a
@@ -2659,7 +2678,12 @@ class SlackAdapter(BasePlatformAdapter):
                 # Only append if the blocks contain text not already present
                 # in the plain text field (avoids duplication).
                 stripped_blocks = blocks_text.strip()
-                if stripped_blocks and stripped_blocks not in text.strip():
+                if (
+                    stripped_blocks
+                    and stripped_blocks not in text.strip()
+                    and stripped_blocks != raw_original_text.strip()
+                    and stripped_blocks != mention_stripped_original_text.strip()
+                ):
                     logger.debug(
                         "Slack: extracted additional text from blocks "
                         "(likely quoted/forwarded content): %s",
@@ -2824,7 +2848,7 @@ class SlackAdapter(BasePlatformAdapter):
         #   3. The message is in a thread where the bot was previously @mentioned, OR
         #   4. There's an existing session for this thread (survives restarts)
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
-        routing_text = original_text or ""
+        routing_text = raw_original_text or ""
         is_mentioned = bool(
             (bot_uid and f"<@{bot_uid}>" in routing_text)
             or self._slack_message_matches_mention_patterns(routing_text)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1129,7 +1129,14 @@ class TestBangPrefixCommands:
     command before downstream processing.
     """
 
-    def _make_event(self, text, thread_ts=None, channel_type="im", channel="D123"):
+    def _make_event(
+        self,
+        text,
+        thread_ts=None,
+        channel_type="im",
+        channel="D123",
+        blocks=None,
+    ):
         evt = {
             "text": text,
             "user": "U_USER",
@@ -1139,6 +1146,8 @@ class TestBangPrefixCommands:
         }
         if thread_ts:
             evt["thread_ts"] = thread_ts
+        if blocks is not None:
+            evt["blocks"] = blocks
         return evt
 
     @pytest.mark.asyncio
@@ -1174,6 +1183,15 @@ class TestBangPrefixCommands:
         assert msg_event.source.thread_id == "1111111111.000001"
 
     @pytest.mark.asyncio
+    async def test_leading_bot_mention_before_bang_command_is_stripped(self, adapter):
+        """Slack includes the addressed bot mention in app_mention text."""
+        await adapter._handle_slack_message(self._make_event("<@U_BOT> !status"))
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/status"
+        assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
     async def test_bang_unknown_token_passes_through_unchanged(self, adapter):
         """``!nice work`` is just a casual message — must NOT be rewritten."""
         await adapter._handle_slack_message(self._make_event("!nice work"))
@@ -1189,6 +1207,35 @@ class TestBangPrefixCommands:
 
         msg_event = adapter.handle_message.call_args[0][0]
         assert msg_event.text.startswith("/stop@hermes")
+        assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_bang_command_does_not_reappend_matching_rich_text(self, adapter):
+        """Slack's rich_text block mirrors plain text for normal messages.
+
+        ``!commands`` is rewritten to ``/commands`` before rich block extraction.
+        The dedupe check must compare against Slack's original plain text too;
+        otherwise the matching rich_text block is appended as a bogus argument
+        and downstream handlers see ``/commands\n!commands``.
+        """
+        blocks = [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [{"type": "text", "text": "!commands"}],
+                    }
+                ],
+            }
+        ]
+
+        await adapter._handle_slack_message(
+            self._make_event("!commands", blocks=blocks)
+        )
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/commands"
         assert msg_event.message_type == MessageType.COMMAND
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes two Slack alternate command-prefix edge cases for messages like `!commands` and `<@bot> !status`.

Hermes rewrites known `!cmd` messages to `/cmd` because Slack native slash commands do not work in threads. In practice, Slack can decorate those messages before they reach the adapter:

- ordinary Slack messages can include both plain `text` and mirrored `rich_text` blocks;
- app/channel mentions include the literal leading bot mention in `text`, for example `<@U_BOT> !status`.

Before this change, those shapes either duplicated the original bang command or prevented command parsing from seeing the command at the start of the message.

## Root cause

The command normalization path only handled text that already started with `!`.

For `!commands` with matching rich text blocks, the adapter rewrote the plain text to `/commands`, then compared extracted block text against the rewritten text only. Because the block still contained `!commands`, it was appended as extra content and downstream handlers saw:

```text
/commands
!commands
```

For `<@bot> !status`, routing correctly detected that the bot was mentioned, but the command parser still received the leading mention text. That made the message an addressed prompt rather than a gateway command.

## Changes Made

- Preserve the raw Slack message text for routing and rich-text dedupe.
- Strip only a leading literal bot mention before command detection and downstream message text construction.
- Avoid appending block text when it exactly mirrors either the raw Slack text or the mention-stripped text.
- Add regressions for both `!commands` rich-text duplication and `<@U_BOT> !status` command parsing.

## Reproduction

Rich text duplication before this change:

1. Send a Slack event with `text: "!commands"`.
2. Include a matching `rich_text` block containing `!commands`.
3. The adapter rewrites the plain text to `/commands`.
4. The block extraction appends `!commands`, so the command parser receives duplicate content.

Leading mention before this change:

1. Send a Slack app mention/message event with `text: "<@U_BOT> !status"`.
2. Routing sees the bot mention and processes the event.
3. Command detection does not see `!status` at the start, so it is handled as normal message text instead of `/status`.

After this change, the downstream command text is exactly `/commands` or `/status` respectively.

## How to Test

- `python -m pytest tests/gateway/test_slack.py::TestBangPrefixCommands -q`
- `scripts/run_tests.sh tests/gateway/test_slack.py -q`
- `python -m ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py`

## Issue / PR search

I searched for existing issues and PRs around Slack `!commands`, rich text blocks, alternate command prefixes, duplicate command content, and mention-prefixed bang commands, and did not find an existing match.

## Checklist

- [x] Bug fix
- [x] Regression tests added
- [x] Relevant Slack gateway tests pass
- [x] Lint check passes
- [x] Documentation not required; this preserves existing command syntax