### PR TITLE
fix(security): scope session_search to the caller's own sessions in multi-user gateways

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2988,6 +2988,7 @@ class SessionDB:
         archived_only: bool = False,
         id_query: str = None,
         search_query: str = None,
+        user_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -3046,6 +3047,12 @@ class SessionDB:
         if source:
             where_clauses.append("s.source = ?")
             params.append(source)
+        if user_id is not None:
+            # Scope to the caller's own sessions in multi-user gateway
+            # contexts so browsing/recent-session listing cannot surface
+            # another user's sessions (same boundary as resolve_session_by_title).
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
@@ -4469,6 +4476,7 @@ class SessionDB:
         offset: int = 0,
         sort: str = None,
         include_inactive: bool = False,
+        user_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -4551,6 +4559,13 @@ class SessionDB:
             where_clauses.append(f"m.role IN ({role_placeholders})")
             params.extend(role_filter)
 
+        if user_id is not None:
+            # Scope to the caller's own sessions in multi-user gateway
+            # contexts so one user cannot search another user's conversation
+            # history (same security boundary as resolve_session_by_title).
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id)
+
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])
 
@@ -4626,6 +4641,9 @@ class SessionDB:
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
+                if user_id is not None:
+                    tri_where.append("s.user_id = ?")
+                    tri_params.append(user_id)
                 tri_sql = f"""
                     SELECT
                         m.id,
@@ -4683,6 +4701,9 @@ class SessionDB:
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
+                if user_id is not None:
+                    like_where.append("s.user_id = ?")
+                    like_params.append(user_id)
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
                            substr(m.content,

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1581,6 +1581,43 @@ class TestFTS5Search:
         assert isinstance(results, list)
         assert elapsed < 1.0
 
+    def test_search_scopes_by_user_id(self, db):
+        """A scoped search (multi-user gateway) must not return another user's
+        messages — the same security boundary as resolve_session_by_title/#60914."""
+        db.create_session(session_id="s_a", source="telegram", user_id="tg-userA")
+        db.append_message("s_a", role="user", content="USER_A_SECRET about the launch")
+
+        db.create_session(session_id="s_b", source="telegram", user_id="tg-userB")
+        db.append_message("s_b", role="user", content="USER_B_SECRET banking credentials")
+
+        # User A searching USER_B's term — must be empty when scoped.
+        results = db.search_messages("USER_B_SECRET", user_id="tg-userA")
+        assert results == []
+
+        # User B can find its own.
+        results = db.search_messages("USER_B_SECRET", user_id="tg-userB")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s_b"
+
+        # Unscoped search (single-user / CLI) still finds everything.
+        results = db.search_messages("USER_B_SECRET")
+        assert len(results) == 1
+
+    def test_search_user_id_scope_cjk_path(self, db):
+        """The CJK (trigram / LIKE) fallback paths must also honor user_id."""
+        db.create_session(session_id="s_a", source="telegram", user_id="tg-userA")
+        db.append_message("s_a", role="user", content="用户A的私密项目细节")
+
+        db.create_session(session_id="s_b", source="telegram", user_id="tg-userB")
+        db.append_message("s_b", role="user", content="用户B的银行登录信息")
+
+        # Scope to user A — must not see user B's CJK content.
+        results = db.search_messages("用户B", user_id="tg-userA")
+        assert results == []
+
+        results = db.search_messages("用户B", user_id="tg-userB")
+        assert len(results) == 1
+
 
 # =========================================================================
 # CJK (Chinese/Japanese/Korean) LIKE fallback
@@ -4028,6 +4065,27 @@ class TestExcludeSources:
         )
         sources = [r["source"] for r in results]
         assert sources == ["cli"]
+
+    def test_list_sessions_rich_scopes_by_user_id(self, db):
+        """Browsing recent sessions in a multi-user gateway must not surface
+        another user's sessions."""
+        db.create_session("s_a", "telegram", user_id="tg-userA")
+        db.create_session("s_b", "telegram", user_id="tg-userB")
+
+        sessions = db.list_sessions_rich(user_id="tg-userA")
+        ids = [s["id"] for s in sessions]
+        assert "s_a" in ids
+        assert "s_b" not in ids
+
+        sessions = db.list_sessions_rich(user_id="tg-userB")
+        ids = [s["id"] for s in sessions]
+        assert "s_b" in ids
+        assert "s_a" not in ids
+
+        # Unscoped still returns both.
+        sessions = db.list_sessions_rich()
+        ids = [s["id"] for s in sessions]
+        assert "s_a" in ids and "s_b" in ids
 
 
 class TestResolveSessionByNameOrId:

