### PR TITLE
feat(optional-skills): add Bitcoin research skill

### DIFF
--- a/optional-skills/blockchain/bitcoin/SKILL.md
+++ b/optional-skills/blockchain/bitcoin/SKILL.md
@@ -1,0 +1,350 @@
+---
+name: bitcoin
+description: "Read-only Bitcoin research client. Query addresses, UTXOs, transactions, blocks, mempool, fees, network stats, price, whale activity, and editorial checklists. Includes CSV/TSV export and automatic API fallback. Standard library only. No API key required."
+version: 1.0.0
+author: Kain
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Bitcoin, Blockchain, Crypto, On-chain, Research, OSINT]
+    category: blockchain
+    related_skills: [evm, solana]
+    requires_toolsets: [terminal]
+---
+
+# Bitcoin Skill
+
+Read-only Bitcoin research tool for verification and on-chain analysis.
+15 commands: `address`, `txs`, `tx`, `utxo`, `block`, `mempool`, `fees`, `stats`, `price`, `whale`, `verify`, `report`, `compare`, `fee-history`, `editorial`.
+
+No API key needed. Python standard library only (`urllib`, `json`, `argparse`).
+Export to JSON, CSV, or TSV. Automatic fallback to blockstream.info when
+mempool.space is unreachable.
+
+Data sources:
+- **mempool.space** public API for on-chain data, mempool, fees, hashrate, difficulty
+- **blockstream.info** public API as automatic fallback when mempool.space is unreachable or rate-limited
+- **CoinGecko** public API for BTC price and market data
+
+> **Editorial use only.** This skill does not provide financial advice, price
+> predictions, or trading signals. Always cite sources when writing for publication.
+
+---
+
+## When to Use
+
+- User asks to verify a Bitcoin address or transaction mentioned in an article.
+- User wants balance, transaction count, or fiat value of an address.
+- User wants details of a specific transaction: inputs, outputs, fee, fee rate.
+- User wants block data: height, timestamp, transaction count, subsidy.
+- User wants current mempool congestion and recommended fee rates.
+- User wants network stats: hashrate, difficulty, retarget estimate, BTC price.
+- User wants a quick whale scan of large unconfirmed mempool transactions.
+- User wants to fact-check a claim and needs a checklist for Bitcoin stories.
+- User is preparing an article or report and needs verifiable on-chain data.
+
+---
+
+## Prerequisites
+
+Python 3.8+ standard library only. No pip installs required.
+
+Pricing: CoinGecko free API (rate-limited, ~10-30 req/min).
+On-chain data: mempool.space public API (rate-limited, free).
+
+Helper script path: `~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py`
+
+---
+
+## Quick Reference
+
+```bash
+SCRIPT=~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py
+
+# Address (confirmed + unconfirmed balance, tx counts, fiat value)
+python3 $SCRIPT address <address> [--currency usd|eur] [--no-fiat]
+
+# Recent transactions for an address
+python3 $SCRIPT txs <address> [--limit 25] [--currency usd|eur] [--no-fiat] [--format json|csv|tsv]
+
+# Spendable UTXOs for an address
+python3 $SCRIPT utxo <address> [--currency usd|eur] [--no-fiat] [--format json|csv|tsv]
+
+# Transaction details
+python3 $SCRIPT tx <txid> [--verbose] [--currency usd|eur] [--no-fiat]
+
+# Block (by height or hash)
+python3 $SCRIPT block <height_or_hash>
+
+# Mempool summary
+python3 $SCRIPT mempool
+
+# Recommended fees
+python3 $SCRIPT fees
+
+# Network stats + BTC price
+python3 $SCRIPT stats [--currency usd|eur] [--no-fiat]
+
+# BTC price
+python3 $SCRIPT price [--currencies usd,eur]
+
+# Large unconfirmed transactions (whale watch)
+python3 $SCRIPT whale [--threshold 1.0] [--limit 10] [--currency usd|eur] [--no-fiat]
+
+# Verify address or txid existence
+python3 $SCRIPT verify <address_or_txid>
+
+# Combined report for an address or transaction
+python3 $SCRIPT report <address_or_txid> [--currency usd|eur] [--no-fiat]
+
+# Compare multiple addresses
+python3 $SCRIPT compare <address1> <address2> ... [--currency usd|eur] [--no-fiat] [--format json|csv|tsv]
+
+# Historical fee rate distribution
+python3 $SCRIPT fee-history [--period 1w|1m|3m|6m|1y] [--format json|csv|tsv]
+
+# Editorial fact-check checklist
+python3 $SCRIPT editorial [general|address|txs|tx|utxo|fees|mining|price|compare|report]
+```
+
+---
+
+## Procedure
+
+### 0. Setup Check
+
+```bash
+python3 --version   # 3.8+ required
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py fees
+```
+
+### 1. Address Lookup
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py \
+  address bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh
+```
+
+Output: confirmed balance, unconfirmed balance, transaction counts,
+fiat value at current BTC price.
+
+### 2. Address Transaction History
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py \
+  txs bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh --limit 25 --format csv
+```
+
+Lists the most recent confirmed transactions for the address. For each
+transaction reports txid, block height, time, fee rate, and the net value
+moved to/from the address. Defaults to the latest 25 transactions returned
+by mempool.space. Use `--format csv` or `--format tsv` for spreadsheet import.
+
+### 3. Address UTXOs
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py \
+  utxo bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh
+```
+
+Lists unspent transaction outputs (UTXOs) for the address, with value,
+confirmation status, and block reference. Useful for deeper address analysis
+and wallet research.
+
+### 4. Transaction Details
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py \
+  tx 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
+```
+
+Use `--verbose` to include full input and output lists. Output includes
+confirmation status, block, fee, fee rate, size, input/output totals.
+
+### 5. Block Lookup
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py block 840000
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py \
+  block 0000000000000000000320283a032748cef8227873ff4872689bf23f1cda83a5
+```
+
+Output includes height, timestamp, transaction count, difficulty, and
+calculated coinbase subsidy. Total reward (subsidy + fees) is **not**
+returned by mempool.space for this endpoint anymore, so fees and total
+reward are left empty with an explanatory note.
+
+### 6. Mempool and Fees
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py mempool
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py fees
+```
+
+Use these together to understand network congestion before writing about
+fee spikes or transaction delays.
+
+### 7. Network Stats
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py stats
+```
+
+Output: current tip height/hash, hashrate (formatted in EH/s), 7-day
+average hashrate, difficulty, remaining blocks to retarget, estimated
+retarget change, BTC price, 24h change.
+
+### 8. Price Check
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py price
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py price --currencies usd,eur,gbp
+```
+
+Output: BTC price, market cap, 24h volume, and 24h change for each
+currency requested.
+
+### 9. Whale Watch
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py whale
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py whale --threshold 5 --limit 5
+```
+
+Scans the ~10 most recently arrived mempool transactions and returns those
+above the threshold. Useful for spotting large unconfirmed movements, but
+**not exhaustive** — it does not scan the full mempool.
+
+### 10. Verify an Address or Transaction
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py \
+  verify bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py \
+  verify 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
+```
+
+Returns `valid: true` if the identifier exists on-chain. Useful for
+fact-checking claims in articles or social media posts.
+
+### 11. Combined Report
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py \
+  report bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py \
+  report 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
+```
+
+Returns a single-page summary of an address (balance, recent transactions)
+or a transaction (fee, inputs/outputs), convenient for quick fact-checking.
+
+### 12. Compare Addresses
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py \
+  compare addr1 addr2 addr3 --format csv
+```
+
+Compares balances, transaction counts, and unconfirmed activity across
+multiple addresses. Useful for clustering research or exchange analysis.
+
+### 13. Historical Fee Rates
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py fee-history --period 1m
+```
+
+Returns per-block fee-rate distributions (min, p10, median, p90, max) for
+the selected period. Includes summary statistics and a sample of recent
+blocks to give context on whether current fees are high or low.
+
+### 14. Editorial Checklist
+
+```bash
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py editorial
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py editorial tx
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py editorial mining
+```
+
+Prints a JSON checklist tailored to the topic. Use before publishing
+Bitcoin stories to catch common sourcing and interpretation mistakes.
+
+---
+
+## Supported Data and Sources
+
+| Data | Source | Notes |
+|------|--------|-------|
+| Address balance, tx counts | mempool.space `/address` | Confirmed vs unconfirmed split. Automatic fallback to blockstream.info. |
+| Address transaction history | mempool.space `/address/{addr}/txs` | Last 50 confirmed transactions (default return); `--limit N` shows first N from the list. |
+| Address UTXOs | mempool.space `/address/{addr}/utxo` | Spendable outputs with confirmation status. |
+| Transaction details | mempool.space `/tx` | Includes fee, fee rate, confirmation status. |
+| Block metadata | mempool.space `/block` | Subsidy calculated locally; fees/reward no longer provided by API. |
+| Mempool summary | mempool.space `/mempool` | vsize, count, fee histogram. |
+| Fee rates | mempool.space `/v1/fees/recommended` | fastest/halfHour/hour/economy/minimum. |
+| Fee history | mempool.space `/v1/mining/blocks/fee-rates/{period}` | min/p10/median/p90/max per block. |
+| Hashrate / difficulty | mempool.space `/v1/mining/hashrate` and difficulty-adjustments | 7-day average from daily buckets. |
+| BTC price | CoinGecko `/simple/price` | Market cap, 24h volume, 24h change. |
+| Whale watch | mempool.space `/mempool/recent` | Last ~10 arrivals only. |
+
+---
+
+## Editorial Guidelines
+
+When using this skill to support articles, reports, or fact-checks:
+
+1. **Always cite the source.** For on-chain data, mention mempool.space or
+the block explorer used. For price data, mention CoinGecko.
+2. **Distinguish confirmed from unconfirmed.** Unconfirmed balances and
+mempool data can change quickly.
+3. **Do not infer ownership.** An address balance does not identify who
+controls it unless there is public, verifiable attribution.
+4. **Avoid price predictions.** The skill reports current and historical
+data; it does not forecast.
+5. **Cross-check sensitive claims.** For high-stakes stories, verify
+addresses and transactions against more than one explorer.
+6. **Use the editorial checklist.** Run `editorial <topic>` before final
+review to catch sloppy claims about fees, mining, or large transactions.
+
+---
+
+## Pitfalls
+
+- **mempool.space rate limits and fallbacks**: the client automatically falls back to blockstream.info when mempool.space returns 5xx errors or is unreachable. For 429 throttling, wait a minute and retry, or use `--no-fiat` to reduce total requests.
+- **CSV/TSV format**: several commands (`txs`, `utxo`, `compare`, `fee-history`) support `--format csv` and `--format tsv` for spreadsheet import.
+- **CoinGecko rate limits**: price lookups share the same free-tier pool.
+Avoid rapid sequential calls with many currencies. Use `--no-fiat` to skip
+price conversion entirely when only BTC values are needed.
+- **Address verification is not validation**: `verify` confirms the address
+was used on-chain, not that it is currently safe or legitimate.
+- **Transaction verification depends on network propagation**: a very recent
+transaction may not appear immediately across all API endpoints.
+- **Block reward vs subsidy**: the `subsidy` field is the fixed coinbase
+emission calculated from block height. The total block reward also includes
+fees, which are no longer returned by the mempool.space `/block` endpoint
+used here.
+- **Privacy heuristics are out of scope**: this skill does not perform
+clustering, taint analysis, or address de-anonymization.
+- **Whale watch is not exhaustive**: it only inspects the last ~10
+recently-arrived mempool transactions.
+- **No testnet support**: this version queries mainnet only.
+
+---
+
+## Verification
+
+```bash
+# Should print current recommended Bitcoin fee rates
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py fees
+
+# Should print the latest block height, hashrate, and BTC price
+python3 ~/.hermes/skills/blockchain/bitcoin/scripts/bitcoin_client.py stats
+```
+
+---
+
+## License
+
+MIT

--- a/optional-skills/blockchain/bitcoin/SKILL.md
+++ b/optional-skills/blockchain/bitcoin/SKILL.md
@@ -2,7 +2,7 @@
 name: bitcoin
 description: "Read-only Bitcoin research client for on-chain data."
 version: 1.0.0
-author: Kain
+author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:

--- a/optional-skills/blockchain/bitcoin/SKILL.md
+++ b/optional-skills/blockchain/bitcoin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bitcoin
-description: "Read-only Bitcoin research client. Query addresses, UTXOs, transactions, blocks, mempool, fees, network stats, price, whale activity, and editorial checklists. Includes CSV/TSV export and automatic API fallback. Standard library only. No API key required."
+description: "Read-only Bitcoin research client for on-chain data."
 version: 1.0.0
 author: Kain
 license: MIT

--- a/optional-skills/blockchain/bitcoin/references/api-notes.md
+++ b/optional-skills/blockchain/bitcoin/references/api-notes.md
@@ -1,0 +1,58 @@
+# Bitcoin Skill — Reference Notes
+
+## API Quirks and Implementation Notes
+
+### mempool.space `/block/{hash}` endpoint
+
+As of mid-2026, the `/block/{hash}` endpoint no longer returns `reward` or
+`fees`. The client calculates the coinbase subsidy locally from the block
+height (50 BTC halved every 210,000 blocks). Total block reward would be
+`subsidy + fees`, but fees are not available without paginating the full
+transaction list of the block, which is too expensive for a quick lookup.
+
+The client leaves `fees_sats`, `fees_btc`, `reward_sats`, `reward_btc` as
+`null` and includes a `note` explaining this.
+
+### Hashrate units
+
+mempool.space returns hashrate in H/s (hashes per second). The client
+formats these into SI units (EH/s, ZH/s) for human readability and exposes
+the raw H/s values as `*_hs` fields.
+
+### Address `first_seen` / `last_seen`
+
+mempool.space does not return these fields on the `/address/{addr}`
+endpoint. The client does not fabricate them. If activity timestamps are
+needed, inspect individual transactions with the `tx` command or an
+explorer that exposes this data.
+
+### `/mempool/recent` whale watch
+
+This endpoint returns the last ~10 transactions that arrived in the
+mempool. It is a convenience sampler, not a full mempool scan. Large
+confirmed transactions require inspecting blocks or using a different API.
+
+### CoinGecko currency handling
+
+The client supports any CoinGecko-compatible currency code. The
+`fiat_currency` field is returned in upper case, and fiat formatting uses
+`$` for USD, `€` for EUR, and the code prefix for other currencies.
+
+## Useful Endpoints
+
+- Address: `GET /api/address/{addr}`
+- Transaction: `GET /api/tx/{txid}`
+- Block by height: `GET /api/block-height/{height}` (returns hash as text)
+- Block: `GET /api/block/{hash}`
+- Block status: `GET /api/block/{hash}/status`
+- Mempool: `GET /api/mempool`
+- Recommended fees: `GET /api/v1/fees/recommended`
+- Hashrate: `GET /api/v1/mining/hashrate/{interval}`
+- Difficulty adjustments: `GET /api/v1/mining/difficulty-adjustments/{interval}`
+- Recent mempool txs: `GET /api/mempool/recent`
+
+## Trusted Sources
+
+- mempool.space (on-chain data, mempool, fees, hashrate, difficulty)
+- blockstream.info (fallback on-chain API, same endpoints as mempool.space)
+- CoinGecko (BTC price, market cap, volume, 24h change)

--- a/optional-skills/blockchain/bitcoin/scripts/bitcoin_client.py
+++ b/optional-skills/blockchain/bitcoin/scripts/bitcoin_client.py
@@ -583,8 +583,15 @@ def cmd_stats(args):
 
     next_retarget = None
     if diff_adj and isinstance(diff_adj, list) and len(diff_adj) > 0:
-        latest = diff_adj[-1]
-        if isinstance(latest, list) and len(latest) >= 4:
+        # mempool.space returns difficulty-adjustment rows newest-first, but
+        # defensively select the row with the maximum timestamp to avoid
+        # depending on ordering.
+        latest = max(
+            (row for row in diff_adj if isinstance(row, list) and len(row) >= 4),
+            key=lambda row: row[0] if isinstance(row[0], (int, float)) else 0,
+            default=None,
+        )
+        if latest is not None:
             next_retarget = {
                 "estimated_change_percent": latest[3],
                 "last_adjustment_height": latest[1],

--- a/optional-skills/blockchain/bitcoin/scripts/bitcoin_client.py
+++ b/optional-skills/blockchain/bitcoin/scripts/bitcoin_client.py
@@ -1,0 +1,870 @@
+#!/usr/bin/env python3
+"""
+Bitcoin read-only client for Hermes.
+Query addresses, transactions, blocks, mempool, fees, network stats, price,
+and large unconfirmed transactions (whale watch).
+Standard library only (urllib, json, argparse). No API key required.
+"""
+import argparse
+import json
+import math
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+MEMPOOL_API = "https://mempool.space/api"
+FALLBACK_APIS = [
+    "https://mempool.space/api",
+    "https://blockstream.info/api",
+]
+COINGECKO_API = "https://api.coingecko.com/api/v3"
+
+# Simple in-process price cache to reduce CoinGecko rate-limit hits.
+_PRICE_CACHE = {"data": None, "currency": None, "ts": 0.0}
+_PRICE_CACHE_TTL = 60.0  # seconds
+
+
+def fetch_json_with_fallback(path_or_url, timeout=30, retries=2):
+    """Fetch JSON from the primary mempool.space API, falling back to other
+    public explorers if the primary returns 5xx or network errors. The argument
+    can be a full URL or a path starting with /.
+    """
+    if path_or_url.startswith("http"):
+        candidates = [path_or_url]
+    else:
+        candidates = [base + path_or_url for base in FALLBACK_APIS]
+
+    last_error = None
+    for url in candidates:
+        req = urllib.request.Request(url, headers={
+            "User-Agent": "HermesBitcoinSkill/1.0",
+            "Accept": "application/json",
+        })
+        for attempt in range(retries + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    return json.loads(resp.read().decode("utf-8"))
+            except urllib.error.HTTPError as e:
+                body = e.read().decode("utf-8", errors="ignore")[:200]
+                last_error = RuntimeError(f"HTTP {e.code}: {body}")
+                if e.code == 429 and attempt < retries:
+                    time.sleep(2 ** attempt)
+                    continue
+                # For 4xx client errors, do not retry the same URL but try next candidate.
+                if 400 <= e.code < 500 and e.code != 429:
+                    break
+            except urllib.error.URLError as e:
+                last_error = RuntimeError(f"Network error: {e.reason}")
+                break
+    raise last_error
+
+
+def fetch_json(url, timeout=30, retries=2):
+    """Fetch JSON from url with retries on 429, raise on failure."""
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "HermesBitcoinSkill/1.0",
+        "Accept": "application/json",
+    })
+    last_error = None
+    for attempt in range(retries + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="ignore")[:200]
+            last_error = RuntimeError(f"HTTP {e.code}: {body}")
+            if e.code == 429 and attempt < retries:
+                time.sleep(2 ** attempt)
+                continue
+            raise last_error from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"Network error: {e.reason}") from e
+    raise last_error
+
+
+def fetch_text(url, timeout=30, retries=2):
+    """Fetch plain text from url with retries on 429."""
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "HermesBitcoinSkill/1.0",
+        "Accept": "text/plain",
+    })
+    last_error = None
+    for attempt in range(retries + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return resp.read().decode("utf-8").strip()
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="ignore")[:200]
+            last_error = RuntimeError(f"HTTP {e.code}: {body}")
+            if e.code == 429 and attempt < retries:
+                time.sleep(2 ** attempt)
+                continue
+            raise last_error from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"Network error: {e.reason}") from e
+    raise last_error
+
+
+def get_btc_price(currency="usd", use_cache=True):
+    """Fetch BTC price from CoinGecko with short-lived in-process cache."""
+    if not use_cache:
+        return {}
+    currency = currency.lower()
+    now = time.time()
+    if use_cache and _PRICE_CACHE["data"] is not None and _PRICE_CACHE["currency"] == currency and (now - _PRICE_CACHE["ts"]) < _PRICE_CACHE_TTL:
+        return _PRICE_CACHE["data"]
+    url = f"{COINGECKO_API}/simple/price?ids=bitcoin&vs_currencies={currency}&include_24hr_change=true"
+    data = fetch_json(url).get("bitcoin", {})
+    _PRICE_CACHE["data"] = data
+    _PRICE_CACHE["currency"] = currency
+    _PRICE_CACHE["ts"] = now
+    return data
+
+
+def fmt_btc(sats):
+    return f"{sats / 1e8:.8f} BTC"
+
+
+def fmt_fiat(value, price_btc=None, currency="usd"):
+    if price_btc is None:
+        return None
+    currency = currency.lower()
+    amount = value * price_btc / 1e8
+    if currency == "usd":
+        return f"${amount:,.2f}"
+    if currency == "eur":
+        return f"€{amount:,.2f}"
+    return f"{currency.upper()} {amount:,.2f}"
+
+
+def fmt_time_unix(ts):
+    try:
+        dt = datetime.utcfromtimestamp(ts).replace(tzinfo=timezone.utc)
+        return dt.strftime("%Y-%m-%d %H:%M UTC")
+    except Exception:
+        return str(ts)
+
+
+def fmt_time(iso_str_or_ts):
+    if iso_str_or_ts is None:
+        return None
+    if isinstance(iso_str_or_ts, (int, float)):
+        return fmt_time_unix(iso_str_or_ts)
+    try:
+        dt = datetime.fromisoformat(iso_str_or_ts.replace("Z", "+00:00"))
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    except Exception:
+        return iso_str_or_ts
+
+
+def format_hashrate(hs):
+    """Format hashrate in H/s to human readable SI unit."""
+    if hs is None or hs == 0:
+        return None
+    units = ["H/s", "kH/s", "MH/s", "GH/s", "TH/s", "PH/s", "EH/s", "ZH/s"]
+    exp = min(int(math.log10(hs) / 3), len(units) - 1)
+    val = hs / (10 ** (exp * 3))
+    return f"{val:.3f} {units[exp]}"
+
+
+def block_subsidy(height):
+    """Calculate coinbase subsidy (sats) for a given block height."""
+    halvings = height // 210_000
+    if halvings >= 64:
+        return 0
+    return int(50 * 1e8) >> halvings
+
+
+def net_value_for_address(tx, address):
+    """Net value (sats) moving to/from address in this transaction."""
+    received = 0
+    spent = 0
+    for inp in tx.get("vin", []):
+        prevout = inp.get("prevout") or {}
+        if prevout.get("scriptpubkey_address") == address:
+            spent += prevout.get("value", 0)
+    for out in tx.get("vout", []):
+        if out.get("scriptpubkey_address") == address:
+            received += out.get("value", 0)
+    return received - spent
+
+
+def fee_rate_for_tx(tx):
+    fee = tx.get("fee", 0)
+    vsize = tx.get("vsize")
+    if not vsize and tx.get("weight"):
+        vsize = math.ceil(tx.get("weight") / 4)
+    if not vsize:
+        return None
+    return round(fee / vsize, 2)
+
+
+def cmd_address(args):
+    addr = args.address
+    data = fetch_json_with_fallback(f"/address/{addr}")
+    chain_stats = data.get("chain_stats", {})
+    mempool_stats = data.get("mempool_stats", {})
+    price = get_btc_price(args.currency, use_cache=not args.no_fiat)
+    price_btc = price.get(args.currency)
+
+    funded = chain_stats.get("funded_txo_sum", 0)
+    spent = chain_stats.get("spent_txo_sum", 0)
+    balance = funded - spent
+    mempool_funded = mempool_stats.get("funded_txo_sum", 0)
+    mempool_spent = mempool_stats.get("spent_txo_sum", 0)
+    unconfirmed_balance = mempool_funded - mempool_spent
+
+    result = {
+        "address": addr,
+        "balance_sats": balance,
+        "balance_btc": balance / 1e8,
+        "balance_fiat": fmt_fiat(balance, price_btc, args.currency) if not args.no_fiat else None,
+        "unconfirmed_balance_sats": unconfirmed_balance,
+        "unconfirmed_balance_btc": unconfirmed_balance / 1e8,
+        "tx_count_confirmed": chain_stats.get("tx_count", 0),
+        "tx_count_unconfirmed": mempool_stats.get("tx_count", 0),
+        "fiat_currency": args.currency.upper() if not args.no_fiat else None,
+        "btc_price": price_btc if not args.no_fiat else None,
+        "btc_24h_change_percent": price.get(f"{args.currency}_24h_change") if not args.no_fiat else None,
+    }
+    print(json.dumps(result, indent=2))
+
+
+def cmd_txs(args):
+    """List recent confirmed transactions for an address."""
+    addr = args.address
+    limit = max(1, args.limit)
+    txs = fetch_json_with_fallback(f"/address/{addr}/txs")
+    price = get_btc_price(args.currency, use_cache=not args.no_fiat)
+    price_btc = price.get(args.currency)
+
+    results = []
+    for tx in txs[:limit]:
+        status = tx.get("status") or {}
+        net_value = net_value_for_address(tx, addr)
+        results.append({
+            "txid": tx.get("txid"),
+            "confirmed": status.get("confirmed", False),
+            "block_height": status.get("block_height"),
+            "block_time": fmt_time(status.get("block_time")),
+            "fee_sats": tx.get("fee"),
+            "fee_rate_sat_vb": fee_rate_for_tx(tx),
+            "net_value_sats": net_value,
+            "net_value_btc": net_value / 1e8,
+            "net_value_fiat": fmt_fiat(net_value, price_btc, args.currency) if not args.no_fiat else None,
+            "is_coinbase": any(i.get("is_coinbase") for i in tx.get("vin", [])),
+        })
+
+    if getattr(args, "format", "json").lower() in ("csv", "tsv"):
+        print(format_csv(results, args.format, args.currency, price_btc))
+        return
+
+    output = {
+        "address": addr,
+        "count": len(results),
+        "fiat_currency": args.currency.upper() if not args.no_fiat else None,
+        "btc_price": price_btc if not args.no_fiat else None,
+        "btc_24h_change_percent": price.get(f"{args.currency}_24h_change") if not args.no_fiat else None,
+        "transactions": results,
+        "note": "mempool.space returns the latest 50 confirmed transactions by default. Use pagination or a block explorer for deeper history.",
+    }
+    print(json.dumps(output, indent=2))
+
+
+def cmd_utxo(args):
+    """List spendable UTXOs for an address."""
+    addr = args.address
+    utxos = fetch_json_with_fallback(f"/address/{addr}/utxo")
+    price = get_btc_price(args.currency, use_cache=not args.no_fiat)
+    price_btc = price.get(args.currency)
+
+    results = []
+    total = 0
+    for u in utxos:
+        value = u.get("value", 0)
+        status = u.get("status") or {}
+        total += value
+        results.append({
+            "txid": u.get("txid"),
+            "vout": u.get("vout"),
+            "value_sats": value,
+            "value_btc": value / 1e8,
+            "value_fiat": fmt_fiat(value, price_btc, args.currency) if not args.no_fiat else None,
+            "confirmed": status.get("confirmed", False),
+            "block_height": status.get("block_height"),
+            "block_time": fmt_time(status.get("block_time")),
+        })
+
+    if getattr(args, "format", "json").lower() in ("csv", "tsv"):
+        print(format_csv(results, args.format, args.currency, price_btc))
+        return
+
+    output = {
+        "address": addr,
+        "utxo_count": len(results),
+        "total_value_sats": total,
+        "total_value_btc": total / 1e8,
+        "total_value_fiat": fmt_fiat(total, price_btc, args.currency) if not args.no_fiat else None,
+        "fiat_currency": args.currency.upper() if not args.no_fiat else None,
+        "btc_price": price_btc if not args.no_fiat else None,
+        "utxos": results,
+    }
+    print(json.dumps(output, indent=2))
+
+
+def cmd_report(args):
+    """Generate a combined report for an address or transaction."""
+    query = args.query
+    is_txid = len(query) == 64 and all(c in "0123456789abcdefABCDEF" for c in query)
+    price = get_btc_price(args.currency, use_cache=not args.no_fiat)
+    price_btc = price.get(args.currency)
+    result = {
+        "query": query,
+        "type": "transaction" if is_txid else "address",
+        "btc_price": price_btc if not args.no_fiat else None,
+        "fiat_currency": args.currency.upper() if not args.no_fiat else None,
+    }
+    if is_txid:
+        tx_data = fetch_json_with_fallback(f"/tx/{query}")
+        status = tx_data.get("status") or {}
+        inputs = tx_data.get("vin", [])
+        outputs = tx_data.get("vout", [])
+        input_total = sum((i.get("prevout") or {}).get("value", 0) for i in inputs)
+        output_total = sum(o.get("value", 0) for o in outputs)
+        is_coinbase = any(i.get("is_coinbase") for i in inputs)
+        fee = 0 if is_coinbase else input_total - output_total
+        vsize = tx_data.get("vsize")
+        if not vsize and tx_data.get("weight"):
+            vsize = math.ceil(tx_data.get("weight") / 4)
+        if not vsize:
+            vsize = 1
+        result["transaction"] = {
+            "txid": query,
+            "confirmed": status.get("confirmed", False),
+            "block_height": status.get("block_height"),
+            "block_time": fmt_time(status.get("block_time")),
+            "fee_sats": fee,
+            "fee_rate_sat_vb": round(fee / vsize, 2),
+            "input_count": len(inputs),
+            "output_count": len(outputs),
+            "input_total_sats": input_total,
+            "output_total_sats": output_total,
+            "is_coinbase": is_coinbase,
+        }
+    else:
+        addr_data = fetch_json_with_fallback(f"/address/{query}")
+        chain_stats = addr_data.get("chain_stats", {})
+        mempool_stats = addr_data.get("mempool_stats", {})
+        funded = chain_stats.get("funded_txo_sum", 0)
+        spent = chain_stats.get("spent_txo_sum", 0)
+        balance = funded - spent
+        mempool_funded = mempool_stats.get("funded_txo_sum", 0)
+        mempool_spent = mempool_stats.get("spent_txo_sum", 0)
+        unconfirmed_balance = mempool_funded - mempool_spent
+        txs = fetch_json_with_fallback(f"/address/{query}/txs")[:5]
+        recent = []
+        for tx in txs:
+            status = tx.get("status") or {}
+            recent.append({
+                "txid": tx.get("txid"),
+                "block_height": status.get("block_height"),
+                "block_time": fmt_time(status.get("block_time")),
+                "net_value_sats": net_value_for_address(tx, query),
+                "fee_rate_sat_vb": fee_rate_for_tx(tx),
+            })
+        result["address"] = {
+            "balance_sats": balance,
+            "balance_btc": balance / 1e8,
+            "balance_fiat": fmt_fiat(balance, price_btc, args.currency) if not args.no_fiat else None,
+            "unconfirmed_balance_sats": unconfirmed_balance,
+            "tx_count_confirmed": chain_stats.get("tx_count", 0),
+            "recent_transactions": recent,
+        }
+    print(json.dumps(result, indent=2))
+
+
+def cmd_compare(args):
+    """Compare balance and activity across multiple addresses."""
+    price = get_btc_price(args.currency, use_cache=not args.no_fiat)
+    price_btc = price.get(args.currency)
+    addresses = args.addresses
+    results = []
+    total_balance = 0
+    total_tx_count = 0
+    for addr in addresses:
+        data = fetch_json_with_fallback(f"/address/{addr}")
+        chain_stats = data.get("chain_stats", {})
+        mempool_stats = data.get("mempool_stats", {})
+        balance = chain_stats.get("funded_txo_sum", 0) - chain_stats.get("spent_txo_sum", 0)
+        total_balance += balance
+        tx_count = chain_stats.get("tx_count", 0)
+        total_tx_count += tx_count
+        results.append({
+            "address": addr,
+            "balance_sats": balance,
+            "balance_btc": balance / 1e8,
+            "balance_fiat": fmt_fiat(balance, price_btc, args.currency) if not args.no_fiat else None,
+            "tx_count": tx_count,
+            "unconfirmed_tx_count": mempool_stats.get("tx_count", 0),
+        })
+
+    if getattr(args, "format", "json").lower() in ("csv", "tsv"):
+        print(format_csv(results, args.format, args.currency, price_btc))
+        return
+
+    output = {
+        "addresses_compared": len(addresses),
+        "total_balance_sats": total_balance,
+        "total_balance_btc": total_balance / 1e8,
+        "total_balance_fiat": fmt_fiat(total_balance, price_btc, args.currency) if not args.no_fiat else None,
+        "total_tx_count": total_tx_count,
+        "fiat_currency": args.currency.upper() if not args.no_fiat else None,
+        "btc_price": price_btc if not args.no_fiat else None,
+        "results": results,
+    }
+    print(json.dumps(output, indent=2))
+
+
+def cmd_fee_history(args):
+    """Historical average fee rates by block."""
+    period = args.period
+    if period not in ("1w", "1m", "3m", "6m", "1y"):
+        raise RuntimeError("Period must be one of: 1w, 1m, 3m, 6m, 1y")
+    data = fetch_json(f"{MEMPOOL_API}/v1/mining/blocks/fee-rates/{period}")
+    rows = []
+    for row in data:
+        rows.append({
+            "avg_height": row.get("avgHeight"),
+            "time": fmt_time(row.get("timestamp")),
+            "min_sat_vb": row.get("avgFee_0"),
+            "p10_sat_vb": row.get("avgFee_10"),
+            "median_sat_vb": row.get("avgFee_50"),
+            "p90_sat_vb": row.get("avgFee_90"),
+            "max_sat_vb": row.get("avgFee_100"),
+        })
+
+    if getattr(args, "format", "json").lower() in ("csv", "tsv"):
+        print(format_csv(rows, args.format))
+        return
+
+    summary = {
+        "period": period,
+        "blocks": len(rows),
+        "median_min": round(sum(r["min_sat_vb"] for r in rows) / len(rows), 2) if rows else None,
+        "median_p50": round(sum(r["median_sat_vb"] for r in rows) / len(rows), 2) if rows else None,
+        "median_p90": round(sum(r["p90_sat_vb"] for r in rows) / len(rows), 2) if rows else None,
+        "max_observed": max((r["max_sat_vb"] for r in rows), default=None),
+        "fee_history_sample": rows[-7:],
+    }
+    print(json.dumps(summary, indent=2))
+
+
+def cmd_tx(args):
+    txid = args.txid
+    data = fetch_json_with_fallback(f"/tx/{txid}")
+    status = data.get("status") or {}
+    price = get_btc_price(args.currency, use_cache=not args.no_fiat)
+    price_btc = price.get(args.currency)
+
+    inputs = data.get("vin", [])
+    outputs = data.get("vout", [])
+    input_total = sum((i.get("prevout") or {}).get("value", 0) for i in inputs)
+    output_total = sum(o.get("value", 0) for o in outputs)
+    is_coinbase = any(i.get("is_coinbase") for i in inputs)
+    fee = 0 if is_coinbase else input_total - output_total
+    vsize = data.get("vsize")
+    if not vsize and data.get("weight"):
+        vsize = math.ceil(data.get("weight") / 4)
+    if not vsize:
+        vsize = 1
+
+    result = {
+        "txid": txid,
+        "confirmed": status.get("confirmed", False),
+        "block_height": status.get("block_height"),
+        "block_hash": status.get("block_hash"),
+        "block_time": fmt_time(status.get("block_time")),
+        "fee_sats": fee,
+        "fee_btc": fee / 1e8,
+        "fee_fiat": fmt_fiat(fee, price_btc, args.currency) if not args.no_fiat else None,
+        "fee_rate_sat_vb": round(fee / vsize, 2) if vsize else None,
+        "size": data.get("size"),
+        "vsize": vsize,
+        "version": data.get("version"),
+        "locktime": data.get("locktime"),
+        "input_count": len(inputs),
+        "output_count": len(outputs),
+        "input_total_sats": input_total,
+        "output_total_sats": output_total,
+        "is_coinbase": is_coinbase,
+        "fiat_currency": args.currency.upper() if not args.no_fiat else None,
+        "btc_price": price_btc if not args.no_fiat else None,
+    }
+    if args.verbose:
+        result["inputs"] = inputs
+        result["outputs"] = outputs
+    print(json.dumps(result, indent=2))
+
+
+def cmd_block(args):
+    query = args.block
+    if query.isdigit():
+        block_hash = fetch_text(f"{MEMPOOL_API}/block-height/{query}")
+        height = int(query)
+    else:
+        block_hash = query
+        status = fetch_json(f"{MEMPOOL_API}/block/{block_hash}/status")
+        height = status.get("height")
+    data = fetch_json(f"{MEMPOOL_API}/block/{block_hash}")
+
+    subsidy = block_subsidy(height)
+    result = {
+        "id": data.get("id"),
+        "height": height,
+        "version": data.get("version"),
+        "timestamp": fmt_time(data.get("timestamp")),
+        "tx_count": data.get("tx_count"),
+        "size": data.get("size"),
+        "weight": data.get("weight"),
+        "merkle_root": data.get("merkle_root"),
+        "previousblockhash": data.get("previousblockhash"),
+        "mediantime": fmt_time(data.get("mediantime")),
+        "nonce": data.get("nonce"),
+        "bits": data.get("bits"),
+        "difficulty": data.get("difficulty"),
+        "subsidy_sats": subsidy,
+        "subsidy_btc": subsidy / 1e8,
+        "fees_sats": None,
+        "fees_btc": None,
+        "reward_sats": None,
+        "reward_btc": None,
+        "note": "Reward and fees are no longer returned by mempool.space /block endpoint. Subsidy is calculated from height.",
+    }
+    print(json.dumps(result, indent=2))
+
+
+def cmd_mempool(args):
+    url = f"{MEMPOOL_API}/mempool"
+    data = fetch_json(url)
+    result = {
+        "count": data.get("count"),
+        "vsize": data.get("vsize"),
+        "vsize_mb": round(data.get("vsize", 0) / 1e6, 3) if data.get("vsize") else None,
+        "total_fee_sats": data.get("total_fee"),
+        "total_fee_btc": data.get("total_fee", 0) / 1e8,
+        "fee_histogram": data.get("fee_histogram", [])[:10],
+    }
+    print(json.dumps(result, indent=2))
+
+
+def cmd_fees(args):
+    url = f"{MEMPOOL_API}/v1/fees/recommended"
+    data = fetch_json(url)
+    print(json.dumps(data, indent=2))
+
+
+def cmd_stats(args):
+    tip_height = int(fetch_text(f"{MEMPOOL_API}/blocks/tip/height"))
+    tip_hash = fetch_text(f"{MEMPOOL_API}/block-height/{tip_height}")
+    block = fetch_json(f"{MEMPOOL_API}/block/{tip_hash}")
+    hashrate_data = fetch_json(f"{MEMPOOL_API}/v1/mining/hashrate/1m")
+    diff_adj = fetch_json(f"{MEMPOOL_API}/v1/mining/difficulty-adjustments/1m")
+    price = get_btc_price(args.currency, use_cache=not args.no_fiat)
+    price_btc = price.get(args.currency)
+
+    current_hashrate = hashrate_data.get("currentHashrate")
+    avg_7d = None
+    hashrates = hashrate_data.get("hashrates", [])
+    if hashrates:
+        window = hashrates[-7:]
+        avg_7d = sum(h.get("avgHashrate", 0) for h in window) / len(window)
+
+    next_retarget = None
+    if diff_adj and isinstance(diff_adj, list) and len(diff_adj) > 0:
+        latest = diff_adj[-1]
+        if isinstance(latest, list) and len(latest) >= 4:
+            next_retarget = {
+                "estimated_change_percent": latest[3],
+                "last_adjustment_height": latest[1],
+                "last_adjustment_timestamp": fmt_time(latest[0]),
+                "current_difficulty": hashrate_data.get("currentDifficulty") or block.get("difficulty"),
+            }
+
+    result = {
+        "tip_height": tip_height,
+        "tip_hash": tip_hash,
+        "tip_time": fmt_time(block.get("timestamp")),
+        "difficulty": block.get("difficulty"),
+        "current_hashrate_hs": current_hashrate,
+        "current_hashrate_formatted": format_hashrate(current_hashrate),
+        "avg_hashrate_7d_hs": avg_7d,
+        "avg_hashrate_7d_formatted": format_hashrate(avg_7d),
+        "next_retarget": next_retarget,
+        "btc_price": price_btc if not args.no_fiat else None,
+        "fiat_currency": args.currency.upper() if not args.no_fiat else None,
+        "btc_24h_change_percent": price.get(f"{args.currency}_24h_change") if not args.no_fiat else None,
+    }
+    print(json.dumps(result, indent=2))
+
+
+def cmd_price(args):
+    currencies = args.currencies.split(",")
+    vs = ",".join(currencies)
+    url = f"{COINGECKO_API}/simple/price?ids=bitcoin&vs_currencies={vs}&include_24hr_change=true&include_market_cap=true&include_24hr_vol=true"
+    data = fetch_json(url)
+    print(json.dumps(data.get("bitcoin", {}), indent=2))
+
+
+def cmd_whale(args):
+    """Report large unconfirmed transactions from the mempool."""
+    threshold_btc = args.threshold
+    threshold_sats = int(threshold_btc * 1e8)
+    data = fetch_json(f"{MEMPOOL_API}/mempool/recent")
+    price = get_btc_price(args.currency, use_cache=not args.no_fiat)
+    price_btc = price.get(args.currency)
+
+    whales = [t for t in data if t.get("value", 0) >= threshold_sats]
+    whales.sort(key=lambda x: x.get("value", 0), reverse=True)
+
+    results = []
+    for w in whales[:args.limit]:
+        value = w.get("value", 0)
+        fee = w.get("fee", 0)
+        vsize = w.get("vsize", 1)
+        results.append({
+            "txid": w.get("txid"),
+            "value_sats": value,
+            "value_btc": value / 1e8,
+            "value_fiat": fmt_fiat(value, price_btc, args.currency) if not args.no_fiat else None,
+            "fee_sats": fee,
+            "fee_rate_sat_vb": round(fee / vsize, 2) if vsize else None,
+            "vsize": vsize,
+        })
+
+    output = {
+        "threshold_btc": threshold_btc,
+        "count": len(results),
+        "fiat_currency": args.currency.upper() if (price_btc and not args.no_fiat) else None,
+        "btc_price": price_btc if not args.no_fiat else None,
+        "transactions": results,
+        "note": "Whale watch scans the last ~10 recently-arrived mempool transactions. It is not exhaustive.",
+    }
+    print(json.dumps(output, indent=2))
+
+
+def cmd_verify(args):
+    query = args.query
+    if len(query) == 64 and all(c in "0123456789abcdefABCDEF" for c in query):
+        try:
+            fetch_json_with_fallback(f"/tx/{query}")
+            print(json.dumps({"type": "transaction", "identifier": query, "valid": True}, indent=2))
+            return
+        except RuntimeError as e:
+            print(json.dumps({"type": "transaction", "identifier": query, "valid": False, "error": str(e)}, indent=2))
+            return
+    elif (query.startswith("1") or query.startswith("3") or query.startswith("bc1")) and 25 <= len(query) <= 90:
+        try:
+            fetch_json_with_fallback(f"/address/{query}")
+            print(json.dumps({"type": "address", "identifier": query, "valid": True}, indent=2))
+            return
+        except RuntimeError as e:
+            print(json.dumps({"type": "address", "identifier": query, "valid": False, "error": str(e)}, indent=2))
+            return
+    else:
+        print(json.dumps({"type": "unknown", "identifier": query, "valid": False, "error": "Not a recognized Bitcoin txid or address format"}, indent=2))
+
+
+CHECKLISTS = {
+    "general": [
+        "Cite mempool.space and CoinGecko as primary sources.",
+        "Distinguish confirmed data from unconfirmed mempool data.",
+        "Do not infer ownership of an address without public attribution.",
+        "Avoid price predictions and trading advice.",
+        "Cross-check high-stakes claims against a second block explorer.",
+    ],
+    "address": [
+        "Confirm the address exists on-chain before reporting its balance.",
+        "Report confirmed balance separately from unconfirmed balance.",
+        "Do not assume the address owner based on balance alone.",
+        "Include the timestamp or block height of the latest activity if relevant.",
+        "Note that privacy tools (CoinJoin, mixers) can obscure address meaning.",
+    ],
+    "txs": [
+        "Verify every txid independently before using it in a story.",
+        "Report net value relative to the address, not just absolute transaction size.",
+        "Distinguish incoming (positive net value) from outgoing (negative net value).",
+        "Do not assume a transaction proves payment to a specific entity.",
+    ],
+    "utxo": [
+        "Confirm each UTXO exists and is confirmed before reporting it as spendable.",
+        "Remember that UTXO value alone does not reveal address ownership.",
+        "Large numbers of small UTXOs may indicate dust or exchange wallet behavior.",
+    ],
+    "compare": [
+        "Do not imply ownership links between addresses based only on balance patterns.",
+        "Report aggregate totals with the correct fiat conversion and timestamp.",
+        "Note that the same entity may control multiple addresses, but this skill does not prove it.",
+    ],
+    "report": [
+        "Verify the query type (address vs transaction) before interpreting the report.",
+        "Cross-check any headline numbers with the raw txid or address in a block explorer.",
+        "Include the timestamp of the report because balances and mempool data change quickly.",
+    ],
+    "tx": [
+        "Verify the txid exists and is confirmed before describing it as final.",
+        "Report block height, timestamp, and fee rate.",
+        "Distinguish coinbase transactions from normal transactions.",
+        "Do not infer the purpose of a transaction from inputs/outputs alone.",
+        "For large transfers, verify the receiving address is not an exchange hot wallet unless proven.",
+    ],
+    "fees": [
+        "Report the exact fee rate tier (fastest/halfHour/hour/economy/minimum).",
+        "Note that mempool congestion changes quickly.",
+        "Compare current fees with a recent average to give context.",
+        "Mention whether data is from mempool.space recommended fees endpoint.",
+    ],
+    "mining": [
+        "Report difficulty, hashrate, and retarget estimate with units (EH/s, %).",
+        "Use 7-day average hashrate rather than instantaneous current hashrate for trend context.",
+        "Calculate subsidy correctly from block height (halvings every 210,000 blocks).",
+        "Do not confuse subsidy with total block reward (subsidy + fees).",
+    ],
+    "price": [
+        "Quote the fiat currency and the timestamp of the price check.",
+        "Include 24h change and note the source (CoinGecko).",
+        "Avoid implying causation between on-chain events and short-term price moves.",
+    ],
+}
+
+
+def cmd_editorial(args):
+    topic = args.topic
+    items = CHECKLISTS.get(topic, CHECKLISTS["general"])
+    print(json.dumps({"topic": topic, "checklist": items}, indent=2))
+
+
+def format_csv(rows, fmt, currency="usd", price_btc=None):
+    """Convert list of dicts to CSV or TSV."""
+    if not rows:
+        return ""
+    delimiter = "\t" if fmt.lower() == "tsv" else ","
+    headers = list(rows[0].keys())
+    lines = [delimiter.join(headers)]
+    for row in rows:
+        values = []
+        for h in headers:
+            v = row.get(h)
+            if v is None:
+                values.append("")
+            elif isinstance(v, (list, dict)):
+                values.append(json.dumps(v))
+            else:
+                s = str(v)
+                if delimiter == "," and (("," in s) or ("\n" in s) or ('"' in s)):
+                    s = '"' + s.replace('"', '""') + '"'
+                values.append(s)
+        lines.append(delimiter.join(values))
+    return "\n".join(lines)
+
+
+def _add_format_arg(parser):
+    parser.add_argument("--format", default="json", choices=["json", "csv", "tsv"], help="Output format (default: json)")
+
+
+def _add_fiat_args(parser):
+    parser.add_argument("--currency", default="usd", help="Fiat currency for price conversion (default: usd)")
+    parser.add_argument("--no-fiat", action="store_true", help="Skip fiat price conversion (avoids CoinGecko call)")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="bitcoin_client.py",
+        description="Read-only Bitcoin research client for Hermes",
+    )
+    parser.add_argument("--currency", default="usd", help=argparse.SUPPRESS)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_addr = sub.add_parser("address", help="Address balance and stats")
+    p_addr.add_argument("address")
+    _add_fiat_args(p_addr)
+    p_addr.set_defaults(func=cmd_address)
+
+    p_txs = sub.add_parser("txs", help="Recent transactions for an address")
+    p_txs.add_argument("address")
+    p_txs.add_argument("--limit", type=int, default=10, help="Number of transactions to return (default: 10)")
+    _add_fiat_args(p_txs)
+    _add_format_arg(p_txs)
+    p_txs.set_defaults(func=cmd_txs)
+
+    p_utxo = sub.add_parser("utxo", help="Spendable UTXOs for an address")
+    p_utxo.add_argument("address")
+    _add_fiat_args(p_utxo)
+    _add_format_arg(p_utxo)
+    p_utxo.set_defaults(func=cmd_utxo)
+
+    p_report = sub.add_parser("report", help="Combined report for an address or txid")
+    p_report.add_argument("query")
+    _add_fiat_args(p_report)
+    p_report.set_defaults(func=cmd_report)
+
+    p_compare = sub.add_parser("compare", help="Compare multiple addresses")
+    p_compare.add_argument("addresses", nargs="+")
+    _add_fiat_args(p_compare)
+    _add_format_arg(p_compare)
+    p_compare.set_defaults(func=cmd_compare)
+
+    p_feehist = sub.add_parser("fee-history", help="Historical average fee rates")
+    p_feehist.add_argument("--period", default="1m", choices=["1w", "1m", "3m", "6m", "1y"], help="Period (default: 1m)")
+    _add_format_arg(p_feehist)
+    p_feehist.set_defaults(func=cmd_fee_history)
+
+    p_tx = sub.add_parser("tx", help="Transaction details")
+    p_tx.add_argument("txid")
+    p_tx.add_argument("--verbose", action="store_true", help="Include full inputs/outputs")
+    _add_fiat_args(p_tx)
+    p_tx.set_defaults(func=cmd_tx)
+
+    p_block = sub.add_parser("block", help="Block by height or hash")
+    p_block.add_argument("block")
+    p_block.set_defaults(func=cmd_block)
+
+    p_mempool = sub.add_parser("mempool", help="Mempool summary")
+    p_mempool.set_defaults(func=cmd_mempool)
+
+    p_fees = sub.add_parser("fees", help="Recommended fee rates")
+    p_fees.set_defaults(func=cmd_fees)
+
+    p_stats = sub.add_parser("stats", help="Network stats and BTC price")
+    _add_fiat_args(p_stats)
+    p_stats.set_defaults(func=cmd_stats)
+
+    p_price = sub.add_parser("price", help="BTC price in one or more currencies")
+    p_price.add_argument("--currencies", default="usd,eur", help="Comma-separated currencies")
+    p_price.set_defaults(func=cmd_price)
+
+    p_whale = sub.add_parser("whale", help="Large unconfirmed transactions in the mempool")
+    p_whale.add_argument("--threshold", type=float, default=1.0, help="Minimum transaction value in BTC (default: 1.0)")
+    p_whale.add_argument("--limit", type=int, default=10, help="Maximum results to return (default: 10)")
+    _add_fiat_args(p_whale)
+    p_whale.set_defaults(func=cmd_whale)
+
+    p_verify = sub.add_parser("verify", help="Verify existence of address or txid")
+    p_verify.add_argument("query")
+    p_verify.set_defaults(func=cmd_verify)
+
+    p_editorial = sub.add_parser("editorial", help="Print editorial fact-check checklist")
+    p_editorial.add_argument("topic", nargs="?", default="general", choices=["general", "address", "txs", "tx", "utxo", "fees", "mining", "price", "compare", "report"], help="Tailor checklist to topic")
+    p_editorial.set_defaults(func=cmd_editorial)
+
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except Exception as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/blockchain/bitcoin/templates/fact-check.md
+++ b/optional-skills/blockchain/bitcoin/templates/fact-check.md
@@ -1,0 +1,43 @@
+# Bitcoin Fact-Check Template
+
+Use this template when verifying a Bitcoin claim for publication.
+
+## Claim
+
+[Write the exact claim here.]
+
+## Sources
+
+- [ ] mempool.space
+- [ ] CoinGecko
+- [ ] Second block explorer (e.g. blockchair.com, blockchain.com)
+- [ ] Other: ___________
+
+## On-chain Verification
+
+| Item | Value | Source |
+|------|-------|--------|
+| Address / txid | | |
+| Confirmed? | | |
+| Block height | | |
+| Timestamp (UTC) | | |
+| Amount (BTC) | | |
+| Fee rate (sat/vB) | | |
+| Current BTC price | | |
+
+## Interpretation Checklist
+
+- [ ] I did not infer ownership from the address alone.
+- [ ] I distinguished confirmed balance from unconfirmed balance.
+- [ ] I did not describe an unconfirmed transaction as final.
+- [ ] I cited the source and timestamp of the data.
+- [ ] I avoided price predictions or trading advice.
+- [ ] I cross-checked high-stakes claims against a second source.
+
+## Verdict
+
+[Verified / Partially verified / Misleading / False]
+
+## Notes
+
+[Any caveats, missing data, or follow-up checks needed.]

--- a/tests/skills/test_bitcoin_skill.py
+++ b/tests/skills/test_bitcoin_skill.py
@@ -1,0 +1,268 @@
+"""Tests for optional-skills/blockchain/bitcoin/scripts/bitcoin_client.py."""
+
+import json
+import sys
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "blockchain"
+    / "bitcoin"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import bitcoin_client as btc
+
+
+class TestFmtHelpers:
+    def test_fmt_btc(self):
+        assert btc.fmt_btc(100_000_000) == "1.00000000 BTC"
+        assert btc.fmt_btc(0) == "0.00000000 BTC"
+
+    def test_fmt_fiat_usd(self):
+        assert btc.fmt_fiat(100_000_000, 50000, "usd") == "$50,000.00"
+
+    def test_fmt_fiat_eur(self):
+        assert btc.fmt_fiat(100_000_000, 45000, "eur") == "€45,000.00"
+
+    def test_fmt_fiat_none(self):
+        assert btc.fmt_fiat(100_000_000, None, "usd") is None
+
+    def test_format_hashrate(self):
+        assert btc.format_hashrate(1e18) == "1.000 EH/s"
+        assert btc.format_hashrate(1e15) == "1.000 PH/s"
+        assert btc.format_hashrate(0) is None
+        assert btc.format_hashrate(None) is None
+
+
+class TestBlockSubsidy:
+    def test_genesis_subsidy(self):
+        assert btc.block_subsidy(0) == 50 * 100_000_000
+
+    def test_first_halving(self):
+        assert btc.block_subsidy(210_000) == 25 * 100_000_000
+
+    def test_second_halving(self):
+        assert btc.block_subsidy(420_000) == 12.5 * 100_000_000
+
+    def test_post_64_halvings(self):
+        assert btc.block_subsidy(64 * 210_000) == 0
+
+
+class TestFeeRateForTx:
+    def test_fee_rate_from_vsize(self):
+        tx = {"fee": 1000, "vsize": 250}
+        assert btc.fee_rate_for_tx(tx) == 4.0
+
+    def test_fee_rate_from_weight(self):
+        tx = {"fee": 1000, "weight": 1000}
+        assert btc.fee_rate_for_tx(tx) == 4.0
+
+    def test_fee_rate_missing_size(self):
+        tx = {"fee": 1000}
+        assert btc.fee_rate_for_tx(tx) is None
+
+
+class TestCmdStatsDifficultyAdjustmentOrdering:
+    """mempool.space returns difficulty-adjustment rows newest-first, but the
+    implementation must select the row with the maximum timestamp regardless of
+    list ordering.
+    """
+
+    @mock.patch("bitcoin_client.fetch_text")
+    @mock.patch("bitcoin_client.fetch_json")
+    @mock.patch("bitcoin_client.get_btc_price")
+    def test_selects_max_timestamp_not_last_element(
+        self, mock_price, mock_fetch_json, mock_fetch_text
+    ):
+        mock_fetch_text.side_effect = ["850000", "0000000000000000000000000000000000000000000000000000000000000001"]
+        mock_price.return_value = {"usd": 50000.0}
+
+        # Rows are [timestamp, height, difficulty, estimated_change_percent]
+        # Newest-first ordering: the first row has the largest timestamp.
+        diff_adj = [
+            [1752009600, 850000, 85000000000000.0, 2.5],
+            [1751923200, 848832, 83000000000000.0, -1.2],
+            [1751836800, 847664, 82000000000000.0, 0.5],
+        ]
+
+        mock_fetch_json.side_effect = [
+            {"timestamp": 1752009600, "difficulty": 85000000000000.0},
+            {"currentHashrate": 1e18, "currentDifficulty": 85000000000000.0, "hashrates": []},
+            diff_adj,
+        ]
+
+        class Args:
+            currency = "usd"
+            no_fiat = False
+
+        btc.cmd_stats(Args())
+        output = sys.stdout.getvalue() if hasattr(sys.stdout, "getvalue") else None
+
+    @mock.patch("bitcoin_client.fetch_text")
+    @mock.patch("bitcoin_client.fetch_json")
+    @mock.patch("bitcoin_client.get_btc_price")
+    def test_selects_max_timestamp_when_oldest_first(
+        self, mock_price, mock_fetch_json, mock_fetch_text
+    ):
+        mock_fetch_text.side_effect = ["850000", "0000000000000000000000000000000000000000000000000000000000000001"]
+        mock_price.return_value = {"usd": 50000.0}
+
+        # Oldest-first ordering: the last row has the largest timestamp.
+        diff_adj = [
+            [1751836800, 847664, 82000000000000.0, 0.5],
+            [1751923200, 848832, 83000000000000.0, -1.2],
+            [1752009600, 850000, 85000000000000.0, 2.5],
+        ]
+
+        mock_fetch_json.side_effect = [
+            {"timestamp": 1752009600, "difficulty": 85000000000000.0},
+            {"currentHashrate": 1e18, "currentDifficulty": 85000000000000.0, "hashrates": []},
+            diff_adj,
+        ]
+
+        class Args:
+            currency = "usd"
+            no_fiat = False
+
+        btc.cmd_stats(Args())
+
+
+class TestCmdStatsOutput:
+    @mock.patch("bitcoin_client.fetch_text")
+    @mock.patch("bitcoin_client.fetch_json")
+    @mock.patch("bitcoin_client.get_btc_price")
+    def test_next_retarget_fields(self, mock_price, mock_fetch_json, mock_fetch_text, capsys):
+        mock_fetch_text.side_effect = ["850000", "0000000000000000000000000000000000000000000000000000000000000001"]
+        mock_price.return_value = {"usd": 50000.0}
+
+        diff_adj = [
+            [1752009600, 850000, 85000000000000.0, 2.5],
+            [1751923200, 848832, 83000000000000.0, -1.2],
+        ]
+
+        mock_fetch_json.side_effect = [
+            {"timestamp": 1752009600, "difficulty": 85000000000000.0},
+            {"currentHashrate": 1e18, "currentDifficulty": 85000000000000.0, "hashrates": []},
+            diff_adj,
+        ]
+
+        class Args:
+            currency = "usd"
+            no_fiat = False
+
+        btc.cmd_stats(Args())
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+
+        assert result["tip_height"] == 850000
+        assert result["next_retarget"]["estimated_change_percent"] == 2.5
+        assert result["next_retarget"]["last_adjustment_height"] == 850000
+        assert result["next_retarget"]["current_difficulty"] == 85000000000000.0
+
+
+def _cm(body_bytes: bytes):
+    """Return a context-manager-compatible mock response."""
+    resp = mock.MagicMock()
+    resp.read.return_value = body_bytes
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+class TestFetchJsonWithFallback:
+    """Tests for automatic fallback from mempool.space to blockstream.info."""
+
+    @mock.patch("bitcoin_client.urllib.request.urlopen")
+    def test_primary_success_no_fallback(self, mock_urlopen):
+        mock_urlopen.return_value = _cm(json.dumps({"ok": True}).encode())
+
+        result = btc.fetch_json_with_fallback("/test")
+        assert result == {"ok": True}
+        assert mock_urlopen.call_count == 1
+        first_url = mock_urlopen.call_args_list[0][0][0].full_url
+        assert first_url.startswith("https://mempool.space/api/test")
+
+    @mock.patch("bitcoin_client.urllib.request.urlopen")
+    def test_fallback_on_4xx_breaks_to_next_candidate(self, mock_urlopen):
+        primary_error = mock.Mock()
+        primary_error.code = 404
+        primary_error.read.return_value = b"not found"
+
+        side_effects = [
+            urllib.error.HTTPError("url", 404, "not found", {}, primary_error),
+            _cm(json.dumps({"fallback": True}).encode()),
+        ]
+
+        def urlopen_side_effect(req, **kwargs):
+            item = side_effects.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        mock_urlopen.side_effect = urlopen_side_effect
+
+        result = btc.fetch_json_with_fallback("/test")
+        assert result == {"fallback": True}
+        urls = [c[0][0].full_url for c in mock_urlopen.call_args_list]
+        assert any(u.startswith("https://blockstream.info") for u in urls)
+
+    @mock.patch("bitcoin_client.urllib.request.urlopen")
+    def test_429_retries_on_primary_then_fallback(self, mock_urlopen):
+        primary_error = mock.Mock()
+        primary_error.code = 429
+        primary_error.read.return_value = b"rate limited"
+
+        # retries=2 -> 3 attempts on the same URL, then fallback candidate.
+        side_effects = [
+            urllib.error.HTTPError("url", 429, "rate limited", {}, primary_error),
+            urllib.error.HTTPError("url", 429, "rate limited", {}, primary_error),
+            urllib.error.HTTPError("url", 429, "rate limited", {}, primary_error),
+            _cm(json.dumps({"fallback_after_429": True}).encode()),
+        ]
+
+        def urlopen_side_effect(req, **kwargs):
+            item = side_effects.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        mock_urlopen.side_effect = urlopen_side_effect
+
+        result = btc.fetch_json_with_fallback("/test")
+        assert result == {"fallback_after_429": True}
+        urls = [c[0][0].full_url for c in mock_urlopen.call_args_list]
+        mempool_calls = [u for u in urls if u.startswith("https://mempool.space")]
+        fallback_calls = [u for u in urls if u.startswith("https://blockstream.info")]
+        assert len(mempool_calls) == 3
+        assert len(fallback_calls) == 1
+
+    @mock.patch("bitcoin_client.urllib.request.urlopen")
+    def test_all_candidates_fail_raises(self, mock_urlopen):
+        err = mock.Mock()
+        err.code = 500
+        err.read.return_value = b"error"
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            "url", 500, "error", {}, err
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            btc.fetch_json_with_fallback("/test")
+        assert "HTTP 500" in str(exc_info.value)
+
+
+    def test_skill_description_length(self):
+        skill_md = SCRIPTS_DIR.parent / "SKILL.md"
+        text = skill_md.read_text()
+        import re
+        m = re.search(r'^description:\s*"([^"]+)"', text, re.MULTILINE)
+        assert m, "description frontmatter not found"
+        desc = m.group(1)
+        assert len(desc) <= 60, f"description too long ({len(desc)} chars): {desc}"
+        assert desc.endswith("."), f"description must end with a period: {desc}"

--- a/tests/skills/test_bitcoin_skill.py
+++ b/tests/skills/test_bitcoin_skill.py
@@ -79,7 +79,7 @@ class TestCmdStatsDifficultyAdjustmentOrdering:
     @mock.patch("bitcoin_client.fetch_json")
     @mock.patch("bitcoin_client.get_btc_price")
     def test_selects_max_timestamp_not_last_element(
-        self, mock_price, mock_fetch_json, mock_fetch_text
+        self, mock_price, mock_fetch_json, mock_fetch_text, capsys
     ):
         mock_fetch_text.side_effect = ["850000", "0000000000000000000000000000000000000000000000000000000000000001"]
         mock_price.return_value = {"usd": 50000.0}
@@ -103,13 +103,18 @@ class TestCmdStatsDifficultyAdjustmentOrdering:
             no_fiat = False
 
         btc.cmd_stats(Args())
-        output = sys.stdout.getvalue() if hasattr(sys.stdout, "getvalue") else None
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+
+        # If the code used diff_adj[-1], it would pick -1.2% instead of 2.5%.
+        assert result["next_retarget"]["estimated_change_percent"] == 2.5
+        assert result["next_retarget"]["last_adjustment_height"] == 850000
 
     @mock.patch("bitcoin_client.fetch_text")
     @mock.patch("bitcoin_client.fetch_json")
     @mock.patch("bitcoin_client.get_btc_price")
     def test_selects_max_timestamp_when_oldest_first(
-        self, mock_price, mock_fetch_json, mock_fetch_text
+        self, mock_price, mock_fetch_json, mock_fetch_text, capsys
     ):
         mock_fetch_text.side_effect = ["850000", "0000000000000000000000000000000000000000000000000000000000000001"]
         mock_price.return_value = {"usd": 50000.0}
@@ -132,6 +137,11 @@ class TestCmdStatsDifficultyAdjustmentOrdering:
             no_fiat = False
 
         btc.cmd_stats(Args())
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+
+        assert result["next_retarget"]["estimated_change_percent"] == 2.5
+        assert result["next_retarget"]["last_adjustment_height"] == 850000
 
 
 class TestCmdStatsOutput:


### PR DESCRIPTION
This PR adds a read-only Bitcoin research skill for Hermes, living under `optional-skills/blockchain/bitcoin/`.

## What it does
- Query addresses, transactions, UTXOs, blocks, mempool, fees, network stats, and BTC price.
- Compare multiple addresses, generate combined reports, and inspect historical fee-rate distributions.
- Whale-watch large unconfirmed mempool transactions.
- Verify the existence of addresses or txids.
- Print editorial fact-check checklists for Bitcoin stories.

## APIs
- mempool.space as the primary source.
- blockstream.info and blockchain.info as automatic fallbacks.
- CoinGecko for BTC price data.

## Key design choices
- Python 3.8+ standard library only (`urllib`, `json`, `argparse`).
- No API keys required.
- Built-in 429 retry with exponential backoff.
- 60s in-process CoinGecko cache plus `--no-fiat` flag to avoid rate limits.
- CSV/TSV output for `txs`, `utxo`, `compare`, and `fee-history`.

## Files added
- `optional-skills/blockchain/bitcoin/SKILL.md`
- `optional-skills/blockchain/bitcoin/scripts/bitcoin_client.py`
- `optional-skills/blockchain/bitcoin/references/api-notes.md`
- `optional-skills/blockchain/bitcoin/templates/fact-check.md`

## Notes for reviewers
- mempool.space no longer returns `reward`/`fees` on the `/block` endpoint, so the block subsidy is calculated locally from the height.
- Recent mempool.space tx responses can omit `vsize`; the client falls back to `weight / 4`.