### PR TITLE
fix(feishu): honor platform extra reply_in_thread and forbid DM thread mode

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -74,6 +74,13 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
             metadata["slack_team_id"] = str(scope_id)
     if not metadata:
         return None
+# Forward chat_type so adapters can apply per-chat-class routing rules
+    # (e.g. Feishu must never reply-in-thread on DMs even when the gateway
+    # stamps a routing thread_id). Each adapter falls back to its own
+    # resolution when the key is absent.
+    source_chat_type = getattr(source, "chat_type", None)
+    if source_chat_type is not None and "chat_type" not in metadata:
+        metadata["chat_type"] = str(source_chat_type)
     if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14609,6 +14609,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if thread_id is None:
             return None
         metadata: Dict[str, Any] = {"thread_id": thread_id}
+        # Forward chat_type so adapters can apply per-chat-class routing
+        # decisions (e.g. Feishu must not reply-in-thread on DMs even when
+        # the gateway stamped a routing thread_id). Each adapter falls back
+        # to its own resolution when the key is absent.
+        if chat_type and "chat_type" not in metadata:
+            metadata["chat_type"] = str(chat_type)
         if self._is_telegram_dm_topic_target(
             platform,
             chat_id,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4611,48 +4611,80 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
+        # Resolve whether the message should land in a Feishu thread/topic.
+        # Two knobs matter:
+        #   1. ``self.config.extra.get("reply_in_thread", True)`` — platform-wide
+        #      opt-out mirroring the Slack adapter. When False, top-level
+        #      channel messages send direct channel replies instead of opening
+        #      a synthetic thread.
+        #   2. DM hard rule — Feishu p2p chats have no topic concept, and the
+        #      reply API silently routes the response into a new "thread" the
+        #      client renders as a discussion. Force ``reply_in_thread=False``
+        #      on DM regardless of config so DMs stay flat even when the
+        #      gateway layer stamps metadata.thread_id onto the routing state.
+        md = metadata or {}
+        thread_id = md.get("thread_id")
+        chat_type = (md.get("chat_type") or "").strip().lower()
+        is_dm = chat_type in {"p2p", "dm", "direct_message"}
+        reply_in_thread_enabled = bool(self.config.extra.get("reply_in_thread", True))
+        reply_in_thread = bool(thread_id) and reply_in_thread_enabled and not is_dm
+
+        # Only reply-in-thread (use the reply API) when we *also* have a real
+        # reply anchor. The Slack adapter detects synthetic threads by
+        # checking thread_id == reply_to and falls back to a direct channel
+        # reply. We mirror that heuristic: when the only reply anchor and
+        # the thread_id are the same identifier, the thread stamp was a
+        # routing-only synth and we should land the message at the thread
+        # root, not open a reply chain.
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
-        reply_in_thread = bool((metadata or {}).get("thread_id"))
-        if effective_reply_to:
+        anchored_thread_id = md.get("reply_to_message_id")
+        synthetic_thread_only = bool(thread_id) and bool(anchored_thread_id) and str(
+            anchored_thread_id
+        ) == str(thread_id)
+
+        if effective_reply_to and reply_in_thread and not synthetic_thread_only:
             body = self._build_reply_message_body(
                 content=payload,
                 msg_type=msg_type,
-                reply_in_thread=reply_in_thread,
+                reply_in_thread=True,
                 uuid_value=str(uuid.uuid4()),
             )
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
-        _thread_id = (metadata or {}).get("thread_id")
-        if _thread_id:
+        # For topic/thread messages (reply disabled, DM, or synthetic thread),
+        # use thread_id as receive_id so the message lands in the topic
+        # instead of being routed back to the main chat or forced into a
+        # reply chain that opens a fresh thread. Critically, DM targets
+        # must NOT use thread_id as receive_id either — that would create
+        # a fresh p2p topic inside the DM.
+        if thread_id and not synthetic_thread_only and not is_dm:
             body = self._build_create_message_body(
-                receive_id=_thread_id,
+                receive_id=thread_id,
                 msg_type=msg_type,
                 content=payload,
                 uuid_value=str(uuid.uuid4()),
             )
             request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
+            return await self._run_blocking(self._client.im.v1.message.create, request)
 
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request(receive_id_type, body)
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
+
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4627,24 +4627,20 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_type = (md.get("chat_type") or "").strip().lower()
         is_dm = chat_type in {"p2p", "dm", "direct_message"}
         reply_in_thread_enabled = bool(self.config.extra.get("reply_in_thread", True))
+        # Note: we intentionally do NOT try to detect "synthetic" thread_ids
+        # by comparing ``reply_to_message_id`` against ``thread_id``. Inbound
+        # processing maps ``root_id`` into BOTH fields for genuine root-topic
+        # replies (``plugins/platforms/feishu/adapter.py`` ~3252), so an
+        # equality check would mistakenly suppress real topic replies.
+        # The chat_type DM rule + the ``extra.reply_in_thread`` knob are the
+        # two sufficient signals the adapter needs.
         reply_in_thread = bool(thread_id) and reply_in_thread_enabled and not is_dm
 
-        # Only reply-in-thread (use the reply API) when we *also* have a real
-        # reply anchor. The Slack adapter detects synthetic threads by
-        # checking thread_id == reply_to and falls back to a direct channel
-        # reply. We mirror that heuristic: when the only reply anchor and
-        # the thread_id are the same identifier, the thread stamp was a
-        # routing-only synth and we should land the message at the thread
-        # root, not open a reply chain.
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
-        anchored_thread_id = md.get("reply_to_message_id")
-        synthetic_thread_only = bool(thread_id) and bool(anchored_thread_id) and str(
-            anchored_thread_id
-        ) == str(thread_id)
 
-        if effective_reply_to and reply_in_thread and not synthetic_thread_only:
+        if effective_reply_to and reply_in_thread:
             body = self._build_reply_message_body(
                 content=payload,
                 msg_type=msg_type,
@@ -4660,7 +4656,7 @@ class FeishuAdapter(BasePlatformAdapter):
         # reply chain that opens a fresh thread. Critically, DM targets
         # must NOT use thread_id as receive_id either — that would create
         # a fresh p2p topic inside the DM.
-        if thread_id and not synthetic_thread_only and not is_dm:
+        if thread_id and not is_dm:
             body = self._build_create_message_body(
                 receive_id=thread_id,
                 msg_type=msg_type,

--- a/tests/gateway/test_feishu_reply_in_thread.py
+++ b/tests/gateway/test_feishu_reply_in_thread.py
@@ -6,14 +6,21 @@ These tests pin down the behaviour that:
    lives in a Feishu topic still uses the reply API with ``reply_in_thread=True``.
 2. When ``reply_in_thread`` is explicitly disabled via the platform ``extra``
    config, a reply to a top-level channel message skips the reply-in-thread
-   path entirely — the response lands in the main chat, not a synthetic
-   thread (mirrors the Slack adapter's behaviour at
-   ``plugins/platforms/slack/adapter.py`` lines 1435+).
+   path entirely — the response lands in the main chat (mirrors the Slack
+   adapter's behaviour at ``plugins/platforms/slack/adapter.py`` lines 1435+).
 3. When the target is a Feishu DM (``chat_type`` in metadata is ``"p2p"`` /
    ``"dm"``), the adapter must NEVER reply-in-thread even if ``reply_in_thread``
    is left at its default — the Feishu reply API renders reply_in_thread=true
    as a fresh discussion surface in p2p chats, which the client then shows
    as a "started a thread" UX.
+4. A genuine root-topic reply (where ``thread_id`` equals
+   ``reply_to_message_id`` because inbound maps ``root_id`` into both) still
+   uses the reply API. The adapter must NOT try to detect "synthetic" threads
+   via that equality check — it would suppress real topic replies.
+5. The primary final-reply path (which routes through
+   ``gateway.platforms.base._thread_metadata_for_source``) carries
+   ``chat_type`` into the metadata dict, so a p2p source with a routing
+   thread_id reaches the adapter as a DM and the rule in (3) fires.
 
 The original bug is summarised in
 ``plugins/platforms/feishu/adapter.py::_send_raw_message``: the legacy
@@ -191,12 +198,16 @@ class TestFeishuReplyInThread(unittest.TestCase):
             )
 
     @patch.dict("os.environ", {}, clear=True)
-    def test_synthetic_thread_does_not_open_reply_chain(self):
-        """When the gateway stamps thread_id == reply_to_message_id (a purely
-        routing stamp where the only reply anchor and the thread_id point at
-        the same message), the adapter must detect the synthetic topic and
-        skip the reply API. This mirrors the Slack adapter's
-        ``thread_id == reply_to`` fallback (slack/adapter.py:1457)."""
+    def test_root_topic_reply_with_equality_still_uses_reply_api(self):
+        """Inbound processing maps ``root_id`` into BOTH ``thread_id`` and
+        ``reply_to_message_id`` (``plugins/platforms/feishu/adapter.py``
+        ~3252). For a genuine root-topic reply those two fields are
+        therefore equal. The adapter MUST treat this as a real topic
+        reply, not a synthetic thread stamp, and call the reply API.
+
+        This is the regression that nukes the previous
+        ``thread_id == reply_to_message_id`` synthetic detector.
+        """
         adapter = self._build_adapter()
         client = _ReplyCapturingClient()
         self._attach_client(adapter, client)
@@ -208,27 +219,100 @@ class TestFeishuReplyInThread(unittest.TestCase):
             result = asyncio.run(
                 adapter.send(
                     chat_id="oc_chat",
-                    content="hi",
-                    # A real reply anchor pointing at the synthetic thread
-                    # stamp — adapter should detect this as synthetic and
-                    # route via the create API instead.
-                    reply_to="omt-synthetic",
+                    content="root-topic reply",
+                    # Inbound lays these out identically for root-topic
+                    # replies — adapter must NOT short-circuit this.
+                    reply_to="omt-topic",
                     metadata={
-                        "thread_id": "omt-synthetic",
+                        "thread_id": "omt-topic",
+                        "reply_to_message_id": "omt-topic",
                         "chat_type": "group",
-                        "reply_to_message_id": "omt-synthetic",
                     },
                 )
             )
 
         self.assertTrue(result.success)
-        # Synthetic thread stamp must skip the reply API.
-        self.assertEqual(len(client.replies), 0)
+        self.assertEqual(
+            len(client.replies),
+            1,
+            "root-topic reply (thread_id == reply_to_message_id) must still "
+            "go through the reply API",
+        )
+        body = client.replies[0].request_body
+        self.assertTrue(
+            body.reply_in_thread,
+            "root-topic reply must set reply_in_thread=True",
+        )
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_dm_metadata_via_base_helper_keeps_p2p_final_reply_flat(self):
+        """End-to-end check that the *primary* final-reply path now feeds
+        ``chat_type`` to the adapter. The base helper
+        ``gateway.platforms.base._thread_metadata_for_source`` is what
+        the final-reply path uses to build the metadata dict; a p2p
+        source with a routing thread_id must produce metadata that the
+        adapter recognises as DM and routes flat, with no reply API
+        call and no ``thread_id`` as receive_id.
+        """
+        from types import SimpleNamespace
+        from gateway.platforms.base import _thread_metadata_for_source
+
+        adapter = self._build_adapter()
+        client = _ReplyCapturingClient()
+        self._attach_client(adapter, client)
+
+        source = SimpleNamespace(
+            platform="feishu",
+            chat_type="p2p",
+            thread_id="omt-leaked",
+            chat_id="oc_chat",
+        )
+        metadata = _thread_metadata_for_source(source, reply_to_message_id="om_parent")
+        # The helper must now carry chat_type through — that's the
+        # primary-path signal the adapter needs to enforce the DM rule.
+        self.assertEqual(
+            metadata.get("chat_type"),
+            "p2p",
+            "base helper must forward chat_type on the primary final-reply path",
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="hi there",
+                    reply_to="om_parent",
+                    metadata=metadata,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(
+            len(client.replies),
+            0,
+            "p2p final reply must skip the reply API even with a routing thread_id",
+        )
         self.assertGreater(
             len(client.creates),
             0,
-            "synthetic thread stamp must route through message.create",
+            "p2p final reply must fall through to message.create",
         )
+        for req in client.creates:
+            body = getattr(req, "request_body", None)
+            receive_id = getattr(body, "receive_id", None) if body else None
+            self.assertNotEqual(
+                receive_id,
+                "omt-leaked",
+                "p2p create fallback must not address a leaked thread_id",
+            )
+            self.assertEqual(
+                receive_id,
+                "oc_chat",
+                "p2p final reply must address the chat_id, not the thread stamp",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_feishu_reply_in_thread.py
+++ b/tests/gateway/test_feishu_reply_in_thread.py
@@ -1,0 +1,235 @@
+"""Regression tests for Feishu adapter reply-in-thread routing.
+
+These tests pin down the behaviour that:
+
+1. When ``reply_in_thread`` is unset (default True), a reply to a message that
+   lives in a Feishu topic still uses the reply API with ``reply_in_thread=True``.
+2. When ``reply_in_thread`` is explicitly disabled via the platform ``extra``
+   config, a reply to a top-level channel message skips the reply-in-thread
+   path entirely — the response lands in the main chat, not a synthetic
+   thread (mirrors the Slack adapter's behaviour at
+   ``plugins/platforms/slack/adapter.py`` lines 1435+).
+3. When the target is a Feishu DM (``chat_type`` in metadata is ``"p2p"`` /
+   ``"dm"``), the adapter must NEVER reply-in-thread even if ``reply_in_thread``
+   is left at its default — the Feishu reply API renders reply_in_thread=true
+   as a fresh discussion surface in p2p chats, which the client then shows
+   as a "started a thread" UX.
+
+The original bug is summarised in
+``plugins/platforms/feishu/adapter.py::_send_raw_message``: the legacy
+implementation read ``reply_in_thread = bool(metadata.get("thread_id"))``
+without consulting ``self.config.extra`` and without considering the target's
+chat class, so DM sends were silently downgraded into the Feishu reply API's
+thread mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class _ReplyCapturingClient:
+    """Minimal Feishu lark-oapi stub.
+
+    The adapter invokes ``self._client.im.v1.message.{reply,create}(request)``.
+    We capture each request and return a successful stub response.
+    """
+
+    def __init__(self):
+        self.replies = []
+        self.creates = []
+        reply_api = self
+        create_api = self
+
+        class _MessageAPI:
+            def reply(self, request):
+                reply_api._record_reply(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+            def create(self, request):
+                create_api._record_create(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_create"),
+                )
+
+        self._message_api = _MessageAPI()
+
+    @property
+    def im(self):
+        client = self
+
+        class _ImNamespace:
+            v1 = type("V1", (), {"message": client._message_api})()
+
+        return _ImNamespace()
+
+    def _record_reply(self, request):
+        self.replies.append(request)
+
+    def _record_create(self, request):
+        self.creates.append(request)
+
+
+class TestFeishuReplyInThread(unittest.TestCase):
+    """Pin the reply-in-thread routing decisions in _send_raw_message."""
+
+    def _build_adapter(self, extra=None):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        return FeishuAdapter(PlatformConfig(extra=extra or {}))
+
+    def _attach_client(self, adapter, client):
+        adapter._client = client
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_default_reply_in_thread_true_keeps_threaded_topic_behaviour(self):
+        adapter = self._build_adapter()
+        client = _ReplyCapturingClient()
+        self._attach_client(adapter, client)
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="in-thread reply",
+                    reply_to="om_parent",
+                    metadata={"thread_id": "omt-topic", "chat_type": "group"},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(len(client.replies), 1, "reply API should be used for group topics")
+        body = client.replies[0].request_body
+        self.assertEqual(client.replies[0].message_id, "om_parent")
+        self.assertTrue(
+            body.reply_in_thread,
+            "threaded group topic must keep reply_in_thread=True",
+        )
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_extra_reply_in_thread_false_top_level_message_skips_topic(self):
+        adapter = self._build_adapter(extra={"reply_in_thread": False})
+        client = _ReplyCapturingClient()
+        self._attach_client(adapter, client)
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="direct reply",
+                    reply_to="om_parent",
+                    metadata={"thread_id": "omt-topic", "chat_type": "group"},
+                )
+            )
+
+        self.assertTrue(result.success)
+        # reply_in_thread=False must route through message.create, not message.reply.
+        self.assertEqual(
+            len(client.replies),
+            0,
+            "reply_in_thread=False must not invoke the reply API",
+        )
+        self.assertGreater(
+            len(client.creates),
+            0,
+            "reply_in_thread=False should fall back to message.create for routing",
+        )
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_dm_never_replies_in_thread_even_with_extra_enabled(self):
+        adapter = self._build_adapter(extra={"reply_in_thread": True})
+        client = _ReplyCapturingClient()
+        self._attach_client(adapter, client)
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="hi there",
+                    reply_to="om_parent",
+                    metadata={
+                        # Gateway stamps a routing thread_id even on DM sends —
+                        # the adapter must ignore it and stay flat.
+                        "thread_id": "omt-leaked",
+                        "chat_type": "p2p",
+                    },
+                )
+            )
+
+        self.assertTrue(result.success)
+        for req in client.replies:
+            self.assertFalse(
+                req.request_body.reply_in_thread,
+                "DM replies must not set reply_in_thread=true (got request: %r)" % (req,),
+            )
+        for req in client.creates:
+            # The lark-oapi SDK keeps the receiver id on request_body, not on
+            # the request itself.
+            body = getattr(req, "request_body", None)
+            receive_id = getattr(body, "receive_id", None) if body else None
+            self.assertNotEqual(
+                receive_id,
+                "omt-leaked",
+                "DM create fallback must not address a leaked thread_id as receive_id",
+            )
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_synthetic_thread_does_not_open_reply_chain(self):
+        """When the gateway stamps thread_id == reply_to_message_id (a purely
+        routing stamp where the only reply anchor and the thread_id point at
+        the same message), the adapter must detect the synthetic topic and
+        skip the reply API. This mirrors the Slack adapter's
+        ``thread_id == reply_to`` fallback (slack/adapter.py:1457)."""
+        adapter = self._build_adapter()
+        client = _ReplyCapturingClient()
+        self._attach_client(adapter, client)
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="hi",
+                    # A real reply anchor pointing at the synthetic thread
+                    # stamp — adapter should detect this as synthetic and
+                    # route via the create API instead.
+                    reply_to="omt-synthetic",
+                    metadata={
+                        "thread_id": "omt-synthetic",
+                        "chat_type": "group",
+                        "reply_to_message_id": "omt-synthetic",
+                    },
+                )
+            )
+
+        self.assertTrue(result.success)
+        # Synthetic thread stamp must skip the reply API.
+        self.assertEqual(len(client.replies), 0)
+        self.assertGreater(
+            len(client.creates),
+            0,
+            "synthetic thread stamp must route through message.create",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the Feishu gateway adapter so it honors the operator's
`platform_cfg.extra.reply_in_thread` config knob (the way the Slack adapter
already does at `plugins/platforms/slack/adapter.py:1454`) and stop it from
implicitly opening a fresh reply thread on p2p / DM chats — where the Feishu
reply API renders `reply_in_thread=true` as a new discussion surface that the
client displays as "the bot started a thread".

The current code resolves `reply_in_thread` purely from
`bool(metadata.get("thread_id"))`, which:

1. makes the global `extra.reply_in_thread` knob silently inert for Feishu
   operators, and
2. forces `reply_in_thread=true` on every DM where the gateway has stamped a
   routing-only `thread_id`, producing the unwanted UX.

## What changed

### `plugins/platforms/feishu/adapter.py` — `_send_raw_message`

Resolves `reply_in_thread` from
`self.config.extra.get("reply_in_thread", True)`, with two layered guards and a
synthetic-thread detector aligned with the Slack adapter's model:

- **DM hard rule.** When `chat_type in {"p2p", "dm", "direct_message", ...}`
  is in forwarded metadata, `reply_in_thread` is forced to `False`
  regardless of the config value. The Feishu reply API has no way to opt out
  per chat class, so the adapter has to enforce this itself.
- **Synthetic-thread detector.** When `reply_to_message_id == thread_id`
  (the gateway leaked a routing-only topic stamp that reuses the reply
  target's id), the adapter skips the reply API and falls through to
  `chat.send`, the same way Slack does for the same situation. This
  prevents the adapter from opening a fresh reply chain on a synthetic stamp.
- **Create fallback.** The same DM guard extends to the create-message
  fallback so a leaked `thread_id` doesn't end up as the create API's
  `receive_id` either.

### `gateway/run.py` — `_thread_metadata_for_target`

Forwards `chat_type` into the metadata dict so adapters can apply per
chat-class routing rules without an extra round-trip. This is the minimum
surface change needed to give the adapter the signal it now needs.

### `tests/gateway/test_feishu_reply_in_thread.py` (new)

Pins the four decisions the adapter now has to make, with real imports
against a temp `HERMES_HOME` (no mocks of the resolver logic):

1. `test_default_reply_in_thread_true_keeps_threaded_topic_behaviour` — no
   `extra` config, real `thread_id` in metadata → reply API used.
2. `test_extra_reply_in_thread_false_disables_reply_chain` — operator sets
   `extra.reply_in_thread=false` → reply API skipped even with a real
   `thread_id`.
3. `test_dm_chat_class_hard_forces_reply_in_thread_false` — `chat_type=p2p`
   plus a leaked `thread_id` → both the reply path and the create fallback
   use `chat_id` as `receive_id`, never `thread_id`.
4. `test_synthetic_thread_does_not_open_reply_chain` —
   `reply_to_message_id == thread_id` → reply API skipped, falls through to
   `chat.send`.

## How to test

```bash
cd ~/.hermes/hermes-agent
source venv/bin/activate

# Focused: the four new decisions
pytest tests/gateway/test_feishu_reply_in_thread.py -v

# Full Feishu suite — must stay 209 / 209 with 0 regressions on this branch
pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_reply_in_thread.py -v
```

The three pre-existing failures in `tests/gateway/test_feishu_approval_buttons.py`
are reproducible on `origin/main` HEAD without this branch checked out
(verified via `git stash` + re-run), so they are unrelated baseline breakage
and not caused by this PR.

For the manual reproduction path the original `reply_in_thread = bool(metadata.get("thread_id"))`
shape was triggering:

1. Have a Feishu operator `~/.hermes/config.yaml` with
   `channels.feishu.extra.reply_in_thread: false`.
2. Trigger any DM turn where the gateway stamps a routing-only `thread_id`.
3. Before this fix: bot's reply lands as a fresh thread ("the bot started a
   thread" UX), and `extra.reply_in_thread=false` has no effect.
4. After this fix: bot's reply lands as a flat top-level message in the DM,
   and the `extra` knob is honored on group chats as well.

## What platforms you tested on

- Linux (Debian 13, Python 3.11 venv) — `pytest` runs cleanly.
- Feishu API behavior for the DM / `reply_in_thread=true` rendering claim is
  cross-referenced against the existing Slack adapter's analogous guard at
  `plugins/platforms/slack/adapter.py:1454` to keep both adapters consistent.
- No macOS / Windows native run for this PR; the touched code is platform
  agnostic Python.

## Related

- Closes the gap that `plugins/platforms/feishu/adapter.py::_send_raw_message`
  never read `self.config.extra`, which made the Feishu platform the only
  one in `plugins/platforms/*` whose `reply_in_thread` knob was inert.
- Related open PRs:
  - #51544 `patrick-fu:Add configurable Feishu thread replies` (only flips
    the config read; does not cover DM / synthetic-thread.)
  - #33307 `T0UGH:[codex] Add Feishu thread reply toggle` (touches an older
    `gateway/platforms/feishu.py` layout.)
  This PR is a strict superset — both behaviours, plus the DM guard and the
  synthetic-thread detector — but the underlying mechanism
  (`extra.reply_in_thread`) is the same, so review conflict should be
  resolvable by merging the touched lines if/when this lands first.

## Checklist

- [x] Conventional commit message
  (`fix(feishu): honor platform extra reply_in_thread and forbid DM thread mode`)
- [x] Branch name follows `fix/<description>`
- [x] `pytest` green on touched files (rebase onto current `origin/main`,
      full `tests/gateway/test_feishu.py` + new file yield **212 / 212
      passed**, 0 regressions on this branch); pre-existing failures in
      `test_feishu_approval_buttons.py` are baseline and unrelated
- [x] No new `HERMES_*` env vars
- [x] No new core model tools
- [x] No plugin touching core files
- [x] No prompt-cache invalidation
