### PR TITLE
fix(agent): persist steer metadata to session db

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -40,7 +40,11 @@ from agent.message_sanitization import (
     tool_result_id_variants,
 )
 from agent.prompt_builder import format_steer_marker
-from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
+from agent.tool_dispatch_helpers import (
+    _session_db_text_content,
+    _trajectory_normalize_msg,
+    make_tool_result_message,
+)
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import (
     STATUS_EXHAUSTED,
@@ -4495,6 +4499,63 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
 
 
 
+def _merged_steer_applied(existing: Any, steer_text: str) -> Any:
+    """Merge steer metadata without losing earlier applied steer text."""
+    if existing is None:
+        return [steer_text]
+    if isinstance(existing, list):
+        return [*existing, steer_text]
+    if isinstance(existing, str):
+        return [existing, steer_text] if existing else [steer_text]
+    return [existing, steer_text]
+
+
+def _persist_tool_result_steer(agent, tool_msg: dict) -> None:
+    session_db = getattr(agent, "_session_db", None)
+    update = getattr(session_db, "update_message_steer", None)
+    if not callable(update):
+        return
+    session_id = getattr(agent, "session_id", None)
+    tool_call_id = tool_msg.get("tool_call_id")
+    if not session_id or not tool_call_id:
+        return
+    try:
+        update(
+            session_id,
+            tool_call_id,
+            _session_db_text_content(tool_msg.get("content")),
+            tool_msg.get("_steer_applied"),
+        )
+    except Exception as exc:
+        logger.debug("Failed to persist /steer update for tool result: %s", exc)
+
+
+def apply_steer_to_tool_message(agent, tool_msg: dict, steer_text: str) -> bool:
+    """Append steer text to one tool result and persist the mutation if possible."""
+    if not isinstance(tool_msg, dict) or not steer_text:
+        return False
+    marker = format_steer_marker(steer_text)
+    existing_content = tool_msg.get("content", "")
+    if not isinstance(existing_content, str):
+        # Anthropic multimodal content blocks — preserve them and append
+        # a text block at the end.
+        try:
+            blocks = list(existing_content) if existing_content else []
+            blocks.append({"type": "text", "text": marker.lstrip()})
+            tool_msg["content"] = blocks
+        except Exception:
+            # Fall back to string replacement if content shape is unexpected.
+            tool_msg["content"] = f"{existing_content}{marker}"
+    else:
+        tool_msg["content"] = existing_content + marker
+    tool_msg["_steer_applied"] = _merged_steer_applied(
+        tool_msg.get("_steer_applied"),
+        steer_text,
+    )
+    _persist_tool_result_steer(agent, tool_msg)
+    return True
+
+
 def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: int) -> None:
     """Append any pending /steer text to the last tool result in this turn.
 
@@ -4538,20 +4599,7 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
             existing = getattr(agent, "_pending_steer", None)
             agent._pending_steer = (existing + "\n" + steer_text) if existing else steer_text
         return
-    marker = format_steer_marker(steer_text)
-    existing_content = messages[target_idx].get("content", "")
-    if not isinstance(existing_content, str):
-        # Anthropic multimodal content blocks — preserve them and append
-        # a text block at the end.
-        try:
-            blocks = list(existing_content) if existing_content else []
-            blocks.append({"type": "text", "text": marker.lstrip()})
-            messages[target_idx]["content"] = blocks
-        except Exception:
-            # Fall back to string replacement if content shape is unexpected.
-            messages[target_idx]["content"] = f"{existing_content}{marker}"
-    else:
-        messages[target_idx]["content"] = existing_content + marker
+    apply_steer_to_tool_message(agent, messages[target_idx], steer_text)
     _ra().logger.info(
         "Delivered /steer to agent after tool batch (%d chars): %s",
         len(steer_text),

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -26,6 +26,7 @@ import sys
 import time
 from typing import Any, Dict, List, Optional
 
+from agent.agent_runtime_helpers import apply_steer_to_tool_message
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.conversation_compression import (
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
@@ -341,6 +342,27 @@ def _moa_client_consumes_prepared_request(client: Any) -> bool:
     """
     completions = getattr(getattr(client, "chat", None), "completions", None)
     return callable(getattr(completions, "prepare", None))
