### PR TITLE
fix(security): scope cron jobs to the caller's own user_id in multi-user gateways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ apps/desktop/demo/
 # PR body is the archive. See the hermes-agent-dev skill's
 # pr-infographic-workflow reference (storage rule + lapse #8 / #COMMIT-1).
 infographic/
+
+# Local scratch / repro directories. Throwaway artifacts, never part of the app.
+scratch/

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2213,11 +2213,14 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     # Inject output from referenced cron jobs as context.
     context_from = job.get("context_from")
     if context_from:
-        from cron.jobs import OUTPUT_DIR
+        from cron.jobs import OUTPUT_DIR, get_job as _get_job_ctx
         if isinstance(context_from, str):
             context_from = [context_from]
+        job_owner_id = (job.get("origin") or {}).get("user_id")
         for source_job_id in context_from:
-            # Guard against path traversal — valid job IDs are 12-char hex strings
+            # Guard against path traversal — valid job IDs are 12-char hex
+            # strings. Must run before ownership check because an invalid job_id
+            # is neither a valid store key nor a safe filesystem path.
             if not source_job_id or not all(c in "0123456789abcdef" for c in source_job_id):
                 logger.warning(
                     "context_from: skipping invalid job_id %r for job_id=%r name=%r%s",
@@ -2227,6 +2230,25 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                     _cron_job_origin_log_suffix(job),
                 )
                 continue
+            # Ownership check: in multi-user mode only read output from jobs
+            # owned by the same user to prevent cross-user data leak (#61016).
+            if job_owner_id is not None:
+                source_job = _get_job_ctx(source_job_id)
+                if source_job:
+                    source_owner = (source_job.get("origin") or {}).get("user_id")
+                    if source_owner != job_owner_id:
+                        logger.warning(
+                            "context_from: skipping job %r owned by different user "
+                            "for job_id=%r name=%r%s",
+                            source_job_id,
+                            job.get("id"),
+                            job.get("name"),
+                            _cron_job_origin_log_suffix(job),
+                        )
+                        continue
+                else:
+                    # Source job was deleted — skip silently.
+                    continue
             try:
                 job_output_dir = OUTPUT_DIR / source_job_id
                 if not job_output_dir.exists():

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -1,6 +1,8 @@
 """Tests for tools/cronjob_tools.py — prompt scanning, schedule/list/remove dispatchers."""
 
 import json
