### PR TITLE
fix(teams): ingest authenticated and channel attachments

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -18,8 +18,9 @@ Configuration in config.yaml:
           client_secret: "your-secret"      # or TEAMS_CLIENT_SECRET env var
           tenant_id: "your-tenant-id"       # or TEAMS_TENANT_ID env var
           port: 3978                        # or TEAMS_PORT env var
-          respond_to_all_messages: false     # or TEAMS_RESPOND_TO_ALL_MESSAGES env var
-          mode_allowed_users: "aad-id-1,aad-id-2" # or TEAMS_MODE_ALLOWED_USERS env var
+          respond_to_all_messages: false
+          mode_allowed_users: "aad-id-1,aad-id-2"
+          response_mode_state_file: "~/.hermes/state/teams_response_modes.json"
 """
 
 from __future__ import annotations
@@ -721,16 +722,14 @@ class TeamsAdapter(BasePlatformAdapter):
             default=True,
         )
         self._default_respond_to_all_messages = _parse_bool(
-            extra.get("respond_to_all_messages")
-            or os.getenv("TEAMS_RESPOND_TO_ALL_MESSAGES", ""),
+            extra.get("respond_to_all_messages"),
             default=False,
         )
-        self._respond_to_all_messages = self._default_respond_to_all_messages
         self._mode_allowed_users = self._parse_allowed_users(
             extra.get("mode_allowed_users")
-            or os.getenv("TEAMS_MODE_ALLOWED_USERS", "")
             or os.getenv("TEAMS_ALLOWED_USERS", "")
         )
+        self._response_mode_state_file = extra.get("response_mode_state_file")
         self._response_mode_state = self._load_response_mode_state()
         self._graph_ingest_client: Any | None = None
         self._graph_ingest_warning_logged = False
@@ -1281,7 +1280,7 @@ class TeamsAdapter(BasePlatformAdapter):
         ):
             logger.debug(
                 "[teams] Ignoring unmentioned %s message because "
-                "TEAMS_RESPOND_TO_ALL_MESSAGES is not enabled",
+                "respond_to_all_messages is not enabled",
                 chat_type,
             )
             return
@@ -1430,11 +1429,11 @@ class TeamsAdapter(BasePlatformAdapter):
         if isinstance(modes, dict) and str(chat_id) in modes:
             return "conversation override"
         if self._default_respond_to_all_messages:
-            return "config/env default"
+            return "config default"
         return "default"
 
     def _response_mode_state_path(self):
-        override = os.getenv("TEAMS_RESPONSE_MODE_STATE_FILE", "").strip()
+        override = str(self._response_mode_state_file or "").strip()
         if override:
             from pathlib import Path
 
@@ -1531,7 +1530,7 @@ class TeamsAdapter(BasePlatformAdapter):
         if not self._is_mode_admin(activity):
             await self.send(
                 chat_id,
-                "Only Teams mode admins can change the response mode. Configure `TEAMS_MODE_ALLOWED_USERS` or `mode_allowed_users` with the authorized AAD object IDs.",
+                "Only Teams mode admins can change the response mode. Configure `platforms.teams.extra.mode_allowed_users` with the authorized AAD object IDs.",
                 reply_to=reply_to,
             )
             return True

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import html
+import inspect
 import json
 import logging
 import os
@@ -804,7 +805,38 @@ class TeamsAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[teams] Disconnected")
 
-    async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
+    async def _get_bot_bearer_token(self) -> Optional[str]:
+        """Return the current Bot Framework bearer token, if the SDK exposes one."""
+        app = self._app
+        if app is None:
+            return None
+
+        # Avoid MagicMock's dynamic attribute creation in tests while still
+        # supporting the SDK's class method and explicit test doubles.
+        class_getter = getattr(type(app), "_get_bot_token", None)
+        instance_getter_defined = "_get_bot_token" in getattr(app, "__dict__", {})
+        if class_getter is None and not instance_getter_defined:
+            return None
+
+        token_getter = getattr(app, "_get_bot_token", None)
+        if not callable(token_getter):
+            return None
+
+        token = token_getter()
+        if inspect.isawaitable(token):
+            token = await token
+        if not token:
+            return None
+        value = str(token).strip()
+        return value or None
+
+    async def _fetch_attachment_bytes(
+        self,
+        url: str,
+        timeout: float = 30.0,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> bytes:
         """Download attachment bytes with SSRF protection.
 
         Teams file attachments carry pre-authenticated SharePoint download
@@ -825,12 +857,59 @@ class TeamsAdapter(BasePlatformAdapter):
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            response = await client.get(
-                url,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"},
-            )
+            request_headers = {
+                "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"
+            }
+            if headers:
+                request_headers.update({k: v for k, v in headers.items() if v})
+            response = await client.get(url, headers=request_headers)
             response.raise_for_status()
             return response.content
+
+    async def _cache_image_attachment(
+        self,
+        url: str,
+        content_type: str,
+        filename: str = "",
+    ) -> Optional[tuple[str, str, str]]:
+        """Cache a Teams image attachment and return path, MIME type, and kind.
+
+        Inline Teams image ``contentUrl`` values can require the bot's bearer
+        token. Public image URLs are still supported through the generic fallback.
+        """
+        token = await self._get_bot_bearer_token()
+        if token:
+            try:
+                data = await self._fetch_attachment_bytes(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Accept": "image/*,*/*;q=0.8",
+                    },
+                )
+            except Exception as exc:
+                status_code = getattr(getattr(exc, "response", None), "status_code", None)
+                if status_code not in (401, 403):
+                    raise
+                logger.debug(
+                    "[teams] Authenticated image fetch returned %s; trying public fetch",
+                    status_code,
+                )
+            else:
+                cached = cache_media_bytes(
+                    data,
+                    filename=filename,
+                    mime_type=content_type,
+                    default_kind="image",
+                )
+                if not cached:
+                    raise ValueError("Downloaded Teams image attachment was not a supported image")
+                return cached.path, cached.media_type, cached.kind
+
+        cached_path = await cache_image_from_url(url)
+        if not cached_path:
+            return None
+        return cached_path, content_type, "image"
 
     async def _on_message(self, ctx: ActivityContext[MessageActivity]) -> None:
         """Process an incoming Teams message and dispatch to the gateway."""
@@ -932,11 +1011,16 @@ class TeamsAdapter(BasePlatformAdapter):
 
             if content_url and content_type.startswith("image/"):
                 try:
-                    cached = await cache_image_from_url(content_url)
+                    cached = await self._cache_image_attachment(
+                        content_url,
+                        content_type,
+                        att_name,
+                    )
                     if cached:
-                        media_urls.append(cached)
-                        media_types.append(content_type)
-                        media_kinds.append("image")
+                        path, media_type, kind = cached
+                        media_urls.append(path)
+                        media_types.append(media_type)
+                        media_kinds.append(kind)
                 except Exception as e:
                     logger.warning("[teams] Failed to cache image attachment: %s", e)
                 continue

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -23,6 +23,7 @@ Configuration in config.yaml:
 from __future__ import annotations
 
 import asyncio
+import base64
 import html
 import inspect
 import json
@@ -712,6 +713,13 @@ class TeamsAdapter(BasePlatformAdapter):
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
         self._conv_refs: Dict[str, Any] = {}
+        self._graph_ingest_enabled = _parse_bool(
+            extra.get("graph_ingest_attachments")
+            or os.getenv("TEAMS_GRAPH_INGEST_ATTACHMENTS", ""),
+            default=True,
+        )
+        self._graph_ingest_client: Any | None = None
+        self._graph_ingest_warning_logged = False
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         # Lazy-install the Teams SDK on demand (parity with Slack/Discord/etc.),
@@ -911,6 +919,291 @@ class TeamsAdapter(BasePlatformAdapter):
             return None
         return cached_path, content_type, "image"
 
