### PR TITLE
fix(whatsapp): add silent group skip path

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -354,7 +354,10 @@ def compress_context(
         f"{approx_tokens:,}" if approx_tokens else "unknown", agent.model,
         focus_topic,
     )
-    agent._emit_status(COMPACTION_STATUS)
+    agent._emit_status(
+        COMPACTION_STATUS,
+        customer_facing=False,
+    )
 
     # ── Compression lock ────────────────────────────────────────────────
     # Atomic, state.db-backed lock per session_id.  Without this, two

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -271,19 +271,22 @@ def check_compression_model_feasibility(agent: Any) -> None:
 
 
 def replay_compression_warning(agent: Any) -> None:
-    """Re-send the compression warning through ``status_callback``.
+    """Re-send the compression warning through filtered status plumbing.
 
     During ``__init__`` the gateway's ``status_callback`` is not yet
     wired, so ``_emit_status`` only reaches ``_vprint`` (CLI).  This
     method is called once at the start of the first
-    ``run_conversation()`` — by then the gateway has set the callback,
-    so every platform (Telegram, Discord, Slack, etc.) receives the
-    warning.
+    ``run_conversation()`` — by then the gateway has set the callback.
+
+    Compression warnings are operator/runtime diagnostics, not customer-facing
+    chat replies. Route through ``_emit_status(customer_facing=False)`` instead
+    of calling ``status_callback`` directly so WhatsApp/Slack/etc. inherit the
+    same suppression filter used by retry/compression lifecycle banners.
     """
     msg = getattr(agent, "_compression_warning", None)
     if msg and agent.status_callback:
         try:
-            agent.status_callback("lifecycle", msg)
+            agent._emit_status(msg, customer_facing=False)
         except Exception:
             pass
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3034,7 +3034,10 @@ def run_conversation(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._buffer_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
+                    agent._buffer_status(
+                        f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...",
+                        customer_facing=False,
+                    )
 
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
@@ -3047,18 +3050,24 @@ def run_conversation(
                     # messages to the new session, not skipping them.
                     conversation_history = None
 
-                    # Re-estimate tokens after compression.  Same-message-count
+                    # Re-estimate tokens after compression. Same-message-count
                     # compression (tool-result pruning, in-place summarization)
                     # can materially reduce request size without reducing the
-                    # message array.  (#39550)
+                    # message array. (#39550)
                     new_tokens = estimate_messages_tokens_rough(messages)
                     approx_tokens = new_tokens  # update for downstream logging
 
                     if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95):
                         if len(messages) < original_len:
-                            agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                            agent._buffer_status(
+                                f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...",
+                                customer_facing=False,
+                            )
                         else:
-                            agent._buffer_status(f"🗜️ Compressed ~{original_tokens:,} → ~{new_tokens:,} tokens, retrying...")
+                            agent._buffer_status(
+                                f"🗜️ Compressed ~{original_tokens:,} → ~{new_tokens:,} tokens, retrying...",
+                                customer_facing=False,
+                            )
                         time.sleep(2)  # Brief pause between compression retries
                         _retry.restart_with_compressed_messages = True
                         break
@@ -3201,7 +3210,10 @@ def run_conversation(
                             "failed": True,
                             "compression_exhausted": True,
                         }
-                    agent._buffer_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
+                    agent._buffer_status(
+                        f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...",
+                        customer_facing=False,
+                    )
 
                     original_len = len(messages)
                     original_tokens = estimate_messages_tokens_rough(messages)
@@ -3223,9 +3235,15 @@ def run_conversation(
 
                     if len(messages) < original_len or (new_tokens > 0 and new_tokens < original_tokens * 0.95) or (new_ctx and new_ctx < old_ctx):
                         if len(messages) < original_len:
-                            agent._buffer_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                            agent._buffer_status(
+                                f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...",
+                                customer_facing=False,
+                            )
                         elif new_tokens > 0 and new_tokens < original_tokens * 0.95:
-                            agent._buffer_status(f"🗜️ Compressed ~{original_tokens:,} → ~{new_tokens:,} tokens, retrying...")
+                            agent._buffer_status(
+                                f"🗜️ Compressed ~{original_tokens:,} → ~{new_tokens:,} tokens, retrying...",
+                                customer_facing=False,
+                            )
                         time.sleep(2)  # Brief pause between compression retries
                         _retry.restart_with_compressed_messages = True
                         break

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -60,7 +60,8 @@ def finalize_turn(
         _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
         agent._emit_status(
             f"⚠️ Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
-            "— asking model to summarise"
+            "— asking model to summarise",
+            customer_facing=False,
         )
         if not agent.quiet_mode:
             agent._safe_print(

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1022,7 +1022,7 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:
                     bridged["exclusive_bot_mentions"] = platform_cfg["exclusive_bot_mentions"]
-                if plat == Platform.TELEGRAM and "observe_unmentioned_group_messages" in platform_cfg:
+                if plat in {Platform.TELEGRAM, Platform.WHATSAPP} and "observe_unmentioned_group_messages" in platform_cfg:
                     bridged["observe_unmentioned_group_messages"] = platform_cfg["observe_unmentioned_group_messages"]
                 if "dm_policy" in platform_cfg:
                     bridged["dm_policy"] = platform_cfg["dm_policy"]

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -525,6 +525,11 @@ class GatewayConfig:
     # raw passthrough.
     filter_silence_narration: bool = True
 
+    # Silent-response / diagnostics controls. Defaults preserve historical UX:
+    # empty/failed turns are surfaced unless explicitly opted into silent mode.
+    allow_silent_response: bool = False
+    suppress_provider_diagnostics_in_chat: bool = False
+
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
 
@@ -649,6 +654,8 @@ class GatewayConfig:
             "sessions_dir": str(self.sessions_dir),
             "always_log_local": self.always_log_local,
             "filter_silence_narration": self.filter_silence_narration,
+            "allow_silent_response": self.allow_silent_response,
+            "suppress_provider_diagnostics_in_chat": self.suppress_provider_diagnostics_in_chat,
             "stt_enabled": self.stt_enabled,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
@@ -737,6 +744,12 @@ class GatewayConfig:
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
             filter_silence_narration=_coerce_bool(
                 data.get("filter_silence_narration"), True
+            ),
+            allow_silent_response=_coerce_bool(
+                data.get("allow_silent_response"), False
+            ),
+            suppress_provider_diagnostics_in_chat=_coerce_bool(
+                data.get("suppress_provider_diagnostics_in_chat"), False
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
@@ -881,6 +894,21 @@ def load_gateway_config() -> GatewayConfig:
                     "filter_silence_narration"
                 ]
 
+            gateway_cfg = yaml_cfg.get("gateway")
+            if isinstance(gateway_cfg, dict):
+                for _gateway_policy_key in (
+                    "allow_silent_response",
+                    "suppress_provider_diagnostics_in_chat",
+                ):
+                    if _gateway_policy_key in gateway_cfg:
+                        gw_data[_gateway_policy_key] = gateway_cfg[_gateway_policy_key]
+            for _gateway_policy_key in (
+                "allow_silent_response",
+                "suppress_provider_diagnostics_in_chat",
+            ):
+                if _gateway_policy_key in yaml_cfg:
+                    gw_data[_gateway_policy_key] = yaml_cfg[_gateway_policy_key]
+
             if "unauthorized_dm_behavior" in yaml_cfg:
                 gw_data["unauthorized_dm_behavior"] = _normalize_unauthorized_dm_behavior(
                     yaml_cfg.get("unauthorized_dm_behavior"),
@@ -891,7 +919,6 @@ def load_gateway_config() -> GatewayConfig:
             # ``gateway.platforms`` are loaded the same way as top-level
             # ``platforms``. Merge nested first so top-level config keeps
             # precedence, matching the existing gateway.streaming fallback.
-            gateway_cfg = yaml_cfg.get("gateway")
             gateway_platforms = gateway_cfg.get("platforms") if isinstance(gateway_cfg, dict) else None
             platforms_data = gw_data.setdefault("platforms", {})
             if not isinstance(platforms_data, dict):
@@ -1023,6 +1050,10 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "allow_silent_response" in platform_cfg:
+                    bridged["allow_silent_response"] = platform_cfg["allow_silent_response"]
+                if "suppress_diagnostics" in platform_cfg:
+                    bridged["suppress_diagnostics"] = platform_cfg["suppress_diagnostics"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/group_routing.py
+++ b/gateway/group_routing.py
@@ -1,0 +1,628 @@
+"""Gateway-level WhatsApp group routing policy.
+
+This module is deliberately deterministic: it runs before any LLM reply
+planning and decides whether an incoming WhatsApp message may enter the
+public-response path. Skipped messages are still logged and ingested into the
+session transcript/task-open-loop state so Hermes stays in the loop without
+speaking in groups by default.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Literal, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+RoutingAction = Literal[
+    "no_reply_silent_ingest",
+    "no_reply_task_update",
+    "private_alert_to_jacob",
+    "authorized_private_follow_up",
+    "public_group_reply",
+    "ask_jacob_privately",
+    "ignore_non_actionable_noise",
+]
+
+AddresseeClassification = Literal[
+    "addressed_to_hermes",
+    "addressed_to_jacob",
+    "addressed_to_specific_other_people",
+    "addressed_to_group",
+    "ambient_context",
+    "ambiguous",
+]
+
+_GATEWAY_ACTION = Literal["skip", "allow", "rewrite"]
+
+_DIRECT_HERMES_RE = re.compile(
+    r"(?ix)"
+    r"(?:^|[\s>¿¡,.;:!\-])"
+    r"(?:@?(?:jack|hermes)|/(?:jack|hermes))"
+    r"(?:\s*[:,;\-]|\s+|$)"
+)
+
+_JACOB_RE = re.compile(r"(?i)(?:^|[\s@,.;:!\-])jacob(?:\s*[:,;\-]|\s+|$)")
+
+_ACTIONABLE_RE = re.compile(
+    r"(?ix)\b("
+    r"can\s+you|could\s+you|please|pls|confirm|follow\s+up|handle\s+this|"
+    r"support|let\s+me\s+know|available|pending|block(?:ed|er)?|stuck|"
+    r"need(?:s|ed)?|schedule|deliver|send|pay|payment|meeting|call|"
+    r"puedes|podr[ií]as|me\s+ayudas|ap[oó]yalo|apoyarlo|ay[uú]dalo|"
+    r"confirma(?:s|r)?|confirmaci[oó]n|disponibilidad|queda\s+pendiente|"
+    r"av[ií]same|dale\s+seguimiento|seguimiento|necesito\s+que|por\s+favor|"
+    r"pendiente|bloquead[oa]|atorad[oa]|pago|entrega|reuni[oó]n|llamada"
+    r")\b"
+)
+
+_BLOCKER_RE = re.compile(
+    r"(?ix)\b(block(?:ed|er)?|stuck|urgent|asap|cannot|can't|failed|failure|"
+    r"bloquead[oa]|atorad[oa]|urgente|no\s+puedo|fall[oó]|error|problema)\b"
+)
+
+_DEADLINE_RE = re.compile(
+    r"(?ix)\b("
+    r"today|tomorrow|tonight|this\s+(?:morning|afternoon|evening|week)|"
+    r"monday|tuesday|wednesday|thursday|friday|saturday|sunday|"
+    r"hoy|ma[nñ]ana|esta\s+(?:ma[nñ]ana|tarde|noche|semana)|"
+    r"lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bado|domingo|"
+    r"\d{1,2}(?::\d{2})?\s*(?:am|pm)|\d{1,2}/\d{1,2}(?:/\d{2,4})?"
+    r")\b"
+)
+
+_ACK_OR_PARROT_RE = re.compile(
+    r"(?ix)^\s*(noted|understood|ok(?:ay)?|on\s+it|got\s+it|sounds\s+good|"
+    r"anotado|entendido|de\s+acuerdo|va|sale|listo)\s*[.!]*\s*$"
+)
+
+_ALLOWED_ACTION_VERBS_RE = re.compile(
+    r"(?ix)\b("
+    r"send|ask|remind|summari[sz]e|coordinate|follow\s+up|reply|tell|"
+    r"message|dm|contact|avisa|pregunta|recuerda|resume|coordina|"
+    r"dale\s+seguimiento|manda|env[ií]a|contesta|escribe"
+    r")\b"
+)
+
+_NAME_TAG_RE = re.compile(r"@([\w.+\-]+)")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _as_platform_name(platform: Any) -> str:
+    return str(getattr(platform, "value", platform) or "").lower()
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _normalize_jid(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    # Baileys can expose linked-device JIDs as ``user:device@server`` while
+    # native WhatsApp mentions use the bare ``user@server``.  Mention matching
+    # must compare those canonical bare JIDs; replacing ':' with '@' produces
+    # ``user@device@server`` and makes real @Jack mentions look like mentions
+    # of another participant.
+    if ":" in text and "@" in text:
+        local, server = text.split("@", 1)
+        text = f"{local.split(':', 1)[0]}@{server}"
+    return text
+
+
+def _lower_set(values: Iterable[Any]) -> set[str]:
+    return {str(v).strip().lower() for v in values if str(v).strip()}
+
+
+def _get_extra(config: Any) -> dict[str, Any]:
+    if isinstance(config, dict):
+        return config
+    return getattr(config, "extra", {}) if config is not None else {}
+
+
+def _deep_get(mapping: Any, *keys: str, default: Any = None) -> Any:
+    cur = mapping
+    for key in keys:
+        if isinstance(cur, dict):
+            cur = cur.get(key)
+        else:
+            return default
+        if cur is None:
+            return default
+    return cur
+
+
+@dataclass
+class GroupRoutingConfig:
+    enabled: bool = True
+    group_mode: str = "mention_only"
+    allowed_public_reply: bool = False
+    allowed_dm_followup: bool = False
+    noise_tolerance: str = "low"
+    default_followup_channel: str = "private_jacob"
+    hermes_aliases: list[str] = field(default_factory=lambda: ["jack", "hermes"])
+    jacob_aliases: list[str] = field(default_factory=lambda: ["jacob"])
+
+    @classmethod
+    def from_gateway_config(cls, config: Any) -> "GroupRoutingConfig":
+        raw = {}
+        # GatewayConfig keeps top-level user config in ``raw`` in newer builds,
+        # but tests and some paths pass dicts. Accept both shapes and platform
+        # extra overrides for compatibility.
+        if isinstance(config, dict):
+            raw = _deep_get(config, "gateway", "whatsapp_group_routing", default={}) or {}
+        else:
+            raw = getattr(config, "whatsapp_group_routing", None) or {}
+            raw = raw or _deep_get(getattr(config, "raw", {}), "gateway", "whatsapp_group_routing", default={}) or {}
+        platform_extra = {}
+        try:
+            from gateway.config import Platform
+            platforms = getattr(config, "platforms", None)
+            platform_cfg = platforms.get(Platform.WHATSAPP) if platforms is not None else None
+            platform_extra = _get_extra(platform_cfg)
+        except Exception:
+            platform_extra = {}
+        platform_policy = platform_extra.get("group_routing") if isinstance(platform_extra, dict) else {}
+        if isinstance(platform_policy, dict):
+            raw = {**raw, **platform_policy}
+        aliases = raw.get("aliases", {}) if isinstance(raw.get("aliases"), dict) else {}
+        hermes_aliases = aliases.get("hermes") or aliases.get("jack") or raw.get("hermes_aliases")
+        jacob_aliases = aliases.get("jacob") or raw.get("jacob_aliases")
+        return cls(
+            enabled=_coerce_bool(raw.get("enabled", True)),
+            group_mode=str(raw.get("group_mode", "mention_only") or "mention_only"),
+            allowed_public_reply=_coerce_bool(raw.get("allowed_public_reply", False)),
+            allowed_dm_followup=_coerce_bool(raw.get("allowed_dm_followup", False)),
+            noise_tolerance=str(raw.get("noise_tolerance", "low") or "low"),
+            default_followup_channel=str(raw.get("default_followup_channel", "private_jacob") or "private_jacob"),
+            hermes_aliases=[str(a).lower() for a in _as_list(hermes_aliases or ["jack", "hermes"])],
+            jacob_aliases=[str(a).lower() for a in _as_list(jacob_aliases or ["jacob"])],
+        )
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class ExtractedTask:
+    task_title: str
+    requested_action: str
+    owner: Optional[str]
+    requester: Optional[str]
+    affected_people: list[str]
+    due_date: Optional[str]
+    pending_confirmations: list[str]
+    blocker_indicators: list[str]
+    source_platform: str
+    source_group: Optional[str]
+    source_message_id: Optional[str]
+    public_reply_authorization: bool
+    follow_up_mode: str
+    next_follow_up_time: Optional[str]
+    confidence: float
+    missing_information: list[str] = field(default_factory=list)
+
+
+@dataclass
+class WhatsAppRoutingDecision:
+    platform: str
+    chat_type: str
+    chat_id: Optional[str]
+    message_id: Optional[str]
+    sender_id: Optional[str]
+    addressee_classification: AddresseeClassification
+    selected_action: RoutingAction
+    public_reply_allowed: bool
+    should_call_llm_reply_generator: bool
+    should_call_send_message: bool
+    should_send_reaction: bool
+    should_ingest_context: bool
+    should_extract_task: bool
+    should_alert_jacob_privately: bool
+    reason: str
+    gateway_action: _GATEWAY_ACTION
+    group_mode: str = "mention_only"
+    context_updated: bool = False
+    task_update_created: bool = False
+    extracted_task: Optional[ExtractedTask] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.pop("gateway_action", None)
+        return data
+
+    def as_hook_result(self) -> dict[str, Any]:
+        result = {"action": self.gateway_action, "reason": self.reason, "routing_decision": self.to_dict()}
+        if self.gateway_action == "skip":
+            result["skip"] = True
+        return result
+
+
+class WhatsAppGroupRoutingPolicy:
+    def __init__(self, config: GroupRoutingConfig | None = None):
+        self.config = config or GroupRoutingConfig()
+
+    @classmethod
+    def from_gateway_config(cls, config: Any) -> "WhatsAppGroupRoutingPolicy":
+        return cls(GroupRoutingConfig.from_gateway_config(config))
+
+    def evaluate(self, event: Any) -> WhatsAppRoutingDecision:
+        source = getattr(event, "source", None)
+        raw = getattr(event, "raw_message", None) or {}
+        platform = _as_platform_name(getattr(source, "platform", ""))
+        chat_type = str(getattr(source, "chat_type", "") or ("group" if raw.get("isGroup") else "dm"))
+        chat_id = getattr(source, "chat_id", None) or raw.get("chatId")
+        message_id = getattr(event, "message_id", None) or raw.get("messageId")
+        sender_id = getattr(source, "user_id", None) or raw.get("senderId") or raw.get("from")
+        text = str(getattr(event, "text", "") or raw.get("body") or "")
+
+        if platform != "whatsapp" or chat_type != "group" or not self.config.enabled:
+            return WhatsAppRoutingDecision(
+                platform=platform,
+                chat_type=chat_type,
+                chat_id=chat_id,
+                message_id=message_id,
+                sender_id=sender_id,
+                addressee_classification="addressed_to_hermes" if chat_type == "dm" else "ambient_context",
+                selected_action="public_group_reply" if chat_type == "group" else "public_group_reply",
+                public_reply_allowed=True,
+                should_call_llm_reply_generator=True,
+                should_call_send_message=True,
+                should_send_reaction=True,
+                should_ingest_context=False,
+                should_extract_task=False,
+                should_alert_jacob_privately=False,
+                reason="not_whatsapp_group_or_policy_disabled",
+                gateway_action="allow",
+                group_mode=self.config.group_mode,
+            )
+
+        classification, reason = self.classify_addressee(text, raw, sender_id)
+        actionable = self.is_actionable(text)
+        urgent_blocker = self.is_urgent_blocker(text)
+
+        if classification == "addressed_to_hermes":
+            public_allowed = self.config.allowed_public_reply or self.config.group_mode in {"mention_only", "authorized_coordination", "active_ops"}
+            return WhatsAppRoutingDecision(
+                platform="whatsapp",
+                chat_type="group",
+                chat_id=chat_id,
+                message_id=message_id,
+                sender_id=sender_id,
+                addressee_classification=classification,
+                selected_action="public_group_reply",
+                public_reply_allowed=public_allowed,
+                should_call_llm_reply_generator=public_allowed,
+                should_call_send_message=public_allowed,
+                should_send_reaction=public_allowed,
+                should_ingest_context=True,
+                should_extract_task=actionable,
+                should_alert_jacob_privately=False,
+                reason=reason,
+                gateway_action="allow" if public_allowed else "skip",
+                group_mode=self.config.group_mode,
+            )
+
+        if urgent_blocker:
+            return WhatsAppRoutingDecision(
+                platform="whatsapp",
+                chat_type="group",
+                chat_id=chat_id,
+                message_id=message_id,
+                sender_id=sender_id,
+                addressee_classification=classification,
+                selected_action="private_alert_to_jacob",
+                public_reply_allowed=False,
+                should_call_llm_reply_generator=False,
+                should_call_send_message=False,
+                should_send_reaction=False,
+                should_ingest_context=True,
+                should_extract_task=True,
+                should_alert_jacob_privately=True,
+                reason="private_alert_preferred",
+                gateway_action="skip",
+                group_mode=self.config.group_mode,
+            )
+
+        selected: RoutingAction
+        if actionable:
+            selected = "no_reply_task_update"
+        elif classification == "ambient_context":
+            selected = "ignore_non_actionable_noise"
+        else:
+            selected = "no_reply_silent_ingest"
+
+        skip_reason = {
+            "addressed_to_specific_other_people": "addressed_to_specific_other_people",
+            "addressed_to_group": "ambient_group_context",
+            "addressed_to_jacob": "group_message_not_addressed_to_hermes",
+            "ambient_context": "ambient_group_context",
+            "ambiguous": "group_message_not_addressed_to_hermes",
+        }.get(classification, "group_message_not_addressed_to_hermes")
+
+        return WhatsAppRoutingDecision(
+            platform="whatsapp",
+            chat_type="group",
+            chat_id=chat_id,
+            message_id=message_id,
+            sender_id=sender_id,
+            addressee_classification=classification,
+            selected_action=selected,
+            public_reply_allowed=False,
+            should_call_llm_reply_generator=False,
+            should_call_send_message=False,
+            should_send_reaction=False,
+            should_ingest_context=True,
+            should_extract_task=actionable,
+            should_alert_jacob_privately=False,
+            reason=skip_reason,
+            gateway_action="skip",
+            group_mode=self.config.group_mode,
+        )
+
+    def classify_addressee(self, text: str, raw: dict[str, Any], sender_id: Any = None) -> tuple[AddresseeClassification, str]:
+        mentioned_ids = {_normalize_jid(v) for v in raw.get("mentionedIds") or raw.get("mentionedJid") or [] if _normalize_jid(v)}
+        bot_ids = {_normalize_jid(v) for v in raw.get("botIds") or [] if _normalize_jid(v)}
+        quoted_participant = _normalize_jid(raw.get("quotedParticipant"))
+        raw_body = str(raw.get("body") or "")
+        normalized_text = " ".join((text or "").split())
+        raw_normalized_text = " ".join(raw_body.split())
+        combined_text = " ".join(part for part in [normalized_text, raw_normalized_text] if part)
+        lower_text = normalized_text.lower()
+        lower_combined_text = combined_text.lower()
+
+        adapter_trigger_reason = raw.get("_hermes_direct_group_trigger_reason")
+        if adapter_trigger_reason:
+            return "addressed_to_hermes", str(adapter_trigger_reason)
+
+        if bot_ids and mentioned_ids:
+            if mentioned_ids & bot_ids:
+                return "addressed_to_hermes", "mentioned_hermes_metadata"
+            return "addressed_to_specific_other_people", "addressed_to_specific_other_people"
+
+        # WhatsApp/Baileys may expose a display/native mention as raw body text
+        # (for example ``@Jack Assistant`` or ``@277365414441152``) and the
+        # adapter may already have stripped it out of event.text before this
+        # hard gate runs. Check the raw body as well, otherwise a real @Jack
+        # group mention can be silently misclassified as a mention of another
+        # participant.
+        if bot_ids and raw_normalized_text:
+            raw_lower = raw_normalized_text.lower()
+            for bot_id in bot_ids:
+                bare_id = bot_id.split("@", 1)[0].lower()
+                if bare_id and (f"@{bare_id}" in raw_lower or raw_lower.startswith(bare_id)):
+                    return "addressed_to_hermes", "mentioned_hermes_text"
+
+        if quoted_participant and bot_ids and quoted_participant in bot_ids:
+            return "addressed_to_hermes", "reply_to_hermes_message"
+
+        if self._direct_hermes_text_address(combined_text):
+            return "addressed_to_hermes", "direct_hermes_text_address"
+
+        if self._direct_jacob_text_address(combined_text):
+            return "addressed_to_jacob", "addressed_to_jacob"
+
+        text_tags = _NAME_TAG_RE.findall(combined_text)
+        if text_tags:
+            hermes_aliases = _lower_set(self.config.hermes_aliases)
+            if any(tag.lower().strip("@") in hermes_aliases for tag in text_tags):
+                return "addressed_to_hermes", "direct_hermes_text_address"
+            return "addressed_to_specific_other_people", "addressed_to_specific_other_people"
+
+        if _ACTIONABLE_RE.search(lower_combined_text):
+            # With no metadata/name target, phrases like "can you" in a group are
+            # ambiguous. Low-noise default is still no public reply.
+            return "ambiguous", "group_message_not_addressed_to_hermes"
+
+        if lower_combined_text and any(token in lower_combined_text for token in ("everyone", "equipo", "team", "todos", "grupo")):
+            return "addressed_to_group", "ambient_group_context"
+        return "ambient_context", "ambient_group_context"
+
+    def _direct_hermes_text_address(self, text: str) -> bool:
+        if not text:
+            return False
+        for alias in self.config.hermes_aliases:
+            alias_re = re.compile(
+                rf"(?i)(?:^\s*(?:/?@?{re.escape(alias)})\b\s*[:,;\-]?|@{re.escape(alias)}\b)"
+            )
+            if alias_re.search(text):
+                return True
+        return bool(_DIRECT_HERMES_RE.match(text))
+
+    def _direct_jacob_text_address(self, text: str) -> bool:
+        if not text:
+            return False
+        for alias in self.config.jacob_aliases:
+            alias_re = re.compile(rf"(?i)(?:^|[\s@,.;:!\-]){re.escape(alias)}(?:\s*[:,;\-]|\s+|$)")
+            if alias_re.search(text):
+                return True
+        return bool(_JACOB_RE.search(text))
+
+    @staticmethod
+    def is_actionable(text: str) -> bool:
+        return bool(_ACTIONABLE_RE.search(text or ""))
+
+    @staticmethod
+    def is_urgent_blocker(text: str) -> bool:
+        return bool(_BLOCKER_RE.search(text or ""))
+
+    def extract_task(self, event: Any, decision: WhatsAppRoutingDecision) -> Optional[ExtractedTask]:
+        if not decision.should_extract_task:
+            return None
+        source = getattr(event, "source", None)
+        raw = getattr(event, "raw_message", None) or {}
+        text = str(getattr(event, "text", "") or raw.get("body") or "").strip()
+        mentioned = [str(v) for v in (raw.get("mentionedIds") or raw.get("mentionedJid") or [])]
+        owner = mentioned[0] if mentioned else None
+        missing: list[str] = []
+        if owner is None and decision.addressee_classification in {"ambiguous", "addressed_to_group"}:
+            missing.append("owner")
+        deadline_match = _DEADLINE_RE.search(text)
+        due_date = deadline_match.group(0) if deadline_match else None
+        blocker_indicators = [m.group(0) for m in _BLOCKER_RE.finditer(text)]
+        pending = []
+        if re.search(r"(?i)confirm|confirma|confirmaci[oó]n|me\s+confirmas|por\s+favor\s+confirma", text):
+            pending.append("confirmation")
+        action = _summarize_action(text)
+        task = ExtractedTask(
+            task_title=_title_from_text(text),
+            requested_action=action,
+            owner=owner,
+            requester=getattr(source, "user_id", None) or raw.get("senderId"),
+            affected_people=mentioned,
+            due_date=due_date,
+            pending_confirmations=pending,
+            blocker_indicators=blocker_indicators,
+            source_platform=decision.platform,
+            source_group=getattr(source, "chat_id", None) or raw.get("chatId"),
+            source_message_id=decision.message_id,
+            public_reply_authorization=decision.public_reply_allowed,
+            follow_up_mode=self.config.default_followup_channel,
+            next_follow_up_time=due_date,
+            confidence=0.75 if owner else 0.55,
+            missing_information=missing,
+        )
+        decision.extracted_task = task
+        return task
+
+    @staticmethod
+    def should_suppress_public_reply(draft: str, source_text: str = "", *, owns_next_action: bool = False) -> bool:
+        text = (draft or "").strip()
+        if not text:
+            return True
+        if _ACK_OR_PARROT_RE.match(text):
+            return True
+        if not owns_next_action and source_text:
+            source_words = {w.lower() for w in re.findall(r"\w{4,}", source_text)}
+            draft_words = {w.lower() for w in re.findall(r"\w{4,}", text)}
+            if draft_words and len(draft_words & source_words) / max(len(draft_words), 1) > 0.72:
+                return True
+        return False
+
+
+def _title_from_text(text: str) -> str:
+    clean = " ".join((text or "").split())
+    if len(clean) <= 90:
+        return clean or "Operational follow-up"
+    return clean[:87].rstrip() + "..."
+
+
+def _summarize_action(text: str) -> str:
+    clean = " ".join((text or "").split())
+    return clean or "Review message and update open loop"
+
+
+class SilentGroupStateStore:
+    """Persists skipped context and extracted open loops locally."""
+
+    def __init__(self, session_store: Any = None):
+        self.session_store = session_store
+        base = get_hermes_home()
+        self.log_path = base / "logs" / "whatsapp_group_routing.jsonl"
+        self.state_path = base / "gateway" / "whatsapp_group_open_loops.jsonl"
+
+    def apply(self, event: Any, decision: WhatsAppRoutingDecision, policy: WhatsAppGroupRoutingPolicy) -> WhatsAppRoutingDecision:
+        if decision.should_extract_task:
+            task = policy.extract_task(event, decision)
+            decision.task_update_created = task is not None
+            if task is not None:
+                self._append_jsonl(self.state_path, {"timestamp": _utc_now(), "task": asdict(task), "decision": decision.to_dict()})
+        if decision.should_ingest_context:
+            decision.context_updated = self._append_observed_transcript(event, decision)
+        self.log_decision(event, decision)
+        return decision
+
+    def _append_observed_transcript(self, event: Any, decision: WhatsAppRoutingDecision) -> bool:
+        if not self.session_store:
+            return False
+        try:
+            source = getattr(event, "source", None)
+            if source is None:
+                return False
+            # Use a group-scoped source so later addressed messages in the same
+            # group can retrieve skipped context regardless of sender.
+            try:
+                import dataclasses
+                shared_source = dataclasses.replace(source, user_id=None, user_name=None, user_id_alt=None)
+            except Exception:
+                shared_source = source
+            session_entry = self.session_store.get_or_create_session(shared_source)
+            sender = getattr(source, "user_name", None) or getattr(source, "user_id", None) or "unknown"
+            content = {
+                "observed_whatsapp_group_context": True,
+                "sender": sender,
+                "text": getattr(event, "text", "") or "",
+                "decision": decision.to_dict(),
+            }
+            entry = {
+                "role": "user",
+                "content": json.dumps(content, ensure_ascii=False, sort_keys=True),
+                "timestamp": _utc_now(),
+                "observed": True,
+                "routing_decision": decision.to_dict(),
+            }
+            if decision.message_id:
+                entry["message_id"] = str(decision.message_id)
+            self.session_store.append_to_transcript(session_entry.session_id, entry)
+            return True
+        except Exception as exc:
+            logger.warning("WhatsApp group routing: failed to ingest skipped context: %s", exc)
+            return False
+
+    def log_decision(self, event: Any, decision: WhatsAppRoutingDecision) -> None:
+        record = {
+            "timestamp": _utc_now(),
+            **decision.to_dict(),
+            "context_updated": decision.context_updated,
+            "task_update_created": decision.task_update_created,
+            "skip_reason": decision.reason,
+        }
+        self._append_jsonl(self.log_path, record)
+        logger.info("whatsapp_group_routing_decision %s", json.dumps(record, ensure_ascii=False, sort_keys=True))
+
+    @staticmethod
+    def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+        except Exception as exc:
+            logger.warning("WhatsApp group routing: failed to append %s: %s", path, exc)
+
+
+def route_whatsapp_group_event(event: Any, *, gateway_config: Any = None, session_store: Any = None) -> WhatsAppRoutingDecision:
+    policy = WhatsAppGroupRoutingPolicy.from_gateway_config(gateway_config)
+    decision = policy.evaluate(event)
+    if decision.gateway_action == "skip" or decision.should_ingest_context or decision.should_extract_task:
+        decision = SilentGroupStateStore(session_store=session_store).apply(event, decision, policy)
+    return decision
+
+
+__all__ = [
+    "ExtractedTask",
+    "GroupRoutingConfig",
+    "SilentGroupStateStore",
+    "WhatsAppGroupRoutingPolicy",
+    "WhatsAppRoutingDecision",
+    "route_whatsapp_group_event",
+]

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3747,6 +3747,25 @@ class BasePlatformAdapter(ABC):
         lowered = error.lower()
         return "timed out" in lowered or "readtimeout" in lowered or "writetimeout" in lowered
 
+    def _suppress_delivery_diagnostics_in_chat(self) -> bool:
+        """Return True when adapter-generated failure/status text must stay local.
+
+        This is a final platform-layer guard for errors that bypass the agent
+        status sanitizer: send retry exhaustion, plain-text fallback banners,
+        and exception-handler "sorry/error" messages. WhatsApp chats are not an
+        operator console, so suppress by default there while preserving legacy
+        behavior elsewhere unless explicitly configured.
+        """
+        extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        configured = extra.get("suppress_delivery_diagnostics")
+        if configured is None:
+            configured = extra.get("suppress_diagnostics")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.strip().lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return _platform_name(getattr(self, "platform", None)) == "whatsapp"
+
     def _unwrap_ephemeral(self, response: Any) -> Tuple[Optional[str], int]:
         """Unwrap a handler response into (text, ttl_seconds).
 
@@ -3836,8 +3855,12 @@ class BasePlatformAdapter(ABC):
                 if not (result.retryable or self._is_retryable_error(error_str)):
                     break  # error switched to non-transient — fall through to plain-text fallback
             else:
-                # All retries exhausted (loop completed without break) — notify user
+                # All retries exhausted (loop completed without break). Keep
+                # adapter-generated delivery diagnostics out of customer-facing
+                # platforms such as WhatsApp; the failure is logged locally.
                 logger.error("[%s] Failed to deliver response after %d retries: %s", self.name, max_retries, error_str)
+                if self._suppress_delivery_diagnostics_in_chat():
+                    return result
                 notice = (
                     "\u26a0\ufe0f Message delivery failed after multiple attempts. "
                     "Please try again \u2014 your request was processed but the response could not be sent."
@@ -3849,6 +3872,13 @@ class BasePlatformAdapter(ABC):
                 return result
 
         # Non-network / post-retry formatting failure: try plain text as fallback
+        if self._suppress_delivery_diagnostics_in_chat():
+            logger.warning(
+                "[%s] Send failed: %s — suppressing plain-text diagnostic fallback for customer-facing platform",
+                self.name,
+                error_str,
+            )
+            return result
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
         fallback_result = await self.send(
             chat_id=chat_id,
@@ -4900,22 +4930,25 @@ class BasePlatformAdapter(ABC):
         except Exception as e:
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
-            # Send the error to the user so they aren't left with radio silence
-            try:
-                error_type = type(e).__name__
-                error_detail = str(e)[:300] if str(e) else "no details available"
-                _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
-                await self.send(
-                    chat_id=event.source.chat_id,
-                    content=(
-                        f"Sorry, I encountered an error ({error_type}).\n"
-                        f"{error_detail}\n"
-                        "Try again or use /reset to start a fresh session."
-                    ),
-                    metadata=_thread_metadata,
-                )
-            except Exception:
-                pass  # Last resort — don't let error reporting crash the handler
+            # Send the error to the user on operator-facing platforms only.
+            # WhatsApp/customer-facing chats must not receive stack/service
+            # diagnostics when the gateway or handler fails.
+            if not self._suppress_delivery_diagnostics_in_chat():
+                try:
+                    error_type = type(e).__name__
+                    error_detail = str(e)[:300] if str(e) else "no details available"
+                    _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                    await self.send(
+                        chat_id=event.source.chat_id,
+                        content=(
+                            f"Sorry, I encountered an error ({error_type}).\n"
+                            f"{error_detail}\n"
+                            "Try again or use /reset to start a fresh session."
+                        ),
+                        metadata=_thread_metadata,
+                    )
+                except Exception:
+                    pass  # Last resort — don't let error reporting crash the handler
         finally:
             # Stop typing before any deferred callback work.  Post-delivery
             # callbacks may perform platform I/O; a stuck callback must not

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -34,6 +34,31 @@ _AUDIO_EXTS = frozenset({'.ogg', '.opus', '.mp3', '.wav', '.m4a', '.flac'})
 _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
+_INVISIBLE_DELIVERY_CHARS_RE = re.compile(r"[\u200B\u200C\u200D\u2060\uFEFF\u180E\u2061-\u2064]")
+_SILENT_FINAL_RESPONSE_SENTINELS = {"[SILENT]", "[[SILENT]]", "<SILENT>", "SILENCIO"}
+_NO_DELIVERY_STATUS_RE = re.compile(
+    r"^silencio\s*(?:[.!¡!。]|[-–—:]\s*(?:no\s+(?:(?:fui|estoy|me)\s+)?aludid[oa]|no\s+(?:reply|respuesta)|sin\s+respuesta).*)?$",
+    re.IGNORECASE,
+)
+_INTERNAL_NOTES_LEAK_RE = re.compile(
+    r"(?:trilium|trillium|trillum|notes\.revoluciones\.mx)",
+    re.IGNORECASE,
+)
+
+
+def _contains_internal_notes_leak(text) -> bool:
+    return bool(_INTERNAL_NOTES_LEAK_RE.search(str(text or "")))
+
+
+def _has_visible_delivery_text(text) -> bool:
+    cleaned = _INVISIBLE_DELIVERY_CHARS_RE.sub("", str(text or ""))
+    candidate = cleaned.strip().strip("`\"'“”‘’").strip()
+    if not candidate:
+        return False
+    return (
+        candidate.upper() not in _SILENT_FINAL_RESPONSE_SENTINELS
+        and not _NO_DELIVERY_STATUS_RE.fullmatch(candidate)
+    )
 
 
 def _platform_name(platform) -> str:
@@ -2191,6 +2216,10 @@ class BasePlatformAdapter(ABC):
         self._post_delivery_callbacks: Dict[str, Any] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
+        # Optional early pre-dispatch policy. Runs before session guarding and
+        # before _process_message_background starts typing indicators, so a
+        # skip result creates no visible platform output.
+        self._pre_dispatch_handler: Optional[Callable[[MessageEvent], Awaitable[dict | None]]] = None
         # Auto-TTS on voice input: ``_auto_tts_default`` is the global default
         # (``voice.auto_tts`` in config.yaml, pushed by GatewayRunner on connect).
         # Per-chat overrides live in two sets populated from ``_voice_mode``:
@@ -2622,6 +2651,17 @@ class BasePlatformAdapter(ABC):
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
+
+    def set_pre_dispatch_handler(self, handler: Optional[Callable[[MessageEvent], Awaitable[dict | None]]]) -> None:
+        """Set an optional early policy hook for incoming messages.
+
+        The handler runs in :meth:`handle_message` before the adapter starts any
+        background processing or typing indicators. Return
+        ``{"action": "skip"}`` to create a true no-visible-output path,
+        ``{"action": "rewrite", "text": "..."}`` to replace the inbound text,
+        or ``{"action": "allow"}``/``None`` for normal dispatch.
+        """
+        self._pre_dispatch_handler = handler
     
     def set_session_store(self, session_store: Any) -> None:
         """
@@ -4329,6 +4369,27 @@ class BasePlatformAdapter(ABC):
         # downstream delivery all agree on the same lane.
         self._apply_topic_recovery(event)
 
+        pre_dispatch = getattr(self, "_pre_dispatch_handler", None)
+        if pre_dispatch is not None and not getattr(event, "internal", False):
+            try:
+                pre_result = await pre_dispatch(event)
+            except Exception:
+                logger.warning("[%s] pre-dispatch handler failed", self.name, exc_info=True)
+                pre_result = None
+            if isinstance(pre_result, dict):
+                action = pre_result.get("action")
+                if action == "skip":
+                    logger.info(
+                        "[%s] pre-dispatch skip: reason=%s platform=%s chat=%s",
+                        self.name,
+                        pre_result.get("reason"),
+                        _platform_name(getattr(event.source, "platform", None)),
+                        getattr(event.source, "chat_id", "unknown"),
+                    )
+                    return
+                if action == "rewrite" and isinstance(pre_result.get("text"), str):
+                    event.text = pre_result["text"]
+
         session_key = build_session_key(
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
@@ -4719,7 +4780,26 @@ class BasePlatformAdapter(ABC):
                         except OSError:
                             pass
 
-                # Send the text portion
+                # Send the text portion. Guard against final responses that are
+                # technically non-empty but render as an empty WhatsApp/Telegram
+                # bubble (zero-width characters) or internal no-reply sentinels.
+                if text_content and not _has_visible_delivery_text(text_content):
+                    logger.warning(
+                        "[%s] Suppressing non-visible/silent response (%d chars) to %s",
+                        self.name, len(text_content), event.source.chat_id,
+                    )
+                    text_content = ""
+                if (
+                    text_content
+                    and event.source.platform == Platform.WHATSAPP
+                    and event.source.chat_type == "group"
+                    and _contains_internal_notes_leak(text_content)
+                ):
+                    logger.error(
+                        "[%s] Suppressing WhatsApp group response with internal notes leak to %s",
+                        self.name, event.source.chat_id,
+                    )
+                    text_content = ""
                 if text_content and not _tts_caption_delivered:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
                     _reply_anchor = _reply_anchor_for_event(event)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -76,6 +76,8 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|configured\s+compression\s+model\s+.+\s+failed"
     r"|no\s+auxiliary\s+llm\s+provider\s+configured"
     r"|auto-lowered\s+compression\s+threshold"
+    r"|auto-compaction\s+was\s+raised"
+    r"|codex\s+gpt-5\.5\s+caps\s+context"
     r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
     r"|preflight\s+compression"
     r"|rate\s+limited\.\s+waiting\s+\d"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9779,6 +9779,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+
+        whatsapp_context_bundle = None
+        whatsapp_context_preview = None
+        if source.platform == Platform.WHATSAPP and getattr(event, "message_id", None):
+            try:
+                from gateway.whatsapp_context import WhatsAppContextStore
+
+                _wa_context_store = WhatsAppContextStore(get_hermes_home() / "whatsapp_context")
+                whatsapp_context_bundle = _wa_context_store.build_context_bundle(
+                    str(source.chat_id),
+                    str(event.message_id),
+                    limit=50,
+                )
+                whatsapp_context_preview = whatsapp_context_bundle.render_for_prompt()
+                if whatsapp_context_preview:
+                    event.text = f"{whatsapp_context_preview}\n\n[Current addressed WhatsApp message]\n{event.text}"
+                _wa_context_store.record_reply_observability(
+                    chat_id=str(source.chat_id),
+                    trigger_message_id=str(event.message_id),
+                    context_bundle=whatsapp_context_bundle,
+                    final_prompt_preview=event.text or "",
+                )
+                logger.info(
+                    "whatsapp context bundle: trigger=%s context_ids=%s media=%s state=%s unreadable=%s",
+                    event.message_id,
+                    whatsapp_context_bundle.context_message_ids,
+                    whatsapp_context_bundle.media_paths,
+                    whatsapp_context_bundle.task_state,
+                    [ev.message_id for ev in whatsapp_context_bundle.unreadable_media],
+                )
+            except Exception as exc:
+                logger.warning(
+                    "whatsapp context bundle failed for chat=%s message=%s: %s",
+                    source.chat_id,
+                    getattr(event, "message_id", None),
+                    exc,
+                )
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -369,33 +369,136 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
     return bool(_GATEWAY_PROVIDER_ERROR_SHAPE_RE.search(body))
 
 
-def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
-    """Sanitize final gateway replies before sending them to high-noise chats.
+_GATEWAY_DIAGNOSTIC_MESSAGE_RE = re.compile(
+    r"("
+    r"model returned no response"
+    r"|processing (?:completed but no response was generated|stopped:)"
+    r"|response remained (?:truncated|incomplete)"
+    r"|codex response remained incomplete"
+    r"|empty/malformed response"
+    r"|provider authentication failed"
+    r"|request failed:"
+    r"|encountered an error"
+    r")",
+    re.IGNORECASE,
+)
 
-    Telegram is Bob's mobile inbox, so it should receive concise, safe provider
-    failure categories instead of raw HTTP bodies, request IDs, or policy text.
-    Other platforms keep the existing behaviour for now.
-    """
+
+def _looks_like_gateway_diagnostic_message(text: str) -> bool:
     if not text:
-        return text
-    if _gateway_platform_value(platform) != "telegram":
+        return False
+    body = str(text).strip()
+    return bool(
+        _GATEWAY_DIAGNOSTIC_MESSAGE_RE.search(body)
+        or _looks_like_gateway_provider_error(body)
+    )
+
+
+def _coerce_gateway_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+        return default
+    return is_truthy_value(value, default=default)
+
+
+def _gateway_platform_extra(config: Any, platform: Any) -> dict:
+    try:
+        platforms = getattr(config, "platforms", {}) or {}
+        platform_cfg = platforms.get(platform)
+        if platform_cfg is None:
+            platform_value = _gateway_platform_value(platform)
+            for key, candidate in platforms.items():
+                if _gateway_platform_value(key) == platform_value:
+                    platform_cfg = candidate
+                    break
+        extra = getattr(platform_cfg, "extra", {}) if platform_cfg is not None else {}
+        return extra if isinstance(extra, dict) else {}
+    except Exception:
+        return {}
+
+
+def _gateway_effective_allow_silent_response(config: Any, platform: Any) -> bool:
+    """Return whether empty model replies should be treated as intentional silence.
+
+    WhatsApp needs this by default: a no-reply model decision should not turn
+    into an alarming public group message. Other platforms retain the historical
+    default unless explicitly configured.
+    """
+    if _coerce_gateway_bool(getattr(config, "allow_silent_response", None), False):
+        return True
+    default = _gateway_platform_value(platform) == "whatsapp"
+    return _coerce_gateway_bool(
+        _gateway_platform_extra(config, platform).get("allow_silent_response"),
+        default,
+    )
+
+
+def _gateway_effective_suppress_provider_diagnostics(config: Any, platform: Any) -> bool:
+    """Return whether provider/internal diagnostics should stay out of chat.
+
+    WhatsApp group chats are not an operator console. Keep model retry/incomplete
+    diagnostics local by default there, while preserving existing behavior for
+    other platforms unless configured.
+    """
+    if _coerce_gateway_bool(
+        getattr(config, "suppress_provider_diagnostics_in_chat", None),
+        False,
+    ):
+        return True
+    default = _gateway_platform_value(platform) == "whatsapp"
+    return _coerce_gateway_bool(
+        _gateway_platform_extra(config, platform).get("suppress_diagnostics"),
+        default,
+    )
+
+
+def _sanitize_gateway_final_response(
+    platform: Any,
+    text: str,
+    *,
+    suppress_provider_diagnostics: bool = False,
+) -> str:
+    """Sanitize final gateway replies before sending them to chat."""
+    if not text:
         return text
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
+    if suppress_provider_diagnostics and _looks_like_gateway_diagnostic_message(redacted):
+        return ""
+
+    if _gateway_platform_value(platform) != "telegram":
+        return redacted
+
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted
 
 
-def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
+def _prepare_gateway_status_message(
+    platform: Any,
+    event_type: str,
+    message: str,
+    *,
+    suppress_provider_diagnostics: bool = False,
+) -> Optional[str]:
     """Filter/sanitize agent status callbacks before platform delivery."""
     text = str(message or "").strip()
     if not text:
         return None
+
+    text = _redact_gateway_user_facing_secrets(text)
+    if suppress_provider_diagnostics and _looks_like_gateway_diagnostic_message(text):
+        return None
+
     if _gateway_platform_value(platform) != "telegram":
         return text
 
-    text = _redact_gateway_user_facing_secrets(text)
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
         return None
     if _looks_like_gateway_provider_error(text):
@@ -2343,11 +2446,26 @@ import weakref as _weakref
 _gateway_runner_ref: _weakref.ref = lambda: None
 
 
+def _agent_result_is_clean_silent_empty(agent_result: dict) -> bool:
+    """Return True only for empty turns that can safely mean "no chat reply"."""
+    if not isinstance(agent_result, dict):
+        return False
+    if agent_result.get("failed") or agent_result.get("partial") or agent_result.get("error"):
+        return False
+    if agent_result.get("interrupted"):
+        return False
+    if agent_result.get("completed") is False:
+        return False
+    return True
+
+
 def _normalize_empty_agent_response(
     agent_result: dict,
     response: str,
     *,
     history_len: int = 0,
+    allow_silent_response: bool = False,
+    suppress_provider_diagnostics: bool = False,
 ) -> str:
     """Normalize empty/None agent responses into user-facing messages.
 
@@ -2364,7 +2482,12 @@ def _normalize_empty_agent_response(
     if response:
         return response
 
+    if allow_silent_response and _agent_result_is_clean_silent_empty(agent_result):
+        return ""
+
     if agent_result.get("failed"):
+        if suppress_provider_diagnostics:
+            return ""
         error_detail = agent_result.get("error", "unknown error")
         error_str = str(error_detail).lower()
         is_context_failure = any(
@@ -2385,6 +2508,8 @@ def _normalize_empty_agent_response(
     api_calls = int(agent_result.get("api_calls", 0) or 0)
     if api_calls > 0 and not agent_result.get("interrupted"):
         if agent_result.get("partial"):
+            if suppress_provider_diagnostics:
+                return ""
             err = agent_result.get("error", "processing incomplete")
             return f"⚠️ Processing stopped: {str(err)[:200]}. Try again."
         return (
@@ -10182,18 +10307,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             except Exception:
                 _intentional_silence = False
+            _allow_silent_response = _gateway_effective_allow_silent_response(
+                self.config,
+                source.platform,
+            )
+            _suppress_provider_diagnostics = _gateway_effective_suppress_provider_diagnostics(
+                self.config,
+                source.platform,
+            )
 
             # Convert the agent's internal "(empty)" sentinel into a
-            # user-friendly message.  "(empty)" means the model failed to
-            # produce visible content after exhausting all retries (nudge,
-            # prefill, empty-retry, fallback).  Sending the raw sentinel
-            # looks like a bug; a short explanation is more helpful.
+            # user-friendly message unless this platform treats a clean empty
+            # turn as intentional silence.
             if response == "(empty)" and not _intentional_silence:
-                response = (
-                    "⚠️ The model returned no response after processing tool "
-                    "results. This can happen with some models — try again or "
-                    "rephrase your question."
-                )
+                if _allow_silent_response and _agent_result_is_clean_silent_empty(agent_result):
+                    response = ""
+                else:
+                    response = (
+                        "⚠️ The model returned no response after processing tool "
+                        "results. This can happen with some models — try again or "
+                        "rephrase your question."
+                    )
+
             agent_messages = agent_result.get("messages", [])
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
@@ -10238,11 +10373,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.
-            if not _intentional_silence:
+            if _intentional_silence:
+                response = ""
+            else:
                 response = _normalize_empty_agent_response(
-                    agent_result, response, history_len=len(history),
+                    agent_result,
+                    response,
+                    history_len=len(history),
+                    allow_silent_response=_allow_silent_response,
+                    suppress_provider_diagnostics=_suppress_provider_diagnostics,
                 )
-                response = _sanitize_gateway_final_response(source.platform, response)
+                response = _sanitize_gateway_final_response(
+                    source.platform,
+                    response,
+                    suppress_provider_diagnostics=_suppress_provider_diagnostics,
+                )
 
             # Ordering contract: the agent thread already updated the contextvar
             # in conversation_compression.py; propagate to SessionEntry + _save().
@@ -15827,6 +15972,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 source.platform,
                 event_type,
                 message,
+                suppress_provider_diagnostics=_gateway_effective_suppress_provider_diagnostics(
+                    self.config,
+                    source.platform,
+                ),
             )
             if prepared_message is None:
                 logger.debug(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -391,6 +391,17 @@ _GATEWAY_DIAGNOSTIC_MESSAGE_RE = re.compile(
     re.IGNORECASE,
 )
 
+_GATEWAY_INTERNAL_CONTROL_MESSAGE_RE = re.compile(
+    r"("
+    r"^\[IMPORTANT:\s*(?:Background process|.*watch pattern|.*Watch pattern)"
+    r"|^\[Background process\s+proc_[A-Za-z0-9_\-]+\s+(?:finished|completed|is still running)"
+    r"|^\s*⏩\s*Steer queued\s+[—-]\s+arrives after the next tool call"
+    r"|^\s*Steer (?:queued|failed|rejected)\b"
+    r"|^\[Your active task list was preserved across context compression\]"
+    r")",
+    re.IGNORECASE | re.DOTALL,
+)
+
 
 def _looks_like_gateway_diagnostic_message(text: str) -> bool:
     if not text:
@@ -398,6 +409,7 @@ def _looks_like_gateway_diagnostic_message(text: str) -> bool:
     body = str(text).strip()
     return bool(
         _GATEWAY_DIAGNOSTIC_MESSAGE_RE.search(body)
+        or _GATEWAY_INTERNAL_CONTROL_MESSAGE_RE.search(body)
         or _looks_like_gateway_provider_error(body)
     )
 
@@ -466,14 +478,38 @@ def _gateway_effective_suppress_provider_diagnostics(config: Any, platform: Any)
     )
 
 
-_SILENT_FINAL_RESPONSE_SENTINELS = {"[SILENT]", "[[SILENT]]", "<SILENT>"}
+_SILENT_FINAL_RESPONSE_SENTINELS = {"[SILENT]", "[[SILENT]]", "<SILENT>", "SILENCIO"}
+_INVISIBLE_DELIVERY_CHARS_RE = re.compile(r"[\u200B\u200C\u200D\u2060\uFEFF\u180E\u2061-\u2064]")
+_NO_DELIVERY_STATUS_RE = re.compile(
+    r"^silencio\s*(?:[.!¡!。]|[-–—:]\s*(?:no\s+(?:(?:fui|estoy|me)\s+)?aludid[oa]|no\s+(?:reply|respuesta)|sin\s+respuesta).*)?$",
+    re.IGNORECASE,
+)
+
+
+def _strip_invisible_delivery_chars(text: Any) -> str:
+    """Remove characters that can make a chat bubble look blank."""
+    return _INVISIBLE_DELIVERY_CHARS_RE.sub("", str(text or ""))
+
+
+def _normalize_no_delivery_candidate(text: Any) -> str:
+    """Normalize exact model no-reply markers before delivery decisions."""
+    return _strip_invisible_delivery_chars(text).strip().strip("`\"'“”‘’").strip()
+
+
+def _has_visible_delivery_text(text: Any) -> bool:
+    """Return True only when *text* has visible, non-whitespace content."""
+    return bool(_strip_invisible_delivery_chars(text).strip())
 
 
 def _is_silent_final_response_sentinel(text: Any) -> bool:
     """Return True when a model final response means no visible reply."""
     if text is None:
         return False
-    return str(text).strip().upper() in _SILENT_FINAL_RESPONSE_SENTINELS
+    candidate = _normalize_no_delivery_candidate(text)
+    return (
+        candidate.upper() in _SILENT_FINAL_RESPONSE_SENTINELS
+        or bool(_NO_DELIVERY_STATUS_RE.fullmatch(candidate))
+    )
 
 
 def _sanitize_gateway_final_response(
@@ -485,6 +521,10 @@ def _sanitize_gateway_final_response(
     """Sanitize final gateway replies before sending them to chat."""
     if not text:
         return text
+
+    text = _strip_invisible_delivery_chars(text)
+    if not text.strip():
+        return ""
 
     if _is_silent_final_response_sentinel(text):
         return ""
@@ -517,6 +557,12 @@ def _prepare_gateway_status_message(
 
     text = _redact_gateway_user_facing_secrets(text)
     if suppress_provider_diagnostics and _looks_like_gateway_diagnostic_message(text):
+        return None
+
+    # WhatsApp has no safe non-chat status surface. Internal progress/status
+    # banners in WhatsApp groups are user-visible noise, so suppress them
+    # unconditionally instead of falling back to adapter.send().
+    if _gateway_platform_value(platform) == "whatsapp":
         return None
 
     if _gateway_platform_value(platform) != "telegram":
@@ -829,19 +875,20 @@ def _build_replay_entry(role: str, content: Any, msg: Dict[str, Any]) -> Dict[st
 
 
 _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER = "observed Telegram group context"
-_OBSERVED_GROUP_CONTEXT_HEADER = "[Observed Telegram group context - context only, not requests]"
+_OBSERVED_GROUP_CONTEXT_HEADER = "[Observed group context - context only, not requests]"
 _CURRENT_ADDRESSED_MESSAGE_HEADER = "[Current addressed message - answer only this unless it explicitly asks you to use the observed context]"
 
 
-def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool:
-    """Return True for Telegram group turns that may include observed chatter.
+def _uses_observed_group_context(channel_prompt: Optional[str]) -> bool:
+    """Return True for turns that may include observed group chatter.
 
-    Telegram's observe-unmentioned mode persists skipped group chatter so a
-    later @mention can see it. Those rows must not replay as ordinary user
-    turns: a weak wake word like ``@bot cambio`` should not make the model treat
-    old unmentioned chatter as pending work. The Telegram adapter marks these
-    turns with a channel prompt; this helper keeps the run-path check explicit
-    and unit-testable.
+    Observe-unmentioned mode persists skipped group chatter so a later direct
+    trigger can see it. Those rows must not replay as ordinary user turns: a
+    weak wake word like ``@bot cambio`` should not make the model treat old
+    unmentioned chatter as pending work. Telegram historically marked these
+    turns with a channel prompt; WhatsApp stores rows with ``observed=True``
+    and may not have a prompt marker, so callers also separate rows by that
+    flag below.
     """
 
     return bool(channel_prompt and _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER in channel_prompt)
@@ -894,7 +941,7 @@ def _build_gateway_agent_history(
     _msg_tz = _get_msg_tz()
     agent_history: List[Dict[str, Any]] = []
     observed_group_context: List[str] = []
-    separate_observed_context = _uses_telegram_observed_group_context(channel_prompt)
+    separate_observed_context = _uses_observed_group_context(channel_prompt)
 
     for msg in history or []:
         role = msg.get("role")
@@ -913,7 +960,7 @@ def _build_gateway_agent_history(
         content = msg.get("content")
         if inject_timestamps and role == "user" and isinstance(content, str):
             content = _render_msg_ts(content, msg.get("timestamp"), tz=_msg_tz)
-        if separate_observed_context and msg.get("observed") and role == "user" and content:
+        if (separate_observed_context or msg.get("observed")) and msg.get("observed") and role == "user" and content:
             observed_group_context.append(str(content).strip())
             continue
 
@@ -6172,6 +6219,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             
             # Set up message + fatal error handlers
             adapter.set_message_handler(self._handle_message)
+            adapter.set_pre_dispatch_handler(self._pre_gateway_dispatch)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -6972,6 +7020,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         continue
 
                     adapter.set_message_handler(self._handle_message)
+                    adapter.set_pre_dispatch_handler(self._pre_gateway_dispatch)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -7819,6 +7868,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not adapter:
             return
 
+        # WhatsApp has no private/status surface for internal operational
+        # notices; sending them through adapter.send() makes them visible in
+        # user chats/groups. Suppress instead.
+        if getattr(source, "platform", None) == Platform.WHATSAPP:
+            logger.debug("Suppressing internal platform notice for WhatsApp")
+            return
+
         config = getattr(self, "config", None)
         notice_delivery = "public"
         if config and hasattr(config, "get_notice_delivery"):
@@ -7843,6 +7899,62 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         await adapter.send(source.chat_id, content, metadata=metadata)
+
+    async def _pre_gateway_dispatch(self, event: MessageEvent) -> Optional[dict]:
+        """Run the hard pre-dispatch gate before adapter-visible processing.
+
+        This is the gateway-level no-reply path for WhatsApp groups: skipped
+        events are ingested/logged by the policy and never reach typing,
+        reactions, agent/LLM dispatch, or sendMessage.
+        """
+        source = event.source
+        platform_name = source.platform.value if getattr(source, "platform", None) else "unknown"
+        results: list[dict] = []
+
+        if platform_name == "whatsapp" and getattr(source, "chat_type", None) == "group":
+            try:
+                from gateway.group_routing import route_whatsapp_group_event
+
+                decision = route_whatsapp_group_event(
+                    event,
+                    gateway_config=self.config,
+                    session_store=self.session_store,
+                )
+                result = decision.as_hook_result()
+                results.append(result)
+            except Exception as exc:
+                logger.warning("WhatsApp group routing policy failed: %s", exc, exc_info=True)
+
+        # Preserve the public plugin hook as an extension point. It now runs
+        # early enough to return a true no-visible-output skip. The later
+        # _handle_message hook pass is skipped when this marker is set.
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+            plugin_results = _invoke_hook(
+                "pre_gateway_dispatch",
+                event=event,
+                gateway=self,
+                session_store=self.session_store,
+            )
+        except Exception as _hook_exc:
+            logger.warning("pre_gateway_dispatch invocation failed: %s", _hook_exc)
+            plugin_results = []
+
+        for plugin_result in plugin_results:
+            if isinstance(plugin_result, dict):
+                results.append(plugin_result)
+
+        setattr(event, "_pre_gateway_dispatch_evaluated", True)
+        for result in results:
+            action = result.get("action")
+            if action == "skip":
+                return result
+            if action == "rewrite":
+                return result
+            if action == "allow":
+                return result
+        return {"action": "allow", "reason": "pre_dispatch_no_policy_match"}
 
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
@@ -7886,7 +7998,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         #   {"action": "allow"}   /   None          -> normal dispatch
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
         # (e.g. customer handover ingest) without triggering the pairing flow.
-        if not is_internal:
+        if not is_internal and not getattr(event, "_pre_gateway_dispatch_evaluated", False):
             try:
                 from hermes_cli.plugins import invoke_hook as _invoke_hook
                 _hook_results = _invoke_hook(
@@ -13863,6 +13975,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return
         platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
+        if platform_name == "whatsapp":
+            logger.info(
+                "Suppressing watch-pattern process notification for WhatsApp chat=%s process=%s",
+                source.chat_id,
+                evt.get("session_id", "unknown"),
+            )
+            return
         adapter = None
         for p, a in self.adapters.items():
             if p.value == platform_name:
@@ -13982,6 +14101,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         message_id = str(watcher.get("message_id") or "").strip() or None
         agent_notify = watcher.get("notify_on_complete", False)
         notify_mode = self._load_background_notifications_mode()
+        if str(platform_name).strip().lower() == "whatsapp":
+            # WhatsApp chats/groups are customer-facing surfaces, not an operator
+            # console. Keep background process lifecycle/output notifications out
+            # of WhatsApp even when a tool was started with notify_on_complete.
+            agent_notify = False
+            notify_mode = "off"
+            logger.debug(
+                "Process watcher notifications forced off for WhatsApp process %s chat=%s",
+                session_id,
+                chat_id,
+            )
 
         logger.debug("Process watcher started: %s (every %ss, notify=%s, agent_notify=%s)",
                       session_id, interval, notify_mode, agent_notify)
@@ -16425,7 +16555,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             return
                 _deliver_bg_review_message(message)
 
-            agent.background_review_callback = _bg_review_send
+            # Background review delivery is internal status, not user content.
+            # WhatsApp has no non-chat status surface; never send these banners
+            # into WhatsApp chats/groups.
+            if source.platform == Platform.WHATSAPP:
+                agent.background_review_callback = None
+            else:
+                agent.background_review_callback = _bg_review_send
             # Register the release hook on the adapter so base.py's finally
             # block can fire it after delivering the main response.
             if _status_adapter and session_key:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -381,6 +381,12 @@ _GATEWAY_DIAGNOSTIC_MESSAGE_RE = re.compile(
     r"|provider authentication failed"
     r"|request failed:"
     r"|encountered an error"
+    r"|message delivery failed"
+    r"|response formatting failed"
+    r"|hermes gateway (?:starting|started|stopped|running|status)"
+    r"|gateway (?:service )?(?:is )?(?:down|offline|not running|not loaded|starting|stopped|running)"
+    r"|not connected to whatsapp"
+    r"|bootstrap failed"
     r")",
     re.IGNORECASE,
 )
@@ -460,6 +466,16 @@ def _gateway_effective_suppress_provider_diagnostics(config: Any, platform: Any)
     )
 
 
+_SILENT_FINAL_RESPONSE_SENTINELS = {"[SILENT]", "[[SILENT]]", "<SILENT>"}
+
+
+def _is_silent_final_response_sentinel(text: Any) -> bool:
+    """Return True when a model final response means no visible reply."""
+    if text is None:
+        return False
+    return str(text).strip().upper() in _SILENT_FINAL_RESPONSE_SENTINELS
+
+
 def _sanitize_gateway_final_response(
     platform: Any,
     text: str,
@@ -470,7 +486,12 @@ def _sanitize_gateway_final_response(
     if not text:
         return text
 
+    if _is_silent_final_response_sentinel(text):
+        return ""
+
     redacted = _redact_gateway_user_facing_secrets(str(text))
+    if _is_silent_final_response_sentinel(redacted):
+        return ""
     if suppress_provider_diagnostics and _looks_like_gateway_diagnostic_message(redacted):
         return ""
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -657,12 +657,17 @@ def is_shared_multi_user_session(
 
     Mirrors the isolation rules in :func:`build_session_key`:
       - DMs are never shared.
+      - WhatsApp groups/channels are always shared per chat. WhatsApp group
+        messages are a single conversation; splitting them by sender makes the
+        bot lose the message it just sent and the reply it just received.
       - Threads are shared unless ``thread_sessions_per_user`` is True.
       - Non-thread group/channel sessions are shared unless
         ``group_sessions_per_user`` is True (default: True = isolated).
     """
     if source.chat_type == "dm":
         return False
+    if source.platform == Platform.WHATSAPP:
+        return True
     if source.thread_id:
         return not thread_sessions_per_user
     return not group_sessions_per_user
@@ -711,6 +716,11 @@ def build_session_key(
 
     Group/channel rules:
       - chat_id identifies the parent group/channel.
+      - WhatsApp group/channel chats always use one shared per-chat session.
+        The participant id is never appended, even when the generic
+        ``group_sessions_per_user`` flag is enabled. WhatsApp groups behave as
+        a shared operational transcript, and splitting by sender causes the
+        assistant to lose context across adjacent messages in the same chat.
       - user_id/user_id_alt isolates participants within that parent chat when available when
         ``group_sessions_per_user`` is enabled.
       - thread_id differentiates threads within that parent chat.  When
@@ -766,10 +776,16 @@ def build_session_key(
     if source.thread_id:
         key_parts.append(source.thread_id)
 
+    # WhatsApp groups are always one shared per-chat transcript. The public
+    # reply policy still decides whether Jack speaks; session sharing only
+    # ensures same-chat context is coherent across Jacob, staff, and vendors.
+    if source.platform == Platform.WHATSAPP:
+        isolate_user = False
     # In threads, default to shared sessions (all participants see the same
     # conversation).  Per-user isolation only applies when explicitly enabled
     # via thread_sessions_per_user, or when there is no thread (regular group).
-    isolate_user = group_sessions_per_user
+    else:
+        isolate_user = group_sessions_per_user
     if source.thread_id and not thread_sessions_per_user:
         isolate_user = False
 

--- a/gateway/whatsapp_context.py
+++ b/gateway/whatsapp_context.py
@@ -1,0 +1,479 @@
+"""WhatsApp per-chat event log, context bundle, and deterministic task state.
+
+This module intentionally sits below prompting.  Mention-only WhatsApp groups still
+need to ingest every message, media filename, and receipt confirmation so a later
+mention can build grounded context before the LLM is called.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+_PAYMENT_WORD_RE = re.compile(
+    r"\b(payment|paid|receipt|proof|transfer|transaction|comprobante|pago|pagos|pagado|transferencia|recibo|spei|cep)\b",
+    re.IGNORECASE,
+)
+_CONFIRM_RECEIPT_RE = re.compile(
+    r"\b(confirmo\s+de\s+recibido|confirmado|recibido|recibida|received|confirmed)\b",
+    re.IGNORECASE,
+)
+_AMOUNT_RE = re.compile(
+    r"(?:\$\s*)?(\d{1,3}(?:[,.]\d{3})*(?:[,.]\d{1,2})?|\d+(?:[,.]\d{1,2})?)\s*(k|mil|mxn|usd|pesos|dolares|dólares)?",
+    re.IGNORECASE,
+)
+_CASE_RE = re.compile(
+    r"\b(?:Mercantil|Civil|Familiar|Penal|Exp(?:ediente)?\.?|Caso)\s*[#:]?\s*\d{1,6}\s*/\s*\d{2,4}\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class WhatsAppChatEvent:
+    chat_id: str
+    message_id: str
+    sender_id: str = ""
+    sender_name: str = ""
+    timestamp: str = ""
+    text_body: str = ""
+    message_type: str = "text"
+    quoted_message_id: str | None = None
+    mentioned_users: list[str] = field(default_factory=list)
+    media_filename: str | None = None
+    media_mime_type: str | None = None
+    local_media_path: str | None = None
+    extracted_text: str | None = None
+    download_extraction_status: str = "none"
+    raw: dict[str, Any] = field(default_factory=dict)
+    should_reply: bool = False
+
+
+@dataclass
+class WhatsAppPaymentState:
+    payment_proof_sent: bool = False
+    receipt_confirmed_by_counterparty: bool = False
+    amount: str | None = None
+    recipient_payee: str | None = None
+    sender: str | None = None
+    date_time: str | None = None
+    filename: str | None = None
+    linked_case_project: str | None = None
+    proof_message_id: str | None = None
+    confirmation_message_id: str | None = None
+
+    def as_prompt_dict(self) -> dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v not in (None, "", False)} | {
+            "payment_proof_sent": self.payment_proof_sent,
+            "receipt_confirmed_by_counterparty": self.receipt_confirmed_by_counterparty,
+        }
+
+
+@dataclass
+class WhatsAppContextBundle:
+    chat_id: str
+    trigger_message_id: str
+    current_message: WhatsAppChatEvent
+    recent_events: list[WhatsAppChatEvent]
+    quoted_chain: list[WhatsAppChatEvent]
+    recent_media: list[WhatsAppChatEvent]
+    task_state: dict[str, Any]
+    guardrails: dict[str, Any]
+    context_message_ids: list[str]
+    media_paths: list[str]
+    unreadable_media: list[WhatsAppChatEvent]
+    relevant_entities: list[str]
+
+    def render_for_prompt(self) -> str:
+        lines: list[str] = [
+            "[WhatsApp Context Bundle — same-chat evidence before answering]",
+            f"chat_id: {self.chat_id}",
+            f"trigger_message_id: {self.trigger_message_id}",
+            f"context_message_ids: {', '.join(self.context_message_ids)}",
+        ]
+        if self.relevant_entities:
+            lines.append("relevant_entities: " + ", ".join(self.relevant_entities))
+        if self.task_state:
+            lines.append("task_state: " + json.dumps(self.task_state, ensure_ascii=False, sort_keys=True))
+        if self.guardrails.get("block_payment_recommendation"):
+            lines.extend(
+                [
+                    "GUARDRAIL: Payment proof and/or receipt confirmation already exists in this chat.",
+                    "Do not recommend paying, authorizing payment, or sending the comprobante again.",
+                    "Move forward: request date/time of diligence; confirm application of payment to the correct case; request official receipt; ask what action remains pending.",
+                ]
+            )
+        if self.unreadable_media:
+            lines.append(
+                "Veo que se envió un archivo, pero no pude descargarlo o leerlo. Reenvíalo o respóndeme directamente al archivo."
+            )
+            lines.append("Do not pretend the unreadable media was read.")
+        lines.append("recent_messages:")
+        for ev in self.recent_events:
+            bits = [ev.message_id, ev.sender_name or ev.sender_id or "unknown", ev.message_type]
+            if ev.media_filename:
+                bits.append(f"file={ev.media_filename}")
+            if ev.local_media_path:
+                bits.append(f"path={ev.local_media_path}")
+            lines.append("- [" + " | ".join(bits) + f"] {ev.text_body}".rstrip())
+            if ev.extracted_text:
+                lines.append(f"  extracted_text: {ev.extracted_text[:4000]}")
+        if self.quoted_chain:
+            lines.append("quoted_chain:")
+            for ev in self.quoted_chain:
+                lines.append(f"- [{ev.message_id}] {ev.sender_name or ev.sender_id}: {ev.text_body}")
+        return "\n".join(lines).strip()
+
+
+class WhatsAppContextStore:
+    """Append-only per-chat WhatsApp event log plus context bundle builder."""
+
+    def __init__(self, root: Path | str):
+        self.root = Path(root)
+        self.chats_dir = self.root / "chats"
+        self.observability_dir = self.root / "reply-observability"
+        self.chats_dir.mkdir(parents=True, exist_ok=True)
+        self.observability_dir.mkdir(parents=True, exist_ok=True)
+
+    def ingest_bridge_message(self, data: dict[str, Any]) -> WhatsAppChatEvent:
+        event = self._event_from_bridge_message(data)
+        self._append_event(event)
+        return event
+
+    def build_context_bundle(self, chat_id: str, trigger_message_id: str, *, limit: int = 50) -> WhatsAppContextBundle:
+        events = self.load_chat_events(chat_id)
+        by_id = {ev.message_id: ev for ev in events}
+        current = by_id.get(trigger_message_id)
+        if current is None:
+            raise KeyError(f"No WhatsApp event {trigger_message_id!r} in chat {chat_id!r}")
+        idx = events.index(current)
+        recent = events[max(0, idx - limit + 1): idx + 1]
+        quoted_chain = self._quoted_chain(current, by_id)
+        recent_media = [ev for ev in recent if ev.message_type in {"image", "pdf", "document", "audio"} or ev.media_filename]
+        unreadable = [ev for ev in recent_media if self._media_unreadable(ev)]
+        payment_state = self._extract_payment_state(recent)
+        task_state = payment_state.as_prompt_dict()
+        entities = self._extract_entities(recent, current)
+        guardrails = {
+            "block_payment_recommendation": bool(
+                payment_state.payment_proof_sent or payment_state.receipt_confirmed_by_counterparty
+            )
+        }
+        context_ids = []
+        for ev in [*recent, *quoted_chain]:
+            if ev.message_id not in context_ids:
+                context_ids.append(ev.message_id)
+        media_paths = [ev.local_media_path for ev in recent_media if ev.local_media_path]
+        return WhatsAppContextBundle(
+            chat_id=chat_id,
+            trigger_message_id=trigger_message_id,
+            current_message=current,
+            recent_events=recent,
+            quoted_chain=quoted_chain,
+            recent_media=recent_media,
+            task_state=task_state,
+            guardrails=guardrails,
+            context_message_ids=context_ids,
+            media_paths=media_paths,
+            unreadable_media=unreadable,
+            relevant_entities=entities,
+        )
+
+    def record_reply_observability(
+        self,
+        *,
+        chat_id: str,
+        trigger_message_id: str,
+        context_bundle: WhatsAppContextBundle,
+        final_prompt_preview: str,
+        extraction_results: dict[str, Any] | None = None,
+    ) -> Path:
+        row = {
+            "timestamp": _now_iso(),
+            "chat_id": chat_id,
+            "trigger_message_id": trigger_message_id,
+            "context_message_ids": context_bundle.context_message_ids,
+            "media_files_included": context_bundle.media_paths,
+            "extracted_state_included": context_bundle.task_state,
+            "final_prompt_context_preview": final_prompt_preview[:8000],
+            "pdf_ocr_extraction": extraction_results or self._extraction_summary(context_bundle),
+        }
+        path = self.observability_dir / f"{_safe_name(chat_id)}.jsonl"
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+        return path
+
+    def load_chat_events(self, chat_id: str) -> list[WhatsAppChatEvent]:
+        path = self._chat_path(chat_id)
+        if not path.exists():
+            return []
+        events: list[WhatsAppChatEvent] = []
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                payload = json.loads(line)
+                events.append(WhatsAppChatEvent(**payload))
+        return events
+
+    def _append_event(self, event: WhatsAppChatEvent) -> None:
+        path = self._chat_path(event.chat_id)
+        existing_ids = {ev.message_id for ev in self.load_chat_events(event.chat_id)}
+        if event.message_id in existing_ids:
+            return
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(asdict(event), ensure_ascii=False, sort_keys=True) + "\n")
+
+    def _chat_path(self, chat_id: str) -> Path:
+        self.chats_dir.mkdir(parents=True, exist_ok=True)
+        return self.chats_dir / f"{_safe_name(chat_id)}.jsonl"
+
+    def _event_from_bridge_message(self, data: dict[str, Any]) -> WhatsAppChatEvent:
+        chat_id = str(data.get("chatId") or data.get("from") or "")
+        message_id = str(data.get("messageId") or data.get("id") or f"missing-{_now_iso()}")
+        media_filename = _first_nonempty(
+            data.get("mediaFileName"), data.get("fileName"), data.get("filename"), data.get("documentFileName"),
+            *_as_list(data.get("mediaFileNames")), *_as_list(data.get("fileNames")),
+        )
+        media_type_raw = str(data.get("mediaType") or "").lower()
+        has_media = bool(data.get("hasMedia") or media_filename or data.get("mediaUrls"))
+        msg_type = "text"
+        if has_media:
+            if "image" in media_type_raw:
+                msg_type = "image"
+            elif "audio" in media_type_raw or "ptt" in media_type_raw:
+                msg_type = "audio"
+            elif media_filename and media_filename.lower().endswith(".pdf"):
+                msg_type = "pdf"
+            else:
+                msg_type = "document"
+        local_media_path = self._local_media_path(data)
+        extracted_text = _first_nonempty(
+            data.get("extractedText"), data.get("extracted_text"), data.get("ocrText"), data.get("ocr_text")
+        )
+        if not extracted_text and local_media_path:
+            extracted_text = self._best_effort_extract_text(local_media_path)
+        status = str(
+            data.get("mediaDownloadStatus")
+            or data.get("downloadStatus")
+            or ("extracted" if extracted_text else "downloaded" if local_media_path else "failed" if has_media else "none")
+        )
+        mentioned = [str(v) for v in _as_list(data.get("mentionedIds"))]
+        bot_ids = {str(v).lower() for v in _as_list(data.get("botIds"))}
+        text = str(data.get("body") or data.get("text") or "")
+        should_reply = bool({m.lower() for m in mentioned} & bot_ids) or bool(re.search(r"@\s*(jack|hermes)\b", text, re.I))
+        return WhatsAppChatEvent(
+            chat_id=chat_id,
+            message_id=message_id,
+            sender_id=str(data.get("senderId") or data.get("from") or ""),
+            sender_name=str(data.get("senderName") or data.get("pushName") or ""),
+            timestamp=str(data.get("timestamp") or _now_iso()),
+            text_body=text,
+            message_type=msg_type,
+            quoted_message_id=_first_nonempty(data.get("quotedMessageId"), data.get("replyToMessageId")),
+            mentioned_users=mentioned,
+            media_filename=media_filename,
+            media_mime_type=_first_nonempty(data.get("mediaMimeType"), data.get("mimeType"), _mime_from_type(msg_type, media_filename)),
+            local_media_path=local_media_path,
+            extracted_text=extracted_text,
+            download_extraction_status=status,
+            raw=dict(data),
+            should_reply=should_reply,
+        )
+
+    def _local_media_path(self, data: dict[str, Any]) -> str | None:
+        candidates = [
+            data.get("mediaPath"), data.get("localMediaPath"), data.get("documentPath"),
+            *_as_list(data.get("mediaUrls")), *_as_list(data.get("media_paths")),
+        ]
+        for value in candidates:
+            if not value:
+                continue
+            text = str(value)
+            if text.startswith("file://"):
+                text = text[7:]
+            if text.startswith("/"):
+                return text
+        return None
+
+    def _best_effort_extract_text(self, path: str) -> str | None:
+        p = Path(path)
+        if not p.exists() or not p.is_file():
+            return None
+        if p.suffix.lower() in {".txt", ".md", ".csv", ".json", ".xml", ".yaml", ".yml", ".log"}:
+            try:
+                return p.read_text(encoding="utf-8", errors="replace")[:100_000]
+            except OSError:
+                return None
+        # Optional PDF extraction: use pypdf if present, otherwise report as downloaded but unread.
+        if p.suffix.lower() == ".pdf":
+            try:
+                from pypdf import PdfReader  # type: ignore
+
+                reader = PdfReader(str(p))
+                chunks = [(page.extract_text() or "") for page in reader.pages[:20]]
+                text = "\n".join(chunks).strip()
+                return text[:100_000] or None
+            except Exception:
+                return None
+        return None
+
+    def _quoted_chain(self, current: WhatsAppChatEvent, by_id: dict[str, WhatsAppChatEvent]) -> list[WhatsAppChatEvent]:
+        chain: list[WhatsAppChatEvent] = []
+        seen: set[str] = set()
+        qid = current.quoted_message_id
+        while qid and qid not in seen:
+            seen.add(qid)
+            ev = by_id.get(qid)
+            if ev is None:
+                break
+            chain.append(ev)
+            qid = ev.quoted_message_id
+        return chain
+
+    def _extract_payment_state(self, events: Iterable[WhatsAppChatEvent]) -> WhatsAppPaymentState:
+        state = WhatsAppPaymentState()
+        for ev in events:
+            haystack = "\n".join(
+                part for part in [ev.text_body, ev.media_filename or "", ev.extracted_text or ""] if part
+            )
+            if (ev.media_filename or ev.message_type in {"pdf", "image", "document"}) and _PAYMENT_WORD_RE.search(haystack):
+                state.payment_proof_sent = True
+                state.filename = state.filename or ev.media_filename
+                state.proof_message_id = state.proof_message_id or ev.message_id
+                state.sender = state.sender or ev.sender_name or ev.sender_id
+                state.date_time = state.date_time or ev.timestamp
+                state.amount = state.amount or _extract_amount(haystack)
+                state.recipient_payee = state.recipient_payee or _extract_payee(haystack)
+                state.linked_case_project = state.linked_case_project or _extract_case(haystack)
+            if _CONFIRM_RECEIPT_RE.search(ev.text_body or ""):
+                state.receipt_confirmed_by_counterparty = True
+                state.confirmation_message_id = state.confirmation_message_id or ev.message_id
+        return state
+
+    def _extract_entities(self, events: Iterable[WhatsAppChatEvent], current: WhatsAppChatEvent) -> list[str]:
+        text = "\n".join(
+            part
+            for ev in events
+            for part in [ev.text_body, ev.media_filename or "", ev.extracted_text or "", ev.sender_name]
+            if part
+        ) + "\n" + current.text_body
+        entities: list[str] = []
+        for needle in ["Eduardo", "Gestión Inmobiliaria y Legal", "Gestión Inmobiliaria Y Legal"]:
+            if needle.lower() in text.lower() and needle not in entities:
+                entities.append(needle)
+        case = _extract_case(text)
+        if case and case not in entities:
+            entities.append(case)
+        return entities
+
+    @staticmethod
+    def _media_unreadable(ev: WhatsAppChatEvent) -> bool:
+        if ev.message_type not in {"image", "pdf", "document", "audio"} and not ev.media_filename:
+            return False
+        status = (ev.download_extraction_status or "").lower()
+        if status in {"failed", "download_failed", "extraction_failed", "unreadable"}:
+            return True
+        if not ev.local_media_path:
+            return True
+        if ev.message_type in {"pdf", "image", "document"} and not ev.extracted_text:
+            return True
+        return False
+
+    @staticmethod
+    def _extraction_summary(bundle: WhatsAppContextBundle) -> dict[str, Any]:
+        return {
+            ev.message_id: {
+                "filename": ev.media_filename,
+                "status": ev.download_extraction_status,
+                "has_extracted_text": bool(ev.extracted_text),
+            }
+            for ev in bundle.recent_media
+        }
+
+
+def _extract_amount(text: str) -> str | None:
+    candidates: list[tuple[float, str]] = []
+    for match in _AMOUNT_RE.finditer(text):
+        raw, suffix = match.group(1), (match.group(2) or "")
+        # Avoid treating case numbers/years as payment amounts.
+        span = match.span()
+        surrounding = text[max(0, span[0] - 15): span[1] + 15]
+        if "/" in surrounding and not suffix:
+            continue
+        normalized = raw.replace(",", "")
+        try:
+            value = float(normalized)
+        except ValueError:
+            value = 0.0
+        if suffix.lower() in {"k", "mil"} and value < 1000:
+            value *= 1000
+        if value >= 100:
+            display = f"${value:,.0f}" if value.is_integer() else f"${value:,.2f}"
+            candidates.append((value, display))
+    if not candidates:
+        return None
+    # Payment proofs usually mention the payment amount as the largest currency-like number.
+    return sorted(candidates, reverse=True)[0][1]
+
+
+def _extract_payee(text: str) -> str | None:
+    if re.search(r"gesti[oó]n\s+inmobiliaria\s+y\s+legal", text, re.I):
+        return "Gestión Inmobiliaria y Legal"
+    m = re.search(r"(?:beneficiario|recipient|payee|a nombre de|para)\s*[:\-]?\s*([^\n.;,]{3,80})", text, re.I)
+    if m:
+        return m.group(1).strip()
+    return None
+
+
+def _extract_case(text: str) -> str | None:
+    m = _CASE_RE.search(text)
+    if not m:
+        return None
+    return re.sub(r"\s*/\s*", "/", m.group(0)).strip()
+
+
+def _mime_from_type(msg_type: str, filename: str | None) -> str | None:
+    if msg_type == "image":
+        return "image/jpeg"
+    if msg_type == "audio":
+        return "audio/ogg"
+    if filename and filename.lower().endswith(".pdf"):
+        return "application/pdf"
+    if msg_type == "document":
+        return "application/octet-stream"
+    return None
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, set):
+        return list(value)
+    return [value]
+
+
+def _first_nonempty(*values: Any) -> str | None:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value)
+        if text:
+            return text
+    return None
+
+
+def _safe_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value or "unknown")[:180]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2288,6 +2288,15 @@ DEFAULT_CONFIG = {
         # Default (None) uses the built-in "⚕ *Hermes Agent*" header.
         # Set to "" (empty string) to disable the header entirely.
         # Supports \n for newlines, e.g. "🤖 *My Bot*\n──────\n"
+        "reply_prefix": None,
+        # Default public-group behavior: read/retain all group context, but
+        # only visibly reply when mentioned, replied-to, slash-invoked, or in a
+        # configured free-response chat.
+        "require_mention": True,
+        "free_response_chats": "",
+        "observe_unmentioned_group_messages": True,
+        "group_policy": "open",
+        "group_allow_from": "*",
     },
 
     # Telegram platform settings (gateway mode)
@@ -2708,6 +2717,22 @@ DEFAULT_CONFIG = {
             # bounding CPU / memory / upstream-LLM-quota exhaustion from a
             # request flood. Set to 0 to disable the cap entirely.
             "max_concurrent_runs": 10,
+        },
+
+        # Gateway-level WhatsApp group routing policy. Runs before agent/LLM
+        # dispatch so groups default to quiet observation unless Hermes is
+        # directly addressed or the group is explicitly configured otherwise.
+        "whatsapp_group_routing": {
+            "enabled": True,
+            "group_mode": "mention_only",  # observe_only, mention_only, authorized_coordination, active_ops
+            "allowed_public_reply": False,
+            "allowed_dm_followup": False,
+            "noise_tolerance": "low",  # low, medium, high
+            "default_followup_channel": "private_jacob",  # private_jacob, direct_owner, group
+            "aliases": {
+                "hermes": ["hermes", "jack"],
+                "jacob": ["jacob"],
+            },
         },
     },
 

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -266,6 +266,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
+    _has_visible_delivery_text,
     cache_image_from_url,
     cache_audio_from_url,
 )
@@ -394,8 +395,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             or config.extra.get("allowFrom")
             or os.getenv("WHATSAPP_ALLOWED_USERS")
         )
