### PR TITLE
fix(cli): clear background processes on session reset (#60853)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7001,6 +7001,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self.agent.session_id = self.session_id
             self.agent.session_start = self.session_start
             self.agent.reset_session_state()
+            try:
+                from tools.process_registry import process_registry
+                process_registry.kill_all()
+            except Exception:
+                pass
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = 0
             if hasattr(self.agent, "_todo_store"):


### PR DESCRIPTION
Fixes issue #60853, where the status bar gear icon (⚙ N) persists even after all background terminal processes have exited.

The Problem:
The status bar UI snapshot relies on process_registry.count_running() to determine the number of active background processes. However, when a session is reset (via /reset or /new), the process_registry was not being explicitly cleared. This led to stale ProcessSession objects remaining in the registry's _running dict, causing the UI to report a non-zero process count indefinitely.

The Fix:
Added an explicit process_registry.kill_all() call to the new_session method in cli.py. This ensures that whenever a new session starts:
1. Any orphaned background terminal processes are immediately reaped.
2. The process_registry state is synchronized, correctly resetting the background process count to zero.

Verification:
- Ran the dedicated test suite: scripts/run_tests.sh tests/cli/test_cli_background_status_indicator.py
- Confirmed that all 23 tests pass, ensuring that the background process indicator behaves correctly during session transitions.