### PR TITLE
feat(feishu): add ignore_at_all config to opt out of @everyone triggering the bot

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -409,6 +409,7 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    ignore_at_all: bool = False
 
 
 @dataclass
@@ -1600,6 +1601,9 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            ignore_at_all=_to_boolean(
+                extra.get("ignore_at_all", os.getenv("FEISHU_IGNORE_AT_ALL", "false"))
+            ),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1632,6 +1636,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._ignore_at_all = settings.ignore_at_all
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -4331,7 +4336,7 @@ class FeishuAdapter(BasePlatformAdapter):
     def _mentions_self(self, message: Any) -> bool:
         # @_all is Feishu's @everyone placeholder.
         raw_content = getattr(message, "content", "") or ""
-        if "@_all" in raw_content:
+        if "@_all" in raw_content and not self._ignore_at_all:
             return True
         mentions = getattr(message, "mentions", None) or []
         if mentions and self._message_mentions_bot(mentions):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -3499,6 +3499,81 @@ class TestGroupMentionAtAll(unittest.TestCase):
         self.assertTrue(_admits_group(adapter, message, allowed_sender, ""))
 
 
+class TestIgnoreAtAll(unittest.TestCase):
+    """Tests for ignore_at_all config: when true, @everyone does NOT count as a bot mention."""
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open", "FEISHU_IGNORE_AT_ALL": "true"}, clear=True)
+    def test_ignore_at_all_rejects_at_everyone_message(self):
+        """When ignore_at_all=true, @_all should not pass the mention gate."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(
+            content='{"text":"@_all 请注意"}',
+            mentions=[],
+            chat_type="group",
+            chat_id="oc_test",
+        )
+        sender = SimpleNamespace(sender_type="user", sender_id=SimpleNamespace(open_id="ou_any", user_id=None))
+        # Should be rejected because @_all no longer counts as mentioning the bot.
+        self.assertIsNotNone(adapter._admit(sender, message))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_default_ignore_at_all_false_accepts_at_everyone(self):
+        """By default (ignore_at_all=false), @_all still passes the mention gate."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(
+            content='{"text":"@_all 请注意"}',
+            mentions=[],
+            chat_type="group",
+            chat_id="oc_test",
+        )
+        sender = SimpleNamespace(sender_type="user", sender_id=SimpleNamespace(open_id="ou_any", user_id=None))
+        self.assertIsNone(adapter._admit(sender, message))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open", "FEISHU_IGNORE_AT_ALL": "true"}, clear=True)
+    def test_ignore_at_all_does_not_affect_explicit_bot_mention(self):
+        """When ignore_at_all=true, a direct @bot mention should still pass."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._bot_open_id = "ou_bot123"
+        message = SimpleNamespace(
+            content='{"text":"@_user_1 hello"}',
+            mentions=[SimpleNamespace(
+                id=SimpleNamespace(open_id="ou_bot123", user_id=None),
+                name="Bot",
+                key="@_user_1",
+            )],
+            chat_type="group",
+            chat_id="oc_test",
+        )
+        sender = SimpleNamespace(sender_type="user", sender_id=SimpleNamespace(open_id="ou_any", user_id=None))
+        self.assertIsNone(adapter._admit(sender, message))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open", "FEISHU_IGNORE_AT_ALL": "true"}, clear=True)
+    def test_ignore_at_all_does_not_affect_dm(self):
+        """ignore_at_all should not affect DMs which bypass the mention gate entirely."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(
+            content='{"text":"@_all please check"}',
+            mentions=[],
+            chat_type="p2p",
+            chat_id="ou_dm",
+        )
+        sender = SimpleNamespace(sender_type="user", sender_id=SimpleNamespace(open_id="ou_any", user_id=None))
+        # DMs always bypass the mention gate.
+        self.assertIsNone(adapter._admit(sender, message))
+
+
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestSenderNameResolution(unittest.TestCase):
     """Tests for _resolve_sender_name_from_api (contact API + cache)."""

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -245,6 +245,29 @@ FEISHU_REQUIRE_MENTION=false
 
 For per-chat control, set `require_mention` on a `group_rules` entry — see [Per-Group Access Control](#per-group-access-control) below.
 
+### Ignoring @everyone
+
+By default, Feishu's `@所有人` (`@everyone`) counts as a mention of the bot, so the bot responds in groups whenever someone uses `@所有人`. If you want the bot to **only** respond to explicit `@bot` mentions (not `@everyone`), set `ignore_at_all` to `true`:
+
+```yaml
+# config.yaml
+feishu:
+  ignore_at_all: true
+```
+
+Or via environment variable:
+
+```bash
+FEISHU_IGNORE_AT_ALL=true
+```
+
+When `ignore_at_all` is `true`:
+
+- `@所有人` / `@everyone` messages are **not** treated as mentioning the bot.
+- Direct `@bot` mentions still work as expected.
+- DMs are unaffected (they always bypass the mention gate).
+- The group policy (`open` / `allowlist` / `disabled`) is still enforced independently.
+
 ### Bot Identity
 
 Hermes auto-detects the bot's `open_id` and display name on startup. You only need to set these manually when auto-detection cannot reach the Feishu API, or when your app uses tenant-scoped user IDs:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/feishu.md
@@ -211,6 +211,29 @@ FEISHU_REQUIRE_MENTION=false
 
 如需按群控制，在 `group_rules` 条目中设置 `require_mention`——参见下方[按群访问控制](#per-group-access-control)。
 
+### 忽略 @所有人
+
+默认情况下，飞书的 `@所有人`（`@everyone`）会被视为提及了机器人，因此只要有人使用 `@所有人`，机器人就会在群中响应。如果你希望机器人**仅**响应明确的 `@bot` 提及（而非 `@所有人`），请将 `ignore_at_all` 设为 `true`：
+
+```yaml
+# config.yaml
+feishu:
+  ignore_at_all: true
+```
+
+或通过环境变量：
+
+```bash
+FEISHU_IGNORE_AT_ALL=true
+```
+
+当 `ignore_at_all` 为 `true` 时：
+
+- `@所有人` / `@everyone` 消息**不会**被视为提及了机器人。
+- 直接 `@bot` 提及仍然正常工作。
+- 私信不受影响（私信始终绕过提及门控）。
+- 群组策略（`open` / `allowlist` / `disabled`）仍然独立生效。
+
 ### 机器人身份
 
 Hermes 在启动时自动检测机器人的 `open_id` 和显示名称。仅当自动检测无法访问飞书 API，或你的应用使用租户范围用户 ID 时，才需要手动设置：


### PR DESCRIPTION
## Summary

Add an `ignore_at_all` configuration option to the Feishu gateway adapter, allowing users to prevent `@所有人` (`@everyone`) from counting as a bot mention in group chats.

By default, the bot still responds to `@所有人` (backward compatible), but this can be turned off via config or environment variable.

## Motivation

Currently, the Feishu bot responds to `@所有人` (`@everyone`) messages in groups because `_mentions_self()` treats `@_all` (Feishu's internal `@everyone` placeholder) as equivalent to an explicit `@bot` mention. This is often undesirable — group admins frequently use `@所有人` for announcements that are not directed at the bot, causing unnecessary and noisy responses.

Users should be able to opt out of this behavior so the bot only responds to explicit `@bot` mentions.

## Changes

- **`plugins/platforms/feishu/adapter.py`**:
  - Add `ignore_at_all: bool = False` to `FeishuAdapterSettings` (default: `False`, backward compatible)
  - Add `FEISHU_IGNORE_AT_ALL` env var support in `FeishuAdapter._load_settings()`
  - Add `ignore_at_all` config key support via `extra.get("ignore_at_all", ...)`
  - Apply setting in `_apply_settings()` → `self._ignore_at_all`
  - Gate the `@_all` check in `_mentions_self()` on `not self._ignore_at_all`

- **`tests/gateway/test_feishu.py`**:
  - Add `TestIgnoreAtAll` test class with 4 tests:
    - `test_ignore_at_all_rejects_at_everyone_message` — `@_all` is rejected when `ignore_at_all=true`
    - `test_default_ignore_at_all_false_accepts_at_everyone` — default behavior preserved
    - `test_ignore_at_all_does_not_affect_explicit_bot_mention` — direct `@bot` still works
    - `test_ignore_at_all_does_not_affect_dm` — DMs bypass mention gate regardless

- **`website/docs/user-guide/messaging/feishu.md`**:
  - Add "Ignoring @everyone" section documenting the new config

- **`website/i18n/zh-Hans/.../feishu.md`**:
  - Add corresponding Chinese documentation

## Configuration

```yaml
# config.yaml
feishu:
  ignore_at_all: true
```

Or via environment variable:

```bash
FEISHU_IGNORE_AT_ALL=true
```

## Behavior when `ignore_at_all=true`

- `@所有人` / `@everyone` messages are **not** treated as mentioning the bot.
- Direct `@bot` mentions still work as expected.
- DMs are unaffected (they always bypass the mention gate).
- The group policy (`open` / `allowlist` / `disabled`) is still enforced independently.

## Backward Compatibility

Fully backward compatible. Default is `ignore_at_all: false`, preserving existing behavior where `@所有人` counts as a bot mention.