+        # Jacob correction 2026-06-16: reactions are public WhatsApp noise.
+        # Use a real quiet-window debounce so rapid multi-message thoughts get
+        # one reaction on the latest/key message instead of one reaction per
+        # sentence. Configurable via whatsapp.extra.reaction_batch_delay_seconds.
         self._reaction_batch_delay_seconds = self._coerce_float_extra(
-            "reaction_batch_delay_seconds", 4.0
+            "reaction_batch_delay_seconds", 30.0
         )
         self._pending_reactions: Dict[str, Dict[str, Any]] = {}
         self._pending_reaction_tasks: Dict[str, asyncio.Task] = {}
@@ -460,7 +465,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     def _should_react_to_event(self, event: MessageEvent) -> bool:
         """Return True when this inbound WhatsApp message should get a receipt reaction."""
-        if not self._reactions_enabled:
+        if not getattr(self, "_reactions_enabled", False):
             return False
         if getattr(event.source, "chat_type", None) != "group":
             return False
@@ -488,7 +493,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     def _should_react_to_message_data(self, data: Dict[str, Any]) -> bool:
         """Return True when raw incoming WhatsApp data should get a receipt reaction."""
-        if not self._reactions_enabled:
+        if not getattr(self, "_reactions_enabled", False):
             return False
         if not data.get("isGroup", False):
             return False
