### PR TITLE
fix(gateway): bound final shutdown cleanup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,6 +68,7 @@ _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+_SHUTDOWN_CLEANUP_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
@@ -3431,6 +3432,79 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else:
                 return max(0.0, timeout)
         return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
+
+    def _shutdown_cleanup_timeout_secs(self) -> float:
+        """Return the per-step timeout for late shutdown cleanup hooks."""
+        raw = os.getenv("HERMES_GATEWAY_SHUTDOWN_CLEANUP_TIMEOUT", "").strip()
+        if raw:
+            try:
+                timeout = float(raw)
+            except ValueError:
+                logger.warning(
+                    "Ignoring invalid HERMES_GATEWAY_SHUTDOWN_CLEANUP_TIMEOUT=%r",
+                    raw,
+                )
+            else:
+                return max(0.0, timeout)
+        return _SHUTDOWN_CLEANUP_TIMEOUT_SECS_DEFAULT
+
+    async def _run_bounded_shutdown_step(
+        self,
+        label: str,
+        func: Callable[[], Any],
+        *,
+        timeout: Optional[float] = None,
+    ) -> bool:
+        """Run a synchronous late-shutdown step without letting it wedge exit.
+
+        This is for best-effort cleanup after adapters are already down. The
+        worker is daemonized so a timed-out cleanup cannot keep the Python
+        process alive after the gateway has decided to exit.
+        """
+        timeout = self._shutdown_cleanup_timeout_secs() if timeout is None else timeout
+        if timeout <= 0:
+            try:
+                func()
+            except Exception as exc:
+                logger.debug("Shutdown phase %s failed: %s", label, exc)
+            return True
+
+        loop = asyncio.get_running_loop()
+        fut: concurrent.futures.Future = concurrent.futures.Future()
+
+        def _runner() -> None:
+            try:
+                result = func()
+            except BaseException as exc:  # noqa: BLE001 - report best-effort failures
+                fut.set_exception(exc)
+            else:
+                fut.set_result(result)
+
+        thread = threading.Thread(
+            target=_runner,
+            name=f"hermes-shutdown-{label}",
+            daemon=True,
+        )
+        thread.start()
+
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(asyncio.wrap_future(fut, loop=loop)),
+                timeout,
+            )
+            return True
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Shutdown phase %s exceeded %.1fs; continuing shutdown so the "
+                "gateway process can exit. The daemon cleanup thread may still "
+                "finish in the background. (#58666)",
+                label,
+                timeout,
+            )
+            return False
+        except Exception as exc:
+            logger.debug("Shutdown phase %s failed: %s", label, exc)
+            return True
 
     def _platform_connect_timeout_secs(self) -> float:
         """Return the per-platform connect timeout used during startup/retry."""
@@ -8322,9 +8396,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # where drain succeeded without interrupt, and (b) anything
             # that got respawned between the earlier call and adapter
             # disconnect (defense in depth; safe to call repeatedly).
-            _kill_tool_subprocesses("final-cleanup")
+            final_cleanup_done = await GatewayRunner._run_bounded_shutdown_step(
+                self,
+                "final-cleanup",
+                lambda: _kill_tool_subprocesses("final-cleanup"),
+                timeout=GatewayRunner._shutdown_cleanup_timeout_secs(self),
+            )
             logger.info(
-                "Shutdown phase: final-cleanup tool kill done at +%.2fs",
+                "Shutdown phase: final-cleanup tool kill %s at +%.2fs",
+                "done" if final_cleanup_done else "timed out",
                 _phase_elapsed(),
             )
 

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,10 +1,11 @@
 import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import gateway.run as gateway_run
-from gateway.config import HomeChannel, Platform
+from gateway.config import ChannelOverride, HomeChannel, Platform
 from gateway.platforms.base import MessageEvent
 from gateway.restart import GATEWAY_SERVICE_RESTART_EXIT_CODE
 from gateway.session import build_session_key
@@ -170,6 +171,58 @@ async def test_gateway_stop_launchd_service_restart_keeps_nonzero_exit(tmp_path,
         await runner.stop(restart=True, service_restart=True)
 
     assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_bounds_final_cleanup_after_channel_override_restart(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    """A wedged late cleanup must not keep launchd/service restarts alive.
+
+    Regression for #58666: with Telegram ``channel_overrides`` configured, the
+    reporter saw the shutdown log stop immediately after adapter disconnect,
+    before ``Gateway stopped`` / housekeeping shutdown could run.
+    """
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_GATEWAY_SHUTDOWN_CLEANUP_TIMEOUT", "0.01")
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner.config.platforms[Platform.TELEGRAM].channel_overrides = {
+        "-1234567890": ChannelOverride(system_prompt="You are a test assistant.")
+    }
+
+    entered_cleanup = threading.Event()
+    release_cleanup = threading.Event()
+
+    def _wedged_kill_all(task_id=None):
+        entered_cleanup.set()
+        release_cleanup.wait(timeout=5)
+        return 0
+
+    import tools.process_registry as _pr
+
+    monkeypatch.setattr(_pr.process_registry, "kill_all", _wedged_kill_all)
+
+    try:
+        with (
+            caplog.at_level("WARNING", logger="gateway.run"),
+            patch("gateway.status.remove_pid_file"),
+            patch("gateway.status.write_runtime_status"),
+        ):
+            await asyncio.wait_for(
+                runner.stop(restart=True, service_restart=True),
+                timeout=1,
+            )
+    finally:
+        release_cleanup.set()
+
+    assert entered_cleanup.is_set()
+    adapter.disconnect.assert_awaited_once()
+    assert runner._shutdown_event.is_set() is True
+    assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+    assert "Shutdown phase final-cleanup exceeded 0.0s" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #58666.

When `/restart` is requested under a service manager, the gateway already sets `_shutdown_event` after adapter teardown, but it immediately runs final tool/environment cleanup inline on the event loop. If that best-effort cleanup wedges, the loop never yields back to the main gateway task, so housekeeping never stops and launchd/systemd never observes process exit.

This adds a bounded late-shutdown cleanup helper for the post-adapter `final-cleanup` phase:

- runs the synchronous cleanup in a daemon worker thread so a wedged hook cannot keep the process alive
- waits up to `gateway.shutdown_cleanup_timeout` (default 5s)
- logs and continues shutdown if the cleanup is wedged
- keeps existing inline behavior available with timeout `0`

The regression mirrors the reported Telegram `channel_overrides` configuration and forces only the post-disconnect cleanup to hang. `stop(restart=True, service_restart=True)` now still completes and preserves the service-restart exit code.

## Duplicate / overlap check

- Exact open PR search for `58666 in:title,body`: no results.
- Preflight warning overlaps were broad keyword hits for `channel_overrides`, `final-cleanup`, and `restart`; inspected relevant recent PRs (#60359, #59079) and they do not cover this post-disconnect shutdown wedge.

## Validation

```bash
uv run --extra dev pytest tests/gateway/test_gateway_shutdown.py -q
# 21 passed

uv run --extra dev pytest tests/gateway/test_restart_drain.py tests/gateway/test_bounded_adapter_teardown.py tests/gateway/test_channel_overrides.py -q
# 45 passed

uv run --extra dev ruff check gateway/run.py tests/gateway/test_gateway_shutdown.py
# All checks passed

git diff --check
# pass

gitleaks git --log-opts='origin/main..HEAD' --redact .
# no leaks found
```