### PR TITLE
fix(whatsapp): make group chats observe-only

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -22,6 +22,7 @@ import platform
 import re
 import signal
 import subprocess
+from datetime import datetime, timezone
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
@@ -829,7 +830,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._bridge_process = None
         self._close_bridge_log()
         print(f"[{self.name}] Disconnected")
-    
+
+    def _is_group_chat(self, chat_id: str) -> bool:
+        """True if chat_id is a WhatsApp group (@g.us)."""
+        return str(chat_id or "").strip().lower().endswith("@g.us")
+
     async def send(
         self,
         chat_id: str,
@@ -852,6 +857,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
 
         chat_id = to_whatsapp_jid(chat_id)
+
+        # Read-only in groups: never send outbound messages to group chats.
+        if self._is_group_chat(chat_id):
+            logger.info("[%s] Suppressing outbound message to group %s (read-only)", self.name, chat_id)
+            return SendResult(success=True, message_id=None)
 
         try:
             import aiohttp
@@ -943,6 +953,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """Send any media file via bridge /send-media endpoint."""
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
+        # Read-only in groups: suppress all outbound media to group chats.
+        if self._is_group_chat(chat_id):
+            return SendResult(success=True, message_id=None)
         bridge_exit = await self._check_managed_bridge_exit()
         if bridge_exit:
             return SendResult(success=False, error=bridge_exit)
@@ -997,6 +1010,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
+        if self._is_group_chat(chat_id):
+            return SendResult(success=True, message_id=None)
         bridge_exit = await self._check_managed_bridge_exit()
         if bridge_exit:
             return SendResult(success=False, error=bridge_exit)
@@ -1081,6 +1096,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """Send a native WhatsApp location pin via the Baileys bridge."""
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
+        if self._is_group_chat(chat_id):
+            return SendResult(success=True, message_id=None)
         bridge_exit = await self._check_managed_bridge_exit()
         if bridge_exit:
             return SendResult(success=False, error=bridge_exit)
@@ -1186,6 +1203,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """Send typing indicator via bridge."""
         if not self._running or not self._http_session:
             return
+        if self._is_group_chat(chat_id):
+            return
         if await self._check_managed_bridge_exit():
             return
         
@@ -1249,6 +1268,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     if resp.status == 200:
                         messages = await resp.json()
                         for msg_data in messages:
+                            if self._should_observe_group_message(msg_data):
+                                event = await self._build_message_event(
+                                    msg_data,
+                                    observe_only=True,
+                                )
+                                if event:
+                                    self._observe_group_message(event)
+                                continue
+
                             event = await self._build_message_event(msg_data)
                             if event:
                                 if event.message_type == MessageType.TEXT:
@@ -1266,6 +1294,76 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 await asyncio.sleep(5)
             
             await asyncio.sleep(1)  # Poll interval
+
+    def _should_observe_group_message(self, data: Dict[str, Any]) -> bool:
+        """Return True for allowed WhatsApp groups that should be stored only.
+
+        WhatsApp groups are deliberately read-only for the agent: allowed group
+        messages are absorbed into the transcript as observed context, but never
+        dispatched to ``handle_message`` or text batching.  This is stronger than
+        mention gating: even direct mentions, replies to the bot, slash commands,
+        or free-response group config must not trigger an agent turn.
+        """
+        chat_id = str(data.get("chatId") or "")
+        if not data.get("isGroup", False) and not self._is_group_chat(chat_id):
+            return False
+        if self._is_broadcast_chat(chat_id):
+            return False
+        return self._is_group_allowed(chat_id)
+
+    def _observe_group_message(self, event: MessageEvent) -> None:
+        """Persist a WhatsApp group event as observed context without replying."""
+        store = getattr(self, "_session_store", None)
+        if not store:
+            return
+        try:
+            session_entry = store.get_or_create_session(event.source)
+            message_id = str(event.message_id) if event.message_id else ""
+            if message_id and store.has_platform_message_id(
+                session_entry.session_id,
+                message_id,
+            ):
+                logger.info(
+                    "[%s] Skipping duplicate observed WhatsApp group message: chat=%s message_id=%s",
+                    getattr(self, "name", "whatsapp"),
+                    event.source.chat_id,
+                    message_id,
+                )
+                return
+
+            content = self._observed_group_message_content(event)
+            entry: Dict[str, Any] = {
+                "role": "user",
+                "content": content,
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "observed": True,
+            }
+            if message_id:
+                entry["message_id"] = message_id
+            store.append_to_transcript(session_entry.session_id, entry)
+            logger.info(
+                "[%s] WhatsApp group message observed (no agent turn): chat=%s from=%s",
+                getattr(self, "name", "whatsapp"),
+                event.source.chat_id,
+                event.source.user_id or "unknown",
+            )
+        except Exception as exc:
+            logger.warning(
+                "[%s] Failed to observe WhatsApp group message: %s",
+                getattr(self, "name", "whatsapp"),
+                exc,
+            )
+
+    def _observed_group_message_content(self, event: MessageEvent) -> str:
+        """Human-readable transcript text for a passive WhatsApp group event."""
+        author = event.source.user_name or event.source.user_id or "unknown sender"
+        text = (event.text or "").strip()
+        if not text:
+            media_label = getattr(event.message_type, "value", str(event.message_type)).lower()
+            text = f"[{media_label} received]"
+        if event.media_urls:
+            text = f"{text}\n[Media attachments: {len(event.media_urls)}]"
+        return f"[WhatsApp group observation from {author}] {text}"
 
     # ── Text debounce batching ──────────────────────────────────────
 
@@ -1327,10 +1425,22 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
 
-    async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
-        """Build a MessageEvent from bridge message data, downloading images to cache."""
+    async def _build_message_event(
+        self,
+        data: Dict[str, Any],
+        *,
+        observe_only: bool = False,
+    ) -> Optional[MessageEvent]:
+        """Build a MessageEvent from bridge data, downloading media to cache.
+
+        ``observe_only`` is used for WhatsApp groups that are allowed to be
+        passively absorbed but must never trigger an agent response.
+        """
         try:
-            if not self._should_process_message(data):
+            if observe_only:
+                if not self._should_observe_group_message(data):
+                    return None
+            elif not self._should_process_message(data):
                 return None
 
             # Determine message type
@@ -1353,7 +1463,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     msg_type = MessageType.DOCUMENT
             
             # Determine chat type
-            is_group = data.get("isGroup", False)
+            is_group = data.get("isGroup", False) or self._is_group_chat(data.get("chatId", ""))
             chat_type = "group" if is_group else "dm"
             
             # Build source

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -634,7 +634,10 @@ async function startSocket() {
           } catch {}
           continue;
         }
