### PR TITLE
fix(agent): exclude Ollama Cloud from local-Ollama stop misreport + separator-safe continuation join (#60928)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2653,7 +2653,9 @@ def run_conversation(
                                 _retry.restart_with_length_continuation = True
                                 break
 
-                            partial_response = agent._strip_think_blocks("".join(truncated_response_parts)).strip()
+                            # ponytail: join with newline so a part-boundary
+                            # MEDIA: tag stays delimiter-separated (#60928).
+                            partial_response = agent._strip_think_blocks("\n".join(truncated_response_parts)).strip()
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             return {
@@ -6263,7 +6265,10 @@ def run_conversation(
                 codex_ack_continuations = 0
 
                 if truncated_response_parts:
-                    final_response = "".join(truncated_response_parts) + final_response
+                    # ponytail: join with newline, not "". A MEDIA: tag at a
+                    # part boundary must be followed by a delimiter so
+                    # MEDIA_TAG_CLEANUP_RE's lookahead fires (#60928).
+                    final_response = "\n".join([*truncated_response_parts, final_response])
                     truncated_response_parts = []
                     length_continue_retries = 0
                 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -877,6 +877,32 @@ def _notify_context_engine_turn_complete(
         )
 
 
+def _join_continuation_parts(parts: list) -> str:
+    """Join truncated-continuation parts, preserving MEDIA: tags.
+
+    Prose/code is concatenated with ``""`` so "Part 1" + "Part 2" stays
+    "Part 1 Part 2" (see run_agent/test_run_agent.py). The only place a
+    delimiter is required is a MEDIA: tag boundary: ``MEDIA_TAG_CLEANUP_RE``
+    needs a trailing delimiter, so when a part ends with a complete MEDIA
+    tag and the next part does not begin with whitespace, a newline is
+    inserted between them. This keeps the cleanup regex's lookahead firing
+    without corrupting ordinary continuation text (#60928, teknium1 review).
+    """
+    if not parts:
+        return ""
+    from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
+
+    out: list = [parts[0]]
+    for p in parts[1:]:
+        prev = out[-1]
+        _prev_ends_media = bool(MEDIA_TAG_CLEANUP_RE.search(prev + "\n")) and not prev.endswith(("\n", " ", "\t"))
+        if _prev_ends_media and not (p[:1].isspace() if p else False):
+            out.append("\n" + p)
+        else:
+            out.append(p)
+    return "".join(out)
+
+
 def run_conversation(
     agent,
     user_message: Any,
@@ -2653,9 +2679,7 @@ def run_conversation(
                                 _retry.restart_with_length_continuation = True
                                 break
 
-                            # ponytail: join with newline so a part-boundary
-                            # MEDIA: tag stays delimiter-separated (#60928).
-                            partial_response = agent._strip_think_blocks("\n".join(truncated_response_parts)).strip()
+                            partial_response = agent._strip_think_blocks(_join_continuation_parts(truncated_response_parts)).strip()
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             return {
@@ -6265,10 +6289,10 @@ def run_conversation(
                 codex_ack_continuations = 0
 
                 if truncated_response_parts:
-                    # ponytail: join with newline, not "". A MEDIA: tag at a
-                    # part boundary must be followed by a delimiter so
-                    # MEDIA_TAG_CLEANUP_RE's lookahead fires (#60928).
-                    final_response = "\n".join([*truncated_response_parts, final_response])
+                    # Join truncated parts: prose/code stays ""-concatenated;
+                    # a MEDIA: tag at a boundary gets a delimiter so the
+                    # cleanup regex's lookahead fires (#60928).
+                    final_response = _join_continuation_parts([*truncated_response_parts, final_response])
                     truncated_response_parts = []
                     length_continue_retries = 0
                 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1613,8 +1613,10 @@ class AIAgent:
         if "ollama" in self._base_url_lower or ":11434" in self._base_url_lower:
             # ponytail: ollama.com is Ollama *Cloud* (hosted, reports
             # finish_reason correctly) — must not trigger the local-Ollama
-            # stop-misreport workaround. #60928.
-            if "ollama.com" in self._base_url_lower:
+            # stop-misreport workaround. #60928. Use the host-matches helper
+            # (not a raw substring) so lookalike hosts like
+            # ollama.com.attacker.test don't match. See teknium1 review #60988.
+            if base_url_host_matches(self._base_url_lower, "ollama.com"):
                 return False
             return True
         return provider_lower == "ollama"

--- a/run_agent.py
+++ b/run_agent.py
@@ -1611,6 +1611,11 @@ class AIAgent:
         if "glm" not in model_lower and provider_lower != "zai":
             return False
         if "ollama" in self._base_url_lower or ":11434" in self._base_url_lower:
+            # ponytail: ollama.com is Ollama *Cloud* (hosted, reports
+            # finish_reason correctly) — must not trigger the local-Ollama
+            # stop-misreport workaround. #60928.
+            if "ollama.com" in self._base_url_lower:
+                return False
             return True
         return provider_lower == "ollama"
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5389,6 +5389,32 @@ class TestRunConversation:
         assert second_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in second_call_messages[-1]["content"]
 
+    def test_length_continuation_media_boundary_stays_delimited(self, agent):
+        """A MEDIA: tag at the truncation boundary must stay delimiter-separated
+        through the real continuation loop (regression for #60928).
+
+        If the join glued the parts, the tag would become
+        ``MEDIA:/tmp/img.pngcaption`` with no trailing delimiter and the
+        downstream cleanup regex could not strip it.
+        """
+        self._setup_agent(agent)
+        first = _mock_response(content="see MEDIA:/tmp/img.png", finish_reason="length")
+        second = _mock_response(content="caption text", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [first, second]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        final = result["final_response"]
+        assert "MEDIA:/tmp/img.png" in final
+        # The tag must not be glued to the following word.
+        assert "MEDIA:/tmp/img.pngcaption" not in final
+
     def test_length_continuation_preserves_large_provider_default_output_cap(self, agent):
         """Continuation retries must not shrink a higher provider default cap."""
         self._setup_agent(agent)

--- a/tests/test_ollama_cloud_stop_misreport.py
+++ b/tests/test_ollama_cloud_stop_misreport.py
@@ -99,30 +99,39 @@ class TestOllamaCloudNotLocal:
 class TestTruncatedJoinKeepsMediaDelimiter:
     """Bug 2 (#60928): a part-boundary MEDIA: tag must stay delimiter-separated.
 
-    The continuation join now uses ``"\\n".join`` instead of ``"".join`` so the
-    tag is followed by a delimiter and MEDIA_TAG_CLEANUP_RE still strips it.
+    ``_join_continuation_parts`` concatenates prose/code with ``""`` (so
+    "Part 1" + "Part 2" stays "Part 1 Part 2") but inserts a delimiter only
+    at a MEDIA: tag boundary, where MEDIA_TAG_CLEANUP_RE needs a trailing
+    delimiter to strip the directive.
     """
 
-    def test_joined_media_tag_is_stripped(self):
+    def test_prose_stays_glued(self):
+        from agent.conversation_loop import _join_continuation_parts
+
+        assert _join_continuation_parts(["Part 1 ", "Part 2"]) == "Part 1 Part 2"
+
+    def test_media_boundary_gets_delimiter(self):
+        from agent.conversation_loop import _join_continuation_parts
         from gateway.platforms.base import _strip_media_tag_directives
 
         part1 = "Here is your file: MEDIA:/tmp/audio/tts_20260708_052306.ogg"
         part2 = "It's a warm and humid day."
-        # ponytail: mirrors the fixed join in conversation_loop.py.
-        assembled = "\n".join([part1, part2])
+        assembled = _join_continuation_parts([part1, part2])
 
         cleaned = _strip_media_tag_directives(assembled)
         assert "MEDIA:/tmp/audio/tts_20260708_052306.ogg" not in cleaned
         assert cleaned.strip().startswith("Here is your file:")
 
-    def test_old_glued_join_leaves_raw_tag(self):
-        # Documents the bug class: the pre-fix "".join glues the tag to the
-        # next word so the cleanup regex's lookahead can't match.
+    def test_media_tag_at_start_of_next_part(self):
+        # Previous part ends with prose; next part is a bare MEDIA: tag. The
+        # helper must not glue them into one un-delimited token.
+        from agent.conversation_loop import _join_continuation_parts
         from gateway.platforms.base import _strip_media_tag_directives
 
-        part1 = "MEDIA:/tmp/audio/tts_20260708_052306.ogg"
-        part2 = "It's a warm day."
-        glued = "".join([part1, part2])  # pre-fix behavior
+        part1 = "see this:"
+        part2 = "MEDIA:/tmp/img/plot.png some caption"
+        assembled = _join_continuation_parts([part1, part2])
 
-        cleaned = _strip_media_tag_directives(glued)
-        assert "MEDIA:/tmp/audio/tts_20260708_052306.ogg" in cleaned
+        cleaned = _strip_media_tag_directives(assembled)
+        assert "MEDIA:/tmp/img/plot.png" not in cleaned
+        assert cleaned.strip().startswith("see this:")

--- a/tests/test_ollama_cloud_stop_misreport.py
+++ b/tests/test_ollama_cloud_stop_misreport.py
@@ -1,0 +1,128 @@
+"""Regression tests for #60928: Ollama Cloud (ollama.com) stop→truncated false positive.
+
+Ollama Cloud is a hosted OpenAI-compatible API that reports finish_reason
+correctly. The local-Ollama workaround in ``_is_ollama_glm_backend`` must not
+fire for ``ollama.com`` (only for genuinely local Ollama: port 11434,
+``ollama.`` hostnames, or ``provider: ollama``).
+"""
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _tool_defs(*names):
+    return [
+        {"type": "function", "function": {"name": n, "description": n, "parameters": {}}}
+        for n in names
+    ]
+
+
+class _FakeOpenAI:
+    def __init__(self, **kw):
+        self.api_key = kw.get("api_key", "test")
+        self.base_url = kw.get("base_url", "http://test")
+
+    def close(self):
+        pass
+
+
+def _make_agent(monkeypatch, *, base_url, provider, model):
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: _tool_defs("web_search"))
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+    return AIAgent(
+        api_key="test-key",
+        base_url=base_url,
+        provider=provider,
+        model=model,
+        api_mode="chat_completions",
+        max_iterations=4,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+class TestOllamaCloudNotLocal:
+    """ollama.com must not trip the local-Ollama GLM workaround (#60928)."""
+
+    def test_ollama_cloud_host_excluded(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            base_url="https://ollama.com/v1",
+            provider="ollama-cloud",
+            model="glm-5.2",
+        )
+        assert agent._is_ollama_glm_backend() is False
+
+    def test_ollama_cloud_subdomain_excluded(self, monkeypatch):
+        # ponytail: catches the latent variant where the host matches but
+        # isn't the public cloud domain.
+        agent = _make_agent(
+            monkeypatch,
+            base_url="https://api.ollama.com/v1",
+            provider="ollama-cloud",
+            model="glm-5.2",
+        )
+        assert agent._is_ollama_glm_backend() is False
+
+    def test_local_ollama_port_still_detected(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            base_url="http://localhost:11434/v1",
+            provider="ollama",
+            model="glm-5.2",
+        )
+        assert agent._is_ollama_glm_backend() is True
+
+    def test_local_ollama_hostname_still_detected(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            base_url="http://ollama.local:11434/v1",
+            provider="ollama",
+            model="glm-5.2",
+        )
+        assert agent._is_ollama_glm_backend() is True
+
+    def test_non_glm_model_not_flagged(self, monkeypatch):
+        # The workaround only applies to GLM-family models + zai provider.
+        agent = _make_agent(
+            monkeypatch,
+            base_url="http://localhost:11434/v1",
+            provider="ollama",
+            model="llama3.1",
+        )
+        assert agent._is_ollama_glm_backend() is False
+
+
+class TestTruncatedJoinKeepsMediaDelimiter:
+    """Bug 2 (#60928): a part-boundary MEDIA: tag must stay delimiter-separated.
+
+    The continuation join now uses ``"\\n".join`` instead of ``"".join`` so the
+    tag is followed by a delimiter and MEDIA_TAG_CLEANUP_RE still strips it.
+    """
+
+    def test_joined_media_tag_is_stripped(self):
+        from gateway.platforms.base import _strip_media_tag_directives
+
+        part1 = "Here is your file: MEDIA:/tmp/audio/tts_20260708_052306.ogg"
+        part2 = "It's a warm and humid day."
+        # ponytail: mirrors the fixed join in conversation_loop.py.
+        assembled = "\n".join([part1, part2])
+
+        cleaned = _strip_media_tag_directives(assembled)
+        assert "MEDIA:/tmp/audio/tts_20260708_052306.ogg" not in cleaned
+        assert cleaned.strip().startswith("Here is your file:")
+
+    def test_old_glued_join_leaves_raw_tag(self):
+        # Documents the bug class: the pre-fix "".join glues the tag to the
+        # next word so the cleanup regex's lookahead can't match.
+        from gateway.platforms.base import _strip_media_tag_directives
+
+        part1 = "MEDIA:/tmp/audio/tts_20260708_052306.ogg"
+        part2 = "It's a warm day."
+        glued = "".join([part1, part2])  # pre-fix behavior
+
+        cleaned = _strip_media_tag_directives(glued)
+        assert "MEDIA:/tmp/audio/tts_20260708_052306.ogg" in cleaned


### PR DESCRIPTION


---
**Review feedback addressed (teknium1):**
1. Replaced raw `"ollama.com" in base_url` with `base_url_host_matches(self._base_url_lower, "ollama.com")` (avoids lookalike-host false matches; covered by tests/test_base_url_hostname.py).
2. Reverted the blanket `"
".join` in the truncation-continuation join to `""` concatenation (keeps `"Part 1 Part 2"` per test_run_agent.py) and added `_join_continuation_parts` which inserts a delimiter ONLY at a MEDIA: tag boundary, so MEDIA_TAG_CLEANUP_RE still fires. Re-tested: prose contract + MEDIA-strip both pass.

Closes #60928