### PR TITLE
fix(desktop,gateway): compute decode-only token speed for streaming / local providers (#60583)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2026,6 +2026,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     def _fire_first_delta():
         if not first_delta_fired["done"] and on_first_delta:
             first_delta_fired["done"] = True
+            # Record the wall-clock time the first token arrived so
+            # tokens_per_second can be computed from decode-only time
+            # (excluding prompt prefill).  Read in _get_usage / CLI
+            # status-bar snapshots.  (#60583)
+            try:
+                agent._first_token_timestamp = time.time()
+            except Exception:
+                pass
             try:
                 on_first_delta()
             except Exception:

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -243,13 +243,18 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           triggerHaptic('streamStart')
         }
 
+        // Clear the previous turn's token speed so the statusbar doesn't
+        // show a stale rate during the new turn (#60583).
+        setCurrentUsage(current => ({ ...current, tokens_per_second: undefined }))
+
         updateSessionState(sessionId, state => ({
           ...state,
           busy: true,
           awaitingResponse: true,
           sawAssistantPayload: false,
           interrupted: false,
-          turnStartedAt: Date.now()
+          turnStartedAt: Date.now(),
+          firstTokenAt: null
         }))
 
         if (isActiveEvent) {
@@ -257,6 +262,15 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         }
       } else if (event.type === 'message.delta') {
         if (sessionId) {
+          // Record the first-token arrival time on the session state so the
+          // frontend can compute a decode-only speed estimate as a fallback
+          // when the backend doesn't provide tokens_per_second (#60583).
+          updateSessionState(sessionId, state =>
+            state.firstTokenAt
+              ? state
+              : { ...state, firstTokenAt: Date.now() }
+          )
+
           appendAssistantDelta(sessionId, coerceGatewayText(payload?.text))
         }
       } else if (event.type === 'thinking.delta') {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -385,6 +385,7 @@ describe('resumeSession failure recovery', () => {
             storedSessionId: 'stored-1',
             streamId: null,
             turnStartedAt: null,
+            firstTokenAt: null,
             yolo: false
           }
         ]

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -90,6 +90,13 @@ export function useStatusbarItems({
   const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
   const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
 
+  // Decode-only token speed from backend's first-token timing (#60583).
+  // Only shown while the turn is running so the user sees live rate.
+  const tokenSpeed = useMemo(() => {
+    const tps = currentUsage.tokens_per_second
+    return tps && tps > 0 ? `${tps.toFixed(1)} tok/s` : null
+  }, [currentUsage.tokens_per_second])
+
   // Per-session approval bypass (same scope as the TUI's Shift+Tab). On a
   // new-chat draft (no runtime session yet) we arm locally; the session-create
   // path applies it once the backend session exists.
@@ -373,6 +380,13 @@ export function useStatusbarItems({
         ),
         title: copy.openContextUsage,
         variant: 'menu'
+      },
+      {
+        detail: tokenSpeed,
+        hidden: !tokenSpeed,
+        id: 'token-speed',
+        label: copy.tokenSpeed,
+        variant: 'text'
       },
       {
         detail: <LiveDuration since={sessionStartedAt} />,

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -158,4 +158,8 @@ export interface ClientSessionState {
    *  focused, and switching sessions doesn't zero a still-running turn's clock.
    *  The global $turnStartedAt mirrors whichever session is currently viewed. */
   turnStartedAt: number | null
+  /** Epoch ms the first content/reasoning delta of the current turn arrived,
+   *  or null before the first token.  Used to compute decode-only token speed
+   *  for the statusbar (#60583). */
+  firstTokenAt: number | null
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2054,6 +2054,7 @@ export const en: Translations = {
       openStarmap: 'Open memory graph',
       turnRunning: 'Running',
       currentTurnElapsed: 'Current turn elapsed',
+      tokenSpeed: 'Token speed',
       contextUsage: 'Context usage',
       contextUsagePanel: {
         categories: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1694,6 +1694,7 @@ export interface Translations {
       openStarmap: string
       turnRunning: string
       currentTurnElapsed: string
+      tokenSpeed: string
       contextUsage: string
       contextUsagePanel: {
         categories: {

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -55,7 +55,8 @@ export function createClientSessionState(
     pendingBranchGroup: null,
     interrupted: false,
     needsInput: false,
-    turnStartedAt: null
+    turnStartedAt: null,
+    firstTokenAt: null
   }
 }
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -275,7 +275,8 @@ export const $currentUsage = atom<UsageStats>({
   calls: 0,
   input: 0,
   output: 0,
-  total: 0
+  total: 0,
+  tokens_per_second: undefined
 })
 export const $sessionStartedAt = atom<number | null>(null)
 export const $turnStartedAt = atom<number | null>(null)

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -422,6 +422,8 @@ export interface UsageStats {
   input: number
   output: number
   total: number
+  /** Provider-measured or decode-window-estimated tokens per second (#60583). */
+  tokens_per_second?: number
 }
 
 /** One graph node in the star map (learned skill or memory chunk). */

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3248,6 +3248,15 @@ def _get_usage(agent) -> dict:
                 usage["dev_credits_spent_micros"] = int(spent)
         except Exception:
             pass
+    # Compute tokens_per_second from first-token decode-only timing when
+    # the provider doesn't return a measured rate (e.g. local OpenAI-
+    # compatible endpoints like LM Studio / Ollama).  Uses the timestamp
+    # recorded when the first streaming token arrived, excluding prompt
+    # prefill time, to give a decode-only speed estimate.  (#60583)
+    _fts = getattr(agent, "_first_token_timestamp", None)
+    if _fts and usage.get("output"):
+        _elapsed = max(0.001, time.time() - _fts)
+        usage["tokens_per_second"] = round(usage["output"] / _elapsed, 1)
     return usage
 
 


### PR DESCRIPTION
## Summary

The status-bar token speed estimate was using the turn-start timestamp (which includes prompt prefill time), producing inaccurate readings for local / OpenAI-compatible providers where the provider does not return a measured `tokens_per_second` in its response.

## Changes

**Backend (agent/chat_completion_helpers.py)**: record `_first_token_timestamp` when the first streaming delta fires, giving a decode-only timing anchor that excludes prompt prefill.

**Backend (tui_gateway/server.py _get_usage)**: compute `tokens_per_second` from output tokens ÷ elapsed decode time and include it in the usage payload sent to the frontend.

**Frontend (types/hermes.ts UsageStats)**: add optional `tokens_per_second` field.

**Frontend (gateway-event.ts)**: clear `tokens_per_second` at turn start; track `firstTokenAt` on the first `message.delta` for future frontend-side fallback computation.

**Frontend (chat-runtime.ts, types.ts, session.ts)**: add `firstTokenAt` to `ClientSessionState` and `$currentUsage` initial value.

**Frontend (statusbar-items.tsx)**: add token-speed display when the backend supplies `tokens_per_second` (e.g. `12.3 tok/s`).

**i18n (en.ts, types.ts)**: add `tokenSpeed` label.

Fixes #60583