+    @staticmethod
+    def _object_field(value: Any, *names: str) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            for name in names:
+                if name in value:
+                    return value[name]
+            return None
+        data = getattr(value, "__dict__", None)
+        if isinstance(data, dict):
+            for name in names:
+                if name in data:
+                    return data[name]
+        if type(value).__module__.startswith("unittest.mock"):
+            return None
+        for name in names:
+            try:
+                current = getattr(value, name)
+            except Exception:
+                continue
+            if type(current).__module__.startswith("unittest.mock"):
+                continue
+            return current
+        return None
+
+    @classmethod
+    def _nested_field(cls, value: Any, *paths: tuple[str, ...]) -> Any:
+        for path in paths:
+            current = value
+            for name in path:
+                current = cls._object_field(current, name)
+                if current is None:
+                    break
+            else:
+                return current
+        return None
+
+    @staticmethod
+    def _string_value(value: Any) -> str:
+        if isinstance(value, str):
+            return value.strip()
+        if isinstance(value, (int, float)):
+            return str(value).strip()
+        return ""
+
+    @staticmethod
+    def _clean_mime_type(value: Any) -> str:
+        raw = str(value or "").split(";", 1)[0].strip().lower()
+        return raw if "/" in raw else ""
+
+    @staticmethod
+    def _sharing_url_to_graph_token(url: str) -> str:
+        encoded = base64.urlsafe_b64encode(url.encode("utf-8")).decode("ascii")
+        return f"u!{encoded.rstrip('=')}"
+
+    def _graph_message_path_for_activity(
+        self,
+        activity: Any,
+        conv_type: str,
+    ) -> Optional[str]:
+        msg_id = self._string_value(self._object_field(activity, "id"))
+        if not msg_id:
+            return None
+
+        conversation = self._object_field(activity, "conversation")
+        channel_data = (
+            self._object_field(activity, "channel_data", "channelData")
+            or self._object_field(activity, "channeldata")
+            or {}
+        )
+
+        if conv_type == "groupChat":
+            chat_id = self._string_value(self._object_field(conversation, "id"))
+            if not chat_id:
+                return None
+            return f"/chats/{quote(chat_id, safe='')}/messages/{quote(msg_id, safe='')}"
+
+        if conv_type != "channel":
+            return None
+
+        team_id = self._string_value(
+            self._nested_field(
+                channel_data,
+                ("team", "aadGroupId"),
+                ("team", "aad_group_id"),
+                ("team", "id"),
+            )
+        )
+        channel_id = self._string_value(
+            self._nested_field(
+                channel_data,
+                ("channel", "id"),
+                ("teamsChannelId",),
+                ("channelId",),
+            )
+        ) or self._string_value(self._object_field(conversation, "id"))
+        if not team_id or not channel_id:
+            return None
+
+        reply_to_id = self._string_value(
+            self._object_field(activity, "reply_to_id", "replyToId")
+            or self._nested_field(channel_data, ("replyToId",), ("reply_to_id",))
+        )
+        base = (
+            f"/teams/{quote(team_id, safe='')}/channels/"
+            f"{quote(channel_id, safe='')}/messages"
+        )
+        if reply_to_id and reply_to_id != msg_id:
+            return (
+                f"{base}/{quote(reply_to_id, safe='')}/replies/"
+                f"{quote(msg_id, safe='')}"
+            )
+        return f"{base}/{quote(msg_id, safe='')}"
+
+    def _build_graph_ingest_client(self) -> Any | None:
+        if self._graph_ingest_client is not None:
+            return self._graph_ingest_client
+
+        try:
+            from tools.microsoft_graph_auth import (
+                GraphCredentials,
+                MicrosoftGraphTokenProvider,
+            )
+            from tools.microsoft_graph_client import MicrosoftGraphClient
+
+            credentials = GraphCredentials.from_env(required=False)
+            if credentials is None:
+                if not (self._tenant_id and self._client_id and self._client_secret):
+                    return None
+                credentials = GraphCredentials(
+                    tenant_id=self._tenant_id,
+                    client_id=self._client_id,
+                    client_secret=self._client_secret,
+                )
+            self._graph_ingest_client = MicrosoftGraphClient(
+                MicrosoftGraphTokenProvider(credentials),
+                user_agent="Hermes-Agent/teams-attachment-ingest",
+            )
+            return self._graph_ingest_client
+        except Exception as exc:
+            if not self._graph_ingest_warning_logged:
+                logger.info("[teams] Graph attachment ingest unavailable: %s", exc)
+                self._graph_ingest_warning_logged = True
+            return None
+
+    @staticmethod
+    def _message_may_have_graph_media(
+        *,
+        text: str,
+        saw_attachment: bool,
+    ) -> bool:
+        if saw_attachment:
+            return True
+        lowered = (text or "").lower()
+        return (
+            "<img" in lowered
+            or "<attachment" in lowered
+            or "hostedcontents" in lowered
+        )
+
+    async def _cache_graph_reference_attachment(
+        self,
+        graph_client: Any,
+        attachment: dict[str, Any],
+    ) -> Optional[tuple[str, str, str]]:
+        content_url = self._string_value(attachment.get("contentUrl"))
+        if not content_url:
+            return None
+
+        content_type = str(attachment.get("contentType") or "").strip().lower()
+        filename = self._string_value(attachment.get("name")) or "teams-attachment"
+        share_token = self._sharing_url_to_graph_token(content_url)
+        binary = await graph_client.get_bytes(
+            f"/shares/{quote(share_token, safe='!')}/driveItem/content"
+        )
+        mime_type = self._clean_mime_type(binary.content_type)
+        if content_type and content_type != "reference" and "/" in content_type:
+            mime_type = mime_type or content_type
+        cached = cache_media_bytes(
+            binary.content,
+            filename=filename,
+            mime_type=mime_type,
+        )
+        if not cached:
+            return None
+        return cached.path, cached.media_type, cached.kind
+
+    async def _cache_graph_hosted_content(
+        self,
+        graph_client: Any,
+        message_path: str,
+        hosted: dict[str, Any],
+        index: int,
+    ) -> Optional[tuple[str, str, str]]:
+        hosted_id = self._string_value(hosted.get("id"))
+        if not hosted_id:
+            return None
+        binary = await graph_client.get_bytes(
+            f"{message_path}/hostedContents/{quote(hosted_id, safe='')}/$value"
+        )
+        cached = cache_media_bytes(
+            binary.content,
+            filename=f"teams-hosted-content-{index}",
+            mime_type=self._clean_mime_type(binary.content_type),
+            default_kind="image",
+        )
+        if not cached:
+            return None
+        return cached.path, cached.media_type, cached.kind
+
+    async def _cache_graph_message_media(
+        self,
+        activity: Any,
+        conv_type: str,
+    ) -> list[tuple[str, str, str]]:
+        """Cache Teams channel/group media that only Graph exposes reliably."""
+        if not self._graph_ingest_enabled or conv_type not in {"channel", "groupChat"}:
+            return []
+
+        message_path = self._graph_message_path_for_activity(activity, conv_type)
+        if not message_path:
+            return []
+
+        graph_client = self._build_graph_ingest_client()
+        if graph_client is None:
+            return []
+
+        cached_media: list[tuple[str, str, str]] = []
+        try:
+            message = await graph_client.get_json(message_path)
+        except Exception as exc:
+            logger.debug("[teams] Failed to read Teams message via Graph: %s", exc)
+            return []
+
+        for attachment in (message or {}).get("attachments") or []:
+            if not isinstance(attachment, dict):
+                continue
+            content_type = str(attachment.get("contentType") or "").strip().lower()
+            content_url = self._string_value(attachment.get("contentUrl"))
+            if not content_url or content_type == "forwardedmessagereference":
+                continue
+            try:
+                cached = await self._cache_graph_reference_attachment(
+                    graph_client,
+                    attachment,
+                )
+                if cached:
+                    cached_media.append(cached)
+            except Exception as exc:
+                logger.warning(
+                    "[teams] Failed to cache Graph message attachment '%s': %s",
+                    attachment.get("name") or content_url,
+                    exc,
+                )
+
+        try:
+            hosted_contents = await graph_client.collect_paginated(
+                f"{message_path}/hostedContents"
+            )
+        except Exception as exc:
+            logger.debug("[teams] Failed to list Teams hosted content via Graph: %s", exc)
+            hosted_contents = []
+
+        for index, hosted in enumerate(hosted_contents, start=1):
+            if not isinstance(hosted, dict):
+                continue
+            try:
+                cached = await self._cache_graph_hosted_content(
+                    graph_client,
+                    message_path,
+                    hosted,
+                    index,
+                )
+                if cached:
+                    cached_media.append(cached)
+            except Exception as exc:
+                logger.warning(
+                    "[teams] Failed to cache Graph hosted content '%s': %s",
+                    hosted.get("id"),
+                    exc,
+                )
+
+        return cached_media
+
     async def _on_message(self, ctx: ActivityContext[MessageActivity]) -> None:
         """Process an incoming Teams message and dispatch to the gateway."""
         activity = ctx.activity
@@ -969,6 +1262,7 @@ class TeamsAdapter(BasePlatformAdapter):
         media_urls = []
         media_types = []
         media_kinds = []
+        saw_media_attachment = False
         for att in getattr(activity, "attachments", None) or []:
             content_url = getattr(att, "content_url", None)
             content_type = (getattr(att, "content_type", None) or "").lower()
@@ -981,6 +1275,7 @@ class TeamsAdapter(BasePlatformAdapter):
                 continue
             if content_type.startswith("application/vnd.microsoft.card"):
                 continue
+            saw_media_attachment = True
 
             if content_type == "application/vnd.microsoft.teams.file.download.info":
                 # File consent-free download: content carries a pre-authed
@@ -1041,6 +1336,18 @@ class TeamsAdapter(BasePlatformAdapter):
                         "[teams] Failed to cache attachment '%s' (%s): %s",
                         att_name or content_url, content_type, e,
                     )
+
+        if not media_urls and self._message_may_have_graph_media(
+            text=text,
+            saw_attachment=saw_media_attachment,
+        ):
+            for path, media_type, kind in await self._cache_graph_message_media(
+                activity,
+                conv_type,
+            ):
+                media_urls.append(path)
+                media_types.append(media_type)
+                media_kinds.append(kind)
 
         # Classification: DOCUMENT wins over PHOTO/VIDEO/AUDIO for mixed
         # attachments — run.py's image handling keys off the per-path image/*

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -18,6 +18,8 @@ Configuration in config.yaml:
           client_secret: "your-secret"      # or TEAMS_CLIENT_SECRET env var
           tenant_id: "your-tenant-id"       # or TEAMS_TENANT_ID env var
           port: 3978                        # or TEAMS_PORT env var
