### PR TITLE
fix(docker): sanitize non-C Windows drive cwd

### DIFF
--- a/tests/tools/test_container_cwd_sanitize.py
+++ b/tests/tools/test_container_cwd_sanitize.py
@@ -27,6 +27,12 @@ class TestIsUnusableContainerCwd:
         assert tt._is_unusable_container_cwd(r"C:\Users\someuser") is True
 
 
+    def test_windows_non_c_backslash_host_path_rejected(self):
+        assert tt._is_unusable_container_cwd(r"E:\SomeRoot\project") is True
+
+    def test_windows_non_c_forwardslash_host_path_rejected(self):
+        assert tt._is_unusable_container_cwd("D:/SomeRoot/project") is True
+
     def test_posix_home_host_path_rejected(self):
         assert tt._is_unusable_container_cwd("/home/ben/projects") is True
 
@@ -35,6 +41,30 @@ class TestIsUnusableContainerCwd:
         assert tt._CONTAINER_BACKENDS == frozenset(
             {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
         )
+
+
+class TestGetEnvConfigWindowsDriveCwd:
+    def test_non_c_windows_host_cwd_replaced_for_docker_by_default(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CWD", r"E:\SomeRoot\project")
+        monkeypatch.delenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", raising=False)
+
+        config = tt._get_env_config()
+
+        assert config["cwd"] == "/root"
+        assert config["host_cwd"] is None
+        assert config["docker_mount_cwd_to_workspace"] is False
+
+    def test_non_c_windows_host_cwd_maps_to_workspace_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CWD", r"E:\SomeRoot\project")
+        monkeypatch.setenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "true")
+
+        config = tt._get_env_config()
+
+        assert config["cwd"] == "/workspace"
+        assert config["host_cwd"] == r"E:\SomeRoot\project"
+        assert config["docker_mount_cwd_to_workspace"] is True
 
 
 class TestOverrideCwdSanitizedAtCallSite:
@@ -107,6 +137,9 @@ class TestOverrideCwdSanitizedAtCallSite:
             "It must be sanitized back to config['cwd']."
         )
 
+    def test_non_c_windows_host_override_does_not_reach_container(self, monkeypatch):
+        cwd = self._run_and_capture_cwd(monkeypatch, r"E:\SomeRoot\project")
+        assert cwd == "/root"
 
     def test_valid_container_override_is_preserved(self, monkeypatch):
         # RL/benchmark envs set an in-container path; it must pass through.
@@ -197,6 +230,9 @@ class TestFileOpsCwdSanitizedAtCallSite:
             "It must be sanitized back to config['cwd']."
         )
 
+    def test_non_c_windows_host_override_does_not_reach_container(self, monkeypatch):
+        cwd = self._run_and_capture_cwd(monkeypatch, r"E:\SomeRoot\project")
+        assert cwd == "/workspace"
 
     def test_valid_container_override_is_preserved(self, monkeypatch):
         # RL/benchmark envs set an in-container path; it must pass through.

