### PR TITLE
fix(mcp): forget stale servers after reload timeout

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4,6 +4,7 @@ All tests use mocks -- no real MCP servers or subprocesses are started.
 """
 
 import asyncio
+import concurrent.futures
 import json
 import threading
 import time
@@ -1599,6 +1600,76 @@ class TestShutdown:
         assert len(_servers) == 0
         # Parallel: ~1s, not ~3s. Allow some margin.
         assert elapsed < 2.5, f"Shutdown took {elapsed:.1f}s, expected ~1s (parallel)"
+
+    def test_shutdown_timeout_forgets_stale_servers_and_tools(self):
+        """A timed-out reload teardown must still clear stale registry state.
+
+        Otherwise a subsequent discover pass treats dead server names as
+        already connected, leaving the old MCP tool list visible even though
+        every call fails on a closed transport.
+        """
+        import tools.mcp_tool as mcp_mod
+        from tools.mcp_tool import MCPServerTask, shutdown_mcp_servers
+        from tools.registry import registry
+        from toolsets import resolve_toolset, validate_toolset
+
+        with mcp_mod._lock:
+            mcp_mod._servers.clear()
+            mcp_mod._server_connecting.clear()
+            mcp_mod._server_connect_errors.clear()
+
+        registry.register(
+            name="mcp__test__ping",
+            toolset="mcp-test",
+            schema={
+                "name": "mcp__test__ping",
+                "description": "Ping",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda *_args, **_kwargs: "{}",
+        )
+        registry.register_toolset_alias("test", "mcp-test")
+
+        server = MCPServerTask("test")
+        server._registered_tool_names = ["mcp__test__ping"]
+        with mcp_mod._lock:
+            mcp_mod._servers["test"] = server
+            mcp_mod._server_connecting.add("test")
+            mcp_mod._server_connect_errors["test"] = "stale session"
+
+        fake_future = MagicMock()
+        fake_future.result.side_effect = concurrent.futures.TimeoutError()
+        fake_loop = MagicMock()
+        fake_loop.is_running.return_value = True
+        scheduled = {}
+
+        def _fake_schedule(coro, _loop, **_kwargs):
+            scheduled["coro"] = coro
+            return fake_future
+
+        try:
+            assert validate_toolset("test") is True
+            assert "mcp__test__ping" in resolve_toolset("test")
+
+            with patch.object(mcp_mod, "_mcp_loop", fake_loop), \
+                 patch("agent.async_utils.safe_schedule_threadsafe", side_effect=_fake_schedule), \
+                 patch("tools.mcp_tool._stop_mcp_loop"):
+                shutdown_mcp_servers()
+        finally:
+            coro = scheduled.get("coro")
+            if coro is not None:
+                coro.close()
+            with mcp_mod._lock:
+                mcp_mod._servers.clear()
+                mcp_mod._server_connecting.clear()
+                mcp_mod._server_connect_errors.clear()
+
+        with mcp_mod._lock:
+            assert mcp_mod._servers == {}
+            assert mcp_mod._server_connecting == set()
+            assert mcp_mod._server_connect_errors == {}
+        assert "mcp__test__ping" not in registry.get_all_tool_names()
+        assert validate_toolset("test") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5422,11 +5422,37 @@ def shutdown_mcp_servers():
     the anyio cancel-scope cleanup happens in the same Task that opened it.
     All servers are shut down in parallel via ``asyncio.gather``.
     """
+    def _forget_all_servers() -> None:
+        """Drop all registered MCP server state, even on teardown failure.
+
+        Reload must fail closed: once we decide to tear down MCP, the next
+        discovery pass needs a clean slate. If shutdown hangs or the loop is
+        already unhealthy, leaving ``_servers`` populated makes
+        ``discover_mcp_tools()`` treat dead sessions as already connected,
+        preserving stale tool registrations that then fail every call with a
+        closed transport error.
+        """
+        with _lock:
+            servers_to_forget = list(_servers.values())
+            _servers.clear()
+            _server_connecting.clear()
+            _server_connect_errors.clear()
+        for server in servers_to_forget:
+            try:
+                server._deregister_tools()
+            except Exception:
+                logger.debug(
+                    "Error deregistering MCP server '%s' during forced forget",
+                    getattr(server, "name", "<unknown>"),
+                    exc_info=True,
+                )
+
     with _lock:
         servers_snapshot = list(_servers.values())
 
     # Fast path: nothing to shut down.
     if not servers_snapshot:
+        _forget_all_servers()
         _stop_mcp_loop()
         return
 
@@ -5457,6 +5483,11 @@ def shutdown_mcp_servers():
                 future.result(timeout=15)
             except BaseException as exc:
                 logger.debug("Error during MCP shutdown: %s", exc)
+                _forget_all_servers()
+        else:
+            _forget_all_servers()
+    else:
+        _forget_all_servers()
 
     _stop_mcp_loop()
 


### PR DESCRIPTION
## What does this PR do?

Fixes a reload-specific MCP failure mode where a timed-out `shutdown_mcp_servers()` could stop the loop but leave `_servers` populated with stale stdio server objects. The next discovery pass would then treat those dead names as already connected, preserving the old tool list even though every stdio tool call immediately failed on a closed transport.

## Related Issue

Fixes #61010

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Make `tools/mcp_tool.py:shutdown_mcp_servers()` fail closed by forgetting all registered MCP server state when teardown times out or cannot be scheduled.
- Clear `_servers`, `_server_connecting`, and `_server_connect_errors` before the next discovery pass so dead stdio servers cannot masquerade as connected after `/reload-mcp` or config-triggered reloads.
- Deregister stale MCP tools during the forced-forget path so cached tool lists cannot survive a failed teardown.
- Add a regression test covering the timed-out shutdown path in `tests/tools/test_mcp_tool.py`.

## How to Test

1. `uv run pytest tests/tools/test_mcp_tool.py -k shutdown -q`
2. `uv run pytest tests/gateway/test_mcp_reload_refreshes_cached_agents.py -q`
3. `uv run python -m py_compile tools/mcp_tool.py tests/tools/test_mcp_tool.py && git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu-compatible local toolchain via `uv` / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Repro symptom from #61010: after reload, stdio MCP tools stayed listed but every call failed with `ClosedResourceError`.
- Local proof: targeted shutdown/reload tests pass, syntax check passes, and `git diff --check` is clean.