+          respond_to_all_messages: false     # or TEAMS_RESPOND_TO_ALL_MESSAGES env var
+          mode_allowed_users: "aad-id-1,aad-id-2" # or TEAMS_MODE_ALLOWED_USERS env var
 """
 
 from __future__ import annotations
@@ -718,6 +720,18 @@ class TeamsAdapter(BasePlatformAdapter):
             or os.getenv("TEAMS_GRAPH_INGEST_ATTACHMENTS", ""),
             default=True,
         )
+        self._default_respond_to_all_messages = _parse_bool(
+            extra.get("respond_to_all_messages")
+            or os.getenv("TEAMS_RESPOND_TO_ALL_MESSAGES", ""),
+            default=False,
+        )
+        self._respond_to_all_messages = self._default_respond_to_all_messages
+        self._mode_allowed_users = self._parse_allowed_users(
+            extra.get("mode_allowed_users")
+            or os.getenv("TEAMS_MODE_ALLOWED_USERS", "")
+            or os.getenv("TEAMS_ALLOWED_USERS", "")
+        )
+        self._response_mode_state = self._load_response_mode_state()
         self._graph_ingest_client: Any | None = None
         self._graph_ingest_warning_logged = False
 
@@ -1227,6 +1241,7 @@ class TeamsAdapter(BasePlatformAdapter):
         text = ""
         if hasattr(activity, "text") and activity.text:
             text = activity.text
+        mentioned = self._is_bot_mentioned(activity, text)
         # Strip <at>BotName</at> HTML tags that Teams prepends for @mentions
         if "<at>" in text:
             import re
@@ -1243,6 +1258,33 @@ class TeamsAdapter(BasePlatformAdapter):
             chat_type = "channel"
         else:
             chat_type = "dm"
+
+        responds_to_all = self._conversation_responds_to_all(conv.id)
+        if await self._maybe_handle_response_mode_command(
+            text=text,
+            chat_id=conv.id,
+            chat_type=chat_type,
+            activity=activity,
+            mentioned=mentioned,
+            reply_to=msg_id,
+        ):
+            return
+
+        # Teams can deliver every channel/group-chat message when the app has
+        # RSC all-message permissions. Keep DMs conversational, but require an
+        # explicit mention in shared spaces unless the operator opts into the
+        # all-message behavior.
+        if (
+            chat_type in {"group", "channel"}
+            and not responds_to_all
+            and not mentioned
+        ):
+            logger.debug(
+                "[teams] Ignoring unmentioned %s message because "
+                "TEAMS_RESPOND_TO_ALL_MESSAGES is not enabled",
+                chat_type,
+            )
+            return
 
         # Build source
         from_account = activity.from_
@@ -1374,6 +1416,192 @@ class TeamsAdapter(BasePlatformAdapter):
             message_id=msg_id,
         )
         await self.handle_message(event)
+
+    def _conversation_responds_to_all(self, chat_id: str) -> bool:
+        modes = self._response_mode_state.get("conversation_modes", {})
+        if isinstance(modes, dict):
+            entry = modes.get(str(chat_id))
+            if isinstance(entry, dict) and "respond_to_all_messages" in entry:
+                return bool(entry.get("respond_to_all_messages"))
+        return self._default_respond_to_all_messages
+
+    def _conversation_mode_source(self, chat_id: str) -> str:
+        modes = self._response_mode_state.get("conversation_modes", {})
+        if isinstance(modes, dict) and str(chat_id) in modes:
+            return "conversation override"
+        if self._default_respond_to_all_messages:
+            return "config/env default"
+        return "default"
+
+    def _response_mode_state_path(self):
+        override = os.getenv("TEAMS_RESPONSE_MODE_STATE_FILE", "").strip()
+        if override:
+            from pathlib import Path
+
+            return Path(override).expanduser()
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "state" / "teams_response_modes.json"
+
+    def _load_response_mode_state(self) -> dict[str, Any]:
+        path = self._response_mode_state_path()
+        try:
+            if not path.exists():
+                return {"version": 1, "conversation_modes": {}}
+            data = json.loads(path.read_text(encoding="utf-8") or "{}")
+            if not isinstance(data, dict):
+                return {"version": 1, "conversation_modes": {}}
+            modes = data.get("conversation_modes")
+            if not isinstance(modes, dict):
+                data["conversation_modes"] = {}
+            data.setdefault("version", 1)
+            return data
+        except Exception as exc:
+            logger.warning("[teams] Failed to load response mode state: %s", exc)
+            return {"version": 1, "conversation_modes": {}}
+
+    def _save_response_mode_state(self) -> None:
+        path = self._response_mode_state_path()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            payload = json.dumps(self._response_mode_state, indent=2, sort_keys=True)
+            path.write_text(payload + "\n", encoding="utf-8")
+        except Exception as exc:
+            logger.warning("[teams] Failed to save response mode state: %s", exc)
+
+    @staticmethod
+    def _parse_allowed_users(raw: Any) -> set[str]:
+        if isinstance(raw, (list, tuple, set)):
+            return {str(item).strip() for item in raw if str(item).strip()}
+        if isinstance(raw, str):
+            return {item.strip() for item in raw.split(",") if item.strip()}
+        return set()
+
+    def _is_mode_admin(self, activity: Any) -> bool:
+        from_account = activity.from_
+        user_id = getattr(from_account, "aad_object_id", None) or getattr(from_account, "id", "")
+        user_id = str(user_id or "").strip()
+        return bool(user_id and ("*" in self._mode_allowed_users or user_id in self._mode_allowed_users))
+
+    def _parse_response_mode_command(self, text: str) -> str | None:
+        normalized = " ".join((text or "").strip().split()).lower()
+        if not normalized:
+            return None
+        command_prefixes = ("/teams-mode", "teams mode", "teams-mode")
+        args: str | None = None
+        for prefix in command_prefixes:
+            if normalized == prefix:
+                args = ""
+                break
+            if normalized.startswith(prefix + " "):
+                args = normalized[len(prefix):].strip()
+                break
+        if args is None:
+            return None
+        if not args or args in {"status", "show", "current"}:
+            return "status"
+        if args in {"all", "on", "respond-all", "respond_all", "respond to all", "listen-all", "listen_all"}:
+            return "all"
+        if args in {"mentions", "mention", "mentions-only", "mention-only", "mentions_only", "off"}:
+            return "mentions"
+        if args in {"default", "reset", "clear"}:
+            return "default"
+        return "help"
+
+    async def _maybe_handle_response_mode_command(
+        self,
+        *,
+        text: str,
+        chat_id: str,
+        chat_type: str,
+        activity: Any,
+        mentioned: bool,
+        reply_to: str | None,
+    ) -> bool:
+        command = self._parse_response_mode_command(text)
+        if command is None:
+            return False
+
+        # Shared-space mode changes should be deliberate. If all-message mode is
+        # on and someone types a command-looking phrase without mentioning the
+        # bot, consume it so it does not become agent input.
+        if chat_type in {"group", "channel"} and not mentioned:
+            return True
+
+        if not self._is_mode_admin(activity):
+            await self.send(
+                chat_id,
+                "Only Teams mode admins can change the response mode. Configure `TEAMS_MODE_ALLOWED_USERS` or `mode_allowed_users` with the authorized AAD object IDs.",
+                reply_to=reply_to,
+            )
+            return True
+
+        if command == "all":
+            modes = self._response_mode_state.setdefault("conversation_modes", {})
+            modes[str(chat_id)] = {"respond_to_all_messages": True}
+            self._save_response_mode_state()
+            await self.send(
+                chat_id,
+                "Teams response mode for this conversation is now `respond-all`.",
+                reply_to=reply_to,
+            )
+            return True
+        if command == "mentions":
+            modes = self._response_mode_state.setdefault("conversation_modes", {})
+            modes[str(chat_id)] = {"respond_to_all_messages": False}
+            self._save_response_mode_state()
+            await self.send(
+                chat_id,
+                "Teams response mode for this conversation is now `mentions-only`.",
+                reply_to=reply_to,
+            )
+            return True
+        if command == "default":
+            modes = self._response_mode_state.setdefault("conversation_modes", {})
+            if isinstance(modes, dict):
+                modes.pop(str(chat_id), None)
+            self._save_response_mode_state()
+            current = "respond-all" if self._conversation_responds_to_all(chat_id) else "mentions-only"
+            await self.send(
+                chat_id,
+                f"Teams response mode for this conversation now follows the default: `{current}`.",
+                reply_to=reply_to,
+            )
+            return True
+        if command == "status":
+            current = "respond-all" if self._conversation_responds_to_all(chat_id) else "mentions-only"
+            await self.send(
+                chat_id,
+                f"Teams response mode for this conversation is `{current}` ({self._conversation_mode_source(chat_id)}).",
+                reply_to=reply_to,
+            )
+            return True
+
+        await self.send(
+            chat_id,
+            "Use `/teams-mode mentions`, `/teams-mode all`, `/teams-mode status`, or `/teams-mode default`.",
+            reply_to=reply_to,
+        )
+        return True
+
+    def _is_bot_mentioned(self, activity: Any, text: str) -> bool:
+        """Return True when the incoming Teams activity explicitly mentions this bot."""
+        bot_id = self._client_id or (self._app.id if self._app else "")
+        entities = getattr(activity, "entities", None) or []
+        saw_mention_entity = False
+        for entity in entities:
+            if self._object_field(entity, "type") != "mention":
+                continue
+            saw_mention_entity = True
+            mentioned = self._object_field(entity, "mentioned") or {}
+            mentioned_id = self._string_value(self._object_field(mentioned, "id"))
+            if bot_id and mentioned_id == bot_id:
+                return True
+        if saw_mention_entity:
+            return False
+        if "<at>" in (text or "").lower():
+            return True
+        return False
 
     async def _send_card(self, chat_id: str, card: "AdaptiveCard") -> "Any":
         """Send an AdaptiveCard, using a stored ConversationReference when available."""

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -618,6 +618,7 @@ class TestTeamsMessageHandling:
         tenant_id="tenant-789",
         activity_id="activity-001",
         attachments=None,
+        entities=None,
     ):
         activity = MagicMock()
         activity.text = text
@@ -632,12 +633,24 @@ class TestTeamsMessageHandling:
         activity.conversation.name = "Test Chat"
         activity.conversation.tenant_id = tenant_id
         activity.attachments = attachments or []
+        activity.entities = entities or []
         return activity
 
     def _make_ctx(self, activity):
         ctx = MagicMock()
         ctx.activity = activity
         return ctx
+
+    def _bot_mention_entity(self):
+        return {
+            "type": "mention",
+            "mentioned": {"id": "bot-id", "name": "Hermes"},
+        }
+
+    def _ready_app(self, adapter):
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter._app.send = AsyncMock(return_value=SimpleNamespace(id="sent-mode-reply"))
 
     @pytest.mark.anyio
     async def test_personal_message_creates_dm_event(self):
@@ -664,11 +677,16 @@ class TestTeamsMessageHandling:
         adapter._app.id = "bot-id"
         adapter.handle_message = AsyncMock()
 
-        activity = self._make_activity(conversation_type="groupChat")
+        activity = self._make_activity(
+            text="<at>Hermes</at> hello group",
+            conversation_type="groupChat",
+            entities=[self._bot_mention_entity()],
+        )
         await adapter._on_message(self._make_ctx(activity))
 
         event = adapter.handle_message.call_args[0][0]
         assert event.source.chat_type == "group"
+        assert event.text == "hello group"
 
     @pytest.mark.anyio
     async def test_channel_message_creates_channel_event(self):
@@ -679,11 +697,249 @@ class TestTeamsMessageHandling:
         adapter._app.id = "bot-id"
         adapter.handle_message = AsyncMock()
 
-        activity = self._make_activity(conversation_type="channel")
+        activity = self._make_activity(
+            text="<at>Hermes</at> hello channel",
+            conversation_type="channel",
+            entities=[self._bot_mention_entity()],
+        )
         await adapter._on_message(self._make_ctx(activity))
 
         event = adapter.handle_message.call_args[0][0]
         assert event.source.chat_type == "channel"
+        assert event.text == "hello channel"
+
+    @pytest.mark.anyio
+    async def test_group_message_without_mention_is_ignored_by_default(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(
+            text="ambient group chatter",
+            conversation_type="groupChat",
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_channel_message_without_mention_is_ignored_by_default(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(
+            text="ambient channel chatter",
+            conversation_type="channel",
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_group_message_without_mention_allowed_when_respond_all_configured(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id",
+            client_secret="secret",
+            tenant_id="tenant",
+            respond_to_all_messages=True,
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(
+            text="ambient group chatter",
+            conversation_type="groupChat",
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.text == "ambient group chatter"
+        assert event.source.chat_type == "group"
+
+    @pytest.mark.anyio
+    async def test_channel_message_without_mention_allowed_when_respond_all_env_set(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_RESPOND_TO_ALL_MESSAGES", "true")
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id",
+            client_secret="secret",
+            tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(
+            text="ambient channel chatter",
+            conversation_type="channel",
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.text == "ambient channel chatter"
+        assert event.source.chat_type == "channel"
+
+    @pytest.mark.anyio
+    async def test_other_user_mention_does_not_wake_bot(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(
+            text="<at>Ada</at> can you check this?",
+            conversation_type="channel",
+            entities=[
+                {
+                    "type": "mention",
+                    "mentioned": {"id": "other-user-id", "name": "Ada"},
+                }
+            ],
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_mode_command_allows_authorized_user_to_enable_respond_all(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id",
+            client_secret="secret",
+            tenant_id="tenant",
+            mode_allowed_users="aad-456",
+        ))
+        self._ready_app(adapter)
+        adapter.handle_message = AsyncMock()
+
+        command_activity = self._make_activity(
+            text="<at>Hermes</at> /teams-mode all",
+            conversation_type="channel",
+            entities=[self._bot_mention_entity()],
+        )
+        await adapter._on_message(self._make_ctx(command_activity))
+
+        adapter.handle_message.assert_not_awaited()
+        adapter._app.send.assert_awaited_once()
+        assert adapter._conversation_responds_to_all(command_activity.conversation.id) is True
+
+        ambient_activity = self._make_activity(
+            text="ambient channel chatter",
+            conversation_type="channel",
+            activity_id="activity-002",
+        )
+        await adapter._on_message(self._make_ctx(ambient_activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.text == "ambient channel chatter"
+        assert event.source.chat_type == "channel"
+
+    @pytest.mark.anyio
+    async def test_mode_command_can_disable_respond_all_for_conversation(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id",
+            client_secret="secret",
+            tenant_id="tenant",
+            respond_to_all_messages=True,
+            mode_allowed_users="aad-456",
+        ))
+        self._ready_app(adapter)
+        adapter.handle_message = AsyncMock()
+
+        command_activity = self._make_activity(
+            text="<at>Hermes</at> /teams-mode mentions",
+            conversation_type="groupChat",
+            entities=[self._bot_mention_entity()],
+        )
+        await adapter._on_message(self._make_ctx(command_activity))
+
+        assert adapter._conversation_responds_to_all(command_activity.conversation.id) is False
+        ambient_activity = self._make_activity(
+            text="ambient group chatter",
+            conversation_type="groupChat",
+            activity_id="activity-002",
+        )
+        await adapter._on_message(self._make_ctx(ambient_activity))
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_mode_command_rejects_unauthorized_user(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id",
+            client_secret="secret",
+            tenant_id="tenant",
+            mode_allowed_users="aad-authorized",
+        ))
+        self._ready_app(adapter)
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(
+            text="<at>Hermes</at> /teams-mode all",
+            conversation_type="channel",
+            entities=[self._bot_mention_entity()],
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+        adapter._app.send.assert_awaited_once()
+        sent_text = adapter._app.send.call_args[0][1]
+        assert "Only Teams mode admins" in sent_text
+        assert adapter._conversation_responds_to_all(activity.conversation.id) is False
+
+    @pytest.mark.anyio
+    async def test_unmentioned_mode_command_is_consumed_in_shared_space(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id",
+            client_secret="secret",
+            tenant_id="tenant",
+            respond_to_all_messages=True,
+            mode_allowed_users="aad-456",
+        ))
+        self._ready_app(adapter)
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(
+            text="/teams-mode status",
+            conversation_type="channel",
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+        adapter._app.send.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_mode_command_persists_conversation_override(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id",
+            client_secret="secret",
+            tenant_id="tenant",
+            mode_allowed_users="aad-456",
+        ))
+        self._ready_app(adapter)
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(
+            text="<at>Hermes</at> /teams-mode all",
+            conversation_type="channel",
+            entities=[self._bot_mention_entity()],
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        restored = TeamsAdapter(_make_config(
+            client_id="bot-id",
+            client_secret="secret",
+            tenant_id="tenant",
+        ))
+        assert restored._conversation_responds_to_all(activity.conversation.id) is True
 
     @pytest.mark.anyio
     async def test_user_id_uses_aad_object_id(self):
@@ -757,7 +1013,10 @@ class TestTeamsAttachmentClassification:
 
     def _make_adapter(self):
         adapter = TeamsAdapter(_make_config(
-            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+            client_id="bot-id",
+            client_secret="secret",
+            tenant_id="tenant",
+            respond_to_all_messages=True,
         ))
         adapter._app = MagicMock()
         adapter._app.id = "bot-id"

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -764,20 +764,33 @@ class TestTeamsAttachmentClassification:
         adapter.handle_message = AsyncMock()
         return adapter
 
-    def _make_activity(self, attachments, text="see attached"):
+    def _make_activity(
+        self,
+        attachments,
+        text="see attached",
+        *,
+        activity_id="activity-att-001",
+        conversation_type="personal",
+        channel_data=None,
+        reply_to_id=None,
+    ):
         activity = MagicMock()
         activity.text = text
-        activity.id = "activity-att-001"
+        activity.id = activity_id
         activity.from_ = MagicMock()
         activity.from_.id = "user-123"
         activity.from_.aad_object_id = "aad-456"
         activity.from_.name = "Test User"
         activity.conversation = MagicMock()
         activity.conversation.id = "19:abc@thread.v2"
-        activity.conversation.conversation_type = "personal"
+        activity.conversation.conversation_type = conversation_type
         activity.conversation.name = "Test Chat"
         activity.conversation.tenant_id = "tenant-789"
         activity.attachments = attachments
+        if channel_data is not None:
+            activity.channel_data = channel_data
+        if reply_to_id is not None:
+            activity.reply_to_id = reply_to_id
         return activity
 
     def _make_ctx(self, activity):
@@ -929,6 +942,166 @@ class TestTeamsAttachmentClassification:
         adapter._fetch_attachment_bytes = AsyncMock(side_effect=Exception("boom"))
 
         activity = self._make_activity([self._file_download_attachment()])
+        await adapter._on_message(self._make_ctx(activity))
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.TEXT
+        assert event.media_urls == []
+
+    @pytest.mark.anyio
+    async def test_channel_hosted_image_falls_back_to_graph(self):
+        from gateway.platforms.base import MessageType
+
+        class FakeGraphClient:
+            def __init__(self):
+                self.paths = []
+
+            async def get_json(self, path):
+                self.paths.append(("get_json", path))
+                return {"attachments": []}
+
+            async def collect_paginated(self, path):
+                self.paths.append(("collect_paginated", path))
+                return [{"id": "hosted-id"}]
+
+            async def get_bytes(self, path):
+                self.paths.append(("get_bytes", path))
+                return SimpleNamespace(content=b"image-bytes", content_type="image/png")
+
+        adapter = self._make_adapter()
+        graph_client = FakeGraphClient()
+        adapter._build_graph_ingest_client = MagicMock(return_value=graph_client)
+
+        cached_media = SimpleNamespace(
+            path="/tmp/graph-img.png",
+            media_type="image/png",
+            kind="image",
+        )
+        channel_data = {
+            "team": {"aadGroupId": "team-guid"},
+            "channel": {"id": "19:channel@thread.tacv2"},
+        }
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_teams_mod, "cache_image_from_url", AsyncMock(return_value=None))
+            cache_media = MagicMock(return_value=cached_media)
+            mp.setattr(_teams_mod, "cache_media_bytes", cache_media)
+
+            activity = self._make_activity(
+                [self._image_attachment()],
+                activity_id="1614618259349",
+                conversation_type="channel",
+                channel_data=channel_data,
+            )
+            await adapter._on_message(self._make_ctx(activity))
+
+        message_path = (
+            "/teams/team-guid/channels/19%3Achannel%40thread.tacv2/"
+            "messages/1614618259349"
+        )
+        assert graph_client.paths == [
+            ("get_json", message_path),
+            ("collect_paginated", f"{message_path}/hostedContents"),
+            ("get_bytes", f"{message_path}/hostedContents/hosted-id/$value"),
+        ]
+        cache_media.assert_called_once_with(
+            b"image-bytes",
+            filename="teams-hosted-content-1",
+            mime_type="image/png",
+            default_kind="image",
+        )
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/graph-img.png"]
+
+    @pytest.mark.anyio
+    async def test_channel_reference_attachment_uses_graph_shares_download(self):
+        from gateway.platforms.base import MessageType
+
+        class FakeGraphClient:
+            def __init__(self):
+                self.paths = []
+
+            async def get_json(self, path):
+                self.paths.append(("get_json", path))
+                return {
+                    "attachments": [
+                        {
+                            "contentType": "reference",
+                            "contentUrl": "https://contoso.sharepoint.com/sites/team/Shared Documents/file.pdf",
+                            "name": "file.pdf",
+                        }
+                    ]
+                }
+
+            async def collect_paginated(self, path):
+                self.paths.append(("collect_paginated", path))
+                return []
+
+            async def get_bytes(self, path):
+                self.paths.append(("get_bytes", path))
+                return SimpleNamespace(content=b"%PDF-1.4 graph", content_type="application/pdf")
+
+        adapter = self._make_adapter()
+        adapter._fetch_attachment_bytes = AsyncMock(side_effect=Exception("bot download failed"))
+        graph_client = FakeGraphClient()
+        adapter._build_graph_ingest_client = MagicMock(return_value=graph_client)
+
+        cached_media = SimpleNamespace(
+            path="/tmp/file.pdf",
+            media_type="application/pdf",
+            kind="document",
+        )
+        channel_data = {
+            "team": {"aadGroupId": "team-guid"},
+            "channel": {"id": "19:channel@thread.tacv2"},
+        }
+
+        with pytest.MonkeyPatch.context() as mp:
+            cache_media = MagicMock(return_value=cached_media)
+            mp.setattr(_teams_mod, "cache_media_bytes", cache_media)
+
+            activity = self._make_activity(
+                [self._file_download_attachment()],
+                activity_id="1614618259349",
+                conversation_type="channel",
+                channel_data=channel_data,
+            )
+            await adapter._on_message(self._make_ctx(activity))
+
+        share_token = adapter._sharing_url_to_graph_token(
+            "https://contoso.sharepoint.com/sites/team/Shared Documents/file.pdf"
+        )
+        assert (
+            "get_bytes",
+            f"/shares/{share_token}/driveItem/content",
+        ) in graph_client.paths
+        cache_media.assert_called_once_with(
+            b"%PDF-1.4 graph",
+            filename="file.pdf",
+            mime_type="application/pdf",
+        )
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_urls == ["/tmp/file.pdf"]
+
+    @pytest.mark.anyio
+    async def test_plain_channel_text_does_not_call_graph(self):
+        from gateway.platforms.base import MessageType
+
+        adapter = self._make_adapter()
+        adapter._build_graph_ingest_client = MagicMock(side_effect=AssertionError("Graph should not run"))
+
+        activity = self._make_activity(
+            [],
+            text="plain channel message",
+            activity_id="1614618259349",
+            conversation_type="channel",
+            channel_data={
+                "team": {"aadGroupId": "team-guid"},
+                "channel": {"id": "19:channel@thread.tacv2"},
+            },
+        )
         await adapter._on_message(self._make_ctx(activity))
 
         event = adapter.handle_message.call_args[0][0]

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -896,6 +896,28 @@ class TestTeamsMessageHandling:
         assert adapter._conversation_responds_to_all(activity.conversation.id) is False
 
     @pytest.mark.anyio
+    async def test_mode_command_allows_existing_teams_allowlist_fallback(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_ALLOWED_USERS", "aad-456")
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id",
+            client_secret="secret",
+            tenant_id="tenant",
+        ))
+        self._ready_app(adapter)
+        adapter.handle_message = AsyncMock()
+
+        activity = self._make_activity(
+            text="<at>Hermes</at> /teams-mode all",
+            conversation_type="channel",
+            entities=[self._bot_mention_entity()],
+        )
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter.handle_message.assert_not_awaited()
+        adapter._app.send.assert_awaited_once()
+        assert adapter._conversation_responds_to_all(activity.conversation.id) is True
+
+    @pytest.mark.anyio
     async def test_unmentioned_mode_command_is_consumed_in_shared_space(self):
         adapter = TeamsAdapter(_make_config(
             client_id="bot-id",

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -882,6 +882,46 @@ class TestTeamsAttachmentClassification:
         assert event.media_urls == ["/tmp/img.png"]
 
     @pytest.mark.anyio
+    async def test_image_content_url_uses_bot_token(self):
+        from gateway.platforms.base import MessageType
+
+        adapter = self._make_adapter()
+        adapter._app = SimpleNamespace(id="bot-id")
+        adapter._app._get_bot_token = AsyncMock(return_value="bot-token")
+        adapter._fetch_attachment_bytes = AsyncMock(return_value=b"\x89PNG\r\n\x1a\nfake")
+        cached_media = SimpleNamespace(
+            path="/tmp/img.png",
+            media_type="image/png",
+            kind="image",
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            cache_media = MagicMock(return_value=cached_media)
+            cache_public = AsyncMock(side_effect=AssertionError("public fallback should not run"))
+            mp.setattr(_teams_mod, "cache_media_bytes", cache_media)
+            mp.setattr(_teams_mod, "cache_image_from_url", cache_public)
+
+            activity = self._make_activity([self._image_attachment()])
+            await adapter._on_message(self._make_ctx(activity))
+
+        adapter._fetch_attachment_bytes.assert_awaited_once()
+        fetch_kwargs = adapter._fetch_attachment_bytes.await_args.kwargs
+        assert fetch_kwargs["headers"]["Authorization"] == "Bearer bot-token"
+        assert fetch_kwargs["headers"]["Accept"] == "image/*,*/*;q=0.8"
+        cache_media.assert_called_once_with(
+            b"\x89PNG\r\n\x1a\nfake",
+            filename="img.png",
+            mime_type="image/png",
+            default_kind="image",
+        )
+        cache_public.assert_not_awaited()
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/img.png"]
+        assert event.media_types == ["image/png"]
+
+    @pytest.mark.anyio
     async def test_download_failure_degrades_to_text(self):
         from gateway.platforms.base import MessageType
 

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -765,12 +765,12 @@ class TestTeamsMessageHandling:
         assert event.source.chat_type == "group"
 
     @pytest.mark.anyio
-    async def test_channel_message_without_mention_allowed_when_respond_all_env_set(self, monkeypatch):
-        monkeypatch.setenv("TEAMS_RESPOND_TO_ALL_MESSAGES", "true")
+    async def test_channel_message_without_mention_allowed_when_respond_all_configured(self):
         adapter = TeamsAdapter(_make_config(
             client_id="bot-id",
             client_secret="secret",
             tenant_id="tenant",
+            respond_to_all_messages=True,
         ))
         adapter._app = MagicMock()
         adapter._app.id = "bot-id"
@@ -917,12 +917,14 @@ class TestTeamsMessageHandling:
         adapter._app.send.assert_not_awaited()
 
     @pytest.mark.anyio
-    async def test_mode_command_persists_conversation_override(self):
+    async def test_mode_command_persists_conversation_override(self, tmp_path):
+        state_file = tmp_path / "teams-response-modes.json"
         adapter = TeamsAdapter(_make_config(
             client_id="bot-id",
             client_secret="secret",
             tenant_id="tenant",
             mode_allowed_users="aad-456",
+            response_mode_state_file=str(state_file),
         ))
         self._ready_app(adapter)
         adapter.handle_message = AsyncMock()
@@ -938,6 +940,7 @@ class TestTeamsMessageHandling:
             client_id="bot-id",
             client_secret="secret",
             tenant_id="tenant",
+            response_mode_state_file=str(state_file),
         ))
         assert restored._conversation_responds_to_all(activity.conversation.id) is True
 

--- a/tests/tools/test_microsoft_graph_client.py
+++ b/tests/tools/test_microsoft_graph_client.py
@@ -135,6 +135,52 @@ class TestMicrosoftGraphClient:
         assert result["content_type"] == "video/mp4"
         assert result["size_bytes"] == len(b"meeting-recording")
 
+    async def test_get_bytes_returns_binary_content(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=b"image-bytes",
+                headers={"content-type": "image/png"},
+            )
+
+        client = MicrosoftGraphClient(
+            _make_provider(),
+            transport=httpx.MockTransport(handler),
+        )
+        result = await client.get_bytes("/teams/team/channels/channel/messages/msg/hostedContents/id/$value")
+
+        assert result.content == b"image-bytes"
+        assert result.content_type == "image/png"
+
+    async def test_get_bytes_follows_graph_download_redirect(self):
+        seen_urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_urls.append(str(request.url))
+            if str(request.url) == "https://graph.microsoft.com/v1.0/shares/u!abc/driveItem/content":
+                return httpx.Response(
+                    302,
+                    headers={"Location": "https://contoso.sharepoint.com/download"},
+                )
+            return httpx.Response(
+                200,
+                content=b"sharepoint-file",
+                headers={"content-type": "application/pdf"},
+            )
+
+        client = MicrosoftGraphClient(
+            _make_provider(),
+            transport=httpx.MockTransport(handler),
+        )
+        result = await client.get_bytes("/shares/u!abc/driveItem/content")
+
+        assert seen_urls == [
+            "https://graph.microsoft.com/v1.0/shares/u!abc/driveItem/content",
+            "https://contoso.sharepoint.com/download",
+        ]
+        assert result.content == b"sharepoint-file"
+        assert result.content_type == "application/pdf"
+
     async def test_download_to_file_streams_large_payload_in_chunks(
         self, tmp_path: Path, monkeypatch
     ):

--- a/tests/tools/test_microsoft_graph_client.py
+++ b/tests/tools/test_microsoft_graph_client.py
@@ -29,6 +29,21 @@ def _make_provider() -> MicrosoftGraphTokenProvider:
     return provider
 
 
+class _BodyShouldNotBeRead(httpx.AsyncByteStream):
+    async def __aiter__(self):
+        raise AssertionError("oversized Content-Length should reject before body read")
+        yield b""
+
+
+class _ChunkedBody(httpx.AsyncByteStream):
+    def __init__(self, *chunks: bytes) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
 @pytest.mark.anyio
 class TestMicrosoftGraphClient:
     async def test_attaches_bearer_token_header(self):
@@ -180,6 +195,47 @@ class TestMicrosoftGraphClient:
         ]
         assert result.content == b"sharepoint-file"
         assert result.content_type == "application/pdf"
+
+    async def test_get_bytes_rejects_oversized_content_length_before_reading_body(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                stream=_BodyShouldNotBeRead(),
+                headers={
+                    "content-length": "5",
+                    "content-type": "image/png",
+                },
+            )
+
+        client = MicrosoftGraphClient(
+            _make_provider(),
+            transport=httpx.MockTransport(handler),
+        )
+
+        with pytest.raises(ValueError, match="too large"):
+            await client.get_bytes(
+                "/teams/team/channels/channel/messages/msg/hostedContents/id/$value",
+                max_bytes=4,
+            )
+
+    async def test_get_bytes_rejects_oversized_chunked_body(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                stream=_ChunkedBody(b"12", b"345"),
+                headers={"content-type": "image/png"},
+            )
+
+        client = MicrosoftGraphClient(
+            _make_provider(),
+            transport=httpx.MockTransport(handler),
+        )
+
+        with pytest.raises(ValueError, match="too large"):
+            await client.get_bytes(
+                "/teams/team/channels/channel/messages/msg/hostedContents/id/$value",
+                max_bytes=4,
+            )
 
     async def test_download_to_file_streams_large_payload_in_chunks(
         self, tmp_path: Path, monkeypatch

--- a/tools/microsoft_graph_client.py
+++ b/tools/microsoft_graph_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncIterator, Awaitable, Callable
 
@@ -17,6 +18,14 @@ DEFAULT_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
 
 class MicrosoftGraphClientError(RuntimeError):
     """Base class for Graph client failures."""
+
+
+@dataclass(frozen=True)
+class MicrosoftGraphBinaryResponse:
+    """Binary response returned by Microsoft Graph."""
+
+    content: bytes
+    content_type: str | None = None
 
 
 class MicrosoftGraphAPIError(MicrosoftGraphClientError):
@@ -112,6 +121,26 @@ class MicrosoftGraphClient:
         if response.status_code == 204 or not response.content:
             return {"deleted": True, "status_code": response.status_code}
         return self._decode_json(response)
+
+    async def get_bytes(
+        self,
+        path: str,
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> MicrosoftGraphBinaryResponse:
+        response_headers = {"Accept": "*/*"}
+        if headers:
+            response_headers.update(headers)
+        response = await self._request(
+            "GET",
+            path,
+            headers=response_headers,
+            follow_redirects=True,
+        )
+        return MicrosoftGraphBinaryResponse(
+            content=response.content,
+            content_type=response.headers.get("content-type"),
+        )
 
     async def iterate_pages(
         self,
@@ -264,6 +293,7 @@ class MicrosoftGraphClient:
         params: dict[str, Any] | None = None,
         json_body: Any | None = None,
         headers: dict[str, str] | None = None,
+        follow_redirects: bool = False,
     ) -> httpx.Response:
         url = self._resolve_url(path_or_url)
         attempt = 0
@@ -287,6 +317,7 @@ class MicrosoftGraphClient:
                 async with httpx.AsyncClient(
                     timeout=httpx.Timeout(self.timeout),
                     transport=self._transport,
+                    follow_redirects=follow_redirects,
                 ) as client:
                     response = await client.request(
                         method,

--- a/tools/microsoft_graph_client.py
+++ b/tools/microsoft_graph_client.py
@@ -127,19 +127,99 @@ class MicrosoftGraphClient:
         path: str,
         *,
         headers: dict[str, str] | None = None,
+        max_bytes: int | None = None,
+        chunk_size: int = 65536,
     ) -> MicrosoftGraphBinaryResponse:
         response_headers = {"Accept": "*/*"}
         if headers:
             response_headers.update(headers)
-        response = await self._request(
-            "GET",
-            path,
-            headers=response_headers,
-            follow_redirects=True,
-        )
-        return MicrosoftGraphBinaryResponse(
-            content=response.content,
-            content_type=response.headers.get("content-type"),
+        url = self._resolve_url(path)
+        limit = self._resolve_binary_max_bytes(max_bytes)
+
+        attempt = 0
+        last_error: Exception | None = None
+
+        while attempt <= self.max_retries:
+            token = await self.token_provider.get_access_token(
+                force_refresh=attempt > 0 and self._should_refresh_token(last_error)
+            )
+            request_headers = {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+                "User-Agent": self.user_agent,
+            }
+            request_headers.update(response_headers)
+
+            try:
+                async with httpx.AsyncClient(
+                    timeout=httpx.Timeout(self.timeout),
+                    transport=self._transport,
+                    follow_redirects=True,
+                ) as client:
+                    async with client.stream(
+                        "GET",
+                        url,
+                        headers=request_headers,
+                    ) as response:
+                        if response.status_code >= 400:
+                            # Error bodies are expected to be small and need to
+                            # be materialized so API errors include details.
+                            await response.aread()
+                            api_error = self._build_api_error("GET", url, response)
+                            last_error = api_error
+
+                            if (
+                                response.status_code == 401
+                                and attempt < self.max_retries
+                            ):
+                                self.token_provider.clear_cache()
+                                await self._sleep(self._retry_delay(response, attempt))
+                                attempt += 1
+                                continue
+
+                            if (
+                                self._should_retry(response)
+                                and attempt < self.max_retries
+                            ):
+                                await self._sleep(self._retry_delay(response, attempt))
+                                attempt += 1
+                                continue
+
+                            raise api_error
+
+                        content_length = response.headers.get("content-length")
+                        if content_length:
+                            try:
+                                declared_size = int(content_length)
+                            except ValueError:
+                                declared_size = None
+                            if declared_size is not None:
+                                self._validate_binary_size(declared_size, limit)
+
+                        chunks: list[bytes] = []
+                        total = 0
+                        async for chunk in response.aiter_bytes(chunk_size=chunk_size):
+                            if not chunk:
+                                continue
+                            total += len(chunk)
+                            self._validate_binary_size(total, limit)
+                            chunks.append(chunk)
+                        return MicrosoftGraphBinaryResponse(
+                            content=b"".join(chunks),
+                            content_type=response.headers.get("content-type"),
+                        )
+            except httpx.HTTPError as exc:
+                last_error = exc
+                if attempt >= self.max_retries:
+                    raise MicrosoftGraphClientError(
+                        f"Microsoft Graph binary request failed for GET {url}: {exc}"
+                    ) from exc
+                await self._sleep(self._retry_delay(None, attempt))
+                attempt += 1
+                continue
+
+        raise MicrosoftGraphClientError(
+            f"Microsoft Graph binary request exhausted retries for GET {url}."
         )
 
     async def iterate_pages(
@@ -384,6 +464,34 @@ class MicrosoftGraphClient:
     @staticmethod
     def _should_refresh_token(error: Exception | None) -> bool:
         return isinstance(error, MicrosoftGraphAPIError) and error.status_code == 401
+
+    @staticmethod
+    def _resolve_binary_max_bytes(max_bytes: int | None) -> int:
+        if max_bytes is not None:
+            return int(max_bytes)
+        try:
+            from gateway.platforms.base import get_inbound_media_max_bytes
+
+            return int(get_inbound_media_max_bytes())
+        except Exception:
+            return 128 * 1024 * 1024
+
+    @staticmethod
+    def _validate_binary_size(size: int, max_bytes: int) -> None:
+        try:
+            from gateway.platforms.base import validate_inbound_media_size
+
+            validate_inbound_media_size(
+                size,
+                media_type="Graph media",
+                max_bytes=max_bytes,
+            )
+        except ImportError:
+            if max_bytes and size > max_bytes:
+                raise ValueError(
+                    f"Microsoft Graph binary response is too large "
+                    f"({size} bytes > {max_bytes} bytes)"
+                )
 
     @staticmethod
     def _retry_delay(response: httpx.Response | None, attempt: int) -> float:

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -22,6 +22,19 @@ Need meeting summaries from Microsoft Graph events rather than normal bot conver
 
 Teams delivers @mentions as regular messages with `<at>BotName</at>` tags, which Hermes strips automatically before processing.
 
+If your Teams app has resource-specific consent (RSC) permissions that make Teams deliver every group-chat or channel message to the bot, Hermes still ignores unmentioned group/channel messages by default. Set `TEAMS_RESPOND_TO_ALL_MESSAGES=true` or `platforms.teams.extra.respond_to_all_messages: true` only when you intentionally want the bot to process every message in shared spaces by default.
+
+Mode admins can also change the behavior for the current Teams conversation from inside Teams:
+
+```text
+@Hermes /teams-mode status
+@Hermes /teams-mode all
+@Hermes /teams-mode mentions
+@Hermes /teams-mode default
+```
+
+`all` makes Hermes process every delivered message in that conversation, `mentions` requires @mentions again, and `default` clears the conversation override so it follows `TEAMS_RESPOND_TO_ALL_MESSAGES` or `respond_to_all_messages`. Group-chat and channel mode commands must mention the bot; unmentioned command-like messages are consumed in shared spaces so they do not reach the agent as normal prompts. Hermes stores these overrides under `HERMES_HOME/state/teams_response_modes.json`.
+
 ---
 
 For source or local installs, include the Teams extra so the bundled adapter can
@@ -146,6 +159,9 @@ Open the printed link in your browser — it opens directly in the Teams client.
 | `TEAMS_HOME_CHANNEL` | Conversation ID for cron/proactive message delivery |
 | `TEAMS_HOME_CHANNEL_NAME` | Display name for the home channel |
 | `TEAMS_PORT` | Webhook port (default: `3978`) |
+| `TEAMS_RESPOND_TO_ALL_MESSAGES` | Set `true` to process every group-chat/channel message delivered by Teams; default requires @mention outside DMs |
+| `TEAMS_MODE_ALLOWED_USERS` | Comma-separated AAD object IDs allowed to run `/teams-mode`; defaults to `TEAMS_ALLOWED_USERS` |
+| `TEAMS_RESPONSE_MODE_STATE_FILE` | Optional path for persisted per-conversation `/teams-mode` overrides |
 
 ### config.yaml
 
@@ -160,6 +176,8 @@ platforms:
       client_secret: "your-secret"
       tenant_id: "your-tenant-id"
       port: 3978
+      respond_to_all_messages: false
+      mode_allowed_users: "aad-object-id-1,aad-object-id-2"
 ```
 
 ---
@@ -198,7 +216,7 @@ platforms:
       graph_ingest_attachments: false
 ```
 
-To use channel or group-chat Graph media fallback, configure the Teams app manifest with `webApplicationInfo` and `authorization.permissions.resourceSpecific` entries for `ChannelMessage.Read.Group` and/or `ChatMessage.Read.Chat`. The Entra app ID can be the same as the bot ID. Microsoft documents this manifest shape in [Receive all messages for bots and agents](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-messages-for-bots-and-agents).
+To use channel or group-chat Graph media fallback, configure the Teams app manifest with `webApplicationInfo` and `authorization.permissions.resourceSpecific` entries for `ChannelMessage.Read.Group` and/or `ChatMessage.Read.Chat`. The Entra app ID can be the same as the bot ID. Microsoft documents this manifest shape in [Receive all messages for bots and agents](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-messages-for-bots-and-agents). Those permissions can make Teams deliver every message to the bot; Hermes still requires an @mention outside DMs unless you set `respond_to_all_messages` or enable `respond-all` with `/teams-mode all` in that conversation.
 
 For Graph authentication, Hermes uses `MSGRAPH_TENANT_ID`, `MSGRAPH_CLIENT_ID`, and `MSGRAPH_CLIENT_SECRET` when present. If those are not set, it falls back to the Teams bot credentials. Reading SharePoint or OneDrive file bytes through Graph Drive content can require app-level file permissions such as `Files.Read.All` or `Sites.Read.All`, depending on your tenant policy; see Microsoft's [Download driveItem content](https://learn.microsoft.com/en-us/graph/api/driveitem-get-content) permissions table.
 

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -239,6 +239,7 @@ Make sure your configured port (`TEAMS_PORT`, default `3978`) is reachable from 
 | Bot responds with auth errors | Verify `TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, and `TEAMS_TENANT_ID` are all set correctly |
 | `No inference provider configured` | Check that `ANTHROPIC_API_KEY` (or another provider key) is set in `~/.hermes/.env` |
 | Bot receives messages but ignores them | Your AAD object ID may not be in `TEAMS_ALLOWED_USERS`. Run `teams status --verbose` to find it |
+| Image attachments do not reach the agent and logs show `[teams] Failed to cache image attachment` | Update Hermes to a version with authenticated Teams image fetches. Teams image `contentUrl` values can require the bot's Bot Framework token, so also verify `TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, and `TEAMS_TENANT_ID` are correct |
 | Tunnel URL changes on restart | devtunnel URLs are persistent if you use a named tunnel (`devtunnel create hermes-bot`). ngrok and cloudflared generate a new URL each run unless you have a paid plan — update the bot endpoint with `teams app update` when it changes |
 | Teams shows "This bot is not responding" | The webhook returned an error. Check `docker logs hermes` for tracebacks |
 | `[teams] Failed to connect` in logs | The SDK failed to authenticate. Double-check your credentials and that the tenant ID matches the account you used in `teams login` |

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -177,6 +177,31 @@ When the agent needs to run a potentially dangerous command, it sends an Adaptiv
 
 Clicking a button resolves the approval inline and replaces the card with the decision.
 
+### Channel and Group Chat Media
+
+Teams delivers personal-chat attachments through the normal Bot Framework attachment payload. Channel and group-chat messages can be more fragmented: inline images may be exposed as Graph hosted content, while file attachments are often SharePoint or OneDrive references.
+
+Hermes handles this in layers:
+
+1. Cache the Bot Framework attachment payload first.
+2. If a channel or group-chat message looked like it had media but no media was cached, read the message through Microsoft Graph.
+3. Download inline images from the message's `hostedContents`.
+4. Download reference attachments through the Graph Drive `/shares/{shareId}/driveItem/content` endpoint and cache them as images, documents, video, or audio based on the returned bytes and filename.
+
+Graph media fallback is enabled by default. Disable it if you only want Bot Framework attachment handling:
+
+```yaml
+platforms:
+  teams:
+    enabled: true
+    extra:
+      graph_ingest_attachments: false
+```
+
+To use channel or group-chat Graph media fallback, configure the Teams app manifest with `webApplicationInfo` and `authorization.permissions.resourceSpecific` entries for `ChannelMessage.Read.Group` and/or `ChatMessage.Read.Chat`. The Entra app ID can be the same as the bot ID. Microsoft documents this manifest shape in [Receive all messages for bots and agents](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-messages-for-bots-and-agents).
+
+For Graph authentication, Hermes uses `MSGRAPH_TENANT_ID`, `MSGRAPH_CLIENT_ID`, and `MSGRAPH_CLIENT_SECRET` when present. If those are not set, it falls back to the Teams bot credentials. Reading SharePoint or OneDrive file bytes through Graph Drive content can require app-level file permissions such as `Files.Read.All` or `Sites.Read.All`, depending on your tenant policy; see Microsoft's [Download driveItem content](https://learn.microsoft.com/en-us/graph/api/driveitem-get-content) permissions table.
+
 ### Meeting Summary Delivery (Teams Meeting Pipeline)
 
 When the [Teams meeting pipeline plugin](/user-guide/messaging/msgraph-webhook) is enabled, this adapter also handles outbound delivery of meeting summaries — one Teams integration surface, not two. After a meeting's transcript is summarized, the writer posts the summary into your chosen Teams target.
@@ -240,6 +265,7 @@ Make sure your configured port (`TEAMS_PORT`, default `3978`) is reachable from 
 | `No inference provider configured` | Check that `ANTHROPIC_API_KEY` (or another provider key) is set in `~/.hermes/.env` |
 | Bot receives messages but ignores them | Your AAD object ID may not be in `TEAMS_ALLOWED_USERS`. Run `teams status --verbose` to find it |
 | Image attachments do not reach the agent and logs show `[teams] Failed to cache image attachment` | Update Hermes to a version with authenticated Teams image fetches. Teams image `contentUrl` values can require the bot's Bot Framework token, so also verify `TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, and `TEAMS_TENANT_ID` are correct |
+| Channel or group-chat images/files still do not reach the agent | Verify the manifest has `ChannelMessage.Read.Group` and/or `ChatMessage.Read.Chat` under `authorization.permissions.resourceSpecific`, reinstall or update the app in that conversation, and make sure the Graph app can read hosted content and SharePoint/OneDrive file bytes |
 | Tunnel URL changes on restart | devtunnel URLs are persistent if you use a named tunnel (`devtunnel create hermes-bot`). ngrok and cloudflared generate a new URL each run unless you have a paid plan — update the bot endpoint with `teams app update` when it changes |
 | Teams shows "This bot is not responding" | The webhook returned an error. Check `docker logs hermes` for tracebacks |
 | `[teams] Failed to connect` in logs | The SDK failed to authenticate. Double-check your credentials and that the tenant ID matches the account you used in `teams login` |

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -22,7 +22,7 @@ Need meeting summaries from Microsoft Graph events rather than normal bot conver
 
 Teams delivers @mentions as regular messages with `<at>BotName</at>` tags, which Hermes strips automatically before processing.
 
-If your Teams app has resource-specific consent (RSC) permissions that make Teams deliver every group-chat or channel message to the bot, Hermes still ignores unmentioned group/channel messages by default. Set `TEAMS_RESPOND_TO_ALL_MESSAGES=true` or `platforms.teams.extra.respond_to_all_messages: true` only when you intentionally want the bot to process every message in shared spaces by default.
+If your Teams app has resource-specific consent (RSC) permissions that make Teams deliver every group-chat or channel message to the bot, Hermes still ignores unmentioned group/channel messages by default. Set `platforms.teams.extra.respond_to_all_messages: true` only when you intentionally want the bot to process every message in shared spaces by default.
 
 Mode admins can also change the behavior for the current Teams conversation from inside Teams:
 
@@ -33,7 +33,7 @@ Mode admins can also change the behavior for the current Teams conversation from
 @Hermes /teams-mode default
 ```
 
-`all` makes Hermes process every delivered message in that conversation, `mentions` requires @mentions again, and `default` clears the conversation override so it follows `TEAMS_RESPOND_TO_ALL_MESSAGES` or `respond_to_all_messages`. Group-chat and channel mode commands must mention the bot; unmentioned command-like messages are consumed in shared spaces so they do not reach the agent as normal prompts. Hermes stores these overrides under `HERMES_HOME/state/teams_response_modes.json`.
+`all` makes Hermes process every delivered message in that conversation, `mentions` requires @mentions again, and `default` clears the conversation override so it follows `respond_to_all_messages`. Group-chat and channel mode commands must mention the bot; unmentioned command-like messages are consumed in shared spaces so they do not reach the agent as normal prompts. Hermes stores these overrides under `HERMES_HOME/state/teams_response_modes.json` by default. Set `platforms.teams.extra.response_mode_state_file` if you need a custom state-file path.
 
 ---
 
@@ -159,9 +159,6 @@ Open the printed link in your browser — it opens directly in the Teams client.
 | `TEAMS_HOME_CHANNEL` | Conversation ID for cron/proactive message delivery |
 | `TEAMS_HOME_CHANNEL_NAME` | Display name for the home channel |
 | `TEAMS_PORT` | Webhook port (default: `3978`) |
-| `TEAMS_RESPOND_TO_ALL_MESSAGES` | Set `true` to process every group-chat/channel message delivered by Teams; default requires @mention outside DMs |
-| `TEAMS_MODE_ALLOWED_USERS` | Comma-separated AAD object IDs allowed to run `/teams-mode`; defaults to `TEAMS_ALLOWED_USERS` |
-| `TEAMS_RESPONSE_MODE_STATE_FILE` | Optional path for persisted per-conversation `/teams-mode` overrides |
 
 ### config.yaml
 
@@ -178,6 +175,7 @@ platforms:
       port: 3978
       respond_to_all_messages: false
       mode_allowed_users: "aad-object-id-1,aad-object-id-2"
+      response_mode_state_file: "~/.hermes/state/teams_response_modes.json"
 ```
 
 ---


### PR DESCRIPTION
## What does this PR do?

Fixes Microsoft Teams inbound media attachments that do not reach Hermes in two common cases, and prevents Teams RSC all-message delivery from making Hermes respond to every shared-space message by default.

Media fixes:

1. Inline image `contentUrl` values that require Bot Framework authorization.
2. Channel or group-chat media that Teams exposes through Microsoft Graph rather than as a directly downloadable Bot Framework attachment.

Shared-space response fix:

1. Personal chats still respond to every message.
2. Group chats and channels now require an explicit bot @mention by default.
3. Operators can still opt into all-message handling globally with `platforms.teams.extra.respond_to_all_messages: true`.
4. Authorized Teams users can select the response mode for the current conversation from inside Teams with `/teams-mode`.

In production the media bug produced logs like `[teams] Failed to cache image attachment: Client error '401 Unauthorized' ...`, leaving the agent with only the text portion of the message. The channel/group chat case affects inline images stored as Graph `hostedContents` and files stored as SharePoint/OneDrive references.

The adapter now keeps the existing fast media path first, then falls back to Graph only when a channel or group-chat message looked like it had media but no media was cached.

The response-mode change addresses the side effect of Teams RSC permissions: those permissions may cause Teams to deliver every channel/group-chat message to the bot. Hermes now ignores unmentioned shared-space messages unless the deployment or that conversation explicitly opts into `respond-all`.

## Related Issue

No public issue found. I searched existing issues and PRs for:

- `Teams image attachment 401`
- `Teams contentUrl`
- `Teams channel hostedContents`
- `chatMessageAttachment contentUrl`
- `Teams receive all messages`
- `respond_to_all_messages`

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `plugins/platforms/teams/adapter.py`
  - Added `_get_bot_bearer_token()` to retrieve the SDK-managed Bot Framework token when available.
  - Extended `_fetch_attachment_bytes()` to accept optional request headers.
  - Added `_cache_image_attachment()` so Teams image attachments are fetched with the bot bearer token before falling back to the public image downloader.
  - Added optional Graph fallback for channel/group-chat media.
  - Reads Graph message attachments and downloads SharePoint/OneDrive reference files through `/shares/{shareId}/driveItem/content`.
  - Reads Graph `hostedContents` for inline Teams-hosted images.
  - Preserves the existing Bot Framework path as the primary path and avoids Graph calls for plain text messages.
  - Requires bot @mentions for channel/group-chat messages by default, even when Teams delivers all messages via RSC.
  - Adds `platforms.teams.extra.respond_to_all_messages` to opt into all-message handling globally.
  - Adds per-conversation `/teams-mode` commands: `status`, `all`, `mentions`, and `default`.
  - Restricts `/teams-mode` changes to `platforms.teams.extra.mode_allowed_users`, with the existing Teams allowlist as a fallback.
  - Persists conversation overrides under `HERMES_HOME/state/teams_response_modes.json` by default, or `platforms.teams.extra.response_mode_state_file` when configured.
- `tools/microsoft_graph_client.py`
  - Added `get_bytes()` for binary Graph downloads.
  - Allows Graph binary downloads to follow the 302 redirect used by Drive content endpoints.
  - Bounds Graph binary reads before buffering by checking `Content-Length` and incremental streamed byte totals against the inbound media cap.
- `tests/gateway/test_teams.py`
  - Added regression coverage for bot-token image downloads.
  - Added coverage for Graph hosted images, Graph reference attachments, and the no-Graph plain-text path.
  - Added coverage for mention-gated shared-space messages.
  - Added coverage for `/teams-mode` authorization, persistence, and per-conversation overrides.
- `tests/tools/test_microsoft_graph_client.py`
  - Added coverage for binary content and redirect-following.
  - Added oversized Graph binary response regressions for both declared `Content-Length` and chunked/no-length bodies.
- `website/docs/user-guide/messaging/teams.md`
  - Documented channel/group-chat media ingestion, RSC manifest requirements, Graph credentials, and troubleshooting.
  - Documented shared-space response modes and `/teams-mode` commands using `config.yaml` settings for non-secret behavior controls.

## How to Test

1. Reproduce the authenticated attachment case on current upstream behavior:
   - Send a Microsoft Teams message with an image attachment whose `contentUrl` requires Bot Framework auth.
   - Observe Hermes logs like `[teams] Failed to cache image attachment: Client error '401 Unauthorized' ...`.
   - The resulting message event has no image media path for the agent.
2. Reproduce the channel/group-chat media case:
   - Install a Teams app with `ChannelMessage.Read.Group` or `ChatMessage.Read.Chat` RSC permissions.
   - Send an inline image or file in a channel/group chat.
   - If Teams does not provide a directly cacheable Bot Framework attachment, the current adapter emits text-only.
3. Reproduce the shared-space response issue:
   - Install a Teams app with all-message RSC permissions.
   - Send a normal, unmentioned channel/group-chat message.
   - Current behavior can dispatch the ambient message into Hermes.
   - With this PR, Hermes ignores it unless the bot is mentioned or response mode is set to `respond-all`.
4. Verify `/teams-mode`:
   - Mention the bot in a Teams channel/group chat and send `@Hermes /teams-mode status`.
   - As an authorized mode admin, send `@Hermes /teams-mode all`.
   - Send an unmentioned message in that conversation and verify Hermes processes it.
   - Send `@Hermes /teams-mode mentions` and verify unmentioned messages are ignored again.
5. Verify the focused tests:
   ```bash
   python -m py_compile plugins/platforms/teams/adapter.py tools/microsoft_graph_client.py tests/gateway/test_teams.py tests/tools/test_microsoft_graph_client.py
   python -m pytest tests/gateway/test_teams.py tests/tools/test_microsoft_graph_client.py -q
   ```

Local verification in an isolated venv:

```text
tests/gateway/test_teams.py tests/tools/test_microsoft_graph_client.py
85 passed in 0.68s
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS local checkout; Ubuntu Server VM for the original image-auth production patch

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact, or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## For New Skills

N/A

## Screenshots / Logs

Before:

```text
WARNING hermes_plugins.teams_platform.adapter: [teams] Failed to cache image attachment: Client error '401 Unauthorized' ...
Unmentioned channel/group-chat messages delivered through RSC could be dispatched to Hermes.
Graph binary attachment fallback buffered the response before the shared inbound-media cap could reject oversized content.
```

After:

```text
Teams image contentUrl fetch includes Authorization: Bearer <bot-token>
Graph hosted content and reference attachments cache into MessageEvent.media_urls
Graph binary reads are rejected by Content-Length or streamed byte count before buffering beyond the inbound media cap
Plain channel text does not trigger Graph media reads
Unmentioned shared-space messages are ignored unless that conversation or profile is in respond-all mode
```

