### PR TITLE
fix(gateway): honor systemd unit scope in shutdown check

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -342,13 +342,18 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
 
     # Try to identify our unit name and ask systemctl for its config.
     unit_name: Optional[str] = None
+    cgroup_path: Optional[str] = None
     try:
         # /proc/self/cgroup gives us "0::/user.slice/.../hermes-gateway.service"
         with open("/proc/self/cgroup", encoding="utf-8") as fh:
             for line in fh:
                 # systemd cgroup line ends with the unit name
                 if ".service" in line:
-                    parts = line.strip().split("/")
+                    stripped = line.strip()
+                    path_start = stripped.find("/")
+                    if path_start != -1:
+                        cgroup_path = stripped[path_start:]
+                    parts = stripped.split("/")
                     for p in reversed(parts):
                         if p.endswith(".service"):
                             unit_name = p
@@ -360,11 +365,20 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     if not unit_name:
         return None
 
-    # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
-    # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # Query the manager that actually owns the unit. ``systemctl --user show``
+    # returns the default TimeoutStopUSec for unknown units, so probing the
+    # wrong scope first can yield a false "stale unit" warning for a healthy
+    # system-scope service.
+    scope_flags: list[list[str]]
+    if cgroup_path and cgroup_path.startswith("/system.slice/"):
+        scope_flags = [[]]
+    elif cgroup_path and cgroup_path.startswith("/user.slice/"):
+        scope_flags = [["--user"]]
+    else:
+        scope_flags = [["--user"], []]
+
     timeout_us: Optional[int] = None
-    for flag in (["--user"], []):
+    for flag in scope_flags:
         try:
             result = subprocess.run(
                 ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import signal
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -248,3 +250,68 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+    def test_system_scope_unit_queries_system_manager_only(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        monkeypatch.setattr(
+            "builtins.open",
+            lambda *_args, **_kwargs: io.StringIO(
+                "0::/system.slice/hermes-gateway-duke.service\n"
+            ),
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            calls.append(list(cmd))
+            return SimpleNamespace(
+                returncode=0,
+                stdout="TimeoutStopUSec=4min\n",
+            )
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert calls == [[
+            "systemctl",
+            "show",
+            "hermes-gateway-duke.service",
+            "--property=TimeoutStopUSec",
+        ]]
+        assert result is not None
+        assert result["unit"] == "hermes-gateway-duke.service"
+        assert result["timeout_stop_sec"] == 240.0
+        assert result["mismatch"] is False
+
+    def test_user_scope_unit_queries_user_manager_only(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        monkeypatch.setattr(
+            "builtins.open",
+            lambda *_args, **_kwargs: io.StringIO(
+                "0::/user.slice/user-1000.slice/user@1000.service/app.slice/hermes-gateway.service\n"
+            ),
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            calls.append(list(cmd))
+            return SimpleNamespace(
+                returncode=0,
+                stdout="TimeoutStopUSec=5min\n",
+            )
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert calls == [[
+            "systemctl",
+            "--user",
+            "show",
+            "hermes-gateway.service",
+            "--property=TimeoutStopUSec",
+        ]]
+        assert result is not None
+        assert result["unit"] == "hermes-gateway.service"
+        assert result["timeout_stop_sec"] == 300.0
+        assert result["mismatch"] is False


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive stale-systemd-unit warning in shutdown forensics. For system-scope gateway services, Hermes was querying `systemctl --user show` first; systemd returns the default `TimeoutStopUSec=1min 30s` for unknown user units, so the code could warn on every startup even when the real system unit had sufficient stop time configured.

## Related Issue

Fixes #61003

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Record the cgroup path while discovering the current `.service` unit.
- Use the cgroup owner slice to choose the correct `systemctl` manager: system scope for `/system.slice/...`, user scope for `/user.slice/...`.
- Keep a user-then-system fallback only when the cgroup path does not clearly identify the manager.
- Add regression tests for both system-scope and user-scope units in `tests/gateway/test_shutdown_forensics.py`.

## How to Test

1. `uv run pytest tests/gateway/test_shutdown_forensics.py -k CheckSystemdTimingAlignment -q`
2. `uv run python -m py_compile gateway/shutdown_forensics.py tests/gateway/test_shutdown_forensics.py`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local toolchain via `uv` / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Local proof: the new system-scope and user-scope alignment tests pass, syntax check passes, and `git diff --check` is clean.
- Note: the broader `tests/gateway/test_shutdown_forensics.py -q` file still has one unrelated preexisting failure in `TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output` on this machine; the alignment-specific slice passes.
