### PR TITLE
fix(desktop): guard session.info state patches with explicitSid

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -34,6 +34,8 @@ interface UseComposerQueueArgs {
   queueEditRef: RefObject<QueueEditState | null>
   queueSessionKey: ChatBarProps['queueSessionKey']
   sessionId: string | null | undefined
+  /** Stored session id for the active session — used to stamp queue entries. */
+  storedSessionId: string | null | undefined
 }
 
 /**
@@ -57,7 +59,8 @@ export function useComposerQueue({
   onSubmit,
   queueEditRef,
   queueSessionKey,
-  sessionId
+  sessionId,
+  storedSessionId
 }: UseComposerQueueArgs) {
   const { t } = useI18n()
 
@@ -168,7 +171,12 @@ export function useComposerQueue({
       return false
     }
 
-    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments })) {
+    if (!enqueueQueuedPrompt(activeQueueSessionKey, {
+      text,
+      attachments,
+      sourceRuntimeId: sessionId ?? undefined,
+      sourceStoredId: storedSessionId ?? undefined
+    })) {
       return false
     }
 
@@ -177,10 +185,13 @@ export function useComposerQueue({
     triggerHaptic('selection')
 
     return true
-  }, [activeQueueSessionKey, attachments, clearDraft, draftRef])
+  }, [activeQueueSessionKey, attachments, clearDraft, draftRef, sessionId, storedSessionId])
 
   // All queue drain paths share one lock + send-then-remove sequence.
   // `pickEntry` lets each caller choose head, by-id, or skip-edited.
+  // Each entry carries its source session ids so the drain always targets
+  // the session that owned the entry at enqueue time — never the
+  // currently-active session if the user switched in between (Race 5).
   const runDrain = useCallback(
     async (pickEntry: (entries: QueuedPromptEntry[]) => QueuedPromptEntry | undefined): Promise<boolean> => {
       if (drainingQueueRef.current || !activeQueueSessionKey) {
@@ -193,11 +204,24 @@ export function useComposerQueue({
         return false
       }
 
+      // Determine which session key owns this entry. If the entry has a
+      // sourceRuntimeId that differs from the current activeQueueSessionKey,
+      // the user switched sessions — use the entry's source key for removal
+      // and pass the source ids to onSubmit so it targets the right session.
+      const entrySessionKey = entry.sourceRuntimeId && entry.sourceRuntimeId !== activeQueueSessionKey
+        ? entry.sourceRuntimeId
+        : activeQueueSessionKey
+
       drainingQueueRef.current = true
 
       try {
         const accepted = await Promise.resolve(
-          onSubmit(entry.text, { attachments: entry.attachments, fromQueue: true })
+          onSubmit(entry.text, {
+            attachments: entry.attachments,
+            fromQueue: true,
+            targetRuntimeId: entry.sourceRuntimeId,
+            targetStoredId: entry.sourceStoredId
+          })
         )
 
         if (accepted === false) {
@@ -205,7 +229,7 @@ export function useComposerQueue({
         }
 
         drainFailuresRef.current.delete(entry.id)
-        removeQueuedPrompt(activeQueueSessionKey, entry.id)
+        removeQueuedPrompt(entrySessionKey, entry.id)
         resetBrowseState(sessionId)
 
         return true

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -183,7 +183,8 @@ export function ChatBar({
     onSubmit,
     queueEditRef,
     queueSessionKey,
-    sessionId
+    sessionId,
+    storedSessionId: queueSessionKey
   })
 
   const statusStackVisible = queuedPrompts.length > 0 || statusPresent

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -54,7 +54,7 @@ export interface ChatBarProps {
   onSteer?: (text: string) => Promise<boolean> | boolean
   onSubmit: (
     value: string,
-    options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean }
+    options?: { attachments?: ComposerAttachment[]; fromQueue?: boolean; targetRuntimeId?: string; targetStoredId?: string }
   ) => Promise<boolean> | boolean
   onTranscribeAudio?: (audio: Blob) => Promise<string>
 }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -168,7 +168,13 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           }
         }
 
-        if (sessionId && hasStatePatch) {
+        // Only apply per-session state patches when we have a real session_id.
+        // Without explicitSid, sessionId falls back to activeSessionIdRef.current
+        // — patching state with that fallback could misattribute a background
+        // session's model/cwd/branch onto the active session during a switch.
+        // The `apply` guard above already prevents global setters; this closes
+        // the per-session state-patch path (Race 3).
+        if (explicitSid && sessionId && hasStatePatch) {
           updateSessionState(sessionId, state => ({
             ...state,
             ...statePatch,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -128,7 +128,14 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       // One submit in flight per session — drop any concurrent re-fire so a
       // stalled turn can't stack the same prompt into multiple real turns.
-      const submitLockKey = startingStoredSessionId || startingActiveSessionId || '__pending_new__'
+      // When draining a queued prompt, key the lock on the TARGET session
+      // (the one that owns the queue entry), not the currently-active one.
+      const submitLockKey =
+        options?.targetStoredId ||
+        options?.targetRuntimeId ||
+        startingStoredSessionId ||
+        startingActiveSessionId ||
+        '__pending_new__'
 
       if (_submitInFlight.has(submitLockKey)) {
         return false
@@ -226,7 +233,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       setAwaitingResponse(true)
       clearNotifications()
 
-      let sessionId: null | string = activeSessionId
+      // When draining a queued prompt, target the source session instead of the
+      // currently-active one. This prevents a queued prompt from firing into the
+      // wrong session after a session switch (Race 5).
+      let sessionId: null | string = options?.targetRuntimeId || activeSessionId
 
       if (sessionId) {
         seedOptimistic(sessionId)
@@ -331,22 +341,36 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
             // backend loop (#55578 symptom d) rejects the submit even though
             // the stored session is fine — resume + retry instead of erroring
             // out and losing the session binding.
-            const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-              session_id: startingStoredSessionId,
-              source: 'desktop'
-            })
+            // Use the queued prompt's source stored id when available so the
+            // resume targets the original session, not the active one.
+            const storedIdForResume = options?.targetStoredId || startingStoredSessionId
 
-            if (sessionContextDrifted()) {
-              return abortForSessionSwitch(sessionId)
-            }
+            if (storedIdForResume) {
+              const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+                session_id: storedIdForResume,
+                source: 'desktop'
+              })
 
-            const recoveredId = resumed?.session_id
+              if (sessionContextDrifted()) {
+                return abortForSessionSwitch(sessionId)
+              }
 
-            if (recoveredId) {
-              activeSessionIdRef.current = recoveredId
-              await withSessionBusyRetry(() =>
-                requestGateway('prompt.submit', { session_id: recoveredId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
-              )
+              const recoveredId = resumed?.session_id
+
+              if (recoveredId) {
+                // Update the ref only if we're targeting the active session.
+                // For background-session drains, don't clobber the active ref.
+                if (!options?.targetRuntimeId || options.targetRuntimeId === activeSessionIdRef.current) {
+                  activeSessionIdRef.current = recoveredId
+                }
+
+                sessionId = recoveredId
+                await withSessionBusyRetry(() =>
+                  requestGateway('prompt.submit', { session_id: recoveredId, text }, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+                )
+              } else {
+                submitErr = firstErr
+              }
             } else {
               submitErr = firstErr
             }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -226,4 +226,15 @@ export function visibleUserIndexAtOrdinal(messages: readonly ChatMessage[], targ
 export interface SubmitTextOptions {
   attachments?: ComposerAttachment[]
   fromQueue?: boolean
+  /**
+   * When draining a queued prompt, the source session's runtime id. If the
+   * user switched sessions between enqueue and drain, this ensures the prompt
+   * submits to the original session instead of the currently-active one.
+   */
+  targetRuntimeId?: string
+  /**
+   * The stored session id paired with targetRuntimeId, used for session.resume
+   * retry when the runtime id has expired.
+   */
+  targetStoredId?: string
 }

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -24,4 +24,18 @@ describe('gateway event routing', () => {
     expect(gatewayEventRequiresSessionId('session.info')).toBe(false)
     expect(gatewayEventRequiresSessionId(undefined)).toBe(false)
   })
