### PR TITLE
fix(gateway): close /resume session-existence oracle (CWE-203)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3590,24 +3590,30 @@ class GatewaySlashCommandsMixin:
         except Exception as e:
             logger.debug("Failed to resolve resume continuation for %s: %s", target_id, e)
 
+        # Authorization / scoping gate. A session id/title is a routing handle,
+        # not authority: bind /resume to the caller's own platform/user/chat on
+        # every adapter so one user can't attach to another's persisted
+        # transcript (CWE-639). When the target exists but the caller is not
+        # authorized, we return the SAME generic "not found" response as for a
+        # genuinely missing session. Otherwise the previously-distinct
+        # "blocked: belongs to a different user or chat" and "different Matrix
+        # room (<room>)" messages let any caller confirm the existence of — and,
+        # on Matrix, learn the room name of — every other user's session: an
+        # information-disclosure oracle (CWE-203) in a shared, multi-tenant
+        # gateway (the residual called out on PR #60914).
+        _resume_allowed = True
         if source.platform == Platform.MATRIX:
             target_origin = self._gateway_session_origin_for_id(target_id)
             if not self._same_matrix_room(source, target_origin) and not allow_cross_room:
-                if target_origin is None:
-                    return t("gateway.resume.matrix_blocked_no_origin", name=name)
-                return t(
-                    "gateway.resume.matrix_blocked_other_room",
-                    room=target_origin.chat_name or target_origin.chat_id,
-                    name=name,
-                )
+                _resume_allowed = False
         elif not await self._resume_target_allowed(
             source, target_id, allow_override=(allow_all or allow_cross_room)
         ):
-            # IDOR guard: a session id/title is a routing handle, not authority.
-            # Bind /resume to the caller's own platform/user/chat on every
-            # non-Matrix adapter so one user can't attach to another's
-            # persisted transcript.
-            return t("gateway.resume.blocked_not_owner", name=name)
+            _resume_allowed = False
+        if not _resume_allowed:
+            # Collapse "exists-but-not-yours" and "doesn't exist" into one
+            # response so a caller cannot enumerate other users' sessions.
+            return t("gateway.resume.not_found", name=name)
 
         # Check if already on that session
         current_entry = self.session_store.get_or_create_session(source)

--- a/tests/gateway/test_matrix_project_context_isolation.py
+++ b/tests/gateway/test_matrix_project_context_isolation.py
@@ -393,8 +393,9 @@ async def test_matrix_resume_does_not_cross_rooms_by_default():
 
     result = await runner._handle_resume_command(_event("/resume Project A Plan", source_b))
 
-    assert "blocked" in result
-    assert PROJECT_A_NAME in result
+    assert "No session found" in result
+    assert "Project A Plan" in result
+    assert PROJECT_A_ROOM_ID not in result
     runner.session_store.switch_session.assert_not_called()
 
 
@@ -447,7 +448,8 @@ async def test_matrix_resume_quoted_title_cross_room_blocked():
         _event('/resume "Project A Plan"', source_b)
     )
 