+
+
+_EPHEMERAL_API_MESSAGE_FIELDS = (
+    "reasoning",
+    "finish_reason",
+    "_steer_applied",
+    "_length_continuation_fragment",
+    "_length_continuation_nudge",
+)
+
+
+def strip_ephemeral_api_fields(api_msg: dict) -> None:
+    """Remove internal-only fields before later wire sanitization.
+
+    ``_thinking_prefill`` intentionally survives this pass: the subsequent
+    thinking-only-message filter needs that marker to drop repaired prefill
+    stubs. The transport removes remaining underscore-prefixed keys before
+    provider submission.
+    """
+    for field in _EPHEMERAL_API_MESSAGE_FIELDS:
+        api_msg.pop(field, None)
 
 
 def _join_truncated_parts(parts: List[str]) -> str:
@@ -2119,20 +2141,7 @@ def run_conversation(
             for _si in range(len(messages) - 1, -1, -1):
                 _sm = messages[_si]
                 if isinstance(_sm, dict) and _sm.get("role") == "tool":
-                    from agent.prompt_builder import format_steer_marker
-                    marker = format_steer_marker(_pre_api_steer)
-                    existing = _sm.get("content", "")
-                    if isinstance(existing, str):
-                        _sm["content"] = existing + marker
-                    else:
-                        # Multimodal content blocks — append text block
-                        try:
-                            blocks = list(existing) if existing else []
-                            blocks.append({"type": "text", "text": marker})
-                            _sm["content"] = blocks
-                        except Exception:
-                            pass
-                    _injected = True
+                    _injected = apply_steer_to_tool_message(agent, _sm, _pre_api_steer)
                     logger.debug(
                         "Pre-API-call steer drain: injected into tool msg at index %d",
                         _si,
@@ -2328,18 +2337,10 @@ def run_conversation(
             # This ensures multi-turn reasoning context is preserved
             agent._copy_reasoning_content_for_api(msg, api_msg)
 
-            # Remove 'reasoning' field - it's for trajectory storage only
-            # We've copied it to 'reasoning_content' for the API above
-            if "reasoning" in api_msg:
-                api_msg.pop("reasoning")
-            # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
-            if "finish_reason" in api_msg:
-                api_msg.pop("finish_reason")
-            # _thinking_prefill survives here intentionally: the drop pass below
-            # needs it. The transport strips all underscore keys before the wire.
-            # Strip length-continuation marks; not every transport drops underscore keys.
-            api_msg.pop("_length_continuation_fragment", None)
-            api_msg.pop("_length_continuation_nudge", None)
+            # Strip internal storage/UI-only fields. Reasoning was copied to
+            # reasoning_content above; /steer text is already in content.
+            # _thinking_prefill survives intentionally for the drop pass below.
+            strip_ephemeral_api_fields(api_msg)
             # Strip Codex Responses API fields (call_id, response_item_id) for
             # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
             # Uses new dicts so the internal messages list retains the fields

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -430,6 +430,26 @@ def _multimodal_text_summary(value: Any) -> str:
         return str(value)
 
 
+def _session_db_text_content(value: Any) -> Any:
+    """Apply the session store's text-only multimodal persistence policy."""
+    if _is_multimodal_tool_result(value):
+        return _multimodal_text_summary(value)
+    if not isinstance(value, list):
+        return value
+
+    text_parts = []
+    for part in value:
+        if isinstance(part, dict) and part.get("type") == "text":
+            text_parts.append(str(part.get("text", "")))
+        elif isinstance(part, dict) and part.get("type") in {
+            "image",
+            "image_url",
+            "input_image",
+        }:
+            text_parts.append("[screenshot]")
+    return "\n".join(text_parts) if text_parts else None
+
+
 def _append_subdir_hint_to_multimodal(value: Dict[str, Any], hint: str) -> None:
     """Mutate a multimodal tool-result envelope to append a subdir hint.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11079,6 +11079,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         _compressed_summary: bool = False,
         timestamp: Any = None,
         api_content: Optional[str] = None,
+        steer_applied: Any = None,
         display_kind: Optional[str] = None,
         display_metadata: Optional[Dict[str, Any]] = None,
         compression_lock_holder: Optional[str] = None,
@@ -11121,6 +11122,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             except (json.JSONDecodeError, TypeError):
                 tool_calls = []
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+        steer_applied_json = (
+            json.dumps(steer_applied) if steer_applied is not None else None
+        )
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
         stored_content = self._encode_content(content)
@@ -11150,10 +11154,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
+                   tool_calls, tool_name, effect_disposition, steer_applied,
+                   timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, _compressed_summary, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -11162,6 +11167,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     tool_calls_json,
                     _scrub_surrogates(tool_name),
                     effect_disposition,
+                    steer_applied_json,
                     message_timestamp,
                     token_count,
                     finish_reason,
@@ -11316,6 +11322,40 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ),
             )
             return True
+
+        return bool(self._execute_write(_do))
+
+    def update_message_steer(
+        self,
+        session_id: str,
+        tool_call_id: str,
+        content: Any,
+        steer_applied: Any,
+    ) -> bool:
+        """Update an already-persisted active tool result after /steer lands.
+
+        Tool rows are appended before steer can be applied. Match only the
+        active tool result for this session/tool_call_id so archived or forked
+        rows are not rewritten.
+        """
+        if not session_id or not tool_call_id:
+            return False
+        stored_content = self._encode_content(content)
+        steer_applied_json = (
+            json.dumps(steer_applied) if steer_applied is not None else None
+        )
+
+        def _do(conn):
+            cursor = conn.execute(
+                """UPDATE messages
+                   SET content = ?, steer_applied = ?
+                   WHERE session_id = ?
+                     AND tool_call_id = ?
+                     AND role = 'tool'
+                     AND active = 1""",
+                (stored_content, steer_applied_json, session_id, tool_call_id),
+            )
+            return cursor.rowcount > 0
 
         return bool(self._execute_write(_do))
 
@@ -11526,7 +11566,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchone()
 
         return row[0] if row else None
-
     def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
         """Insert *messages* as fresh active rows for *session_id*.
 
@@ -11572,6 +11611,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 except (json.JSONDecodeError, TypeError):
                     tool_calls = []
             tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+            steer_applied_json = (
+                json.dumps(msg.get("_steer_applied"))
+                if msg.get("_steer_applied") is not None
+                else None
+            )
             # Accept either `platform_message_id` (new explicit name) or
             # `message_id` (yuanbao's existing convention on message dicts).
             platform_msg_id = (
@@ -11582,10 +11626,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
             cur = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
+                   tool_calls, tool_name, effect_disposition, steer_applied,
+                   timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, _compressed_summary, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -11594,6 +11639,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     tool_calls_json,
                     _scrub_surrogates(msg.get("tool_name")),
                     msg.get("effect_disposition"),
+                    steer_applied_json,
                     message_timestamp,
                     msg.get("token_count"),
                     msg.get("finish_reason"),
@@ -12092,7 +12138,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
                     msg["tool_calls"] = []
             if msg.get("display_metadata") is not None:
-                msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
+                msg["display_metadata"] = self._decode_display_metadata(
+                    msg["display_metadata"]
+                )
+            if msg.get("steer_applied") is not None:
+                try:
+                    msg["_steer_applied"] = json.loads(msg["steer_applied"])
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning(
+                        "Failed to deserialize steer_applied in get_messages, "
+                        "falling back to raw value"
+                    )
+                    msg["_steer_applied"] = msg["steer_applied"]
             result.append(msg)
         return result
 
@@ -12356,6 +12413,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # SELECT can feed both the model-fed and display views.
     _CONVERSATION_ROW_COLUMNS = (
         "id, role, content, tool_call_id, tool_calls, tool_name, effect_disposition, "
+        "steer_applied, "
         "finish_reason, reasoning, reasoning_content, reasoning_details, "
         "codex_reasoning_items, codex_message_items, platform_message_id, observed, "
         "_compressed_summary, timestamp, "
@@ -12434,6 +12492,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 msg["tool_name"] = row["tool_name"]
             if row["effect_disposition"]:
                 msg["effect_disposition"] = row["effect_disposition"]
+            if row["steer_applied"] is not None:
+                try:
+                    msg["_steer_applied"] = json.loads(row["steer_applied"])
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning(
+                        "Failed to deserialize steer_applied in conversation replay, "
+                        "falling back to raw value"
+                    )
+                    msg["_steer_applied"] = row["steer_applied"]
             if row["tool_calls"]:
                 try:
                     msg["tool_calls"] = json.loads(row["tool_calls"])

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -436,6 +436,7 @@ CREATE TABLE IF NOT EXISTS messages (
     tool_calls TEXT,
     tool_name TEXT,
     effect_disposition TEXT,
+    steer_applied TEXT,
     timestamp REAL NOT NULL,
     token_count INTEGER,
     finish_reason TEXT,

--- a/run_agent.py
+++ b/run_agent.py
@@ -214,6 +214,7 @@ from agent.tool_dispatch_helpers import (
     _paths_overlap,  # noqa: F401  # re-exported for tests that `from run_agent import _paths_overlap`
     _is_multimodal_tool_result,
     _multimodal_text_summary,
+    _session_db_text_content,
     _append_subdir_hint_to_multimodal,  # noqa: F401  # re-exported for tests that `from run_agent import _append_subdir_hint_to_multimodal`
     _extract_file_mutation_targets,
     _extract_landed_file_mutation_paths,
@@ -2326,20 +2327,9 @@ class AIAgent:
                     and sanitize_context(content).strip() != content.strip()
                 ):
                     _row_api_content = content
-                # Persist multimodal tool results as their text summary only —
-                # base64 images would bloat the session DB and aren't useful
-                # for cross-session replay.
-                if _is_multimodal_tool_result(content):
-                    content = _multimodal_text_summary(content)
-                elif isinstance(content, list):
-                    # List of OpenAI-style content parts: strip images, keep text.
-                    _txt = []
-                    for p in content:
-                        if isinstance(p, dict) and p.get("type") == "text":
-                            _txt.append(str(p.get("text", "")))
-                        elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
-                            _txt.append("[screenshot]")
-                    content = "\n".join(_txt) if _txt else None
+                # Keep session persistence text-only; image blocks belong in
+                # live provider context, not state.db.
+                content = _session_db_text_content(content)
                 tool_calls_data = None
                 if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
                     tool_calls_data = [
@@ -2363,6 +2353,7 @@ class AIAgent:
                     "codex_reasoning_items": msg.get("codex_reasoning_items"),
                     "codex_message_items": msg.get("codex_message_items"),
                     "_compressed_summary": bool(msg.get(COMPRESSED_SUMMARY_METADATA_KEY)),
+                    "_steer_applied": msg.get("_steer_applied"),
                     "timestamp": _row_timestamp,
                     "api_content": _row_api_content,
                     # Standalone reference handoffs are always hidden, even

--- a/tests/hermes_state/test_steer_metadata_persistence.py
+++ b/tests/hermes_state/test_steer_metadata_persistence.py
@@ -1,0 +1,153 @@
+import json
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        yield session_db
+    finally:
+        session_db.close()
+
+
+def test_update_message_steer_round_trips_content_and_metadata(db):
+    db.create_session(session_id="s1", source="cli")
+    db.append_message(
+        "s1",
+        role="tool",
+        content="tool output",
+        tool_call_id="call-1",
+        tool_name="terminal",
+    )
+
+    updated = db.update_message_steer(
+        "s1",
+        "call-1",
+        "tool output\n\n<steer>look at stderr</steer>",
+        ["look at stderr"],
+    )
+
+    assert updated is True
+    messages = db.get_messages("s1")
+    assert messages[0]["content"].endswith("<steer>look at stderr</steer>")
+    assert messages[0]["_steer_applied"] == ["look at stderr"]
+
+    conversation = db.get_messages_as_conversation("s1")
+    assert conversation[0]["content"].endswith("<steer>look at stderr</steer>")
+    assert conversation[0]["_steer_applied"] == ["look at stderr"]
+
+
+def test_update_message_steer_only_updates_active_tool_row(db):
+    db.create_session(session_id="s1", source="cli")
+    db.append_message(
+        "s1",
+        role="tool",
+        content="archived output",
+        tool_call_id="call-1",
+    )
+    with db._lock:
+        db._conn.execute(
+            "UPDATE messages SET active = 0 WHERE session_id = ?",
+            ("s1",),
+        )
+        db._conn.commit()
+    db.append_message(
+        "s1",
+        role="tool",
+        content="active output",
+        tool_call_id="call-1",
+    )
+
+    updated = db.update_message_steer(
+        "s1",
+        "call-1",
+        "active output\nsteered",
+        ["steered"],
+    )
+
+    assert updated is True
+    rows = db._conn.execute(
+        "SELECT content, steer_applied, active FROM messages "
+        "WHERE session_id = ? ORDER BY id",
+        ("s1",),
+    ).fetchall()
+    assert rows[0]["content"] == "archived output"
+    assert rows[0]["steer_applied"] is None
+    assert rows[0]["active"] == 0
+    assert rows[1]["content"] == "active output\nsteered"
+    assert json.loads(rows[1]["steer_applied"]) == ["steered"]
+    assert rows[1]["active"] == 1
+
+
+def test_replace_messages_preserves_steer_metadata(db):
+    db.create_session(session_id="s1", source="cli")
+    db.replace_messages(
+        "s1",
+        [
+            {
+                "role": "tool",
+                "content": "tool output",
+                "tool_call_id": "call-1",
+                "_steer_applied": ["focus here"],
+            },
+        ],
+    )
+
+    assert db.get_messages("s1")[0]["_steer_applied"] == ["focus here"]
+    assert db.get_messages_as_conversation("s1")[0]["_steer_applied"] == ["focus here"]
+
+
+def test_archive_and_compact_preserves_steer_metadata(db):
+    db.create_session(session_id="s1", source="cli")
+    db.append_message("s1", role="user", content="before compact")
+
+    inserted = db.archive_and_compact(
+        "s1",
+        [
+            {
+                "role": "tool",
+                "content": "compacted tool output",
+                "tool_call_id": "call-1",
+                "_steer_applied": ["keep this steer"],
+            },
+        ],
+    )
+
+    assert inserted == 1
+    conversation = db.get_messages_as_conversation("s1")
+    assert len(conversation) == 1
+    assert conversation[0]["_steer_applied"] == ["keep this steer"]
+
+
+def test_get_resume_conversations_preserves_steer_metadata(db):
+    db.create_session("solo", "cli")
+    db.append_message("solo", role="user", content="hi")
+    db.append_message(
+        "solo",
+        role="assistant",
+        content="",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "terminal", "arguments": "{}"},
+            }
+        ],
+    )
+    db.append_message(
+        "solo",
+        role="tool",
+        content="tool output<steer>focus here</steer>",
+        tool_call_id="call-1",
+        steer_applied=["focus here"],
+    )
+    db.append_message("solo", role="assistant", content="hello")
+
+    model_history, display_history = db.get_resume_conversations("solo")
+
+    assert model_history[2]["_steer_applied"] == ["focus here"]
+    assert display_history[2]["_steer_applied"] == ["focus here"]

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -501,6 +501,7 @@ class TestSteerInjection:
         assert "ls output B" in messages[3]["content"]
         assert STEER_MARKER_OPEN in messages[3]["content"]
         assert "please also check auth.log" in messages[3]["content"]
+        assert messages[3]["_steer_applied"] == ["please also check auth.log"]
         # And pending_steer is consumed.
         assert agent._pending_steer is None
 
@@ -545,6 +546,107 @@ class TestSteerInjection:
         assert new_content[0] == {"type": "text", "text": "existing output"}
         assert new_content[1]["type"] == "text"
         assert "extra note" in new_content[1]["text"]
+        assert messages[-1]["_steer_applied"] == ["extra note"]
+
+    def test_persists_already_flushed_tool_result_update(self):
+        class _FakeSessionDB:
+            def __init__(self):
+                self.calls = []
+
+            def update_message_steer(
+                self, session_id, tool_call_id, content, steer_applied
+            ):
+                self.calls.append((session_id, tool_call_id, content, steer_applied))
+                return True
+
+        agent = _bare_agent()
+        agent.session_id = "session-1"
+        agent._session_db = _FakeSessionDB()
+        agent.steer("use the JSON summary")
+        messages = [
+            {
+                "role": "tool",
+                "content": "raw output",
+                "tool_call_id": "call-1",
+            }
+        ]
+
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+
+        assert agent._session_db.calls == [
+            (
+                "session-1",
+                "call-1",
+                messages[0]["content"],
+                ["use the JSON summary"],
+            )
+        ]
+
+    def test_multimodal_flush_steer_reload_stays_text_only(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "state.db"
+        session_db = SessionDB(db_path)
+        session_db.create_session("session-1", "cli")
+
+        agent = _bare_agent()
+        agent.session_id = "session-1"
+        agent._session_db = session_db
+        agent._session_db_created = True
+        agent._last_flushed_db_idx = 0
+        agent._flushed_db_message_ids = set()
+        messages = [
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": [
+                    {"type": "text", "text": "visible tool summary"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,not-persisted"},
+                    },
+                ],
+            }
+        ]
+
+        agent._flush_messages_to_session_db(messages)
+        initially_stored = session_db.get_messages("session-1")[0]
+        assert initially_stored["content"] == "visible tool summary\n[screenshot]"
+
+        agent.steer("inspect the text summary only")
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+        assert isinstance(messages[0]["content"], list)
+        assert messages[0]["content"][1]["type"] == "image_url"
+
+        session_db.close()
+        reloaded_db = SessionDB(db_path)
+        try:
+            reloaded = reloaded_db.get_messages("session-1")[0]
+        finally:
+            reloaded_db.close()
+
+        assert isinstance(reloaded["content"], str)
+        assert "visible tool summary" in reloaded["content"]
+        assert "[screenshot]" in reloaded["content"]
+        assert "inspect the text summary only" in reloaded["content"]
+        assert "data:image" not in reloaded["content"]
+        assert reloaded["_steer_applied"] == ["inspect the text summary only"]
+
+    def test_multiple_applied_steers_merge_metadata(self):
+        agent = _bare_agent()
+        messages = [
+            {
+                "role": "tool",
+                "content": "raw output",
+                "tool_call_id": "call-1",
+                "_steer_applied": "first",
+            }
+        ]
+
+        agent.steer("second")
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+
+        assert messages[0]["_steer_applied"] == ["first", "second"]
 
 
 
@@ -650,6 +752,26 @@ class TestPreApiCallSteerDrain:
 
 
 class TestSteerMarkerContract:
+    def test_steer_metadata_is_stripped_before_thinking_prefill_drop(self):
+        from agent.conversation_loop import strip_ephemeral_api_fields
+
+        api_msg = {
+            "role": "tool",
+            "content": "tool output",
+            "_steer_applied": ["hi"],
+            "reasoning": "internal",
+            "finish_reason": "tool_calls",
+            "_thinking_prefill": True,
+        }
+
+        strip_ephemeral_api_fields(api_msg)
+
+        assert api_msg == {
+            "role": "tool",
+            "content": "tool output",
+            "_thinking_prefill": True,
+        }
+
     def test_system_prompt_note_describes_the_real_marker(self):
         """The system-prompt note tells the model which marker to trust; it
         must reference the exact open/close the injector emits, or the model


### PR DESCRIPTION
## Summary

Fixes #58599.

`/steer` mutates a tool result after that tool row has already been appended to `state.db`, so the in-content steer marker and `_steer_applied` metadata are lost on reload/fork/compaction. This adds the missing durable update path:

- adds a nullable `messages.steer_applied` column through the existing SCHEMA_SQL reconciliation path
- adds `SessionDB.update_message_steer(session_id, tool_call_id, content, steer_applied)` scoped to active tool rows only
- updates both steer application windows to persist the mutated tool result:
  - post-tool-batch `apply_pending_steer_to_tool_results()`
  - pre-API-call steer drain
- rehydrates `_steer_applied` from `get_messages()` and `get_messages_as_conversation()`
- preserves `_steer_applied` through `append_message`, `replace_messages`, and `archive_and_compact`
- strips `_steer_applied` from provider-facing API message copies so strict APIs never see the internal metadata

## Relationship to #58604

Preflight found #58604, which adds live-session `_steer_applied` surfacing and explicitly calls durable DB persistence out of scope as the follow-up tracked by #58599. This PR is that durable follow-up. It aligns `_steer_applied` with #58604's list-of-steer-texts shape and keeps the provider-copy stripping behavior compatible.

## Duplicate / overlap check

- Exact open PR search for `58599 in:title,body`: no results.
- Broad keyword warnings were inspected. #58604 is related but does not persist the already-written DB row; other hits were durable/state/session keyword overlap outside this root cause.

## Validation

```bash
uv run --extra dev pytest tests/run_agent/test_steer.py tests/test_hermes_state.py::TestMessageStorage -q
# 63 passed

uv run --extra dev pytest tests/test_hermes_state.py tests/run_agent/test_session_reset_fix.py tests/hermes_cli/test_session_handoff.py -q
# 346 passed

uv run --extra dev ruff check hermes_state.py run_agent.py agent/agent_runtime_helpers.py agent/conversation_loop.py tests/run_agent/test_steer.py tests/test_hermes_state.py
# All checks passed

git diff --check
# pass

gitleaks git --log-opts='origin/main..HEAD' --redact .
# no leaks found
```