--- a/tests/tools/test_session_search_cross_user.py
+++ b/tests/tools/test_session_search_cross_user.py
@@ -1,0 +1,158 @@
+"""Cross-user isolation tests for the session_search tool (P1, gateway).
+
+In a multi-user gateway (Telegram / Discord / Slack) every user's agent runs a
+separate session that carries a ``user_id``. The session_search tool must scope
+its queries to the caller's own sessions, otherwise one user can read another
+user's conversation history — the same security boundary as CVE-2026-11461
+(/resume cross-user access).
+
+These tests prove that:
+  * FTS message search (``search_messages``) cannot return another user's
+    message content when scoped by ``user_id``;
+  * the title-match path (``resolve_session_by_title``) cannot resolve another
+    user's session by title;
+  * the browse / recent-sessions path (``list_sessions_rich``) cannot surface
+    another user's session titles.
+
+They mirror the regression style of test_hermes_state.py / test_resume_command.py.
+
+Note: the tool intentionally hides the caller's *current* session (its content
+is already in context), so "owner can see own" assertions use a *different*
+session owned by the same user_id — not the current_session_id.
+"""
+
+import json
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+from tools.session_search_tool import session_search
+
+
+@pytest.fixture
+def gateway_db(tmp_path):
+    """A shared state.db with two distinct gateway users' sessions."""
+    db = SessionDB(tmp_path / "state.db")
+    now = int(time.time())
+
+    # User A — telegram (current session + a separate owned session)
+    db.create_session("s_userA", source="telegram", user_id="tg-userA")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+        (now - 5000, "User A private project", "s_userA"),
+    )
+    db.append_message("s_userA", role="user",
+                      content="A is working on the current thing")
+
+    db.create_session("s_userA_secret", source="telegram", user_id="tg-userA")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+        (now - 4500, "User A secret project", "s_userA_secret"),
+    )
+    db.append_message("s_userA_secret", role="user",
+                      content="SECRET_A_TERM planning the alpha launch")
+
+    # User B — telegram, with TWO sessions:
+    #   s_userB_current — B's "current" session (used as current_session_id)
+    #   s_userB_secret  — a different B-owned session that must be visible to B
+    #                     but hidden from A.
+    db.create_session("s_userB_current", source="telegram", user_id="tg-userB")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+        (now - 4000, "User B current project", "s_userB_current"),
+    )
+    db.append_message("s_userB_current", role="user",
+                      content="B is working on the current thing")
+
+    db.create_session("s_userB_secret", source="telegram", user_id="tg-userB")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+        (now - 3000, "User B private project", "s_userB_secret"),
+    )
+    db.append_message("s_userB_secret", role="user",
+                      content="SECRET_B_TERM my bank login credentials discussion")
+    db.append_message("s_userB_secret", role="assistant",
+                      content="SECRET_B_TERM noted, here is the plan.")
+    db._conn.commit()
+    return db
+
+
+class TestCrossUserDiscoveryLeak:
+    def test_userA_cannot_search_userB_messages(self, gateway_db):
+        """User A's agent searching for B's unique term returns nothing."""
+        result = json.loads(session_search(
+            query="SECRET_B_TERM", db=gateway_db, current_session_id="s_userA"
+        ))
+        assert result["success"] is True
+        assert result["count"] == 0, "user A leaked user B's message content"
+        assert result["results"] == []
+
+    def test_userB_can_search_own_other_session(self, gateway_db):
+        """User B (current=s_userB_current) can find a *different* B-owned
+        session that contains the term."""
+        result = json.loads(session_search(
+            query="SECRET_B_TERM", db=gateway_db, current_session_id="s_userB_current"
+        ))
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["results"][0]["session_id"] == "s_userB_secret"
+
+    def test_userA_searching_own_term_only_returns_own(self, gateway_db):
+        # Sanity: A (current=s_userA) searching a *different* A-owned session's
+        # term only returns A's own session, never B's.
+        result = json.loads(session_search(
+            query="SECRET_A_TERM", db=gateway_db, current_session_id="s_userA"
+        ))
+        assert result["count"] == 1
+        assert result["results"][0]["session_id"] == "s_userA_secret"
+
+
+class TestCrossUserTitleLeak:
+    def test_userA_cannot_resolve_userB_title(self, gateway_db):
+        """Title-match must scope by user_id — A cannot open B's session by title."""
+        result = json.loads(session_search(
+            query="User B private project", db=gateway_db,
+            current_session_id="s_userA",
+        ))
+        assert result["success"] is True
+        for hit in result["results"]:
+            assert hit["session_id"] != "s_userB_secret"
+
+    def test_userB_can_resolve_own_title(self, gateway_db):
+        # B (current=s_userB_current) resolving B's *other* session title.
+        result = json.loads(session_search(
+            query="User B private project", db=gateway_db,
+            current_session_id="s_userB_current",
+        ))
+        assert result["count"] == 1
+        assert result["results"][0]["session_id"] == "s_userB_secret"
+
+
+class TestCrossUserBrowseLeak:
+    def test_userA_browse_excludes_userB_session(self, gateway_db):
+        result = json.loads(session_search(
+            db=gateway_db, current_session_id="s_userA"
+        ))
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_userB_secret" not in sids, "user A's browse leaked user B's session"
+        assert "s_userB_current" not in sids
+
+    def test_userB_browse_includes_own_other_session(self, gateway_db):
+        result = json.loads(session_search(
+            db=gateway_db, current_session_id="s_userB_current"
+        ))
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_userB_secret" in sids, "user B should see own other session"
+        assert "s_userA" not in sids
+
+
+class TestUnscopedSingleUserStillWorks:
+    """Backward compatibility: single-user (CLI) sessions have user_id=None and
+    must remain fully searchable when no caller identity is supplied."""
+
+    def test_no_caller_identity_returns_all(self, gateway_db):
+        result = json.loads(session_search(query="SECRET_B_TERM", db=gateway_db))
+        # No current_session_id → no scoping → both users' content visible.
+        assert result["count"] == 1
+        assert result["results"][0]["session_id"] == "s_userB_secret"

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -103,6 +103,27 @@ def _resolve_to_parent(db, session_id: str) -> str:
     return cur
 
 
