### PR TITLE
feat: add adaptive model routing

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -139,6 +139,38 @@ model:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
 
 # =============================================================================
+# Hermes Adaptive Model Routing (main agent turns; opt-in)
+# =============================================================================
+# Chooses a configured model tier for each main user turn before the AIAgent is
+# constructed. This is Hermes-level model selection, not OpenRouter's provider
+# routing below. It does not affect auxiliary.* side tasks, fallback_providers,
+# delegation.model, or cron job explicit model overrides.
+#
+# model_routing:
+#   enabled: false
+#   default_tier: balanced
+#   log_decisions: true
+#   tiers:
+#     cheap:
+#       provider: openrouter
+#       model: google/gemini-3-flash-preview
+#     balanced:
+#       provider: openrouter
+#       model: anthropic/claude-sonnet-4.6
+#     best:
+#       provider: anthropic
+#       model: claude-opus-4-6
+#
+# Manual language overrides win over heuristics:
+#   "use cheap model", "quick answer" -> cheap
+#   "use best model", "think deeply", "use Fable" -> best
+#
+# Built-in heuristics route short/simple turns to cheap, normal coding/tool use
+# to balanced, and architecture, hard debugging, large refactors, Hermes
+# internals, security/privacy, and high-stakes advice to best. Bad/missing tier
+# config fails closed to the current configured model.
+
+# =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)
 # =============================================================================
 # Control how requests are routed across providers on OpenRouter.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3779,7 +3779,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     resolved_session_key or "", model, override_model,
                     override_runtime.get("provider"),
                 )
-                return override_model, override_runtime
+                return override_model, {**override_runtime, "_session_model_override": True}
             # Override exists but has no api_key — fall through to env-based
             # resolution and apply model/provider from the override on top.
             logger.debug(
@@ -3838,6 +3838,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs
             )
+            runtime_kwargs["_session_model_override"] = True
 
         # When the config has no model.default but a provider was resolved
         # (e.g. user ran `hermes auth add openai-codex` without `hermes model`),
@@ -3915,6 +3916,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 tuple(runtime["args"]),
             ),
         }
+
+        try:
+            from hermes_cli.model_routing import apply_route_to_turn
+
+            route = apply_route_to_turn(
+                route=route,
+                user_message=user_message,
+                config=getattr(self, "_user_config", None) or _load_gateway_config(),
+                explicit_override=bool(runtime_kwargs.get("_session_model_override")),
+            )
+        except Exception:
+            pass
 
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -203,6 +203,24 @@ class CLIAgentSetupMixin:
             ),
         }
 
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.model_routing import apply_route_to_turn
+
+            # CLI --model/--provider/model switching is already reflected in
+            # self.model/self.requested_provider and must remain authoritative.
+            # There is no reliable session flag here, so only route when the
+            # feature is enabled and a tier fully resolves; failures leave route
+            # untouched.
+            route = apply_route_to_turn(
+                route=route,
+                user_message=user_message,
+                config=load_config(),
+                explicit_override=False,
+            )
+        except Exception:
+            pass
+
         service_tier = getattr(self, "service_tier", None)
         if not service_tier:
             route["request_overrides"] = None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -963,6 +963,21 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    # Main-agent adaptive model routing. Distinct from OpenRouter provider_routing
+    # (within-model provider selection), auxiliary.* side-task routing,
+    # fallback_providers failure recovery, and delegation/cron explicit overrides.
+    # Inert unless enabled; incomplete/bad routes fail closed to the configured
+    # primary model for the turn.
+    "model_routing": {
+        "enabled": False,
+        "default_tier": "balanced",
+        "log_decisions": True,
+        "tiers": {
+            "cheap": {"provider": "", "model": ""},
+            "balanced": {"provider": "", "model": ""},
+            "best": {"provider": "", "model": ""},
+        },
+    },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
@@ -5185,7 +5200,7 @@ def check_config_version() -> Tuple[int, int]:
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
+    "fallback_providers", "model_routing", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "moa", "custom_providers", "context", "memory", "gateway",
     "sessions", "streaming", "updates", "mcp_servers",