--- a/tests/tools/test_container_cwd_sanitize.py
+++ b/tests/tools/test_container_cwd_sanitize.py
@@ -17,7 +17,31 @@ Both paths now share ``_is_unusable_container_cwd()``; these tests pin its
 behaviour so neither path can regress.
 """
 
+import ntpath
+
+import pytest
+
 import tools.terminal_tool as tt
+
+
+@pytest.fixture
+def emulate_windows_drive_isabs(monkeypatch):
+    """Give drive-letter samples native-Windows ``isabs()`` semantics.
+
+    CI normally runs this file on POSIX, where ``os.path.isabs('E:\\...')`` is
+    false and the legacy relative-path guard would reject the sample even
+    without the Windows-drive fix. Keep POSIX semantics for Linux-container
+    paths such as ``/root`` while using ``ntpath`` for drive-letter inputs.
+    """
+    host_isabs = tt.os.path.isabs
+    windows_isabs = ntpath.isabs
+
+    def isabs(path):
+        if ntpath.splitdrive(path)[0]:
+            return windows_isabs(path)
+        return host_isabs(path)
+
+    monkeypatch.setattr(tt.os.path, "isabs", isabs)
 
 
 class TestIsUnusableContainerCwd:
@@ -27,10 +51,14 @@ class TestIsUnusableContainerCwd:
         assert tt._is_unusable_container_cwd(r"C:\Users\someuser") is True
 
 
-    def test_windows_non_c_backslash_host_path_rejected(self):
+    def test_windows_non_c_backslash_host_path_rejected(
+        self, emulate_windows_drive_isabs
+    ):
         assert tt._is_unusable_container_cwd(r"E:\SomeRoot\project") is True
 
-    def test_windows_non_c_forwardslash_host_path_rejected(self):
+    def test_windows_non_c_forwardslash_host_path_rejected(
+        self, emulate_windows_drive_isabs
+    ):
         assert tt._is_unusable_container_cwd("D:/SomeRoot/project") is True
 
     def test_posix_home_host_path_rejected(self):
@@ -44,7 +72,9 @@ class TestIsUnusableContainerCwd:
 
 
 class TestGetEnvConfigWindowsDriveCwd:
-    def test_non_c_windows_host_cwd_replaced_for_docker_by_default(self, monkeypatch):
+    def test_non_c_windows_host_cwd_replaced_for_docker_by_default(
+        self, monkeypatch, emulate_windows_drive_isabs
+    ):
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         monkeypatch.setenv("TERMINAL_CWD", r"E:\SomeRoot\project")
         monkeypatch.delenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", raising=False)
@@ -55,7 +85,9 @@ class TestGetEnvConfigWindowsDriveCwd:
         assert config["host_cwd"] is None
         assert config["docker_mount_cwd_to_workspace"] is False
 
-    def test_non_c_windows_host_cwd_maps_to_workspace_when_enabled(self, monkeypatch):
+    def test_non_c_windows_host_cwd_maps_to_workspace_when_enabled(
+        self, monkeypatch, emulate_windows_drive_isabs
+    ):
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         monkeypatch.setenv("TERMINAL_CWD", r"E:\SomeRoot\project")
         monkeypatch.setenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "true")
@@ -137,7 +169,9 @@ class TestOverrideCwdSanitizedAtCallSite:
             "It must be sanitized back to config['cwd']."
         )
 
-    def test_non_c_windows_host_override_does_not_reach_container(self, monkeypatch):
+    def test_non_c_windows_host_override_does_not_reach_container(
+        self, monkeypatch, emulate_windows_drive_isabs
+    ):
         cwd = self._run_and_capture_cwd(monkeypatch, r"E:\SomeRoot\project")
         assert cwd == "/root"
 
@@ -230,7 +264,9 @@ class TestFileOpsCwdSanitizedAtCallSite:
             "It must be sanitized back to config['cwd']."
         )
 
-    def test_non_c_windows_host_override_does_not_reach_container(self, monkeypatch):
+    def test_non_c_windows_host_override_does_not_reach_container(
+        self, monkeypatch, emulate_windows_drive_isabs
+    ):
         cwd = self._run_and_capture_cwd(monkeypatch, r"E:\SomeRoot\project")
         assert cwd == "/workspace"
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1636,12 +1636,23 @@ def _safe_getcwd() -> str:
 
 
 # Path prefixes that identify a *host* working directory which cannot exist
-# inside a container sandbox. Covers POSIX user dirs and Windows drive paths
-# (``C:\Users\...`` / ``C:/Users/...``) — the latter is how a Windows host's
-# cwd looks when it leaks toward a Linux container's ``-w`` flag.
+# inside a container sandbox. Covers common POSIX user dirs plus the legacy
+# C-drive Windows cases; arbitrary Windows drives are handled by the regex below.
 _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
+_WINDOWS_DRIVE_CWD_RE = re.compile(r"^[A-Za-z]:[\\/]")
 
 _CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+
+
+def _is_windows_drive_cwd(cwd: str) -> bool:
+    return bool(cwd and _WINDOWS_DRIVE_CWD_RE.match(cwd))
+
+
+def _is_host_cwd_for_container(cwd: str) -> bool:
+    """Return True when *cwd* names a host path, not an in-container cwd."""
+    if not cwd:
+        return False
+    return any(cwd.startswith(p) for p in _HOST_CWD_PREFIXES) or _is_windows_drive_cwd(cwd)
 
 
 def _plugin_env_flag(env_type: str, attr: str, default=False):
@@ -1693,11 +1704,9 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     """
     if not cwd:
         return False
-    if any(cwd.startswith(p) for p in _HOST_CWD_PREFIXES):
+    if _is_host_cwd_for_container(cwd):
         return True
-    # Relative paths (".", "src/") can't be a container workdir either. Windows
-    # drive paths are absolute on Windows but os.path.isabs() is False on a
-    # POSIX host, so they're already caught by the prefix check above.
+    # Relative paths (".", "src/") can't be a container workdir either.
     if not os.path.isabs(cwd):
         return True
     return False
@@ -1817,9 +1826,11 @@ def _get_env_config() -> Dict[str, Any]:
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
         docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
-        candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
+        candidate = os.path.expanduser(docker_cwd_source)
+        if not _is_windows_drive_cwd(candidate):
+            candidate = os.path.abspath(candidate)
         if (
-            any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
+            _is_host_cwd_for_container(candidate)
             or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))
         ):
             host_cwd = candidate

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1326,10 +1326,10 @@ def _safe_getcwd() -> str:
 
 
 # Path prefixes that identify a *host* working directory which cannot exist
-# inside a container sandbox. Covers POSIX user dirs and Windows drive paths
-# (``C:\Users\...`` / ``C:/Users/...``) — the latter is how a Windows host's
-# cwd looks when it leaks toward a Linux container's ``-w`` flag.
+# inside a container sandbox. Covers common POSIX user dirs plus the legacy
+# C-drive Windows cases; arbitrary Windows drives are handled by the regex below.
 _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