-    assert "blocked" in result
+    assert "No session found" in result
+    assert PROJECT_A_ROOM_ID not in result
     runner.session_store.switch_session.assert_not_called()
 
 

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -402,6 +402,85 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_blocked_is_indistinguishable_from_not_found(self, tmp_path):
+        """Regression for the /resume existence oracle (CWE-203): a session title
+        that exists but is owned by another user/chat must produce the SAME reply
+        as the same title when it does not exist at all. Otherwise the distinct
+        'different user or chat' message lets any caller confirm the existence of
+        every other user's session title in a shared multi-tenant gateway."""
+        from hermes_state import SessionDB
+
+        title = "Victim Secret Project"
+
+        # (a) Title exists, owned by a different user.
+        db_victim = SessionDB(db_path=tmp_path / "victim.db")
+        db_victim.create_session("victim_uid", "telegram", user_id="99999", chat_id="55555")
+        db_victim.set_session_title("victim_uid", title)
+        db_victim.create_session("current_session_001", "telegram", user_id="12345", chat_id="67890")
+        runner_victim = _make_runner(session_db=db_victim,
+                                     current_session_id="current_session_001",
+                                     event=_make_event(text=f"/resume {title}"))
+        blocked = await runner_victim._handle_resume_command(_make_event(text=f"/resume {title}"))
+        runner_victim.session_store.switch_session.assert_not_called()
+        db_victim.close()
+
+        # (b) Same title, but it does not exist for anyone.
+        db_missing = SessionDB(db_path=tmp_path / "missing.db")
+        db_missing.create_session("current_session_001", "telegram", user_id="12345", chat_id="67890")
+        runner_missing = _make_runner(session_db=db_missing,
+                                      current_session_id="current_session_001",
+                                      event=_make_event(text=f"/resume {title}"))
+        missing = await runner_missing._handle_resume_command(_make_event(text=f"/resume {title}"))
+        runner_missing.session_store.switch_session.assert_not_called()
+        db_missing.close()
+
+        # No resume happened, and the reply does not reveal that the title exists.
+        assert "Resumed" not in blocked
+        assert "different user" not in blocked.lower()
+        assert "belongs to" not in blocked.lower()
+        # Blocked (exists-but-not-yours) must be byte-for-byte identical to
+        # not-found (does-not-exist) for the SAME title.
+        assert blocked == missing
+        assert "No session found" in blocked
+
+    @pytest.mark.asyncio
+    async def test_resume_matrix_blocked_does_not_reveal_room(self, tmp_path):
+        """Matrix variant of the existence oracle: a session owned by another
+        Matrix room must not leak that room's name/ID. The previous reply
+        embedded the victim room ('different Matrix room (<room>)'), letting a
+        caller learn which room another user's session lives in."""
+        from hermes_state import SessionDB
+        from gateway.config import Platform as _Platform
+        from gateway.session import SessionSource as _SessionSource
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("victim_room_b", "matrix", user_id="@bob:hs",
+                          chat_id="!room-b:hs", chat_type="group")
+        db.set_session_title("victim_room_b", "Victim Matrix Session")
+        db.create_session("current_session_001", "matrix", user_id="@alice:hs",
+                          chat_id="!room-a:hs", chat_type="group")
+
+        caller_event = _make_event(text="/resume Victim Matrix Session",
+                                   platform=_Platform.MATRIX,
+                                   user_id="@alice:hs", chat_id="!room-a:hs")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001",
+                              event=caller_event)
+        # The persisted victim session's live origin lives in a different room.
+        runner._gateway_session_origin_for_id = lambda sid: _SessionSource(
+            platform=_Platform.MATRIX, chat_id="!room-b:hs",
+            chat_type="group", user_id="@bob:hs")
+
+        result = await runner._handle_resume_command(caller_event)
+
+        runner.session_store.switch_session.assert_not_called()
+        assert "Resumed" not in result
+        # No room identifier must be disclosed.
+        assert "!room-b:hs" not in result
+        assert "different Matrix room" not in result
+        assert "No session found" in result
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_resume_resolves_by_session_id(self, tmp_path):
         """The gateway should accept a bare session ID, not just a title.
 


### PR DESCRIPTION
## Summary

`/resume <title>` in a shared, multi-user gateway leaks the existence of — and on
Matrix, the room name of — **other users' sessions**. Although the authorization
guard (CWE-639, addressed separately in #60914) already prevents *attaching* to a
foreign session, the handler still returns **distinguishable** responses:

- title/ID does not exist → `No session found matching '<x>'`
- title/ID exists but is owned by another user → `⚠️ /resume blocked: '<x>' belongs to a different user or chat`
- Matrix, owned by another room → `... belongs to a different Matrix room (<room>)`

A caller who loops over candidate titles can therefore **confirm which sessions
exist** and, on Matrix, **learn the victim's room name/ID** — a classic
information-disclosure oracle (CWE-203) in a multi-tenant gateway.

## Root cause

`gateway/slash_commands.py` `_handle_resume_command` resolves the user-supplied
name through the **global, unscoped** `SessionDB.get_session` / `resolve_session_by_title`
(hermes_state.py:2814 / 2823, which query the whole `sessions` table), then splits
into distinct `blocked_not_owner` / `matrix_blocked_*` vs `not_found` responses.

## Fix

Collapse every "resolved but not authorized" outcome into the **same generic
`not_found` response** as a genuinely missing session. The IDOR authorization
guard still runs and still blocks the switch — only the *observable reply* is now
indistinguishable, so a caller can no longer enumerate other users' sessions or
learn their Matrix room.

This is the hardening the #60914 reviewer flagged as a residual ("make the blocked
and not-found responses indistinguishable, that's a genuine hardening on top of the
existing guard"). It is a **separate issue from #60914**: that PR fixes the
*access* path (CWE-639); this one fixes the *existence/room oracle* (CWE-203) that
remains after the guard.

## Tests

- `tests/gateway/test_resume_command.py::test_resume_blocked_is_indistinguishable_from_not_found`
  — proves the blocked reply for an existing foreign title is byte-for-byte
  identical to the not-found reply for the same title (no "different user" /
  "belongs to" leak).
- `tests/gateway/test_resume_command.py::test_resume_matrix_blocked_does_not_reveal_room`
  — proves a Matrix cross-room blocked resume does not disclose the victim room id
  (`!room-b:hs`) or "different Matrix room".
- Full `test_resume_command.py` + `test_session_boundary_security_state.py` pass
  (59 passed).