+from typing import Optional
+
 import pytest
 
 from tools.cronjob_tools import (
@@ -704,3 +706,226 @@ class TestValidateCronBaseUrl:
 
     def test_base_url_without_provider_rejected(self):
         assert self._v(None, "https://x.example/v1") is not None
+
+
+# =========================================================================
+# Cross-user isolation in multi-user gateway context
+# =========================================================================
+
+from gateway.session_context import set_session_vars, clear_session_vars
+
+
+class TestCronCrossUserIsolation:
+    """Users must not see or mutate each other's cron jobs in multi-user
+    gateway contexts. When ``HERMES_SESSION_USER_ID`` is set, the cron tool
+    scopes list/remove/pause/resume/run/update to jobs whose ``origin.user_id``
+    matches the caller. When unset (CLI/TUI), all jobs are visible."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+        # Ensure session ContextVars are clean per test
+        tokens = set_session_vars()
+        yield
+        clear_session_vars(tokens)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _set_caller(self, user_id: Optional[str]):
+        """Set the session env so the cron tool resolves *user_id* as the
+        calling user.  Pass ``None`` to simulate CLI/TUI mode (no user
+        identity)."""
+        if user_id is not None:
+            return set_session_vars(platform="telegram", chat_id="999", user_id=user_id)
+        return set_session_vars()
+
+    def _create_job_as(self, owner_id: str, name: str) -> str:
+        """Create a cron job owned by *owner_id* and return its ID."""
+        # The gateway always sets platform + chat_id + user_id. Without
+        # platform+chat_id, _origin_from_env() returns None and no origin
+        # is captured — the ownership check would then always fail.
+        tokens = set_session_vars(platform="telegram", chat_id="999", user_id=owner_id)
+        try:
+            result = json.loads(
+                cronjob(
+                    action="create",
+                    prompt=f"Job owned by {owner_id}",
+                    schedule="every 1h",
+                    name=name,
+                )
+            )
+            assert result["success"] is True
+            return result["job_id"]
+        finally:
+            clear_session_vars(tokens)
+
+    # ------------------------------------------------------------------
+    # List scoping
+    # ------------------------------------------------------------------
+
+    def test_list_shows_own_jobs(self):
+        """A user sees only their own jobs when HERMES_SESSION_USER_ID is set."""
+        alice_job = self._create_job_as("alice", "Alice Job")
+        tokens = self._set_caller("alice")
+        try:
+            listing = json.loads(cronjob(action="list"))
+            assert listing["success"] is True
+            assert listing["count"] == 1
+            assert listing["jobs"][0]["job_id"] == alice_job
+            assert listing["jobs"][0]["name"] == "Alice Job"
+        finally:
+            clear_session_vars(tokens)
+
+    def test_list_hides_other_users_jobs(self):
+        """User B must not see User A's jobs."""
+        self._create_job_as("alice", "Secret Job")
+        tokens = self._set_caller("bob")
+        try:
+            listing = json.loads(cronjob(action="list"))
+            assert listing["success"] is True
+            assert listing["count"] == 0
+        finally:
+            clear_session_vars(tokens)
+
+    def test_list_shows_all_jobs_when_no_user_id(self):
+        """CLI/TUI mode (no HERMES_SESSION_USER_ID) shows all jobs — backward
+        compatible."""
+        self._create_job_as("alice", "Alice Job")
+        self._create_job_as("bob", "Bob Job")
+        # No caller identity set → should see both
+        listing = json.loads(cronjob(action="list"))
+        assert listing["success"] is True
+        assert listing["count"] == 2
+
+    # ------------------------------------------------------------------
+    # Remove ownership
+    # ------------------------------------------------------------------
+
+    def test_remove_own_job_succeeds(self):
+        alice_job = self._create_job_as("alice", "My Job")
+        tokens = self._set_caller("alice")
+        try:
+            result = json.loads(cronjob(action="remove", job_id=alice_job))
+            assert result["success"] is True
+        finally:
+            clear_session_vars(tokens)
+
+    def test_remove_other_users_job_blocked(self):
+        alice_job = self._create_job_as("alice", "Secret")
+        tokens = self._set_caller("bob")
+        try:
+            result = json.loads(cronjob(action="remove", job_id=alice_job))
+            assert result["success"] is False
+            assert "access denied" in result.get("error", "").lower() or "not found" in result.get("error", "").lower()
+        finally:
+            clear_session_vars(tokens)
+
+    # ------------------------------------------------------------------
+    # Pause / resume ownership
+    # ------------------------------------------------------------------
+
+    def test_pause_own_job_succeeds(self):
+        alice_job = self._create_job_as("alice", "My Job")
+        tokens = self._set_caller("alice")
+        try:
+            result = json.loads(cronjob(action="pause", job_id=alice_job))
+            assert result["success"] is True
+            assert result["job"]["state"] == "paused"
+        finally:
+            clear_session_vars(tokens)
+
+    def test_pause_other_users_job_blocked(self):
+        alice_job = self._create_job_as("alice", "Secret")
+        tokens = self._set_caller("bob")
+        try:
+            result = json.loads(cronjob(action="pause", job_id=alice_job))
+            assert result["success"] is False
+        finally:
+            clear_session_vars(tokens)
+
+    def test_resume_other_users_job_blocked(self):
+        alice_job = self._create_job_as("alice", "Secret")
+        # Alice pauses it first
+        tokens = self._set_caller("alice")
+        try:
+            json.loads(cronjob(action="pause", job_id=alice_job))
+        finally:
+            clear_session_vars(tokens)
+        # Bob tries to resume
+        tokens = self._set_caller("bob")
+        try:
+            result = json.loads(cronjob(action="resume", job_id=alice_job))
+            assert result["success"] is False
+        finally:
+            clear_session_vars(tokens)
+
+    # ------------------------------------------------------------------
+    # Update ownership
+    # ------------------------------------------------------------------
+
+    def test_update_own_job_succeeds(self):
+        alice_job = self._create_job_as("alice", "My Job")
+        tokens = self._set_caller("alice")
+        try:
+            result = json.loads(
+                cronjob(action="update", job_id=alice_job, name="Updated Name")
+            )
+            assert result["success"] is True
+            assert result["job"]["name"] == "Updated Name"
+        finally:
+            clear_session_vars(tokens)
+
+    def test_update_other_users_job_blocked(self):
+        alice_job = self._create_job_as("alice", "Secret")
+        tokens = self._set_caller("bob")
+        try:
+            result = json.loads(
+                cronjob(action="update", job_id=alice_job, name="Hacked")
+            )
+            assert result["success"] is False
+        finally:
+            clear_session_vars(tokens)
+
+    # ------------------------------------------------------------------
+    # Run ownership
+    # ------------------------------------------------------------------
+
+    def test_run_other_users_job_blocked(self):
+        alice_job = self._create_job_as("alice", "Secret")
+        tokens = self._set_caller("bob")
+        try:
+            result = json.loads(cronjob(action="run", job_id=alice_job))
+            assert result["success"] is False
+        finally:
+            clear_session_vars(tokens)
+
+    # ------------------------------------------------------------------
+    # Mixed users: scoping is per-user, not global
+    # ------------------------------------------------------------------
+
+    def test_multiple_users_independent_jobs(self):
+        """Each user sees only their own jobs when scoped."""
+        alice_job = self._create_job_as("alice", "Alice Data")
+        bob_job = self._create_job_as("bob", "Bob Data")
+
+        # Alice sees her job
+        tokens = self._set_caller("alice")
+        try:
+            listing = json.loads(cronjob(action="list"))
+            assert listing["count"] == 1
+            assert listing["jobs"][0]["job_id"] == alice_job
+        finally:
+            clear_session_vars(tokens)
+
+        # Bob sees his job
+        tokens = self._set_caller("bob")
+        try:
+            listing = json.loads(cronjob(action="list"))
+            assert listing["count"] == 1
+            assert listing["jobs"][0]["job_id"] == bob_job
+        finally:
+            clear_session_vars(tokens)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -818,6 +818,34 @@ def cronjob(
         try:
             job = resolve_job_ref(job_id)
         except AmbiguousJobReference as exc:
+            caller_owner = _caller_owner_id()
+            if caller_owner is not None:
+                owned = [m for m in exc.matches if _owner_matches(m, caller_owner)]
+                if not owned:
+                    return json.dumps(
+                        {"success": False, "error": f"Job with ID or name '{job_id}' not found. Use cronjob(action='list') to inspect jobs."},
+                        indent=2,
+                    )
+                if len(owned) == 1:
+                    job = owned[0]
+                else:
+                    owned_ids = ", ".join(m["id"] for m in owned)
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "error": f"Job name '{exc.ref}' is ambiguous — matches {len(owned)} jobs: {owned_ids}. Use the job ID instead.",
+                            "matches": [
+                                {
+                                    "id": m["id"],
+                                    "name": m.get("name"),
+                                    "schedule": m.get("schedule_display"),
+                                    "next_run_at": m.get("next_run_at"),
+                                }
+                                for m in owned
+                            ],
+                        },
+                        indent=2,
+                    )
             return json.dumps(
                 {
                     "success": False,
@@ -839,7 +867,10 @@ def cronjob(
                 {"success": False, "error": f"Job with ID or name '{job_id}' not found. Use cronjob(action='list') to inspect jobs."},
                 indent=2,
             )
-        # Resolve to canonical ID (supports name-based lookup)
+        # Resolve to canonical ID (supports name-based lookup).
+        # Save the original user input for access-denied errors so the resolved
+        # canonical ID is not leaked to a caller who does not own the job.
+        _original_ref = job_id
         job_id = job["id"]
 
         # Ownership gate for multi-user gateway contexts.
@@ -847,7 +878,7 @@ def cronjob(
         caller_owner = _caller_owner_id()
         if caller_owner is not None and not _owner_matches(job, caller_owner):
             return json.dumps(
-                {"success": False, "error": f"Job '{job_id}' not found or access denied. Use cronjob(action='list') to inspect your jobs."},
+                {"success": False, "error": f"Job '{_original_ref}' not found or access denied. Use cronjob(action='list') to inspect your jobs."},
                 indent=2,
             )
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -308,6 +308,29 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
     return None
 
 
+def _caller_owner_id() -> Optional[str]:
+    """Resolve the calling user's identity for ownership scoping.
+
+    In gateway mode the session env carries ``HERMES_SESSION_USER_ID``.
+    When set, cron operations are scoped to jobs whose ``origin.user_id``
+    matches — users can only see and manage their own jobs. In CLI/TUI/ACP
+    mode the env var is absent and this returns ``None``, which means no
+    filtering (full backward compatibility, all jobs visible).
+
+    Returns ``None`` when no user identity is available (single-user modes).
+    """
+    from gateway.session_context import get_session_env
+    return get_session_env("HERMES_SESSION_USER_ID") or None
+
+
+def _owner_matches(job: Dict[str, Any], owner_id: Optional[str]) -> bool:
+    """Return True when ``owner_id`` is None (no scoping active) or the
+    job's ``origin.user_id`` matches ``owner_id``."""
+    if owner_id is None:
+        return True  # no scoping — all jobs visible
+    return (job.get("origin") or {}).get("user_id") == owner_id
+
+
 def _local_delivery_notice(job: Dict[str, Any], user_deliver: Optional[str]) -> Optional[str]:
     """Return an informational notice when a created job won't deliver anywhere.
 
@@ -774,7 +797,11 @@ def cronjob(
             )
 
         if normalized == "list":
-            jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
+            owner_id = _caller_owner_id()
+            all_jobs = list_jobs(include_disabled=include_disabled)
+            if owner_id is not None:
+                all_jobs = [j for j in all_jobs if _owner_matches(j, owner_id)]
+            jobs = [_format_job(job) for job in all_jobs]
             return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
 
         if not job_id:
@@ -806,6 +833,15 @@ def cronjob(
             )
         # Resolve to canonical ID (supports name-based lookup)
         job_id = job["id"]
+
+        # Ownership gate for multi-user gateway contexts.
+        # Users can only mutate (remove/pause/resume/run/update) jobs they own.
+        caller_owner = _caller_owner_id()
+        if caller_owner is not None and not _owner_matches(job, caller_owner):
+            return json.dumps(
+                {"success": False, "error": f"Job '{job_id}' not found or access denied. Use cronjob(action='list') to inspect your jobs."},
+                indent=2,
+            )
 
         if normalized == "remove":
             removed = remove_job(job_id)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -748,10 +748,18 @@ def cronjob(
             if context_from:
                 from cron.jobs import get_job as _get_job
                 refs = [context_from] if isinstance(context_from, str) else context_from
+                _create_owner = _caller_owner_id()
                 for ref_id in refs:
-                    if not _get_job(ref_id):
+                    ref_job = _get_job(ref_id)
+                    if not ref_job:
                         return tool_error(
                             f"context_from job '{ref_id}' not found. "
+                            "Use cronjob(action='list') to see available jobs.",
+                            success=False,
+                        )
+                    if _create_owner is not None and not _owner_matches(ref_job, _create_owner):
+                        return tool_error(
+                            f"context_from job '{ref_id}' not found or access denied. "
                             "Use cronjob(action='list') to see available jobs.",
                             success=False,
                         )
@@ -948,9 +956,16 @@ def cronjob(
                 if refs:
                     from cron.jobs import get_job as _get_job
                     for ref_id in refs:
-                        if not _get_job(ref_id):
+                        ref_job = _get_job(ref_id)
+                        if not ref_job:
                             return tool_error(
                                 f"context_from job '{ref_id}' not found. "
+                                "Use cronjob(action='list') to see available jobs.",
+                                success=False,
+                            )
+                        if caller_owner is not None and not _owner_matches(ref_job, caller_owner):
+                            return tool_error(
+                                f"context_from job '{ref_id}' not found or access denied. "
                                 "Use cronjob(action='list') to see available jobs.",
                                 success=False,
                             )


### PR DESCRIPTION
## What does this PR do?

The cron tool (\cronjob\) stores all jobs in a single per-profile JSON file. In a multi-user gateway context (Telegram, Discord, Slack, etc.) every user on a shared profile could previously list, remove, pause, resume, update, or run any other user's cron jobs — a full CRUD cross-user isolation gap.

### Fix

Added ownership scoping to \	ools/cronjob_tools.py\:
- \_caller_owner_id()\ — resolves the calling user from \HERMES_SESSION_USER_ID\ (set by the gateway per-agent-invocation).
- \_owner_matches()\ — checks a job's stored \origin.user_id\ against the caller.
- \ction=list\ — filters returned jobs to the caller when a user identity is available. Falls back to showing all jobs in CLI/TUI/ACP mode (no user identity).
- \ction=remove|pause|resume|run|update\ — rejects mutations on jobs the caller does not own.
- \ction=create\ and \ction=update\ — reject \context_from\ refs pointing to jobs the caller does not own.
- \_build_job_prompt\ (runtime in \cron/scheduler.py\) — only reads output from \context_from\ source jobs whose \origin.user_id\ matches the current job's owner.

CLI/TUI/ACP sessions have no \HERMES_SESSION_USER_ID\, so the new scoping is a no-op for them.

## Related Issue

Fixes a cross-user CRUD isolation vulnerability in multi-user gateways.

## Changes Made

- \	ools/cronjob_tools.py\: Add \_caller_owner_id()\, \_owner_matches()\, scope list/mutation paths, scope \context_from\ in create/update
- \cron/scheduler.py\: Scope \context_from\ output read at runtime by owner
- \	ests/tools/test_cronjob_tools.py\: Add \TestCronCrossUserIsolation\ class