@@ -580,32 +585,65 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "participant": raw_message.get("senderId") or raw_message.get("participant") or sender_id,
                 "emoji": emoji,
             }
-            async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/react",
-                json=payload,
-                timeout=aiohttp.ClientTimeout(total=5),
-            ) as resp:
-                if resp.status == 200:
-                    logger.info(
-                        "[%s] Reacted to WhatsApp group message %s in %s with %s",
+            for attempt in range(2):
+                async with self._http_session.post(
+                    f"http://127.0.0.1:{self._bridge_port}/react",
+                    json=payload,
+                    timeout=aiohttp.ClientTimeout(total=5),
+                ) as resp:
+                    if resp.status == 200:
+                        logger.info(
+                            "[%s] Reacted to WhatsApp group message %s in %s with %s",
+                            self.name,
+                            message_id,
+                            chat_id,
+                            emoji,
+                        )
+                        return True
+
+                    body = await resp.text()
+                    if resp.status == 429 and attempt == 0:
+                        retry_after = self._extract_reaction_retry_after_seconds(body)
+                        if retry_after > 0:
+                            logger.info(
+                                "[%s] WhatsApp reaction delayed for message %s in %s; retrying in %.1fs",
+                                self.name,
+                                message_id,
+                                chat_id,
+                                retry_after,
+                            )
+                            await asyncio.sleep(retry_after)
+                            continue
+
+                    logger.warning(
+                        "[%s] WhatsApp reaction failed (%s) for message %s in %s: %s",
                         self.name,
+                        resp.status,
                         message_id,
                         chat_id,
-                        emoji,
+                        body[:300],
                     )
-                    return True
-                body = await resp.text()
-                logger.warning(
-                    "[%s] WhatsApp reaction failed (%s) for message %s in %s: %s",
-                    self.name,
-                    resp.status,
-                    message_id,
-                    chat_id,
-                    body[:300],
-                )
+                    return False
         except Exception as exc:
             logger.warning("[%s] WhatsApp reaction failed for %s in %s: %s", self.name, message_id, chat_id, exc)
         return False
+
+    @staticmethod
+    def _extract_reaction_retry_after_seconds(body: str) -> float:
+        """Parse bridge retryAfterSeconds from a 429 reaction response."""
+        try:
+            payload = json.loads(body or "{}")
+        except Exception:
+            return 0.0
+        try:
+            retry_after = float(payload.get("retryAfterSeconds") or 0)
+        except (TypeError, ValueError):
+            return 0.0
+        if retry_after <= 0:
+            return 0.0
+        # Keep the bridge's retry contract useful without letting a malformed
+        # response park the gateway's background task indefinitely.
+        return min(retry_after, 60.0)
 
     def _effective_reply_prefix(self) -> str:
         """Return the prefix the Node bridge will add in self-chat mode."""
@@ -651,7 +689,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if isinstance(configured, str):
                 return configured.lower() in {"true", "1", "yes", "on"}
             return bool(configured)
-        return os.getenv("WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES", "false").lower() in {"true", "1", "yes", "on"}
+        return os.getenv("WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES", "true").lower() in {"true", "1", "yes", "on"}
 
     @staticmethod
     def _coerce_allow_list(raw) -> set[str]:
@@ -744,7 +782,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return ""
         normalized = str(value).strip()
         if ":" in normalized and "@" in normalized:
-            normalized = normalized.replace(":", "@", 1)
+            local, server = normalized.split("@", 1)
+            normalized = f"{local.split(':', 1)[0]}@{server}"
         return normalized
 
     def _bot_ids_from_message(self, data: Dict[str, Any]) -> set[str]:
@@ -834,6 +873,29 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return True
         return self._should_consider_reply_to_reaction_sender_message(data)
 
+    def _whatsapp_direct_group_trigger_reason(self, data: Dict[str, Any]) -> Optional[str]:
+        """Return why a group message directly addressed Hermes, if it did.
+
+        The gateway pre-dispatch hard gate runs after the adapter has already
+        cleaned visible bot mention text out of ``event.text``. Preserve the
+        adapter's original direct-trigger decision in ``raw_message`` so the
+        second gate does not misclassify a native/display @Jack mention as a
+        mention of another participant.
+        """
+        chat_id_raw = str(data.get("chatId") or "")
+        if self._is_broadcast_chat(chat_id_raw) or not data.get("isGroup", False):
+            return None
+        body = str(data.get("body") or "").strip()
+        if body.startswith("/"):
+            return "slash_command"
+        if self._message_is_reply_to_bot(data):
+            return "reply_to_hermes_message"
+        if self._message_mentions_bot(data):
+            return "mentioned_hermes_metadata"
+        if self._message_matches_mention_patterns(data):
+            return "direct_hermes_text_address"
+        return None
+
     def _should_consider_reply_to_reaction_sender_message(self, data: Dict[str, Any]) -> bool:
         """Let approved Jacob-origin group messages reach the agent for reply/silence choice.
 
@@ -841,7 +903,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         gateway should still dispatch the message so Jack can decide whether a
         concise WhatsApp reply is useful.
         """
-        if not self._reactions_enabled:
+        if not getattr(self, "_reactions_enabled", False):
             return False
         if not self._coerce_bool_extra("reply_consider_reaction_senders", True):
             return False
@@ -873,7 +935,25 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         sender_id = event.source.user_id or "unknown"
         sender = event.source.user_name or sender_id
         text = event.text or ""
-        return f"[{sender} ({sender_id})]: {text}" if text else f"[{sender} ({sender_id})]"
+        media_bits = []
+        if event.media_urls:
+            for idx, url in enumerate(event.media_urls, start=1):
+                mtype = ""
+                if idx - 1 < len(event.media_types):
+                    mtype = event.media_types[idx - 1] or ""
+                label = "media"
+                if event.message_type == MessageType.PHOTO:
+                    label = "image"
+                elif event.message_type == MessageType.VIDEO:
+                    label = "video"
+                elif event.message_type == MessageType.VOICE:
+                    label = "voice"
+                elif event.message_type == MessageType.DOCUMENT:
+                    label = "document"
+                suffix = f" ({mtype})" if mtype else ""
+                media_bits.append(f"[{label} received{suffix}: {url}]")
+        observed = "\n".join(part for part in [text, *media_bits] if part)
+        return f"[{sender} ({sender_id})]: {observed}" if observed else f"[{sender} ({sender_id})]"
 
     @staticmethod
     def _whatsapp_group_observe_shared_source(source):
@@ -1397,7 +1477,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if bridge_exit:
             return SendResult(success=False, error=bridge_exit)
 
-        if not content or not content.strip():
+        if not _has_visible_delivery_text(content):
+            logger.warning(
+                "[Whatsapp] Suppressing non-visible/silent send (%d chars) to %s",
+                len(str(content or "")), chat_id,
+            )
             return SendResult(success=True, message_id=None)
 
         chat_id = to_whatsapp_jid(chat_id)
@@ -1407,6 +1491,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
             # Format and chunk the message
             formatted = self.format_message(content)
+            if not _has_visible_delivery_text(formatted):
+                logger.warning(
+                    "[Whatsapp] Suppressing non-visible/silent formatted send (%d chars) to %s",
+                    len(str(formatted or "")), chat_id,
+                )
+                return SendResult(success=True, message_id=None)
             chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
 
             raw_mentions = metadata.get("mentions") if isinstance(metadata, dict) else None
@@ -1430,6 +1520,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     json=payload,
                     timeout=aiohttp.ClientTimeout(total=30)
                 ) as resp:
