### PR TITLE
fix(agent): prevent text-only main model from leaking into vision provider client (#57948)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4454,7 +4454,15 @@ def resolve_provider_client(
     # return the actual current runtime model when the caller did not explicitly
     # request one. (# compression-current-model)
     if not model and provider != "auto":
-        model = _get_aux_model_for_provider(provider) or _read_main_model() or model
+        aux_model = _get_aux_model_for_provider(provider)
+        if aux_model:
+            model = aux_model
+        elif not is_vision:
+            # For non-vision tasks only: fall back to the main runtime model.
+            # Vision tasks must NOT inherit the text-only main model — doing so
+            # injects a text-only model into the vision provider's client, causing
+            # a 400 "Unexpected item type in content" on the first call (#57948).
+            model = _read_main_model() or model
 
     def _needs_codex_wrap(client_obj, base_url_str: str, model_str: str) -> bool:
         """Decide if a plain OpenAI client should be wrapped for Responses API.


### PR DESCRIPTION
## Summary

Fixes a bug where `vision_analyze` returns a **400 "Unexpected item type in content"** on its first call when the main model is text-only (e.g. `deepseek-chat`) and no vision auxiliary model is explicitly configured. The error occurs because the text-only main model leaks into the vision provider's client initialization.

## Root Cause

In `resolve_provider_client()`, when `model` is `None` and `provider` is not `"auto"`, the fallback logic calls:

```python
model = _get_aux_model_for_provider(provider) or _read_main_model() or model
```

This unconditionally falls back to `_read_main_model()` — the main runtime model — even when the client is being created for a **vision** task. If the main model is text-only, it gets injected as the model name for the vision provider client, causing the upstream API to reject the request with a 400 error on the very first message (since a text-only model receives image content it cannot process).

## Change

In `agent/auxiliary_client.py`, the vision-aware fallback now:

1. Uses `_get_aux_model_for_provider(provider)` if available (same as before).
2. Falls back to `_read_main_model()` **only when `is_vision` is `False`** — vision tasks skip this fallback entirely.

```python
# Before:
model = _get_aux_model_for_provider(provider) or _read_main_model() or model

# After:
aux_model = _get_aux_model_for_provider(provider)
if aux_model:
    model = aux_model
elif not is_vision:
    # Vision tasks must NOT inherit the text-only main model
    model = _read_main_model() or model
```

## Verification

- 326 tests pass, 9 pre-existing failures (unrelated to this change)
- The fix targets the exact call path: `resolve_provider_client` → fallback model assignment for vision tasks
- No other call sites are affected — the `is_vision` guard is specific to this single entry point