### PR TITLE
fix(telegram): preserve link preview disable on edits

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4852,6 +4852,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     text=content,
+                    **self._link_preview_kwargs(),
                 )
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = content
@@ -4864,6 +4865,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     message_id=int(message_id),
                     text=formatted,
                     parse_mode=ParseMode.MARKDOWN_V2,
+                    **self._link_preview_kwargs(),
                 )
             except Exception as fmt_err:
                 # "Message is not modified" is a no-op, not an error
@@ -4881,6 +4883,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     text=_plain,
+                    **self._link_preview_kwargs(),
                 )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -4909,6 +4912,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     text=truncated,
+                    **self._link_preview_kwargs(),
                 )
                 self._last_overflow_preview[_preview_key] = truncated
                 return SendResult(success=True, message_id=message_id)
@@ -4934,6 +4938,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         chat_id=normalize_telegram_chat_id(chat_id),
                         message_id=int(message_id),
                         text=content,
+                        **self._link_preview_kwargs(),
                     )
                     return SendResult(success=True, message_id=message_id)
                 except Exception as retry_err:
@@ -5041,6 +5046,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         message_id=int(message_id),
                         text=formatted,
                         parse_mode=ParseMode.MARKDOWN_V2,
+                        **self._link_preview_kwargs(),
                     )
                 except Exception as fmt_err:
                     if "not modified" not in str(fmt_err).lower():
@@ -5053,12 +5059,14 @@ class TelegramAdapter(BasePlatformAdapter):
                             chat_id=normalize_telegram_chat_id(chat_id),
                             message_id=int(message_id),
                             text=_strip_mdv2(first_chunk),
+                            **self._link_preview_kwargs(),
                         )
             else:
                 await self._bot.edit_message_text(
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     text=first_chunk,
+                    **self._link_preview_kwargs(),
                 )
         except Exception as e:
             err_str = str(e).lower()

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -486,7 +486,64 @@ async def test_send_escapes_chunk_indicator_for_markdownv2(adapter):
 
 
 class TestEditMessageStreamingSafety:
+    @staticmethod
+    def _assert_link_previews_disabled(kwargs):
+        assert (
+            kwargs.get("disable_web_page_preview") is True
+            or kwargs.get("link_preview_options") is not None
+        )
 
+    @pytest.mark.asyncio
+    async def test_non_final_edit_disables_link_preview_when_configured(self):
+        adapter = TelegramAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="fake-token",
+                extra={"disable_link_previews": True},
+            )
+        )
+        adapter._bot = MagicMock()
+        adapter._bot.edit_message_text = AsyncMock()
+
+        result = await adapter.edit_message(
+            "123",
+            "456",
+            "partial https://example.com",
+            finalize=False,
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.edit_message_text.await_args.kwargs
+        self._assert_link_previews_disabled(kwargs)
+
+    @pytest.mark.asyncio
+    async def test_final_edit_disables_link_preview_on_markdown_and_plain_fallback(
+        self,
+    ):
+        adapter = TelegramAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="fake-token",
+                extra={"disable_link_previews": True},
+            )
+        )
+        adapter._bot = MagicMock()
+        adapter._bot.edit_message_text = AsyncMock(
+            side_effect=[Exception("bad markdown"), None]
+        )
+
+        result = await adapter.edit_message(
+            "123",
+            "456",
+            "final https://example.com **bold**",
+            finalize=True,
+        )
+
+        assert result.success is True
+        first_call = adapter._bot.edit_message_text.await_args_list[0].kwargs
+        second_call = adapter._bot.edit_message_text.await_args_list[1].kwargs
+        self._assert_link_previews_disabled(first_call)
+        self._assert_link_previews_disabled(second_call)
 
     @pytest.mark.asyncio
     async def test_message_too_long_splits_into_continuations_not_silent_truncation(self):
@@ -525,6 +582,35 @@ class TestEditMessageStreamingSafety:
         # Continuations were sent threaded as replies for visual grouping.
         assert adapter._bot.send_message.await_count == len(result.continuation_message_ids)
 
+    @pytest.mark.asyncio
+    async def test_message_too_long_first_chunk_edit_disables_link_preview(self):
+        adapter = TelegramAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="fake-token",
+                extra={"disable_link_previews": True},
+            )
+        )
+        adapter._bot = MagicMock()
+        adapter._bot.edit_message_text = AsyncMock()
+        _next_id = [1000]
+
+        async def _fake_send(**kwargs):
+            _next_id[0] += 1
+            return SimpleNamespace(message_id=_next_id[0])
+
+        adapter._bot.send_message = AsyncMock(side_effect=_fake_send)
+
+        result = await adapter.edit_message(
+            "123",
+            "456",
+            "https://example.com " + ("x" * 6000),
+            finalize=True,
+        )
+
+        assert result.success is True
+        first_edit = adapter._bot.edit_message_text.await_args_list[0].kwargs
+        self._assert_link_previews_disabled(first_edit)
 
     @pytest.mark.asyncio
     async def test_mid_stream_overflow_truncates_instead_of_splitting(self):


### PR DESCRIPTION
## What does this PR do?

Fixes the Telegram legacy edit path so `platforms.telegram.extra.disable_link_previews: true` is honored when assistant output is updated via `edit_message_text`.

The initial send path already passed `link_preview_options`, but streaming edits, final MarkdownV2 edits, plain-text fallback edits, retry edits, and overflow first-chunk edits did not. That let Telegram create URL preview cards during response edits even though the user had disabled link previews.

## Related Issue

Fixes #61018

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: pass `self._link_preview_kwargs()` through all legacy Telegram `edit_message_text` calls used by streaming edits, final MarkdownV2 edits, fallback edits, retry edits, and overflow first-chunk edits.
- `tests/gateway/test_telegram_format.py`: add regressions proving `disable_link_previews` is preserved for non-final edits, final Markdown/fallback edits, and overflow first-chunk edits.

## How to Test

1. `./.venv/bin/pytest tests/gateway/test_telegram_format.py::TestEditMessageStreamingSafety -q`
2. `./.venv/bin/pytest tests/gateway/test_telegram_format.py -q`
3. `./.venv/bin/python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_format.py`
4. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS with repo `.venv` / Python 3.11-compatible test environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — adapter kwargs only, no platform-specific file/process behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused validation passed locally:

- `./.venv/bin/pytest tests/gateway/test_telegram_format.py::TestEditMessageStreamingSafety -q` — 12 passed
- `./.venv/bin/pytest tests/gateway/test_telegram_format.py -q` — 112 passed
- `./.venv/bin/python -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_format.py`
- `git diff --check`
