### PR TITLE
fix(gateway): offload channel directory session scans off the event loop

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -6,6 +6,7 @@ Built on gateway startup, refreshed periodically (every 5 min), and saved to
 action="list" and for resolving human-friendly channel names to numeric IDs.
 """
 
+import asyncio
 import json
 import logging
 from datetime import datetime
@@ -121,7 +122,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     for platform, adapter in adapters.items():
         try:
             if platform == Platform.DISCORD:
-                platforms["discord"] = _build_discord(adapter)
+                platforms["discord"] = await asyncio.to_thread(_build_discord, adapter)
             elif platform == Platform.SLACK:
                 platforms["slack"] = await _build_slack(adapter)
         except Exception as e:
@@ -142,7 +143,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
             or plat_name not in adapter_platform_names
         ):
             continue
-        platforms[plat_name] = _build_from_sessions(plat_name)
+        platforms[plat_name] = await asyncio.to_thread(_build_from_sessions, plat_name)
 
     # Include plugin-registered platforms (dynamic enum members aren't in
     # Platform.__members__, so the loop above misses them). Same
@@ -156,7 +157,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
                 and entry.name not in platforms
                 and entry.name in adapter_platform_names
             ):
-                platforms[entry.name] = _build_from_sessions(entry.name)
+                platforms[entry.name] = await asyncio.to_thread(_build_from_sessions, entry.name)
     except Exception:
         pass
 
@@ -223,7 +224,7 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
     """
     team_clients = getattr(adapter, "_team_clients", None) or {}
     if not team_clients:
-        return _build_from_sessions("slack")
+        return await asyncio.to_thread(_build_from_sessions, "slack")
 
     channels: List[Dict[str, Any]] = []
     seen_ids: set = set()
@@ -267,7 +268,7 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
             continue
 
     # Merge in DM/group entries discovered from session history.
-    for entry in _build_from_sessions("slack"):
+    for entry in await asyncio.to_thread(_build_from_sessions, "slack"):
         if entry.get("id") not in seen_ids:
             channels.append(entry)
             seen_ids.add(entry.get("id"))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -300,6 +300,7 @@ AUTHOR_MAP = {
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
     "iamgexin@qq.com": "nullptr0807",  # PR #60956 salvage (gateway hygiene in-place compaction; #60947)
+    "embwl0x@users.noreply.github.com": "embwl0x",  # PR #60810 salvage (channel directory offload)
     "caztronics@yahoo.com": "doncazper",
     "30668368+alex107ivanov@users.noreply.github.com": "alex107ivanov",
     "210088133+rungmc357@users.noreply.github.com": "rungmc357",

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -82,6 +83,85 @@ class TestBuildChannelDirectoryWrites:
             result = load_directory()
 
         assert result == previous
+
+
+class TestBuildChannelDirectoryOffload:
+    def test_discord_builder_runs_off_event_loop_thread(self, tmp_path):
+        from gateway.config import Platform
+
+        cache_file = tmp_path / "channel_directory.json"
+        loop_thread = threading.get_ident()
+        builder_threads = []
+
+        def fake_build_discord(_adapter):
+            builder_threads.append(threading.get_ident())
+            return []
+
+        with patch("gateway.channel_directory._build_discord", side_effect=fake_build_discord), \
+             patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            asyncio.run(build_channel_directory({Platform.DISCORD: object()}))
+
+        assert builder_threads
+        assert all(tid != loop_thread for tid in builder_threads)
+
+    def test_session_discovery_runs_off_event_loop_thread(self, tmp_path):
+        from gateway.config import Platform
+
+        cache_file = tmp_path / "channel_directory.json"
+        loop_thread = threading.get_ident()
+        calls = []
+
+        def fake_build_from_sessions(platform_name):
+            calls.append((platform_name, threading.get_ident()))
+            return []
+
+        with patch("gateway.channel_directory._build_from_sessions", side_effect=fake_build_from_sessions), \
+             patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            asyncio.run(build_channel_directory({Platform.TELEGRAM: object()}))
+
+        assert [name for name, _ in calls] == ["telegram"]
+        assert calls[0][1] != loop_thread
+
+    def test_plugin_session_discovery_runs_off_event_loop_thread(self, tmp_path):
+        cache_file = tmp_path / "channel_directory.json"
+        loop_thread = threading.get_ident()
+        calls = []
+        plugin_entry = SimpleNamespace(name="irc")
+
+        def fake_build_from_sessions(platform_name):
+            calls.append((platform_name, threading.get_ident()))
+            return []
+
+        with patch("gateway.channel_directory._build_from_sessions", side_effect=fake_build_from_sessions), \
+             patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+             patch(
+                 "gateway.platform_registry.platform_registry.plugin_entries",
+                 return_value=[plugin_entry],
+             ):
+            asyncio.run(build_channel_directory({"irc": object()}))
+
+        assert [name for name, _ in calls] == ["irc"]
+        assert calls[0][1] != loop_thread
+
+    def test_slack_session_merge_runs_off_event_loop_thread(self):
+        loop_thread = threading.get_ident()
+        calls = []
+
+        class FakeSlackClient:
+            async def users_conversations(self, **_kwargs):
+                return {"ok": True, "channels": []}
+
+        def fake_build_from_sessions(platform_name):
+            calls.append((platform_name, threading.get_ident()))
+            return [{"id": "D1", "name": "Alice", "type": "dm"}]
+
+        adapter = SimpleNamespace(_team_clients={"T1": FakeSlackClient()})
+        with patch("gateway.channel_directory._build_from_sessions", side_effect=fake_build_from_sessions):
+            channels = asyncio.run(_build_slack(adapter))
+
+        assert channels == [{"id": "D1", "name": "Alice", "type": "dm"}]
+        assert [name for name, _ in calls] == ["slack"]
+        assert calls[0][1] != loop_thread
 
 
 class TestResolveChannelName:


### PR DESCRIPTION
## Summary
Channel directory builds no longer block the gateway event loop. Salvages PR #60810 by @embwl0x (earliest and most complete of three competing fixes; #60840 by @AlexFucuson9 and #60919 by @AIalliAI closed as duplicates with credit).

Root cause: `build_channel_directory()` is async and runs on the gateway event loop, but `_build_discord()` (guild/channel cache walk) and `_build_from_sessions()` (synchronous SQLite SessionDB scans) were called inline — on large session databases this stalls message delivery for every connected platform.

## Changes
- `gateway/channel_directory.py`: wrap all five blocking builder call sites in `asyncio.to_thread` — the Discord cache walk, session-based discovery, plugin-platform discovery, and both `_build_from_sessions("slack")` merges inside `_build_slack()` (the two sites the duplicate PRs missed).
- `tests/gateway/test_channel_directory.py`: thread-identity regression tests asserting the builders never run on the loop thread (+80 LOC).
- `scripts/release.py`: AUTHOR_MAP entry for @embwl0x.

## Validation
| | Result |
|---|---|
| tests/gateway/test_channel_directory.py | 43/43 pass |

Contributor authorship preserved via cherry-pick; merge with rebase.

## Infographic

![channel-directory-offload](https://v3b.fal.media/files/b/0aa17125/LWvZTCuS11pLKhjuYeibE_WQHCHc3C.png)
