### PR TITLE
fix(profile-distribution): add timeout to git clone in _git_clone

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -381,6 +381,7 @@ def _git_clone(url: str, dest: Path) -> None:
             ["git", "clone", "--depth", "1", url, str(dest)],
             check=True,
             capture_output=True,
+            timeout=300,
         )
     except FileNotFoundError as exc:
         raise DistributionError("git is required for git-URL installs") from exc


### PR DESCRIPTION
## Summary

Add a 300-second timeout to the `subprocess.run` call in `_git_clone()` within `hermes_cli/profile_distribution.py`.

## Problem

The `git clone` operation in `_git_clone()` had no `timeout` parameter. When cloning from a slow, unresponsive, or misconfigured remote (or a broken git URL), `subprocess.run` would hang indefinitely, blocking the entire CLI process that invoked the distribution install.

This is the same class of bug already fixed in `tools/lazy_deps.py`, `hermes_cli/mcp_catalog.py`, and other areas of the codebase.

## Fix

Added `timeout=300` to the `subprocess.run` call. 300 seconds is consistent with other git clone timeout values in the codebase (e.g., `mcp_catalog.py`). On timeout, `subprocess.TimeoutExpired` is raised, which propagates as an uncaught exception — the caller's try/except chain (via the broader CLI error handling) will report the failure rather than silently hanging forever.

## Testing
- Syntax check passed (py_compile)
- Consistent with existing timeout values used for git clone operations elsewhere in the codebase