### PR TITLE
fix(auxiliary): respect explicit auxiliary.vision.model over _PROVIDER_VISION_MODELS mapping

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5307,7 +5307,14 @@ def resolve_vision_provider_client(
         main_provider = _read_main_provider()
         main_model = _read_main_model()
         if main_provider and main_provider not in {"auto", ""}:
-            vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
+            # Use explicit auxiliary.vision.model if configured, otherwise fall back to
+            # provider-specific vision model mapping or main model. This fixes #60381
+            # where a user-provided vision model (glm-4v-flash) was overwritten by the
+            # hardcoded zai → glm-5v-turbo mapping, causing "model not found" errors.
+            if resolved_model and resolved_model != "auto":
+                vision_model = resolved_model
+            else:
+                vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
             if main_provider == "nous":
                 sync_client, default_model = _resolve_strict_vision_backend(
                     main_provider, vision_model

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4144,6 +4144,43 @@ class TestVisionAutoSkipsKimiCoding:
         assert client is fake_kimi_client
         gcc_mock.assert_called_once()
 
+    def test_explicit_auxiliary_vision_model_overrides_mapping(self, monkeypatch, tmp_path):
+        """When auxiliary.vision.model is explicitly configured, it should be
+        respected over the _PROVIDER_VISION_MODELS mapping (#60381).
+        """
+        # Setup minimal config to avoid import errors
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("model:\n  provider: zai\n  default: zai-pro\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("GLM_API_KEY", "test-key")
+        
+        # Mock the vision support check to return True
+        monkeypatch.setattr(
+            "agent.auxiliary_client._main_model_supports_vision",
+            lambda p, m: True,
+        )
+        
+        # Mock _get_cached_client to return a client and the model it was called with
+        def fake_cached_client(provider, model, *args, **kwargs):
+            # This should be called with glm-4v-flash (from auxiliary.vision.model),
+            # NOT glm-5v-turbo (from _PROVIDER_VISION_MODELS mapping)
+            fake_client = MagicMock(name=f"{provider}_client")
+            return fake_client, model
+        
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client", fake_cached_client,
+        )
+        
+        # Call with explicit model argument (simulates auxiliary.vision.model)
+        provider, client, model = resolve_vision_provider_client(
+            model="glm-4v-flash",
+        )
+        
+        # Verify the explicit model was used
+        assert model == "glm-4v-flash", f"Expected glm-4v-flash, got {model}"
+        # The provider should be zai (from _read_main_provider)
+        assert provider == "zai"
+
     def test_skip_set_covers_exactly_known_entries(self):
         """Guard against accidental widening of the skip list."""
         from agent.auxiliary_client import _PROVIDERS_WITHOUT_VISION


### PR DESCRIPTION
## What does this PR do?

Respects explicitly-configured `auxiliary.vision.model` values over the hardcoded `_PROVIDER_VISION_MODELS` mapping in vision auto-detect mode. When users configure a specific vision model (e.g., `auxiliary.vision.model: glm-4v-flash` for the Zhipu provider), the previous code ignored this and forced the provider's mapped default (e.g., `glm-5v-turbo` for ZAI), causing "model not found" errors when the mapped model doesn't exist on the endpoint the user is targeting. The fix checks if `resolved_model` (from `auxiliary.vision.model`) is explicitly set and not `"auto"`, and uses that instead of applying `_PROVIDER_VISION_MODELS.get(main_provider, main_model)`.


## Related Issue

Fixes #60381


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)


## Changes Made

- `agent/auxiliary_client.py`: In `resolve_vision_provider_client`'s auto-detect branch, check for explicit `auxiliary.vision.model` before applying `_PROVIDER_VISION_MODELS` mapping
- `tests/agent/test_auxiliary_client.py`: Added regression test `test_explicit_auxiliary_vision_model_overrides_mapping`


## How to Test

Run the regression test:
```bash
pytest tests/agent/test_auxiliary_client.py::TestVisionAutoSkipsKimiCoding::test_explicit_auxiliary_vision_model_overrides_mapping -xvs
```

Observed result: Test passes. The test verifies that when `resolve_vision_provider_client(model="glm-4v-flash")` is called with an explicit model argument, the auto-detect path uses that model (assert `model == "glm-4v-flash"`), NOT the mapped default from `_PROVIDER_VISION_MODELS["zai"]` (which is `glm-5v-turbo`).


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_auxiliary_client.py::TestVisionAutoSkipsKimiCoding -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A