+                    if resp.status == 204:
+                        # Bridge-level no-visible-content guard suppressed the send.
+                        continue
                     if resp.status == 200:
                         data = await resp.json()
                         last_message_id = data.get("messageId")
@@ -1759,6 +1852,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             should_observe = False if should_process else self._should_observe_unmentioned_group_message(data)
             if not should_process and not should_observe:
                 return None
+            direct_group_trigger_reason = self._whatsapp_direct_group_trigger_reason(data) if should_process else None
+            if direct_group_trigger_reason:
+                data["_hermes_direct_group_trigger_reason"] = direct_group_trigger_reason
 
             # Determine message type
             msg_type = MessageType.TEXT

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -16,12 +16,15 @@ with different backends via a bridge pattern.
 """
 
 import asyncio
+import dataclasses
+import json
 import logging
 import os
 import platform
 import re
 import signal
 import subprocess
+from datetime import datetime, timezone
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
@@ -450,6 +453,17 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
+    def _whatsapp_observe_unmentioned_group_messages(self) -> bool:
+        """Return whether skipped unmentioned group messages are stored as context."""
+        configured = self.config.extra.get("observe_unmentioned_group_messages")
+        if configured is None:
+            configured = self.config.extra.get("ingest_unmentioned_group_messages")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES", "false").lower() in {"true", "1", "yes", "on"}
+
     @staticmethod
     def _coerce_allow_list(raw) -> set[str]:
         """Parse allow_from / group_allow_from from config or env var."""
@@ -628,6 +642,58 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if self._message_mentions_bot(data):
             return True
         return self._message_matches_mention_patterns(data)
+
+    def _should_observe_unmentioned_group_message(self, data: Dict[str, Any]) -> bool:
+        """Return True when a group message should be stored but not dispatched."""
+        if not self._whatsapp_observe_unmentioned_group_messages():
+            return False
+        chat_id_raw = str(data.get("chatId") or "")
+        if self._is_broadcast_chat(chat_id_raw):
+            return False
+        if not data.get("isGroup", False):
+            return False
+        if not self._is_group_allowed(chat_id_raw):
+            return False
+        # Do not double-store messages that should already trigger the agent.
+        return not self._should_process_message(data)
+
+    @staticmethod
+    def _whatsapp_group_observe_attributed_text(event: MessageEvent) -> str:
+        sender_id = event.source.user_id or "unknown"
+        sender = event.source.user_name or sender_id
+        text = event.text or ""
+        return f"[{sender} ({sender_id})]: {text}" if text else f"[{sender} ({sender_id})]"
+
+    @staticmethod
+    def _whatsapp_group_observe_shared_source(source):
+        """Use a shared group-scoped source so later triggers see the same context."""
+        return dataclasses.replace(source, user_id=None, user_name=None, user_id_alt=None)
+
+    def _observe_unmentioned_group_message(self, event: MessageEvent) -> None:
+        """Append skipped WhatsApp group chatter to the target session without dispatching."""
+        store = getattr(self, "_session_store", None)
+        if not store:
+            return
+        try:
+            shared_source = self._whatsapp_group_observe_shared_source(event.source)
+            session_entry = store.get_or_create_session(shared_source)
+            entry = {
+                "role": "user",
+                "content": self._whatsapp_group_observe_attributed_text(event),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "observed": True,
+            }
+            if event.message_id:
+                entry["message_id"] = str(event.message_id)
+            store.append_to_transcript(session_entry.session_id, entry)
+            logger.info(
+                "[%s] WhatsApp group message observed (no bot trigger): chat=%s from=%s",
+                self.name,
+                event.source.chat_id,
+                event.source.user_id or "unknown",
+            )
+        except Exception as exc:
+            logger.warning("[%s] Failed to observe WhatsApp group message: %s", self.name, exc)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
@@ -1360,7 +1426,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
-            if not self._should_process_message(data):
+            should_process = self._should_process_message(data)
+            should_observe = False if should_process else self._should_observe_unmentioned_group_message(data)
+            if not should_process and not should_observe:
                 return None
 
             # Determine message type
@@ -1482,7 +1550,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
-            return MessageEvent(
+            event = MessageEvent(
                 text=body,
                 message_type=msg_type,
                 source=source,
@@ -1491,6 +1559,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 media_urls=cached_urls,
                 media_types=media_types,
             )
+            if should_observe:
+                self._observe_unmentioned_group_message(event)
+                return None
+            return event
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")
             return None
@@ -1609,6 +1681,8 @@ def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
     import json as _json
     if "require_mention" in whatsapp_cfg and not os.getenv("WHATSAPP_REQUIRE_MENTION"):
         os.environ["WHATSAPP_REQUIRE_MENTION"] = str(whatsapp_cfg["require_mention"]).lower()
+    if "observe_unmentioned_group_messages" in whatsapp_cfg and not os.getenv("WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES"):
+        os.environ["WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES"] = str(whatsapp_cfg["observe_unmentioned_group_messages"]).lower()
     if "mention_patterns" in whatsapp_cfg and not os.getenv("WHATSAPP_MENTION_PATTERNS"):
         os.environ["WHATSAPP_MENTION_PATTERNS"] = _json.dumps(whatsapp_cfg["mention_patterns"])
     frc = whatsapp_cfg.get("free_response_chats")

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -359,7 +359,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._dm_policy = str(config.extra.get("dm_policy") or os.getenv("WHATSAPP_DM_POLICY", "open")).strip().lower()
         self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
-        self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        self._group_allow_from = self._coerce_allow_list(
+            config.extra.get("group_allow_from")
+            or config.extra.get("groupAllowFrom")
+            or os.getenv("WHATSAPP_GROUP_ALLOWED_USERS")
+        )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
@@ -410,6 +414,220 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not math.isfinite(parsed) or parsed < 0:
             return float(default)
         return parsed
+
+    def _effective_reply_prefix(self) -> str:
+        """Return the prefix the Node bridge will add in self-chat mode."""
+        whatsapp_mode = os.getenv("WHATSAPP_MODE", "self-chat")
+        if whatsapp_mode != "self-chat":
+            return ""
+        if self._reply_prefix is not None:
+            return self._reply_prefix.replace("\\n", "\n")
+        env_prefix = os.getenv("WHATSAPP_REPLY_PREFIX")
+        if env_prefix is not None:
+            return env_prefix.replace("\\n", "\n")
+        return self.DEFAULT_REPLY_PREFIX
+
+    def _outgoing_chunk_limit(self) -> int:
+        """Reserve room for the bridge-side prefix so final WhatsApp text fits."""
+        prefix_len = len(self._effective_reply_prefix())
+        # Keep enough space for truncate_message's pagination indicator and
+        # code-fence repair even if a user configures a very long prefix.
+        return max(1024, self.MAX_MESSAGE_LENGTH - prefix_len)
+
+    def _whatsapp_require_mention(self) -> bool:
+        configured = self.config.extra.get("require_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("WHATSAPP_REQUIRE_MENTION", "false").lower() in {"true", "1", "yes", "on"}
+
+    def _whatsapp_free_response_chats(self) -> set[str]:
+        raw = self.config.extra.get("free_response_chats")
+        if raw is None:
+            raw = os.getenv("WHATSAPP_FREE_RESPONSE_CHATS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    @staticmethod
+    def _coerce_allow_list(raw) -> set[str]:
+        """Parse allow_from / group_allow_from from config or env var."""
+        if raw is None:
+            return set()
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    @staticmethod
+    def _is_broadcast_chat(chat_id: str) -> bool:
+        """True for WhatsApp pseudo-chats that aren't real conversations.
+
+        Covers Status updates (Stories) and Channel/Newsletter broadcasts.
+        These show up as inbound messages on Baileys but the agent should
+        never reply — answering a Story update spams the contact's status
+        feed, and Channel posts aren't addressable in the first place.
+        """
+        if not chat_id:
+            return False
+        cid = chat_id.strip().lower()
+        if cid == "status@broadcast":
+            return True
+        # @broadcast suffix covers status@broadcast plus any future
+        # broadcast-list variants. @newsletter is the Channel JID suffix.
+        if cid.endswith("@broadcast") or cid.endswith("@newsletter"):
+            return True
+        return False
+
+    @property
+    def enforces_own_access_policy(self) -> bool:
+        """WhatsApp gates DM/group access at intake via dm_policy/group_policy."""
+        return True
+
+    def _is_dm_allowed(self, sender_id: str) -> bool:
+        """Check whether a DM from the given sender should be processed."""
+        if self._dm_policy == "disabled":
+            return False
+        if self._dm_policy == "allowlist":
+            return sender_id in self._allow_from
+        # "open" — all DMs allowed
+        return True
+
+    def _is_group_allowed(self, chat_id: str) -> bool:
+        """Check whether a group chat should be processed."""
+        if self._group_policy == "disabled":
+            return False
+        if self._group_policy == "allowlist":
+            if "*" in self._group_allow_from:
+                return True
+            return chat_id in self._group_allow_from
+        # "open" — all groups allowed
+        return True
+
+    def _compile_mention_patterns(self):
+        patterns = self.config.extra.get("mention_patterns")
+        if patterns is None:
+            raw = os.getenv("WHATSAPP_MENTION_PATTERNS", "").strip()
+            if raw:
+                try:
+                    patterns = json.loads(raw)
+                except Exception:
+                    patterns = [part.strip() for part in raw.splitlines() if part.strip()]
+                    if not patterns:
+                        patterns = [part.strip() for part in raw.split(",") if part.strip()]
+        if patterns is None:
+            return []
+        if isinstance(patterns, str):
+            patterns = [patterns]
+        if not isinstance(patterns, list):
+            logger.warning("[%s] whatsapp mention_patterns must be a list or string; got %s", self.name, type(patterns).__name__)
+            return []
+
+        compiled = []
+        for pattern in patterns:
+            if not isinstance(pattern, str) or not pattern.strip():
+                continue
+            try:
+                compiled.append(re.compile(pattern, re.IGNORECASE))
+            except re.error as exc:
+                logger.warning("[%s] Invalid WhatsApp mention pattern %r: %s", self.name, pattern, exc)
+        if compiled:
+            logger.info("[%s] Loaded %d WhatsApp mention pattern(s)", self.name, len(compiled))
+        return compiled
+
+    @staticmethod
+    def _normalize_whatsapp_id(value: Optional[str]) -> str:
+        if not value:
+            return ""
+        normalized = str(value).strip()
+        if ":" in normalized and "@" in normalized:
+            normalized = normalized.replace(":", "@", 1)
+        return normalized
+
+    def _bot_ids_from_message(self, data: Dict[str, Any]) -> set[str]:
+        bot_ids = set()
+        for candidate in data.get("botIds") or []:
+            normalized = self._normalize_whatsapp_id(candidate)
+            if normalized:
+                bot_ids.add(normalized)
+        return bot_ids
+
+    def _message_is_reply_to_bot(self, data: Dict[str, Any]) -> bool:
+        quoted_participant = self._normalize_whatsapp_id(data.get("quotedParticipant"))
+        if not quoted_participant:
+            return False
+        return quoted_participant in self._bot_ids_from_message(data)
+
+    def _message_mentions_bot(self, data: Dict[str, Any]) -> bool:
+        bot_ids = self._bot_ids_from_message(data)
+        if not bot_ids:
+            return False
+        mentioned_ids = {
+            nid
+            for candidate in (data.get("mentionedIds") or [])
+            if (nid := self._normalize_whatsapp_id(candidate))
+        }
+        if mentioned_ids & bot_ids:
+            return True
+
+        body = str(data.get("body") or "")
+        lower_body = body.lower()
+        for bot_id in bot_ids:
+            bare_id = bot_id.split("@", 1)[0].lower()
+            if bare_id and (f"@{bare_id}" in lower_body or bare_id in lower_body):
+                return True
+        return False
+
+    def _message_matches_mention_patterns(self, data: Dict[str, Any]) -> bool:
+        if not self._mention_patterns:
+            return False
+        body = str(data.get("body") or "")
+        return any(pattern.search(body) for pattern in self._mention_patterns)
+
+    def _clean_bot_mention_text(self, text: str, data: Dict[str, Any]) -> str:
+        if not text:
+            return text
+        bot_ids = self._bot_ids_from_message(data)
+        cleaned = text
+        for bot_id in bot_ids:
+            bare_id = bot_id.split("@", 1)[0]
+            if bare_id:
+                cleaned = re.sub(rf"@{re.escape(bare_id)}\b[,:\-]*\s*", "", cleaned)
+        return cleaned.strip() or text
+
+    def _should_process_message(self, data: Dict[str, Any]) -> bool:
+        chat_id_raw = str(data.get("chatId") or "")
+        # WhatsApp uses pseudo-chats for Status updates (Stories) and
+        # Channel/Newsletter broadcasts. These are not real conversations
+        # and the agent should never reply to them — even in self-chat mode
+        # where the bridge may surface them as "fromMe" events.
+        if self._is_broadcast_chat(chat_id_raw):
+            return False
+        is_group = data.get("isGroup", False)
+        if is_group:
+            chat_id = chat_id_raw
+            if not self._is_group_allowed(chat_id):
+                return False
+        else:
+            sender_id = str(data.get("senderId") or data.get("from") or "")
+            if not self._is_dm_allowed(sender_id):
+                return False
+            # DMs that pass the policy gate are always processed
+            return True
+        # Group messages: check mention / free-response settings
+        chat_id = str(data.get("chatId") or "")
+        if chat_id in self._whatsapp_free_response_chats():
+            return True
+        if not self._whatsapp_require_mention():
+            return True
+        body = str(data.get("body") or "").strip()
+        if body.startswith("/"):
+            return True
+        if self._message_is_reply_to_bot(data):
+            return True
+        if self._message_mentions_bot(data):
+            return True
+        return self._message_matches_mention_patterns(data)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -29,6 +29,7 @@ from datetime import datetime, timezone
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
 from typing import Dict, Optional, Any
+from urllib.parse import quote
 
 from hermes_constants import (
     find_node_executable,
@@ -1274,6 +1275,110 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._close_bridge_log()
         print(f"[{self.name}] Disconnected")
     
+    def format_message(self, content: str) -> str:
+        """Convert standard markdown to WhatsApp-compatible formatting.
+
+        WhatsApp supports: *bold*, _italic_, ~strikethrough~, ```code```,
+        and monospaced `inline`. Standard markdown uses different syntax
+        for bold/italic/strikethrough, so we convert here.
+
+        Code blocks (``` fenced) and inline code (`) are protected from
+        conversion via placeholder substitution.
+        """
+        if not content:
+            return content
+
+        # --- 1. Protect fenced code blocks from formatting changes ---
+        _FENCE_PH = "\x00FENCE"
+        fences: list[str] = []
+
+        def _save_fence(m: re.Match) -> str:
+            fences.append(m.group(0))
+            return f"{_FENCE_PH}{len(fences) - 1}\x00"
+
+        result = re.sub(r"```[\s\S]*?```", _save_fence, content)
+
+        # --- 2. Protect inline code ---
+        _CODE_PH = "\x00CODE"
+        codes: list[str] = []
+
+        def _save_code(m: re.Match) -> str:
+            codes.append(m.group(0))
+            return f"{_CODE_PH}{len(codes) - 1}\x00"
+
+        result = re.sub(r"`[^`\n]+`", _save_code, result)
+
+        # --- 3. Convert markdown formatting to WhatsApp syntax ---
+        # Bold: **text** or __text__ → *text*
+        result = re.sub(r"\*\*(.+?)\*\*", r"*\1*", result)
+        result = re.sub(r"__(.+?)__", r"*\1*", result)
+        # Strikethrough: ~~text~~ → ~text~
+        result = re.sub(r"~~(.+?)~~", r"~\1~", result)
+        # Italic: *text* is already WhatsApp italic — leave as-is
+        # _text_ is already WhatsApp italic — leave as-is
+
+        # --- 4. Convert markdown headers to bold text ---
+        # # Header → *Header*
+        result = re.sub(r"^#{1,6}\s+(.+)$", r"*\1*", result, flags=re.MULTILINE)
+
+        # --- 5. Convert markdown links: [text](url) → text (url) ---
+        result = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 (\2)", result)
+
+        # --- 6. Restore protected sections ---
+        for i, fence in enumerate(fences):
+            result = result.replace(f"{_FENCE_PH}{i}\x00", fence)
+        for i, code in enumerate(codes):
+            result = result.replace(f"{_CODE_PH}{i}\x00", code)
+
+        return result
+
+    async def _resolve_visible_mentions(
+        self,
+        chat_id: str,
+        text: str,
+        existing_mentions: Optional[list[str]] = None,
+    ) -> list[str]:
+        """Resolve visible @digits in group text into native WhatsApp mentions.
+
+        The visible token must match a group participant localpart. This avoids
+        pretending a plain-text @number is a mention while still fixing normal
+        gateway final responses that cannot otherwise attach mention metadata.
+        """
+        mentions = []
+        seen = set()
+        for mention in existing_mentions or []:
+            jid = str(mention or "").strip()
+            if jid and jid not in seen:
+                mentions.append(jid)
+                seen.add(jid)
+
+        tokens = list(dict.fromkeys(re.findall(r"(?<!\w)@(\d{5,})\b", str(text or ""))))
+        if not tokens or not str(chat_id or "").endswith("@g.us") or not self._http_session:
+            return mentions
+
+        try:
+            import aiohttp
+
+            async with self._http_session.get(
+                f"http://127.0.0.1:{self._bridge_port}/chat/{quote(chat_id, safe='')}",
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                if resp.status != 200:
+                    return mentions
+                data = await resp.json()
+        except Exception as exc:
+            logger.debug("[%s] Unable to resolve WhatsApp mentions for %s: %s", self.name, chat_id, exc)
+            return mentions
+
+        participants = {str(item or "").strip() for item in data.get("participants") or []}
+        for token in tokens:
+            for candidate in (f"{token}@lid", f"{token}@s.whatsapp.net"):
+                if candidate in participants and candidate not in seen:
+                    mentions.append(candidate)
+                    seen.add(candidate)
+                    break
+        return mentions
+
     async def send(
         self,
         chat_id: str,
@@ -1304,12 +1409,18 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             formatted = self.format_message(content)
             chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
 
+            raw_mentions = metadata.get("mentions") if isinstance(metadata, dict) else None
+            mentions = [str(item).strip() for item in raw_mentions or [] if str(item).strip()]
+            mentions = await self._resolve_visible_mentions(chat_id, formatted, mentions)
+
             last_message_id = None
-            for chunk in chunks:
+            for chunk_index, chunk in enumerate(chunks):
                 payload: Dict[str, Any] = {
                     "chatId": chat_id,
                     "message": chunk,
                 }
+                if mentions and chunk_index == 0:
+                    payload["mentions"] = mentions
                 if reply_to and last_message_id is None:
                     # Only reply-to on the first chunk
                     payload["replyTo"] = reply_to

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -34,6 +34,7 @@ from urllib.parse import quote
 from hermes_constants import (
     find_node_executable,
     get_hermes_dir,
+    get_hermes_home,
     with_hermes_node_path,
 )
 
@@ -471,6 +472,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return False
         if not getattr(event, "message_id", None):
             return False
+        raw_message = getattr(event, "raw_message", None) or {}
+        if self._looks_like_payment_intake_message(raw_message):
+            # Keep the event-level reaction path in lockstep with the raw
+            # bridge-data path. Some callers may already have a MessageEvent
+            # and would otherwise bypass the payment-intake guard below.
+            return False
         sender_id = self._normalize_whatsapp_id(getattr(event.source, "user_id", None))
         if self._reaction_allow_from and "*" not in self._reaction_allow_from and sender_id not in self._reaction_allow_from:
             return False
@@ -499,13 +506,63 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return False
         if not data.get("messageId"):
             return False
+        if self._looks_like_payment_intake_message(data):
+            # Payment proofs/details are not ack-only chat. A thumbs-up can be
+            # misread as "recorded/reconciled" while the payment SOP still
+            # requires extracting the proof, duplicate-guarding, recording or
+            # correcting the ledger entry, attaching the proof, and verifying
+            # the balance. Leave these unreacted so they surface as open-loop
+            # context instead of getting a false closure signal.
+            return False
         sender_id = self._normalize_whatsapp_id(data.get("senderId") or data.get("from"))
         if self._reaction_allow_from and "*" not in self._reaction_allow_from and sender_id not in self._reaction_allow_from:
             return False
         return True
 
+    @staticmethod
+    def _looks_like_payment_intake_message(data: Dict[str, Any]) -> bool:
+        """Detect WhatsApp payment-proof/payment-info messages before reactions.
+
+        The bridge may receive PDFs/images with no caption. In that case the
+        filename/path is often the only signal, e.g. ``pago 25k ger..pdf``.
+        Treat these as workflow intake, not simple confirmations eligible for a
+        👍/✅ reaction.
+        """
+        parts: list[str] = [str(data.get("body") or "")]
+        for key in ("fileName", "filename", "documentFileName", "mediaFileName"):
+            value = data.get(key)
+            if value:
+                parts.append(str(value))
+        for key in ("fileNames", "filenames", "mediaFileNames", "mediaUrls"):
+            value = data.get(key) or []
+            if isinstance(value, (list, tuple, set)):
+                parts.extend(str(v) for v in value if v)
+            elif value:
+                parts.append(str(value))
+
+        haystack = " ".join(parts).lower()
+        if not haystack:
+            return False
+        return bool(
+            re.search(
+                r"\b(payment|paid|receipt|proof|transfer|transaction|comprobante|pago|pagos|pagado|transferencia|recibo|spei|cep|toro\s*pagos)\b",
+                haystack,
+            )
+        )
+
     def _reaction_batch_key(self, chat_id: str, sender_id: Optional[str]) -> str:
         return f"{chat_id}:{self._normalize_whatsapp_id(sender_id) or 'unknown'}"
+
+    def _cancel_pending_reaction_for_message_data(self, data: Dict[str, Any]) -> None:
+        """Cancel any debounced ack for this chat/sender when a payment proof arrives."""
+        chat_id = str(data.get("chatId") or "")
+        if not chat_id:
+            return
+        key = self._reaction_batch_key(chat_id, data.get("senderId") or data.get("from"))
+        self._pending_reactions.pop(key, None)
+        task = self._pending_reaction_tasks.pop(key, None)
+        if task and not task.done():
+            task.cancel()
 
     def _reaction_emoji_for_message_data(self, data: Dict[str, Any]) -> str:
         configured = (self._reaction_emoji or "auto").strip()
@@ -796,9 +853,70 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     def _message_is_reply_to_bot(self, data: Dict[str, Any]) -> bool:
         quoted_participant = self._normalize_whatsapp_id(data.get("quotedParticipant"))
-        if not quoted_participant:
+        if quoted_participant and quoted_participant in self._bot_ids_from_message(data):
+            return True
+        return self._quoted_message_was_sent_by_hermes(data)
+
+    @staticmethod
+    def _quoted_message_id_from_message(data: Dict[str, Any]) -> str:
+        """Return the quoted/replied-to WhatsApp message id, if present."""
+        for key in (
+            "quotedMessageId",
+            "quotedId",
+            "replyToMessageId",
+            "replyToId",
+            "quotedStanzaId",
+        ):
+            value = str(data.get(key) or "").strip()
+            if value:
+                return value
+        quoted = data.get("quotedMessage")
+        if isinstance(quoted, dict):
+            nested = quoted.get("id")
+            if isinstance(nested, dict):
+                for key in ("id", "_serialized"):
+                    value = str(nested.get(key) or "").strip()
+                    if value:
+                        return value
+            value = str(nested or quoted.get("messageId") or "").strip()
+            if value:
+                return value
+        return ""
+
+    def _quoted_message_was_sent_by_hermes(self, data: Dict[str, Any]) -> bool:
+        """Fallback reply-to-bot detection using Hermes' outbound WhatsApp ledger.
+
+        WhatsApp bridge events sometimes include ``quotedMessageId`` but omit
+        ``quotedParticipant``. In mention-only groups, replies to a Jack message
+        are still addressed to Jack. Without this fallback the adapter observes
+        the group message, queues a native reaction, and never dispatches the
+        actual action request to the agent.
+        """
+        quoted_message_id = self._quoted_message_id_from_message(data)
+        if not quoted_message_id:
             return False
-        return quoted_participant in self._bot_ids_from_message(data)
+        chat_id = str(data.get("chatId") or "").strip()
+        if not chat_id:
+            return False
+        sent_path = get_hermes_home() / "whatsapp" / "sent-messages.jsonl"
+        try:
+            lines = sent_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            return False
+        for line in reversed(lines[-2000:]):
+            if quoted_message_id not in line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if (
+                str(entry.get("messageId") or "").strip() == quoted_message_id
+                and str(entry.get("chatId") or "").strip() == chat_id
+                and bool(entry.get("fromMe"))
+            ):
+                return True
+        return False
 
     def _message_mentions_bot(self, data: Dict[str, Any]) -> bool:
         bot_ids = self._bot_ids_from_message(data)
@@ -1398,8 +1516,17 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # _text_ is already WhatsApp italic — leave as-is
 
         # --- 4. Convert markdown headers to bold text ---
-        # # Header → *Header*
-        result = re.sub(r"^#{1,6}\s+(.+)$", r"*\1*", result, flags=re.MULTILINE)
+        # # Header → *Header*. If the header content was already bold in
+        # Markdown (e.g. "# **Title**"), step 3 has converted it to
+        # "# *Title*"; strip that wrapper before adding the header wrapper so
+        # WhatsApp does not receive literal doubled asterisks.
+        def _convert_header(m: re.Match) -> str:
+            header = m.group(1).strip()
+            if len(header) >= 2 and header[0] == header[-1] and header[0] in {"*", "_"}:
+                header = header[1:-1].strip()
+            return f"*{header}*"
+
+        result = re.sub(r"^#{1,6}\s+(.+)$", _convert_header, result, flags=re.MULTILINE)
 
         # --- 5. Convert markdown links: [text](url) → text (url) ---
         result = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 (\2)", result)
@@ -1482,7 +1609,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "[Whatsapp] Suppressing non-visible/silent send (%d chars) to %s",
                 len(str(content or "")), chat_id,
             )
-            return SendResult(success=True, message_id=None)
+            return SendResult(
+                success=False,
+                error="message has no visible content",
+                raw_response={"suppressed": True},
+            )
 
         chat_id = to_whatsapp_jid(chat_id)
 
@@ -1496,7 +1627,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     "[Whatsapp] Suppressing non-visible/silent formatted send (%d chars) to %s",
                     len(str(formatted or "")), chat_id,
                 )
-                return SendResult(success=True, message_id=None)
+                return SendResult(
+                    success=False,
+                    error="message has no visible content after formatting",
+                    raw_response={"suppressed": True},
+                )
             chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
 
             raw_mentions = metadata.get("mentions") if isinstance(metadata, dict) else None
@@ -1504,6 +1639,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             mentions = await self._resolve_visible_mentions(chat_id, formatted, mentions)
 
             last_message_id = None
+            suppressed_chunks = 0
             for chunk_index, chunk in enumerate(chunks):
                 payload: Dict[str, Any] = {
                     "chatId": chat_id,
@@ -1522,6 +1658,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 ) as resp:
                     if resp.status == 204:
                         # Bridge-level no-visible-content guard suppressed the send.
+                        suppressed_chunks += 1
                         continue
                     if resp.status == 200:
                         data = await resp.json()
@@ -1533,6 +1670,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 # Small delay between chunks to avoid rate limiting
                 if len(chunks) > 1:
                     await asyncio.sleep(0.3)
+
+            if last_message_id is None and suppressed_chunks:
+                return SendResult(
+                    success=False,
+                    error="message has no visible content after bridge sanitization",
+                    raw_response={"suppressed": True, "suppressed_chunks": suppressed_chunks},
+                )
 
             return SendResult(
                 success=True,
@@ -1837,10 +1981,31 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
 
+    def _ingest_whatsapp_context_event(self, data: Dict[str, Any]) -> None:
+        """Persist every inbound WhatsApp event to the per-chat context log.
+
+        This runs before mention-gating returns.  It must be best-effort: a
+        context-log write failure should never break message delivery or make
+        the bridge disconnect.
+        """
+        try:
+            from hermes_constants import get_hermes_home
+            from gateway.whatsapp_context import WhatsAppContextStore
+
+            store = WhatsAppContextStore(get_hermes_home() / "whatsapp_context")
+            store.ingest_bridge_message(data)
+        except Exception as exc:
+            logger.debug("[whatsapp] context ingest failed: %s", exc, exc_info=True)
+
     async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
-            if self._should_react_to_message_data(data):
+            if self._looks_like_payment_intake_message(data):
+                # If a normal message was queued for a delayed reaction and a
+                # payment proof follows in the same burst, cancel the pending
+                # ack. A delayed 👍 near the proof still reads as false closure.
+                self._cancel_pending_reaction_for_message_data(data)
+            elif self._should_react_to_message_data(data):
                 self._queue_reaction_message_data(
                     chat_id=str(data.get("chatId") or ""),
                     message_id=str(data.get("messageId") or ""),
@@ -1848,13 +2013,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     raw_message=data,
                 )
 
-            should_process = self._should_process_message(data)
-            should_observe = False if should_process else self._should_observe_unmentioned_group_message(data)
-            if not should_process and not should_observe:
-                return None
-            direct_group_trigger_reason = self._whatsapp_direct_group_trigger_reason(data) if should_process else None
-            if direct_group_trigger_reason:
-                data["_hermes_direct_group_trigger_reason"] = direct_group_trigger_reason
+            # Determine message type and media state before mention-gating.  In
+            # mention-only WhatsApp groups Hermes must stay silent unless
+            # addressed, but still ingest every same-chat event/media so a later
+            # mention can build the correct context bundle.
 
             # Determine message type
             msg_type = MessageType.TEXT
@@ -1975,15 +2137,35 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
+            log_data = dict(data)
+            log_data["body"] = body
+            log_data["mediaUrls"] = cached_urls
+            if media_types:
+                log_data["mediaMimeType"] = media_types[0]
+            if msg_type == MessageType.DOCUMENT and cached_urls and body:
+                # Text-readable documents may have been injected into body above;
+                # preserve that extraction for the deterministic context bundle.
+                log_data.setdefault("extractedText", body)
+            self._ingest_whatsapp_context_event(log_data)
+
+            should_process = self._should_process_message(data)
+            should_observe = False if should_process else self._should_observe_unmentioned_group_message(data)
+            direct_group_trigger_reason = self._whatsapp_direct_group_trigger_reason(data) if should_process else None
+            if direct_group_trigger_reason:
+                data["_hermes_direct_group_trigger_reason"] = direct_group_trigger_reason
+                log_data["_hermes_direct_group_trigger_reason"] = direct_group_trigger_reason
+
             event = MessageEvent(
                 text=body,
                 message_type=msg_type,
                 source=source,
-                raw_message=data,
+                raw_message=log_data,
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
             )
+            if not should_process and not should_observe:
+                return None
             if should_observe:
                 self._observe_unmentioned_group_message(event)
                 return None

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -368,6 +368,36 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             or os.getenv("WHATSAPP_GROUP_ALLOWED_USERS")
         )
         self._mention_patterns = self._compile_mention_patterns()
+        self._reactions_enabled = self._coerce_bool_extra(
+            "reactions",
+            os.getenv("WHATSAPP_REACTIONS", "false").lower() in {"true", "1", "yes", "on"},
+        )
+        self._reaction_emoji = str(
+            config.extra.get("reaction_emoji")
+            or os.getenv("WHATSAPP_REACTION_EMOJI")
+            or "auto"
+        ).strip() or "auto"
+        self._reaction_allow_from = self._coerce_allow_list(
+            config.extra.get("reaction_allow_from")
+            or os.getenv("WHATSAPP_REACTION_ALLOWED_USERS")
+            or config.extra.get("allow_from")
+            or config.extra.get("allowFrom")
+            or os.getenv("WHATSAPP_ALLOWED_USERS")
+        )
+        self._reply_consider_allow_from = self._coerce_allow_list(
+            config.extra.get("reply_consider_allow_from")
+            or os.getenv("WHATSAPP_REPLY_CONSIDER_ALLOWED_USERS")
+            or config.extra.get("reaction_allow_from")
+            or os.getenv("WHATSAPP_REACTION_ALLOWED_USERS")
+            or config.extra.get("allow_from")
+            or config.extra.get("allowFrom")
+            or os.getenv("WHATSAPP_ALLOWED_USERS")
+        )
+        self._reaction_batch_delay_seconds = self._coerce_float_extra(
+            "reaction_batch_delay_seconds", 4.0
+        )
+        self._pending_reactions: Dict[str, Dict[str, Any]] = {}
+        self._pending_reaction_tasks: Dict[str, asyncio.Task] = {}
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
         self._bridge_log: Optional[Path] = None
@@ -417,6 +447,164 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not math.isfinite(parsed) or parsed < 0:
             return float(default)
         return parsed
+
+    def _coerce_bool_extra(self, key: str, default: bool) -> bool:
+        """Read a boolean from ``config.extra`` with env-style string handling."""
+        value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
+        if value is None:
+            return bool(default)
+        if isinstance(value, str):
+            return value.strip().lower() in {"true", "1", "yes", "on"}
+        return bool(value)
+
+    def _should_react_to_event(self, event: MessageEvent) -> bool:
+        """Return True when this inbound WhatsApp message should get a receipt reaction."""
+        if not self._reactions_enabled:
+            return False
+        if getattr(event.source, "chat_type", None) != "group":
+            return False
+        if not getattr(event, "message_id", None):
+            return False
+        sender_id = self._normalize_whatsapp_id(getattr(event.source, "user_id", None))
+        if self._reaction_allow_from and "*" not in self._reaction_allow_from and sender_id not in self._reaction_allow_from:
+            return False
+        return True
+
+    async def _react_to_event(self, event: MessageEvent) -> bool:
+        """Queue a native reaction for a recent WhatsApp event."""
+        if not self._should_react_to_event(event):
+            return False
+        message_id = getattr(event, "message_id", None)
+        if not message_id:
+            return False
+        self._queue_reaction_message_data(
+            chat_id=event.source.chat_id,
+            message_id=message_id,
+            sender_id=getattr(event.source, "user_id", None),
+            raw_message=event.raw_message or {},
+        )
+        return True
+
+    def _should_react_to_message_data(self, data: Dict[str, Any]) -> bool:
+        """Return True when raw incoming WhatsApp data should get a receipt reaction."""
+        if not self._reactions_enabled:
+            return False
+        if not data.get("isGroup", False):
+            return False
+        if not data.get("messageId"):
+            return False
+        sender_id = self._normalize_whatsapp_id(data.get("senderId") or data.get("from"))
+        if self._reaction_allow_from and "*" not in self._reaction_allow_from and sender_id not in self._reaction_allow_from:
+            return False
+        return True
+
+    def _reaction_batch_key(self, chat_id: str, sender_id: Optional[str]) -> str:
+        return f"{chat_id}:{self._normalize_whatsapp_id(sender_id) or 'unknown'}"
+
+    def _reaction_emoji_for_message_data(self, data: Dict[str, Any]) -> str:
+        configured = (self._reaction_emoji or "auto").strip()
+        if configured.lower() != "auto":
+            return configured
+        text = str(data.get("body") or "").lower()
+        if any(word in text for word in ("urgent", "stolen", "emergency", "asap", "now ", "ahora", "robar", "robado")):
+            return "🚨"
+        if "?" in text or any(word in text for word in ("can you", "could you", "please", "puedes", "puede", "favor", "investigate", "check", "revisa")):
+            return "👀"
+        if any(word in text for word in ("paid", "payment", "transfer", "receipt", "proof", "pago", "transferencia", "comprobante")):
+            return "✅"
+        if any(word in text for word in ("thanks", "thank you", "gracias", "great", "good", "perfecto", "excelente")):
+            return "🙏"
+        return "👍"
+
+    def _queue_reaction_message_data(
+        self,
+        *,
+        chat_id: str,
+        message_id: str,
+        sender_id: Optional[str],
+        raw_message: Dict[str, Any],
+    ) -> None:
+        """Debounce WhatsApp reactions so message bursts receive one receipt."""
+        key = self._reaction_batch_key(chat_id, sender_id)
+        self._pending_reactions[key] = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "sender_id": sender_id,
+            "raw_message": raw_message,
+            "emoji": self._reaction_emoji_for_message_data(raw_message),
+        }
+        prior = self._pending_reaction_tasks.get(key)
+        if prior and not prior.done():
+            prior.cancel()
+        self._pending_reaction_tasks[key] = asyncio.create_task(self._flush_reaction_batch(key))
+
+    async def _flush_reaction_batch(self, key: str) -> None:
+        current_task = asyncio.current_task()
+        try:
+            await asyncio.sleep(self._reaction_batch_delay_seconds)
+            pending = self._pending_reactions.pop(key, None)
+            if not pending:
+                return
+            await self._react_to_message_data(
+                chat_id=pending["chat_id"],
+                message_id=pending["message_id"],
+                sender_id=pending.get("sender_id"),
+                raw_message=pending.get("raw_message") or {},
+                emoji=pending.get("emoji") or "👍",
+            )
+        except asyncio.CancelledError:
+            raise
+        finally:
+            if self._pending_reaction_tasks.get(key) is current_task:
+                self._pending_reaction_tasks.pop(key, None)
+
+    async def _react_to_message_data(
+        self,
+        *,
+        chat_id: str,
+        message_id: str,
+        sender_id: Optional[str],
+        raw_message: Dict[str, Any],
+        emoji: str,
+    ) -> bool:
+        """React natively to a recent WhatsApp message via the Node bridge."""
+        if not self._running or not self._http_session:
+            return False
+        try:
+            import aiohttp
+
+            payload = {
+                "chatId": chat_id,
+                "messageId": message_id,
+                "participant": raw_message.get("senderId") or raw_message.get("participant") or sender_id,
+                "emoji": emoji,
+            }
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/react",
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                if resp.status == 200:
+                    logger.info(
+                        "[%s] Reacted to WhatsApp group message %s in %s with %s",
+                        self.name,
+                        message_id,
+                        chat_id,
+                        emoji,
+                    )
+                    return True
+                body = await resp.text()
+                logger.warning(
+                    "[%s] WhatsApp reaction failed (%s) for message %s in %s: %s",
+                    self.name,
+                    resp.status,
+                    message_id,
+                    chat_id,
+                    body[:300],
+                )
+        except Exception as exc:
+            logger.warning("[%s] WhatsApp reaction failed for %s in %s: %s", self.name, message_id, chat_id, exc)
+        return False
 
     def _effective_reply_prefix(self) -> str:
         """Return the prefix the Node bridge will add in self-chat mode."""
@@ -641,7 +829,29 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return True
         if self._message_mentions_bot(data):
             return True
-        return self._message_matches_mention_patterns(data)
+        if self._message_matches_mention_patterns(data):
+            return True
+        return self._should_consider_reply_to_reaction_sender_message(data)
+
+    def _should_consider_reply_to_reaction_sender_message(self, data: Dict[str, Any]) -> bool:
+        """Let approved Jacob-origin group messages reach the agent for reply/silence choice.
+
+        Native reactions are only a receipt signal. For approved senders, the
+        gateway should still dispatch the message so Jack can decide whether a
+        concise WhatsApp reply is useful.
+        """
+        if not self._reactions_enabled:
+            return False
+        if not self._coerce_bool_extra("reply_consider_reaction_senders", True):
+            return False
+        if not data.get("isGroup", False):
+            return False
+        sender_id = self._normalize_whatsapp_id(data.get("senderId") or data.get("from"))
+        if not sender_id:
+            return False
+        if self._reply_consider_allow_from:
+            return "*" in self._reply_consider_allow_from or sender_id in self._reply_consider_allow_from
+        return False
 
     def _should_observe_unmentioned_group_message(self, data: Dict[str, Any]) -> bool:
         """Return True when a group message should be stored but not dispatched."""
@@ -1426,6 +1636,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
+            if self._should_react_to_message_data(data):
+                self._queue_reaction_message_data(
+                    chat_id=str(data.get("chatId") or ""),
+                    message_id=str(data.get("messageId") or ""),
+                    sender_id=data.get("senderId") or data.get("from"),
+                    raw_message=data,
+                )
+
             should_process = self._should_process_message(data)
             should_observe = False if should_process else self._should_observe_unmentioned_group_message(data)
             if not should_process and not should_observe:

--- a/run_agent.py
+++ b/run_agent.py
@@ -879,22 +879,26 @@ class AIAgent:
     # (agent.log) are unaffected — every individual emission site still
     # writes to ``logger.warning`` / ``logger.info`` for diagnosis.
 
-    def _buffer_status(self, message: str) -> None:
+    def _buffer_status(self, message: str, customer_facing: bool = True) -> None:
         """Buffer a retry/fallback status message.
 
