### PR TITLE
fix(whatsapp): silent Node spawn on Windows via windows_detach_popen_kwargs (salvage #60647)

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -27,6 +27,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
 from typing import Dict, Optional, Any
 
+from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
 from hermes_constants import (
     find_node_executable,
     get_hermes_dir,
@@ -648,8 +649,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 ],
                 stdout=bridge_log_fh,
                 stderr=bridge_log_fh,
-                start_new_session=True,
                 env=bridge_env,
+                **windows_detach_popen_kwargs(),
             )
             _write_bridge_pidfile(self._session_path, self._bridge_process.pid)
             


### PR DESCRIPTION
## Summary
Salvage of #60647 by @kyssta-exe — the WhatsApp bridge no longer spawns Node.js with a visible console window on Windows. Fixes #60508.

Root cause: the bridge `connect()` used bare `start_new_session=True`, the exact anti-pattern `windows_detach_popen_kwargs()` (hermes_cli/_subprocess_compat.py) exists to replace — on Windows that spawns a flashing console subject to CTRL-event kill loops.

## Changes
- `plugins/platforms/whatsapp/adapter.py`: swap `start_new_session=True` for `**windows_detach_popen_kwargs()` at the Node spawn. Windows gets detached creationflags; POSIX behavior is byte-identical (the helper returns `start_new_session=True` there).

## Validation
| | Result |
|---|---|
| WhatsApp-related targeted tests | pass |
| POSIX semantics | unchanged (helper returns same kwarg) |

Supersedes duplicate PRs #60516, #60605, #59285, #29807 targeting the same symptom — this variant is minimal and reuses the sanctioned shared helper. Contributor commit cherry-picked (re-attributed from the generic "Hermes Agent" identity to @kyssta-exe); rebase-merge.

## Infographic

![whatsapp-windows-detach](https://v3b.fal.media/files/b/0aa16ea4/KBedcvVKxf0XEC2Hd0Ry0_Gf5StvCU.png)
