### PR TITLE
fix(#55985): guard start_login() call — BasicAuthProvider has no OAuth redirect flow

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -194,7 +194,11 @@ async def auth_login(request: Request, provider: str, next: str = ""):
         )
 
     try:
-        ls = p.start_login(redirect_uri=_redirect_uri(request))
+        # 🐛 patch(#55985): guard start_login() — BasicAuthProvider has no OAuth flow
+        if hasattr(p, "start_login") and callable(p.start_login):
+            ls = p.start_login(redirect_uri=_redirect_uri(request))
+        else:
+            ls = None
     except ProviderError as e:
         audit_log(
             AuditEvent.LOGIN_FAILURE,

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -194,11 +194,7 @@ async def auth_login(request: Request, provider: str, next: str = ""):
         )
 
     try:
-        # 🐛 patch(#55985): guard start_login() — BasicAuthProvider has no OAuth flow
-        if hasattr(p, "start_login") and callable(p.start_login):
-            ls = p.start_login(redirect_uri=_redirect_uri(request))
-        else:
-            ls = None
+        ls = p.start_login(redirect_uri=_redirect_uri(request))
     except ProviderError as e:
         audit_log(
             AuditEvent.LOGIN_FAILURE,
@@ -210,12 +206,19 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             status_code=503,
             detail=f"Provider unreachable: {e}",
         )
+    except NotImplementedError:
+        ls = None
 
     audit_log(
         AuditEvent.LOGIN_START,
         provider=provider,
         ip=_client_ip(request),
     )
+
+    # 🐛 fix(#55985): BasicAuthProvider has no OAuth redirect flow.
+    # password-only providers fall through to password login page.
+    if ls is None:
+        return RedirectResponse(url=request.url_for("login_page"), status_code=302)
 
     resp = RedirectResponse(url=ls.redirect_url, status_code=302)
     # Pack the provider name into the PKCE cookie so the callback can


### PR DESCRIPTION
## Description

`BasicAuthProvider.start_login()` raises `NotImplementedError` because password-only provider has no OAuth redirect flow. This causes `GET /health` with Basic Auth to return `302 → /auth/login?provider=basic → 500`.

## Root cause

`dashboard_auth/routes.py` line 197 unconditionally calls:
```python
ls = p.start_login(redirect_uri=_redirect_uri(request))
```

`BasicAuthProvider` does not implement `start_login()` — it inherits the base class stub that raises `NotImplementedError`. This exception is NOT caught by the surrounding `except ProviderError` block, so it propagates to the error handler → 500.

## Fix

Two-part fix:

1. **Catch `NotImplementedError`** in addition to `ProviderError` — set `ls = None`
2. **Guard `ls.redirect_url`** — if `ls is None` (password-only provider), redirect to the login page (`/login`) which renders the password form

```python
except NotImplementedError:
    ls = None

# ... audit_log ...

if ls is None:
    return RedirectResponse(url=request.url_for("login_page"), status_code=302)
```

Note: `hasattr(p, "start_login") and callable(p.start_login)` guard does NOT work because `BasicAuthProvider` inherits `start_login()` from the base class — it exists, it just raises `NotImplementedError`.

## Impact

- ✅ `GET /health` with Basic Auth returns 302 → `/login` (login form, 200) instead of 302 → `/auth/login?provider=basic` → 500
- ✅ All OAuth/OIDC providers continue to work unchanged
- ✅ Minimal change: 8 lines added, 1 line changed

Closes #55985