### PR TITLE
fix(gateway): resolve CVE-2026-11461 by scoping session-by-title resolution to source and user_id

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12683,7 +12683,11 @@ class GatewayRunner:
                 return t("gateway.resume.list_failed", error=e)
 
         # Resolve the name to a session ID.
-        target_id = self._session_db.resolve_session_by_title(name)
+        user_source = source.platform.value if source.platform else None
+        user_id = str(source.user_id) if getattr(source, "user_id", None) else None
+        target_id = self._session_db.resolve_session_by_title(
+            name, source=user_source, user_id=user_id
+        )
         if not target_id:
             return t("gateway.resume.not_found", name=name)
         # Compression creates child continuations that hold the live transcript.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1065,35 +1065,59 @@ class SessionDB:
             row = cursor.fetchone()
         return row["title"] if row else None
 
-    def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
-        """Look up a session by exact title. Returns session dict or None."""
+    def get_session_by_title(
+        self, title: str, *, source: Optional[str] = None, user_id: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Look up a session by exact title, scoped optionally by source and user_id.
+
+        Returns session dict or None.
+        """
+        query = "SELECT * FROM sessions WHERE title = ?"
+        params = [title]
+        if source is not None:
+            query += " AND source = ?"
+            params.append(source)
+        if user_id is not None:
+            query += " AND user_id = ?"
+            params.append(user_id)
+
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT * FROM sessions WHERE title = ?", (title,)
-            )
+            cursor = self._conn.execute(query, tuple(params))
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def resolve_session_by_title(self, title: str) -> Optional[str]:
+    def resolve_session_by_title(
+        self, title: str, *, source: Optional[str] = None, user_id: Optional[str] = None
+    ) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
         If the exact title exists, returns that session's ID.
         If not, searches for "title #N" variants and returns the latest one.
         If the exact title exists AND numbered variants exist, returns the
         latest numbered variant (the most recent continuation).
+
+        This query is scoped optionally by source and user_id to prevent
+        unauthorized cross-context session access.
         """
         # First try exact match
-        exact = self.get_session_by_title(title)
+        exact = self.get_session_by_title(title, source=source, user_id=user_id)
 
         # Also search for numbered variants: "title #2", "title #3", etc.
         # Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+        query = "SELECT id, title, started_at FROM sessions WHERE title LIKE ? ESCAPE '\\'"
+        params = [f"{escaped} #%"]
+        if source is not None:
+            query += " AND source = ?"
+            params.append(source)
+        if user_id is not None:
+            query += " AND user_id = ?"
+            params.append(user_id)
+        query += " ORDER BY started_at DESC"
+
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT id, title, started_at FROM sessions "
-                "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
-                (f"{escaped} #%",),
-            )
+            cursor = self._conn.execute(query, tuple(params))
             numbered = cursor.fetchall()
 
         if numbered:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2060,6 +2060,25 @@ class TestTitleLineage:
     def test_resolve_nonexistent_title(self, db):
         assert db.resolve_session_by_title("nonexistent") is None
 
+    def test_resolve_scoped_by_source_and_user_id(self, db):
+        """Testing resolve_session_by_title limits search to matching source/user_id."""
+        db.create_session("s1", "cli", user_id="userA")
+        db.set_session_title("s1", "private project")
+
+        db.create_session("s2", "telegram", user_id="userB")
+        db.set_session_title("s2", "private project #2")
+
+        # Resolving without constraint returns latest matching (s2)
+        assert db.resolve_session_by_title("private project") == "s2"
+
+        # Resolving with match
+        assert db.resolve_session_by_title("private project", source="cli", user_id="userA") == "s1"
+        assert db.resolve_session_by_title("private project", source="telegram", user_id="userB") == "s2"
+
+        # Resolving with mismatch returns None
+        assert db.resolve_session_by_title("private project", source="telegram", user_id="userA") is None
+        assert db.resolve_session_by_title("private project", source="cli", user_id="userB") is None
+
     def test_next_title_no_existing(self, db):
         """With no existing sessions, base title is returned as-is."""
         assert db.get_next_title_in_lineage("my project") == "my project"


### PR DESCRIPTION
Fixes #CVE-2026-11461

## What changed and why

In multi-user gateway contexts (such as Telegram, Discord, and Slack), users could resume other users' active sessions and access their conversation history using the `/resume <title>` command. This allowed unauthorized cross-context session access simply by guessing or knowing the session title.

This issue stems from a two-stage root cause:
- Stage 1 (Surface Symptom): The `/resume` command handler resolved session targets purely by their title string via `resolve_session_by_title()`.
- Stage 2 (Deeper Mechanism): The underlying `resolve_session_by_title` and `get_session_by_title` functions in `SessionDB` queried the SQLite database globally without checking `source` (platform) or `user_id` boundaries. While single-user CLI executions do not require strict isolation, a shared gateway instance must restrict queries to the caller's specific source and user ID to maintain security boundaries.

## Fix

- **hermes_state.py**: Updated `get_session_by_title()` and `resolve_session_by_title()` to accept optional keyword-only `source` and `user_id` parameters and filter database lookups accordingly.
- **gateway/run.py**: Modified the `/resume` command handler to resolve titles using the sender's `user_source` and `user_id` context.
- **tests/test_hermes_state.py**: Added `test_resolve_scoped_by_source_and_user_id` regression test verifying that mismatching contexts yield `None` while matching contexts resolve correctly.

## What this does NOT change

- Local CLI session resumes: Resolving sessions via `hermes_cli/main.py` is unaffected as it does not pass scoped parameters, ensuring backward compatibility.
- DB schema structure, message storage format, or event handlers.

## How to test

Run the newly added regression test:
```bash
PYTHONPATH=. .venv/bin/pytest tests/test_hermes_state.py -k "test_resolve_scoped_by_source_and_user_id" -o addopts=""
```

And verify existing gateway session boundary test suite still passes:
```bash
PYTHONPATH=. .venv/bin/pytest tests/gateway/test_session_boundary_security_state.py -o addopts=""
```

## Platforms tested

Linux. Pure Python logic.