### PR TITLE
test(console): drop duplicate '--tui' parametrize case

### DIFF
--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -533,7 +533,6 @@ def test_hosted_console_blocks_known_footgun_arguments_before_confirmation(line)
         "desktop",
         "login",
         "logout",
-        "--tui",
         "logs | cat",
         "config show > out.txt",
     ],


### PR DESCRIPTION
﻿## What does this PR do?

Removes a redundant duplicate `parametrize` case in `tests/hermes_cli/test_console_engine.py`.

`test_console_rejects_destructive_and_shell_like_commands` lists its `line` inputs in a single `@pytest.mark.parametrize`, and `"--tui"` appears **twice** — once at line 511 (alongside `"--cli"`) and again at line 536 (between `"logout"` and `"logs | cat"`). Pytest runs the second copy as a separate `[--tui1]` case that re-executes the exact same assertion on the exact same input, adding zero coverage.

```diff
         "logout",
-        "--tui",
         "logs | cat",
```

## Type of Change

- [x] Test cleanup (no production code changed)

## Notes

- Coverage is unchanged: the `"--tui"` case is still exercised by its first occurrence (line 511). Only the redundant duplicate is dropped — no test is removed.
- 1 test file changed, −1 line.
- Provable by reading the parametrize list: the identical string appears twice.

## Validation

```bash
scripts/run_tests.sh tests/hermes_cli/test_console_engine.py::test_console_rejects_destructive_and_shell_like_commands -v
```