-        if (WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+        // In bot mode, allow all group messages through — the gateway's
+        // group_policy handles access control. Only apply the allowlist to DMs.
+        // Pairing-mode DMs are also forwarded so the gateway can issue pairing codes.
+        if (!isGroup && WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
           try {
             console.log(JSON.stringify({
               event: 'ignored',

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -290,7 +290,7 @@ class TestBridgeRuntimeFailure:
 
     @pytest.mark.asyncio
     async def test_send_leaves_group_jid_untouched(self):
-        """A fully-qualified group JID must pass through unchanged."""
+        """Group JIDs are read-only: send is suppressed, returns success."""
         adapter = _make_adapter()
         adapter._running = True
         adapter._bridge_process = None
@@ -305,8 +305,8 @@ class TestBridgeRuntimeFailure:
         result = await adapter.send("123456789-987654321@g.us", "hello")
 
         assert result.success is True
-        payload = mock_session.post.call_args.kwargs["json"]
-        assert payload["chatId"] == "123456789-987654321@g.us"
+        # Group sends are suppressed (read-only mode) — no HTTP call made.
+        mock_session.post.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_poll_messages_marks_retryable_fatal_when_managed_bridge_exits(self):

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,5 +1,8 @@
 import json
-from unittest.mock import AsyncMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
@@ -414,3 +417,127 @@ def test_is_broadcast_chat_helper_recognizes_common_jids():
     assert WhatsAppAdapter._is_broadcast_chat("120363001234567890@g.us") is False
     assert WhatsAppAdapter._is_broadcast_chat("") is False
     assert WhatsAppAdapter._is_broadcast_chat(None) is False  # type: ignore[arg-type]
+
+
+def test_group_jid_is_observed_even_if_bridge_omits_is_group_flag():
+    adapter = _make_adapter(group_policy="open", require_mention=False)
+    data = _group_message("jid-only group")
+    data.pop("isGroup")
+
+    assert adapter._should_observe_group_message(data) is True
+
+
+class _AsyncCM:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_allowed_group_messages_are_observed_even_without_response_trigger():
+    adapter = _make_adapter(
+        group_policy="open",
+        require_mention=True,
+        mention_patterns=[r"^\s*agus\b"],
+    )
+    data = _group_message("ordinary family chatter")
+
+    # Old response-trigger policy says this should not be answered.  The new
+    # observe-only policy is broader: allowed groups are still absorbed as
+    # context even when they do not mention the bot.
+    assert adapter._should_process_message(data) is False
+    assert adapter._should_observe_group_message(data) is True
+
+    event = await adapter._build_message_event(data, observe_only=True)
+
+    assert event is not None
+    assert event.source.chat_type == "group"
+    assert event.text == "ordinary family chatter"
+
+
+@pytest.mark.asyncio
+async def test_poll_observes_whatsapp_group_without_dispatching_agent(monkeypatch):
+    adapter = _make_adapter(group_policy="open", require_mention=False)
+    adapter._running = True
+    adapter._bridge_port = 19876
+    adapter._http_session = MagicMock()
+    adapter._check_managed_bridge_exit = AsyncMock(return_value=None)
+    adapter._observe_group_message = MagicMock()
+    adapter._enqueue_text_event = MagicMock()
+    adapter.handle_message = AsyncMock()
+
+    response = MagicMock()
+    response.status = 200
+    response.json = AsyncMock(return_value=[_group_message("please do not answer this")])
+    adapter._http_session.get = MagicMock(return_value=_AsyncCM(response))
+
+    async def stop_after_iteration(_delay):
+        adapter._running = False
+
+    monkeypatch.setattr("plugins.platforms.whatsapp.adapter.asyncio.sleep", stop_after_iteration)
+
+    await adapter._poll_messages()
+
+    adapter._observe_group_message.assert_called_once()
+    adapter._enqueue_text_event.assert_not_called()
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_observed_whatsapp_group_message_is_persisted_as_observed_context():
+    adapter = _make_adapter(group_policy="open", require_mention=False)
+    event = await adapter._build_message_event(
+        _group_message(
+            "dinner moved to 7",
+            senderId="447700900123@s.whatsapp.net",
+            senderName="Jenny",
+            messageId="wamid-1",
+        ),
+        observe_only=True,
+    )
+    store = MagicMock()
+    store.get_or_create_session.return_value = SimpleNamespace(session_id="session-1")
+    store.has_platform_message_id.return_value = False
+    adapter._session_store = store
+
+    adapter._observe_group_message(event)
+
+    store.get_or_create_session.assert_called_once_with(event.source)
+    store.has_platform_message_id.assert_called_once_with("session-1", "wamid-1")
+    store.append_to_transcript.assert_called_once()
+    _, entry = store.append_to_transcript.call_args.args
+    assert entry["role"] == "user"
+    assert entry["observed"] is True
+    assert entry["message_id"] == "wamid-1"
+    assert "WhatsApp group observation from Jenny" in entry["content"]
+    assert "dinner moved to 7" in entry["content"]
+
+
+def test_duplicate_observed_whatsapp_group_message_is_not_repersisted():
+    adapter = _make_adapter(group_policy="open", require_mention=False)
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    event = MessageEvent(
+        text="already seen",
+        message_type=MessageType.TEXT,
+        source=adapter.build_source(
+            chat_id="120363001234567890@g.us",
+            chat_type="group",
+            user_id="447700900123@s.whatsapp.net",
+            user_name="Jenny",
+        ),
+        message_id="wamid-dupe",
+    )
+    store = MagicMock()
+    store.get_or_create_session.return_value = SimpleNamespace(session_id="session-1")
+    store.has_platform_message_id.return_value = True
+    adapter._session_store = store
+
+    adapter._observe_group_message(event)
+
+    store.append_to_transcript.assert_not_called()

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -225,6 +225,19 @@ gateway:
 
 Set `text_batch_delay_seconds: 0` to dispatch each message immediately (disables batching).
 
+### Group chats are observe-only
+
+For the Baileys bridge, WhatsApp group chats are intentionally **read-only** for the agent. If a group passes `group_policy` / `group_allow_from`, Hermes stores inbound group messages in the session transcript as passive `observed` context, but it does **not** dispatch them to the agent and does **not** generate a reply. This applies even when a group message mentions the bot, replies to a previous bot message, starts with a slash command, or matches `require_mention` / `mention_patterns` / `free_response_chats` settings.
+
+This design lets the agent retain useful life/context signals from allowed groups without risking an automated response into a multi-person chat. The outbound send path also suppresses group JIDs as a defense-in-depth fallback, but the primary guard is inbound: group messages should be absorbed before any agent turn is started.
+
+To fully disable group ingestion rather than observe it, set:
+
+```yaml
+whatsapp:
+  group_policy: disabled
+```
+
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- observe allowed WhatsApp group messages as passive transcript context instead of dispatching an agent turn
- suppress all outbound WhatsApp group sends as a defense-in-depth fallback
- allow bridge group intake while leaving DM allowlist enforcement intact
- document group observe-only semantics in the WhatsApp guide

## Test plan
- python -m pytest tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_whatsapp_connect.py -q
- python -m pytest tests/gateway/test_whatsapp*.py -q
- python -m py_compile plugins/platforms/whatsapp/adapter.py gateway/platforms/whatsapp_common.py

## Deployment verification
- installed PA gateway as launchd service: ai.hermes.gateway-pa
- verified service command: hermes_cli.main --profile pa gateway run --replace
- verified WhatsApp bridge process uses the PA profile session directory