-        Stored as a (kind, text) tuple where ``kind`` is one of:
+        Stored as a tuple where ``kind`` is one of:
         - ``"status"``  -> replays via ``_emit_status``
         - ``"vprint"``  -> replays via ``_vprint(force=True)``
         - ``"warn"``    -> replays via ``_emit_warning``
         Used to defer noisy retry chatter until we know whether the
         turn ultimately recovered or failed.
+
+        ``customer_facing`` is carried through replay so internal-only retry
+        and compression banners cannot leak to WhatsApp/Slack/etc. if the
+        buffer is flushed after terminal failure.
         """
         try:
             buf = getattr(self, "_retry_status_buffer", None)
             if buf is None:
                 buf = []
                 self._retry_status_buffer = buf
-            buf.append(("status", message))
+            buf.append(("status", message, customer_facing))
         except Exception:
             # Never break the retry loop on a buffer hiccup.
             pass
@@ -932,10 +936,15 @@ class AIAgent:
             # Drain first so a callback exception doesn't double-emit.
             messages = list(buf)
             buf.clear()
-            for kind, msg in messages:
+            for item in messages:
                 try:
+                    if len(item) == 3:
+                        kind, msg, customer_facing = item
+                    else:
+                        kind, msg = item
+                        customer_facing = True
                     if kind == "status":
-                        self._emit_status(msg)
+                        self._emit_status(msg, customer_facing=customer_facing)
                     elif kind == "warn":
                         self._emit_warning(msg)
                     else:

--- a/run_agent.py
+++ b/run_agent.py
@@ -783,12 +783,31 @@ class AIAgent:
             and getattr(self, "platform", "") == "cli"
         )
 
-    def _emit_status(self, message: str) -> None:
-        """Emit a lifecycle status message to both CLI and gateway channels.
+    # Platforms whose end-users are external/customer-facing rather than the
+    # operator/admin running Hermes directly. Internal lifecycle/status banners
+    # are suppressed on these surfaces so implementation details do not leak
+    # into chat threads. Refs: https://github.com/NousResearch/hermes-agent/issues/28208
+    _CUSTOMER_FACING_PLATFORMS = frozenset({
+        "whatsapp", "slack", "signal", "telegram", "discord",
+    })
+
+    # Defensive glyph fallback for call sites that have not been migrated to
+    # the explicit ``customer_facing=False`` kwarg. Kept narrow on purpose:
+    # the currently reported leak is the compression banner family.
+    _INTERNAL_STATUS_PREFIXES = (
+        "\U0001f5dc",  # 🗜 context-pressure / compression banner family
+    )
+
+    def _emit_status(self, message: str, customer_facing: bool = True) -> None:
+        """Emit a lifecycle status message to CLI and selectively to gateway.
 
         CLI users see the message via ``_vprint(force=True)`` so it is always
-        visible regardless of verbose/quiet mode.  Gateway consumers receive
-        it through ``status_callback("lifecycle", ...)``.
+        visible regardless of verbose/quiet mode.
+
+        Gateway consumers receive it through ``status_callback("lifecycle", ...)``
+        unless the runtime ``platform`` is customer-facing and the message is
+        explicitly internal-only (``customer_facing=False``) or starts with a
+        known internal-status glyph.
 
         This helper never raises — exceptions are swallowed so it cannot
         interrupt the retry/fallback logic.
@@ -797,6 +816,14 @@ class AIAgent:
             self._vprint(f"{self.log_prefix}{message}", force=True)
         except Exception:
             pass
+
+        platform = (getattr(self, "platform", "") or "").lower()
+        if platform in self._CUSTOMER_FACING_PLATFORMS:
+            if not customer_facing:
+                return
+            if message.startswith(self._INTERNAL_STATUS_PREFIXES):
+                return
+
         if self.status_callback:
             try:
                 self.status_callback("lifecycle", message)

--- a/run_agent.py
+++ b/run_agent.py
@@ -791,11 +791,12 @@ class AIAgent:
         "whatsapp", "slack", "signal", "telegram", "discord",
     })
 
-    # Defensive glyph fallback for call sites that have not been migrated to
+    # Defensive prefix fallback for call sites that have not been migrated to
     # the explicit ``customer_facing=False`` kwarg. Kept narrow on purpose:
-    # the currently reported leak is the compression banner family.
+    # these are internal lifecycle/status banners, not user-facing replies.
     _INTERNAL_STATUS_PREFIXES = (
         "\U0001f5dc",  # 🗜 context-pressure / compression banner family
+        "⚠️ Iteration budget exhausted",
     )
 
     def _emit_status(self, message: str, customer_facing: bool = True) -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -797,6 +797,7 @@ class AIAgent:
     _INTERNAL_STATUS_PREFIXES = (
         "\U0001f5dc",  # 🗜 context-pressure / compression banner family
         "⚠️ Iteration budget exhausted",
+        "ℹ Codex gpt-5.5 caps context",
     )
 
     def _emit_status(self, message: str, customer_facing: bool = True) -> None:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -80,6 +80,29 @@ const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   : process.env.WHATSAPP_REPLY_PREFIX.replace(/\\n/g, '\n');
 const MAX_MESSAGE_LENGTH = parseInt(process.env.WHATSAPP_MAX_MESSAGE_LENGTH || '4096', 10);
 const CHUNK_DELAY_MS = parseInt(process.env.WHATSAPP_CHUNK_DELAY_MS || '300', 10);
+const INVISIBLE_DELIVERY_CHARS_RE = /[\u200B\u200C\u200D\u2060\uFEFF\u180E\u2061-\u2064]/g;
+const SILENT_FINAL_RESPONSE_SENTINELS = new Set(['[SILENT]', '[[SILENT]]', '<SILENT>', 'SILENCIO']);
+const NO_DELIVERY_STATUS_RE = /^silencio\s*(?:[.!¡!。]|[-–—:]\s*(?:no\s+(?:(?:fui|estoy|me)\s+)?aludid[oa]|no\s+(?:reply|respuesta)|sin\s+respuesta).*)?$/i;
+const INTERNAL_STATUS_BANNER_RE = /^[^A-Za-z0-9]*(?:Self-improvement review:|Memory updated\b|User profile updated\b|Skill '[^']+' (?:created|updated|patched)\b|Model returned empty after tool calls|Preflight compression:|Compacting context|compacting context|Session compressed \d+ times|Codex gpt-5\.5 caps context|Opt back out:|Interrupted during API call|Interrupting current task|\[IMPORTANT:\s*Background process|Hermes Gateway Starting)/i;
+
+function isInternalStatusBanner(message) {
+  const cleaned = String(message ?? '').replace(INVISIBLE_DELIVERY_CHARS_RE, '').trim();
+  if (!cleaned) return false;
+  return cleaned.split(/\r?\n/).every(line => {
+    const t = line.trim();
+    return !t || INTERNAL_STATUS_BANNER_RE.test(t);
+  });
+}
+
+function hasVisibleDeliveryText(message) {
+  const cleaned = String(message ?? '').replace(INVISIBLE_DELIVERY_CHARS_RE, '').trim();
+  const candidate = cleaned.replace(/^[`"'“”‘’]+|[`"'“”‘’]+$/g, '').trim();
+  return candidate.length > 0
+    && !SILENT_FINAL_RESPONSE_SENTINELS.has(candidate.toUpperCase())
+    && !NO_DELIVERY_STATUS_RE.test(candidate)
+    && !isInternalStatusBanner(candidate);
+}
+
 // Per-call timeout for sock.sendMessage(). Baileys occasionally hangs forever
 // when uploading media to WhatsApp servers (and, less often, on text sends),
 // which pins the bridge's HTTP handler until the upstream aiohttp timeout
@@ -180,9 +203,59 @@ function findRecentMessageKey(chatId, messageId = null) {
   return items[items.length - 1];
 }
 
+function groupReactionGuard(chatId, target) {
+  if (!chatId?.endsWith('@g.us') || !target) return { allowed: true };
+  const now = Date.now();
+  const targetMs = Number(target.timestamp || 0) * 1000;
+  if (targetMs && now - targetMs < MIN_GROUP_REACTION_DELAY_MS) {
+    return {
+      allowed: false,
+      status: 429,
+      error: 'Group reaction delayed by anti-spam policy; wait before reacting to message bursts.',
+      retryAfterSeconds: Math.ceil((MIN_GROUP_REACTION_DELAY_MS - (now - targetMs)) / 1000),
+    };
+  }
+  const cutoff = now - GROUP_REACTION_WINDOW_MS;
+  const prior = (recentGroupReactions.get(chatId) || []).filter(ts => ts >= cutoff);
+  if (prior.length >= MAX_GROUP_REACTIONS_PER_WINDOW) {
+    return {
+      allowed: false,
+      status: 429,
+      error: 'Group reaction cap reached; avoid reacting to every message in a burst.',
+      retryAfterSeconds: Math.ceil((prior[0] + GROUP_REACTION_WINDOW_MS - now) / 1000),
+    };
+  }
+  recentGroupReactions.set(chatId, prior);
+  return { allowed: true };
+}
+
+function recordGroupReaction(chatId) {
+  if (!chatId?.endsWith('@g.us')) return;
+  const now = Date.now();
+  const cutoff = now - GROUP_REACTION_WINDOW_MS;
+  const prior = (recentGroupReactions.get(chatId) || []).filter(ts => ts >= cutoff);
+  prior.push(now);
+  recentGroupReactions.set(chatId, prior);
+}
+
+function sanitizeGroupOutboundText(chatId, text) {
+  if (!chatId?.endsWith('@g.us')) return text;
+  let out = String(text ?? '');
+  // External groups should never see private stack/tool names or internal note-system brands.
+  out = out.replace(/https?:\/\/notes\.revoluciones\.mx\S*/gi, 'notes');
+  out = out.replace(/\bTrill?ium\b/gi, 'notes');
+  return out;
+}
+
 function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  const text = String(value).trim();
+  const atIdx = text.indexOf('@');
+  if (atIdx > 0) {
+    const local = text.slice(0, atIdx).split(':')[0];
+    return `${local}${text.slice(atIdx)}`;
+  }
+  return text;
 }
 
 function getMessageContent(msg) {
@@ -235,6 +308,10 @@ const MAX_QUEUE_SIZE = 100;
 // consumes /messages destructively, so /react needs its own small cache.
 const recentMessageKeys = new Map();
 const MAX_RECENT_KEYS_PER_CHAT = 50;
+const MIN_GROUP_REACTION_DELAY_MS = Number(process.env.WHATSAPP_GROUP_REACTION_DELAY_MS || 30000);
+const GROUP_REACTION_WINDOW_MS = Number(process.env.WHATSAPP_GROUP_REACTION_WINDOW_MS || 120000);
+const MAX_GROUP_REACTIONS_PER_WINDOW = Number(process.env.WHATSAPP_GROUP_REACTION_MAX_PER_WINDOW || 2);
+const recentGroupReactions = new Map();
 
 // Track recently sent message IDs to prevent echo-back loops with media
 const recentlySentIds = new Set();
@@ -566,9 +643,11 @@ app.post('/react', async (req, res) => {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
 
-  const { chatId, emoji = '👍', messageId, participant } = req.body || {};
-  if (!chatId || !emoji) {
-    return res.status(400).json({ error: 'chatId and emoji are required' });
+  const body = req.body || {};
+  const { chatId, messageId, participant } = body;
+  const emoji = Object.prototype.hasOwnProperty.call(body, 'emoji') ? String(body.emoji ?? '') : '👍';
+  if (!chatId) {
+    return res.status(400).json({ error: 'chatId is required' });
   }
 
   const cached = findRecentMessageKey(chatId, messageId || null);
@@ -576,6 +655,13 @@ app.post('/react', async (req, res) => {
   const targetParticipant = participant || cached?.participant || null;
   if (!targetMessageId) {
     return res.status(404).json({ error: 'No recent incoming message cached for chatId; provide messageId and participant' });
+  }
+  const reactionGuard = groupReactionGuard(chatId, cached);
+  if (!reactionGuard.allowed) {
+    return res.status(reactionGuard.status || 429).json({
+      error: reactionGuard.error,
+      retryAfterSeconds: reactionGuard.retryAfterSeconds,
+    });
   }
 
   const key = { remoteJid: chatId, id: targetMessageId, fromMe: false };
@@ -585,6 +671,7 @@ app.post('/react', async (req, res) => {
 
   try {
     const sent = await sendWithTimeout(chatId, { react: { text: emoji, key } });
+    recordGroupReaction(chatId);
     res.json({
       success: true,
       messageId: sent?.key?.id || null,
@@ -639,12 +726,20 @@ app.post('/send', async (req, res) => {
   }
 
   const { chatId, message, replyTo, mentions } = req.body;
-  if (!chatId || !message) {
+  if (!chatId || message === undefined || message === null) {
     return res.status(400).json({ error: 'chatId and message are required' });
+  }
+  const outwardMessage = sanitizeGroupOutboundText(chatId, message);
+  if (!hasVisibleDeliveryText(outwardMessage)) {
+    return res.status(204).end();
   }
 
   try {
-    const chunks = splitLongMessage(formatOutgoingMessage(message));
+    const formattedMessage = formatOutgoingMessage(outwardMessage);
+    if (!hasVisibleDeliveryText(formattedMessage)) {
+      return res.status(204).end();
+    }
+    const chunks = splitLongMessage(formattedMessage);
     const messageIds = [];
     for (let i = 0; i < chunks.length; i += 1) {
       const sent = await sendWithTimeout(chatId, textPayload(chunks[i], i === 0 ? mentions : []));
@@ -678,13 +773,21 @@ app.post('/edit', async (req, res) => {
   }
 
   const { chatId, messageId, message, mentions } = req.body;
-  if (!chatId || !messageId || !message) {
+  if (!chatId || !messageId || message === undefined || message === null) {
     return res.status(400).json({ error: 'chatId, messageId, and message are required' });
+  }
+  const outwardMessage = sanitizeGroupOutboundText(chatId, message);
+  if (!hasVisibleDeliveryText(outwardMessage)) {
+    return res.status(400).json({ error: 'message has no visible content' });
   }
 
   try {
     const key = { id: messageId, fromMe: true, remoteJid: chatId };
-    const chunks = splitLongMessage(formatOutgoingMessage(message));
+    const formattedMessage = formatOutgoingMessage(outwardMessage);
+    if (!hasVisibleDeliveryText(formattedMessage)) {
+      return res.status(400).json({ error: 'message has no visible content after formatting' });
+    }
+    const chunks = splitLongMessage(formattedMessage);
     const messageIds = [];
 
     await sendWithTimeout(chatId, textPayload(chunks[0], mentions, { edit: key }));
@@ -760,6 +863,9 @@ app.post('/send-media', async (req, res) => {
   if (!chatId || !filePath) {
     return res.status(400).json({ error: 'chatId and filePath are required' });
   }
+  const outwardCaption = caption === undefined || caption === null
+    ? undefined
+    : sanitizeGroupOutboundText(chatId, caption);
 
   try {
     if (!existsSync(filePath)) {
@@ -773,10 +879,10 @@ app.post('/send-media', async (req, res) => {
 
     switch (type) {
       case 'image':
-        msgPayload = { image: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'image/jpeg' };
+        msgPayload = { image: buffer, caption: outwardCaption || undefined, mimetype: MIME_MAP[ext] || 'image/jpeg' };
         break;
       case 'video':
-        msgPayload = { video: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'video/mp4' };
+        msgPayload = { video: buffer, caption: outwardCaption || undefined, mimetype: MIME_MAP[ext] || 'video/mp4' };
         break;
       case 'audio': {
         // WhatsApp only renders a native voice bubble (ptt) when the file is ogg/opus.
@@ -811,7 +917,7 @@ app.post('/send-media', async (req, res) => {
         msgPayload = {
           document: buffer,
           fileName: fileName || path.basename(filePath),
-          caption: caption || undefined,
+          caption: outwardCaption || undefined,
           mimetype: MIME_MAP[ext] || 'application/octet-stream',
         };
         break;
@@ -821,7 +927,7 @@ app.post('/send-media', async (req, res) => {
 
     trackSentMessageId(sent, {
       chatId,
-      text: caption || fileName || filePath,
+      text: outwardCaption || fileName || filePath,
       kind: type || 'media',
     });
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -9,6 +9,7 @@
  *   GET  /messages       - Long-poll for new incoming messages
  *   POST /send           - Send a message { chatId, message, replyTo? }
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
+ *   POST /react          - React to a message { chatId, emoji, messageId?, participant? }
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
  *   POST /typing         - Send typing indicator { chatId }
  *   GET  /chat/:id       - Get chat info
@@ -139,6 +140,26 @@ function trackSentMessageId(sent) {
   }
 }
 
+function rememberIncomingMessageKey(msg, chatId, senderId) {
+  if (msg?.key?.fromMe || !msg?.key?.id || !chatId) return;
+  const entry = {
+    messageId: msg.key.id,
+    participant: chatId.endsWith('@g.us') ? (msg.key.participant || senderId || null) : null,
+    timestamp: Number(msg.messageTimestamp || Date.now() / 1000),
+  };
+  const items = recentMessageKeys.get(chatId) || [];
+  items.push(entry);
+  while (items.length > MAX_RECENT_KEYS_PER_CHAT) items.shift();
+  recentMessageKeys.set(chatId, items);
+}
+
+function findRecentMessageKey(chatId, messageId = null) {
+  const items = recentMessageKeys.get(chatId) || [];
+  if (!items.length) return null;
+  if (messageId) return items.find(item => item.messageId === messageId) || null;
+  return items[items.length - 1];
+}
+
 function normalizeWhatsAppId(value) {
   if (!value) return '';
   return String(value).replace(':', '@');
@@ -189,6 +210,11 @@ const logger = pino({ level: 'warn' });
 // Message queue for polling
 const messageQueue = [];
 const MAX_QUEUE_SIZE = 100;
+
+// Recent incoming message keys for native reactions. The Python gateway
+// consumes /messages destructively, so /react needs its own small cache.
+const recentMessageKeys = new Map();
+const MAX_RECENT_KEYS_PER_CHAT = 50;
 
 // Track recently sent message IDs to prevent echo-back loops with media
 const recentlySentIds = new Set();
@@ -332,6 +358,10 @@ async function startSocket() {
           } catch {}
           continue;
         }
+      }
+
+      if (!msg.key.fromMe) {
+        rememberIncomingMessageKey(msg, chatId, senderId);
       }
 
       const messageContent = getMessageContent(msg);
@@ -509,13 +539,64 @@ app.get('/messages', (req, res) => {
   res.json(msgs);
 });
 
+// React to a recent incoming message. If messageId is omitted, react to the
+// latest cached non-fromMe message for that chat.
+app.post('/react', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const { chatId, emoji = '👍', messageId, participant } = req.body || {};
+  if (!chatId || !emoji) {
+    return res.status(400).json({ error: 'chatId and emoji are required' });
+  }
+
+  const cached = findRecentMessageKey(chatId, messageId || null);
+  const targetMessageId = messageId || cached?.messageId;
+  const targetParticipant = participant || cached?.participant || null;
+  if (!targetMessageId) {
+    return res.status(404).json({ error: 'No recent incoming message cached for chatId; provide messageId and participant' });
+  }
+
+  const key = { remoteJid: chatId, id: targetMessageId, fromMe: false };
+  if (chatId.endsWith('@g.us') && targetParticipant) {
+    key.participant = targetParticipant;
+  }
+
+  try {
+    const sent = await sendWithTimeout(chatId, { react: { text: emoji, key } });
+    res.json({
+      success: true,
+      messageId: sent?.key?.id || null,
+      targetMessageId,
+      participant: targetParticipant,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+function normalizeMentions(mentions) {
+  if (!Array.isArray(mentions)) return [];
+  return mentions
+    .map(jid => String(jid || '').trim())
+    .filter(jid => jid.endsWith('@s.whatsapp.net') || jid.endsWith('@lid'));
+}
+
+function textPayload(text, mentions = [], extra = {}) {
+  const normalizedMentions = normalizeMentions(mentions);
+  return normalizedMentions.length
+    ? { text, mentions: normalizedMentions, ...extra }
+    : { text, ...extra };
+}
+
 // Send a message
 app.post('/send', async (req, res) => {
   if (!sock || connectionState !== 'connected') {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
 
-  const { chatId, message, replyTo } = req.body;
+  const { chatId, message, replyTo, mentions } = req.body;
   if (!chatId || !message) {
     return res.status(400).json({ error: 'chatId and message are required' });
   }
@@ -524,7 +605,7 @@ app.post('/send', async (req, res) => {
     const chunks = splitLongMessage(formatOutgoingMessage(message));
     const messageIds = [];
     for (let i = 0; i < chunks.length; i += 1) {
-      const sent = await sendWithTimeout(chatId, { text: chunks[i] });
+      const sent = await sendWithTimeout(chatId, textPayload(chunks[i], i === 0 ? mentions : []));
       trackSentMessageId(sent);
       if (sent?.key?.id) messageIds.push(sent.key.id);
       if (chunks.length > 1 && i < chunks.length - 1) {
@@ -548,7 +629,7 @@ app.post('/edit', async (req, res) => {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
 
-  const { chatId, messageId, message } = req.body;
+  const { chatId, messageId, message, mentions } = req.body;
   if (!chatId || !messageId || !message) {
     return res.status(400).json({ error: 'chatId, messageId, and message are required' });
   }
@@ -558,10 +639,10 @@ app.post('/edit', async (req, res) => {
     const chunks = splitLongMessage(formatOutgoingMessage(message));
     const messageIds = [];
 
-    await sendWithTimeout(chatId, { text: chunks[0], edit: key });
+    await sendWithTimeout(chatId, textPayload(chunks[0], mentions, { edit: key }));
     if (chunks.length > 1) {
       for (let i = 1; i < chunks.length; i += 1) {
-        const sent = await sendWithTimeout(chatId, { text: chunks[i] });
+        const sent = await sendWithTimeout(chatId, textPayload(chunks[i]));
         trackSentMessageId(sent);
         if (sent?.key?.id) messageIds.push(sent.key.id);
         if (i < chunks.length - 1) {

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -473,6 +473,7 @@ async function startSocket() {
       let body = '';
       let hasMedia = false;
       let mediaType = '';
+      let mediaFileName = '';
       const mediaUrls = [];
 
       if (messageContent.conversation) {
@@ -530,6 +531,7 @@ async function startSocket() {
         hasMedia = true;
         mediaType = 'document';
         const fileName = messageContent.documentMessage.fileName || 'document';
+        mediaFileName = fileName;
         try {
           const buf = await downloadMediaMessage(msg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage });
           mkdirSync(DOCUMENT_CACHE_DIR, { recursive: true });
@@ -544,7 +546,7 @@ async function startSocket() {
 
       // For media without caption, use a placeholder so the API message is never empty
       if (hasMedia && !body) {
-        body = `[${mediaType} received]`;
+        body = mediaFileName ? `[${mediaType} received: ${mediaFileName}]` : `[${mediaType} received]`;
       }
 
       // Ignore Hermes' own reply messages in self-chat mode to avoid loops.
@@ -577,6 +579,8 @@ async function startSocket() {
         body,
         hasMedia,
         mediaType,
+        mediaFileName,
+        mediaFileNames: mediaFileName ? [mediaFileName] : [],
         mediaUrls,
         mentionedIds,
         quotedMessageId,

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -24,7 +24,7 @@ import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
-import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, appendFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
 import { execSync } from 'child_process';
@@ -47,6 +47,7 @@ const WHATSAPP_DEBUG =
 
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
+const HERMES_HOME = process.env.HERMES_HOME || path.join(process.env.HOME || '~', '.hermes');
 // Cache directories: the Python gateway passes the profile-aware paths via
 // env (HERMES_HOME-aware, new cache/ layout).  Fall back to the legacy
 // hardcoded locations for bridges launched outside the gateway.
@@ -56,6 +57,7 @@ const DOCUMENT_CACHE_DIR = process.env.HERMES_DOCUMENT_CACHE_DIR
   || path.join(process.env.HOME || '~', '.hermes', 'document_cache');
 const AUDIO_CACHE_DIR = process.env.HERMES_AUDIO_CACHE_DIR
   || path.join(process.env.HOME || '~', '.hermes', 'audio_cache');
+const SENT_LEDGER_PATH = path.join(HERMES_HOME, 'whatsapp', 'sent-messages.jsonl');
 
 // Self-hash of this script file.  Reported in /health so the Python gateway
 // can detect a running bridge that predates the current bridge.js and
@@ -131,12 +133,30 @@ function splitLongMessage(message, maxLength = MAX_MESSAGE_LENGTH) {
   return chunks;
 }
 
-function trackSentMessageId(sent) {
-  if (sent?.key?.id) {
-    recentlySentIds.add(sent.key.id);
-    if (recentlySentIds.size > MAX_RECENT_IDS) {
-      recentlySentIds.delete(recentlySentIds.values().next().value);
-    }
+function trackSentMessageId(sent, meta = {}) {
+  if (!sent?.key?.id) return;
+
+  recentlySentIds.add(sent.key.id);
+  if (recentlySentIds.size > MAX_RECENT_IDS) {
+    recentlySentIds.delete(recentlySentIds.values().next().value);
+  }
+
+  try {
+    mkdirSync(path.dirname(SENT_LEDGER_PATH), { recursive: true });
+    const entry = {
+      timestamp: new Date().toISOString(),
+      chatId: sent.key.remoteJid || meta.chatId || null,
+      messageId: sent.key.id,
+      fromMe: !!sent.key.fromMe,
+      participant: sent.key.participant || null,
+      kind: meta.kind || 'text',
+      chunkIndex: meta.chunkIndex ?? null,
+      chunkCount: meta.chunkCount ?? null,
+      textPreview: meta.text ? String(meta.text).slice(0, 500) : null,
+    };
+    appendFileSync(SENT_LEDGER_PATH, `${JSON.stringify(entry)}\n`);
+  } catch (err) {
+    console.warn('[bridge] Failed to write sent-message ledger:', err.message);
   }
 }
 
@@ -590,6 +610,28 @@ function textPayload(text, mentions = [], extra = {}) {
     : { text, ...extra };
 }
 
+app.get('/sent', (req, res) => {
+  try {
+    if (!existsSync(SENT_LEDGER_PATH)) return res.json({ success: true, messages: [] });
+    const limit = Math.max(1, Math.min(parseInt(req.query.limit || '50', 10) || 50, 500));
+    const chatId = req.query.chatId ? String(req.query.chatId) : '';
+    const q = req.query.q ? String(req.query.q).toLowerCase() : '';
+    const lines = readFileSync(SENT_LEDGER_PATH, 'utf8').split('\n').filter(Boolean);
+    const messages = [];
+    for (let i = lines.length - 1; i >= 0 && messages.length < limit; i -= 1) {
+      try {
+        const entry = JSON.parse(lines[i]);
+        if (chatId && entry.chatId !== chatId) continue;
+        if (q && !String(entry.textPreview || '').toLowerCase().includes(q)) continue;
+        messages.push(entry);
+      } catch {}
+    }
+    res.json({ success: true, messages });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Send a message
 app.post('/send', async (req, res) => {
   if (!sock || connectionState !== 'connected') {
@@ -606,7 +648,13 @@ app.post('/send', async (req, res) => {
     const messageIds = [];
     for (let i = 0; i < chunks.length; i += 1) {
       const sent = await sendWithTimeout(chatId, textPayload(chunks[i], i === 0 ? mentions : []));
-      trackSentMessageId(sent);
+      trackSentMessageId(sent, {
+        chatId,
+        text: chunks[i],
+        kind: 'text',
+        chunkIndex: i,
+        chunkCount: chunks.length,
+      });
       if (sent?.key?.id) messageIds.push(sent.key.id);
       if (chunks.length > 1 && i < chunks.length - 1) {
         await sleep(CHUNK_DELAY_MS);
@@ -643,7 +691,13 @@ app.post('/edit', async (req, res) => {
     if (chunks.length > 1) {
       for (let i = 1; i < chunks.length; i += 1) {
         const sent = await sendWithTimeout(chatId, textPayload(chunks[i]));
-        trackSentMessageId(sent);
+        trackSentMessageId(sent, {
+          chatId,
+          text: chunks[i],
+          kind: 'edit-continuation',
+          chunkIndex: i,
+          chunkCount: chunks.length,
+        });
         if (sent?.key?.id) messageIds.push(sent.key.id);
         if (i < chunks.length - 1) {
           await sleep(CHUNK_DELAY_MS);
@@ -652,6 +706,26 @@ app.post('/edit', async (req, res) => {
     }
 
     res.json({ success: true, messageIds });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Delete/retract a previously sent message by exact WhatsApp message id.
+app.post('/delete', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const { chatId, messageId } = req.body;
+  if (!chatId || !messageId) {
+    return res.status(400).json({ error: 'chatId and messageId are required' });
+  }
+
+  try {
+    const key = { remoteJid: chatId, fromMe: true, id: messageId };
+    await sendWithTimeout(chatId, { delete: key });
+    res.json({ success: true, messageId });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -745,7 +819,11 @@ app.post('/send-media', async (req, res) => {
 
     const sent = await sendWithTimeout(chatId, msgPayload);
 
-    trackSentMessageId(sent);
+    trackSentMessageId(sent, {
+      chatId,
+      text: caption || fileName || filePath,
+      kind: type || 'media',
+    });
 
     res.json({ success: true, messageId: sent?.key?.id });
   } catch (err) {

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -20,9 +20,9 @@ from gateway.platforms.base import Platform, PlatformConfig
 # ---------------------------------------------------------------------------
 
 class _StubAdapter(BasePlatformAdapter):
-    def __init__(self):
-        cfg = PlatformConfig()
-        super().__init__(cfg, Platform.TELEGRAM)
+    def __init__(self, platform=Platform.TELEGRAM, *, extra=None):
+        cfg = PlatformConfig(extra=extra or {})
+        super().__init__(cfg, platform)
         self._send_results = []   # queue of SendResult to return per call
         self._send_calls = []     # record of (chat_id, content) sent
 
@@ -248,6 +248,44 @@ class TestSendWithRetryExhausted:
         with patch("asyncio.sleep", new_callable=AsyncMock):
             result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
         assert not result.success  # still failed, but no exception raised
+
+    @pytest.mark.asyncio
+    async def test_whatsapp_suppresses_delivery_failure_notice_after_exhaustion(self):
+        adapter = _StubAdapter(platform=Platform.WHATSAPP)
+        network_err = SendResult(success=False, error="httpx.ConnectError: host unreachable")
+        adapter._send_results = [network_err, network_err, network_err]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
+
+        assert not result.success
+        assert len(adapter._send_calls) == 3  # initial + retries only; no diagnostic notice
+        assert all("delivery failed" not in content.lower() for _, content in adapter._send_calls)
+
+    @pytest.mark.asyncio
+    async def test_whatsapp_suppresses_not_connected_fallback(self):
+        adapter = _StubAdapter(platform=Platform.WHATSAPP)
+        adapter._send_results = [
+            SendResult(success=False, error="Not connected to WhatsApp"),
+        ]
+
+        result = await adapter._send_with_retry("chat1", "hello", max_retries=2)
+
+        assert not result.success
+        assert len(adapter._send_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_whatsapp_suppresses_plain_text_diagnostic_fallback(self):
+        adapter = _StubAdapter(platform=Platform.WHATSAPP)
+        adapter._send_results = [
+            SendResult(success=False, error="Bad Request: formatting failed"),
+        ]
+
+        result = await adapter._send_with_retry("chat1", "**bold**", max_retries=2)
+
+        assert not result.success
+        assert len(adapter._send_calls) == 1
+        assert "plain text" not in adapter._send_calls[-1][1].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -684,10 +684,13 @@ class TestWhatsAppSessionKeyConsistency:
         assert build_session_key(lid_source) == "agent:main:whatsapp:dm:15551234567"
         assert build_session_key(phone_source) == "agent:main:whatsapp:dm:15551234567"
 
-    def test_whatsapp_group_participant_aliases_share_session_key(self, tmp_path, monkeypatch):
-        """With group_sessions_per_user, the same human flipping between
-        phone-JID and LID inside a group must not produce two isolated
-        per-user sessions."""
+    def test_whatsapp_group_participants_share_chat_session_key(self, tmp_path, monkeypatch):
+        """WhatsApp groups are one shared transcript, not one session per sender.
+
+        This prevents Jacob/staff/vendor messages in the same group from being
+        routed into separate Hermes sessions where the assistant cannot see the
+        immediately preceding group context or its own prior response.
+        """
         tmp_home = tmp_path / "hermes-home"
         mapping_dir = tmp_home / "whatsapp" / "session"
         mapping_dir.mkdir(parents=True, exist_ok=True)
@@ -704,7 +707,22 @@ class TestWhatsAppSessionKeyConsistency:
             user_id="999999999999999@lid",
             user_name="Group Member",
         )
-        phone_source = SessionSource(
+        other_source = SessionSource(
+            platform=Platform.WHATSAPP,
+            chat_id="120363000000000000@g.us",
+            chat_type="group",
+            user_id="16667778888@s.whatsapp.net",
+            user_name="Other Member",
+        )
+
+        expected = "agent:main:whatsapp:group:120363000000000000@g.us"
+        assert build_session_key(lid_source, group_sessions_per_user=True) == expected
+        assert build_session_key(other_source, group_sessions_per_user=True) == expected
+
+    def test_whatsapp_group_is_marked_shared_even_when_generic_group_isolation_enabled(self):
+        from gateway.session import is_shared_multi_user_session
+
+        source = SessionSource(
             platform=Platform.WHATSAPP,
             chat_id="120363000000000000@g.us",
             chat_type="group",
@@ -712,9 +730,7 @@ class TestWhatsAppSessionKeyConsistency:
             user_name="Group Member",
         )
 
-        expected = "agent:main:whatsapp:group:120363000000000000@g.us:15551234567"
-        assert build_session_key(lid_source, group_sessions_per_user=True) == expected
-        assert build_session_key(phone_source, group_sessions_per_user=True) == expected
+        assert is_shared_multi_user_session(source, group_sessions_per_user=True) is True
 
     def test_whatsapp_group_shared_sessions_untouched_by_canonicalisation(self):
         """When group_sessions_per_user is False, participant_id is not in the

