### PR TITLE
fix(agent): exclude Ollama Cloud from local-Ollama stop heuristic + separator-safe continuation join

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2706,7 +2706,7 @@ def run_conversation(
                                 _retry.restart_with_length_continuation = True
                                 break
 
-                            partial_response = agent._strip_think_blocks("".join(truncated_response_parts)).strip()
+                            partial_response = agent._strip_think_blocks("\n".join(truncated_response_parts)).strip()
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
                             return {
@@ -6316,7 +6316,7 @@ def run_conversation(
                 codex_ack_continuations = 0
 
                 if truncated_response_parts:
-                    final_response = "".join(truncated_response_parts) + final_response
+                    final_response = "\n".join(truncated_response_parts) + final_response
                     truncated_response_parts = []
                     length_continue_retries = 0
                 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1596,21 +1596,27 @@ class AIAgent:
         """Detect Ollama-hosted GLM models affected by stop misreports.
 
         Ollama can misreport truncated output as finish_reason='stop'.
-        Detection relies on explicit Ollama signatures:
+        Detection relies on local-Ollama signatures:
         - Port 11434 (Ollama default)
-        - "ollama" in the base URL (e.g. ollama.local, /ollama/ path)
+        - ``localhost`` or ``127.0.0.1`` in the base URL
         - provider explicitly set to "ollama"
 
         Crucially it does NOT match arbitrary local/private endpoints
         (LiteLLM/sglang/vLLM/LM Studio proxies, Tailscale boxes), which
         report finish_reason correctly and were the source of #13971's
-        false-positive truncation continuations.
+        false-positive truncation continuations, nor does it match
+        cloud API providers such as ollama.com (the source of #60928's
+        false truncation on Ollama Cloud).
         """
         model_lower = (self.model or "").lower()
         provider_lower = (self.provider or "").lower()
         if "glm" not in model_lower and provider_lower != "zai":
             return False
-        if "ollama" in self._base_url_lower or ":11434" in self._base_url_lower:
+        if (
+            "localhost" in self._base_url_lower
+            or "127.0.0.1" in self._base_url_lower
+            or ":11434" in self._base_url_lower
+        ):
             return True
         return provider_lower == "ollama"
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1596,27 +1596,25 @@ class AIAgent:
         """Detect Ollama-hosted GLM models affected by stop misreports.
 
         Ollama can misreport truncated output as finish_reason='stop'.
-        Detection relies on local-Ollama signatures:
+        Detection relies on explicit local-Ollama signatures:
         - Port 11434 (Ollama default)
-        - ``localhost`` or ``127.0.0.1`` in the base URL
+        - "ollama" in the base URL (e.g. ollama.local, /ollama/ path)
+          but NOT ``ollama.com`` (Ollama Cloud), which reports stop
+          correctly and was the source of #60928's false truncation
         - provider explicitly set to "ollama"
 
         Crucially it does NOT match arbitrary local/private endpoints
         (LiteLLM/sglang/vLLM/LM Studio proxies, Tailscale boxes), which
         report finish_reason correctly and were the source of #13971's
-        false-positive truncation continuations, nor does it match
-        cloud API providers such as ollama.com (the source of #60928's
-        false truncation on Ollama Cloud).
+        false-positive truncation continuations.
         """
         model_lower = (self.model or "").lower()
         provider_lower = (self.provider or "").lower()
         if "glm" not in model_lower and provider_lower != "zai":
             return False
-        if (
-            "localhost" in self._base_url_lower
-            or "127.0.0.1" in self._base_url_lower
-            or ":11434" in self._base_url_lower
-        ):
+        if ":11434" in self._base_url_lower:
+            return True
+        if "ollama" in self._base_url_lower and "ollama.com" not in self._base_url_lower:
             return True
         return provider_lower == "ollama"
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5536,9 +5536,9 @@ class TestRunConversation:
         without ASCII punctuation should not be reclassified as truncated.
         """
         self._setup_agent(agent)
-        # Use a non-localhost IP for sglang to avoid matching the
-        # localhost/127.0.0.1 Ollama signature heuristic (#60928).
-        agent.base_url = "http://192.168.1.100:60000/v1"
+        # Loopback (127.0.0.1) with no Ollama/:11434 signature must NOT
+        # trigger the heuristic — it could be sglang/vLLM/LM Studio.
+        agent.base_url = "http://127.0.0.1:60000/v1"
         agent._base_url_lower = agent.base_url.lower()
         agent.model = "glm-5-fp8"
 
@@ -5688,11 +5688,11 @@ class TestRunConversation:
         must NOT be treated as an Ollama backend. provider='zai' on
         a non-localhost address with no :11434 signature reports stop
         correctly and the response should be delivered as-is.
-
-        Uses a non-localhost IP (192.168.1.1) to avoid matching the
-        localhost Ollama signature heuristic (#60928)."""
+        """
+        # Loopback (localhost) with no Ollama/:11434 signature and
+        # provider='zai' must NOT be treated as an Ollama backend.
         self._setup_agent(agent)
-        agent.base_url = "http://192.168.1.1:8000/v1"
+        agent.base_url = "http://localhost:8000/v1"
         agent._base_url_lower = agent.base_url.lower()
         agent.provider = "zai"
         agent.model = "glm-5-turbo"
@@ -6349,6 +6349,109 @@ class TestRunConversation:
         assert second_call["max_tokens"] <= 65471  # 65535 - 64
         assert agent.context_compressor.context_length == 131_072
         mock_compress.assert_not_called()
+
+    def test_length_continuation_exhausted_uses_newline_join(self, agent):
+        """Exhausted length continuations must join parts with ``\\n`` so
+        MEDIA tags are not fused to adjacent text (#60928)."""
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.1:cloud"
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
+        )
+        # 4 truncated responses needed to exhaust max_length_continuations.
+        # None end with terminal punctuation so the heuristic fires each time.
+        parts = [
+            "Phase one MEDIA:/tmp/p1.ogg",
+            "Phase two MEDIA:/tmp/p2.ogg",
+            "Phase three MEDIA:/tmp/p3.ogg",
+            "Phase four MEDIA:/tmp/p4.ogg",
+        ]
+        truncated_responses = [
+            _mock_response(content=p, finish_reason="stop") for p in parts
+        ]
+
+        agent.client.chat.completions.create.side_effect = [
+            tool_turn,
+            *truncated_responses,
+        ]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert result["api_calls"] == 5
+        # All four parts must be present in the partial response
+        for p in parts:
+            assert p in result["final_response"]
+        # Without \n.join, "oggPhase" would appear — verify newline separation
+        assert "\n" in result["final_response"]
+        assert "oggPhase" not in result["final_response"]
+
+    def test_length_continuation_complete_uses_newline_join(self, agent):
+        """When the final response completes after length continuations,
+        accumulated parts must be joined with ``\\n`` so MEDIA tags are
+        not fused (#60928)."""
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.1:cloud"
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
+        )
+        # Two truncated parts — neither ends with terminal punctuation
+        truncated_1 = _mock_response(
+            content="First batch MEDIA:/tmp/batch1.ogg",
+            finish_reason="stop",
+        )
+        truncated_2 = _mock_response(
+            content="Second batch MEDIA:/tmp/batch2.ogg",
+            finish_reason="stop",
+        )
+        # Final response ends with period — natural ending stops heuristic
+        final_stop = _mock_response(
+            content=" and the final answer is ready.",
+            finish_reason="stop",
+        )
+
+        agent.client.chat.completions.create.side_effect = [
+            tool_turn,
+            truncated_1,
+            truncated_2,
+            final_stop,
+        ]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 4
+        # Both truncated parts must be present
+        assert "First batch MEDIA:/tmp/batch1.ogg" in result["final_response"]
+        assert "Second batch MEDIA:/tmp/batch2.ogg" in result["final_response"]
+        # Without \n.join, "oggSecond" would appear — verify newline separation
+        assert "\n" in result["final_response"]
+        assert "oggSecond" not in result["final_response"]
+        # Final continuation piece should flow naturally
+        assert " and the final answer is ready." in result["final_response"]
 
 
 class TestHookPayloadSanitizesSimpleNamespace:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5532,11 +5532,13 @@ class TestRunConversation:
 
         The stop->length workaround must NOT apply to non-Ollama local
         servers that expose OpenAI-compatible /v1 endpoints (sglang, vLLM,
-        LM Studio, etc.).  A Chinese-text response ending without ASCII
-        punctuation should not be reclassified as truncated.
+        LM Studio, Tailscale boxes, etc.).  A Chinese-text response ending
+        without ASCII punctuation should not be reclassified as truncated.
         """
         self._setup_agent(agent)
-        agent.base_url = "http://127.0.0.1:60000/v1"
+        # Use a non-localhost IP for sglang to avoid matching the
+        # localhost/127.0.0.1 Ollama signature heuristic (#60928).
+        agent.base_url = "http://192.168.1.100:60000/v1"
         agent._base_url_lower = agent.base_url.lower()
         agent.model = "glm-5-fp8"
 
@@ -5644,13 +5646,53 @@ class TestRunConversation:
         third_call_messages = agent.client.chat.completions.create.call_args_list[2].kwargs["messages"]
         assert "truncated by the output length limit" in third_call_messages[-1]["content"]
 
-    def test_zai_via_local_proxy_does_not_trigger_heuristic(self, agent):
-        """Issue #13971: a local LiteLLM proxy forwarding to remote Z.AI
-        must NOT be treated as an Ollama backend. provider='zai' on
-        localhost:8000 with no ollama/:11434 signature reports stop
-        correctly and the response should be delivered as-is."""
+    def test_ollama_cloud_glm_does_not_trigger_heuristic(self, agent):
+        """Ollama Cloud (ollama.com) must NOT trigger the stop->length heuristic.
+
+        #60928: the bare ``ollama`` substring previously matched
+        ``https://ollama.com/v1``, falsely reclassifying legitimate
+        Ollama Cloud ``stop`` responses as truncated.  The heuristic
+        is now scoped to localhost / 127.0.0.1 / port 11434 only.
+        """
         self._setup_agent(agent)
-        agent.base_url = "http://localhost:8000/v1"
+        agent.base_url = "https://ollama.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "glm-5.1:cloud"
+
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(name="web_search", arguments="{}", call_id="c1")],
+        )
+        normal_stop = _mock_response(
+            content="Based on the search results, the best next",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [tool_turn, normal_stop]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        # Must NOT continue — Ollama Cloud reports stop correctly.
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert result["final_response"] == "Based on the search results, the best next"
+
+    def test_zai_via_local_proxy_does_not_trigger_heuristic(self, agent):
+        """Issue #13971: a LiteLLM proxy forwarding to remote Z.AI
+        must NOT be treated as an Ollama backend. provider='zai' on
+        a non-localhost address with no :11434 signature reports stop
+        correctly and the response should be delivered as-is.
+
+        Uses a non-localhost IP (192.168.1.1) to avoid matching the
+        localhost Ollama signature heuristic (#60928)."""
+        self._setup_agent(agent)
+        agent.base_url = "http://192.168.1.1:8000/v1"
         agent._base_url_lower = agent.base_url.lower()
         agent.provider = "zai"
         agent.model = "glm-5-turbo"


### PR DESCRIPTION
## Summary

Two interacting bugs:

**Bug A:** `_is_ollama_glm_backend()` used a bare `"ollama"` substring match that included `ollama.com` cloud URLs, causing false truncation heuristics to fire on hosted OpenAI-compatible endpoints.

**Bug B:** Continuation after truncation joined response parts with `"".join()` — gluing `MEDIA:/…ogg` tags directly to adjacent text, corrupting voice delivery.

## Fix

- `run_agent.py`: Replace substring match with targeted localhost/127.0.0.1/:11434 signatures
- `conversation_loop.py`: Change `"".join()` → `"\n".join()` so MEDIA tags never fuse to adjacent text

Fixes: #60928