### PR TITLE
fix(gateway): offload blocking SQLite calls in channel directory build

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -121,7 +121,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     for platform, adapter in adapters.items():
         try:
             if platform == Platform.DISCORD:
-                platforms["discord"] = _build_discord(adapter)
+                platforms["discord"] = await asyncio.to_thread(_build_discord, adapter)
             elif platform == Platform.SLACK:
                 platforms["slack"] = await _build_slack(adapter)
         except Exception as e:
@@ -142,7 +142,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
             or plat_name not in adapter_platform_names
         ):
             continue
-        platforms[plat_name] = _build_from_sessions(plat_name)
+        platforms[plat_name] = await asyncio.to_thread(_build_from_sessions, plat_name)
 
     # Include plugin-registered platforms (dynamic enum members aren't in
     # Platform.__members__, so the loop above misses them). Same
@@ -156,7 +156,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
                 and entry.name not in platforms
                 and entry.name in adapter_platform_names
             ):
-                platforms[entry.name] = _build_from_sessions(entry.name)
+                platforms[entry.name] = await asyncio.to_thread(_build_from_sessions, entry.name)
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary

`build_channel_directory()` is `async def` but called synchronous `_build_discord()` and `_build_from_sessions()` directly on the event loop. On large `state.db` files, these blocking SQLite calls (10-40s) starve Discord heartbeat tasks, producing `heartbeat blocked for more than 10 seconds` warnings and gateway disconnect/reconnect cycles.

## Fix

Wrap the three sync call sites in `asyncio.to_thread()` so blocking DB work is offloaded from the event loop. The `AsyncSessionDB` offload facade already exists for this purpose but was bypassed by the channel directory builder.

## Changes

- `gateway/channel_directory.py`: 3 `_build_discord`/`_build_from_sessions` calls → `await asyncio.to_thread(...)`

Fixes: #60794