--- a/tests/gateway/test_silent_final_response.py
+++ b/tests/gateway/test_silent_final_response.py
@@ -2,12 +2,37 @@ from __future__ import annotations
 
 import pytest
 
+from gateway.platforms.base import _has_visible_delivery_text
 from gateway.run import _sanitize_gateway_final_response
 
 
-@pytest.mark.parametrize("sentinel", ["[SILENT]", " [[SILENT]] ", "<silent>"])
+@pytest.mark.parametrize(
+    "sentinel",
+    [
+        "[SILENT]",
+        " [[SILENT]] ",
+        "<silent>",
+        "\u200b[SILENT]\u200b",
+        "silencio",
+        "Silencio — no fui aludido directamente.",
+        "`silencio`",
+    ],
+)
 def test_silent_final_response_suppresses_delivery(sentinel):
     assert _sanitize_gateway_final_response("whatsapp", sentinel) == ""
+
+
+@pytest.mark.parametrize("blankish", ["\u200b", "\u200b \n\u2060", "\ufeff\u200d"])
+def test_invisible_only_final_response_suppresses_delivery(blankish):
+    assert _sanitize_gateway_final_response("whatsapp", blankish) == ""
+    assert not _has_visible_delivery_text(blankish)
+
+
+def test_base_delivery_guard_rejects_internal_silent_sentinels():
+    assert not _has_visible_delivery_text("[SILENT]")
+    assert not _has_visible_delivery_text("Silencio — no fui aludido directamente.")
+    assert _has_visible_delivery_text("Actual reply")
+    assert _has_visible_delivery_text("Necesitamos guardar silencio durante la llamada")
 
 
 def test_non_sentinel_response_is_preserved():

--- a/tests/gateway/test_silent_final_response.py
+++ b/tests/gateway/test_silent_final_response.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import pytest
+
+from gateway.run import _sanitize_gateway_final_response
+
+
+@pytest.mark.parametrize("sentinel", ["[SILENT]", " [[SILENT]] ", "<silent>"])
+def test_silent_final_response_suppresses_delivery(sentinel):
+    assert _sanitize_gateway_final_response("whatsapp", sentinel) == ""
+
+
+def test_non_sentinel_response_is_preserved():
+    assert _sanitize_gateway_final_response("whatsapp", "Actual reply") == "Actual reply"

--- a/tests/gateway/test_silent_response_diagnostics.py
+++ b/tests/gateway/test_silent_response_diagnostics.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import yaml
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, load_gateway_config
+from gateway.run import (
+    _gateway_effective_allow_silent_response,
+    _gateway_effective_suppress_provider_diagnostics,
+    _normalize_empty_agent_response,
+    _prepare_gateway_status_message,
+    _sanitize_gateway_final_response,
+)
+
+
+def _codex_incomplete_result() -> dict:
+    return {
+        "final_response": None,
+        "api_calls": 3,
+        "completed": False,
+        "partial": True,
+        "error": "Codex response remained incomplete after 3 continuation attempts",
+    }
+
+
+def test_default_partial_empty_response_still_surfaces_warning():
+    response = _normalize_empty_agent_response(
+        _codex_incomplete_result(),
+        "",
+        history_len=5,
+    )
+
+    assert "Processing stopped" in response
+    assert "Codex response remained incomplete" in response
+
+
+def test_allow_silent_response_keeps_intentional_no_reply_empty():
+    response = _normalize_empty_agent_response(
+        {"final_response": None, "api_calls": 1, "completed": True},
+        "",
+        history_len=5,
+        allow_silent_response=True,
+    )
+
+    assert response == ""
+
+
+def test_allow_silent_response_does_not_hide_partial_without_diagnostic_suppression():
+    response = _normalize_empty_agent_response(
+        _codex_incomplete_result(),
+        "",
+        history_len=5,
+        allow_silent_response=True,
+        suppress_provider_diagnostics=False,
+    )
+
+    assert "Processing stopped" in response
+    assert "Codex response remained incomplete" in response
+
+
+def test_suppress_provider_diagnostics_hides_codex_incomplete_warning():
+    response = _normalize_empty_agent_response(
+        _codex_incomplete_result(),
+        "",
+        history_len=5,
+        allow_silent_response=True,
+        suppress_provider_diagnostics=True,
+    )
+
+    assert response == ""
+
+
+def test_suppress_provider_diagnostics_filters_final_and_status_messages():
+    diagnostic = "⚠️ Processing stopped: Codex response remained incomplete after 3 continuation attempts. Try again."
+
+    assert (
+        _sanitize_gateway_final_response(
+            Platform.WHATSAPP,
+            diagnostic,
+            suppress_provider_diagnostics=True,
+        )
+        == ""
+    )
+    assert (
+        _prepare_gateway_status_message(
+            Platform.WHATSAPP,
+            "model.retry",
+            "⚠️ Empty/malformed response — switching to fallback...",
+            suppress_provider_diagnostics=True,
+        )
+        is None
+    )
+
+
+def test_effective_policy_reads_global_and_platform_specific_flags():
+    global_config = GatewayConfig(allow_silent_response=True)
+    assert _gateway_effective_allow_silent_response(global_config, Platform.WHATSAPP)
+
+    platform_config = GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(
+                extra={
+                    "allow_silent_response": True,
+                    "suppress_diagnostics": True,
+                }
+            )
+        }
+    )
+    assert _gateway_effective_allow_silent_response(platform_config, Platform.WHATSAPP)
+    assert _gateway_effective_suppress_provider_diagnostics(platform_config, Platform.WHATSAPP)
+
+
+def test_whatsapp_defaults_to_silent_no_diagnostics_without_config_flags():
+    config = GatewayConfig()
+
+    assert _gateway_effective_allow_silent_response(config, Platform.WHATSAPP)
+    assert _gateway_effective_suppress_provider_diagnostics(config, Platform.WHATSAPP)
+    assert not _gateway_effective_allow_silent_response(config, Platform.TELEGRAM)
+    assert not _gateway_effective_suppress_provider_diagnostics(config, Platform.TELEGRAM)
+
+
+def test_whatsapp_can_explicitly_opt_out_of_silent_no_diagnostics_defaults():
+    config = GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(
+                extra={
+                    "allow_silent_response": False,
+                    "suppress_diagnostics": False,
+                }
+            )
+        }
+    )
+
+    assert not _gateway_effective_allow_silent_response(config, Platform.WHATSAPP)
+    assert not _gateway_effective_suppress_provider_diagnostics(config, Platform.WHATSAPP)
+
+
+def test_config_yaml_loads_gateway_and_whatsapp_silent_diagnostics(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for name in (
+        "WHATSAPP_REQUIRE_MENTION",
+        "WHATSAPP_MENTION_PATTERNS",
+        "WHATSAPP_FREE_RESPONSE_CHATS",
+        "WHATSAPP_DM_POLICY",
+        "WHATSAPP_ALLOWED_USERS",
+        "WHATSAPP_GROUP_POLICY",
+        "WHATSAPP_GROUP_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "gateway": {
+                    "allow_silent_response": True,
+                    "suppress_provider_diagnostics_in_chat": True,
+                },
+                "whatsapp": {
+                    "allow_silent_response": True,
+                    "suppress_diagnostics": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_gateway_config()
+
+    assert config.allow_silent_response is True
+    assert config.suppress_provider_diagnostics_in_chat is True
+    assert config.platforms[Platform.WHATSAPP].extra["allow_silent_response"] is True
+    assert config.platforms[Platform.WHATSAPP].extra["suppress_diagnostics"] is True

--- a/tests/gateway/test_silent_response_diagnostics.py
+++ b/tests/gateway/test_silent_response_diagnostics.py
@@ -91,6 +91,48 @@ def test_suppress_provider_diagnostics_filters_final_and_status_messages():
     )
 
 
+def test_suppress_provider_diagnostics_filters_gateway_lifecycle_banners():
+    banners = [
+        "⚕ Hermes Gateway Starting...",
+        "Gateway running with 1 platform(s)",
+        "Gateway service is not running",
+        "Not connected to WhatsApp",
+        "Bootstrap failed: 5",
+        "⚠️ Message delivery failed after multiple attempts.",
+        "(Response formatting failed, plain text:)",
+    ]
+
+    for banner in banners:
+        assert (
+            _sanitize_gateway_final_response(
+                Platform.WHATSAPP,
+                banner,
+                suppress_provider_diagnostics=True,
+            )
+            == ""
+        )
+        assert (
+            _prepare_gateway_status_message(
+                Platform.WHATSAPP,
+                "lifecycle",
+                banner,
+                suppress_provider_diagnostics=True,
+            )
+            is None
+        )
+
+
+def test_gateway_lifecycle_text_is_preserved_when_diagnostic_suppression_off():
+    assert (
+        _sanitize_gateway_final_response(
+            Platform.WHATSAPP,
+            "Gateway running with 1 platform(s)",
+            suppress_provider_diagnostics=False,
+        )
+        == "Gateway running with 1 platform(s)"
+    )
+
+
 def test_effective_policy_reads_global_and_platform_specific_flags():
     global_config = GatewayConfig(allow_silent_response=True)
     assert _gateway_effective_allow_silent_response(global_config, Platform.WHATSAPP)

--- a/tests/gateway/test_silent_response_diagnostics.py
+++ b/tests/gateway/test_silent_response_diagnostics.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
 import yaml
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig, load_gateway_config
 from gateway.run import (
+    GatewayRunner,
+    _format_gateway_process_notification,
     _gateway_effective_allow_silent_response,
     _gateway_effective_suppress_provider_diagnostics,
     _normalize_empty_agent_response,
@@ -131,6 +137,104 @@ def test_gateway_lifecycle_text_is_preserved_when_diagnostic_suppression_off():
         )
         == "Gateway running with 1 platform(s)"
     )
+
+
+def test_whatsapp_suppresses_internal_control_final_messages():
+    internal_messages = [
+        "⏩ Steer queued — arrives after the next tool call: 'send this later'",
+        "Steer failed: no active run",
+        "[IMPORTANT: Background process proc_123 completed (exit code 0).\nCommand: true\nOutput:\nok]",
+        "[Background process proc_123 finished with exit code 0~ Here's the final output:\nok]",
+        "[Your active task list was preserved across context compression]",
+    ]
+
+    for message in internal_messages:
+        assert (
+            _sanitize_gateway_final_response(
+                Platform.WHATSAPP,
+                message,
+                suppress_provider_diagnostics=True,
+            )
+            == ""
+        )
+
+
+def test_formatted_watch_notification_is_suppressed_for_whatsapp_final_text():
+    notification = _format_gateway_process_notification(
+        {
+            "type": "watch_match",
+            "session_id": "proc_test",
+            "command": "python long_task.py",
+            "pattern": "ready",
+            "output": "ready",
+        }
+    )
+
+    assert notification
+    assert (
+        _sanitize_gateway_final_response(
+            Platform.WHATSAPP,
+            notification,
+            suppress_provider_diagnostics=True,
+        )
+        == ""
+    )
+
+
+@pytest.mark.asyncio
+async def test_watch_notification_injection_drops_whatsapp_adapter_delivery():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner.adapters = {Platform.WHATSAPP: adapter}
+
+    await runner._inject_watch_notification(
+        "[IMPORTANT: Background process proc_test matched watch pattern \"ready\".]",
+        {
+            "session_id": "proc_test",
+            "platform": "whatsapp",
+            "chat_id": "120363@example@g.us",
+        },
+    )
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_watcher_forces_whatsapp_notifications_off(monkeypatch):
+    import gateway.run as gateway_run
+    import tools.process_registry as process_registry_module
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    runner.adapters = {Platform.WHATSAPP: adapter}
+
+    fake_session = SimpleNamespace(
+        output_buffer="done",
+        exited=True,
+        exit_code=0,
+        command="python long_task.py",
+    )
+    fake_registry = SimpleNamespace(
+        get=lambda session_id: fake_session,
+        is_completion_consumed=lambda session_id: False,
+    )
+
+    monkeypatch.setattr(process_registry_module, "process_registry", fake_registry)
+    monkeypatch.setattr(gateway_run.asyncio, "sleep", AsyncMock())
+
+    await runner._run_process_watcher(
+        {
+            "session_id": "proc_test",
+            "check_interval": 0,
+            "session_key": "agent:main:whatsapp:dm:chat",
+            "platform": "whatsapp",
+            "chat_id": "chat@lid",
+            "notify_on_complete": True,
+        }
+    )
+
+    adapter.send.assert_not_awaited()
+    adapter.handle_message.assert_not_awaited()
 
 
 def test_effective_policy_reads_global_and_platform_specific_flags():

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -248,7 +248,7 @@ def test_observed_group_context_replays_as_current_message_context_not_user_turn
     )
 
     assert agent_history == [{"role": "assistant", "content": "previous explicit reply"}]
-    assert "[Observed Telegram group context - context only, not requests]" in api_message
+    assert "[Observed group context - context only, not requests]" in api_message
     assert "[Current addressed message - answer only this" in api_message
     assert "Acha que dá fazer estoque?" in api_message
     assert "Tem lote e vencimento" in api_message
@@ -295,12 +295,12 @@ def test_observed_group_context_wraps_multimodal_current_message_without_mutatin
     )
 
     assert original[0]["text"] == "[Bob|222]\nsee this image"
-    assert wrapped[0]["text"].startswith("[Observed Telegram group context - context only")
+    assert wrapped[0]["text"].startswith("[Observed group context - context only")
     assert wrapped[0]["text"].endswith("[Bob|222]\nsee this image")
     assert wrapped[1] == original[1]
 
 
-def test_observed_group_context_replays_normally_without_telegram_prompt():
+def test_observed_group_context_is_separated_even_without_platform_prompt():
     from gateway.run import _build_gateway_agent_history
 
     history = [
@@ -309,8 +309,8 @@ def test_observed_group_context_replays_normally_without_telegram_prompt():
 
     agent_history, observed_context = _build_gateway_agent_history(history, channel_prompt=None)
 
-    assert observed_context is None
-    assert agent_history == [{"role": "user", "content": "[Alice|111]\nside chatter"}]
+    assert observed_context == "[Alice|111]\nside chatter"
+    assert agent_history == []
 
 
 def test_observed_group_context_preserves_slash_command_text_for_dispatch():

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -13,6 +13,7 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
         "⚠ Auxiliary title generation failed: HTTP 400: Operation contains cybersecurity risk",
         "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
         "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
+        "ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was raised to 85% (from 45%).",
         "ℹ Configured compression model 'small-model' failed (timeout). Recovered using main model — check auxiliary.compression.model in config.yaml.",
         "⏳ Retrying in 4.2s (attempt 1/3)...",
         "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",

--- a/tests/gateway/test_whatsapp_context_bundle.py
+++ b/tests/gateway/test_whatsapp_context_bundle.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gateway.whatsapp_context import WhatsAppContextStore
+
+
+CHAT_ID = "120363001234567890@g.us"
+BOT_ID = "15551230000@s.whatsapp.net"
+JACOB = "209066827718687@lid"
+COUNTERPARTY = "5216641112222@s.whatsapp.net"
+
+
+def _store(tmp_path: Path) -> WhatsAppContextStore:
+    return WhatsAppContextStore(tmp_path / "wa-context")
+
+
+def _msg(message_id: str, body: str, *, sender=JACOB, sender_name="Jacob", **extra):
+    data = {
+        "chatId": CHAT_ID,
+        "messageId": message_id,
+        "senderId": sender,
+        "senderName": sender_name,
+        "timestamp": "2026-06-21T18:00:00Z",
+        "body": body,
+        "isGroup": True,
+        "mentionedIds": [],
+        "botIds": [BOT_ID],
+    }
+    data.update(extra)
+    return data
+
+
+def test_contract_pdf_is_stored_silently_and_used_when_later_mentioned(tmp_path: Path):
+    store = _store(tmp_path)
+    pdf_path = tmp_path / "contrato.pdf"
+    pdf_path.write_text("CONTRATO DE PRESTACION DE SERVICIOS\nClausula primera: pago y diligencia.", encoding="utf-8")
+
+    store.ingest_bridge_message(
+        _msg(
+            "m1",
+            "[document received: contrato.pdf]",
+            hasMedia=True,
+            mediaType="document",
+            mediaFileName="contrato.pdf",
+            mediaUrls=[str(pdf_path)],
+            extractedText="Contrato: pago realizado; queda agendar diligencia.",
+        )
+    )
+
+    trigger = store.ingest_bridge_message(
+        _msg(
+            "m2",
+            "@Jack dame resumen corto del contrato",
+            mentionedIds=[BOT_ID],
+        )
+    )
+    bundle = store.build_context_bundle(CHAT_ID, trigger.message_id)
+    rendered = bundle.render_for_prompt()
+
+    assert "m1" in bundle.context_message_ids
+    assert str(pdf_path) in bundle.media_paths
+    assert "Contrato: pago realizado" in rendered
+    assert "Reenvíalo" not in rendered
+
+
+def test_payment_proof_and_counterparty_confirmation_advance_next_step(tmp_path: Path):
+    store = _store(tmp_path)
+    proof_path = tmp_path / "pago 9.5k ger.pdf"
+    proof_path.write_text("Comprobante SPEI por $9,500 a Gestión Inmobiliaria y Legal. Mercantil 247/2023.", encoding="utf-8")
+
+    store.ingest_bridge_message(
+        _msg(
+            "m1",
+            "[document received: pago 9.5k ger.pdf]",
+            hasMedia=True,
+            mediaType="document",
+            mediaFileName="pago 9.5k ger.pdf",
+            mediaUrls=[str(proof_path)],
+            extractedText="SPEI $9,500 MXN beneficiario Gestión Inmobiliaria y Legal expediente Mercantil 247/2023",
+        )
+    )
+    store.ingest_bridge_message(
+        _msg(
+            "m2",
+            "Confirmo de recibido",
+            sender=COUNTERPARTY,
+            sender_name="Gestión Inmobiliaria Y Legal",
+        )
+    )
+    trigger = store.ingest_bridge_message(
+        _msg(
+            "m3",
+            "Jack me recuerdas aqui cual es el siguiente paso con @Gestión Inmobiliaria Y Legal ? Ya revisaste si hay nuevos acuerdos o actualizaciones en los casos de Eduardo?",
+            mentionedIds=[BOT_ID],
+        )
+    )
+
+    bundle = store.build_context_bundle(CHAT_ID, trigger.message_id)
+    rendered = bundle.render_for_prompt()
+
+    assert bundle.task_state["payment_proof_sent"] is True
+    assert bundle.task_state["receipt_confirmed_by_counterparty"] is True
+    assert bundle.guardrails["block_payment_recommendation"] is True
+    assert "pago 9.5k ger.pdf" in rendered
+    assert "$9,500" in rendered or "9500" in rendered
+    assert "Mercantil 247/2023" in rendered
+    assert "Do not recommend paying, authorizing payment, or sending the comprobante" in rendered
+    assert "request date/time of diligence" in rendered
+    assert "request official receipt" in rendered
+
+
+def test_download_failure_is_explicit_and_does_not_pretend_to_read_pdf(tmp_path: Path):
+    store = _store(tmp_path)
+    store.ingest_bridge_message(
+        _msg(
+            "m1",
+            "[document received: contrato.pdf]",
+            hasMedia=True,
+            mediaType="document",
+            mediaFileName="contrato.pdf",
+            mediaUrls=[],
+            mediaDownloadStatus="failed",
+        )
+    )
+    trigger = store.ingest_bridge_message(
+        _msg("m2", "@Jack resumelo", mentionedIds=[BOT_ID])
+    )
+
+    bundle = store.build_context_bundle(CHAT_ID, trigger.message_id)
+    rendered = bundle.render_for_prompt()
+
+    assert bundle.unreadable_media
+    assert "Veo que se envió un archivo, pero no pude descargarlo o leerlo. Reenvíalo o respóndeme directamente al archivo." in rendered
+    assert "pretend" in rendered.lower()
+
+
+def test_mention_only_stores_unmentioned_messages_silently_then_uses_them(tmp_path: Path):
+    store = _store(tmp_path)
+
+    first = store.ingest_bridge_message(_msg("m1", "Eduardo: hablaron de Mercantil 247/2023"))
+    second = store.ingest_bridge_message(_msg("m2", "El pago ya quedó enviado"))
+    trigger = store.ingest_bridge_message(
+        _msg("m3", "@Jack siguiente paso?", mentionedIds=[BOT_ID])
+    )
+
+    assert first.should_reply is False
+    assert second.should_reply is False
+    assert trigger.should_reply is True
+
+    bundle = store.build_context_bundle(CHAT_ID, trigger.message_id)
+    assert {"m1", "m2", "m3"}.issubset(set(bundle.context_message_ids))
+    rendered = bundle.render_for_prompt()
+    assert "Eduardo" in rendered
+    assert "Mercantil 247/2023" in rendered

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -228,15 +228,35 @@ class TestSendChunking:
     async def test_empty_message_no_send(self):
         adapter = _make_adapter()
         result = await adapter.send("chat1", "")
-        assert result.success
+        assert not result.success
+        assert result.error == "message has no visible content"
+        assert result.raw_response == {"suppressed": True}
         assert adapter._http_session.post.call_count == 0
 
     @pytest.mark.asyncio
     async def test_whitespace_only_no_send(self):
         adapter = _make_adapter()
         result = await adapter.send("chat1", "   \n  ")
-        assert result.success
+        assert not result.success
+        assert result.error == "message has no visible content"
+        assert result.raw_response == {"suppressed": True}
         assert adapter._http_session.post.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_bridge_204_suppression_is_not_success(self):
+        """Bridge 204 means no visible WhatsApp message was sent."""
+        adapter = _make_adapter()
+        resp = MagicMock(status=204)
+        session = adapter._http_session
+        assert session is not None
+        session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.send("chat1", "visible before bridge sanitizer")
+
+        assert not result.success
+        assert result.message_id is None
+        assert result.error == "message has no visible content after bridge sanitization"
+        assert result.raw_response == {"suppressed": True, "suppressed_chunks": 1}
 
     @pytest.mark.asyncio
     async def test_format_applied_before_send(self):

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -236,6 +236,19 @@ def test_group_policy_allowlist_allows_listed_group():
     assert adapter._should_process_message(_group_message("agus test")) is True
 
 
+def test_group_policy_allowlist_star_allows_all_groups():
+    adapter = _make_adapter(
+        group_policy="allowlist",
+        group_allow_from="*",
+        require_mention=True,
+    )
+
+    # ``*`` is useful for sandbox/testing configs: all groups pass the
+    # allowlist gate, while mention/wake-word gating still controls replies.
+    assert adapter._should_process_message(_group_message("hello")) is False
+    assert adapter._should_process_message(_group_message("/status")) is True
+
+
 def test_group_policy_open_allows_all_groups():
     adapter = _make_adapter(group_policy="open", require_mention=True)
 
@@ -272,6 +285,34 @@ def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
     assert __import__("os").environ["WHATSAPP_DM_POLICY"] == "disabled"
     assert __import__("os").environ["WHATSAPP_GROUP_POLICY"] == "allowlist"
     assert __import__("os").environ["WHATSAPP_GROUP_ALLOWED_USERS"] == "120363001234567890@g.us"
+
+
+def test_adapter_reads_group_allowlist_env_fallback(monkeypatch):
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    monkeypatch.setenv("WHATSAPP_GROUP_POLICY", "allowlist")
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "120363001234567890@g.us")
+    monkeypatch.setenv("WHATSAPP_REQUIRE_MENTION", "false")
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+
+    assert adapter._group_policy == "allowlist"
+    assert adapter._group_allow_from == {"120363001234567890@g.us"}
+    assert adapter._should_process_message(_group_message("hello")) is True
+
+
+def test_adapter_reads_group_allowlist_env_star(monkeypatch):
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    monkeypatch.setenv("WHATSAPP_GROUP_POLICY", "allowlist")
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "*")
+    monkeypatch.setenv("WHATSAPP_REQUIRE_MENTION", "false")
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+
+    assert adapter._group_policy == "allowlist"
+    assert adapter._group_allow_from == {"*"}
+    assert adapter._should_process_message(_group_message("hello")) is True
 
 
 def test_config_bridges_whatsapp_allow_from(monkeypatch, tmp_path):

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -12,7 +12,8 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
                   observe_unmentioned_group_messages=None,
                   reactions=None, reaction_allow_from=None,
                   reply_consider_reaction_senders=None,
