### PR TITLE
fix(agent): switch_model no longer pairs new provider with stale base_url

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1762,13 +1762,30 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # ── Swap core runtime fields ──
         agent.model = new_model
         agent.provider = new_provider
-        # Use new base_url when provided; only fall back to current when the
-        # new provider genuinely has no endpoint (e.g. native SDK providers).
-        # Without this guard the old provider's URL (e.g. Ollama's localhost
-        # address) would persist silently after switching to a cloud provider
-        # that returns an empty base_url string.
+        # Use the new base_url when provided. When it's empty AND the
+        # provider is actually changing, do NOT fall back to the current
+        # (old provider's) URL — that silently pairs the new provider label
+        # with the previous provider's endpoint (e.g. new_provider=minimax
+        # paired with the leftover api.githubcopilot.com URL), and every
+        # request after the switch 400s at the wrong host. This mismatched
+        # pair also gets snapshotted into _primary_runtime below, so it
+        # keeps re-applying on every subsequent turn until a full restart.
+        # Fail loud instead: the caller (model_switch.switch_model())
+        # already resolves base_url for every real provider, so an empty
+        # value here means resolution failed upstream, not that the
+        # provider genuinely has none. Re-selecting the SAME provider with
+        # an empty base_url (e.g. a credential-only refresh) is still fine
+        # to keep the current URL. See #47828.
+        old_norm_provider = (old_provider or "").strip().lower()
+        new_norm_provider = (new_provider or "").strip().lower()
         if base_url:
             agent.base_url = base_url
+        elif old_norm_provider != new_norm_provider:
+            raise ValueError(
+                f"switch_model: no base_url resolved for provider "
+                f"'{new_provider}' (switching from '{old_provider}'); "
+                "refusing to keep the previous provider's endpoint"
+            )
         agent.api_mode = api_mode
         # Invalidate transport cache — new api_mode may need a different transport
         if hasattr(agent, "_transport_cache"):

--- a/tests/run_agent/test_switch_model_stale_base_url.py
+++ b/tests/run_agent/test_switch_model_stale_base_url.py
@@ -1,0 +1,87 @@
+"""Regression tests for #47828: switch_model must not pair a new provider
+label with the previous provider's base_url when the resolver returns no
+new base_url for a genuine provider change.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+from agent.context_compressor import ContextCompressor
+
+
+def _make_agent_with_compressor(provider="copilot", base_url="https://api.githubcopilot.com") -> AIAgent:
+    """Build a minimal AIAgent with a context_compressor, skipping __init__."""
+    agent = AIAgent.__new__(AIAgent)
+
+    agent.model = "claude-opus-4.8"
+    agent.provider = provider
+    agent.base_url = base_url
+    agent.api_key = "sk-primary"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock()
+    agent.quiet_mode = True
+    agent._config_context_length = None
+
+    compressor = ContextCompressor(
+        model=agent.model,
+        threshold_percent=0.50,
+        base_url=base_url,
+        api_key="sk-primary",
+        provider=provider,
+        quiet_mode=True,
+        config_context_length=None,
+    )
+    agent.context_compressor = compressor
+    agent._primary_runtime = {}
+
+    return agent
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=131_072)
+def test_switch_model_rejects_stale_base_url_on_provider_change(mock_ctx_len):
+    """A provider change with no resolved base_url must fail loud instead of
+    silently keeping the previous provider's endpoint (#47828)."""
+    agent = _make_agent_with_compressor(provider="copilot", base_url="https://api.githubcopilot.com")
+
+    with pytest.raises(ValueError, match="no base_url resolved"):
+        agent.switch_model("MiniMax-M3", "custom:minimax", api_key="sk-minimax", base_url="")
+
+    # Rollback must leave the agent fully on the old (provider, base_url) pair —
+    # not a mismatched new-model/old-endpoint hybrid.
+    assert agent.provider == "copilot"
+    assert agent.base_url == "https://api.githubcopilot.com"
+    assert agent.model == "claude-opus-4.8"
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=131_072)
+def test_switch_model_allows_empty_base_url_for_same_provider(mock_ctx_len):
+    """Re-selecting the SAME provider (e.g. a credential-only refresh) with no
+    new base_url must keep the current URL — this is not a provider change."""
+    agent = _make_agent_with_compressor(provider="openrouter", base_url="https://openrouter.ai/api/v1")
+
+    agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="")
+
+    assert agent.provider == "openrouter"
+    assert agent.base_url == "https://openrouter.ai/api/v1"
+    assert agent.model == "new-model"
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=131_072)
+def test_switch_model_applies_new_base_url_on_provider_change(mock_ctx_len):
+    """The normal, resolved-correctly path must still work: new provider +
+    new base_url is applied as-is."""
+    agent = _make_agent_with_compressor(provider="copilot", base_url="https://api.githubcopilot.com")
+
+    agent.switch_model(
+        "MiniMax-M3", "custom:minimax", api_key="sk-minimax", base_url="https://api.minimax.io/v1"
+    )
+
+    assert agent.provider == "custom:minimax"
+    assert agent.base_url == "https://api.minimax.io/v1"
+    assert agent.model == "MiniMax-M3"
+    # _primary_runtime must snapshot the coherent pair so it survives every
+    # subsequent restore_primary_runtime() call across turns.
+    assert agent._primary_runtime["provider"] == "custom:minimax"
+    assert agent._primary_runtime["base_url"] == "https://api.minimax.io/v1"


