### PR TITLE
fix(gateway): preserve launchd runtime from app refresh

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import os
+import plistlib
 import shlex
 import shutil
 import signal
@@ -3985,6 +3986,56 @@ def launchd_plist_is_current() -> bool:
     ) == _normalize_launchd_plist_for_comparison(expected)
 
 
+def _launchd_plist_runtime(plist_text: str) -> tuple[str | None, str | None]:
+    """Return (python_path, HERMES_HOME) from a launchd plist, if parseable."""
+    try:
+        parsed = plistlib.loads(plist_text.encode("utf-8"))
+    except Exception:
+        return None, None
+    if not isinstance(parsed, dict):
+        return None, None
+    args = parsed.get("ProgramArguments")
+    python_path = (
+        args[0] if isinstance(args, list) and args and isinstance(args[0], str) else None
+    )
+    env = parsed.get("EnvironmentVariables")
+    hermes_home = None
+    if isinstance(env, dict):
+        raw_home = env.get("HERMES_HOME")
+        if isinstance(raw_home, str):
+            hermes_home = raw_home
+    return python_path, hermes_home
+
+
+def _path_is_inside_macos_app_bundle(path: str | None) -> bool:
+    if not path:
+        return False
+    parts = Path(path).parts
+    for index, part in enumerate(parts[:-1]):
+        if (
+            part.endswith(".app")
+            and index + 1 < len(parts)
+            and parts[index + 1] == "Contents"
+        ):
+            return True
+    return False
+
+
+def _should_preserve_launchd_runtime(installed_plist: str, new_plist: str) -> bool:
+    """Avoid replacing a user gateway runtime with a GUI app-bundled Python."""
+    installed_python, installed_home = _launchd_plist_runtime(installed_plist)
+    new_python, new_home = _launchd_plist_runtime(new_plist)
+    if not installed_python or not new_python or installed_python == new_python:
+        return False
+    if not _path_is_inside_macos_app_bundle(new_python):
+        return False
+    if _path_is_inside_macos_app_bundle(installed_python):
+        return False
+    if installed_home and new_home and installed_home != new_home:
+        return False
+    return True
+
+
 def refresh_launchd_plist_if_needed() -> bool:
     """Rewrite the installed launchd plist when the generated definition has changed.
 
@@ -3996,7 +4047,17 @@ def refresh_launchd_plist_if_needed() -> bool:
     if not plist_path.exists() or launchd_plist_is_current():
         return False
 
+    installed_plist = plist_path.read_text(encoding="utf-8")
     new_plist = generate_launchd_plist()
+    if _should_preserve_launchd_runtime(installed_plist, new_plist):
+        installed_python, _ = _launchd_plist_runtime(installed_plist)
+        new_python, _ = _launchd_plist_runtime(new_plist)
+        print("↻ Existing launchd gateway service uses a standalone Hermes runtime; leaving it unchanged")
+        print(f"  Current service Python: {installed_python}")
+        print(f"  Refusing to replace it with app-bundled Python: {new_python}")
+        print("  Use 'hermes gateway install --force' from the desired Hermes CLI to switch runtimes.")
+        return False
+
     if _refuse_temp_home_service_write(new_plist, "launchd plist"):
         return False
 
@@ -4124,8 +4185,10 @@ def launchd_install(force: bool = False):
     if plist_path.exists() and not force:
         if not launchd_plist_is_current():
             print(f"↻ Repairing outdated launchd service at: {plist_path}")
-            refresh_launchd_plist_if_needed()
-            print("✓ Service definition updated")
+            if refresh_launchd_plist_if_needed():
+                print("✓ Service definition updated")
+            else:
+                print("Service definition left unchanged")
             return
         print(f"Service already installed at: {plist_path}")
         print("Use --force to reinstall")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -681,6 +681,48 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "bootstrap", domain, str(plist_path)],
         ]
 
+    def test_refresh_preserves_user_venv_when_invoked_from_app_bundle(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        user_python = "/Users/alice/.hermes/hermes-agent/venv/bin/python"
+        user_venv = Path("/Users/alice/.hermes/hermes-agent/venv")
+        app_python = (
+            "/Applications/Hermes Studio.app/Contents/Resources/python/bin/python"
+        )
+        app_venv = Path("/Applications/Hermes Studio.app/Contents/Resources/python")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: user_python)
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: user_venv)
+        installed = gateway_cli.generate_launchd_plist()
+        plist_path.write_text(installed, encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: app_python)
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: app_venv)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: pytest.fail("launchctl should not run"),
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "Popen",
+            lambda *args, **kwargs: pytest.fail("detached reload should not run"),
+        )
+
+        assert gateway_cli.launchd_plist_is_current() is False
+        assert gateway_cli.refresh_launchd_plist_if_needed() is False
+
+        assert plist_path.read_text(encoding="utf-8") == installed
+        out = capsys.readouterr().out
+        assert "Refusing to replace it with app-bundled Python" in out
+        assert user_python in out
+        assert app_python in out
+
     def test_refresh_defers_reload_when_running_inside_gateway_tree(self, tmp_path, monkeypatch):
         """#43842: when the refresh runs inside the gateway's own process tree,
         a direct bootout would kill this CLI before bootstrap. The reload must


### PR DESCRIPTION
## Summary
- prevent launchd plist refresh from replacing an existing standalone gateway runtime with a Hermes Studio.app-bundled Python
- parse installed/generated plist runtime metadata and preserve the existing service when the app-bundled runtime targets the same HERMES_HOME
- report when `gateway install` leaves a protected plist unchanged instead of claiming it updated

Fixes #40278

## Validation
- `uv run --extra dev pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery::test_refresh_preserves_user_venv_when_invoked_from_app_bundle -q` -> 1 passed
- `uv run --extra dev pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery -q` -> 34 passed
- `uv run --extra dev pytest tests/hermes_cli/test_gateway_service.py -q -k "launchd or Launchd"` -> 47 passed, 139 deselected
- `uv run --extra dev pytest tests/hermes_cli/test_gateway.py -q -k "launchd or service"` -> 8 passed, 45 deselected
- `uv run --extra dev ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py` -> passed
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py` -> passed
- `git diff --check origin/main..HEAD` -> passed
- `gitleaks git --log-opts='origin/main..HEAD' --redact .` -> no leaks found

Note: full `tests/hermes_cli/test_gateway_service.py -q` on this macOS host produced 180 passed / 6 failed from existing systemd user-D-Bus preflight failures on non-systemd macOS; the launchd-focused selection above passes.

## Duplicate check
- exact open-PR search for `40278 in:title,body` returned none
- preflight reported broad launchd/plist/get_python_path overlap; inspected the closest open PRs (#15640, #24934, #29965, #40636, #48106, #48229, #55531, #57524, #60390) and they cover service identity, sudo/systemd venv discovery, XML escaping, dashboard launchd, status/labels, or env inheritance rather than this app-bundled runtime overwrite guard
