### PR TITLE
fix(agent): reset fallback chain index after failed early activation (#60955)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3205,6 +3205,11 @@ def run_conversation(
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
                             continue
+                        # Fallback activation failed mid-retry — restore the
+                        # chain index so the retry-exhausted terminal path
+                        # (below) can retry instead of finding
+                        # _fallback_index >= len(chain).  See #60955.
+                        agent._fallback_index = 0
 
                 # ── Auth-failure provider failover ───────────────────────
                 # A 401/403 that survives the per-provider credential-refresh

--- a/tests/run_agent/test_fallback_index_reset_on_failed_early_activation_60955.py
+++ b/tests/run_agent/test_fallback_index_reset_on_failed_early_activation_60955.py
@@ -1,0 +1,76 @@
+"""Regression test for #60955: fallback chain index consumed by failed early
+rate-limit activation prevents terminal retry-exhaustion path from retrying.
+
+Uses direct file-inspection instead of module import (avoids the
+conversation_loop.py import cascade that can hang on Windows).
+
+Bug: when the rate-limit handler in conversation_loop.py calls
+_try_activate_fallback() and it fails (returns False), the internal recursive
+call already incremented _fallback_index past len(_fallback_chain).  The
+terminal "max retries — trying fallback" path checks _has_pending_fallback()
+which sees _fallback_index >= len(chain) and returns False — fallback is never
+retried after the retry budget burns out.
+
+Fix: reset _fallback_index = 0 after the early fallback activation fails,
+so the terminal path can retry instead of finding the chain exhausted.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Resolve the source file relative to this test file
+_HERE = Path(__file__).resolve().parent
+_SRC = (_HERE / "../../agent/conversation_loop.py").resolve()
+
+
+def _get_source() -> str:
+    return _SRC.read_text(encoding="utf-8")
+
+
+class TestFallbackIndexResetOnFailedEarlyActivation:
+    """The rate-limit early-fallback block must reset ``_fallback_index = 0``
+    when ``_try_activate_fallback`` returns False, so the retry-exhaustion
+    terminal path can attempt fallback after the retry budget is consumed."""
+
+    def test_fallback_index_reset_present(self):
+        src = _get_source()
+        # The fix block: just after `continue` at end of the
+        # `if _try_activate_fallback:` block in the rate-limit handler,
+        # there must be a reset guarded by a "Fallback activation failed"
+        # comment referencing #60955.
+        match = re.search(
+            r"(?s)"  # DOTALL
+            r"# Fallback activation failed.*?"
+            r"agent\._fallback_index\s*=\s*0",
+            src,
+        )
+        assert match is not None, (
+            "Failed early-activation fallback index reset NOT found in "
+            "conversation_loop.py — the rate-limit fallback block must reset "
+            "_fallback_index = 0 after _try_activate_fallback returns False. "
+            "See #60955."
+        )
+
+    def test_exactly_one_fallback_reset(self):
+        """Ensure exactly one reset guarded by the 'failed activation' comment
+        (distinct from the primary-recovery reset and other resets)."""
+        src = _get_source()
+        matches = re.findall(
+            r"(?s)# Fallback activation failed.*?_fallback_index\s*=\s*0",
+            src,
+        )
+        assert len(matches) == 1, (
+            f"Expected exactly 1 fallback-activation-failure reset, "
+            f"found {len(matches)}"
+        )
+
+    def test_both_resets_exist(self):
+        """The primary-recovery reset (in the `_try_recover_primary_transport`
+        block) and our new rate-limit reset must both exist independently."""
+        src = _get_source()
+        all_resets = re.findall(r"_fallback_index\s*=\s*0", src)
+        assert len(all_resets) >= 2, (
+            f"Expected at least 2 _fallback_index = 0 assignments "
+            f"(primary-recovery + rate-limit-fallback), found {len(all_resets)}"
+        )


### PR DESCRIPTION
## Summary
Fixes #60955.

When the rate-limit handler calls `_try_activate_fallback()` and it fails (returns False), the internal recursive call already incremented `_fallback_index` past `len(_fallback_chain)`. The remaining retries then see `_fallback_index >= len(chain)` at the fallback gate and skip it entirely — even though the post-retry-exhaustion terminal path at conversation_loop.py:3917 could have succeeded.

## Root cause
`try_activate_fallback()` increments `_fallback_index` *before* attempting activation (line 1271). If activation fails for any reason (missing API key, provider misconfiguration, dedup skip), the recursive fallback tries the next entry. When the chain is exhausted, `_fallback_index >= len(_fallback_chain)` and subsequent calls return False — but the index is never rolled back.

## Fix
After `_try_activate_fallback` returns False in the rate-limit handler, reset `_fallback_index = 0` so the retry-exhaustion terminal path can attempt fallback after the full retry budget is consumed.

## Safety
- The `_unavailable_fallback_keys` set/dict (with TTL per #60785) prevents infinite re-try of genuinely unavailable entries
- `_fallback_activated` is only set on actual activation success, so the primary-recovery cooldown isn't affected
- The primary-recovery path (conversation_loop.py:3913) already resets `_fallback_index = 0` — this mirrors that pattern for the rate-limit path

## Testing
- New companion test (`tests/run_agent/test_fallback_index_reset_on_failed_early_activation_60955.py`) validates the reset exists and can't be accidentally reverted
- All 37 existing fallback tests pass

| Scenario | Before | After |
|---|---|---|
| Single-key pool + 429, fallback activation fails early | Fallback never retried after retries exhaust | Fallback retried after retry-exhaustion threshold |
| Multiple fallback entries, first fails | Index skipped to next entry (unchanged) | Index reset so full chain re-attempted after exhaustion |
| Fallback activates successfully | retry_count=0, continue (unchanged) | Same — continue unaffected |