### PR DESCRIPTION
Fixes #47828

## Root cause

`switch_model()` in `agent/agent_runtime_helpers.py` mutates the agent's runtime fields with an **asymmetric guard**:

```python
agent.model = new_model
agent.provider = new_provider          # always applied
if base_url:
    agent.base_url = base_url          # only applied when truthy
```

`agent.provider` is always updated, but `agent.base_url` only changes when the caller supplies a non-empty value. When the upstream resolver (`hermes_cli/model_switch.py` → `hermes_cli/runtime_provider.py`) legitimately changes provider but returns an empty `base_url` string for that call, the agent ends up with `provider = "minimax"` while `base_url` still points at the *previous* provider's endpoint (e.g. `https://api.githubcopilot.com`). Every request after that switch fires at the wrong host and 400s, exactly matching the repro in #47828 and the corroborating reports from alt-glitch, diegokolling, and AriNova1.

This incoherent `(provider, base_url)` pair doesn't just affect the current turn — it gets snapshotted verbatim into `agent._primary_runtime` right after the swap. `restore_primary_runtime()` reapplies that snapshot at the top of every subsequent turn, so the mismatch survives indefinitely (until process restart), and `_persist_live_session_runtime()` writes it straight into `sessions.model_config` in `state.db`, which is why it's visible there too.

### Why only `switch_model()`

I audited the other two mutation sites the issue's repro paths point at:

- **`try_activate_fallback()`** (`agent/chat_completion_helpers.py`) always derives `base_url` from the *actually constructed* client object (`str(fb_client.base_url)`), never from a possibly-empty hint. Not affected.
- **`_swap_credential()`** (`run_agent.py`) only rotates `api_key`/`base_url` within the *same* provider's credential pool — it never touches `agent.provider`. Not affected.

Both `restore_primary_runtime()` and `try_recover_primary_transport()` restore `model`/`provider`/`base_url`/`api_mode` together, atomically, from `_primary_runtime` — they're safe as long as what's stored there is coherent. `switch_model()` is the only place that could write an incoherent snapshot in the first place.

## Fix

When `base_url` is empty **and** the provider is genuinely changing, `switch_model()` now fails loud instead of silently inheriting the old provider's URL:

```python
old_norm_provider = (old_provider or "").strip().lower()
new_norm_provider = (new_provider or "").strip().lower()
if base_url:
    agent.base_url = base_url
elif old_norm_provider != new_norm_provider:
    raise ValueError(
        f"switch_model: no base_url resolved for provider "
        f"'{new_provider}' (switching from '{old_provider}'); "
        "refusing to keep the previous provider's endpoint"
    )
```

This routes through `switch_model()`'s existing snapshot/rollback `try/except` — the agent is fully restored to its pre-switch state before the exception propagates. Callers already handle this cleanly: `tui_gateway/server.py`'s `_apply_model_switch()` catches the exception and surfaces a "Model switch to X failed; staying on Y" message to the user instead of leaving the session silently broken.

Re-selecting the **same** provider with an empty `base_url` (e.g. a credential-only refresh) is untouched — that's not a provider change, so the current `base_url` is correctly kept as before.

## Testing

Added `tests/run_agent/test_switch_model_stale_base_url.py` (3 new tests):

1. Provider change + empty `base_url` → raises `ValueError`, agent fully rolled back to the pre-switch `(model, provider, base_url)`.
2. Same provider + empty `base_url` → still succeeds, keeps the current `base_url` (preserves the legitimate credential-refresh case).
3. Provider change + valid new `base_url` → still works normally, and `_primary_runtime` snapshots the coherent pair.

Also re-ran every existing test that exercises `switch_model()`/`agent.switch_model()` to confirm no regressions, since a couple of them exercise provider changes:

```
tests/run_agent/test_switch_model_fallback_prune.py
tests/run_agent/test_switch_model_pool_reload_52727.py
tests/run_agent/test_switch_model_rollback.py
tests/run_agent/test_switch_model_stale_base_url.py
tests/run_agent/test_switch_model_context.py
```

```
18 passed in 16.51s
```

None of the existing tests relied on the old (buggy) behavior — every existing call site that changes provider already passes a non-empty `base_url`, so this fix is additive and doesn't require touching any other test.