+_WINDOWS_DRIVE_CWD_RE = re.compile(r"^[A-Za-z]:[\\/]")
 
 _CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
 
@@ -1350,6 +1350,17 @@ def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
     return cwd == "~" or cwd.startswith("~/")
 
 
+def _is_windows_drive_cwd(cwd: str) -> bool:
+    return bool(cwd and _WINDOWS_DRIVE_CWD_RE.match(cwd))
+
+
+def _is_host_cwd_for_container(cwd: str) -> bool:
+    """Return True when *cwd* names a host path, not an in-container cwd."""
+    if not cwd:
+        return False
+    return any(cwd.startswith(p) for p in _HOST_CWD_PREFIXES) or _is_windows_drive_cwd(cwd)
+
+
 def _is_unusable_container_cwd(cwd: str) -> bool:
     """Return True if *cwd* is a host/relative path that won't work as the
     working directory inside a container sandbox.
@@ -1361,11 +1372,9 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     """
     if not cwd:
         return False
-    if any(cwd.startswith(p) for p in _HOST_CWD_PREFIXES):
+    if _is_host_cwd_for_container(cwd):
         return True
-    # Relative paths (".", "src/") can't be a container workdir either. Windows
-    # drive paths are absolute on Windows but os.path.isabs() is False on a
-    # POSIX host, so they're already caught by the prefix check above.
+    # Relative paths (".", "src/") can't be a container workdir either.
     if not os.path.isabs(cwd):
         return True
     return False
@@ -1469,9 +1478,11 @@ def _get_env_config() -> Dict[str, Any]:
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
         docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
-        candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
+        candidate = os.path.expanduser(docker_cwd_source)
+        if not _is_windows_drive_cwd(candidate):
+            candidate = os.path.abspath(candidate)
         if (
-            any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
+            _is_host_cwd_for_container(candidate)
             or (os.path.isabs(candidate) and os.path.isdir(candidate) and not candidate.startswith(("/workspace", "/root")))
         ):
             host_cwd = candidate


### PR DESCRIPTION
## What does this PR do?

Fixes the Docker terminal backend cwd sanitizer so native Windows host paths on any drive letter are treated as host paths before they reach a Linux container `-w` argument.

Before this change, `_HOST_CWD_PREFIXES` only special-cased `C:\\` / `C:/`. On a native-Windows install, paths such as `E:\\SomeRoot\\project` and `D:/SomeRoot/project` are absolute according to Windows path semantics, so they could bypass the relative-path fallback and reach Docker unchanged.

## Related Issue

Fixes #60962.

#60977 is the canonical implementation; competing #61053 was closed in its favor.

## Type of Change

- [x] 🐛 Bug fix
- [x] Cross-platform compatibility fix
- [x] Tests

## Root Cause

The shared sanitizer recognized only C-drive prefixes before falling through to `os.path.isabs()`. That fallback rejects non-C drive samples on POSIX but returns true on native Windows. The same gap affects config-derived cwd, per-task terminal overrides, and file-tool overrides.

## Changes Made

- Add an explicit `^[A-Za-z]:[\\/]` Windows drive-path detector.
- Centralize the host-cwd predicate so config resolution and call-site overrides use the same rule.
- Preserve valid in-container paths such as `/workspace`, `/root`, and `/opt/project`.
- Preserve native Windows drive paths as mount sources when Docker cwd passthrough is enabled while mapping the in-container cwd to `/workspace`.
- Exercise backslash and forward-slash drive paths across config, terminal, and file-operation paths.
- Emulate native-Windows `isabs()` behavior with `ntpath.isabs()` so POSIX CI proves the reported bypass.
- Preserve current main's pruned test structure and `vercel_sandbox` backend coverage.

## How to Test

```bash
scripts/run_tests.sh \
  tests/tools/test_container_cwd_sanitize.py \
  tests/tools/test_modal_sandbox_fixes.py \
  tests/tools/test_terminal_env_bridge.py -- -q

python scripts/check-windows-footguns.py \
  tools/terminal_tool.py \
  tests/tools/test_container_cwd_sanitize.py
```

## Checklist

- [x] Read the contributing guide.
- [x] Conventional commits.
- [x] Searched open and closed competing PRs.
- [x] Focused production change and behavior regressions only.
- [ ] Complete repository suite not run; all affected suites passed.
- [x] Tested on macOS with native-Windows path semantics emulated.

## Validation

Validated after rebasing onto current `main` `98105f31f`; head `d4a743c4b`:

- Related test files: **48 passed, 0 failed**.
- Ruff: passed.
- Windows footgun check: passed.
- `git diff --check`: clean.
- Current-main reproduction with native-Windows `isabs()` semantics returns `False` for `_is_unusable_container_cwd(r"E:\\SomeRoot\\project")`; the rebased branch returns `True`.

## Review Follow-up

The sweeper's POSIX-test concern remains addressed. The regression fixture delegates drive-letter samples to `ntpath.isabs()` while retaining POSIX semantics for Linux-container paths. The current-main test-pruning conflict was resolved by retaining only the non-C drive behavior coverage.
