### PR TITLE
fix(cli): improve light terminal body contrast

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2264,6 +2264,16 @@ def _maybe_remap_for_light_mode(hex_color: str) -> str:
 _LIGHT_MODE_REMAP_UPPER = {k.upper(): v for k, v in _LIGHT_MODE_REMAP.items()}
 
 
+def _readable_body_hex(hex_color: str) -> str:
+    """Readable Hermes-toned foreground for long body text.
+
+    Preserve custom skin body colors, but replace the default dark-theme
+    cornsilk with a darker warm color that remains visible on light terminals
+    without changing the rest of the theme chrome (#60141).
+    """
+    return "#7A5A0F" if (hex_color or "").upper() == "#FFF8DC" else hex_color
+
+
 def _install_skin_light_mode_hook() -> None:
     """Wrap SkinConfig.get_color at import time so EVERY skin color read goes
     through the light-mode remap.  Idempotent."""
@@ -5770,12 +5780,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 from hermes_cli.skin_engine import get_active_skin
                 _skin = get_active_skin()
                 label = _skin.get_branding("response_label", "⚕ Hermes")
-                _text_hex = _skin.get_color("banner_text", "#FFF8DC")
+                _text_hex = _readable_body_hex(_skin.get_color("banner_text", "#FFF8DC"))
             except Exception:
                 label = "⚕ Hermes"
-                _text_hex = "#FFF8DC"
-            # Build a true-color ANSI escape for the response text color
-            # so streamed content matches the Rich Panel appearance.
+                _text_hex = "#7A5A0F"
+            # Keep custom skin body colors, but replace the default dark-theme
+            # cornsilk with a darker Hermes-toned body color that remains
+            # visible on light Terminal.app profiles (#60141).
             try:
                 _r = int(_text_hex[1:3], 16)
                 _g = int(_text_hex[3:5], 16)
@@ -12577,11 +12588,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     _skin = get_active_skin()
                     label = _skin.get_branding("response_label", "⚕ Hermes")
                     _resp_color = _maybe_remap_for_light_mode(_skin.get_color("response_border", "#CD7F32"))
-                    _resp_text = _maybe_remap_for_light_mode(_skin.get_color("banner_text", "#FFF8DC"))
+                    _resp_text = _readable_body_hex(_skin.get_color("banner_text", "#FFF8DC"))
                 except Exception:
                     label = "⚕ Hermes"
                     _resp_color = _maybe_remap_for_light_mode("#CD7F32")
-                    _resp_text = _maybe_remap_for_light_mode("#FFF8DC")
+                    _resp_text = "#7A5A0F"
 
                 is_error_response = result and (result.get("failed") or result.get("partial"))
                 already_streamed = self._stream_started and self._stream_box_opened and not is_error_response
@@ -13075,7 +13086,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             _welcome_text = "Welcome to Hermes Agent! Type your message or /help for commands."
             _welcome_color = "#FFF8DC"
-        self._console_print(f"[{_welcome_color}]{_welcome_text}[/]")
+        self._console_print(f"[{_welcome_color}]{_escape(_welcome_text)}[/]")
 
         # Warm the /model picker's provider-models cache off-thread during this
         # idle window (banner shown, user about to type). The no-args picker

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -55,6 +55,13 @@ def _skin_color(key: str, fallback: str) -> str:
         return get_active_skin().get_color(key, fallback)
     except Exception:
         return fallback
+
+
+def _banner_body_color(dim_color: str) -> str:
+    """Use a readable Hermes-toned body color without changing theme chrome."""
+    return "#7A5A0F" if dim_color.upper() == "#B8860B" else dim_color
+
+
 # =========================================================================
 # ASCII Art & Branding
 # =========================================================================