-                  reply_consider_allow_from=None):
+                  reply_consider_allow_from=None,
+                  reaction_batch_delay_seconds=None):
     from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
     extra = {}
@@ -40,6 +41,8 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
         extra["reply_consider_reaction_senders"] = reply_consider_reaction_senders
     if reply_consider_allow_from is not None:
         extra["reply_consider_allow_from"] = reply_consider_allow_from
+    if reaction_batch_delay_seconds is not None:
+        extra["reaction_batch_delay_seconds"] = reaction_batch_delay_seconds
 
     adapter = object.__new__(WhatsAppAdapter)
     adapter.platform = Platform.WHATSAPP
@@ -54,7 +57,7 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
     adapter._reaction_emoji = str(extra.get("reaction_emoji") or "auto")
     adapter._reaction_allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("reaction_allow_from"))
     adapter._reply_consider_allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("reply_consider_allow_from") or extra.get("reaction_allow_from"))
-    adapter._reaction_batch_delay_seconds = 4.0
+    adapter._reaction_batch_delay_seconds = adapter._coerce_float_extra("reaction_batch_delay_seconds", 30.0)
     adapter._pending_reactions = {}
     adapter._pending_reaction_tasks = {}
     adapter._free_response_chats = adapter._whatsapp_free_response_chats()
@@ -112,6 +115,37 @@ def test_group_messages_can_require_direct_trigger_via_config():
         )
     ) is True
     assert adapter._should_process_message(_group_message("/status")) is True
+
+
+def test_linked_device_bot_id_normalizes_for_native_mention():
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._should_process_message(
+        _group_message(
+            "@Jack Assistant voy a sacar la batería #4068",
+            mentionedIds=["277365414441152@lid"],
+            botIds=["447752478277:6@s.whatsapp.net", "277365414441152:6@lid"],
+        )
+    ) is True
+
+
+def test_direct_group_trigger_reason_marks_adapter_allowed_mentions_for_pre_dispatch():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*@Jack\b"])
+    data = _group_message("@Jack Assistant voy a sacar la batería #4068")
+
+    assert adapter._should_process_message(data) is True
+    assert adapter._whatsapp_direct_group_trigger_reason(data) == "direct_hermes_text_address"
+
+
+@pytest.mark.asyncio
+async def test_build_event_preserves_direct_trigger_reason_after_cleaning_display_mention():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*@Jack\b"])
+    data = _group_message("@Jack Assistant voy a sacar la batería #4068 para trae la moto")
+
+    event = await adapter._build_message_event(data)
+
+    assert event is not None
+    assert event.raw_message["_hermes_direct_group_trigger_reason"] == "direct_hermes_text_address"
 
 
 def test_regex_mention_patterns_allow_custom_wake_words():
@@ -338,6 +372,77 @@ async def test_observed_group_message_is_stored_without_dispatch():
     assert "ordinary group chatter" in entry["content"]
     assert store.sources[0].user_id is None
     assert store.sources[0].chat_id == "120363001234567890@g.us"
+
+
+@pytest.mark.asyncio
+async def test_observed_group_photo_preserves_media_context():
+    class FakeStore:
+        def __init__(self):
+            self.entries = []
+            self.sources = []
+
+        def get_or_create_session(self, source):
+            self.sources.append(source)
+            return type("Session", (), {"session_id": "session-1"})()
+
+        def append_to_transcript(self, session_id, entry):
+            self.entries.append((session_id, entry))
+
+    adapter = _make_adapter(
+        require_mention=True,
+        observe_unmentioned_group_messages=True,
+    )
+    store = FakeStore()
+    adapter.set_session_store(store)
+
+    event = await adapter._build_message_event(
+        _group_message(
+            "licencia frente",
+            senderId="5216640000000@s.whatsapp.net",
+            senderName="Alice",
+            chatName="Test Group",
+            messageId="img-1",
+            hasMedia=True,
+            mediaType="image/jpeg",
+            mediaUrls=["/tmp/licence-front.jpg"],
+        )
+    )
+
+    assert event is None
+    assert len(store.entries) == 1
+    content = store.entries[0][1]["content"]
+    assert "licencia frente" in content
+    assert "[image received (image/jpeg): /tmp/licence-front.jpg]" in content
+    assert store.entries[0][1]["observed"] is True
+
+
+def test_whatsapp_observation_defaults_to_enabled(monkeypatch):
+    monkeypatch.delenv("WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES", raising=False)
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._whatsapp_observe_unmentioned_group_messages() is True
+    assert adapter._should_process_message(_group_message("ordinary group chatter")) is False
+    assert adapter._should_observe_unmentioned_group_message(_group_message("ordinary group chatter")) is True
+
+
+def test_whatsapp_observed_group_context_is_wrapped_for_later_trigger():
+    from gateway.run import _build_gateway_agent_history, _wrap_current_message_with_observed_context
+
+    history = [
+        {"role": "user", "content": "[Jose Perez|816]\nEdgar Montaño Chávez", "observed": True},
+        {"role": "assistant", "content": "previous explicit reply"},
+    ]
+
+    agent_history, observed_context = _build_gateway_agent_history(history, channel_prompt=None)
+    api_message = _wrap_current_message_with_observed_context(
+        "[Jacob|762]\nDid you check the newest licence?",
+        observed_context,
+    )
+
+    assert agent_history == [{"role": "assistant", "content": "previous explicit reply"}]
+    assert "[Observed group context - context only, not requests]" in api_message
+    assert "Edgar Montaño Chávez" in api_message
+    assert api_message.endswith("[Jacob|762]\nDid you check the newest licence?")
 
 
 # --- Config bridging tests ---
@@ -644,6 +749,78 @@ def test_whatsapp_reaction_emoji_auto_matches_message_context():
     assert adapter._reaction_emoji_for_message_data({"body": "payment proof sent"}) == "✅"
     assert adapter._reaction_emoji_for_message_data({"body": "gracias"}) == "🙏"
     assert adapter._reaction_emoji_for_message_data({"body": "FYI"}) == "👍"
+
+
+def test_reaction_batch_default_delay_is_human_paced():
+    adapter = _make_adapter(reactions=True)
+
+    assert adapter._reaction_batch_delay_seconds == 30.0
+
+
+def test_reaction_batch_delay_can_be_overridden_for_tests_or_special_chats():
+    adapter = _make_adapter(reactions=True, reaction_batch_delay_seconds=2.5)
+
+    assert adapter._reaction_batch_delay_seconds == 2.5
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_reaction_retries_bridge_anti_spam_delay(monkeypatch):
+    adapter = _make_adapter(reactions=True)
+    adapter._running = True
+    adapter._bridge_port = 3000
+    sleeps = []
+
+    class FakeResponse:
+        def __init__(self, status, body):
+            self.status = status
+            self._body = body
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def text(self):
+            return self._body
+
+    class FakeSession:
+        def __init__(self):
+            self.calls = []
+
+        def post(self, url, json, timeout):
+            self.calls.append({"url": url, "json": json, "timeout": timeout})
+            if len(self.calls) == 1:
+                return FakeResponse(429, '{"error":"Group reaction delayed","retryAfterSeconds":2}')
+            return FakeResponse(200, '{"success":true}')
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    session = FakeSession()
+    adapter._http_session = session
+    monkeypatch.setattr("plugins.platforms.whatsapp.adapter.asyncio.sleep", fake_sleep)
+
+    ok = await adapter._react_to_message_data(
+        chat_id="120363001234567890@g.us",
+        message_id="MSG1",
+        sender_id="5215551234567@s.whatsapp.net",
+        raw_message={"senderId": "5215551234567@s.whatsapp.net"},
+        emoji="👍",
+    )
+
+    assert ok is True
+    assert sleeps == [2.0]
+    assert len(session.calls) == 2
+    assert session.calls[0]["json"] == session.calls[1]["json"]
+
+
+def test_reaction_retry_after_parser_bounds_bad_or_excessive_values():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    assert WhatsAppAdapter._extract_reaction_retry_after_seconds("not json") == 0.0
+    assert WhatsAppAdapter._extract_reaction_retry_after_seconds('{"retryAfterSeconds":-1}') == 0.0
+    assert WhatsAppAdapter._extract_reaction_retry_after_seconds('{"retryAfterSeconds":120}') == 60.0
 
 
 def test_whatsapp_reaction_queue_keeps_only_latest_message_in_burst(monkeypatch):

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -117,6 +117,65 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter._should_process_message(_group_message("/status")) is True
 
 
+def test_group_reply_to_prior_hermes_message_triggers_without_quoted_participant(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    sent_dir = hermes_home / "whatsapp"
+    sent_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (sent_dir / "sent-messages.jsonl").write_text(
+        json.dumps(
+            {
+                "chatId": "120363001234567890@g.us",
+                "messageId": "3EB09F4212DD2B5A488601",
+                "fromMe": True,
+                "kind": "text",
+                "textPreview": "Public Safety Committee follow-up...",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    adapter = _make_adapter(require_mention=True)
+
+    data = _group_message(
+        "good but you should put the PDF you mention here",
+        quotedMessageId="3EB09F4212DD2B5A488601",
+        quotedParticipant="",
+        hasQuotedMessage=True,
+    )
+
+    assert adapter._should_process_message(data) is True
+    assert adapter._whatsapp_direct_group_trigger_reason(data) == "reply_to_hermes_message"
+
+
+def test_group_reply_to_message_from_other_chat_does_not_trigger(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    sent_dir = hermes_home / "whatsapp"
+    sent_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (sent_dir / "sent-messages.jsonl").write_text(
+        json.dumps(
+            {
+                "chatId": "120363999999999999@g.us",
+                "messageId": "3EB09F4212DD2B5A488601",
+                "fromMe": True,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._should_process_message(
+        _group_message(
+            "good but you should put the PDF you mention here",
+            quotedMessageId="3EB09F4212DD2B5A488601",
+            quotedParticipant="",
+            hasQuotedMessage=True,
+        )
+    ) is False
+
+
 def test_linked_device_bot_id_normalizes_for_native_mention():
     adapter = _make_adapter(require_mention=True)
 
@@ -445,6 +504,104 @@ def test_whatsapp_observed_group_context_is_wrapped_for_later_trigger():
     assert api_message.endswith("[Jacob|762]\nDid you check the newest licence?")
 
 
+@pytest.mark.asyncio
+async def test_whatsapp_context_log_ingests_unmentioned_payment_before_mention_gate(monkeypatch, tmp_path):
+    """Mention-only groups still persist payment/media context before dropping the event."""
+    from gateway.whatsapp_context import WhatsAppContextStore
+
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    proof_path = tmp_path / "pago 25k ger.pdf"
+    proof_path.write_bytes(b"not-a-real-pdf-but-a-bridge-local-file")
+
+    adapter = _make_adapter(
+        require_mention=True,
+        observe_unmentioned_group_messages=False,
+    )
+
+    unmentioned = await adapter._build_message_event(
+        _group_message(
+            "[document received: pago 25k ger.pdf]",
+            messageId="PAY1",
+            senderId="5215551234567@s.whatsapp.net",
+            senderName="Gestión Inmobiliaria Y Legal",
+            hasMedia=True,
+            mediaType="document",
+            mediaFileName="pago 25k ger.pdf",
+            mediaUrls=[str(proof_path)],
+        )
+    )
+
+    assert unmentioned is None
+    store = WhatsAppContextStore(hermes_home / "whatsapp_context")
+    events = store.load_chat_events("120363001234567890@g.us")
+    assert [ev.message_id for ev in events] == ["PAY1"]
+    assert events[0].media_filename == "pago 25k ger.pdf"
+    assert events[0].local_media_path == str(proof_path)
+
+    trigger = await adapter._build_message_event(
+        _group_message(
+            "@Jack siguiente paso?",
+            messageId="ASK1",
+            senderId="209066827718687@lid",
+            senderName="Jacob",
+            mentionedIds=["15551230000@s.whatsapp.net"],
+        )
+    )
+
+    assert trigger is not None
+    bundle = store.build_context_bundle("120363001234567890@g.us", "ASK1")
+    assert {"PAY1", "ASK1"}.issubset(set(bundle.context_message_ids))
+    assert bundle.task_state["payment_proof_sent"] is True
+    assert bundle.guardrails["block_payment_recommendation"] is True
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_context_log_marks_unreadable_media_from_adapter_payload(monkeypatch, tmp_path):
+    """Failed bridge downloads stay explicit in later Context Bundles."""
+    from gateway.whatsapp_context import WhatsAppContextStore
+
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    adapter = _make_adapter(
+        require_mention=True,
+        observe_unmentioned_group_messages=False,
+    )
+
+    dropped = await adapter._build_message_event(
+        _group_message(
+            "[document received: contrato.pdf]",
+            messageId="DOC1",
+            senderId="5215551234567@s.whatsapp.net",
+            senderName="Legal",
+            hasMedia=True,
+            mediaType="document",
+            mediaFileName="contrato.pdf",
+            mediaUrls=[],
+            mediaDownloadStatus="failed",
+        )
+    )
+    assert dropped is None
+
+    trigger = await adapter._build_message_event(
+        _group_message(
+            "@Jack resumelo",
+            messageId="ASK1",
+            senderId="209066827718687@lid",
+            senderName="Jacob",
+            mentionedIds=["15551230000@s.whatsapp.net"],
+        )
+    )
+
+    assert trigger is not None
+    store = WhatsAppContextStore(hermes_home / "whatsapp_context")
+    bundle = store.build_context_bundle("120363001234567890@g.us", "ASK1")
+    rendered = bundle.render_for_prompt()
+    assert [ev.message_id for ev in bundle.unreadable_media] == ["DOC1"]
+    assert "no pude descargarlo o leerlo" in rendered
+    assert "Do not pretend the unreadable media was read." in rendered
+
+
 # --- Config bridging tests ---
 
 def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
@@ -605,7 +762,12 @@ def test_is_broadcast_chat_helper_recognizes_common_jids():
     assert WhatsAppAdapter._is_broadcast_chat(None) is False  # type: ignore[arg-type]
 
 
-def _reaction_event(chat_type="group", sender_id="5215551234567@s.whatsapp.net", message_id: Optional[str] = "ABC123"):
+def _reaction_event(
+    chat_type="group",
+    sender_id="5215551234567@s.whatsapp.net",
+    message_id: Optional[str] = "ABC123",
+    raw_message=None,
+):
     from gateway.platforms.base import MessageEvent, MessageType
     from gateway.session import SessionSource
 
@@ -619,7 +781,7 @@ def _reaction_event(chat_type="group", sender_id="5215551234567@s.whatsapp.net",
         text="hello",
         message_type=MessageType.TEXT,
         source=source,
-        raw_message={"senderId": sender_id},
+        raw_message=raw_message or {"senderId": sender_id},
         message_id=message_id,
     )
 
@@ -670,6 +832,99 @@ def test_whatsapp_group_reactions_happen_before_mention_gating_drop():
     assert adapter._should_process_message(msg) is False
     assert adapter._should_observe_unmentioned_group_message(msg) is False
     assert adapter._should_react_to_message_data(msg) is True
+
+
+def test_whatsapp_group_payment_documents_do_not_get_ack_reactions():
+    adapter = _make_adapter(
+        require_mention=True,
+        reactions=True,
+        reaction_allow_from=["5215551234567@s.whatsapp.net"],
+        observe_unmentioned_group_messages=True,
+        reply_consider_reaction_senders=False,
+    )
+    msg = _group_message(
+        "[document received: pago 25k ger..pdf]",
+        messageId="MSG1",
+        senderId="5215551234567@s.whatsapp.net",
+        from_="5215551234567@s.whatsapp.net",
+        hasMedia=True,
+        mediaType="document",
+        mediaFileName="pago 25k ger..pdf",
+        mediaUrls=["/Users/den/.hermes/document_cache/doc_abc_pago_25k_ger..pdf"],
+    )
+    msg["from"] = msg.pop("from_")
+
+    assert adapter._looks_like_payment_intake_message(msg) is True
+    assert adapter._should_process_message(msg) is False
+    assert adapter._should_observe_unmentioned_group_message(msg) is True
+    assert adapter._should_react_to_message_data(msg) is False
+
+
+def test_whatsapp_group_payment_documents_do_not_get_event_ack_reactions():
+    adapter = _make_adapter(
+        reactions=True,
+        reaction_allow_from=["5215551234567@s.whatsapp.net"],
+    )
+    raw = _group_message(
+        "[document received: pago 25k ger..pdf]",
+        messageId="MSG1",
+        senderId="5215551234567@s.whatsapp.net",
+        mediaFileName="pago 25k ger..pdf",
+    )
+
+    assert adapter._should_react_to_event(_reaction_event(raw_message=raw)) is False
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_payment_proof_cancels_prior_pending_burst_reaction():
+    adapter = _make_adapter(
+        require_mention=True,
+        reactions=True,
+        reaction_allow_from=["5215551234567@s.whatsapp.net"],
+        observe_unmentioned_group_messages=True,
+        reaction_batch_delay_seconds=999,
+    )
+    normal_msg = _group_message(
+        "ordinary update before the next file",
+        messageId="MSG1",
+        senderId="5215551234567@s.whatsapp.net",
+        from_="5215551234567@s.whatsapp.net",
+    )
+    proof_msg = _group_message(
+        "[document received: pago 25k ger..pdf]",
+        messageId="MSG2",
+        senderId="5215551234567@s.whatsapp.net",
+        from_="5215551234567@s.whatsapp.net",
+        hasMedia=True,
+        mediaType="document",
+        mediaFileName="pago 25k ger..pdf",
+        mediaUrls=["/Users/den/.hermes/document_cache/doc_abc_pago_25k_ger..pdf"],
+    )
+    normal_msg["from"] = normal_msg.pop("from_")
+    proof_msg["from"] = proof_msg.pop("from_")
+
+    await adapter._build_message_event(normal_msg)
+    assert adapter._pending_reactions
+
+    await adapter._build_message_event(proof_msg)
+
+    assert adapter._pending_reactions == {}
+    assert adapter._pending_reaction_tasks == {}
+
+
+def test_whatsapp_group_payment_captions_do_not_get_ack_reactions():
+    adapter = _make_adapter(reactions=True, reaction_allow_from=["*"])
+    msg = _group_message(
+        "comprobante de transferencia",
+        messageId="MSG1",
+        senderId="5215551234567@s.whatsapp.net",
+        from_="5215551234567@s.whatsapp.net",
+        hasMedia=True,
+        mediaType="image",
+    )
+    msg["from"] = msg.pop("from_")
+
+    assert adapter._should_react_to_message_data(msg) is False
 
 
 def test_approved_reaction_sender_group_messages_are_considered_for_reply():

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,11 +1,13 @@
 import json
+import pytest
 from unittest.mock import AsyncMock
 
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
 def _make_adapter(require_mention=None, mention_patterns=None, free_response_chats=None,
-                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None):
+                  dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None,
+                  observe_unmentioned_group_messages=None):
     from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
     extra = {}
@@ -23,6 +25,8 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
         extra["group_policy"] = group_policy
     if group_allow_from is not None:
         extra["group_allow_from"] = group_allow_from
+    if observe_unmentioned_group_messages is not None:
+        extra["observe_unmentioned_group_messages"] = observe_unmentioned_group_messages
 
     adapter = object.__new__(WhatsAppAdapter)
     adapter.platform = Platform.WHATSAPP
@@ -257,6 +261,65 @@ def test_group_policy_open_allows_all_groups():
     assert adapter._should_process_message(_group_message("/status")) is True
 
 
+def test_observe_unmentioned_group_messages_with_star_allowlist():
+    adapter = _make_adapter(
+        require_mention=True,
+        group_policy="allowlist",
+        group_allow_from="*",
+        observe_unmentioned_group_messages=True,
+    )
+
+    assert adapter._should_process_message(_group_message("ordinary group chatter")) is False
+    assert adapter._should_observe_unmentioned_group_message(_group_message("ordinary group chatter")) is True
+    assert adapter._should_observe_unmentioned_group_message(
+        _group_message("@15551230000 please reply", mentionedIds=["15551230000@s.whatsapp.net"])
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_observed_group_message_is_stored_without_dispatch():
+    class FakeStore:
+        def __init__(self):
+            self.entries = []
+            self.sources = []
+
+        def get_or_create_session(self, source):
+            self.sources.append(source)
+            return type("Session", (), {"session_id": "session-1"})()
+
+        def append_to_transcript(self, session_id, entry):
+            self.entries.append((session_id, entry))
+
+    adapter = _make_adapter(
+        require_mention=True,
+        group_policy="allowlist",
+        group_allow_from="*",
+        observe_unmentioned_group_messages=True,
+    )
+    store = FakeStore()
+    adapter.set_session_store(store)
+
+    event = await adapter._build_message_event(
+        _group_message(
+            "ordinary group chatter",
+            senderId="5216640000000@s.whatsapp.net",
+            senderName="Alice",
+            chatName="Test Group",
+            messageId="msg-1",
+        )
+    )
+
+    assert event is None
+    assert len(store.entries) == 1
+    session_id, entry = store.entries[0]
+    assert session_id == "session-1"
+    assert entry["observed"] is True
+    assert entry["message_id"] == "msg-1"
+    assert "ordinary group chatter" in entry["content"]
+    assert store.sources[0].user_id is None
+    assert store.sources[0].chat_id == "120363001234567890@g.us"
+
+
 # --- Config bridging tests ---
 
 def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
@@ -266,6 +329,7 @@ def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
         "whatsapp:\n"
         "  dm_policy: disabled\n"
         "  group_policy: allowlist\n"
+        "  observe_unmentioned_group_messages: true\n"
         "  group_allow_from:\n"
         "    - \"120363001234567890@g.us\"\n",
         encoding="utf-8",
@@ -274,6 +338,7 @@ def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.delenv("WHATSAPP_DM_POLICY", raising=False)
     monkeypatch.delenv("WHATSAPP_GROUP_POLICY", raising=False)
+    monkeypatch.delenv("WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES", raising=False)
     monkeypatch.delenv("WHATSAPP_GROUP_ALLOWED_USERS", raising=False)
 
     config = load_gateway_config()
@@ -281,14 +346,16 @@ def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
     assert config is not None
     assert config.platforms[Platform.WHATSAPP].extra["dm_policy"] == "disabled"
     assert config.platforms[Platform.WHATSAPP].extra["group_policy"] == "allowlist"
+    assert config.platforms[Platform.WHATSAPP].extra["observe_unmentioned_group_messages"] is True
     assert config.platforms[Platform.WHATSAPP].extra["group_allow_from"] == ["120363001234567890@g.us"]
     assert __import__("os").environ["WHATSAPP_DM_POLICY"] == "disabled"
     assert __import__("os").environ["WHATSAPP_GROUP_POLICY"] == "allowlist"
+    assert __import__("os").environ["WHATSAPP_OBSERVE_UNMENTIONED_GROUP_MESSAGES"] == "true"
     assert __import__("os").environ["WHATSAPP_GROUP_ALLOWED_USERS"] == "120363001234567890@g.us"
 
 
 def test_adapter_reads_group_allowlist_env_fallback(monkeypatch):
-    from gateway.platforms.whatsapp import WhatsAppAdapter
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
     monkeypatch.setenv("WHATSAPP_GROUP_POLICY", "allowlist")
     monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "120363001234567890@g.us")
@@ -302,7 +369,7 @@ def test_adapter_reads_group_allowlist_env_fallback(monkeypatch):
 
 
 def test_adapter_reads_group_allowlist_env_star(monkeypatch):
-    from gateway.platforms.whatsapp import WhatsAppAdapter
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
     monkeypatch.setenv("WHATSAPP_GROUP_POLICY", "allowlist")
     monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "*")

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import json
 import pytest
 from unittest.mock import AsyncMock
@@ -7,7 +9,10 @@ from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 def _make_adapter(require_mention=None, mention_patterns=None, free_response_chats=None,
                   dm_policy=None, allow_from=None, group_policy=None, group_allow_from=None,
-                  observe_unmentioned_group_messages=None):
+                  observe_unmentioned_group_messages=None,
+                  reactions=None, reaction_allow_from=None,
+                  reply_consider_reaction_senders=None,
+                  reply_consider_allow_from=None):
     from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
     extra = {}
@@ -27,6 +32,14 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
         extra["group_allow_from"] = group_allow_from
     if observe_unmentioned_group_messages is not None:
         extra["observe_unmentioned_group_messages"] = observe_unmentioned_group_messages
+    if reactions is not None:
+        extra["reactions"] = reactions
+    if reaction_allow_from is not None:
+        extra["reaction_allow_from"] = reaction_allow_from
+    if reply_consider_reaction_senders is not None:
+        extra["reply_consider_reaction_senders"] = reply_consider_reaction_senders
+    if reply_consider_allow_from is not None:
+        extra["reply_consider_allow_from"] = reply_consider_allow_from
 
     adapter = object.__new__(WhatsAppAdapter)
     adapter.platform = Platform.WHATSAPP
@@ -37,6 +50,13 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
     adapter._group_policy = str(extra.get("group_policy", "open")).strip().lower()
     adapter._group_allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("group_allow_from"))
     adapter._mention_patterns = adapter._compile_mention_patterns()
+    adapter._reactions_enabled = adapter._coerce_bool_extra("reactions", False)
+    adapter._reaction_emoji = str(extra.get("reaction_emoji") or "auto")
+    adapter._reaction_allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("reaction_allow_from"))
+    adapter._reply_consider_allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("reply_consider_allow_from") or extra.get("reaction_allow_from"))
+    adapter._reaction_batch_delay_seconds = 4.0
+    adapter._pending_reactions = {}
+    adapter._pending_reaction_tasks = {}
     adapter._free_response_chats = adapter._whatsapp_free_response_chats()
     return adapter
 
@@ -478,3 +498,187 @@ def test_is_broadcast_chat_helper_recognizes_common_jids():
     assert WhatsAppAdapter._is_broadcast_chat("120363001234567890@g.us") is False
     assert WhatsAppAdapter._is_broadcast_chat("") is False
     assert WhatsAppAdapter._is_broadcast_chat(None) is False  # type: ignore[arg-type]
+
+
+def _reaction_event(chat_type="group", sender_id="5215551234567@s.whatsapp.net", message_id: Optional[str] = "ABC123"):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="120363001234567890@g.us" if chat_type == "group" else sender_id,
+        chat_type=chat_type,
+        user_id=sender_id,
+    )
+    return MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message={"senderId": sender_id},
+        message_id=message_id,
+    )
+
+
+def test_whatsapp_group_reactions_enabled_for_group_messages():
+    adapter = _make_adapter(reactions=True)
+
+    assert adapter._should_react_to_event(_reaction_event()) is True
+
+
+def test_whatsapp_group_reactions_skip_dms_and_missing_message_ids():
+    adapter = _make_adapter(reactions=True)
+
+    assert adapter._should_react_to_event(_reaction_event(chat_type="dm")) is False
+    assert adapter._should_react_to_event(_reaction_event(message_id=None)) is False
+
+
+def test_whatsapp_group_reactions_respect_sender_allowlist():
+    adapter = _make_adapter(
+        reactions=True,
+        reaction_allow_from=["5215551234567@s.whatsapp.net"],
+    )
+
+    assert adapter._should_react_to_event(
+        _reaction_event(sender_id="5215551234567@s.whatsapp.net")
+    ) is True
+    assert adapter._should_react_to_event(
+        _reaction_event(sender_id="5215559999999@s.whatsapp.net")
+    ) is False
+
+
+def test_whatsapp_group_reactions_happen_before_mention_gating_drop():
+    adapter = _make_adapter(
+        require_mention=True,
+        reactions=True,
+        reaction_allow_from=["5215551234567@s.whatsapp.net"],
+        observe_unmentioned_group_messages=False,
+        reply_consider_reaction_senders=False,
+    )
+    msg = _group_message(
+        "ordinary group chatter without a Jack mention",
+        messageId="MSG1",
+        senderId="5215551234567@s.whatsapp.net",
+        from_="5215551234567@s.whatsapp.net",
+    )
+    msg["from"] = msg.pop("from_")
+
+    assert adapter._should_process_message(msg) is False
+    assert adapter._should_observe_unmentioned_group_message(msg) is False
+    assert adapter._should_react_to_message_data(msg) is True
+
+
+def test_approved_reaction_sender_group_messages_are_considered_for_reply():
+    adapter = _make_adapter(
+        require_mention=True,
+        reactions=True,
+        reaction_allow_from=["5215551234567@s.whatsapp.net"],
+    )
+    msg = _group_message(
+        "Battery 4140 installed in NOW 3150 temporarily",
+        messageId="MSG1",
+        senderId="5215551234567@s.whatsapp.net",
+        from_="5215551234567@s.whatsapp.net",
+    )
+    msg["from"] = msg.pop("from_")
+
+    assert adapter._should_react_to_message_data(msg) is True
+    assert adapter._should_process_message(msg) is True
+    assert adapter._should_observe_unmentioned_group_message(msg) is False
+
+
+def test_non_approved_group_messages_stay_observe_only_when_unmentioned():
+    adapter = _make_adapter(
+        require_mention=True,
+        reactions=True,
+        reaction_allow_from=["5215551234567@s.whatsapp.net"],
+        observe_unmentioned_group_messages=True,
+    )
+    msg = _group_message(
+        "ordinary group chatter without a Jack mention",
+        messageId="MSG1",
+        senderId="5215559999999@s.whatsapp.net",
+        from_="5215559999999@s.whatsapp.net",
+    )
+    msg["from"] = msg.pop("from_")
+
+    assert adapter._should_react_to_message_data(msg) is False
+    assert adapter._should_process_message(msg) is False
+    assert adapter._should_observe_unmentioned_group_message(msg) is True
+
+
+def test_react_to_all_group_members_but_reply_consider_only_approved_senders():
+    adapter = _make_adapter(
+        require_mention=True,
+        reactions=True,
+        reaction_allow_from=["*"],
+        reply_consider_allow_from=["5215551234567@s.whatsapp.net"],
+        observe_unmentioned_group_messages=True,
+    )
+    jacob_msg = _group_message(
+        "Battery 4140 installed in NOW 3150 temporarily",
+        messageId="MSG1",
+        senderId="5215551234567@s.whatsapp.net",
+        from_="5215551234567@s.whatsapp.net",
+    )
+    other_msg = _group_message(
+        "ordinary group chatter without a Jack mention",
+        messageId="MSG2",
+        senderId="5215559999999@s.whatsapp.net",
+        from_="5215559999999@s.whatsapp.net",
+    )
+    jacob_msg["from"] = jacob_msg.pop("from_")
+    other_msg["from"] = other_msg.pop("from_")
+
+    assert adapter._should_react_to_message_data(jacob_msg) is True
+    assert adapter._should_process_message(jacob_msg) is True
+    assert adapter._should_react_to_message_data(other_msg) is True
+    assert adapter._should_process_message(other_msg) is False
+    assert adapter._should_observe_unmentioned_group_message(other_msg) is True
+
+
+def test_whatsapp_reaction_emoji_auto_matches_message_context():
+    adapter = _make_adapter(reactions=True)
+
+    assert adapter._reaction_emoji_for_message_data({"body": "Can you check this?"}) == "👀"
+    assert adapter._reaction_emoji_for_message_data({"body": "NOW 3140 is stolen"}) == "🚨"
+    assert adapter._reaction_emoji_for_message_data({"body": "payment proof sent"}) == "✅"
+    assert adapter._reaction_emoji_for_message_data({"body": "gracias"}) == "🙏"
+    assert adapter._reaction_emoji_for_message_data({"body": "FYI"}) == "👍"
+
+
+def test_whatsapp_reaction_queue_keeps_only_latest_message_in_burst(monkeypatch):
+    adapter = _make_adapter(reactions=True)
+    created = []
+
+    class FakeTask:
+        def __init__(self):
+            self.cancelled = False
+        def done(self):
+            return False
+        def cancel(self):
+            self.cancelled = True
+
+    def fake_create_task(coro):
+        coro.close()
+        task = FakeTask()
+        created.append(task)
+        return task
+
+    monkeypatch.setattr("plugins.platforms.whatsapp.adapter.asyncio.create_task", fake_create_task)
+    adapter._queue_reaction_message_data(
+        chat_id="120363001234567890@g.us",
+        message_id="MSG1",
+        sender_id="5215551234567@s.whatsapp.net",
+        raw_message={"body": "first", "senderId": "5215551234567@s.whatsapp.net"},
+    )
+    adapter._queue_reaction_message_data(
+        chat_id="120363001234567890@g.us",
+        message_id="MSG2",
+        sender_id="5215551234567@s.whatsapp.net",
+        raw_message={"body": "Can you check this?", "senderId": "5215551234567@s.whatsapp.net"},
+    )
+
+    key = adapter._reaction_batch_key("120363001234567890@g.us", "5215551234567@s.whatsapp.net")
+    assert created[0].cancelled is True
+    assert adapter._pending_reactions[key]["message_id"] == "MSG2"
+    assert adapter._pending_reactions[key]["emoji"] == "👀"

