### PR TITLE
fix(desktop): keep interface zoom across reloads

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4167,32 +4167,60 @@ function installPreviewShortcut(window) {
 // survives reloads/restarts) rather than a main-process JSON file. The main
 // process owns setZoomLevel, so we mirror each change into localStorage and
 // read it back on did-finish-load to re-apply after reloads or crash recovery.
-const { ZOOM_STORAGE_KEY, clampZoomLevel, percentToZoomLevel, zoomLevelToPercent } = require('./zoom.cjs')
+const {
+  ZOOM_STORAGE_KEY,
+  createZoomStateCache,
+  percentToZoomLevel,
+  serializeZoomLevel,
+  zoomLevelToPercent
+} = require('./zoom.cjs')
+const zoomState = createZoomStateCache()
 
-function setAndPersistZoomLevel(window, zoomLevel) {
+function applyZoomLevel(window, zoomLevel) {
   if (!window || window.isDestroyed()) return
-  const next = clampZoomLevel(zoomLevel)
+  const next = zoomState.set(window, zoomLevel)
   window.webContents.setZoomLevel(next)
   // Keep any open settings UI in sync, including changes made via the
   // keyboard shortcuts or the View menu.
   window.webContents.send('hermes:zoom:changed', { level: next, percent: zoomLevelToPercent(next) })
+
+  return next
+}
+
+function readPersistedZoomLevel(window) {
+  if (!window || window.isDestroyed()) return Promise.resolve(null)
+
+  return window.webContents
+    .executeJavaScript(
+      `(() => { try { return localStorage.getItem(${JSON.stringify(ZOOM_STORAGE_KEY)}) } catch { return null } })()`
+    )
+    .then(stored => zoomState.resolve(window, stored))
+}
+
+function setAndPersistZoomLevel(window, zoomLevel) {
+  const next = applyZoomLevel(window, zoomLevel)
+  if (next == null) return
   window.webContents
     .executeJavaScript(
-      `try { localStorage.setItem(${JSON.stringify(ZOOM_STORAGE_KEY)}, ${JSON.stringify(String(next))}) } catch {}`
+      `try { localStorage.setItem(${JSON.stringify(ZOOM_STORAGE_KEY)}, ${JSON.stringify(serializeZoomLevel(next))}) } catch {}`
     )
     .catch(error => rememberLog(`[zoom] persist failed: ${error?.message || error}`))
 }
 
 function restorePersistedZoomLevel(window) {
   if (!window || window.isDestroyed()) return
-  window.webContents
-    .executeJavaScript(
-      `(() => { try { return localStorage.getItem(${JSON.stringify(ZOOM_STORAGE_KEY)}) } catch { return null } })()`
-    )
-    .then(stored => {
-      if (stored == null || !window || window.isDestroyed()) return
-      const level = clampZoomLevel(Number(stored))
-      window.webContents.setZoomLevel(level)
+
+  const cached = zoomState.get(window)
+  if (cached != null) {
+    applyZoomLevel(window, cached)
+
+    return
+  }
+
+  readPersistedZoomLevel(window)
+    .then(level => {
+      if (level == null || !window || window.isDestroyed()) return
+      applyZoomLevel(window, level)
     })
     .catch(error => rememberLog(`[zoom] restore failed: ${error?.message || error}`))
 }
@@ -5734,6 +5762,7 @@ function wireCommonWindowHandlers(win) {
   installDevToolsShortcut(win)
   installZoomShortcuts(win)
   installContextMenu(win)
+  win.webContents.on('did-finish-load', () => restorePersistedZoomLevel(win))
   win.webContents.setWindowOpenHandler(details => {
     openExternalUrl(details.url)
 
@@ -6089,7 +6118,6 @@ function createWindow() {
   }
 
   mainWindow.webContents.once('did-finish-load', () => {
-    restorePersistedZoomLevel(mainWindow)
     broadcastBootProgress()
     sendWindowStateChanged()
     startHermes().catch(error => rememberLog(error.stack || error.message))
@@ -6159,9 +6187,15 @@ ipcMain.handle('hermes:window:openNewSession', async () => {
 // --- Text size (zoom) -------------------------------------------------------
 // The settings UI drives the same clamped zoom scale as the Ctrl/Cmd
 // shortcuts and the View menu. Reads and writes target the asking window.
-ipcMain.handle('hermes:zoom:get', event => {
+ipcMain.handle('hermes:zoom:get', async event => {
   const window = BrowserWindow.fromWebContents(event.sender)
-  const level = window && !window.isDestroyed() ? window.webContents.getZoomLevel() : 0
+  let level = zoomState.get(window)
+  if (level == null) {
+    level = await readPersistedZoomLevel(window)
+  }
+  if (level == null) {
+    level = window && !window.isDestroyed() ? window.webContents.getZoomLevel() : 0
+  }
 
   return { level, percent: zoomLevelToPercent(level) }
 })

--- a/apps/desktop/electron/zoom.cjs
+++ b/apps/desktop/electron/zoom.cjs
@@ -17,6 +17,37 @@ function clampZoomLevel(value) {
   return Math.min(Math.max(value, MIN_ZOOM_LEVEL), MAX_ZOOM_LEVEL)
 }
 
+function parseStoredZoomLevel(value) {
+  if (value == null) return null
+  return clampZoomLevel(Number(value))
+}
+
+function serializeZoomLevel(value) {
+  return String(clampZoomLevel(value))
+}
+
+function createZoomStateCache(map = new WeakMap()) {
+  return {
+    get(window) {
+      if (!window) return null
+      return map.has(window) ? map.get(window) : null
+    },
+    set(window, value) {
+      if (!window) return null
+      const level = clampZoomLevel(value)
+      map.set(window, level)
+
+      return level
+    },
+    resolve(window, storedValue) {
+      const cached = this.get(window)
+      if (cached != null) return cached
+
+      return parseStoredZoomLevel(storedValue)
+    }
+  }
+}
+
 function zoomLevelToPercent(level) {
   return Math.round(Math.pow(ZOOM_FACTOR_BASE, clampZoomLevel(level)) * 100)
 }
@@ -29,6 +60,9 @@ function percentToZoomLevel(percent) {
 module.exports = {
   ZOOM_STORAGE_KEY,
   clampZoomLevel,
+  createZoomStateCache,
+  parseStoredZoomLevel,
   percentToZoomLevel,
+  serializeZoomLevel,
   zoomLevelToPercent
 }

--- a/apps/desktop/electron/zoom.test.cjs
+++ b/apps/desktop/electron/zoom.test.cjs
@@ -7,7 +7,15 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
 
-const { ZOOM_STORAGE_KEY, clampZoomLevel, percentToZoomLevel, zoomLevelToPercent } = require('./zoom.cjs')
+const {
+  ZOOM_STORAGE_KEY,
+  clampZoomLevel,
+  createZoomStateCache,
+  parseStoredZoomLevel,
+  percentToZoomLevel,
+  serializeZoomLevel,
+  zoomLevelToPercent
+} = require('./zoom.cjs')
 
 test('storage key stays stable so persisted zoom survives upgrades', () => {
   assert.equal(ZOOM_STORAGE_KEY, 'hermes:desktop:zoomLevel')
@@ -33,6 +41,38 @@ test('percentToZoomLevel rejects garbage', () => {
   assert.equal(percentToZoomLevel(0), 0)
   assert.equal(percentToZoomLevel(-50), 0)
   assert.equal(percentToZoomLevel(undefined), 0)
+})
+
+test('stored zoom serializes and restores the 110 percent preset', () => {
+  const level = percentToZoomLevel(110)
+  const stored = serializeZoomLevel(level)
+
+  assert.equal(zoomLevelToPercent(parseStoredZoomLevel(stored)), 110)
+})
+
+test('missing stored zoom leaves the app at the default 100 percent', () => {
+  assert.equal(parseStoredZoomLevel(null), null)
+  assert.equal(zoomLevelToPercent(0), 100)
+})
+
+test('cached user zoom wins across reload before stale storage can reset it', () => {
+  const win = {}
+  const cache = createZoomStateCache(new Map())
+  const zoom110 = percentToZoomLevel(110)
+
+  cache.set(win, zoom110)
+
+  assert.equal(zoomLevelToPercent(cache.resolve(win, serializeZoomLevel(0))), 110)
+})
+
+test('intentional reset from 110 back to 100 updates the cached source of truth', () => {
+  const win = {}
+  const cache = createZoomStateCache(new Map())
+
+  cache.set(win, percentToZoomLevel(110))
+  cache.set(win, percentToZoomLevel(100))
+
+  assert.equal(zoomLevelToPercent(cache.resolve(win, serializeZoomLevel(percentToZoomLevel(110)))), 100)
 })
 
 test('preset percentages roundtrip within rounding', () => {


### PR DESCRIPTION
## Summary
- keep desktop interface zoom in a main-process per-window cache once the user changes or restores it
- reapply cached/persisted zoom on every renderer load instead of only the first load
- make zoom.get resolve the cached/persisted value so renderer initialization cannot sample a reset 100% webContents value
- add regression coverage for 110% persistence, missing-value default 100%, stale reload storage, and intentional reset back to 100%

Fixes #60693.

## Root cause
Desktop zoom was restored from renderer localStorage only once, on the primary window's first did-finish-load. Later renderer reloads/navigation could leave Electron's page zoom back at level 0 (100%), and renderer settings initialization could read that transient default via zoom.get. User-selected 110% therefore had a path to be visually/statefully replaced by 100% during reload-like events.

## Verification
- node --test apps/desktop/electron/zoom.test.cjs
- node --check apps/desktop/electron/main.cjs
- npm --prefix apps/desktop run test:desktop:platforms (fails in pre-existing/unrelated git-worktree-ops.test.cjs and update-relaunch.test.cjs; both also fail when rerun individually, while electron/zoom.test.cjs passes)

Manual GUI verification was not run in this headless workspace.