### PR TITLE
fix(desktop): attach backend ready watcher before progress await

### DIFF
--- a/apps/desktop/electron/backend-ready.test.ts
+++ b/apps/desktop/electron/backend-ready.test.ts
@@ -98,6 +98,17 @@ test('resolves with a HERMES_BACKEND_READY port (headless `serve`)', async () =>
   assert.equal(await p, 43210)
 })
 
+test('does not satisfy a new watcher from a previous child announcement', async () => {
+  const previous = makeFakeChild()
+  previous.stdout.emit('data', 'HERMES_BACKEND_READY port=43210\n')
+
+  const next = makeFakeChild()
+  await assert.rejects(
+    waitForDashboardPort(next, 20),
+    /Timed out waiting for Hermes backend port announcement \(20ms\)/
+  )
+})
+
 test('parses the port even when the line arrives split across chunks', async () => {
   const child = makeFakeChild()
   const p = waitForDashboardPort(child, 1000)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6896,13 +6896,19 @@ async function startHermes() {
       }
     })
 
-    await advanceBootProgress('backend.port', 'Waiting for Hermes backend to launch', 86)
-
-    // Discover the ephemeral port the child bound to
-    const port = await Promise.race([
+    // Attach the one-shot port watcher before any further await. The backend can
+    // print HERMES_BACKEND_READY immediately after spawn; listening now closes
+    // that ordering gap without replaying the process-global desktop log, which
+    // may contain READY lines from prior or pooled backends.
+    const portAnnouncement = Promise.race([
       waitForDashboardPortAnnouncement(hermesProcess, { readyFile }),
       backendStartFailed
     ])
+
+    await advanceBootProgress('backend.port', 'Waiting for Hermes backend to launch', 86)
+
+    // Discover the ephemeral port the child bound to.
+    const port = await portAnnouncement
 
     if (readyFile) {
       fs.unlink(readyFile, () => {})


### PR DESCRIPTION
Fixes a Desktop local-backend startup race condition where the primary backend can print `HERMES_BACKEND_READY port=<port>` before Desktop starts waiting for the port announcement. In that case the line is visible in `desktop.log`, but Desktop can still time out waiting for the announcement.

This moves primary-backend port watcher construction before the boot-progress await that created the ordering gap, so the watcher is already attached when the backend can emit READY. It does not replay `recentHermesLog()`, avoiding the risk of satisfying a new backend launch from a stale READY line belonging to a previous or pooled backend.

Fixes #60323.

## Test plan

- `npx -y tsx --test apps/desktop/electron/backend-ready.test.ts`
- `git diff --check origin/main..HEAD`
