### PR TITLE
feat(memory): add 90% capacity warning and compact directive

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -363,6 +363,14 @@ class MemoryStore:
             # Calculate what the new total would be
             new_entries = entries + [content]
             new_total = len(ENTRY_DELIMITER.join(new_entries))
+            
+            # 1. Soft warning at 90%
+            warning = ""
+            if new_total >= limit * 0.9:
+                warning = (
+                    f"\n[Soft Warning: Memory at {new_total:,}/{limit:,} ({new_total/limit:.0%}). "
+                    "Auto-consolidation recommended. Use 'memory compact' or manual 'replace'/'remove'.]"
+                )
 
             if new_total > limit:
                 current = self._char_count(target)
@@ -383,7 +391,7 @@ class MemoryStore:
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry added.")
+        return self._success_response(target, f"Entry added.{warning}")
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
@@ -494,6 +502,14 @@ class MemoryStore:
 
         return self._success_response(target, "Entry removed.")
 
+    def compact(self, target: str, directive: str) -> Dict[str, Any]:
+        """Compact memory based on a directive (e.g., 'keep X, shorten Y')."""
+        with self._file_lock(self._path_for(target)):
+            bak = self._reload_target(target)
+            if bak:
+                return _drift_error(self._path_for(target), bak)
+            return self._success_response(target, f"Compact directive received: {directive}. Manual intervention recommended.")
+
     def apply_batch(self, target: str, operations: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Apply a sequence of add/replace/remove ops to one target atomically.
 
@@ -501,8 +517,8 @@ class MemoryStore:
         intermediate overflow is irrelevant. This lets the model free space
         (remove/replace) and add new entries in a SINGLE tool call instead of
         the multi-turn consolidate-then-retry dance that re-sends the whole
-        conversation context several times.
-
+        history multiple times.
+        """
         Semantics: all-or-nothing. If any op is malformed, doesn't match, or
         the net result would exceed the char limit, NOTHING is written and an
         error is returned describing the first failure plus the live state.

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -508,7 +508,18 @@ class MemoryStore:
             bak = self._reload_target(target)
             if bak:
                 return _drift_error(self._path_for(target), bak)
-            return self._success_response(target, f"Compact directive received: {directive}. Manual intervention recommended.")
+            
+            entries = self._entries_for(target)
+            current = self._char_count(target)
+            limit = self._char_limit(target)
+            
+            return {
+                "success": True,
+                "message": f"Consolidation mode active for directive: '{directive}'.",
+                "instructions": "Please use 'memory(action=apply_batch, ...)' to perform the compaction.",
+                "current_entries": entries,
+                "usage": f"{current:,}/{limit:,} chars",
+            }
 
     def apply_batch(self, target: str, operations: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Apply a sequence of add/replace/remove ops to one target atomically.
@@ -518,10 +529,6 @@ class MemoryStore:
         (remove/replace) and add new entries in a SINGLE tool call instead of
         the multi-turn consolidate-then-retry dance that re-sends the whole
         history multiple times.
-        """
-        Semantics: all-or-nothing. If any op is malformed, doesn't match, or
-        the net result would exceed the char limit, NOTHING is written and an
-        error is returned describing the first failure plus the live state.
         """
         if not operations:
             return {"success": False, "error": "operations list is empty."}
@@ -648,7 +655,7 @@ class MemoryStore:
         """Truncated one-line previews of entries for error feedback."""
         return [e[:width] + ("..." if len(e) > width else "") for e in entries]
 
-    def _success_response(self, target: str, message: str = None) -> Dict[str, Any]:
+    def _success_response(self, target: str, message: str = None, warning: str = None) -> Dict[str, Any]:
         # A successful write means the consolidation loop made progress, so the
         # per-turn failure budget resets (the cap counts consecutive failures,
         # not lifetime ones within a turn) (#42405).
@@ -668,12 +675,14 @@ class MemoryStore:
         resp = {
             "success": True,
             "done": True,
+            "message": message or "Success",
             "target": target,
             "usage": f"{pct}% — {current:,}/{limit:,} chars",
             "entry_count": len(entries),
         }
-        if message:
-            resp["message"] = message
+        if warning:
+            resp["warning"] = warning
+        
         resp["note"] = "Write saved. This update is complete — do not repeat it."
         return resp
 


### PR DESCRIPTION
## Summary
Addresses issue #60900 by adding a proactive memory warning and a compact action to the memory tool.

- **Soft warning:** Triggers at 90% capacity to prompt early consolidation.
- **`memory compact`:** New action that acknowledges a consolidation directive.
- **Tests:** Verified with `pytest` for `tools/memory_tool.py`.

Closes #60900