+def _caller_identity(db, current_session_id: Optional[str]) -> tuple:
+    """Resolve ``(user_id, source)`` of the session that owns the current call.
+
+    In a multi-user gateway every user's agent runs a separate session that
+    carries a ``user_id`` (and ``source``/platform). Returning the caller's
+    identity lets the session-search queries scope to that owner so one user
+    cannot read another user's conversation history — the same security
+    boundary enforced for ``/resume`` by CVE-2026-11461. When the caller
+    session is unknown (CLI / single-user), both values are ``None`` and the
+    queries stay unscoped (backward compatible).
+    """
+    if not current_session_id or db is None:
+        return (None, None)
+    try:
+        row = db.get_session(current_session_id) or {}
+    except Exception:
+        logging.debug("get_session failed resolving caller identity for %s", current_session_id, exc_info=True)
+        return (None, None)
+    return (row.get("user_id"), row.get("source"))
+
+
 def _order_for_recall(raw_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Stable-sort FTS rows so interactive sessions rank above automation.
 
@@ -260,10 +281,12 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10) -> str:
 def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
+        caller_user_id, caller_source = _caller_identity(db, current_session_id)
         sessions = db.list_sessions_rich(
             limit=limit + 5,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             order_by_last_active=True,
+            user_id=caller_user_id,
         )  # fetch extra so we can skip current
 
         current_root = _resolve_to_parent(db, current_session_id) if current_session_id else None
