### PR TITLE
fix(gateway): reload fallback_providers for live messaging sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5008,6 +5008,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
         return None
 
+    def _refresh_fallback_model(self) -> list | None:
+        """Re-read fallback_providers from disk for the next agent create/reuse.
+
+        Cron already does this per job via ``get_fallback_chain``; the gateway
+        previously froze ``self._fallback_model`` at process start, so a chain
+        configured (or changed) after ``hermes gateway`` was running never
+        reached messaging sessions even though the same process's cron jobs
+        fell back correctly. Fixes #60955.
+        """
+        self._fallback_model = self._load_fallback_model()
+        return self._fallback_model
+
+    @staticmethod
+    def _apply_fallback_chain_to_agent(agent: Any, chain: list | None) -> None:
+        """Keep a cached agent's fallback chain aligned with current config.
+
+        Skips rewrite while a cooldown is holding the agent on an already-
+        activated fallback provider — ``restore_primary_runtime`` owns that
+        turn-scoped lifecycle. When primary is active (or cooldown expired),
+        replace the chain so mid-uptime ``fallback_providers`` edits take
+        effect without requiring a gateway restart (#60955).
+        """
+        if agent is None:
+            return
+        new_chain = list(chain or [])
+        rate_limited_until = getattr(agent, "_rate_limited_until", 0) or 0
+        if (
+            getattr(agent, "_fallback_activated", False)
+            and rate_limited_until > time.monotonic()
+        ):
+            return
+        agent._fallback_chain = new_chain
+        agent._fallback_model = new_chain[0] if new_chain else None
+        if not getattr(agent, "_fallback_activated", False):
+            agent._fallback_index = 0
+
     def _snapshot_running_agents(self) -> Dict[str, Any]:
         return {
             session_key: agent
@@ -13227,7 +13263,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
                     session_db=getattr(self._session_db, "_db", self._session_db),
-                    fallback_model=self._fallback_model,
+                    # Reload from disk — do not reuse the startup snapshot (#60955).
+                    fallback_model=self._refresh_fallback_model(),
                 )
                 try:
                     return agent.run_conversation(
@@ -18045,6 +18082,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             # Refresh agent max_iterations from current config
                             # (cached agent may have been created with old config)
                             agent.max_iterations = max_iterations
+                            # Refresh fallback chain the same way — a chain
+                            # configured after this agent was cached (or after
+                            # gateway start) must reach the next turn (#60955).
+                            self._apply_fallback_chain_to_agent(
+                                agent, self._refresh_fallback_model(),
+                            )
                             logger.debug("Reusing cached agent for session %s", session_key)
                             reused_cached_agent = True
 
@@ -18100,7 +18143,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     thread_id=source.thread_id,
                     gateway_session_key=session_key,
                     session_db=getattr(self._session_db, "_db", self._session_db),
-                    fallback_model=self._fallback_model,
+                    # Reload from disk — do not reuse the startup snapshot (#60955).
+                    fallback_model=self._refresh_fallback_model(),
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/tests/gateway/test_fallback_chain_reload.py
+++ b/tests/gateway/test_fallback_chain_reload.py
@@ -1,0 +1,165 @@
+"""Regression tests for #60955: gateway must not freeze fallback_providers.
+
+Cron reloads ``fallback_providers`` from disk on every job. The gateway used to
+freeze ``self._fallback_model`` at process start, so a chain configured (or
+edited) after ``hermes gateway`` was already running never reached messaging
+sessions — even though cron in the same process fell back correctly.
+
+These tests pin the reload + cached-agent apply helpers without driving the
+full Feishu session path.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+
+def test_refresh_fallback_model_rereads_config(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "fallback_providers:\n"
+        "  - provider: deepseek\n"
+        "    model: deepseek-v4-flash\n"
+    )
+
+    runner = SimpleNamespace(
+        _fallback_model=None,
+    )
+    runner._load_fallback_model = GatewayRunner._load_fallback_model
+    bound = GatewayRunner._refresh_fallback_model.__get__(runner)
+    chain = bound()
+
+    assert chain == [{"provider": "deepseek", "model": "deepseek-v4-flash"}]
+    assert runner._fallback_model == chain
+
+    cfg.write_text(
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: anthropic/claude-sonnet-4.6\n"
+    )
+    updated = bound()
+    assert updated == [
+        {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"}
+    ]
+    assert runner._fallback_model == updated
+
+
+def test_refresh_fallback_model_clears_when_config_removed(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "fallback_providers:\n"
+        "  - provider: deepseek\n"
+        "    model: deepseek-v4-flash\n"
+    )
+
+    runner = SimpleNamespace(
+        _fallback_model=[{"provider": "stale", "model": "x"}],
+    )
+    runner._load_fallback_model = GatewayRunner._load_fallback_model
+    bound = GatewayRunner._refresh_fallback_model.__get__(runner)
+    assert bound() is not None
+
+    cfg.write_text("model:\n  provider: nvidia\n")
+    assert bound() is None
+    assert runner._fallback_model is None
+
+
+def test_apply_fallback_chain_updates_primary_agent():
+    from gateway.run import GatewayRunner
+
+    agent = SimpleNamespace(
+        _fallback_chain=[],
+        _fallback_model=None,
+        _fallback_index=0,
+        _fallback_activated=False,
+        _rate_limited_until=0,
+    )
+    chain = [{"provider": "deepseek", "model": "deepseek-v4-flash"}]
+    GatewayRunner._apply_fallback_chain_to_agent(agent, chain)
+
+    assert agent._fallback_chain == chain
+    assert agent._fallback_model == chain[0]
+    assert agent._fallback_index == 0
+
+
+def test_apply_fallback_chain_skips_while_cooldown_holds_fallback():
+    """Do not clobber a live fallback activation during its cooldown window."""
+    from gateway.run import GatewayRunner
+
+    live = [{"provider": "deepseek", "model": "deepseek-v4-flash"}]
+    agent = SimpleNamespace(
+        _fallback_chain=live,
+        _fallback_model=live[0],
+        _fallback_index=1,
+        _fallback_activated=True,
+        _rate_limited_until=time.monotonic() + 30,
+    )
+    GatewayRunner._apply_fallback_chain_to_agent(
+        agent,
+        [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"}],
+    )
+
+    assert agent._fallback_chain == live
+    assert agent._fallback_index == 1
+    assert agent._fallback_activated is True
+
+
+def test_apply_fallback_chain_updates_after_cooldown_expires():
+    from gateway.run import GatewayRunner
+
+    agent = SimpleNamespace(
+        _fallback_chain=[{"provider": "deepseek", "model": "old"}],
+        _fallback_model={"provider": "deepseek", "model": "old"},
+        _fallback_index=1,
+        _fallback_activated=True,
+        _rate_limited_until=time.monotonic() - 1,
+    )
+    new_chain = [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"}]
+    GatewayRunner._apply_fallback_chain_to_agent(agent, new_chain)
+
+    assert agent._fallback_chain == new_chain
+    assert agent._fallback_model == new_chain[0]
+    # Activated agents keep their index; restore_primary_runtime owns reset.
+    assert agent._fallback_index == 1
+
+
+def test_background_and_main_agent_paths_call_refresh():
+    """Both AIAgent construction sites must pass a refreshed chain, not the
+    startup snapshot. Source-level invariant — mirrors
+    tests/agent/test_gemini_fast_fallback.py's call-site pin.
+    """
+    from pathlib import Path
+
+    source = Path("gateway/run.py").read_text(encoding="utf-8")
+    assert "fallback_model=self._refresh_fallback_model()" in source
+    assert source.count("fallback_model=self._refresh_fallback_model()") >= 2
+    # The stale startup-snapshot form must not remain at create sites.
+    assert "fallback_model=self._fallback_model," not in source
+
+
+def test_load_fallback_model_static_unchanged_contract(tmp_path, monkeypatch):
+    """_load_fallback_model remains a pure static reader used by refresh."""
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "fallback_providers:\n"
+        "  - provider: deepseek\n"
+        "    model: deepseek-v4-flash\n"
+        "fallback_model:\n"
+        "  provider: nous\n"
+        "  model: Hermes-4\n"
+    )
+
+    chain = GatewayRunner._load_fallback_model()
+    assert chain == [
+        {"provider": "deepseek", "model": "deepseek-v4-flash"},
+        {"provider": "nous", "model": "Hermes-4"},
+    ]


### PR DESCRIPTION
## Summary
- Fixes [#60955](https://github.com/NousResearch/hermes-agent/issues/60955): gateway messaging sessions (Feishu etc.) could burn a full 429 retry budget without activating a configured `fallback_providers` chain, while cron in the same process fell back correctly.
- Root cause is **not** an eager mid-handler hoist past recovery `continue`s (that premise was correctly rejected on #60965). The conversation-loop 429 → fallback path already works when `_fallback_chain` is populated; credential-pool rotation before fallback stays intentional (#11314).
- Real gap: gateway froze `self._fallback_model` at process start, while cron reloads via `get_fallback_chain` every job. A chain configured/edited after `hermes gateway` was already running never reached live messaging agents (including cached ones).
- Change: `_refresh_fallback_model()` re-reads config on agent create (main + background) and on cached-agent reuse (same pattern as api_server/TUI/cron). Cached apply skips rewrite while a rate-limit cooldown is holding an activated fallback.

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_fallback_chain_reload.py tests/gateway/test_auth_fallback.py`
- [ ] Configure `fallback_providers` after gateway is already running; send a messaging turn that 429s on primary; confirm fallback activates (status/`Fallback to …` logs)
- [ ] Confirm multi-key credential pools still rotate before falling back
- [ ] Confirm a cooldown-held activated fallback is not clobbered mid-turn