### PR TITLE
fix(cron): move SessionDB() inside try block to prevent fd leak on skip/block returns (#60859)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2613,14 +2613,7 @@ def run_job(
     # ---------------------------------------------------------------
     from run_agent import AIAgent
 
-    # Initialize SQLite session store so cron job messages are persisted
-    # and discoverable via session_search (same pattern as gateway/run.py).
     _session_db = None
-    try:
-        from hermes_state import SessionDB
-        _session_db = SessionDB()
-    except Exception as e:
-        logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
 
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
@@ -2767,6 +2760,14 @@ def run_job(
     # (every future job blocks on acquire_*); a leaked reader blocks all
     # future writers.  Acquire itself can't leak (it either blocks or returns).
     try:
+        # Initialize SQLite session store so cron job messages are persisted
+        # and discoverable via session_search (same pattern as gateway/run.py).
+        try:
+            from hermes_state import SessionDB
+            _session_db = SessionDB()
+        except Exception as e:
+            logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
+
         if _job_workdir:
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)


### PR DESCRIPTION
## Summary
SessionDB() was constructed before the main try block, but three early-return paths (wake gate skip, prompt injection block, no prompt) fired before the try's finally could close it. Each returned with an open SQLite connection.

## Root Cause
`_session_db = SessionDB()` at line ~2699 eagerly opens sqlite3.connect(). The only .close() was in the finally at line ~3347, reachable only from the agent execution path. Skip paths bypassed it entirely.

## Change
Moved SessionDB() construction inside the main try block. Skip paths now never open a connection; the agent path's existing finally always closes it.

## Verification
360 cron tests pass, 5 pre-existing failures unrelated to this fix.