### PR TITLE
fix(cron): deliver WebUI targets via session store

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -725,6 +725,13 @@ def _deliver_to_webui_session(job: dict, session_id: str, content: str) -> Optio
     safely on every provider instead of landing assistant→assistant). The
     browser picks it up on next reload/poll; no live-push in this phase.
 
+    A target may name a compression parent — the session that existed before
+    context compression forked a continuation child (see
+    ``resolve_resume_session_id``). The WebUI reads through that redirect, so
+    appending to the parent would land the cron message somewhere the active
+    conversation never looks. Resolve the live continuation tip before
+    appending, same as the WebUI/gateway resume path does.
+
     Returns ``None`` on success, or an error string on failure — never
     raises, matching the other delivery paths in ``_deliver_result``.
     """
@@ -738,6 +745,8 @@ def _deliver_to_webui_session(job: dict, session_id: str, content: str) -> Optio
         try:
             resolve = getattr(db, "resolve_session_id", None)
             sid = (resolve(session_id) if callable(resolve) else None) or session_id
+            resolve_resume = getattr(db, "resolve_resume_session_id", None)
+            sid = (resolve_resume(sid) if callable(resolve_resume) else None) or sid
             if not db.get_session(sid):
                 return f"webui session '{session_id}' not found"
             label = job.get("name") or job.get("id") or "cron"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -715,6 +715,48 @@ def _maybe_mirror_cron_delivery(
         )
 
 
+def _deliver_to_webui_session(job: dict, session_id: str, content: str) -> Optional[str]:
+    """Persist a cron delivery into a local WebUI/Hermes session.
+
+    WebUI has no gateway adapter to push through — the session's own
+    ``SessionDB`` row *is* the delivery surface. Appends a labelled USER-role
+    message (same alternation rationale as ``_maybe_mirror_cron_delivery``: a
+    cron delivery is not the agent speaking, and a user-role turn merges
+    safely on every provider instead of landing assistant→assistant). The
+    browser picks it up on next reload/poll; no live-push in this phase.
+
+    Returns ``None`` on success, or an error string on failure — never
+    raises, matching the other delivery paths in ``_deliver_result``.
+    """
+    text = (content or "").strip()
+    if not text:
+        return None
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            resolve = getattr(db, "resolve_session_id", None)
+            sid = (resolve(session_id) if callable(resolve) else None) or session_id
+            if not db.get_session(sid):
+                return f"webui session '{session_id}' not found"
+            label = job.get("name") or job.get("id") or "cron"
+            db.append_message(
+                sid,
+                "user",
+                f"[Cron delivery: {label}]\n{text}",
+                observed=True,
+            )
+            logger.info("Job '%s': delivered to webui session %s", job.get("id", "?"), sid)
+            return None
+        finally:
+            db.close()
+    except Exception as e:
+        msg = f"webui delivery to {session_id} failed: {e}"
+        logger.warning("Job '%s': %s", job.get("id", "?"), msg)
+        return msg
+
+
 def _open_continuable_cron_thread(
     job: dict,
     adapter,
@@ -1092,6 +1134,29 @@ def cron_delivery_targets() -> list[dict]:
     return targets
 
 
+# WebUI delivery is a local session-store surface, not a gateway platform
+# adapter — it must never reach `gateway.config.Platform(...)`. These targets
+# are tagged `kind=_WEBUI_TARGET_KIND` so `_deliver_result` can split them out
+# before the gateway delivery loop.
+_WEBUI_PLATFORM = "webui"
+_WEBUI_TARGET_KIND = "webui_session"
+
+
+def _is_webui_origin(origin: Optional[dict]) -> bool:
+    return bool(origin) and str(origin.get("platform", "")).lower() == _WEBUI_PLATFORM
+
+
+def _webui_delivery_target(session_id: str, thread_id: Optional[str] = None) -> dict:
+    sid = str(session_id)
+    return {
+        "kind": _WEBUI_TARGET_KIND,
+        "platform": _WEBUI_PLATFORM,
+        "chat_id": sid,
+        "session_id": sid,
+        "thread_id": thread_id,
+    }
+
+
 def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[dict]:
     """Resolve one concrete auto-delivery target for a cron job."""
 
@@ -1100,7 +1165,13 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
     if deliver_value == "local":
         return None
 
+    if deliver_value.lower().startswith(f"{_WEBUI_PLATFORM}:"):
+        session_id = deliver_value.split(":", 1)[1].strip()
+        return _webui_delivery_target(session_id) if session_id else None
+
     if deliver_value == "origin":
+        if origin and _is_webui_origin(origin):
+            return _webui_delivery_target(origin["chat_id"], origin.get("thread_id"))
         if origin:
             return {
                 "platform": origin["platform"],
@@ -1479,16 +1550,31 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         _, mirror_text = BasePlatformAdapter.extract_media(content)
         mirror_text = (mirror_text or "").strip()
 
+    # WebUI targets are a local session-store surface, not a gateway platform
+    # — split them out before touching gateway config at all, so a WebUI-only
+    # delivery never depends on (or fails because of) gateway setup.
+    webui_targets = [t for t in targets if t.get("kind") == _WEBUI_TARGET_KIND]
+    gateway_targets = [t for t in targets if t.get("kind") != _WEBUI_TARGET_KIND]
+
+    delivery_errors = []
+
+    for target in webui_targets:
+        err = _deliver_to_webui_session(job, target.get("session_id") or target["chat_id"], content)
+        if err:
+            delivery_errors.append(err)
+
+    if not gateway_targets:
+        return "; ".join(delivery_errors) if delivery_errors else None
+
     try:
         config = load_gateway_config()
     except Exception as e:
         msg = f"failed to load gateway config: {e}"
         logger.error("Job '%s': %s", job["id"], msg)
-        return msg
+        delivery_errors.append(msg)
+        return "; ".join(delivery_errors)
 
-    delivery_errors = []
-
-    for target in targets:
+    for target in gateway_targets:
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -4948,6 +4948,7 @@ class TestDeliverToWebuiSession:
 
         mock_db = MagicMock()
         mock_db.resolve_session_id.return_value = "sess-1"
+        mock_db.resolve_resume_session_id.return_value = "sess-1"
         mock_db.get_session.return_value = {"id": "sess-1"}
 
         with patch("hermes_state.SessionDB", return_value=mock_db):
@@ -4986,3 +4987,76 @@ class TestDeliverToWebuiSession:
 
         assert result is None
         mock_db_cls.assert_not_called()
+
+    def test_compression_parent_target_delivers_to_continuation_child(self, tmp_path):
+        """Regression: targeting a compression parent must land the cron
+        message on the live continuation child, not the frozen parent.
+
+        ``resolve_session_id()`` only resolves an exact/unique-prefix match —
+        it has no notion of compression continuations, so a target naming a
+        parent id resolves right back to that same parent. WebUI reads
+        instead advance through ``resolve_resume_session_id()``, which walks
+        the parent -> child chain forged by auto-compression. Without doing
+        the same redirect here, the delivery would sit on a session the
+        WebUI never re-reads (#60923 review).
+        """
+        import time
+
+        from hermes_state import SessionDB
+        from cron.scheduler import _deliver_to_webui_session
+
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path)
+        base = int(time.time()) - 10_000
+        try:
+            db.create_session("parent-session", source="webui")
+            db.append_message("parent-session", role="user", content="pre-compression turn")
+            db.end_session("parent-session", "compression")
+
+            db.create_session("child-session", source="webui", parent_session_id="parent-session")
+            db.append_message("child-session", role="assistant", content="post-compression reply")
+
+            conn = db._conn
+            conn.execute(
+                "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'parent-session'",
+                (base, base + 50),
+            )
+            conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = 'child-session'",
+                (base + 100,),
+            )
+            conn.commit()
+
+            # Confirm this is a genuine compression lineage per the same
+            # helpers the WebUI/gateway resume path relies on — not just an
+            # assumption this test bakes in.
+            assert db.get_compression_tip("parent-session") == "child-session"
+            assert db.resolve_resume_session_id("parent-session") == "child-session"
+
+            with patch("hermes_state.SessionDB", return_value=db):
+                job = {"id": "job-1", "name": "daily-report"}
+                result = _deliver_to_webui_session(
+                    job, "parent-session", "Here is the report."
+                )
+        finally:
+            # _deliver_to_webui_session already closed the connection via its
+            # own finally block; guard against double-close if it raised
+            # before reaching that point.
+            if db._conn is not None:
+                db.close()
+
+        assert result is None
+
+        verify_db = SessionDB(db_path)
+        try:
+            parent_messages = verify_db.get_messages("parent-session")
+            child_messages = verify_db.get_messages("child-session")
+        finally:
+            verify_db.close()
+
+        assert [m["content"] for m in parent_messages] == ["pre-compression turn"]
+        child_contents = [m["content"] for m in child_messages]
+        assert child_contents == [
+            "post-compression reply",
+            "[Cron delivery: daily-report]\nHere is the report.",
+        ]

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -4810,3 +4810,179 @@ class TestMultiTargetDeliveryContinuesOnFailure:
         assert "a@example.com" in result
         assert "b@example.com" in result
         assert mock_pool.submit.call_count == 2
+
+
+class TestWebuiDeliveryTargetResolution:
+    """WebUI delivery is a local session-store surface, not a gateway platform
+    adapter — it must resolve to a ``webui_session``-kind target and never
+    flow into ``gateway.config.Platform("webui")`` (which raised
+    ``unknown platform 'webui'``, #45360)."""
+
+    def test_webui_origin_resolves_to_webui_session_target(self):
+        from cron.scheduler import _resolve_delivery_targets
+
+        job = {
+            "id": "j",
+            "deliver": "origin",
+            "origin": {"platform": "webui", "chat_id": "abc123"},
+        }
+        assert _resolve_delivery_targets(job) == [
+            {
+                "kind": "webui_session",
+                "platform": "webui",
+                "chat_id": "abc123",
+                "session_id": "abc123",
+                "thread_id": None,
+            }
+        ]
+
+    def test_explicit_webui_target_resolves(self):
+        from cron.scheduler import _resolve_delivery_targets
+
+        job = {"id": "j", "deliver": "webui:sess-42"}
+        assert _resolve_delivery_targets(job) == [
+            {
+                "kind": "webui_session",
+                "platform": "webui",
+                "chat_id": "sess-42",
+                "session_id": "sess-42",
+                "thread_id": None,
+            }
+        ]
+
+    def test_explicit_webui_target_with_empty_session_id_resolves_to_none(self):
+        from cron.scheduler import _resolve_delivery_targets
+
+        job = {"id": "j", "deliver": "webui:"}
+        assert _resolve_delivery_targets(job) == []
+
+    def test_webui_origin_thread_id_preserved(self):
+        from cron.scheduler import _resolve_delivery_targets
+
+        job = {
+            "id": "j",
+            "deliver": "origin",
+            "origin": {"platform": "webui", "chat_id": "abc123", "thread_id": "t1"},
+        }
+        assert _resolve_delivery_targets(job) == [
+            {
+                "kind": "webui_session",
+                "platform": "webui",
+                "chat_id": "abc123",
+                "session_id": "abc123",
+                "thread_id": "t1",
+            }
+        ]
+
+
+class TestWebuiDeliveryDispatch:
+    """``_deliver_result`` must route ``webui_session`` targets through the
+    local SessionDB append helper, never through the gateway adapter/Platform
+    path, and must not load gateway config when every target is WebUI."""
+
+    def test_webui_only_delivery_does_not_load_gateway_config(self):
+        job = {"id": "j", "deliver": "webui:sess-1"}
+        with patch("cron.scheduler._deliver_to_webui_session", return_value=None) as m_deliver, \
+             patch("gateway.config.load_gateway_config") as m_gw_cfg:
+            result = _deliver_result(job, "hello")
+
+        assert result is None
+        m_deliver.assert_called_once_with(job, "sess-1", "hello")
+        m_gw_cfg.assert_not_called()
+
+    def test_webui_delivery_never_constructs_gateway_platform(self):
+        """Regression for #45360: a webui target must not reach Platform("webui")."""
+        job = {"id": "j", "deliver": "webui:sess-1"}
+        with patch("gateway.config.load_gateway_config") as m_gw_cfg, \
+             patch("hermes_state.SessionDB") as mock_db_cls:
+            mock_db = MagicMock()
+            mock_db.resolve_session_id.return_value = "sess-1"
+            mock_db.get_session.return_value = {"id": "sess-1"}
+            mock_db_cls.return_value = mock_db
+
+            result = _deliver_result(job, "hello")
+
+        assert result is None
+        m_gw_cfg.assert_not_called()
+        mock_db.append_message.assert_called_once()
+
+    def test_mixed_webui_and_gateway_targets_both_attempted(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        job = {
+            "id": "j",
+            "deliver": "webui:sess-1,telegram:123",
+        }
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg) as m_gw_cfg, \
+             patch("cron.scheduler._deliver_to_webui_session", return_value=None) as m_webui, \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            result = _deliver_result(job, "hello")
+
+        assert result is None
+        m_webui.assert_called_once_with(job, "sess-1", "hello")
+        m_gw_cfg.assert_called_once()
+        send_mock.assert_called_once()
+
+    def test_webui_delivery_error_is_aggregated(self):
+        job = {"id": "j", "deliver": "webui:missing-session"}
+        with patch(
+            "cron.scheduler._deliver_to_webui_session",
+            return_value="webui session 'missing-session' not found",
+        ):
+            result = _deliver_result(job, "hello")
+
+        assert result is not None
+        assert "missing-session" in result
+
+
+class TestDeliverToWebuiSession:
+    """Unit tests for the SessionDB-backed WebUI delivery helper."""
+
+    def test_appends_labelled_observed_user_message(self):
+        from cron.scheduler import _deliver_to_webui_session
+
+        mock_db = MagicMock()
+        mock_db.resolve_session_id.return_value = "sess-1"
+        mock_db.get_session.return_value = {"id": "sess-1"}
+
+        with patch("hermes_state.SessionDB", return_value=mock_db):
+            job = {"id": "job-1", "name": "daily-report"}
+            result = _deliver_to_webui_session(job, "sess-1", "Here is the report.")
+
+        assert result is None
+        mock_db.append_message.assert_called_once_with(
+            "sess-1",
+            "user",
+            "[Cron delivery: daily-report]\nHere is the report.",
+            observed=True,
+        )
+        mock_db.close.assert_called_once()
+
+    def test_missing_session_returns_error_and_does_not_append(self):
+        from cron.scheduler import _deliver_to_webui_session
+
+        mock_db = MagicMock()
+        mock_db.resolve_session_id.return_value = None
+        mock_db.get_session.return_value = None
+
+        with patch("hermes_state.SessionDB", return_value=mock_db):
+            result = _deliver_to_webui_session({"id": "job-1"}, "does-not-exist", "text")
+
+        assert result is not None
+        assert "does-not-exist" in result
+        mock_db.append_message.assert_not_called()
+        mock_db.close.assert_called_once()
+
+    def test_empty_content_is_a_noop(self):
+        from cron.scheduler import _deliver_to_webui_session
+
+        with patch("hermes_state.SessionDB") as mock_db_cls:
+            result = _deliver_to_webui_session({"id": "job-1"}, "sess-1", "   ")
+
+        assert result is None
+        mock_db_cls.assert_not_called()


### PR DESCRIPTION
## Summary

- Treat WebUI cron delivery as a local `SessionDB` delivery target instead of a gateway platform adapter.
- Support `deliver=origin` when `origin.platform=webui` and explicit `deliver=webui:<session_id>` without constructing `Platform("webui")`.
- Route WebUI targets through `_deliver_to_webui_session()` and split them out before gateway delivery so mixed targets still work.
- Keep the PR focused to the core scheduler/runtime contract only; WebUI-facing controls belong in the separate `nesquena/hermes-webui` repo.

Related to #45360. This PR addresses the `unknown platform 'webui'` delivery/runtime-contract side of that issue by making WebUI a local session-store delivery target rather than a gateway platform. It does not try to bundle the broader WebUI UI selector or the full scheduled-output UX surface.

## Scope reduction after review

The original revision included embedded React WebUI plumbing. After the high-surface-area review, this PR was reduced to the Hermes Agent scheduler core only:

- `cron/scheduler.py`
- `tests/cron/test_scheduler.py`

The deployed standalone WebUI is maintained separately at `nesquena/hermes-webui`, which already has generic cron delivery-options UI/API support. If a visible "This WebUI conversation" selector is still desired, that should be handled as a companion PR there using this backend contract (`webui:<session_id>`). Companion tracking issue: https://github.com/nesquena/hermes-webui/issues/5779

## Relationship to existing #45360 PRs

- #45392 skips WebUI-origin delivery to avoid the error. This PR instead adds a real local WebUI session delivery target and still avoids `Platform("webui")`.
- #45363 covers both WebUI-origin local handling and prompt-only failure-session surfacing. This PR is intentionally narrower on the Hermes Agent side: it focuses on the delivery target contract and explicit `webui:<session_id>` support, leaving WebUI-facing controls to the standalone WebUI repo.

## Compression-continuation review fix

After maintainer review, WebUI delivery now resolves the requested session through `resolve_resume_session_id()` before checking and appending. This prevents a cron message from landing on a compressed parent while the active WebUI conversation reads its continuation child. A real SQLite-backed `SessionDB` regression test covers that parent-to-child delivery.

## Tests

- `python3 -m pytest tests/cron/test_scheduler.py::TestDeliverToWebuiSession tests/cron/test_scheduler.py::TestWebuiDeliveryDispatch tests/cron/test_scheduler.py::TestWebuiDeliveryTargetResolution -q`
  - `12 passed`
- `python3 -m pytest tests/cron/test_scheduler.py -q`
  - `225 passed, 2 warnings`
- `git diff --check`
  - clean

## Notes

Warnings observed locally are existing scheduler-test environment warnings: Discord `audioop` deprecation and a coroutine warning in the delivery-test area. No test failures.
