### PR TITLE
feat(models): swap curated Tencent Hy3 Preview for GA tencent/hy3, drop owl-alpha

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -305,6 +305,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # OpenRouter live metadata reports 262144 (256 × 1024); align the
     # static fallback so cache and offline both agree (issue #22268).
     "hy3-preview": 262144,
+    # Tencent — Hy3 (GA successor to Hy3 Preview), same 256K window.
+    "hy3": 262144,
     # Nemotron — NVIDIA's open-weights series (128K context across all sizes)
     "nemotron": 131072,
     # Arcee

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -67,7 +67,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Xiaomi
     ("xiaomi/mimo-v2.5-pro",                   ""),
     # Tencent
-    ("tencent/hy3-preview",                    ""),
+    ("tencent/hy3",                            ""),
     # StepFun
     ("stepfun/step-3.7-flash",                 ""),
     # NVIDIA
@@ -78,9 +78,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
     ("openrouter/elephant-alpha",              "free"),
-    ("openrouter/owl-alpha",                   "free"),
     ("poolside/laguna-m.1:free",               "free"),
-    ("tencent/hy3-preview:free",               "free"),
+    ("tencent/hy3:free",                       "free"),
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
     ("nvidia/nemotron-3-ultra-550b-a55b:free", "free"),
     ("inclusionai/ring-2.6-1t:free",           "free"),
@@ -211,7 +210,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # Xiaomi
         "xiaomi/mimo-v2.5-pro",
         # Tencent
-        "tencent/hy3-preview",
+        "tencent/hy3",
         # StepFun
         "stepfun/step-3.7-flash",
         # NVIDIA

--- a/run_agent.py
+++ b/run_agent.py
@@ -5337,7 +5337,7 @@ class AIAgent:
             "google/gemini-2",
             "google/gemma-4",
             "qwen/qwen3",
-            "tencent/hy3-preview",
+            "tencent/hy3",
             "xiaomi/",
         )
         return any(model.startswith(prefix) for prefix in reasoning_model_prefixes)

--- a/tests/hermes_cli/test_tencent_tokenhub_provider.py
+++ b/tests/hermes_cli/test_tencent_tokenhub_provider.py
@@ -191,22 +191,22 @@ class TestTencentTokenhubCanonicalProvider:
 
 
 class TestTencentInOpenRouterAndNous:
-    """tencent/hy3-preview:free and tencent/hy3-preview should appear in OpenRouter and Nous curated lists."""
+    """tencent/hy3:free and tencent/hy3 should appear in OpenRouter and Nous curated lists."""
 
     def test_in_openrouter_fallback(self):
         from hermes_cli.models import OPENROUTER_MODELS
         ids = [mid for mid, _ in OPENROUTER_MODELS]
-        assert "tencent/hy3-preview:free" in ids
+        assert "tencent/hy3:free" in ids
 
     def test_paid_in_openrouter_fallback(self):
-        """tencent/hy3-preview (paid, no :free suffix) should also be in OpenRouter list."""
+        """tencent/hy3 (paid, no :free suffix) should also be in OpenRouter list."""
         from hermes_cli.models import OPENROUTER_MODELS
         ids = [mid for mid, _ in OPENROUTER_MODELS]
-        assert "tencent/hy3-preview" in ids
+        assert "tencent/hy3" in ids
 
     def test_in_nous_provider_models(self):
         from hermes_cli.models import _PROVIDER_MODELS
-        assert "tencent/hy3-preview" in _PROVIDER_MODELS["nous"]
+        assert "tencent/hy3" in _PROVIDER_MODELS["nous"]
 
 
 # =============================================================================
@@ -433,7 +433,7 @@ class TestTencentTokenhubCLIDispatch:
 
 
 class TestTencentTokenhubModelCatalogJSON:
-    """Verify tencent/hy3-preview:free and tencent/hy3-preview are present in the website model-catalog.json."""
+    """Verify tencent/hy3:free and tencent/hy3 are present in the website model-catalog.json."""
 
     def test_in_model_catalog_json(self):
         catalog_path = os.path.join(
@@ -457,8 +457,8 @@ class TestTencentTokenhubModelCatalogJSON:
             for provider_entry in providers:
                 for model in provider_entry.get("models", []):
                     all_ids.add(model.get("id", ""))
-        assert "tencent/hy3-preview:free" in all_ids
-        assert "tencent/hy3-preview" in all_ids
+        assert "tencent/hy3:free" in all_ids
+        assert "tencent/hy3" in all_ids
 
 
 # =============================================================================

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-01T20:08:52Z",
+  "updated_at": "2026-07-08T13:38:17Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -105,7 +105,7 @@
           "description": ""
         },
         {
-          "id": "tencent/hy3-preview",
+          "id": "tencent/hy3",
           "description": ""
         },
         {
@@ -129,15 +129,11 @@
           "description": "free"
         },
         {
-          "id": "openrouter/owl-alpha",
-          "description": "free"
-        },
-        {
           "id": "poolside/laguna-m.1:free",
           "description": "free"
         },
         {
-          "id": "tencent/hy3-preview:free",
+          "id": "tencent/hy3:free",
           "description": "free"
         },
         {
@@ -227,7 +223,7 @@
           "id": "xiaomi/mimo-v2.5-pro"
         },
         {
-          "id": "tencent/hy3-preview"
+          "id": "tencent/hy3"
         },
         {
           "id": "stepfun/step-3.7-flash"


### PR DESCRIPTION
## Summary
The curated model lists now offer GA `tencent/hy3` (paid + `:free`) instead of `tencent/hy3-preview`, and `openrouter/owl-alpha` is removed from the free tier.

## Changes
- `hermes_cli/models.py`: OPENROUTER_MODELS — remove `openrouter/owl-alpha`, `tencent/hy3-preview`, `tencent/hy3-preview:free`; add `tencent/hy3`, `tencent/hy3:free`. `_PROVIDER_MODELS["nous"]` swapped to `tencent/hy3`.
- `run_agent.py`: reasoning-prefix list `tencent/hy3-preview` → `tencent/hy3` (prefix match still covers `-preview` if pinned).
- `agent/model_metadata.py`: register `hy3` context length (262,144) alongside the existing `hy3-preview` entry.
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`.
- `tests/hermes_cli/test_tencent_tokenhub_provider.py`: curated-list assertions updated to the new IDs.

Intentionally unchanged: the `tencent-tokenhub` direct provider still serves `hy3-preview` on TokenHub's own endpoint.

## Validation
| | Before | After |
|---|---|---|
| Curated Tencent IDs | `hy3-preview`, `hy3-preview:free` | `hy3`, `hy3:free` |
| `openrouter/owl-alpha` | listed (free) | removed |
| Targeted tests | — | 90/90 pass (tokenhub + model-catalog suites, incl. catalog-sync invariant) |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa16f50/0nCMTFm3caOdqdfW9KG4G_L4Xg8XPA.png)