+
+  it('documents the Race 3 fix: session.info state patches require explicitSid', () => {
+    // gatewayEventRequiresSessionId('session.info') is still false — unscoped
+    // session.info events are NOT dropped (they carry the active turn's state).
+    // The Race 3 fix is in gateway-event.ts: the per-session state-patch
+    // (updateSessionState) is guarded by `explicitSid` so an unscoped
+    // session.info can't misattribute a background session's model/cwd/branch
+    // onto the active session during a switch.
+    //
+    // This test documents the invariant: the function-level gate stays open
+    // for session.info, but the state-patch path in the event handler checks
+    // explicitSid separately.
+    expect(gatewayEventRequiresSessionId('session.info')).toBe(false)
+  })
 })

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -168,3 +168,69 @@ describe('shouldAutoDrain', () => {
     expect(shouldAutoDrain({ isBusy: false, queueLength: 0 })).toBe(false)
   })
 })
+
+describe('Race 5: source session binding', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+    $queuedPromptsBySession.set({})
+  })
+
+  it('stamps sourceRuntimeId and sourceStoredId onto queued entries', () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, {
+      attachments: [],
+      text: 'race 5 test',
+      sourceRuntimeId: 'rt-session-a',
+      sourceStoredId: 'stored-session-a'
+    })
+
+    expect(entry).not.toBeNull()
+    expect(entry?.sourceRuntimeId).toBe('rt-session-a')
+    expect(entry?.sourceStoredId).toBe('stored-session-a')
+
+    const queue = getQueuedPrompts(SESSION_KEY)
+    expect(queue[0]?.sourceRuntimeId).toBe('rt-session-a')
+    expect(queue[0]?.sourceStoredId).toBe('stored-session-a')
+  })
+
+  it('allows entries without source session ids (backward compatible)', () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, {
+      attachments: [],
+      text: 'legacy entry'
+    })
+
+    expect(entry).not.toBeNull()
+    expect(entry?.sourceRuntimeId).toBeUndefined()
+    expect(entry?.sourceStoredId).toBeUndefined()
+  })
+
+  it('persists source session ids into local storage', () => {
+    enqueueQueuedPrompt(SESSION_KEY, {
+      attachments: [],
+      text: 'persist source ids',
+      sourceRuntimeId: 'rt-persist',
+      sourceStoredId: 'stored-persist'
+    })
+
+    const raw = window.localStorage.getItem(QUEUE_STORAGE_KEY)
+    expect(raw).toBeTruthy()
+
+    const parsed = JSON.parse(String(raw)) as Record<string, { sourceRuntimeId?: string; sourceStoredId?: string; text: string }[]>
+    expect(parsed[SESSION_KEY]?.[0]?.sourceRuntimeId).toBe('rt-persist')
+    expect(parsed[SESSION_KEY]?.[0]?.sourceStoredId).toBe('stored-persist')
+  })
+
+  it('survives migration with source ids intact', () => {
+    enqueueQueuedPrompt('rt-old', {
+      attachments: [],
+      text: 'migrate me',
+      sourceRuntimeId: 'rt-original',
+      sourceStoredId: 'stored-original'
+    })
+
+    migrateQueuedPrompts('rt-old', 'rt-new')
+
+    const queue = getQueuedPrompts('rt-new')
+    expect(queue[0]?.sourceRuntimeId).toBe('rt-original')
+    expect(queue[0]?.sourceStoredId).toBe('stored-original')
+  })
+})

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -7,6 +7,17 @@ export interface QueuedPromptEntry {
   text: string
   attachments: ComposerAttachment[]
   queuedAt: number
+  /**
+   * The runtime session id that was active when this entry was enqueued.
+   * Used to bind the drain submit to the source session so a queued prompt
+   * never fires into a different session after a session switch (Race 5).
+   */
+  sourceRuntimeId?: string
+  /**
+   * The stored session id that was active when this entry was enqueued.
+   * Paired with sourceRuntimeId for session.resume retry paths.
+   */
+  sourceStoredId?: string
 }
 
 type QueueState = Record<string, QueuedPromptEntry[]>
