### PR TITLE
fix(cli): set HERMES_YOLO_MODE before plugin discovery

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -14577,6 +14577,13 @@ def main():
         cmd_version(args)
         return
 
+    # --yolo: set env var before plugin discovery imports tools/approval.py,
+    # which freezes _YOLO_MODE_FROZEN at import time. Previously this was set
+    # inside cmd_chat(), after _prepare_agent_startup() had already run
+    # discover_plugins() — the frozen flag was always False (#60328).
+    if getattr(args, "yolo", False):
+        os.environ["HERMES_YOLO_MODE"] = "1"
+
     # Discover Python plugins and register shell hooks once, before any
     # command that can fire lifecycle hooks.  Both are idempotent; gated
     # so introspection/management commands (hermes hooks list, cron


### PR DESCRIPTION
## Summary

`hermes --yolo` has been silently broken since v0.11.0. The `HERMES_YOLO_MODE` env var was set inside `cmd_chat()`, but `_prepare_agent_startup()` (called from `main()` BEFORE `cmd_chat`) triggers `discover_plugins()` which imports `tools/approval.py` — freezing `_YOLO_MODE_FROZEN` to `False` at import time. The env var was always set too late.

## Fix

Move `os.environ["HERMES_YOLO_MODE"] = "1"` from `cmd_chat()` body to `main()`, before `_prepare_agent_startup()`. The existing set inside `cmd_chat()` is preserved for callers that bypass `main()` (e.g. Termux fast path).

## Root Cause

Regression from commit `3988c3c24` (v0.11.0) which moved `discover_plugins()` from inside `cmd_chat()` to `main()`.

Fixes: #60328