@@ -601,6 +608,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
             bare model slug.
     """
     from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
+    from rich.markup import escape as _escape
     from rich.panel import Panel
     from rich.table import Table
     if get_toolset_for_tool is None:
@@ -643,7 +651,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
     # Resolve skin colors once for the entire banner
     accent = _skin_color("banner_accent", "#FFBF00")
     dim = _skin_color("banner_dim", "#B8860B")
-    text = _skin_color("banner_text", "#FFF8DC")
+    body = _banner_body_color(dim)
     session_color = _skin_color("session_border", "#8B8682")
 
     # Use skin's custom caduceus art if provided
@@ -723,7 +731,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
             elif name in lazy_tools:
                 colored_names.append(f"[yellow]{name}[/]")
             else:
-                colored_names.append(f"[{text}]{name}[/]")
+                colored_names.append(f"[{body}]{_escape(name)}[/]")
 
         tools_str = ", ".join(colored_names)
         if len(", ".join(sorted(tool_names))) > 45:
@@ -744,7 +752,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
                 elif name in lazy_tools:
                     colored_names.append(f"[yellow]{name}[/]")
                 else:
-                    colored_names.append(f"[{text}]{name}[/]")
+                    colored_names.append(f"[{body}]{_escape(name)}[/]")
             tools_str = ", ".join(colored_names)
 
         right_lines.append(f"[dim {dim}]{toolset}:[/] {tools_str}")
@@ -766,8 +774,8 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
             status = srv.get("status")
             if srv["connected"]:
                 right_lines.append(
-                    f"[dim {dim}]{srv['name']}[/] [{text}]({srv['transport']})[/] "
-                    f"[dim {dim}]—[/] [{text}]{srv['tools']} tool(s)[/]"
+                    f"[dim {dim}]{_escape(str(srv['name']))}[/] [{body}]({_escape(str(srv['transport']))})[/] "
+                    f"[dim {dim}]—[/] [{body}]{_escape(str(srv['tools']))} tool(s)[/]"
                 )
             elif srv.get("disabled") or status == "disabled":
                 right_lines.append(
@@ -832,7 +840,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
                 parts.append(name)
                 length += _needed
             skills_str = ", ".join(parts)
-            right_lines.append(f"[dim {dim}]{category}:[/] [{text}]{skills_str}[/]")
+            right_lines.append(f"[dim {dim}]{_escape(category)}:[/] [{body}]{_escape(skills_str)}[/]")
     else:
         right_lines.append(f"[dim {dim}]No skills installed[/]")
 
@@ -850,7 +858,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
         from hermes_cli.config import load_config as _load_cfg
         if get_current_runtime(_load_cfg()) == "codex_app_server":
             right_lines.append(
-                f"[bold {accent}]Runtime:[/] [{text}]codex app-server[/] "
+                f"[bold {accent}]Runtime:[/] [{body}]codex app-server[/] "
                 f"[dim {dim}](terminal/file ops/MCP run inside codex)[/]"
             )
     except Exception:
@@ -860,7 +868,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
         from hermes_cli.profiles import get_active_profile_name
         _profile_name = get_active_profile_name()
         if _profile_name and _profile_name != "default":
-            right_lines.append(f"[bold {accent}]Profile:[/] [{text}]{_profile_name}[/]")
+            right_lines.append(f"[bold {accent}]Profile:[/] [{body}]{_escape(_profile_name)}[/]")
     except Exception:
         pass  # Never break the banner over a profiles.py bug
 

--- a/tests/cli/test_stream_delta_think_tag.py
+++ b/tests/cli/test_stream_delta_think_tag.py
@@ -42,6 +42,38 @@ def _make_cli_stub():
     return cli
 
 
+def test_stream_response_body_uses_readable_hermes_foreground(monkeypatch):
+    """The streamed response body must not force dark-theme cornsilk text.
+
+    On light Terminal.app backgrounds that color is nearly invisible. The
+    response border/label can stay themed; the body should use a darker Hermes
+    foreground.
+    """
+    import cli as cli_mod
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.show_reasoning = False
+    cli.show_timestamps = False
+    cli._stream_buf = ""
+    cli._stream_box_opened = False
+    cli._stream_text_ansi = ""
+    cli._stream_table_buf = []
+    cli._in_stream_table = False
+    cli.final_response_markdown = "strip"
+    cli._scrollback_box_width = lambda: 80
+    cli._close_reasoning_box = lambda: None
+    emitted = []
+
+    monkeypatch.setattr(cli_mod, "_cprint", lambda text: emitted.append(text))
+
+    HermesCLI._emit_stream_text(cli, "Hello from Hermes\n")
+
+    assert cli._stream_box_opened is True
+    assert cli._stream_text_ansi == "\033[38;2;122;90;15m"
+    assert "Hello from Hermes" in "".join(emitted)
+
+
 class TestThinkTagInProse:
     """<think> mentioned in prose should NOT trigger reasoning suppression."""
 

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -70,6 +70,39 @@ def test_build_welcome_banner_uses_normalized_toolset_names():
     assert "web_tools:" not in output
 
 
+def test_build_welcome_banner_does_not_force_cornsilk_on_body_text():
+    """Banner body text should use readable Hermes-toned foreground.
+
+    The Hermes gold/amber chrome stays themed, but long text and lists must not
+    use the dark-theme cornsilk foreground because it disappears on light
+    Terminal.app backgrounds.
+    """
+    import io
+
+    with (
+        patch.object(model_tools, "check_tool_availability", return_value=(["file", "skills"], [])),
+        patch.object(banner, "get_available_skills", return_value={"general": ["dogfood"]}),
+        patch.object(banner, "get_update_result", return_value=None),
+        patch.object(tools.mcp_tool, "get_mcp_status", return_value=[]),
+        patch.object(banner, "get_latest_release_tag", return_value=None),
+    ):
+        buf = io.StringIO()
+        console = Console(file=buf, force_terminal=True, color_system="truecolor", width=160)
+        banner.build_welcome_banner(
+            console=console,
+            model="anthropic/test-model",
+            cwd="/tmp/project",
+            tools=[{"function": {"name": "read_file"}}],
+            enabled_toolsets=["file", "skills"],
+            get_toolset_for_tool=lambda name: "file",
+        )
+
+    raw = buf.getvalue()
+    assert "read_file" in raw
+    assert "dogfood" in raw
+    assert "\x1b[38;2;255;248;220m" not in raw
+
+
 def test_build_welcome_banner_title_is_hyperlinked_to_release():
     """Panel title (version label) is wrapped in an OSC-8 hyperlink to the GitHub release."""
     import io


### PR DESCRIPTION
## Summary
- keep Hermes gold/amber chrome unchanged while avoiding dark-theme cornsilk for long body/list text on light terminals
- use a darker Hermes-toned foreground for banner tool/skill body text and assistant response body text
- escape welcome/banner dynamic text without changing the standalone welcome color path

Fixes #60141.
Originated from NVIDIA/NemoClaw#6380.

## Validation
- `uv run python -m py_compile cli.py hermes_cli/banner.py tests/cli/test_stream_delta_think_tag.py tests/hermes_cli/test_banner.py`
- direct streaming smoke: `_emit_stream_text()` uses `\033[38;2;122;90;15m` (`#7A5A0F`) and emits response text
- direct banner smoke: rendered banner includes body text and does not emit cornsilk ANSI (`\x1b[38;2;255;248;220m`)

## Known local test issue
- `uv run python -m pytest tests/cli/test_stream_delta_think_tag.py::test_stream_response_body_uses_readable_hermes_foreground tests/hermes_cli/test_banner.py::test_build_welcome_banner_does_not_force_cornsilk_on_body_text -q` exits 139 in this checkout before producing pytest output. The direct smoke checks above cover the changed behavior locally.
