### PR TITLE
fix: accept qqbot reconnect keyword

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,13 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        QQBot does not currently vary its bootstrap flow between cold start and
+        reconnect, so ``is_reconnect`` is accepted for gateway compatibility but
+        intentionally unused here.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -180,6 +180,8 @@ class TestVoiceAttachmentSSRFProtection:
         client = mock.AsyncMock()
         with mock.patch("gateway.platforms.qqbot.adapter.httpx.AsyncClient", return_value=client) as async_client_cls:
             adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+            adapter._acquire_platform_lock = mock.Mock(return_value=True)
+            adapter._release_platform_lock = mock.Mock()
             adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop after client creation"))
 
             connected = asyncio.run(adapter.connect())
@@ -189,6 +191,18 @@ class TestVoiceAttachmentSSRFProtection:
         kwargs = async_client_cls.call_args.kwargs
         assert kwargs.get("follow_redirects") is True
         assert kwargs.get("event_hooks", {}).get("response") == [_ssrf_redirect_guard]
+
+    def test_connect_accepts_is_reconnect_kwarg(self):
+        from gateway.platforms.qqbot import QQAdapter
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        adapter._acquire_platform_lock = mock.Mock(return_value=True)
+        adapter._release_platform_lock = mock.Mock()
+        adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop after kwarg acceptance"))
+
+        connected = asyncio.run(adapter.connect(is_reconnect=True))
+
+        assert connected is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- accept the gateway reconnect keyword in `QQAdapter.connect`
- document that QQBot currently uses the same bootstrap path for initial connects and reconnects
- add a regression test covering `connect(is_reconnect=True)` so runner-driven reconnects no longer crash on signature mismatch

## Testing
- `/mydata/hermes/hermes-agent/venv/bin/python -m py_compile gateway/platforms/qqbot/adapter.py tests/gateway/test_qqbot.py`
- `/mydata/hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_qqbot.py -q -o addopts=''`