@@ -433,8 +456,15 @@ def _title_match_result(
     db,
     query: str,
     current_lineage_root: Optional[str],
+    source: Optional[str] = None,
+    user_id: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Return a discovery-shaped result when the query matches a session title."""
+    """Return a discovery-shaped result when the query matches a session title.
+
+    ``source``/``user_id`` scope the title lookup to the caller's own sessions
+    so a multi-user gateway user cannot resolve another user's session by title
+    (same security boundary as resolve_session_by_title scoping, CVE-2026-11461).
+    """
     title_query = _normalize_title_query(query)
     if not title_query:
         return None
@@ -445,6 +475,18 @@ def _title_match_result(
         logging.debug("resolve_session_by_title failed for %r", title_query, exc_info=True)
         return None
     if not session_id:
+        return None
+
+    # Scope the resolved session to the caller's own sessions. ``resolve_session_by_title``
+    # may not yet be caller-scoped on this build, so verify ownership explicitly.
+    try:
+        _row = db.get_session(session_id) or {}
+    except Exception:
+        logging.debug("get_session failed for title match %s", session_id, exc_info=True)
+        _row = {}
+    if user_id is not None and _row.get("user_id") != user_id:
+        return None
+    if source is not None and _row.get("source") != source:
         return None
 
     lineage_root = _resolve_to_parent(db, session_id)
@@ -507,7 +549,10 @@ def _discover(
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_to_parent(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    caller_user_id, caller_source = _caller_identity(db, current_session_id)
+    title_result = _title_match_result(
+        db, query, current_lineage_root, source=caller_source, user_id=caller_user_id
+    )
 
     try:
         raw_results = db.search_messages(
@@ -519,6 +564,7 @@ def _discover(
             # of cron rows are still in hand for the demotion pass below.
             offset=0,
             sort=sort,
+            user_id=caller_user_id,
         )
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)
@@ -914,7 +960,11 @@ registry.register(
         sort=args.get("sort"),
         profile=args.get("profile"),
         db=kw.get("db"),
-        current_session_id=kw.get("current_session_id"),
+        # handle_function_call forwards the active session as ``session_id``;
+        # explicit callers (CLI / gateway slash commands) use
+        # ``current_session_id``. Both identify the caller's own session so the
+        # search can be scoped to that owner in multi-user gateway contexts.
+        current_session_id=kw.get("current_session_id") or kw.get("session_id"),
     ),
     check_fn=check_session_search_requirements,
     emoji="🔍",


### PR DESCRIPTION
## What does this PR do?

In a multi-user gateway (Telegram / Discord / Slack) every user's agent runs a separate session that carries a `user_id`. The `session_search` tool performed its lookups against the entire shared `state.db` with no owner scoping, so one user's agent could read another user's conversation history - an FTS message-content leak and a session-title leak. This is the same security boundary violated by CVE-2026-11461 (`/resume` cross-user access), reached through a different, still-unscoped code path.

### Root cause

`session_search` resolved sessions three ways, none scoped to the caller:
- **Discovery (FTS5):** `db.search_messages(query)` - returned other users' message snippets/content.
- **Title match:** `db.resolve_session_by_title(title)` - resolved another user's session by title.
- **Browse/recent:** `db.list_sessions_rich()` - surfaced other users' session titles/previews.

### Fix

- `hermes_state.py`: `search_messages()` and `list_sessions_rich()` now accept an optional `user_id` (and the existing `source` filter) and scope all SQL paths (FTS5 + trigram CJK + LIKE fallback) to the caller's own rows via `s.user_id = ?`.
- `tools/session_search_tool.py`: a new `_caller_identity()` helper resolves the caller's `(user_id, source)` from the current session id, and every search path passes it through. The title-match path additionally verifies resolved-session ownership before returning it.
- Single-user (CLI) behavior is unchanged: sessions there have `user_id = NULL`, so the tool leaves the filter unset and search returns everything as before.

## Related Issue

Fixes a cross-user information disclosure vulnerability (analogous to CVE-2026-11461).

## Changes Made

- `hermes_state.py`: Add `user_id` param to `search_messages()`, `list_sessions_rich()`, scope queries
- `tools/session_search_tool.py`: Add `_caller_identity()` helper, scope all search paths, add title-match ownership verification
- `tests/tools/test_session_search_cross_user.py`: New cross-user isolation tests
- `tests/test_hermes_state.py`: Add scope tests for FTS5, CJK, and LIKE paths

## How to Test

1. Run cross-user isolation tests: `pytest tests/tools/test_session_search_cross_user.py -v`
2. Run existing session_search tests for regression: `pytest tests/tools/test_session_search.py -v`
3. Verify CLI mode is unchanged (no user_id): `pytest tests/test_hermes_state.py -v`
