### PR TITLE
fix(relay): carry routed profile through the passthrough-plane forward too

### DIFF
--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -117,8 +117,13 @@ Both absent ⇒ byte-identical to today. A connector that never sends them, or a
 
 `PassthroughForward` is the wire form of a forwarded passthrough-plane request
 (Class-2/3 webhooks — Discord interactions, Twilio): `{platform, botId, method,
-path, headers: [[k,v],…], bodyB64}`. The body is base64-encoded so arbitrary
-bytes survive the newline-delimited-JSON transport; the gateway base64-decodes
+path, headers: [[k,v],…], bodyB64, profile?}`. `profile` is optional — the
+connector stamps it when NAS resolves the target profile for a Team-Gateway
+interaction; omitting it (single-profile gateways) preserves legacy routing to
+the default `agent:main` session namespace, mirroring the `profile` field the
+`inbound` frame's `SessionSource` already carries (#60586). The body is
+base64-encoded so arbitrary bytes survive the newline-delimited-JSON transport;
+the gateway base64-decodes
 back to the exact bytes the connector forwarded (the connector already verified
 the provider signature and stripped any shared-identity credential at the edge —
 §6 — so the gateway re-processes a sanitized, token-free body and acts on it via

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -763,6 +763,13 @@ class RelayAdapter(BasePlatformAdapter):
             if guild_id
             else None,  # Discord guild → generic scope slot
             message_id=str(payload.get("id")) if payload.get("id") else None,
+            # The HERMES profile this interaction is routed to (multiplex
+            # mode) — mirrors _event_from_wire's profile stamping for plain
+            # relayed messages (#60586). Without this, a Team-Gateway's
+            # Discord slash-command/button/modal always fell back to the
+            # legacy agent:main namespace even when the connector resolved
+            # a specific profile for it.
+            profile=getattr(forward, "profile", None),
         )
         event = MessageEvent(text=text, message_type=message_type, source=source)
         if itype == 3:

--- a/gateway/relay/ws_transport.py
+++ b/gateway/relay/ws_transport.py
@@ -344,6 +344,16 @@ class PassthroughForward:
     path: str
     headers: list[tuple[str, str]]
     body: bytes
+    # The HERMES profile this interaction is routed to (multiplex mode).
+    # Mirrors the ``profile`` field _event_from_wire already carries on the
+    # ``inbound`` frame's SessionSource (#60586) — the connector stamps it
+    # when NAS resolves the target profile for a Team-Gateway interaction;
+    # absent for a single-profile gateway, where it stays None and session
+    # keys keep the legacy ``agent:main`` namespace. Without this, a Discord
+    # slash-command/button/modal relayed through the passthrough plane always
+    # fell back to agent:main even when the equivalent plain message would
+    # have been routed to the correct profile.
+    profile: Optional[str] = None
 
 
 def _passthrough_from_wire(raw: Dict[str, Any]) -> PassthroughForward:
@@ -373,6 +383,7 @@ def _passthrough_from_wire(raw: Dict[str, Any]) -> PassthroughForward:
         path=str(raw.get("path", "")),
         headers=headers,
         body=body,
+        profile=raw.get("profile"),
     )
 
 

--- a/tests/gateway/relay/test_relay_passthrough.py
+++ b/tests/gateway/relay/test_relay_passthrough.py
@@ -44,7 +44,7 @@ def adapter():
     return RelayAdapter(PlatformConfig(), _desc(), transport=StubConnector(_desc()))
 
 
-def _interaction_forward(payload: dict) -> PassthroughForward:
+def _interaction_forward(payload: dict, *, profile: str | None = None) -> PassthroughForward:
     body = json.dumps(payload).encode("utf-8")
     return PassthroughForward(
         platform="discord",
@@ -53,6 +53,7 @@ def _interaction_forward(payload: dict) -> PassthroughForward:
         path="/interactions/discord/appShared",
         headers=[("content-type", "application/json")],
         body=body,
+        profile=profile,
     )
 
 
@@ -73,6 +74,39 @@ def test_passthrough_from_wire_byte_preserves_body():
     assert fwd.bot_id == "appShared"
     assert fwd.body == original
     assert fwd.headers == [("content-type", "application/json")]
+
+
+def test_passthrough_from_wire_stamps_routed_profile():
+    """A connector-routed profile on the wire frame lands on PassthroughForward.
+
+    Mirrors _event_from_wire's profile stamping for the ``inbound`` frame
+    (#60586) — the passthrough plane needs the same carry-through so a
+    Team-Gateway's Discord interactions route to the same profile a plain
+    message would.
+    """
+    wire = {
+        "platform": "discord",
+        "botId": "appShared",
+        "method": "POST",
+        "path": "/interactions/discord/appShared",
+        "headers": [],
+        "bodyB64": "",
+        "profile": "reviewer",
+    }
+    fwd = _passthrough_from_wire(wire)
+    assert fwd.profile == "reviewer"
+
+
+def test_passthrough_from_wire_profile_absent_is_none():
+    """No ``profile`` on the wire (single-profile gateway) → None.
+
+    Back-compat: a connector that never sets ``profile`` yields the legacy
+    behaviour, and session keys stay in the ``agent:main`` namespace.
+    """
+    fwd = _passthrough_from_wire(
+        {"platform": "discord", "botId": "appShared", "method": "POST", "path": "/x", "headers": [], "bodyB64": ""}
+    )
+    assert fwd.profile is None
 
 
 @pytest.mark.asyncio
@@ -123,6 +157,43 @@ async def test_discord_interaction_routes_through_handle_message(adapter, monkey
     assert ev.source.chat_type == "channel"
     # Scope captured so the agent's reply re-asserts scope_id for egress.
     assert adapter._scope_by_chat.get("chan-9") == "guild-7"
+    # Back-compat: no profile on the forward (single-profile gateway) → None,
+    # session keys stay in the legacy agent:main namespace.
+    assert ev.source.profile is None
+
+
+@pytest.mark.asyncio
+async def test_discord_interaction_stamps_routed_profile(adapter, monkeypatch):
+    """A connector-routed profile on the passthrough forward lands on the
+    resulting event's SessionSource, the same way it does for a plain relayed
+    message (#60586) — so a Team-Gateway's Discord slash-command/button/modal
+    routes to the same profile a plain message would, instead of always
+    falling back to agent:main."""
+    await adapter.connect()
+    stub = adapter._transport
+
+    seen = []
+
+    async def fake_handle(event):
+        seen.append(event)
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle)
+
+    fwd = _interaction_forward(
+        {
+            "id": "interaction-2",
+            "type": 2,  # APPLICATION_COMMAND
+            "channel_id": "chan-9",
+            "guild_id": "guild-7",
+            "data": {"name": "summarize"},
+            "member": {"user": {"id": "user-3", "username": "ben"}},
+        },
+        profile="reviewer",
+    )
+    await stub.push_passthrough(fwd, buffer_id=None)
+
+    assert len(seen) == 1
+    assert seen[0].source.profile == "reviewer"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
#60586 stamped `source.profile` from the connector's wire source in `_event_from_wire` so a Team-Gateway (multiplex mode) message routes to the NAS-resolved profile instead of always falling back to the legacy `agent:main` namespace. Its commit message called this "the last missing link for NAS-driven per-profile routing over the relay in multiplex mode" — but the passthrough plane (Discord interactions forwarded via `passthrough_forward`, Phase 5 §5.1) is a second, independent inbound path that builds its own `SessionSource` from scratch in `_discord_interaction_to_event`, and never carried `profile` either:

- `PassthroughForward` (`ws_transport.py`) had no `profile` field at all.
- `_passthrough_from_wire()` never read one off the wire frame.
- `_discord_interaction_to_event()` (`adapter.py`) built its `SessionSource` without a `profile=` kwarg.

So a Discord slash-command / button / modal interaction relayed through a Team-Gateway's passthrough plane always fell back to `agent:main` even when the equivalent plain chat message — going through the exact sibling path #60586 fixed — would correctly route to the connector's resolved profile, silently bypassing the per-profile config/credential scoping multiplex mode exists to enforce.

## Changes
- `gateway/relay/ws_transport.py`: add `profile: Optional[str] = None` to `PassthroughForward`; read it in `_passthrough_from_wire()`.
- `gateway/relay/adapter.py`: pass `profile=getattr(forward, "profile", None)` into the `SessionSource` built in `_discord_interaction_to_event()`.
- `tests/gateway/relay/test_relay_passthrough.py`: wire-level stamping (present/absent) tests, and a full `push_passthrough -> handle_message` round trip asserting the resulting event's `source.profile`.

Mirrors #60586's fix and back-compat contract exactly: `PassthroughForward.profile` defaults to `None`, so an absent wire field (single-profile gateway, or a connector that hasn't shipped the field for this frame type yet) is byte-identical to today.

## Test plan
- [x] New tests reproduce the gap (wire-level and full round-trip) and pass after the fix
- [x] Mutation-verified: reverting the fix makes the new tests — and two pre-existing tests whose shared `_interaction_forward` helper now exercises the new field — fail with `TypeError` against the pre-fix code
- [x] Full relay + capability-surface + nemo-relay-plugin suite (219 tests) passes
- [x] `ruff check` clean on all three changed files