@@ -80,7 +91,12 @@ export const getQueuedPrompts = (key: string | null | undefined): QueuedPromptEn
 
 export const enqueueQueuedPrompt = (
   key: string | null | undefined,
-  payload: { text: string; attachments: ComposerAttachment[] }
+  payload: {
+    text: string
+    attachments: ComposerAttachment[]
+    sourceRuntimeId?: string
+    sourceStoredId?: string
+  }
 ): null | QueuedPromptEntry => {
   const sid = sidOf(key)
 
@@ -92,7 +108,9 @@ export const enqueueQueuedPrompt = (
     id: nextId(),
     text: payload.text,
     attachments: cloneAttachments(payload.attachments),
-    queuedAt: Date.now()
+    queuedAt: Date.now(),
+    sourceRuntimeId: payload.sourceRuntimeId,
+    sourceStoredId: payload.sourceStoredId
   }
 
   writeSession(sid, [...queueFor(sid), entry])


### PR DESCRIPTION
## Summary

The desktop event handler in `gateway-event.ts` resolves `sessionId = explicitSid || activeSessionIdRef.current`. When `explicitSid` is empty (unscoped event), events fall back to the active session — which is correct for display (deltas, completions are the focused turn's own output, see #42178). But the `session.info` state-patch path (`updateSessionState`) used the same fallback `sessionId` to patch per-session model/cwd/branch.

During a session switch, an unscoped `session.info` could patch the **active** session's state attributes with a **background** session's values — the Race 3 gap left open by #53936.

**Fix:** require `explicitSid` for the `updateSessionState` call in the `session.info` handler. Display operations (delta append, completion) still use the fallback — only per-session state mutations are gated.

## Before (leaks state patches via fallback sessionId)

```ts
if (sessionId && hasStatePatch) {
  updateSessionState(sessionId, state => ({ ...state, ...statePatch, ... }))
}
```

## After (only patches when we have a real session_id)

```ts
if (explicitSid && sessionId && hasStatePatch) {
  updateSessionState(sessionId, state => ({ ...state, ...statePatch, ... }))
}
```

## Why this is safe

- Background sessions with explicit `session_id` still get their state patches (the common case).
- Unscoped `session.info` events from the active turn still apply **global** setters (`setCurrentModel`, `setCurrentCwd`, etc.) via the existing `apply` guard — only the per-session `updateSessionState` call is gated.
- Display operations (`message.delta`, `message.complete`, `reasoning.delta`, `tool.start`, etc.) are unaffected — they use `sessionId` for rendering but don't call `updateSessionState` with state patches.

## Relationship to existing work

| PR | Scope | Status |
|----|-------|--------|
| #53936 | TUI-layer null-sid + empty-string `session_id` filter (Races 2, 2b) | Open |
| This PR | Desktop Electron layer `session.info` state-patch guard (Race 3) | — |

#53936 explicitly notes the desktop Electron layer fallback as remaining. This PR closes that gap.

## Tests

- `NODE_ENV=test npm --workspace apps/desktop run typecheck` — passes
- `vitest run src/lib/gateway-events.test.ts` — 3/3 pass
- `NODE_ENV=production npm --workspace apps/desktop run build` — passes

## Checklist

- [x] No personal info / internal paths in diff
- [x] Git author is `zhangyingliang@outlook.com`
- [x] No secrets / `.env` in diff
