### PR TITLE
Secure Command Center work-packet bridge payloads

### DIFF
--- a/apps/desktop/src/app/command-center/index.test.tsx
+++ b/apps/desktop/src/app/command-center/index.test.tsx
@@ -1,0 +1,301 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { setSessions } from '@/store/session'
+
+const createWorkPacketFromSession = vi.fn()
+const getActionStatus = vi.fn()
+const getKanbanBoard = vi.fn()
+const getKanbanTask = vi.fn()
+const getLogs = vi.fn()
+const getStatus = vi.fn()
+const getUsageAnalytics = vi.fn()
+const restartGateway = vi.fn()
+const updateHermes = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  createWorkPacketFromSession: (id: string, profile?: null | string, payload?: unknown) =>
+    createWorkPacketFromSession(id, profile, payload),
+  getActionStatus: (name: string, lines?: number) => getActionStatus(name, lines),
+  getKanbanBoard: () => getKanbanBoard(),
+  getKanbanTask: (id: string) => getKanbanTask(id),
+  getLogs: (params: unknown) => getLogs(params),
+  getStatus: () => getStatus(),
+  getUsageAnalytics: (days: number) => getUsageAnalytics(days),
+  restartGateway: () => restartGateway(),
+  updateHermes: () => updateHermes()
+}))
+
+function renderCommandCenter(onOpenSession = vi.fn(), initialSection: 'sessions' | 'work-packets' = 'work-packets') {
+  return import('./index').then(({ CommandCenterView }) =>
+    render(
+      <I18nProvider configClient={null}>
+        <MemoryRouter initialEntries={['/command-center']}>
+          <CommandCenterView
+            initialSection={initialSection}
+            onClose={vi.fn()}
+            onDeleteSession={vi.fn()}
+            onOpenSession={onOpenSession}
+          />
+        </MemoryRouter>
+      </I18nProvider>
+    )
+  )
+}
+
+beforeEach(() => {
+  setSessions([])
+  getActionStatus.mockResolvedValue({ exit_code: 0, lines: [], name: 'noop', pid: 1, running: false })
+  getLogs.mockResolvedValue({ lines: [] })
+  getStatus.mockResolvedValue({ active_sessions: 0, gateway_running: true, version: 'test' })
+  getUsageAnalytics.mockResolvedValue(null)
+  restartGateway.mockResolvedValue({ name: 'restart', pid: 1 })
+  updateHermes.mockResolvedValue({ name: 'update', pid: 2 })
+  createWorkPacketFromSession.mockResolvedValue({ created: true, task: null, work_packets: { count: 1, open_count: 1 } })
+
+  getKanbanBoard.mockResolvedValue({
+    assignees: ['Hermes'],
+    columns: [
+      {
+        name: 'ready',
+        tasks: [
+          {
+            assignee: 'Hermes',
+            created_at: 1_800_000_000,
+            id: 'task-linked',
+            latest_summary: 'Short card summary',
+            priority: 5,
+            session_bridge: {
+              last_active: 1_800_000_050,
+              profile: 'default',
+              session_exists: true,
+              session_id: 'session-linked',
+              source: 'desktop',
+              title: 'Founder OS linked session'
+            },
+            status: 'ready',
+            title: 'Investigate FounderOS bridge'
+          }
+        ]
+      }
+    ],
+    latest_event_id: 42,
+    now: 1_800_000_100
+  })
+
+  getKanbanTask.mockResolvedValue({
+    task: {
+      assignee: 'Hermes',
+      created_at: 1_800_000_000,
+      id: 'task-linked',
+      latest_summary: 'Full safe handoff summary',
+      priority: 5,
+      session_bridge: {
+        last_active: 1_800_000_050,
+        profile: 'default',
+        session_exists: true,
+        session_id: 'session-linked',
+        source: 'desktop',
+        title: 'Founder OS linked session'
+      },
+      status: 'ready',
+      title: 'Investigate FounderOS bridge'
+    }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('CommandCenterView work packets', () => {
+  it('opens a selected work packet detail and navigates to its linked session', async () => {
+    const onOpenSession = vi.fn()
+
+    await renderCommandCenter(onOpenSession)
+
+    fireEvent.click(await screen.findByText('Investigate FounderOS bridge'))
+
+    await waitFor(() => expect(getKanbanTask).toHaveBeenCalledWith('task-linked'))
+    expect(await screen.findByText('Full safe handoff summary')).toBeTruthy()
+    expect(screen.queryByText('Full task instructions for the FounderOS bridge.')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open linked session' }))
+
+    expect(onOpenSession).toHaveBeenCalledWith('session-linked', 'default')
+  })
+
+  it('opens a session row linked work packet detail without opening the session', async () => {
+    const onOpenSession = vi.fn()
+
+    setSessions([
+      {
+        ended_at: null,
+        id: 'session-linked',
+        input_tokens: 0,
+        is_active: false,
+        last_active: 1_800_000_050,
+        message_count: 3,
+        model: null,
+        output_tokens: 0,
+        preview: null,
+        source: 'desktop',
+        started_at: 1_800_000_000,
+        title: 'Founder OS linked session',
+        tool_call_count: 0,
+        work_packets: {
+          count: 1,
+          latest: {
+            assignee: 'Hermes',
+            id: 'task-linked',
+            priority: 5,
+            status: 'ready',
+            title: 'Investigate FounderOS bridge'
+          },
+          open_count: 1
+        }
+      }
+    ])
+
+    await renderCommandCenter(onOpenSession, 'sessions')
+
+    const badge = await screen.findByRole('button', { name: 'Work packet details: Investigate FounderOS bridge' })
+    expect(badge.textContent).toContain('1/1')
+    fireEvent.click(badge)
+
+    await waitFor(() => expect(getKanbanBoard).toHaveBeenCalled())
+    await waitFor(() => expect(getKanbanTask).toHaveBeenCalledWith('task-linked'))
+    expect(await screen.findByText('Full safe handoff summary')).toBeTruthy()
+    expect(screen.queryByText('Full task instructions for the FounderOS bridge.')).toBeNull()
+    expect(onOpenSession).not.toHaveBeenCalled()
+  })
+
+  it('creates a work packet from an unlinked session and updates the row summary', async () => {
+    const onOpenSession = vi.fn()
+
+    createWorkPacketFromSession.mockResolvedValue({
+      created: true,
+      task: {
+        assignee: 'Hermes',
+        created_at: 1_800_000_120,
+        id: 'task-created',
+        priority: 4,
+        session_id: 'session-unlinked',
+        status: 'ready',
+        title: 'Created packet from session'
+      },
+      work_packets: {
+        count: 1,
+        latest: {
+          assignee: 'Hermes',
+          id: 'task-created',
+          priority: 4,
+          status: 'ready',
+          title: 'Created packet from session'
+        },
+        open_count: 1
+      }
+    })
+    setSessions([
+      {
+        ended_at: null,
+        id: 'session-unlinked',
+        input_tokens: 0,
+        is_active: false,
+        last_active: 1_800_000_110,
+        message_count: 2,
+        model: null,
+        output_tokens: 0,
+        preview: null,
+        source: 'desktop',
+        started_at: 1_800_000_000,
+        title: 'Unlinked FounderOS session',
+        tool_call_count: 0
+      }
+    ])
+
+    await renderCommandCenter(onOpenSession, 'sessions')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Create work packet' }))
+
+    await waitFor(() => expect(createWorkPacketFromSession).toHaveBeenCalledWith('session-unlinked', undefined, undefined))
+    await waitFor(() => expect(getKanbanBoard).toHaveBeenCalled())
+
+    const badge = await screen.findByRole('button', { name: 'Work packet details: Created packet from session' })
+    expect(badge.textContent).toContain('1/1')
+    expect(onOpenSession).not.toHaveBeenCalled()
+  })
+
+  it('opens a linked work packet that is outside the recent list', async () => {
+    const onOpenSession = vi.fn()
+
+    const hiddenTask = {
+      assignee: 'Hermes',
+      created_at: 1_800_000_000,
+      id: 'task-outside-recent',
+      latest_summary: 'Older card summary',
+      priority: 4,
+      session_bridge: {
+        last_active: 1_800_000_050,
+        profile: 'default',
+        session_exists: true,
+        session_id: 'session-outside-recent',
+        source: 'desktop',
+        title: 'Outside recent linked session'
+      },
+      status: 'ready',
+      title: 'Backfill old FounderOS packet'
+    }
+
+    const newerTasks = Array.from({ length: 6 }, (_, index) => ({
+      assignee: 'Hermes',
+      created_at: 1_800_000_100 + index,
+      id: `task-newer-${index}`,
+      latest_summary: `Newer summary ${index}`,
+      priority: 3,
+      session_bridge: {
+        last_active: 1_800_000_200 + index,
+        profile: 'default',
+        session_exists: true,
+        session_id: `session-newer-${index}`,
+        source: 'desktop',
+        title: `Newer linked session ${index}`
+      },
+      status: 'ready',
+      title: `Newer packet ${index}`
+    }))
+
+    getKanbanBoard.mockResolvedValue({
+      assignees: ['Hermes'],
+      columns: [
+        {
+          name: 'ready',
+          tasks: [...newerTasks, hiddenTask]
+        }
+      ],
+      latest_event_id: 43,
+      now: 1_800_000_300
+    })
+    getKanbanTask.mockResolvedValue({
+      task: {
+        ...hiddenTask,
+        latest_summary: 'Full older safe summary'
+      }
+    })
+
+    await renderCommandCenter(onOpenSession)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Work packet details: Backfill old FounderOS packet' }))
+
+    await waitFor(() => expect(getKanbanTask).toHaveBeenCalledWith('task-outside-recent'))
+    expect(await screen.findByText('Full older safe summary')).toBeTruthy()
+    expect(screen.queryByText('Raw old task body should stay hidden.')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open linked session' }))
+
+    expect(onOpenSession).toHaveBeenCalledWith('session-outside-recent', 'default')
+  })
+})

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -7,8 +7,25 @@ import { Button } from '@/components/ui/button'
 import { SearchField } from '@/components/ui/search-field'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { ResponsiveTabs } from '@/components/ui/tab-dropdown'
-import { getActionStatus, getLogs, getStatus, getUsageAnalytics, restartGateway, updateHermes } from '@/hermes'
-import type { ActionStatusResponse, AnalyticsResponse, StatusResponse } from '@/hermes'
+import {
+  createWorkPacketFromSession,
+  getActionStatus,
+  getKanbanBoard,
+  getKanbanTask,
+  getLogs,
+  getStatus,
+  getUsageAnalytics,
+  restartGateway,
+  updateHermes
+} from '@/hermes'
+import type {
+  ActionStatusResponse,
+  AnalyticsResponse,
+  KanbanBoardResponse,
+  KanbanTaskDetailResponse,
+  SessionInfo,
+  StatusResponse
+} from '@/hermes'
 import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { compactNumber } from '@/lib/format'
@@ -18,8 +35,10 @@ import {
   BarChart3,
   Bookmark,
   BookmarkFilled,
+  Clipboard,
   Download,
   MessageCircle,
+  Plus,
   Trash2,
   Wrench
 } from '@/lib/icons'
@@ -28,7 +47,7 @@ import { fmtDateTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $sessions, sessionPinId } from '@/store/session'
+import { $sessions, sessionPinId, setSessions } from '@/store/session'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -37,15 +56,23 @@ import { OverlayView } from '../overlays/overlay-view'
 
 import { MaintenancePanel } from './maintenance'
 
-export type CommandCenterSection = 'maintenance' | 'sessions' | 'system' | 'usage'
+export type CommandCenterSection = 'maintenance' | 'sessions' | 'work-packets' | 'system' | 'usage'
 
-const SECTIONS = ['sessions', 'system', 'usage', 'maintenance'] as const satisfies readonly CommandCenterSection[]
+const SECTIONS = ['sessions', 'work-packets', 'system', 'usage', 'maintenance'] as const satisfies readonly CommandCenterSection[]
 
 const LOG_FILES = ['agent', 'errors', 'gateway', 'desktop'] as const
 const LOG_LEVELS = ['ALL', 'INFO', 'WARNING', 'ERROR'] as const
 
 const USAGE_PERIODS = [7, 30, 90] as const
+const WORK_PACKET_STATUSES = ['triage', 'todo', 'scheduled', 'ready', 'running', 'blocked', 'review', 'done'] as const
+type WorkPacketStatus = (typeof WORK_PACKET_STATUSES)[number]
+type WorkPacketTask = KanbanBoardResponse['columns'][number]['tasks'][number]
+const OPEN_WORK_PACKET_STATUSES = new Set<string>(['triage', 'todo', 'scheduled', 'ready', 'running', 'blocked', 'review'])
 type UsagePeriod = (typeof USAGE_PERIODS)[number]
+
+function workPacketSessionKey(session: SessionInfo): string {
+  return `${session.profile?.trim() || 'default'}:${session.id}`
+}
 
 interface CommandCenterViewProps {
   initialSection?: CommandCenterSection
@@ -53,7 +80,7 @@ interface CommandCenterViewProps {
   onDeleteSession: (sessionId: string) => Promise<void>
   // Accepted for call-site parity; navigation lives in the global Cmd+K palette.
   onNavigateRoute?: (path: string) => void
-  onOpenSession: (sessionId: string) => void
+  onOpenSession: (sessionId: string, profile?: null | string) => void
 }
 
 function formatTimestamp(value?: number | null): string {
@@ -85,11 +112,13 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
 function RowIconButton({
   children,
   className,
+  disabled,
   onClick,
   title
 }: {
   children: ReactNode
   className?: string
+  disabled?: boolean
   onClick: (event: MouseEvent<HTMLButtonElement>) => void
   title: string
 }) {
@@ -97,6 +126,7 @@ function RowIconButton({
     <Button
       aria-label={title}
       className={cn('text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground', className)}
+      disabled={disabled}
       onClick={onClick}
       size="icon-xs"
       title={title}
@@ -146,6 +176,12 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   const [usageLoading, setUsageLoading] = useState(false)
   const [usageError, setUsageError] = useState('')
   const usageRequestRef = useRef(0)
+  const [workPackets, setWorkPackets] = useState<KanbanBoardResponse | null>(null)
+  const [workPacketsLoading, setWorkPacketsLoading] = useState(false)
+  const [workPacketsError, setWorkPacketsError] = useState('')
+  const [creatingWorkPacketSessionIds, setCreatingWorkPacketSessionIds] = useState<Set<string>>(() => new Set())
+  const [focusedWorkPacketTaskId, setFocusedWorkPacketTaskId] = useState<null | string>(null)
+  const workPacketsRequestRef = useRef(0)
 
   const debouncedQuery = useDebouncedValue(query.trim(), 180)
 
@@ -216,6 +252,29 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
     }
   }, [])
 
+  const refreshWorkPackets = useCallback(async () => {
+    const requestId = workPacketsRequestRef.current + 1
+    workPacketsRequestRef.current = requestId
+    setWorkPacketsLoading(true)
+    setWorkPacketsError('')
+
+    try {
+      const response = await getKanbanBoard()
+
+      if (workPacketsRequestRef.current === requestId) {
+        setWorkPackets(response)
+      }
+    } catch (error) {
+      if (workPacketsRequestRef.current === requestId) {
+        setWorkPacketsError(error instanceof Error ? error.message : String(error))
+      }
+    } finally {
+      if (workPacketsRequestRef.current === requestId) {
+        setWorkPacketsLoading(false)
+      }
+    }
+  }, [])
+
   useEffect(() => {
     // Refetch when the panel opens and whenever the log file/level filters
     // change (refreshSystem's identity tracks them).
@@ -230,9 +289,17 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
     }
   }, [refreshUsage, section, usagePeriod])
 
+  useEffect(() => {
+    if (section === 'work-packets' && !workPackets && !workPacketsLoading) {
+      void refreshWorkPackets()
+    }
+  }, [refreshWorkPackets, section, workPackets, workPacketsLoading])
+
   useRefreshHotkey(() => {
     if (section === 'system') {
       void refreshSystem()
+    } else if (section === 'work-packets') {
+      void refreshWorkPackets()
     } else if (section === 'usage') {
       void refreshUsage(usagePeriod)
     }
@@ -251,6 +318,47 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
     return logs.filter(line => line.toLowerCase().includes(needle))
   }, [logQuery, logs])
 
+  const createSessionWorkPacket = useCallback(
+    async (session: SessionInfo) => {
+      const sessionKey = workPacketSessionKey(session)
+
+      setWorkPacketsError('')
+      setCreatingWorkPacketSessionIds(previous => new Set(previous).add(sessionKey))
+
+      try {
+        const response = await createWorkPacketFromSession(session.id, session.profile)
+        const profile = session.profile ?? null
+
+        setSessions(previous =>
+          previous.map(row =>
+            row.id === session.id && (row.profile ?? null) === profile
+              ? { ...row, work_packets: response.work_packets }
+              : row
+          )
+        )
+
+        void refreshWorkPackets()
+      } catch (error) {
+        setWorkPacketsError(error instanceof Error ? error.message : String(error))
+      } finally {
+        setCreatingWorkPacketSessionIds(previous => {
+          const next = new Set(previous)
+          next.delete(sessionKey)
+
+          return next
+        })
+      }
+    },
+    [refreshWorkPackets]
+  )
+
+  const openSessionWorkPacketDetails = useCallback(
+    (taskId: string) => {
+      setFocusedWorkPacketTaskId(taskId)
+      setSection('work-packets')
+    },
+    [setSection]
+  )
   const runSystemAction = useCallback(
     async (kind: 'restart' | 'update') => {
       setSystemError('')
@@ -301,11 +409,13 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
             icon:
               value === 'sessions'
                 ? MessageCircle
-                : value === 'system'
-                  ? Activity
-                  : value === 'maintenance'
-                    ? Wrench
-                    : BarChart3,
+                : value === 'work-packets'
+                  ? Clipboard
+                  : value === 'system'
+                    ? Activity
+                    : value === 'maintenance'
+                      ? Wrench
+                      : BarChart3,
             id: value,
             label: cc.sections[value],
             onSelect: () => setSection(value)
@@ -332,6 +442,11 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                   value={query}
                 />
               )}
+              {section === 'work-packets' && (
+                <Button disabled={workPacketsLoading} onClick={() => void refreshWorkPackets()} size="xs" variant="text">
+                  {workPacketsLoading ? cc.refreshing : cc.refresh}
+                </Button>
+              )}
               {section === 'usage' && (
                 <SegmentedControl
                   onChange={id => setUsagePeriod(Number(id) as UsagePeriod)}
@@ -351,12 +466,25 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                   {filteredSessions.map(session => {
                     const pinId = sessionPinId(session)
                     const pinned = pinnedSessionIds.includes(pinId)
+                    const workPacketSessionId = workPacketSessionKey(session)
+                    const workPacketSummary = session.work_packets
+                    const latestWorkPacket = workPacketSummary?.latest ?? null
+                    const workPacketStatus = latestWorkPacket?.status
+                    const creatingWorkPacket = creatingWorkPacketSessionIds.has(workPacketSessionId)
+
+                    const workPacketStatusLabel = workPacketStatus
+                      ? ((cc.workPacketColumns as Record<string, string>)[workPacketStatus] ?? workPacketStatus)
+                      : ''
+
+                    const workPacketTitle = latestWorkPacket
+                      ? `${cc.sections['work-packets']}: ${latestWorkPacket.title}${workPacketStatusLabel ? ` · ${workPacketStatusLabel}` : ''}`
+                      : cc.sections['work-packets']
 
                     return (
-                      <li className="group flex items-center gap-2 py-2" key={session.id}>
+                      <li className="group flex items-center gap-2 py-2" key={pinId}>
                         <button
                           className="min-w-0 flex-1 text-left"
-                          onClick={() => onOpenSession(session.id)}
+                          onClick={() => onOpenSession(session.id, session.profile)}
                           type="button"
                         >
                           <div className="truncate text-[length:var(--conversation-text-font-size)] font-medium text-foreground">
@@ -366,7 +494,38 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                             {formatTimestamp(session.last_active || session.started_at)}
                           </div>
                         </button>
+                        {workPacketSummary &&
+                          (latestWorkPacket ? (
+                            <button
+                              aria-label={`${cc.workPacketDetails}: ${latestWorkPacket.title}`}
+                              className="inline-flex shrink-0 items-center gap-1 rounded-full bg-(--chrome-action-hover) px-1.5 py-0.5 text-[0.65rem] leading-none text-(--ui-text-secondary) transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                              onClick={() => openSessionWorkPacketDetails(latestWorkPacket.id)}
+                              title={workPacketTitle}
+                              type="button"
+                            >
+                              <Clipboard className="size-3" />
+                              {formatInteger(workPacketSummary.open_count)}/{formatInteger(workPacketSummary.count)}
+                            </button>
+                          ) : (
+                            <span
+                              aria-label={workPacketTitle}
+                              className="inline-flex shrink-0 items-center gap-1 rounded-full bg-(--chrome-action-hover) px-1.5 py-0.5 text-[0.65rem] leading-none text-(--ui-text-secondary)"
+                              title={workPacketTitle}
+                            >
+                              <Clipboard className="size-3" />
+                              {formatInteger(workPacketSummary.open_count)}/{formatInteger(workPacketSummary.count)}
+                            </span>
+                          ))}
                         <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                          {!workPacketSummary && (
+                            <RowIconButton
+                              disabled={creatingWorkPacket}
+                              onClick={() => void createSessionWorkPacket(session)}
+                              title={creatingWorkPacket ? cc.creatingWorkPacket : cc.createWorkPacket}
+                            >
+                              <Plus className="size-3.5" />
+                            </RowIconButton>
+                          )}
                           <RowIconButton
                             onClick={() => (pinned ? unpinSession(pinId) : pinSession(pinId))}
                             title={pinned ? cc.unpinSession : cc.pinSession}
@@ -393,6 +552,16 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                 </ul>
               )}
             </div>
+          ) : section === 'work-packets' ? (
+            <WorkPacketsPanel
+              board={workPackets}
+              error={workPacketsError}
+              focusedTaskId={focusedWorkPacketTaskId}
+              loading={workPacketsLoading}
+              onFocusedTaskHandled={() => setFocusedWorkPacketTaskId(null)}
+              onOpenSession={onOpenSession}
+              onRefresh={() => void refreshWorkPackets()}
+            />
           ) : section === 'usage' ? (
             <UsagePanel
               error={usageError}
@@ -499,6 +668,427 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   )
 }
 
+
+function workPacketTimestamp(task: WorkPacketTask): number {
+  return task.completed_at || task.last_heartbeat_at || task.started_at || task.created_at || 0
+}
+
+interface WorkPacketsPanelProps {
+  board: KanbanBoardResponse | null
+  error: string
+  focusedTaskId: null | string
+  loading: boolean
+  onFocusedTaskHandled: () => void
+  onOpenSession: (sessionId: string, profile?: null | string) => void
+  onRefresh: () => void
+}
+
+function WorkPacketsPanel({
+  board,
+  error,
+  focusedTaskId,
+  loading,
+  onFocusedTaskHandled,
+  onOpenSession,
+  onRefresh
+}: WorkPacketsPanelProps) {
+  const { t } = useI18n()
+  const cc = t.commandCenter
+  const statusLabels = cc.workPacketColumns as Record<string, string>
+  const [selectedTaskId, setSelectedTaskId] = useState<null | string>(null)
+  const [taskDetail, setTaskDetail] = useState<KanbanTaskDetailResponse | null>(null)
+  const [taskDetailError, setTaskDetailError] = useState('')
+  const [taskDetailLoading, setTaskDetailLoading] = useState(false)
+  const taskDetailRequestRef = useRef(0)
+
+  const tasks = useMemo(
+    () =>
+      (board?.columns ?? []).flatMap(column =>
+        column.tasks.map(task => ({
+          ...task,
+          status: task.status || column.name
+        }))
+      ),
+    [board]
+  )
+
+  const countsByStatus = useMemo(() => {
+    const counts = Object.fromEntries(WORK_PACKET_STATUSES.map(status => [status, 0])) as Record<WorkPacketStatus, number>
+
+    for (const task of tasks) {
+      if (WORK_PACKET_STATUSES.includes(task.status as WorkPacketStatus)) {
+        counts[task.status as WorkPacketStatus] += 1
+      }
+    }
+
+    return counts
+  }, [tasks])
+
+  const openCount = useMemo(() => tasks.filter(task => OPEN_WORK_PACKET_STATUSES.has(task.status)).length, [tasks])
+
+  const recent = useMemo(
+    () => [...tasks].sort((a, b) => workPacketTimestamp(b) - workPacketTimestamp(a)).slice(0, 6),
+    [tasks]
+  )
+
+  const selectedTask = useMemo(
+    () => tasks.find(task => task.id === selectedTaskId) ?? null,
+    [selectedTaskId, tasks]
+  )
+
+  const selectedTaskSummary = taskDetail?.task ?? selectedTask
+
+  const detailLinkedSessionId = selectedTaskSummary?.session_bridge?.session_exists
+    ? selectedTaskSummary.session_bridge.session_id
+    : null
+
+  const detailLinkedSessionProfile = selectedTaskSummary?.session_bridge?.session_exists
+    ? selectedTaskSummary.session_bridge.profile
+    : null
+
+  const detailStatus = selectedTaskSummary ? (statusLabels[selectedTaskSummary.status] ?? selectedTaskSummary.status) : ''
+
+  const detailWhen = selectedTaskSummary ? formatTimestamp(workPacketTimestamp(selectedTaskSummary)) : ''
+
+  const detailMeta = selectedTaskSummary
+    ? [detailStatus, selectedTaskSummary.assignee, detailWhen].filter(Boolean).join(' · ')
+    : ''
+
+  const detailSummary = selectedTaskSummary?.latest_summary?.trim() || ''
+
+  const openWorkPacketDetails = useCallback(async (task: WorkPacketTask) => {
+    const requestId = taskDetailRequestRef.current + 1
+    taskDetailRequestRef.current = requestId
+    setSelectedTaskId(task.id)
+    setTaskDetail(null)
+    setTaskDetailError('')
+    setTaskDetailLoading(true)
+
+    try {
+      const response = await getKanbanTask(task.id)
+
+      if (taskDetailRequestRef.current === requestId) {
+        setTaskDetail(response)
+      }
+    } catch (error) {
+      if (taskDetailRequestRef.current === requestId) {
+        setTaskDetailError(error instanceof Error ? error.message : String(error))
+      }
+    } finally {
+      if (taskDetailRequestRef.current === requestId) {
+        setTaskDetailLoading(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!focusedTaskId) {
+      return
+    }
+
+    const task = tasks.find(candidate => candidate.id === focusedTaskId)
+
+    if (!task) {
+      return
+    }
+
+    onFocusedTaskHandled()
+    void openWorkPacketDetails(task)
+  }, [focusedTaskId, onFocusedTaskHandled, openWorkPacketDetails, tasks])
+
+  if (!board) {
+    return (
+      <div className="min-h-0 flex-1">
+        {loading ? (
+          <PageLoader className="min-h-48" label={cc.loadingWorkPackets} />
+        ) : (
+          <EmptyPanel
+            action={
+              <Button onClick={onRefresh} size="xs" variant="text">
+                {cc.retry}
+              </Button>
+            }
+            description={error || cc.noWorkPackets}
+          />
+        )}
+      </div>
+    )
+  }
+
+  const stats = [
+    { label: cc.workPacketStats.open, value: openCount },
+    { label: cc.workPacketStats.ready, value: countsByStatus.ready },
+    { label: cc.workPacketStats.running, value: countsByStatus.running },
+    { label: cc.workPacketStats.blocked, value: countsByStatus.blocked },
+    { label: cc.workPacketStats.review, value: countsByStatus.review },
+    { label: cc.workPacketStats.done, value: countsByStatus.done }
+  ]
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto pb-2">
+      {error && (
+        <span className="inline-flex items-center gap-1 text-[length:var(--conversation-caption-font-size)] text-destructive">
+          <AlertCircle className="size-3.5" />
+          {error}
+        </span>
+      )}
+
+      {tasks.length === 0 ? (
+        <EmptyPanel
+          action={
+            <Button onClick={onRefresh} size="xs" variant="text">
+              {cc.refresh}
+            </Button>
+          }
+          description={cc.noWorkPackets}
+        />
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-4 py-2 sm:grid-cols-3">
+            {stats.map(stat => (
+              <UsageStat key={stat.label} label={stat.label} value={formatInteger(stat.value)} />
+            ))}
+          </div>
+
+          <section>
+            <div className="mb-2 flex items-baseline justify-between gap-3">
+              <span className="text-[0.625rem] font-medium uppercase tracking-[0.08em] text-(--ui-text-tertiary)">
+                {cc.sections['work-packets']}
+              </span>
+              {board.latest_event_id > 0 && (
+                <span className="text-[0.65rem] text-(--ui-text-tertiary)">
+                  {cc.latestKanbanEvent(String(board.latest_event_id))}
+                </span>
+              )}
+            </div>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+              {WORK_PACKET_STATUSES.map(status => (
+                <div
+                  className="rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) px-3 py-2"
+                  key={status}
+                >
+                  <div className="truncate text-[0.65rem] uppercase tracking-[0.08em] text-(--ui-text-tertiary)">
+                    {statusLabels[status] ?? status}
+                  </div>
+                  <div className="mt-1 text-[length:var(--conversation-text-font-size)] font-semibold text-foreground">
+                    {formatInteger(countsByStatus[status])}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <div className="mb-2 flex items-baseline justify-between">
+              <span className="text-[0.625rem] font-medium uppercase tracking-[0.08em] text-(--ui-text-tertiary)">
+                {cc.recentWorkPackets}
+              </span>
+            </div>
+            {recent.length === 0 ? (
+              <div className="grid h-24 place-items-center text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                {cc.noWorkPackets}
+              </div>
+            ) : (
+              <ul className="divide-y divide-(--ui-stroke-tertiary) rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary)">
+                {recent.map(task => {
+                  const timestamp = workPacketTimestamp(task)
+                  const when = formatTimestamp(timestamp)
+                  const status = statusLabels[task.status] ?? task.status
+                  const meta = [status, task.assignee, when].filter(Boolean).join(' · ')
+                  const linkedSessionId = task.session_bridge?.session_exists ? task.session_bridge.session_id : null
+                  const linkedSessionProfile = task.session_bridge?.session_exists ? task.session_bridge.profile : null
+
+                  return (
+                    <li className="px-3 py-2" key={task.id}>
+                      <div className="flex items-start justify-between gap-3">
+                        <button
+                          aria-label={`${cc.workPacketDetails}: ${task.title}`}
+                          className="min-w-0 flex-1 text-left"
+                          onClick={() => void openWorkPacketDetails(task)}
+                          type="button"
+                        >
+                          <div className="truncate text-[length:var(--conversation-text-font-size)] font-medium text-foreground">
+                            {task.title}
+                          </div>
+                          <div className="mt-0.5 truncate text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                            {meta || task.id}
+                          </div>
+                          {task.latest_summary && (
+                            <div className="mt-1 line-clamp-2 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-tertiary)">
+                              {task.latest_summary}
+                            </div>
+                          )}
+                        </button>
+                        <div className="mt-0.5 flex shrink-0 items-center gap-2">
+                          {linkedSessionId && (
+                            <Button
+                              aria-label={`${cc.providerNavigate}: ${task.title}`}
+                              onClick={() => onOpenSession(linkedSessionId, linkedSessionProfile)}
+                              size="xs"
+                              variant="text"
+                            >
+                              <MessageCircle className="size-3" />
+                              {cc.providerNavigate}
+                            </Button>
+                          )}
+                          <span
+                            className={cn(
+                              'shrink-0 rounded-full px-2 py-0.5 text-[0.65rem]',
+                              task.status === 'blocked'
+                                ? 'bg-destructive/10 text-destructive'
+                                : task.status === 'running'
+                                  ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+                                  : 'bg-(--chrome-action-hover) text-(--ui-text-secondary)'
+                            )}
+                          >
+                            {status}
+                          </span>
+                        </div>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </section>
+
+          {tasks.length > recent.length && (
+            <section>
+              <div className="mb-2 flex items-baseline justify-between gap-3">
+                <span className="text-[0.625rem] font-medium uppercase tracking-[0.08em] text-(--ui-text-tertiary)">
+                  {cc.sections['work-packets']}
+                </span>
+                <span className="text-[0.65rem] text-(--ui-text-tertiary)">
+                  {formatInteger(tasks.length)}
+                </span>
+              </div>
+              <div className="grid gap-3 lg:grid-cols-2">
+                {board.columns
+                  .filter(column => column.tasks.length > 0)
+                  .map(column => {
+                    const columnTasks = column.tasks
+                      .map(task => ({
+                        ...task,
+                        status: task.status || column.name
+                      }))
+                      .sort((a, b) => workPacketTimestamp(b) - workPacketTimestamp(a))
+
+                    const columnLabel = statusLabels[column.name] ?? column.name
+
+                    return (
+                      <div
+                        className="min-w-0 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary)"
+                        key={column.name}
+                      >
+                        <div className="flex items-center justify-between gap-2 border-b border-(--ui-stroke-tertiary) px-3 py-2">
+                          <span className="truncate text-[0.65rem] font-medium uppercase tracking-[0.08em] text-(--ui-text-tertiary)">
+                            {columnLabel}
+                          </span>
+                          <span className="rounded-full bg-(--chrome-action-hover) px-2 py-0.5 text-[0.65rem] text-(--ui-text-secondary)">
+                            {formatInteger(columnTasks.length)}
+                          </span>
+                        </div>
+                        <ul className="divide-y divide-(--ui-stroke-tertiary)">
+                          {columnTasks.map(task => {
+                            const timestamp = workPacketTimestamp(task)
+                            const when = formatTimestamp(timestamp)
+                            const status = statusLabels[task.status] ?? task.status
+                            const meta = [status, task.assignee, when].filter(Boolean).join(' · ')
+
+                            return (
+                              <li className="px-3 py-2" key={task.id}>
+                                <button
+                                  aria-label={`${cc.workPacketDetails}: ${task.title}`}
+                                  className="w-full min-w-0 text-left"
+                                  onClick={() => void openWorkPacketDetails(task)}
+                                  type="button"
+                                >
+                                  <div className="truncate text-[length:var(--conversation-text-font-size)] font-medium text-foreground">
+                                    {task.title}
+                                  </div>
+                                  <div className="mt-0.5 truncate text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                                    {meta || task.id}
+                                  </div>
+                                  {task.latest_summary && (
+                                    <div className="mt-1 line-clamp-2 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-tertiary)">
+                                      {task.latest_summary}
+                                    </div>
+                                  )}
+                                </button>
+                              </li>
+                            )
+                          })}
+                        </ul>
+                      </div>
+                    )
+                  })}
+              </div>
+            </section>
+          )}
+
+          {selectedTaskSummary && (
+            <section className="rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-3">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <span className="text-[0.625rem] font-medium uppercase tracking-[0.08em] text-(--ui-text-tertiary)">
+                  {cc.workPacketDetails}
+                </span>
+                {detailLinkedSessionId && (
+                  <Button
+                    aria-label={cc.openLinkedSession}
+                    onClick={() => onOpenSession(detailLinkedSessionId, detailLinkedSessionProfile)}
+                    size="xs"
+                    variant="textStrong"
+                  >
+                    <MessageCircle className="size-3" />
+                    {cc.openLinkedSession}
+                  </Button>
+                )}
+              </div>
+
+              {taskDetailLoading ? (
+                <PageLoader className="min-h-24" label={cc.loadingWorkPacketDetails} />
+              ) : (
+                <div>
+                  <div className="min-w-0">
+                    <div className="truncate text-[length:var(--conversation-text-font-size)] font-medium text-foreground">
+                      {selectedTaskSummary.title}
+                    </div>
+                    <div className="mt-0.5 truncate text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+                      {detailMeta || selectedTaskSummary.id}
+                    </div>
+                  </div>
+
+                  {taskDetailError && (
+                    <div className="mt-2 inline-flex items-center gap-1 text-[length:var(--conversation-caption-font-size)] text-destructive">
+                      <AlertCircle className="size-3.5" />
+                      {taskDetailError || cc.workPacketDetailsFailed}
+                    </div>
+                  )}
+
+                  {detailSummary && (
+                    <div className="mt-3">
+                      <div className="mb-1 text-[0.625rem] font-medium uppercase tracking-[0.08em] text-(--ui-text-tertiary)">
+                        {cc.workPacketSummary}
+                      </div>
+                      <div className="whitespace-pre-wrap text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-secondary)">
+                        {detailSummary}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </section>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+
+function formatInteger(value: null | number | undefined): string {
+  return Number(value ?? 0).toLocaleString()
+}
 interface UsagePanelProps {
   error: string
   loading: boolean

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -103,7 +103,7 @@ import { $terminalTakeover } from './right-sidebar/store'
 import { TerminalPaneChrome } from './right-sidebar/terminal/chrome'
 import { PersistentTerminal } from './right-sidebar/terminal/persistent'
 import { closeActiveTerminal } from './right-sidebar/terminal/terminals'
-import { CRON_ROUTE, NEW_CHAT_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
+import { CRON_ROUTE, NEW_CHAT_ROUTE, routeSessionId, routeSessionProfile, sessionRoute, SETTINGS_ROUTE } from './routes'
 import { SessionPickerOverlay } from './session-picker-overlay'
 import { SessionSwitcher } from './session-switcher'
 import { useContextSuggestions } from './session/hooks/use-context-suggestions'
@@ -208,6 +208,7 @@ export function DesktopController() {
   const narrowViewport = useMediaQuery(SIDEBAR_COLLAPSE_MEDIA_QUERY)
 
   const routedSessionId = routeSessionId(location.pathname)
+  const routedSessionProfile = routeSessionProfile(location.search)
   const routeToken = `${location.pathname}:${location.search}:${location.hash}`
   const routeTokenRef = useRef(routeToken)
   routeTokenRef.current = routeToken
@@ -986,10 +987,12 @@ export function DesktopController() {
     freshDraftReady,
     gatewayState,
     locationPathname: location.pathname,
+    locationSearch: location.search,
     resumeSession,
     resumeFailedSessionId,
     resumeExhaustedSessionId,
     routedSessionId,
+    routedSessionProfile,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
@@ -1098,7 +1101,7 @@ export function DesktopController() {
             onClose={closeOverlayToPreviousRoute}
             onDeleteSession={removeSession}
             onNavigateRoute={path => navigate(path)}
-            onOpenSession={sessionId => navigate(sessionRoute(sessionId))}
+            onOpenSession={(sessionId, profile) => navigate(sessionRoute(sessionId, profile))}
           />
         </Suspense>
       )}

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -86,8 +86,21 @@ export function routeSessionId(pathname: string): string | null {
   return id && !id.includes('/') ? decodeURIComponent(id) : null
 }
 
-export function sessionRoute(sessionId: string): string {
-  return `${SESSION_ROUTE_PREFIX}${encodeURIComponent(sessionId)}`
+export function routeSessionProfile(search: string): string | null {
+  const profile = new URLSearchParams(search).get('profile')?.trim()
+
+  return profile || null
+}
+
+export function sessionRoute(sessionId: string, profile?: null | string): string {
+  const path = `${SESSION_ROUTE_PREFIX}${encodeURIComponent(sessionId)}`
+  const normalizedProfile = profile?.trim()
+
+  if (!normalizedProfile) {
+    return path
+  }
+
+  return `${path}?profile=${encodeURIComponent(normalizedProfile)}`
 }
 
 export function appViewForPath(pathname: string): AppView {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -14,18 +14,32 @@ interface HarnessProps {
   freshDraftReady: boolean
   gatewayState: string
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
+  locationSearch?: string
+  resumeSession: (sessionId: string, focus: boolean, profile?: null | string) => Promise<unknown>
   resumeFailedSessionId?: null | string
   resumeExhaustedSessionId?: null | string
   routedSessionId: null | string
+  routedSessionProfile?: null | string
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: null | string
   selectedStoredSessionIdRef: MutableRefObject<null | string>
   startFreshSessionDraft: (focus: boolean) => unknown
 }
 
-function RouteResumeHarness({ resumeFailedSessionId = null, resumeExhaustedSessionId = null, ...props }: HarnessProps) {
-  useRouteResume({ ...props, resumeExhaustedSessionId, resumeFailedSessionId })
+function RouteResumeHarness({
+  locationSearch = '',
+  resumeFailedSessionId = null,
+  resumeExhaustedSessionId = null,
+  routedSessionProfile = null,
+  ...props
+}: HarnessProps) {
+  useRouteResume({
+    ...props,
+    locationSearch,
+    resumeExhaustedSessionId,
+    resumeFailedSessionId,
+    routedSessionProfile
+  })
 
   return null
 }
@@ -190,6 +204,58 @@ describe('useRouteResume', () => {
 
     expect(resumeSession).toHaveBeenCalledTimes(1)
     expect(resumeSession).toHaveBeenCalledWith('session-2', true)
+  })
+
+  it('resumes with the routed profile when only the profile query changes', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-1' }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['session-1', 'runtime-1']]) }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'session-1' }
+
+    const { rerender } = render(
+      <RouteResumeHarness
+        activeSessionId="runtime-1"
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="open"
+        locationPathname="/session-1"
+        resumeSession={resumeSession}
+        routedSessionId="session-1"
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId="session-1"
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    expect(resumeSession).not.toHaveBeenCalled()
+
+    rerender(
+      <RouteResumeHarness
+        activeSessionId="runtime-1"
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="open"
+        locationPathname="/session-1"
+        locationSearch="?profile=other"
+        resumeSession={resumeSession}
+        routedSessionId="session-1"
+        routedSessionProfile="other"
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId="session-1"
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    expect(resumeSession).toHaveBeenCalledTimes(1)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, 'other')
   })
 
   it('resumes the selected route again when the gateway reconnects', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -11,7 +11,8 @@ interface RouteResumeOptions {
   freshDraftReady: boolean
   gatewayState: string | undefined
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
+  locationSearch: string
+  resumeSession: (sessionId: string, focus: boolean, profile?: null | string) => Promise<unknown>
   // Stored-session id whose most recent resume failed terminally (set by
   // useSessionActions, mirrored from $resumeFailedSessionId). While this equals
   // routedSessionId the window would otherwise latch on the loader forever, so
@@ -24,6 +25,7 @@ interface RouteResumeOptions {
   // signal the effect below uses to reset the attempt counter.
   resumeExhaustedSessionId: string | null
   routedSessionId: string | null
+  routedSessionProfile: string | null
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: string | null
   selectedStoredSessionIdRef: MutableRefObject<string | null>
@@ -73,16 +75,18 @@ export function useRouteResume({
   freshDraftReady,
   gatewayState,
   locationPathname,
+  locationSearch,
   resumeSession,
   resumeFailedSessionId,
   resumeExhaustedSessionId,
   routedSessionId,
+  routedSessionProfile,
   runtimeIdByStoredSessionIdRef,
   selectedStoredSessionId,
   selectedStoredSessionIdRef,
   startFreshSessionDraft
 }: RouteResumeOptions) {
-  const lastPathnameRef = useRef<string | null>(null)
+  const lastRouteLocationRef = useRef<string | null>(null)
   const seenGatewayStateRef = useRef(false)
   const wasGatewayOpenRef = useRef(false)
   // Per-session retry bookkeeping for the bounded auto-retry effect below. Keyed
@@ -98,13 +102,16 @@ export function useRouteResume({
 
   useEffect(() => {
     const gatewayOpen = gatewayState === 'open'
-    const pathnameChanged = lastPathnameRef.current !== locationPathname
+    const routeLocation = `${locationPathname}:${locationSearch}`
+    const previousRouteLocation = lastRouteLocationRef.current
+    const routeLocationChanged = previousRouteLocation !== routeLocation
+    const profileRouteChanged = previousRouteLocation !== null && routeLocationChanged && Boolean(routedSessionProfile)
     // Fire only on a genuine closed->open transition (a reconnect). seenGatewayStateRef
     // stays false until the first effect run, so a session that mounts with the gateway
     // already open is not mistaken for "became open" and does not double-resume with the
     // pathname-driven initial resume below.
     const gatewayBecameOpen = seenGatewayStateRef.current && !wasGatewayOpenRef.current && gatewayOpen
-    lastPathnameRef.current = locationPathname
+    lastRouteLocationRef.current = routeLocation
     seenGatewayStateRef.current = true
     wasGatewayOpenRef.current = gatewayOpen
 
@@ -140,14 +147,16 @@ export function useRouteResume({
       // we're stranded on a routed session that never loaded. The first two
       // guard against a transient /:sid re-resume during "new chat" state clears
       // before the pathname updates from /:sid -> /.
-      const shouldResume = pathnameChanged || gatewayBecameOpen || stuckOnRoutedSession
+      const shouldResume = routeLocationChanged || gatewayBecameOpen || stuckOnRoutedSession
 
       // On a reconnect (gatewayBecameOpen) re-resume even when the route looks
       // `alreadyActive`: the cached runtime id can be stale once the gateway
       // rebinds/reaps the session on its side, and trusting it strands Desktop on
       // a dead id ("session not found"). Otherwise keep skipping when already active.
-      if ((gatewayBecameOpen || !alreadyActive) && shouldResume && !creatingSessionRef.current) {
-        void resumeSession(routedSessionId, true)
+      if ((gatewayBecameOpen || !alreadyActive || profileRouteChanged) && shouldResume && !creatingSessionRef.current) {
+        void (routedSessionProfile
+          ? resumeSession(routedSessionId, true, routedSessionProfile)
+          : resumeSession(routedSessionId, true))
       }
 
       return
@@ -169,8 +178,10 @@ export function useRouteResume({
     freshDraftReady,
     gatewayState,
     locationPathname,
+    locationSearch,
     resumeSession,
     routedSessionId,
+    routedSessionProfile,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionId,
     selectedStoredSessionIdRef,
@@ -267,7 +278,7 @@ export function useRouteResume({
       // having fired. A flapping backend could then hit MAX in a couple of
       // re-renders with far fewer than MAX real attempts. (Point 3)
       retryAttemptRef.current += 1
-      void resumeSession(sessionId, true)
+      void (routedSessionProfile ? resumeSession(sessionId, true, routedSessionProfile) : resumeSession(sessionId, true))
     }, resumeRetryDelayMs(attempt))
 
     return () => clearTimeout(timer)
@@ -280,6 +291,7 @@ export function useRouteResume({
     resumeFailedSessionId,
     resumeExhaustedSessionId,
     routedSessionId,
+    routedSessionProfile,
     selectedStoredSessionIdRef
   ])
 }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -278,7 +278,8 @@ export function useSessionActions({
   }, [navigate, selectedStoredSessionId])
 
   const resumeSession = useCallback(
-    async (storedSessionId: string, replaceRoute = false) => {
+    async (storedSessionId: string, replaceRoute = false, requestedProfile?: null | string) => {
+      const requestedProfileKey = requestedProfile?.trim() || null
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
 
@@ -344,8 +345,8 @@ export function useSessionActions({
       // gateway call (no-op when it's already on that profile / single-profile).
       // resolveStoredSession finds the row by id (cheap), so an uncached pasted
       // id loads as fast as a sidebar click instead of hanging on a list scan.
-      const storedForProfile = await resolveStoredSession(storedSessionId)
-      const sessionProfile = storedForProfile?.profile
+      const storedForProfile = await resolveStoredSession(storedSessionId, requestedProfileKey)
+      const sessionProfile = requestedProfileKey ?? storedForProfile?.profile
 
       if (resumeRequestRef.current !== requestId) {
         return
@@ -363,7 +364,8 @@ export function useSessionActions({
         const cachedState = warmHit.state
 
         const stored =
-          $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ?? storedForProfile
+          $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId, sessionProfile)) ??
+          storedForProfile
 
         const cachedViewState =
           !cachedState.model && stored?.model != null
@@ -432,7 +434,7 @@ export function useSessionActions({
       setSessionStartedAt(Date.now())
 
       const stored =
-        $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ?? storedForProfile
+        $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId, sessionProfile)) ?? storedForProfile
 
       applyStoredSessionPreviewRuntimeInfo(stored)
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -182,31 +182,46 @@ export function patchSessionWorkspace(sessionId: string, cwd: string | undefined
   setSessions(prev => prev.map(session => (session.id === sessionId ? { ...session, cwd } : session)))
 }
 
-export function sessionMatchesStoredId(session: SessionInfo, storedSessionId: string): boolean {
-  return session.id === storedSessionId || session._lineage_root_id === storedSessionId
+export function sessionMatchesStoredId(session: SessionInfo, storedSessionId: string, profile?: null | string): boolean {
+  const idMatches = session.id === storedSessionId || session._lineage_root_id === storedSessionId
+
+  if (!idMatches) {
+    return false
+  }
+
+  return !profile || normalizeProfileKey(session.profile) === normalizeProfileKey(profile)
+}
+
+function sameSessionProfile(a?: null | string, b?: null | string): boolean {
+  return normalizeProfileKey(a) === normalizeProfileKey(b)
 }
 
 export function sessionShouldHaveTranscript(session: SessionInfo | undefined): boolean {
   return (session?.message_count ?? 0) > 0
 }
 
-function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
+function upsertResolvedSession(session: SessionInfo, storedSessionId: string, profile?: null | string) {
   const lineage = session._lineage_root_id ?? session.id
+  const sessionProfile = profile ?? session.profile
 
   setSessions(prev => [
     session,
     ...prev.filter(existing => {
-      if (sessionMatchesStoredId(existing, storedSessionId)) {
+      if (sessionMatchesStoredId(existing, storedSessionId, sessionProfile)) {
         return false
       }
 
-      return (existing._lineage_root_id ?? existing.id) !== lineage
+      return (existing._lineage_root_id ?? existing.id) !== lineage || !sameSessionProfile(existing.profile, sessionProfile)
     })
   ])
 }
 
-export async function resolveStoredSession(storedSessionId: string): Promise<SessionInfo | undefined> {
-  const cached = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+export async function resolveStoredSession(
+  storedSessionId: string,
+  requestedProfile?: null | string
+): Promise<SessionInfo | undefined> {
+  const requestedProfileKey = requestedProfile?.trim() || null
+  const cached = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId, requestedProfileKey))
 
   if (cached) {
     return cached
@@ -216,13 +231,17 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
   // single-profile users and any id on the active profile (e.g. an old session
   // past the sidebar's recent window). 404 just means it's not on this profile.
   try {
-    const session = await getSession(storedSessionId)
+    const session = await getSession(storedSessionId, requestedProfileKey)
 
-    upsertResolvedSession(session, storedSessionId)
+    upsertResolvedSession(session, storedSessionId, requestedProfileKey)
 
     return session
   } catch {
     // Not on the active profile — fall through to the cross-profile probe.
+  }
+
+  if (requestedProfileKey) {
+    return undefined
   }
 
   // Multi-profile only: probe each other profile by id (still one cheap lookup
@@ -239,7 +258,7 @@ export async function resolveStoredSession(storedSessionId: string): Promise<Ses
     try {
       const session = await getSession(storedSessionId, profile)
 
-      upsertResolvedSession(session, storedSessionId)
+      upsertResolvedSession(session, storedSessionId, profile)
 
       return session
     } catch {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -6,6 +6,8 @@ import {
   getGlobalModelOptions,
   getHermesConfig,
   getHermesConfigDefaults,
+  getKanbanBoard,
+  getKanbanTask,
   getProfiles,
   getSessionMessages,
   getStatus,
@@ -151,6 +153,30 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith(
       expect.objectContaining({
         path: '/api/model/options?refresh=1&include_unconfigured=1'
+      })
+    )
+  })
+
+  it('uses the sanitized Command Center work-packet board endpoint', async () => {
+    api.mockResolvedValue({ assignees: [], columns: [], latest_event_id: 0, now: 0 })
+
+    await getKanbanBoard()
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/command-center/work-packets/board'
+      })
+    )
+  })
+
+  it('uses the sanitized Command Center work-packet detail endpoint', async () => {
+    api.mockResolvedValue({ task: { id: 'task-1', status: 'ready', title: 'Task' } })
+
+    await getKanbanTask('task/one')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/command-center/work-packets/tasks/task%2Fone'
       })
     )
   })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -19,6 +19,8 @@ import type {
   EnvVarInfo,
   HermesConfig,
   HermesConfigRecord,
+  KanbanBoardResponse,
+  KanbanTaskDetailResponse,
   LogsResponse,
   McpCatalogResponse,
   McpServerSummary,
@@ -45,6 +47,8 @@ import type {
   SessionInfo,
   SessionMessagesResponse,
   SessionSearchResponse,
+  SessionWorkPacketCreatePayload,
+  SessionWorkPacketCreateResponse,
   SkillHubPreview,
   SkillHubScanResult,
   SkillHubSearchResponse,
@@ -111,6 +115,11 @@ export type {
   GatewayReadyPayload,
   HermesConfig,
   HermesConfigRecord,
+  KanbanBoardColumn,
+  KanbanBoardResponse,
+  KanbanTask,
+  KanbanTaskDetail,
+  KanbanTaskDetailResponse,
   LogsResponse,
   McpCatalogEntry,
   McpCatalogResponse,
@@ -150,6 +159,10 @@ export type {
   SessionRuntimeInfo,
   SessionSearchResponse,
   SessionSearchResult,
+  SessionWorkPacketCreatePayload,
+  SessionWorkPacketCreateResponse,
+  SessionWorkPacketLatest,
+  SessionWorkPacketSummary,
   SkillHubInstalledEntry,
   SkillHubPreview,
   SkillHubResult,
@@ -285,6 +298,21 @@ export function getSession(id: string, profile?: string | null): Promise<Session
   return window.hermesDesktop.api<SessionInfo>({
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}${suffix}`
+  })
+}
+
+export function createWorkPacketFromSession(
+  id: string,
+  profile?: string | null,
+  payload: SessionWorkPacketCreatePayload = {}
+): Promise<SessionWorkPacketCreateResponse> {
+  const suffix = profile ? `?profile=${encodeURIComponent(profile)}` : ''
+
+  return window.hermesDesktop.api<SessionWorkPacketCreateResponse>({
+    ...(profile ? { profile } : {}),
+    path: `/api/sessions/${encodeURIComponent(id)}/work-packets${suffix}`,
+    method: 'POST',
+    body: { ...payload, ...(profile ? { profile } : {}) }
   })
 }
 
@@ -869,6 +897,20 @@ export function getUsageAnalytics(days = 30): Promise<AnalyticsResponse> {
   })
 }
 
+export function getKanbanBoard(): Promise<KanbanBoardResponse> {
+  return window.hermesDesktop.api<KanbanBoardResponse>({
+    ...profileScoped(),
+    path: '/api/command-center/work-packets/board'
+  })
+}
+
+export function getKanbanTask(id: string): Promise<KanbanTaskDetailResponse> {
+  return window.hermesDesktop.api<KanbanTaskDetailResponse>({
+    ...profileScoped(),
+    path: `/api/command-center/work-packets/tasks/${encodeURIComponent(id)}`
+  })
+}
+
 export function getGlobalModelOptions(opts?: {
   refresh?: boolean
   includeUnconfigured?: boolean
@@ -887,7 +929,6 @@ export function getGlobalModelOptions(opts?: {
   if (opts?.explicitOnly !== false) {
     params.set('explicit_only', '1')
   }
-
   return window.hermesDesktop.api<ModelOptionsResponse>({
     ...profileScoped(),
     path: params.size > 0 ? `/api/model/options?${params.toString()}` : '/api/model/options',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1010,10 +1010,11 @@ export const en: Translations = {
     settingsFields: 'Settings fields',
     mcpServers: 'MCP servers',
     archivedChats: 'Archived chats',
-    sections: { maintenance: 'Maintenance', sessions: 'Sessions', system: 'System', usage: 'Usage' },
+    sections: { maintenance: 'Maintenance', sessions: 'Sessions', 'work-packets': 'Work Packets', system: 'System', usage: 'Usage' },
     sectionDescriptions: {
       maintenance: 'Diagnostics, backups, curator, and memory data',
       sessions: 'Search and manage sessions',
+      'work-packets': 'Autonomous Kanban work packets and handoffs',
       system: 'Status, logs, and system actions',
       usage: 'Token, cost, and skill activity over time'
     },
@@ -1026,6 +1027,7 @@ export const en: Translations = {
     },
     sectionEntries: {
       sessions: { title: 'Sessions panel', detail: 'Search, pin, and manage sessions' },
+      'work-packets': { title: 'Work packets panel', detail: 'Kanban queue, blockers, and handoffs' },
       system: { title: 'System panel', detail: 'Gateway status, logs, restart/update' },
       usage: { title: 'Usage panel', detail: 'Token, cost, and skill activity' }
     },
@@ -1034,6 +1036,8 @@ export const en: Translations = {
     refresh: 'Refresh',
     refreshing: 'Refreshing...',
     noResults: 'No matching results found.',
+    createWorkPacket: 'Create work packet',
+    creatingWorkPacket: 'Creating work packet...',
     pinSession: 'Pin session',
     unpinSession: 'Unpin session',
     exportSession: 'Export session',
@@ -1052,6 +1056,33 @@ export const en: Translations = {
     loadingStatus: 'Loading status...',
     recentLogs: 'Recent logs',
     noLogs: 'No logs loaded yet.',
+    loadingWorkPackets: 'Loading work packets...',
+    noWorkPackets: 'No work packets on the active Kanban board yet.',
+    recentWorkPackets: 'Recent work packets',
+    workPacketDetails: 'Work packet details',
+    loadingWorkPacketDetails: 'Loading work packet details...',
+    workPacketDetailsFailed: 'Could not load work packet details.',
+    openLinkedSession: 'Open linked session',
+    workPacketSummary: 'Summary',
+    workPacketStats: {
+      open: 'Open',
+      ready: 'Ready',
+      running: 'Running',
+      blocked: 'Blocked',
+      review: 'Review',
+      done: 'Done'
+    },
+    workPacketColumns: {
+      triage: 'Triage',
+      todo: 'Todo',
+      scheduled: 'Scheduled',
+      ready: 'Ready',
+      running: 'Running',
+      blocked: 'Blocked',
+      review: 'Review',
+      done: 'Done'
+    },
+    latestKanbanEvent: id => `latest event #${id}`,
     days: count => `${count}d`,
     statSessions: 'Sessions',
     statApiCalls: 'API calls',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1027,9 +1027,10 @@ export const ja = defineLocale({
     settingsFields: '設定フィールド',
     mcpServers: 'MCP サーバー',
     archivedChats: 'アーカイブ済みチャット',
-    sections: { sessions: 'セッション', system: 'システム', usage: '使用状況' },
+    sections: { sessions: 'セッション', 'work-packets': 'ワークパケット', system: 'システム', usage: '使用状況' },
     sectionDescriptions: {
       sessions: 'セッションの検索と管理',
+      'work-packets': '自律 Kanban ワークパケットと引き継ぎ',
       system: 'ステータス、ログ、システムアクション',
       usage: 'トークン、コスト、スキルの活動履歴'
     },
@@ -1042,6 +1043,7 @@ export const ja = defineLocale({
     },
     sectionEntries: {
       sessions: { title: 'セッションパネル', detail: 'セッションの検索、ピン留め、管理' },
+      'work-packets': { title: 'ワークパケットパネル', detail: 'Kanban キュー、ブロッカー、引き継ぎ' },
       system: { title: 'システムパネル', detail: 'ゲートウェイのステータス、ログ、再起動/更新' },
       usage: { title: '使用状況パネル', detail: 'トークン、コスト、スキルの活動' }
     },
@@ -1050,6 +1052,8 @@ export const ja = defineLocale({
     refresh: '更新',
     refreshing: '更新中...',
     noResults: '一致する結果が見つかりません。',
+    createWorkPacket: 'ワークパケットを作成',
+    creatingWorkPacket: 'ワークパケットを作成中...',
     pinSession: 'セッションをピン留め',
     unpinSession: 'セッションのピン留めを解除',
     exportSession: 'セッションをエクスポート',
@@ -1068,6 +1072,33 @@ export const ja = defineLocale({
     loadingStatus: 'ステータスを読み込み中...',
     recentLogs: '最近のログ',
     noLogs: 'ログはまだ読み込まれていません。',
+    loadingWorkPackets: 'ワークパケットを読み込み中...',
+    noWorkPackets: 'アクティブな Kanban ボードにワークパケットはまだありません。',
+    recentWorkPackets: '最近のワークパケット',
+    workPacketDetails: 'ワークパケット詳細',
+    loadingWorkPacketDetails: 'ワークパケット詳細を読み込み中...',
+    workPacketDetailsFailed: 'ワークパケット詳細を読み込めませんでした。',
+    openLinkedSession: 'リンク済みセッションを開く',
+    workPacketSummary: '要約',
+    workPacketStats: {
+      open: '未完了',
+      ready: '準備完了',
+      running: '実行中',
+      blocked: 'ブロック中',
+      review: 'レビュー',
+      done: '完了'
+    },
+    workPacketColumns: {
+      triage: 'トリアージ',
+      todo: 'Todo',
+      scheduled: '予定済み',
+      ready: '準備完了',
+      running: '実行中',
+      blocked: 'ブロック中',
+      review: 'レビュー',
+      done: '完了'
+    },
+    latestKanbanEvent: id => `最新イベント #${id}`,
     days: count => `${count}日`,
     statSessions: 'セッション',
     statApiCalls: 'API コール',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -894,15 +894,17 @@ export interface Translations {
     settingsFields: string
     mcpServers: string
     archivedChats: string
-    sections: Record<'maintenance' | 'sessions' | 'system' | 'usage', string>
-    sectionDescriptions: Record<'maintenance' | 'sessions' | 'system' | 'usage', string>
+    sections: Record<'maintenance' | 'sessions' | 'work-packets' | 'system' | 'usage', string>
+    sectionDescriptions: Record<'maintenance' | 'sessions' | 'work-packets' | 'system' | 'usage', string>
     nav: Record<'newChat' | 'settings' | 'skills' | 'messaging' | 'artifacts', { title: string; detail: string }>
-    sectionEntries: Record<'sessions' | 'system' | 'usage', { title: string; detail: string }>
+    sectionEntries: Record<'sessions' | 'work-packets' | 'system' | 'usage', { title: string; detail: string }>
     providerNavigate: string
     providerSessions: string
     refresh: string
     refreshing: string
     noResults: string
+    createWorkPacket: string
+    creatingWorkPacket: string
     pinSession: string
     unpinSession: string
     exportSession: string
@@ -921,6 +923,17 @@ export interface Translations {
     loadingStatus: string
     recentLogs: string
     noLogs: string
+    loadingWorkPackets: string
+    noWorkPackets: string
+    recentWorkPackets: string
+    workPacketDetails: string
+    loadingWorkPacketDetails: string
+    workPacketDetailsFailed: string
+    openLinkedSession: string
+    workPacketSummary: string
+    workPacketStats: Record<'open' | 'ready' | 'running' | 'blocked' | 'review' | 'done', string>
+    workPacketColumns: Record<'triage' | 'todo' | 'scheduled' | 'ready' | 'running' | 'blocked' | 'review' | 'done', string>
+    latestKanbanEvent: (id: string) => string
     days: (count: number) => string
     statSessions: string
     statApiCalls: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -999,9 +999,10 @@ export const zhHant = defineLocale({
     settingsFields: '設定欄位',
     mcpServers: 'MCP 伺服器',
     archivedChats: '已封存聊天',
-    sections: { sessions: '工作階段', system: '系統', usage: '使用量' },
+    sections: { sessions: '工作階段', 'work-packets': '工作包', system: '系統', usage: '使用量' },
     sectionDescriptions: {
       sessions: '搜尋和管理工作階段',
+      'work-packets': '自主 Kanban 工作包與交接',
       system: '狀態、記錄和系統動作',
       usage: '一段時間內的詞元、費用和技能活動'
     },
@@ -1014,6 +1015,7 @@ export const zhHant = defineLocale({
     },
     sectionEntries: {
       sessions: { title: '工作階段面板', detail: '搜尋、釘選和管理工作階段' },
+      'work-packets': { title: '工作包面板', detail: 'Kanban 佇列、阻塞項與交接' },
       system: { title: '系統面板', detail: '閘道狀態、記錄、重新啟動/更新' },
       usage: { title: '使用量面板', detail: '詞元、費用和技能活動' }
     },
@@ -1022,6 +1024,8 @@ export const zhHant = defineLocale({
     refresh: '重新整理',
     refreshing: '重新整理中…',
     noResults: '找不到相符的結果。',
+    createWorkPacket: '建立工作包',
+    creatingWorkPacket: '正在建立工作包…',
     pinSession: '釘選工作階段',
     unpinSession: '取消釘選',
     exportSession: '匯出工作階段',
@@ -1040,6 +1044,33 @@ export const zhHant = defineLocale({
     loadingStatus: '正在載入狀態…',
     recentLogs: '最近記錄',
     noLogs: '尚未載入記錄。',
+    loadingWorkPackets: '正在載入工作包…',
+    noWorkPackets: '目前 Kanban 看板暫無工作包。',
+    recentWorkPackets: '最近工作包',
+    workPacketDetails: '工作包詳細資料',
+    loadingWorkPacketDetails: '正在載入工作包詳細資料…',
+    workPacketDetailsFailed: '無法載入工作包詳細資料。',
+    openLinkedSession: '開啟關聯工作階段',
+    workPacketSummary: '摘要',
+    workPacketStats: {
+      open: '未完成',
+      ready: '就緒',
+      running: '執行中',
+      blocked: '阻塞',
+      review: '審閱',
+      done: '完成'
+    },
+    workPacketColumns: {
+      triage: '分診',
+      todo: '待辦',
+      scheduled: '已排程',
+      ready: '就緒',
+      running: '執行中',
+      blocked: '阻塞',
+      review: '審閱',
+      done: '完成'
+    },
+    latestKanbanEvent: id => `最新事件 #${id}`,
     days: count => `${count} 天`,
     statSessions: '工作階段',
     statApiCalls: 'API 呼叫',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1191,10 +1191,11 @@ export const zh: Translations = {
     settingsFields: '设置字段',
     mcpServers: 'MCP 服务器',
     archivedChats: '已归档对话',
-    sections: { maintenance: '维护', sessions: '会话', system: '系统', usage: '用量' },
+    sections: { maintenance: '维护', sessions: '会话', 'work-packets': '工作包', system: '系统', usage: '用量' },
     sectionDescriptions: {
       maintenance: '诊断、备份、维护器与记忆数据',
       sessions: '搜索与管理会话',
+      'work-packets': '自主 Kanban 工作包与交接',
       system: '状态、日志与系统操作',
       usage: '一段时间内的词元、成本与技能活动'
     },
@@ -1207,6 +1208,7 @@ export const zh: Translations = {
     },
     sectionEntries: {
       sessions: { title: '会话面板', detail: '搜索、置顶与管理会话' },
+      'work-packets': { title: '工作包面板', detail: 'Kanban 队列、阻塞项与交接' },
       system: { title: '系统面板', detail: '网关状态、日志、重启/更新' },
       usage: { title: '用量面板', detail: '词元、成本与技能活动' }
     },
@@ -1215,6 +1217,8 @@ export const zh: Translations = {
     refresh: '刷新',
     refreshing: '刷新中…',
     noResults: '未找到匹配结果。',
+    createWorkPacket: '创建工作包',
+    creatingWorkPacket: '正在创建工作包…',
     pinSession: '置顶会话',
     unpinSession: '取消置顶',
     exportSession: '导出会话',
@@ -1233,6 +1237,33 @@ export const zh: Translations = {
     loadingStatus: '正在加载状态…',
     recentLogs: '最近日志',
     noLogs: '尚未加载日志。',
+    loadingWorkPackets: '正在加载工作包…',
+    noWorkPackets: '当前 Kanban 看板暂无工作包。',
+    recentWorkPackets: '最近工作包',
+    workPacketDetails: '工作包详情',
+    loadingWorkPacketDetails: '正在加载工作包详情…',
+    workPacketDetailsFailed: '无法加载工作包详情。',
+    openLinkedSession: '打开关联会话',
+    workPacketSummary: '摘要',
+    workPacketStats: {
+      open: '未完成',
+      ready: '就绪',
+      running: '运行中',
+      blocked: '阻塞',
+      review: '复核',
+      done: '完成'
+    },
+    workPacketColumns: {
+      triage: '分诊',
+      todo: '待办',
+      scheduled: '已排期',
+      ready: '就绪',
+      running: '运行中',
+      blocked: '阻塞',
+      review: '复核',
+      done: '完成'
+    },
+    latestKanbanEvent: id => `最新事件 #${id}`,
     days: count => `${count} 天`,
     statSessions: '会话',
     statApiCalls: 'API 调用',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -315,6 +315,44 @@ export interface SessionCreateResponse {
   stored_session_id?: string
 }
 
+export interface SessionWorkPacketLatest {
+  assignee?: null | string
+  id: string
+  priority?: null | number
+  status: string
+  title: string
+}
+
+export interface SessionWorkPacketSummary {
+  count: number
+  latest?: null | SessionWorkPacketLatest
+  open_count: number
+}
+
+export interface SessionWorkPacketTask {
+  assignee?: null | string
+  completed_at?: null | number
+  created_at?: null | number
+  id: string
+  priority?: null | number
+  session_id: string
+  started_at?: null | number
+  status: string
+  title: string
+}
+
+export interface SessionWorkPacketCreatePayload {
+  assignee?: null | string
+  priority?: null | number
+  title?: null | string
+}
+
+export interface SessionWorkPacketCreateResponse {
+  created: boolean
+  task: SessionWorkPacketTask
+  work_packets: SessionWorkPacketSummary
+}
+
 export interface SessionInfo {
   archived?: boolean
   cwd?: null | string
@@ -347,6 +385,9 @@ export interface SessionInfo {
   started_at: number
   title: null | string
   tool_call_count: number
+  /** Small read-only summary of Kanban work packets linked through tasks.session_id.
+   *  Present only on session-list responses when matching tasks exist. */
+  work_packets?: null | SessionWorkPacketSummary
   /** Origin platform when this session was handed off from a messaging
    *  platform (e.g. a Telegram thread continued in the desktop app). The live
    *  {@link source} becomes local (tui/desktop) after a handoff, so the origin
@@ -521,6 +562,49 @@ export interface AnalyticsToolEntry {
   tool: string
 }
 
+export interface KanbanSessionBridge {
+  last_active?: null | number
+  profile: string
+  session_exists: boolean
+  session_id: string
+  source?: null | string
+  started_at?: null | number
+  title?: null | string
+}
+
+export interface KanbanTask {
+  assignee?: null | string
+  block_kind?: null | string
+  completed_at?: null | number
+  created_at?: null | number
+  current_step_key?: null | string
+  id: string
+  last_heartbeat_at?: null | number
+  latest_summary?: null | string
+  priority?: null | number
+  session_bridge?: KanbanSessionBridge | null
+  started_at?: null | number
+  status: string
+  title: string
+}
+
+export type KanbanTaskDetail = KanbanTask
+
+export interface KanbanTaskDetailResponse {
+  task: KanbanTaskDetail
+}
+
+export interface KanbanBoardColumn {
+  name: string
+  tasks: KanbanTask[]
+}
+
+export interface KanbanBoardResponse {
+  assignees: string[]
+  columns: KanbanBoardColumn[]
+  latest_event_id: number
+  now: number
+}
 export interface AnalyticsSkillEntry {
   last_used_at: null | number
   manage_count: number

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3849,6 +3849,414 @@ def _strip_session_list_rows(sessions: List[Dict[str, Any]]) -> List[Dict[str, A
         for key in _SESSION_LIST_HEAVY_FIELDS:
             s.pop(key, None)
     return sessions
+_WORK_PACKET_CARD_SUMMARY_PREVIEW_CHARS = 200
+_COMMAND_CENTER_WORK_PACKET_COLUMNS = [
+    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
+]
+
+
+def _session_work_packet_profile_name(profile: Optional[str]) -> str:
+    """Return the profile name used in session-work-packet idempotency keys."""
+    if profile:
+        name, _home = _cron_profile_home(profile)
+        return name
+    return "default"
+
+
+def _session_work_packet_profile_for_row(session: Dict[str, Any]) -> str:
+    raw = str(session.get("profile") or "default").strip()
+    return raw or "default"
+
+
+def _session_work_packet_idempotency_key(profile_name: str, session_id: str) -> str:
+    return f"session-work-packet:{profile_name}:{session_id}"
+
+
+def _session_work_packet_key_from_idempotency(value: Optional[str]) -> Optional[Tuple[str, str]]:
+    if not value:
+        return None
+    prefix = "session-work-packet:"
+    if not value.startswith(prefix):
+        return None
+    rest = value[len(prefix):]
+    if ":" not in rest:
+        return None
+    profile_name, session_id = rest.split(":", 1)
+    profile_name = profile_name.strip()
+    session_id = session_id.strip()
+    if not profile_name or not session_id:
+        return None
+    return profile_name, session_id
+
+
+def _session_work_packet_summaries(sessions: List[Dict[str, Any]]) -> Dict[Tuple[str, str], Dict[str, Any]]:
+    """Return safe Kanban work-packet summaries keyed by (profile, session id).
+
+    Kanban is a shared board across profiles, while session lists are served out
+    of one or more profile ``state.db`` files.  This read-only join lets Desktop
+    show a small FounderOS badge beside linked chats without creating a second
+    task store or mutating gateway/Kanban routing state.  The payload is
+    deliberately tiny and excludes workspace paths, bodies, results, comments,
+    chat ids, user ids, and session keys.
+
+    The join is intentionally profile-qualified through the Desktop promotion
+    idempotency key.  ``tasks.session_id`` alone is not globally unique across
+    Hermes profiles, so raw session-id matches would let one profile inherit
+    another profile's badge when both have the same local session id.
+    """
+    targets: Dict[str, Tuple[str, str]] = {}
+    for session in sessions:
+        sid = str(session.get("id") or "").strip()
+        if not sid:
+            continue
+        profile_name = _session_work_packet_profile_for_row(session)
+        targets[_session_work_packet_idempotency_key(profile_name, sid)] = (profile_name, sid)
+    if not targets:
+        return {}
+
+    try:
+        from hermes_cli import kanban_db as kb
+
+        db_path = kb.kanban_db_path()
+    except Exception as exc:
+        _log.debug("session work-packet summary path lookup failed: %s", exc)
+        return {}
+
+    if not db_path.exists():
+        return {}
+
+    try:
+        import sqlite3
+
+        conn = sqlite3.connect(
+            db_path.resolve().as_uri() + "?mode=ro",
+            uri=True,
+            timeout=0.25,
+            isolation_level=None,
+        )
+        conn.row_factory = sqlite3.Row
+    except Exception as exc:
+        _log.debug("session work-packet summary DB open failed: %s", exc)
+        return {}
+
+    try:
+        keys = sorted(targets)
+        placeholders = ",".join("?" for _ in keys)
+        rows = conn.execute(
+            f"""
+            SELECT id, session_id, idempotency_key, title, status, assignee, priority
+            FROM tasks
+            WHERE idempotency_key IN ({placeholders})
+              AND status != 'archived'
+            ORDER BY COALESCE(completed_at, last_heartbeat_at, started_at, created_at) DESC,
+                     created_at DESC,
+                     id DESC
+            """,
+            keys,
+        ).fetchall()
+    except Exception as exc:
+        _log.debug("session work-packet summary query failed: %s", exc)
+        return {}
+    finally:
+        conn.close()
+
+    summaries: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    for row in rows:
+        key = targets.get(row["idempotency_key"])
+        if key is None:
+            continue
+        summary = summaries.setdefault(
+            key,
+            {"count": 0, "open_count": 0, "latest": None},
+        )
+        summary["count"] += 1
+        if row["status"] not in ("done", "archived"):
+            summary["open_count"] += 1
+        if summary["latest"] is None:
+            summary["latest"] = {
+                "id": row["id"],
+                "title": row["title"],
+                "status": row["status"],
+                "assignee": row["assignee"],
+                "priority": row["priority"],
+            }
+    return summaries
+
+
+def _attach_work_packet_summaries(sessions: List[Dict[str, Any]]) -> None:
+    summaries = _session_work_packet_summaries(sessions)
+    if not summaries:
+        return
+    for session in sessions:
+        sid = str(session.get("id") or "").strip()
+        if not sid:
+            continue
+        summary = summaries.get((_session_work_packet_profile_for_row(session), sid))
+        if summary:
+            session["work_packets"] = summary
+
+
+def _session_work_packet_task_payload(task: Any) -> Dict[str, Any]:
+    """Return the safe task fields needed after promoting a session.
+
+    Work-packet detail APIs already own the full Kanban shape.  The session
+    mutation endpoint only needs enough data for Desktop to update the row badge
+    and avoid a board refresh; keep workspace paths, bodies, results, comments,
+    and gateway routing internals out of this response.
+    """
+    return {
+        "id": task.id,
+        "title": task.title,
+        "status": task.status,
+        "assignee": task.assignee,
+        "priority": task.priority,
+        "session_id": task.session_id,
+        "created_at": task.created_at,
+        "started_at": task.started_at,
+        "completed_at": task.completed_at,
+    }
+
+
+def _fallback_session_work_packet_summary(task: Any) -> Dict[str, Any]:
+    return {
+        "count": 1,
+        "open_count": 0 if task.status in ("done", "archived") else 1,
+        "latest": {
+            "id": task.id,
+            "title": task.title,
+            "status": task.status,
+            "assignee": task.assignee,
+            "priority": task.priority,
+        },
+    }
+
+
+def _profile_name_for_work_packet_task(task: Any) -> Optional[str]:
+    parsed = _session_work_packet_key_from_idempotency(getattr(task, "idempotency_key", None))
+    task_session_id = str(getattr(task, "session_id", None) or "").strip()
+    if parsed and task_session_id and parsed[1] == task_session_id:
+        return parsed[0]
+    return None
+
+
+def _empty_command_center_session_bridge(profile_name: str, session_id: str) -> Dict[str, Any]:
+    return {
+        "profile": profile_name,
+        "session_id": session_id,
+        "session_exists": False,
+        "source": None,
+        "title": None,
+        "started_at": None,
+        "last_active": None,
+    }
+
+
+def _command_center_session_bridges_for(tasks: List[Any]) -> Dict[Tuple[str, str], Dict[str, Any]]:
+    """Return safe profile-qualified session navigation hints for work packets.
+
+    This intentionally reads only ``sessions`` plus message timestamps from
+    ``state.db``. It never exposes gateway chat ids, user ids, session keys,
+    workspace paths, task bodies, task results, comments, events, attachments,
+    or run metadata to the Desktop renderer.
+    """
+    targets: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    for task in tasks:
+        sid = str(getattr(task, "session_id", None) or "").strip()
+        if not sid:
+            continue
+        profile_name = _profile_name_for_work_packet_task(task)
+        if not profile_name:
+            continue
+        key = (profile_name, sid)
+        targets.setdefault(key, _empty_command_center_session_bridge(profile_name, sid))
+    if not targets:
+        return {}
+
+    import sqlite3
+
+    by_profile: Dict[str, List[str]] = {}
+    for profile_name, sid in targets:
+        by_profile.setdefault(profile_name, []).append(sid)
+
+    for profile_name, ids in by_profile.items():
+        try:
+            state_path = (
+                get_hermes_home() / "state.db"
+                if profile_name == "default"
+                else _cron_profile_home(profile_name)[1] / "state.db"
+            )
+        except Exception as exc:
+            _log.debug("work-packet session bridge profile lookup failed for %s: %s", profile_name, exc)
+            continue
+        if not state_path.exists():
+            continue
+
+        conn = None
+        try:
+            conn = sqlite3.connect(
+                state_path.resolve().as_uri() + "?mode=ro",
+                uri=True,
+                timeout=0.25,
+                isolation_level=None,
+            )
+            conn.row_factory = sqlite3.Row
+            placeholders = ",".join("?" for _ in ids)
+            rows = conn.execute(
+                f"""
+                SELECT
+                    s.id,
+                    s.source,
+                    s.title,
+                    s.started_at,
+                    COALESCE(
+                        (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = s.id),
+                        s.started_at
+                    ) AS last_active
+                FROM sessions s
+                WHERE s.id IN ({placeholders})
+                """,
+                ids,
+            ).fetchall()
+        except Exception as exc:
+            _log.debug("work-packet session bridge DB lookup failed for %s: %s", profile_name, exc)
+            continue
+        finally:
+            if conn is not None:
+                conn.close()
+
+        for row in rows:
+            sid = str(row["id"])
+            bridge = targets.get((profile_name, sid))
+            if bridge is None:
+                continue
+            bridge.update(
+                {
+                    "session_exists": True,
+                    "source": row["source"],
+                    "title": row["title"],
+                    "started_at": row["started_at"],
+                    "last_active": row["last_active"],
+                }
+            )
+
+    return targets
+
+
+def _command_center_work_packet_task_payload(
+    task: Any,
+    *,
+    latest_summary: Optional[str] = None,
+    session_bridge: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    payload = {
+        "id": task.id,
+        "title": task.title,
+        "status": task.status,
+        "assignee": task.assignee,
+        "priority": task.priority,
+        "created_at": task.created_at,
+        "started_at": task.started_at,
+        "completed_at": task.completed_at,
+        "last_heartbeat_at": task.last_heartbeat_at,
+        "block_kind": getattr(task, "block_kind", None),
+        "current_step_key": getattr(task, "current_step_key", None),
+        "latest_summary": latest_summary,
+    }
+    if session_bridge is not None:
+        payload["session_bridge"] = session_bridge
+    return payload
+
+
+def _open_kanban_for_command_center():
+    try:
+        from hermes_cli import kanban_db as kb
+
+        kb.init_db()
+        return kb, kb.connect()
+    except Exception as exc:
+        _log.warning("kanban DB open failed for command center work packets: %s", exc)
+        raise HTTPException(status_code=503, detail="Kanban board unavailable")
+
+
+@app.get("/api/command-center/work-packets/board")
+async def get_command_center_work_packets_board(include_archived: bool = False):
+    """Return a Desktop-safe Kanban board summary for Command Center.
+
+    This endpoint is separate from the raw Kanban dashboard plugin API. The
+    Desktop renderer receives only card-safe fields plus optional latest worker
+    summaries; raw task body/result, workspace paths, comments, attachments,
+    events, run metadata, and gateway routing identifiers stay server-side.
+    """
+    kb, conn = _open_kanban_for_command_center()
+    try:
+        tasks = kb.list_tasks(conn, include_archived=include_archived)
+        summary_map = kb.latest_summaries(conn, [task.id for task in tasks])
+        bridge_map = _command_center_session_bridges_for(tasks)
+        latest_event_id = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) AS m FROM task_events"
+        ).fetchone()["m"]
+        columns: Dict[str, List[Dict[str, Any]]] = {name: [] for name in _COMMAND_CENTER_WORK_PACKET_COLUMNS}
+        if include_archived:
+            columns["archived"] = []
+
+        for task in tasks:
+            full = summary_map.get(task.id)
+            preview = full[:_WORK_PACKET_CARD_SUMMARY_PREVIEW_CHARS] if full else None
+            sid = str(task.session_id or "").strip()
+            profile_name = _profile_name_for_work_packet_task(task) if sid else None
+            bridge = bridge_map.get((profile_name, sid)) if profile_name and sid else None
+            payload = _command_center_work_packet_task_payload(
+                task,
+                latest_summary=preview,
+                session_bridge=bridge,
+            )
+            column = task.status if task.status in columns else "todo"
+            columns[column].append(payload)
+
+        assignees = [
+            row["assignee"]
+            for row in conn.execute(
+                "SELECT DISTINCT assignee FROM tasks WHERE assignee IS NOT NULL "
+                "AND status != 'archived' ORDER BY assignee"
+            ).fetchall()
+        ]
+
+        return {
+            "columns": [{"name": name, "tasks": columns[name]} for name in columns.keys()],
+            "assignees": assignees,
+            "latest_event_id": int(latest_event_id),
+            "now": int(time.time()),
+        }
+    finally:
+        conn.close()
+
+
+@app.get("/api/command-center/work-packets/tasks/{task_id}")
+async def get_command_center_work_packet_task(task_id: str):
+    """Return Desktop-safe detail for one work packet.
+
+    Detail may include the full latest worker summary because that is the
+    human handoff surface. It still excludes raw task body/result, comments,
+    attachments, events, workspace paths, and run metadata.
+    """
+    kb, conn = _open_kanban_for_command_center()
+    try:
+        task = kb.get_task(conn, task_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        sid = str(task.session_id or "").strip()
+        bridge_map = _command_center_session_bridges_for([task]) if sid else {}
+        profile_name = _profile_name_for_work_packet_task(task) if sid else None
+        bridge = bridge_map.get((profile_name, sid)) if profile_name and sid else None
+        return {
+            "task": _command_center_work_packet_task_payload(
+                task,
+                latest_summary=kb.latest_summary(conn, task_id),
+                session_bridge=bridge,
+            )
+        }
+    finally:
+        conn.close()
 
 
 @app.get("/api/sessions")
@@ -3940,6 +4348,7 @@ def get_sessions(
                 s["archived"] = bool(s.get("archived"))
             if not full:
                 _strip_session_list_rows(sessions)
+            _attach_work_packet_summaries(sessions)
             return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}
         finally:
             db.close()
@@ -4067,6 +4476,7 @@ def get_profiles_sessions(
     window = merged[offset:offset + limit]
     if not full:
         _strip_session_list_rows(window)
+    _attach_work_packet_summaries(window)
     return {
         "sessions": window,
         "total": total,
@@ -9644,6 +10054,15 @@ class SessionRename(BaseModel):
     profile: Optional[str] = None
 
 
+class SessionWorkPacketCreate(BaseModel):
+    title: Optional[str] = None
+    assignee: Optional[str] = None
+    priority: Optional[int] = None
+    # Explicit body profile beats the query param injected by the Desktop
+    # profile switcher, matching the other scoped write endpoints.
+    profile: Optional[str] = None
+
+
 @app.patch("/api/sessions/{session_id}")
 async def rename_session_endpoint(session_id: str, body: SessionRename):
     """Update a session: rename (or clear its title) and/or archive it.
@@ -9676,6 +10095,94 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
         return result
     finally:
         db.close()
+
+
+@app.post("/api/sessions/{session_id}/work-packets")
+async def create_session_work_packet_endpoint(
+    session_id: str,
+    body: Optional[SessionWorkPacketCreate] = None,
+    profile: Optional[str] = None,
+):
+    """Promote a Hermes session into a Kanban work packet.
+
+    ``tasks.session_id`` remains the durable bridge.  Repeated calls return the
+    existing non-archived packet instead of creating duplicates, so Desktop can
+    safely expose this as a one-click "Create packet" action.
+    """
+    body = body or SessionWorkPacketCreate()
+    target_profile = body.profile if body.profile is not None else profile
+    profile_name = _session_work_packet_profile_name(target_profile)
+
+    db = _open_session_db_for_profile(target_profile)
+    try:
+        sid = db.resolve_session_id(session_id)
+        if not sid:
+            raise HTTPException(status_code=404, detail="Session not found")
+        session = db.get_session(sid)
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+    finally:
+        db.close()
+
+    try:
+        from hermes_cli import kanban_db as kb
+
+        kb.init_db()
+        conn = kb.connect()
+    except Exception as exc:
+        _log.warning("kanban DB open failed for session work-packet create: %s", exc)
+        raise HTTPException(status_code=503, detail="Kanban board unavailable")
+
+    try:
+        idempotency_key = _session_work_packet_idempotency_key(profile_name, sid)
+        existing_row = conn.execute(
+            """
+            SELECT id FROM tasks
+            WHERE idempotency_key = ?
+              AND status != 'archived'
+            ORDER BY COALESCE(completed_at, last_heartbeat_at, started_at, created_at) DESC,
+                     created_at DESC,
+                     id DESC
+            LIMIT 1
+            """,
+            (idempotency_key,),
+        ).fetchone()
+        created = False
+        if existing_row:
+            task = kb.get_task(conn, existing_row["id"])
+        else:
+            raw_title = body.title if body.title is not None else session.get("title")
+            title = (raw_title or "").strip() or f"Session {sid[:8]}"
+            assignee = (body.assignee or "").strip() or None
+            priority = int(body.priority) if body.priority is not None else 0
+            cwd = str(session.get("cwd") or "").strip()
+            task_id = kb.create_task(
+                conn,
+                title=title,
+                body=f"Promoted from Hermes session {sid}.",
+                assignee=assignee,
+                created_by="desktop-session",
+                workspace_kind="dir" if cwd else "scratch",
+                workspace_path=cwd or None,
+                priority=priority,
+                idempotency_key=idempotency_key,
+                session_id=sid,
+            )
+            task = kb.get_task(conn, task_id)
+            created = True
+        if task is None:
+            raise HTTPException(status_code=500, detail="Work packet creation failed")
+        session_row = {"id": sid, "profile": profile_name}
+        summary = _session_work_packet_summaries([session_row]).get((profile_name, sid))
+        return {
+            "created": created,
+            "task": _session_work_packet_task_payload(task),
+            "work_packets": summary or _fallback_session_work_packet_summary(task),
+        }
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    finally:
+        conn.close()
 
 
 @app.get("/api/sessions/{session_id}/export")

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -10,6 +10,17 @@ import pytest
 import yaml
 
 
+def _assert_no_keys(value, forbidden):
+    if isinstance(value, dict):
+        overlap = forbidden.intersection(value)
+        assert not overlap, f"forbidden key(s) present: {sorted(overlap)}"
+        for child in value.values():
+            _assert_no_keys(child, forbidden)
+    elif isinstance(value, list):
+        for child in value:
+            _assert_no_keys(child, forbidden)
+
+
 @pytest.fixture
 def isolated_profiles(tmp_path, monkeypatch, _isolate_hermes_home):
     """Isolated default home + one named profile, each with config + .env."""
@@ -48,6 +59,348 @@ def client(monkeypatch, isolated_profiles):
 
 def _cfg(home):
     return yaml.safe_load((home / "config.yaml").read_text()) or {}
+
+
+class TestProfileScopedSessionWorkPackets:
+    def test_profiles_sessions_include_read_only_work_packet_summary(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        """Session rows should expose safe linked work-packet summaries.
+
+        Kanban owns ``tasks.session_id``. The dashboard session list should join
+        that fact at read time so Desktop can show a small FounderOS badge next
+        to chats without creating or mutating routing state.
+        """
+        from hermes_cli import kanban_db as kb
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(isolated_profiles["default"]))
+        kb.init_db()
+
+        session_id = "sess_work_packet_1"
+        db = SessionDB(db_path=isolated_profiles["default"] / "state.db")
+        try:
+            db.create_session(session_id, "desktop")
+            db.set_session_title(session_id, "FounderOS planning")
+        finally:
+            db.close()
+
+        conn = kb.connect()
+        try:
+            task_id = kb.create_task(
+                conn,
+                title="Wire session badge",
+                assignee="desktop",
+                priority=4,
+                initial_status="running",
+                idempotency_key=f"session-work-packet:default:{session_id}",
+                session_id=session_id,
+            )
+        finally:
+            conn.close()
+
+        expected = {
+            "count": 1,
+            "open_count": 1,
+            "latest": {
+                "id": task_id,
+                "title": "Wire session badge",
+                "status": "ready",
+                "assignee": "desktop",
+                "priority": 4,
+            },
+        }
+
+        resp = client.get("/api/profiles/sessions", params={"profile": "default", "limit": 10})
+        assert resp.status_code == 200, resp.text
+        row = next(s for s in resp.json()["sessions"] if s["id"] == session_id)
+        assert row["work_packets"] == expected
+
+        resp = client.get("/api/sessions", params={"limit": 10})
+        assert resp.status_code == 200, resp.text
+        row = next(s for s in resp.json()["sessions"] if s["id"] == session_id)
+        assert row["work_packets"] == expected
+
+    def test_session_can_be_promoted_to_one_work_packet(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        """A Desktop session can be turned into exactly one Kanban work packet.
+
+        This is the first mutation in the session/work-packet bridge: session
+        metadata seeds a task, ``tasks.session_id`` remains the durable link,
+        and repeated clicks return the existing non-archived packet instead of
+        creating duplicates.
+        """
+        from hermes_cli import kanban_db as kb
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(isolated_profiles["default"]))
+        kb.init_db()
+
+        session_id = "sess_promote_packet_1"
+        db = SessionDB(db_path=isolated_profiles["default"] / "state.db")
+        try:
+            db.create_session(session_id, "desktop", cwd="C:/work/paralloff")
+            db.set_session_title(session_id, "Turn this chat into work")
+        finally:
+            db.close()
+
+        resp = client.post(
+            f"/api/sessions/{session_id}/work-packets",
+            json={"assignee": "desktop", "priority": 3},
+        )
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        assert payload["created"] is True
+        assert payload["task"]["title"] == "Turn this chat into work"
+        assert payload["task"]["session_id"] == session_id
+        assert payload["task"]["assignee"] == "desktop"
+        assert payload["task"]["priority"] == 3
+        assert "created_by" not in payload["task"]
+        assert payload["work_packets"] == {
+            "count": 1,
+            "open_count": 1,
+            "latest": {
+                "id": payload["task"]["id"],
+                "title": "Turn this chat into work",
+                "status": "ready",
+                "assignee": "desktop",
+                "priority": 3,
+            },
+        }
+
+        resp = client.post(f"/api/sessions/{session_id}/work-packets", json={})
+        assert resp.status_code == 200, resp.text
+        second = resp.json()
+        assert second["created"] is False
+        assert second["task"]["id"] == payload["task"]["id"]
+
+        conn = kb.connect()
+        try:
+            tasks = kb.list_tasks(conn, session_id=session_id)
+        finally:
+            conn.close()
+        assert [task.id for task in tasks] == [payload["task"]["id"]]
+
+    def test_command_center_work_packet_endpoints_are_sanitized(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        """Desktop must never receive raw Kanban detail payloads.
+
+        The Command Center bridge can render safe card fields and the latest
+        worker summary, but raw task body/result, workspace paths, comments,
+        events, attachments, and runs must remain server-side.
+        """
+        from hermes_cli import kanban_db as kb
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(isolated_profiles["default"]))
+        kb.init_db()
+
+        session_id = "sess_safe_packet_1"
+        db = SessionDB(db_path=isolated_profiles["default"] / "state.db")
+        try:
+            db.create_session(session_id, "desktop", cwd="C:/private/worktree")
+            db.set_session_title(session_id, "Safe endpoint source session")
+        finally:
+            db.close()
+
+        conn = kb.connect()
+        try:
+            task_id = kb.create_task(
+                conn,
+                title="Safe renderer card",
+                body="RAW BODY DO NOT SEND",
+                assignee="desktop",
+                created_by="desktop-session",
+                tenant="RAW TENANT DO NOT SEND",
+                workspace_kind="dir",
+                workspace_path="C:/private/worktree",
+                priority=5,
+                idempotency_key=f"session-work-packet:default:{session_id}",
+                session_id=session_id,
+            )
+            kb.add_comment(conn, task_id, "reviewer", "RAW COMMENT DO NOT SEND")
+            assert kb.complete_task(
+                conn,
+                task_id,
+                result="RAW RESULT DO NOT SEND",
+                summary="Safe human handoff summary",
+                metadata={"artifacts": ["C:/private/artifact.txt"]},
+            )
+        finally:
+            conn.close()
+
+        forbidden_keys = {
+            "attachments",
+            "body",
+            "comments",
+            "created_by",
+            "events",
+            "links",
+            "result",
+            "runs",
+            "tenant",
+            "tenants",
+            "workspace_kind",
+            "workspace_path",
+        }
+
+        board_resp = client.get("/api/command-center/work-packets/board")
+        assert board_resp.status_code == 200, board_resp.text
+        board_payload = board_resp.json()
+        _assert_no_keys(board_payload, forbidden_keys)
+        board_text = board_resp.text
+        assert "RAW BODY DO NOT SEND" not in board_text
+        assert "RAW COMMENT DO NOT SEND" not in board_text
+        assert "RAW RESULT DO NOT SEND" not in board_text
+        assert "RAW TENANT DO NOT SEND" not in board_text
+        assert "C:/private" not in board_text
+        assert "tenants" not in board_payload
+
+        cards = [task for col in board_payload["columns"] for task in col["tasks"]]
+        card = next(task for task in cards if task["id"] == task_id)
+        assert card["latest_summary"] == "Safe human handoff summary"
+        assert card["session_bridge"] == {
+            "profile": "default",
+            "session_id": session_id,
+            "session_exists": True,
+            "source": "desktop",
+            "title": "Safe endpoint source session",
+            "started_at": card["session_bridge"]["started_at"],
+            "last_active": card["session_bridge"]["last_active"],
+        }
+
+        detail_resp = client.get(f"/api/command-center/work-packets/tasks/{task_id}")
+        assert detail_resp.status_code == 200, detail_resp.text
+        detail_payload = detail_resp.json()
+        _assert_no_keys(detail_payload, forbidden_keys)
+        detail_text = detail_resp.text
+        assert "RAW BODY DO NOT SEND" not in detail_text
+        assert "RAW COMMENT DO NOT SEND" not in detail_text
+        assert "RAW RESULT DO NOT SEND" not in detail_text
+        assert "RAW TENANT DO NOT SEND" not in detail_text
+        assert "C:/private" not in detail_text
+        assert detail_payload["task"]["latest_summary"] == "Safe human handoff summary"
+
+    def test_command_center_does_not_bridge_unqualified_session_ids(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        """A bare tasks.session_id is profile-local and must not become navigation."""
+        from hermes_cli import kanban_db as kb
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(isolated_profiles["default"]))
+        kb.init_db()
+
+        session_id = "sess_unqualified_bridge"
+        db = SessionDB(db_path=isolated_profiles["default"] / "state.db")
+        try:
+            db.create_session(session_id, "desktop")
+            db.set_session_title(session_id, "Should not be linked by bare id")
+        finally:
+            db.close()
+
+        conn = kb.connect()
+        try:
+            bare_task_id = kb.create_task(
+                conn,
+                title="Legacy bare session task",
+                assignee="desktop",
+                priority=2,
+                session_id=session_id,
+            )
+            blank_profile_task_id = kb.create_task(
+                conn,
+                title="Malformed blank-profile session task",
+                assignee="desktop",
+                priority=2,
+                idempotency_key=f"session-work-packet:   :{session_id}",
+                session_id=session_id,
+            )
+        finally:
+            conn.close()
+
+        board_resp = client.get("/api/command-center/work-packets/board")
+        assert board_resp.status_code == 200, board_resp.text
+        cards = [task for col in board_resp.json()["columns"] for task in col["tasks"]]
+        cards_by_id = {task["id"]: task for task in cards}
+        assert "session_bridge" not in cards_by_id[bare_task_id]
+        assert "session_bridge" not in cards_by_id[blank_profile_task_id]
+
+        for task_id in (bare_task_id, blank_profile_task_id):
+            detail_resp = client.get(f"/api/command-center/work-packets/tasks/{task_id}")
+            assert detail_resp.status_code == 200, detail_resp.text
+            assert "session_bridge" not in detail_resp.json()["task"]
+
+    def test_work_packet_bridge_is_profile_qualified_for_duplicate_session_ids(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        """Same local session id in two profiles must not share a badge/task."""
+        from hermes_cli import kanban_db as kb
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(isolated_profiles["default"]))
+        kb.init_db()
+
+        session_id = "sess_duplicate_across_profiles"
+        for profile_name, title in (
+            ("default", "Default profile session"),
+            ("worker_beta", "Worker profile session"),
+        ):
+            db = SessionDB(db_path=isolated_profiles[profile_name] / "state.db")
+            try:
+                db.create_session(session_id, "desktop")
+                db.set_session_title(session_id, title)
+            finally:
+                db.close()
+
+        conn = kb.connect()
+        try:
+            task_id = kb.create_task(
+                conn,
+                title="Worker-only packet",
+                assignee="desktop",
+                priority=2,
+                idempotency_key=f"session-work-packet:worker_beta:{session_id}",
+                session_id=session_id,
+            )
+        finally:
+            conn.close()
+
+        default_resp = client.get("/api/profiles/sessions", params={"profile": "default", "limit": 10})
+        assert default_resp.status_code == 200, default_resp.text
+        default_row = next(s for s in default_resp.json()["sessions"] if s["id"] == session_id)
+        assert "work_packets" not in default_row
+
+        worker_resp = client.get("/api/profiles/sessions", params={"profile": "worker_beta", "limit": 10})
+        assert worker_resp.status_code == 200, worker_resp.text
+        worker_row = next(s for s in worker_resp.json()["sessions"] if s["id"] == session_id)
+        assert worker_row["work_packets"] == {
+            "count": 1,
+            "open_count": 1,
+            "latest": {
+                "id": task_id,
+                "title": "Worker-only packet",
+                "status": "ready",
+                "assignee": "desktop",
+                "priority": 2,
+            },
+        }
+
+        create_default = client.post(f"/api/sessions/{session_id}/work-packets", json={})
+        assert create_default.status_code == 200, create_default.text
+        assert create_default.json()["created"] is True
+        assert create_default.json()["task"]["id"] != task_id
+
+        create_worker = client.post(
+            f"/api/sessions/{session_id}/work-packets",
+            params={"profile": "worker_beta"},
+            json={},
+        )
+        assert create_worker.status_code == 200, create_worker.text
+        assert create_worker.json()["created"] is False
+        assert create_worker.json()["task"]["id"] == task_id
 
 
 class TestProfileScopedConfig:


### PR DESCRIPTION
## Summary
- Add sanitized Command Center work-packet board/detail endpoints for Desktop.
- Route Desktop work-packet UI through the sanitized Command Center API surface instead of raw Kanban plugin endpoints.
- Preserve profile-qualified session identity end-to-end for linked work-packet session navigation/resume.
- Reject unqualified/malformed session work-packet idempotency links instead of default-profile fallback.
- Minimize renderer DTOs by excluding raw Kanban task body/result/comments/events/attachments/runs, workspace paths, tenant(s), and created_by where not needed.

## User-facing result
- Command Center can show work packets and open their linked sessions safely.
- Duplicate local session IDs across profiles no longer risk opening the wrong profile's session.
- Ambiguous work-packet links are omitted instead of being treated as default-profile sessions.

## Verification
- `uv run pytest tests/hermes_cli/test_web_server_profile_unification.py::TestProfileScopedSessionWorkPackets -q` => 5 passed
- `npm run test:ui -- src/hermes.test.ts src/app/command-center/index.test.tsx src/app/session/hooks/use-route-resume.test.tsx` => 22 tests passed
- `npm run typecheck` => passed
- changed-file `npx eslint ...` => passed
- `npm run build` => passed
- renderer-safety static scan => clean
- added-line security scan => clean
- `git diff --cached --check` => passed
- Independent reviewer rerun => VERDICT: PASS

## Review snapshot
- diff SHA256: `d71cad18b4718114764836e65ef586a95e3ba01e90fbf85f3a95c225355cd073`
- stat SHA256: `0d5c170b75bed57939e4c71a93852ddfc7ad7314369d6839466bb505dde66574`
- security scan SHA256: `5ff0456260078fde3a8353571245d0cf0b31c68d4b87ff7cc36a0ab9e98f428a`
