### PR TITLE
fix(memory): warn when memory nears capacity

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -317,6 +317,25 @@ class TestMemoryStoreAdd:
         assert result["success"] is False
         assert "Blocked" in result["error"]
 
+    def test_success_below_soft_capacity_threshold_has_no_warning(self, store):
+        result = store.add("memory", "x" * 449)
+
+        assert result["success"] is True
+        assert result["done"] is True
+        assert result["usage"] == "89% — 449/500 chars"
+        assert "warning" not in result
+        assert "recommendation" not in result
+
+    def test_success_at_soft_capacity_threshold_warns_without_changing_behavior(self, store):
+        result = store.add("memory", "x" * 450)
+
+        assert result["success"] is True
+        assert result["done"] is True
+        assert result["usage"] == "90% — 450/500 chars"
+        assert "90%" in result["warning"]
+        assert "Memory is nearing capacity" in result["warning"]
+        assert "consolidate" in result["recommendation"].lower()
+
 
 class TestMemoryStoreReplace:
     def test_replace_entry(self, store):

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -658,6 +658,14 @@ class MemoryStore:
         }
         if message:
             resp["message"] = message
+        if limit > 0 and current / limit >= 0.9:
+            resp["warning"] = (
+                f"Memory is nearing capacity ({pct}% — {current:,}/{limit:,} chars)."
+            )
+            resp["recommendation"] = (
+                "Consider using replace/remove to consolidate stale, redundant, or "
+                "lower-value entries before adding more memory."
+            )
         resp["note"] = "Write saved. This update is complete — do not repeat it."
         return resp
 
@@ -1146,7 +1154,6 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
 
 
 


### PR DESCRIPTION
Fixes #60905.

## Summary

- Add soft capacity metadata to successful memory writes when usage reaches 90% or higher.
- Preserve existing memory behavior: writes still return `success: true` / `done: true`, no automatic compaction is triggered, and no new memory action enum is added.
- Add regression coverage for below-threshold and at-threshold success responses.

## Validation

- `scripts/run_tests.sh tests/tools/test_memory_tool.py tests/tools/test_memory_tool_schema.py -q`
  - 90 passed