--- a/hermes_cli/model_routing.py
+++ b/hermes_cli/model_routing.py
@@ -1,0 +1,251 @@
+"""Hermes-level adaptive model routing for main agent turns.
+
+This module is deliberately small and inert by default.  It chooses a configured
+model tier for a *main* user turn before an ``AIAgent`` is constructed, reusing
+``resolve_runtime_provider`` for provider/auth/base-url resolution instead of
+adding a parallel provider map.
+
+It is distinct from:
+- ``provider_routing``: OpenRouter's within-model provider-selection knobs.
+- ``auxiliary.*``: side-task LLM routing (compression, vision, titles, ...).
+- ``fallback_providers``: failure recovery after a model/provider errors.
+- ``delegation.*`` / cron job model overrides: explicit task/job routing.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, MutableMapping, Optional
+
+logger = logging.getLogger(__name__)
+
+RouteRuntimeResolver = Callable[..., Mapping[str, Any]]
+
+_OVERRIDE_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
+    (re.compile(r"\b(use|route\s+to|switch\s+to)\s+(the\s+)?(cheapest|cheap|fast|fastest|small|smallest)\s+model\b", re.I), "cheap", "explicit override"),
+    (re.compile(r"\b(quick|fast)\s+(answer|reply|response)\b", re.I), "cheap", "explicit quick-answer override"),
+    (re.compile(r"\b(use|route\s+to|switch\s+to)\s+(the\s+)?(balanced|normal|default)\s+model\b", re.I), "balanced", "explicit override"),
+    (re.compile(r"\b(use|route\s+to|switch\s+to)\s+(the\s+)?(best|strongest|smartest|premium|deepest)\s+model\b", re.I), "best", "explicit override"),
+    (re.compile(r"\b(use|route\s+to|switch\s+to)\s+(fable|opus|o3|gpt-5\.5|gpt5\.5)\b", re.I), "best", "explicit premium-model override"),
+    (re.compile(r"\b(think\s+deeply|deep\s+research|deep\s+reasoning|be\s+very\s+careful)\b", re.I), "best", "explicit deep-reasoning override"),
+)
+
+_BEST_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.I)
+    for p in (
+        r"\b(architecture|architectural|design\s+the\s+system|system\s+design|routing\s+engine)\b",
+        r"\b(hermes\s+internals|provider\s+selection|model\s+routing|fallback\s+chain|prompt\s+cach(?:e|ing)|role\s+alternation)\b",
+        r"\b(difficult|hard|tricky|unknown)\s+(bug|debug|failure|regression)\b",
+        r"\b(large|big|major)\s+(refactor|migration|rewrite|codebase\s+change)\b",
+        r"\b(security|privacy|medical|legal|financial|high[-\s]?stakes)\b",
+        r"\b(audit|review)\s+(the\s+)?(architecture|security|whole\s+repo|codebase)\b",
+    )
+)
+
+_BALANCED_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.I)
+    for p in (
+        r"\b(debug|troubleshoot|fix|implement|add\s+tests?|write\s+code|refactor|build|install|configure)\b",
+        r"\b(use\s+tools?|run\s+tests?|inspect\s+the\s+repo|open\s+a\s+PR|create\s+an\s+issue)\b",
+        r"\b(research|compare|investigate|analy[sz]e)\b",
+    )
+)
+
+_CHEAP_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.I)
+    for p in (
+        r"\b(summarize|summarise|rewrite|rephrase|translate|proofread)\b",
+        r"\b(what\s+is|who\s+is|when\s+is|where\s+is|define|explain\s+briefly)\b",
+    )
+)
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    tier: str
+    provider: str
+    model: str
+    runtime: dict[str, Any]
+    reason: str
+    confidence: float
+    source: str
+
+    @property
+    def signature(self) -> tuple[Any, ...]:
+        return (
+            self.model,
+            self.provider,
+            self.runtime.get("base_url"),
+            self.runtime.get("api_mode"),
+            self.runtime.get("command"),
+            tuple(self.runtime.get("args") or ()),
+        )
+
+
+def routing_enabled(config: Mapping[str, Any]) -> bool:
+    cfg = config.get("model_routing") if isinstance(config, Mapping) else None
+    return isinstance(cfg, Mapping) and bool(cfg.get("enabled", False))
+
+
+def choose_tier(user_message: str, config: Mapping[str, Any]) -> tuple[str, str, float, str]:
+    """Return ``(tier, reason, confidence, source)`` for ``user_message``.
+
+    Deterministic by design: no extra classifier LLM call, no hidden spend.
+    """
+    cfg = config.get("model_routing") if isinstance(config, Mapping) else {}
+    cfg = cfg if isinstance(cfg, Mapping) else {}
+    default_tier = str(cfg.get("default_tier") or "balanced").strip() or "balanced"
+    text = user_message or ""
+    stripped = text.strip()
+
+    for pattern, tier, reason in _OVERRIDE_PATTERNS:
+        if pattern.search(stripped):
+            return tier, reason, 0.99, "override"
+
+    word_count = len(re.findall(r"\w+", stripped))
+    char_count = len(stripped)
+    if char_count <= 80 and word_count <= 14 and "\n" not in stripped:
+        # Keep common tiny acknowledgements and factual one-liners cheap unless
+        # they explicitly ask for a hard/sensitive task.
+        if not any(p.search(stripped) for p in _BEST_PATTERNS):
+            return "cheap", "short/simple user turn", 0.82, "heuristic"
+
+    if any(p.search(stripped) for p in _BEST_PATTERNS):
+        return "best", "architecture/debugging/security/high-stakes task", 0.86, "heuristic"
+    if any(p.search(stripped) for p in _BALANCED_PATTERNS):
+        return "balanced", "normal tool/coding/research task", 0.74, "heuristic"
+    if any(p.search(stripped) for p in _CHEAP_PATTERNS):
+        return "cheap", "simple language/factual task", 0.72, "heuristic"
+    return default_tier, "default routing tier", 0.50, "policy"
+
+
+def _tier_entry(config: Mapping[str, Any], tier: str) -> Optional[Mapping[str, Any]]:
+    cfg = config.get("model_routing") if isinstance(config, Mapping) else None
+    tiers = cfg.get("tiers") if isinstance(cfg, Mapping) else None
+    entry = tiers.get(tier) if isinstance(tiers, Mapping) else None
+    return entry if isinstance(entry, Mapping) else None
+
+
+def resolve_model_route(
+    *,
+    user_message: str,
+    current_model: str,
+    current_runtime: Mapping[str, Any],
+    config: Mapping[str, Any],
+    explicit_override: bool = False,
+    resolver: Optional[RouteRuntimeResolver] = None,
+) -> Optional[RoutingDecision]:
+    """Resolve the effective route for one main-agent turn.
+
+    Returns ``None`` when routing is disabled, an explicit caller/session/job
+    override must win, the chosen tier is incomplete, or provider resolution
+    fails.  Callers should then continue with the already-resolved primary
+    runtime.
+    """
+    if explicit_override or not routing_enabled(config):
+        return None
+    tier, reason, confidence, source = choose_tier(user_message, config)
+    entry = _tier_entry(config, tier)
+    if entry is None:
+        logger.warning("model_routing: tier %r is not configured; using current model", tier)
+        return None
+
+    target_model = str(entry.get("model") or "").strip()
+    target_provider = str(entry.get("provider") or "").strip().lower()
+    target_base_url = str(entry.get("base_url") or "").strip() or None
+    if not target_model or not target_provider:
+        logger.warning("model_routing: tier %r missing provider/model; using current model", tier)
+        return None
+
+    if resolver is None:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        resolver = resolve_runtime_provider
+
+    try:
+        runtime = dict(
+            resolver(
+                requested=target_provider,
+                target_model=target_model,
+                explicit_base_url=target_base_url,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 - fail soft; user turn must continue.
+        logger.warning(
+            "model_routing: provider resolution failed for tier=%s provider=%s model=%s: %s; using current model",
+            tier,
+            target_provider,
+            target_model,
+            exc,
+        )
+        return None
+
+    if entry.get("api_mode"):
+        runtime["api_mode"] = entry.get("api_mode")
+    if entry.get("api_key"):
+        runtime["api_key"] = entry.get("api_key")
+
+    # Preserve max_tokens from the already resolved session/runtime unless the
+    # tier explicitly overrides it.
+    if "max_tokens" in current_runtime and "max_tokens" not in runtime:
+        runtime["max_tokens"] = current_runtime.get("max_tokens")
+    if entry.get("max_tokens") is not None:
+        runtime["max_tokens"] = entry.get("max_tokens")
+
+    provider = str(runtime.get("provider") or target_provider).strip().lower()
+    resolved_model = str(runtime.get("model") or target_model).strip() or target_model
+    runtime.pop("model", None)
+    decision = RoutingDecision(
+        tier=tier,
+        provider=provider,
+        model=resolved_model,
+        runtime=runtime,
+        reason=reason,
+        confidence=confidence,
+        source=source,
+    )
+    logger.info(
+        "model_routing: routed to %s tier: %s/%s (source=%s confidence=%.2f reason=%s)",
+        decision.tier,
+        decision.provider,
+        decision.model,
+        decision.source,
+        decision.confidence,
+        decision.reason,
+    )
+    return decision
+
+
+def apply_route_to_turn(
+    *,
+    route: MutableMapping[str, Any],
+    user_message: str,
+    config: Mapping[str, Any],
+    explicit_override: bool = False,
+    resolver: Optional[RouteRuntimeResolver] = None,
+) -> MutableMapping[str, Any]:
+    """Mutate and return a CLI/gateway turn-route dict when routing applies."""
+    decision = resolve_model_route(
+        user_message=user_message,
+        current_model=str(route.get("model") or ""),
+        current_runtime=route.get("runtime") or {},
+        config=config,
+        explicit_override=explicit_override,
+        resolver=resolver,
+    )
+    if decision is None:
+        return route
+    route["model"] = decision.model
+    route["runtime"] = decision.runtime
+    route["signature"] = decision.signature
+    route["routing_decision"] = {
+        "tier": decision.tier,
+        "provider": decision.provider,
+        "model": decision.model,
+        "reason": decision.reason,
+        "confidence": decision.confidence,
+        "source": decision.source,
+    }
+    return route

--- a/tests/hermes_cli/test_model_routing.py
+++ b/tests/hermes_cli/test_model_routing.py
@@ -1,0 +1,162 @@
+from hermes_cli.model_routing import apply_route_to_turn, choose_tier, resolve_model_route
+
+
+def _config(**overrides):
+    cfg = {
+        "model_routing": {
+            "enabled": True,
+            "default_tier": "balanced",
+            "tiers": {
+                "cheap": {"provider": "openrouter", "model": "cheap-model"},
+                "balanced": {"provider": "openrouter", "model": "balanced-model"},
+                "best": {"provider": "anthropic", "model": "best-model"},
+            },
+        }
+    }
+    cfg["model_routing"].update(overrides)
+    return cfg
+
+
+def _resolver(requested, target_model=None, explicit_base_url=None, **_kwargs):
+    return {
+        "provider": requested,
+        "model": target_model,
+        "api_key": f"key-for-{requested}",
+        "base_url": explicit_base_url or f"https://{requested}.example/v1",
+        "api_mode": "chat_completions",
+    }
+
+
+def _route():
+    return {
+        "model": "primary-model",
+        "runtime": {
+            "provider": "openrouter",
+            "api_key": "primary-key",
+            "base_url": "https://primary.example/v1",
+            "api_mode": "chat_completions",
+            "max_tokens": 1234,
+        },
+        "signature": (
+            "primary-model",
+            "openrouter",
+            "https://primary.example/v1",
+            "chat_completions",
+            None,
+            (),
+        ),
+    }
+
+
+def test_routing_disabled_preserves_existing_route():
+    route = _route()
+    out = apply_route_to_turn(
+        route=route.copy(),
+        user_message="hi",
+        config={"model_routing": {"enabled": False}},
+        resolver=_resolver,
+    )
+    assert out["model"] == "primary-model"
+    assert out["runtime"]["provider"] == "openrouter"
+    assert "routing_decision" not in out
+
+
+def test_explicit_call_override_wins_over_user_phrase():
+    decision = resolve_model_route(
+        user_message="use best model for this",
+        current_model="primary-model",
+        current_runtime=_route()["runtime"],
+        config=_config(),
+        explicit_override=True,
+        resolver=_resolver,
+    )
+    assert decision is None
+
+
+def test_use_best_model_routes_to_best_tier():
+    out = apply_route_to_turn(
+        route=_route(),
+        user_message="use best model and think deeply about this design",
+        config=_config(),
+        resolver=_resolver,
+    )
+    assert out["model"] == "best-model"
+    assert out["runtime"]["provider"] == "anthropic"
+    assert out["routing_decision"]["tier"] == "best"
+    assert out["routing_decision"]["source"] == "override"
+
+
+def test_simple_prompt_routes_cheap():
+    out = apply_route_to_turn(
+        route=_route(),
+        user_message="thanks",
+        config=_config(),
+        resolver=_resolver,
+    )
+    assert out["model"] == "cheap-model"
+    assert out["runtime"]["provider"] == "openrouter"
+    assert out["routing_decision"]["tier"] == "cheap"
+
+
+def test_architecture_debugging_prompt_routes_best():
+    tier, reason, confidence, source = choose_tier(
+        "Investigate Hermes internals and implement model routing architecture",
+        _config(),
+    )
+    assert tier == "best"
+    assert source == "heuristic"
+    assert confidence > 0.8
+    assert "architecture" in reason
+
+
+def test_bad_missing_tier_config_falls_back_safely():
+    cfg = _config(tiers={"cheap": {"provider": "", "model": ""}})
+    out = apply_route_to_turn(
+        route=_route(),
+        user_message="hi",
+        config=cfg,
+        resolver=_resolver,
+    )
+    assert out["model"] == "primary-model"
+    assert "routing_decision" not in out
+
+
+def test_bad_resolver_output_falls_back_safely():
+    def boom(**_kwargs):
+        raise RuntimeError("provider not configured")
+
+    out = apply_route_to_turn(
+        route=_route(),
+        user_message="use best model",
+        config=_config(),
+        resolver=boom,
+    )
+    assert out["model"] == "primary-model"
+    assert "routing_decision" not in out
+
+
+def test_existing_max_tokens_preserved_for_routed_turn():
+    out = apply_route_to_turn(
+        route=_route(),
+        user_message="hi",
+        config=_config(),
+        resolver=_resolver,
+    )
+    assert out["runtime"]["max_tokens"] == 1234
+
+
+def test_tier_max_tokens_can_override_current_runtime():
+    cfg = _config(
+        tiers={
+            "cheap": {"provider": "openrouter", "model": "cheap-model", "max_tokens": 99},
+            "balanced": {"provider": "openrouter", "model": "balanced-model"},
+            "best": {"provider": "anthropic", "model": "best-model"},
+        }
+    )
+    out = apply_route_to_turn(
+        route=_route(),
+        user_message="hi",
+        config=cfg,
+        resolver=_resolver,
+    )
+    assert out["runtime"]["max_tokens"] == 99

--- a/website/docs/user-guide/features/adaptive-model-routing.md
+++ b/website/docs/user-guide/features/adaptive-model-routing.md
@@ -1,0 +1,58 @@
+---
+title: Adaptive Model Routing
+---
+
+# Adaptive Model Routing
+
+Adaptive model routing lets Hermes choose a configured provider/model tier for each **main agent turn** before the `AIAgent` is constructed. It is opt-in and fails closed: when routing is disabled, incomplete, or cannot resolve credentials, Hermes uses the normal configured model.
+
+This is different from adjacent routing features:
+
+- `provider_routing` is OpenRouter's provider selection for an already chosen model.
+- `auxiliary.*` routes side tasks such as compression, vision, approvals, and title generation.
+- `fallback_providers` is failure recovery after the active model/provider errors.
+- `delegation.model` and cron job `model` overrides are explicit worker/job choices and keep taking precedence.
+
+## Configuration
+
+```yaml
+model_routing:
+  enabled: true
+  default_tier: balanced
+  log_decisions: true
+
+  tiers:
+    cheap:
+      provider: openrouter
+      model: google/gemini-3-flash-preview
+
+    balanced:
+      provider: openrouter
+      model: anthropic/claude-sonnet-4.6
+
+    best:
+      provider: anthropic
+      model: claude-opus-4-6
+```
+
+Each tier uses the same provider resolution path as normal Hermes model startup, so configured providers, credential pools, direct endpoints, and provider-specific API modes continue to work.
+
+## Manual overrides
+
+Natural-language overrides win over heuristics:
+
+- `use cheap model`, `quick answer` → `cheap`
+- `use best model`, `use strongest model`, `think deeply`, `use Fable` → `best`
+- `use balanced model` → `balanced`
+
+Explicit runtime choices still win over routing. For example, a session-scoped `/model` override, a cron job model override, or a delegation model override should not be silently replaced by adaptive routing.
+
+## Built-in heuristics
+
+The first implementation is deterministic and does not spend an extra classifier call.
+
+- `cheap`: very short/simple turns, brief factual Q&A, short rewriting/summarization.
+- `balanced`: normal tool use, moderate coding, ordinary troubleshooting, normal research.
+- `best`: architecture, difficult debugging, large refactors, Hermes internals, model/provider selection, security/privacy-sensitive changes, and high-stakes medical/legal/financial reasoning.
+
+Routing decisions are logged with the selected tier, provider/model, source, confidence, and reason.


### PR DESCRIPTION
## What

Adds an opt-in Hermes-level adaptive model-routing layer for main agent turns.

This is deliberately separate from existing adjacent routing systems:
- `provider_routing` remains OpenRouter's within-model provider preference block.
- `auxiliary.*` remains for side-task models such as compression, vision, approvals, and title generation.
- `fallback_providers` remains failure recovery after the active route errors.
- `delegation.*` and cron job model overrides remain explicit worker/job choices.

## Investigation

Before implementing, I inspected the existing model/provider selection paths and related upstream work:
- current CLI/gateway per-turn construction via `_resolve_turn_agent_config`
- runtime provider resolution through `resolve_runtime_provider`
- fallback activation/restoration paths (`try_activate_fallback`, `restore_primary_runtime`)
- config defaults/validation for `fallback_providers`, `auxiliary`, `delegation`, and `provider_routing`
- open PR #59390 (`smart_model_routing`) and PR #54748 (`routing`/tier work)
- issues #54601 (`channel_model_map`) and #55560 (`code_model` slot)

This PR takes the minimal coherent route: deterministic tier routing before agent construction, using the existing runtime provider resolver and without duplicating provider auth/base-url logic.

## Behavior

When `model_routing.enabled` is false, behavior is unchanged.

When enabled:
- short/simple turns route to `cheap`
- normal tool/coding/research turns route to `balanced`
- architecture, hard debugging, large refactors, Hermes internals, model/provider selection, security/privacy, and high-stakes advice route to `best`
- natural-language overrides win: `use cheap model`, `quick answer`, `use best model`, `think deeply`, `use Fable`
- session-scoped gateway `/model` overrides are marked explicit and skip adaptive routing
- bad/missing tier config or provider-resolution failure falls back to the already-resolved current model

## Config example

```yaml
model_routing:
  enabled: true
  default_tier: balanced
  log_decisions: true
  tiers:
    cheap:
      provider: openrouter
      model: google/gemini-3-flash-preview
    balanced:
      provider: openrouter
      model: anthropic/claude-sonnet-4.6
    best:
      provider: anthropic
      model: claude-opus-4-6
```

## Tests

- `python -m pytest tests/hermes_cli/test_model_routing.py -q -o 'addopts='` → 9 passed
- `python -m pytest tests/hermes_cli/test_model_routing.py tests/hermes_cli/test_setup_blank_slate.py tests/agent/test_restore_primary_pool_reselect.py -q -o 'addopts='` → 27 passed
- `ruff check hermes_cli/model_routing.py hermes_cli/cli_agent_setup_mixin.py gateway/run.py tests/hermes_cli/test_model_routing.py` → passed
- `python -m py_compile hermes_cli/model_routing.py hermes_cli/config.py hermes_cli/cli_agent_setup_mixin.py gateway/run.py` → passed