--- a/tests/gateway/test_whatsapp_group_routing.py
+++ b/tests/gateway/test_whatsapp_group_routing.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.group_routing import (
+    GroupRoutingConfig,
+    WhatsAppGroupRoutingPolicy,
+    route_whatsapp_group_event,
+)
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource
+
+
+class FakeSessionStore:
+    def __init__(self):
+        self.entries = []
+
+    def get_or_create_session(self, source):
+        self.source = source
+        return SimpleNamespace(session_id="session-1")
+
+    def append_to_transcript(self, session_id, entry):
+        self.entries.append((session_id, entry))
+
+
+def make_event(
+    text: str,
+    *,
+    chat_type: str = "group",
+    sender_id: str = "5211111111111@s.whatsapp.net",
+    mentioned_ids: list[str] | None = None,
+    bot_ids: list[str] | None = None,
+    quoted_participant: str | None = None,
+    chat_id: str = "120363000000000@g.us",
+) -> MessageEvent:
+    raw = {
+        "body": text,
+        "chatId": chat_id,
+        "chatName": "Ops Group",
+        "isGroup": chat_type == "group",
+        "senderId": sender_id,
+        "senderName": "Sender",
+        "messageId": "msg-1",
+        "mentionedIds": mentioned_ids or [],
+        "botIds": bot_ids or ["999999999999@s.whatsapp.net"],
+    }
+    if quoted_participant:
+        raw["quotedParticipant"] = quoted_participant
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id=chat_id,
+        chat_name="Ops Group",
+        chat_type=chat_type,
+        user_id=sender_id,
+        user_name="Sender",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message=raw,
+        message_id="msg-1",
+    )
+
+
+def evaluate(event: MessageEvent, store: FakeSessionStore | None = None):
+    return route_whatsapp_group_event(
+        event,
+        gateway_config={
+            "gateway": {
+                "whatsapp_group_routing": {
+                    "enabled": True,
+                    "group_mode": "mention_only",
+                    "allowed_public_reply": False,
+                    "allowed_dm_followup": False,
+                    "noise_tolerance": "low",
+                    "default_followup_channel": "private_jacob",
+                    "aliases": {"hermes": ["jack", "hermes"], "jacob": ["jacob"]},
+                }
+            }
+        },
+        session_store=store,
+    )
+
+
+def test_group_message_addressed_to_other_people_does_not_trigger_hermes_reply():
+    store = FakeSessionStore()
+    event = make_event(
+        "@5212222222222 @5213333333333 please coordinate delivery and confirm today",
+        mentioned_ids=["5212222222222@s.whatsapp.net", "5213333333333@s.whatsapp.net"],
+    )
+
+    decision = evaluate(event, store)
+
+    assert decision.addressee_classification == "addressed_to_specific_other_people"
+    assert decision.selected_action == "no_reply_task_update"
+    assert decision.public_reply_allowed is False
+    assert decision.should_call_llm_reply_generator is False
+    assert decision.should_call_send_message is False
+    assert decision.context_updated is True
+    assert decision.task_update_created is True
+    assert store.entries
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "@5212222222222 can you help him with the setup?",
+        "@5212222222222 puedes apoyarlo con la entrega?",
+    ],
+)
+def test_can_you_puedes_resolves_to_tagged_staff_member(text):
+    decision = evaluate(make_event(text, mentioned_ids=["5212222222222@s.whatsapp.net"]))
+
+    assert decision.addressee_classification == "addressed_to_specific_other_people"
+    assert decision.public_reply_allowed is False
+    assert decision.should_extract_task is True
+    assert decision.task_update_created is True
+
+
+@pytest.mark.parametrize("text", ["Jack, follow up with the owner if they do not confirm.", "Hermes: summarize this for the group"])
+def test_jacob_directly_addresses_hermes_allows_dispatch(text):
+    decision = evaluate(make_event(text))
+
+    assert decision.addressee_classification == "addressed_to_hermes"
+    assert decision.gateway_action == "allow"
+    assert decision.public_reply_allowed is True
+    assert decision.should_call_llm_reply_generator is True
+
+
+def test_participant_directly_addresses_hermes_question_allowed():
+    decision = evaluate(make_event("Hermes, can you confirm who owns the next step?", sender_id="521555@s.whatsapp.net"))
+
+    assert decision.addressee_classification == "addressed_to_hermes"
+    assert decision.public_reply_allowed is True
+
+
+def test_reply_to_hermes_message_allowed():
+    decision = evaluate(make_event("What did you mean by that?", quoted_participant="999999999999@s.whatsapp.net"))
+
+    assert decision.addressee_classification == "addressed_to_hermes"
+    assert decision.reason == "reply_to_hermes_message"
+    assert decision.gateway_action == "allow"
+
+
+def test_linked_device_bot_id_matches_native_mention_id():
+    event = make_event(
+        "@Jack Assistant voy a sacar la batería #4068 para trae la moto de plaza galerías",
+        mentioned_ids=["277365414441152@lid"],
+        bot_ids=["447752478277:6@s.whatsapp.net", "277365414441152:6@lid"],
+    )
+
+    decision = evaluate(event)
+
+    assert decision.addressee_classification == "addressed_to_hermes"
+    assert decision.reason == "mentioned_hermes_metadata"
+    assert decision.gateway_action == "allow"
+
+
+def test_adapter_direct_trigger_marker_survives_cleaned_mention_text():
+    event = make_event(
+        "voy a sacar la batería #4068 para trae la moto de plaza galerías",
+    )
+    event.raw_message["_hermes_direct_group_trigger_reason"] = "direct_hermes_text_address"
+
+    decision = evaluate(event)
+
+    assert decision.addressee_classification == "addressed_to_hermes"
+    assert decision.reason == "direct_hermes_text_address"
+    assert decision.gateway_action == "allow"
+
+
+def test_raw_jack_display_mention_survives_cleaned_event_text():
+    event = make_event("voy a sacar la batería #4068 para trae la moto de plaza galerías")
+    event.raw_message["body"] = "@Jack Assistant voy a sacar la batería #4068 para trae la moto de plaza galerías"
+
+    decision = evaluate(event)
+
+    assert decision.addressee_classification == "addressed_to_hermes"
+    assert decision.reason == "direct_hermes_text_address"
+    assert decision.gateway_action == "allow"
+
+
+def test_raw_numeric_bot_mention_survives_cleaned_event_text():
+    event = make_event(
+        "voy a sacar la batería #4068 para trae la moto de plaza galerías",
+        bot_ids=["447752478277:6@s.whatsapp.net", "277365414441152:6@lid"],
+    )
+    event.raw_message["body"] = "@277365414441152 voy a sacar la batería #4068 para trae la moto de plaza galerías"
+
+    decision = evaluate(event)
+
+    assert decision.addressee_classification == "addressed_to_hermes"
+    assert decision.reason == "mentioned_hermes_text"
+    assert decision.gateway_action == "allow"
+
+
+def test_ambient_group_chatter_skips_without_task():
+    decision = evaluate(make_event("Traffic is lighter than yesterday."))
+
+    assert decision.selected_action == "ignore_non_actionable_noise"
+    assert decision.should_call_llm_reply_generator is False
+    assert decision.should_call_send_message is False
+    assert decision.should_extract_task is False
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "The hydraulic jack is in the truck.",
+        "Use the jack stand, not the floor jack.",
+        "That jack adapter is missing.",
+    ],
+)
+def test_word_jack_as_normal_word_is_not_assistant_invocation(text):
+    decision = evaluate(make_event(text))
+
+    assert decision.addressee_classification != "addressed_to_hermes"
+    assert decision.public_reply_allowed is False
+    assert decision.should_call_llm_reply_generator is False
+
+
+def test_urgent_blocker_prefers_private_jacob_alert_and_updates_state():
+    decision = evaluate(make_event("We are blocked because the vendor has not sent the confirmation."))
+
+    assert decision.selected_action == "private_alert_to_jacob"
+    assert decision.should_alert_jacob_privately is True
+    assert decision.public_reply_allowed is False
+    assert decision.task_update_created is True
+
+
+@pytest.mark.parametrize(
+    "text,owner,deadline,pending",
+    [
+        ("@521222 please handle pickup logistics tomorrow", "521222@s.whatsapp.net", "tomorrow", []),
+        ("@vendor please confirm availability today", "vendor@s.whatsapp.net", "today", ["confirmation"]),
+        ("@ana dale seguimiento al pago el viernes", "ana@s.whatsapp.net", "viernes", []),
+    ],
+)
+def test_generic_task_extraction_across_scenarios(text, owner, deadline, pending):
+    decision = evaluate(make_event(text, mentioned_ids=[owner]))
+
+    task = decision.extracted_task
+    assert task is not None
+    assert task.owner == owner
+    assert task.requested_action
+    assert task.due_date == deadline
+    for item in pending:
+        assert item in task.pending_confirmations
+    assert task.source_platform == "whatsapp"
+    assert task.source_message_id == "msg-1"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "@luis puedes apoyarlo",
+        "@luis me confirmas",
+        "@luis tienes disponibilidad mañana?",
+        "@luis queda pendiente la entrega",
+        "@luis avísame cuando esté listo",
+        "@luis dale seguimiento",
+        "@luis necesito que confirmes",
+        "@luis por favor confirma",
+    ],
+)
+def test_spanish_action_phrasing_extracts_task_without_public_reply(text):
+    decision = evaluate(make_event(text, mentioned_ids=["luis@s.whatsapp.net"]))
+
+    assert decision.public_reply_allowed is False
+    assert decision.should_call_llm_reply_generator is False
+    assert decision.should_extract_task is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "@sam can you help him",
+        "@sam please confirm",
+        "@sam are you available tomorrow?",
+        "@sam follow up",
+        "@sam pending confirmation",
+        "@sam let me know",
+        "@sam please support",
+        "@sam can you handle this",
+    ],
+)
+def test_english_action_phrasing_extracts_task_without_public_reply(text):
+    decision = evaluate(make_event(text, mentioned_ids=["sam@s.whatsapp.net"]))
+
+    assert decision.public_reply_allowed is False
+    assert decision.should_call_llm_reply_generator is False
+    assert decision.should_extract_task is True
+
+
+class DummyAdapter(BasePlatformAdapter):
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: str | None = None,
+        metadata: dict | None = None,
+    ) -> SendResult:  # pragma: no cover - should not be called
+        raise AssertionError("send should not be called for skipped group messages")
+
+    async def _keep_typing(
+        self,
+        chat_id: str,
+        interval: float = 2.0,
+        metadata=None,
+        stop_event: asyncio.Event | None = None,
+    ) -> None:  # pragma: no cover - should not be called
+        raise AssertionError("typing should not start for skipped group messages")
+
+    async def get_chat_info(self, chat_id: str):
+        return {"name": chat_id, "type": "group"}
+
+@pytest.mark.asyncio
+async def test_no_reply_path_sends_absolutely_nothing_and_does_not_call_llm():
+    adapter = DummyAdapter(PlatformConfig(enabled=True, extra={}), Platform.WHATSAPP)
+    handler = AsyncMock(return_value="should not run")
+    adapter.set_message_handler(handler)
+    adapter.set_pre_dispatch_handler(AsyncMock(return_value={"action": "skip", "reason": "group_message_not_addressed_to_hermes"}))
+
+    await adapter.handle_message(make_event("@sam please confirm today", mentioned_ids=["sam@s.whatsapp.net"]))
+    await asyncio.sleep(0)
+
+    handler.assert_not_awaited()
+    assert adapter._background_tasks == set()
+
+
+def test_direct_message_behavior_remains_intact():
+    decision = evaluate(make_event("hello jack", chat_type="dm", chat_id="5211111111111@s.whatsapp.net"))
+
+    assert decision.gateway_action == "allow"
+    assert decision.should_call_llm_reply_generator is True
+
+
+def test_anti_parrot_suppresses_acknowledgments_and_restatements():
+    policy = WhatsAppGroupRoutingPolicy(GroupRoutingConfig())
+
+    assert policy.should_suppress_public_reply("Noted") is True
+    assert policy.should_suppress_public_reply(
+        "Please coordinate delivery and confirm today",
+        "@sam please coordinate delivery and confirm today",
+    ) is True
+    assert policy.should_suppress_public_reply("Can you confirm the delivery window?", "Please coordinate delivery") is False

--- a/tests/gateway/test_whatsapp_send_mentions.py
+++ b/tests/gateway/test_whatsapp_send_mentions.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.whatsapp import WhatsAppAdapter
+
+
+class _FakeResponse:
+    status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return {"messageId": "MSG1"}
+
+    async def text(self):
+        return ""
+
+
+class _FakeChatResponse:
+    status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return {
+            "name": "Reto de movilidad Garita Otay a SF",
+            "isGroup": True,
+            "participants": ["20130595618881@lid", "63045875281992@lid"],
+        }
+
+
+class _FakeSession:
+    def __init__(self):
+        self.posts = []
+        self.gets = []
+
+    def post(self, url, *, json, timeout):
+        self.posts.append({"url": url, "json": json, "timeout": timeout})
+        return _FakeResponse()
+
+    def get(self, url, *, timeout):
+        self.gets.append({"url": url, "timeout": timeout})
+        return _FakeChatResponse()
+
+
+async def _no_bridge_exit():
+    return None
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_send_forwards_mentions_metadata_on_first_chunk():
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True, extra={})
+    adapter._running = True
+    adapter._bridge_port = 3000
+    fake_session = _FakeSession()
+    adapter._http_session = fake_session
+    adapter._check_managed_bridge_exit = _no_bridge_exit
+    adapter._outgoing_chunk_limit = lambda: 4096
+
+    result = await adapter.send(
+        "120363406770604689@g.us",
+        "Falta confirmar fecha y hora con @20130595618881.",
+        metadata={"mentions": ["20130595618881@lid"]},
+    )
+
+    assert result.success is True
+    assert fake_session.posts[0]["json"] == {
+        "chatId": "120363406770604689@g.us",
+        "message": "Falta confirmar fecha y hora con @20130595618881.",
+        "mentions": ["20130595618881@lid"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_send_auto_resolves_visible_group_mentions():
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True, extra={})
+    adapter._running = True
+    adapter._bridge_port = 3000
+    fake_session = _FakeSession()
+    adapter._http_session = fake_session
+    adapter._check_managed_bridge_exit = _no_bridge_exit
+    adapter._outgoing_chunk_limit = lambda: 4096
+
+    result = await adapter.send(
+        "120363406770604689@g.us",
+        "Falta confirmar fecha y hora con @20130595618881.",
+    )
+
+    assert result.success is True
+    assert fake_session.gets
+    assert fake_session.posts[0]["json"] == {
+        "chatId": "120363406770604689@g.us",
+        "message": "Falta confirmar fecha y hora con @20130595618881.",
+        "mentions": ["20130595618881@lid"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_send_omits_empty_mentions():
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True, extra={})
+    adapter._running = True
+    adapter._bridge_port = 3000
+    fake_session = _FakeSession()
+    adapter._http_session = fake_session
+    adapter._check_managed_bridge_exit = _no_bridge_exit
+    adapter._outgoing_chunk_limit = lambda: 4096
+
+    result = await adapter.send(
+        "120363406770604689@g.us",
+        "Plain message",
+        metadata={"mentions": ["", "   "]},
+    )
+
+    assert result.success is True
+    assert "mentions" not in fake_session.posts[0]["json"]

--- a/tests/gateway/test_whatsapp_send_mentions.py
+++ b/tests/gateway/test_whatsapp_send_mentions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.whatsapp import WhatsAppAdapter
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
 
 class _FakeResponse:
@@ -129,3 +129,23 @@ async def test_whatsapp_send_omits_empty_mentions():
 
     assert result.success is True
     assert "mentions" not in fake_session.posts[0]["json"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blankish", [" ", "\u200b", "\u200b \n\u2060", "[SILENT]"])
+async def test_whatsapp_send_suppresses_non_visible_content(blankish):
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True, extra={})
+    adapter._running = True
+    adapter._bridge_port = 3000
+    fake_session = _FakeSession()
+    adapter._http_session = fake_session
+    adapter._check_managed_bridge_exit = _no_bridge_exit
+    adapter._outgoing_chunk_limit = lambda: 4096
+
+    result = await adapter.send("120363406770604689@g.us", blankish)
+
+    assert result.success is True
+    assert result.message_id is None
+    assert fake_session.posts == []

--- a/tests/gateway/test_whatsapp_send_mentions.py
+++ b/tests/gateway/test_whatsapp_send_mentions.py
@@ -146,6 +146,8 @@ async def test_whatsapp_send_suppresses_non_visible_content(blankish):
 
     result = await adapter.send("120363406770604689@g.us", blankish)
 
-    assert result.success is True
+    assert result.success is False
     assert result.message_id is None
+    assert result.error == "message has no visible content"
+    assert result.raw_response == {"suppressed": True}
     assert fake_session.posts == []

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -423,20 +423,26 @@ def test_warning_stored_for_gateway_replay(mock_get_client, mock_ctx_len):
 
     # Phase 1: __init__ — _emit_status prints (CLI) but callback is None
     vprint_messages = []
-    agent._emit_status = lambda msg: vprint_messages.append(msg)
+    agent._emit_status = lambda msg, customer_facing=True: vprint_messages.append(
+        (msg, customer_facing)
+    )
     agent._check_compression_model_feasibility()
 
     assert len(vprint_messages) == 1  # CLI got it
+    assert vprint_messages[0][1] is True
     assert agent._compression_warning is not None  # stored for replay
 
     # Phase 2: gateway wires callback post-init, then run_conversation replays
-    callback_events = []
-    agent.status_callback = lambda ev, msg: callback_events.append((ev, msg))
+    emitted = []
+    agent._emit_status = lambda msg, customer_facing=True: emitted.append(
+        (msg, customer_facing)
+    )
+    agent.status_callback = lambda ev, msg: None
     agent._replay_compression_warning()
 
     assert any(
-        ev == "lifecycle" and "Auto-lowered" in msg
-        for ev, msg in callback_events
+        "Auto-lowered" in msg and customer_facing is False
+        for msg, customer_facing in emitted
     )
 
 
@@ -472,6 +478,23 @@ def test_replay_without_callback_is_noop():
     agent._replay_compression_warning()
 
 
+def test_replay_compression_warning_suppresses_customer_facing_callbacks():
+    """Compression-warning replay must not bypass WhatsApp status filtering."""
+    agent = _make_agent()
+    agent.platform = "whatsapp"
+    agent._compression_warning = (
+        "ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was raised "
+        "to 85% (from 45%) to use more of the window before summarizing."
+    )
+    callback_events = []
+    agent.status_callback = lambda ev, msg: callback_events.append((ev, msg))
+    agent._vprint = lambda *args, **kwargs: None
+
+    agent._replay_compression_warning()
+
+    assert callback_events == []
+
+
 @patch("agent.model_metadata.get_model_context_length", return_value=80_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_len):
@@ -483,24 +506,28 @@ def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_
     mock_client.api_key = "sk-aux"
     mock_get_client.return_value = (mock_client, "small-model")
 
-    agent._emit_status = lambda msg: None
+    agent._emit_status = lambda msg, customer_facing=True: None
     agent._check_compression_model_feasibility()
 
     assert agent._compression_warning is not None
 
     # Simulate what run_conversation does
-    callback_events = []
-    agent.status_callback = lambda ev, msg: callback_events.append((ev, msg))
+    emitted = []
+    agent._emit_status = lambda msg, customer_facing=True: emitted.append(
+        (msg, customer_facing)
+    )
+    agent.status_callback = lambda ev, msg: None
     if agent._compression_warning:
         agent._replay_compression_warning()
         agent._compression_warning = None  # as in run_conversation
 
-    assert len(callback_events) == 1
+    assert len(emitted) == 1
+    assert emitted[0][1] is False
 
     # Second turn — nothing replayed
-    callback_events.clear()
+    emitted.clear()
     if agent._compression_warning:
         agent._replay_compression_warning()
         agent._compression_warning = None
 
-    assert len(callback_events) == 0
+    assert len(emitted) == 0

--- a/tests/run_agent/test_emit_status_customer_facing_filter.py
+++ b/tests/run_agent/test_emit_status_customer_facing_filter.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the ``_emit_status`` customer-facing platform filter.
+
+Refs: https://github.com/NousResearch/hermes-agent/issues/28208
+
+When Hermes runs over WhatsApp (or any other customer-facing messaging
+platform), internal Hermes diagnostics like the compression banner
+``"🗜️ Context too large (~156k tokens) — compressing..."`` must not be
+sent into end-user chat threads. The fix routes these emissions through a
+platform-aware filter in ``AIAgent._emit_status``:
+
+* CLI / admin / api surfaces still receive every status (existing behavior).
+* Customer-facing platforms (whatsapp, slack, signal, telegram, discord)
+  drop messages flagged ``customer_facing=False`` and, defensively, any
+  message starting with the compression-banner glyph for un-migrated callers.
+"""
+from __future__ import annotations
+
+import pytest
+
+import run_agent
+
+
+def _stub_agent(platform: str = "") -> tuple[object, list[tuple[str, str]]]:
+    """Build a minimal AIAgent for _emit_status testing without full init."""
+    agent = run_agent.AIAgent.__new__(run_agent.AIAgent)
+    agent.platform = platform
+    agent.log_prefix = ""
+    captured: list[tuple[str, str]] = []
+    agent.status_callback = lambda evt, msg: captured.append((evt, msg))
+    agent._vprint = lambda *a, **k: None  # silence the CLI path
+    return agent, captured
+
+
+@pytest.mark.parametrize(
+    "platform", ["whatsapp", "slack", "signal", "telegram", "discord"],
+)
+def test_compression_status_suppressed_on_customer_facing_platforms(platform):
+    """Explicit customer_facing=False compression banner stays out of customer chats."""
+    agent, captured = _stub_agent(platform)
+    agent._emit_status(
+        "🗜️ Context too large (~156,287 tokens) — compressing (1/3)...",
+        customer_facing=False,
+    )
+    assert captured == [], f"compression status leaked to {platform}: {captured!r}"
+
+
+@pytest.mark.parametrize("platform", ["whatsapp", "slack"])
+def test_glyph_fallback_drops_unmigrated_callers(platform):
+    """Defensive glyph detection drops 🗜 banners even without the kwarg."""
+    agent, captured = _stub_agent(platform)
+    agent._emit_status("🗜️ Compressed 120 → 7 messages, retrying...")
+    assert captured == [], f"glyph-fallback failed on {platform}: {captured!r}"
+
+
+def test_customer_facing_default_lets_normal_messages_through_on_wa():
+    """Real customer-facing messages (no glyph) still reach the gateway."""
+    agent, captured = _stub_agent("whatsapp")
+    agent._emit_status("Müberra Hanım, kalite skoru hazır")
+    assert captured == [("lifecycle", "Müberra Hanım, kalite skoru hazır")]
+
+
+def test_explicit_customer_facing_false_drops_message_without_glyph():
+    """customer_facing=False suppresses even messages without a glyph prefix."""
+    agent, captured = _stub_agent("whatsapp")
+    agent._emit_status("any internal-only banner", customer_facing=False)
+    assert captured == []
+
+
+def test_cli_platform_receives_compression_status():
+    """CLI/admin surface keeps full diagnostic visibility — no suppression."""
+    agent, captured = _stub_agent("cli")
+    agent._emit_status("🗜️ Context too large (~156k)", customer_facing=False)
+    assert captured == [("lifecycle", "🗜️ Context too large (~156k)")]
+
+
+def test_non_customer_facing_platform_passes_through():
+    """Platforms outside the customer-facing set keep visibility."""
+    agent, captured = _stub_agent("api_server")
+    agent._emit_status("🗜️ Compressed", customer_facing=False)
+    assert captured == [("lifecycle", "🗜️ Compressed")]
+
+
+def test_empty_platform_treated_as_non_customer_facing():
+    """A blank ``platform`` attribute is admin-equivalent."""
+    agent, captured = _stub_agent("")
+    agent._emit_status("🗜️ Context too large", customer_facing=False)
+    assert captured == [("lifecycle", "🗜️ Context too large")]
+
+
+def test_status_callback_exception_is_swallowed():
+    """An exception inside ``status_callback`` must not escape ``_emit_status``."""
+    agent = run_agent.AIAgent.__new__(run_agent.AIAgent)
+    agent.platform = "whatsapp"
+    agent.log_prefix = ""
+    agent._vprint = lambda *a, **k: None
+
+    def _explode(evt, msg):
+        raise RuntimeError("boom")
+
+    agent.status_callback = _explode
+    agent._emit_status("Normal customer message")

--- a/tests/run_agent/test_emit_status_customer_facing_filter.py
+++ b/tests/run_agent/test_emit_status_customer_facing_filter.py
@@ -53,6 +53,16 @@ def test_glyph_fallback_drops_unmigrated_callers(platform):
     assert captured == [], f"glyph-fallback failed on {platform}: {captured!r}"
 
 
+@pytest.mark.parametrize("platform", ["whatsapp", "slack"])
+def test_iteration_budget_banner_drops_on_customer_facing_platforms(platform):
+    """Iteration-budget lifecycle banners must not leak to customer chats."""
+    agent, captured = _stub_agent(platform)
+    agent._emit_status(
+        "⚠️ Iteration budget exhausted (60/60) — asking model to summarise"
+    )
+    assert captured == [], f"iteration-budget banner leaked to {platform}: {captured!r}"
+
+
 def test_customer_facing_default_lets_normal_messages_through_on_wa():
     """Real customer-facing messages (no glyph) still reach the gateway."""
     agent, captured = _stub_agent("whatsapp")

--- a/tests/run_agent/test_retry_status_buffer.py
+++ b/tests/run_agent/test_retry_status_buffer.py
@@ -29,7 +29,9 @@ def _make_bare_agent():
 def test_buffer_status_accumulates_then_flushes(capsys):
     agent = _make_bare_agent()
     emitted = []
-    agent._emit_status = lambda msg: emitted.append(("status", msg))
+    agent._emit_status = lambda message, customer_facing=True: emitted.append(
+        ("status", message, customer_facing)
+    )
 
     agent._buffer_status("⏳ Retrying...")
     agent._buffer_status("⚠️ Fallback...")
@@ -37,15 +39,15 @@ def test_buffer_status_accumulates_then_flushes(capsys):
     # Nothing emitted yet — they are buffered.
     assert emitted == []
     assert agent._retry_status_buffer == [
-        ("status", "⏳ Retrying..."),
-        ("status", "⚠️ Fallback..."),
+        ("status", "⏳ Retrying...", True),
+        ("status", "⚠️ Fallback...", True),
     ]
 
     # Flush surfaces them in order through _emit_status.
     agent._flush_status_buffer()
     assert emitted == [
-        ("status", "⏳ Retrying..."),
-        ("status", "⚠️ Fallback..."),
+        ("status", "⏳ Retrying...", True),
+        ("status", "⚠️ Fallback...", True),
     ]
     # Buffer is drained.
     assert agent._retry_status_buffer == []
@@ -54,7 +56,7 @@ def test_buffer_status_accumulates_then_flushes(capsys):
 def test_clear_drops_buffered_messages_silently():
     agent = _make_bare_agent()
     emitted = []
-    agent._emit_status = lambda msg: emitted.append(msg)
+    agent._emit_status = lambda message, customer_facing=True: emitted.append(message)
 
     agent._buffer_status("⏳ Retrying...")
     agent._buffer_status("⚠️ Fallback...")
@@ -86,7 +88,7 @@ def test_buffer_vprint_replays_via_vprint_with_log_prefix():
 def test_flush_empty_buffer_is_noop():
     agent = _make_bare_agent()
     emitted = []
-    agent._emit_status = lambda msg: emitted.append(msg)
+    agent._emit_status = lambda message, customer_facing=True: emitted.append(message)
     agent._vprint = lambda msg, force=False, **kw: emitted.append(msg)
 
     # No buffer attribute yet — flush should be a quiet no-op.
@@ -102,7 +104,7 @@ def test_flush_empty_buffer_is_noop():
 def test_re_buffer_after_flush_works():
     agent = _make_bare_agent()
     emitted = []
-    agent._emit_status = lambda msg: emitted.append(msg)
+    agent._emit_status = lambda message, customer_facing=True: emitted.append(message)
 
     agent._buffer_status("first")
     agent._flush_status_buffer()
@@ -118,7 +120,7 @@ def test_mixed_kinds_replay_through_correct_channels():
     statuses = []
     vprints = []
     warns = []
-    agent._emit_status = lambda msg: statuses.append(msg)
+    agent._emit_status = lambda message, customer_facing=True: statuses.append(message)
     agent._vprint = lambda msg, force=False, **kw: vprints.append((msg, force))
     agent._emit_warning = lambda msg: warns.append(msg)
 
@@ -135,12 +137,25 @@ def test_mixed_kinds_replay_through_correct_channels():
     assert warns == ["warn-1"]
 
 
+def test_buffer_status_preserves_customer_facing_flag_on_replay():
+    agent = _make_bare_agent()
+    emitted = []
+    agent._emit_status = lambda message, customer_facing=True: emitted.append(
+        (message, customer_facing)
+    )
+
+    agent._buffer_status("🗜️ Context too large", customer_facing=False)
+    agent._flush_status_buffer()
+
+    assert emitted == [("🗜️ Context too large", False)]
+
+
 def test_flush_swallows_callback_exceptions():
     agent = _make_bare_agent()
     seen = []
 
-    def boom(msg):
-        seen.append(msg)
+    def boom(message, customer_facing=True):
+        seen.append((message, customer_facing))
         raise RuntimeError("simulated callback failure")
 
     agent._emit_status = boom
@@ -151,6 +166,6 @@ def test_flush_swallows_callback_exceptions():
     agent._flush_status_buffer()
 
     # Both messages were attempted.
-    assert seen == ["first", "second"]
+    assert seen == [("first", True), ("second", True)]
     # Buffer drained regardless of failures.
     assert agent._retry_status_buffer == []


### PR DESCRIPTION
## Summary
- adds an explicit silent delivery path for WhatsApp/group gateway turns so skipped messages do not send blanks or explanations
- preserves observed WhatsApp group context while keeping replies gated to addressed turns
- suppresses customer-facing gateway diagnostics/retry noise for silent skips

Closes #18848

## Test Plan
- uv run --with pytest --with pytest-asyncio --with pyyaml --with aiohttp pytest tests/gateway/test_silent_final_response.py tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_whatsapp_context_bundle.py -q -o 'addopts='

## Notes
- Draft PR because the branch is large and should get maintainer review before merge.