### PR TITLE
fix(dashboard): pass -o flag to hermes backup subcommand

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9660,7 +9660,7 @@ def _new_dashboard_backup_path() -> Path:
 
 @app.post("/api/ops/backup")
 async def run_backup(body: BackupRequest):
-    args = ["backup"]
+    args = ["backup", "-o"]
     archive: Optional[Path] = None
     if body.output:
         args.append(body.output.strip())

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1675,7 +1675,7 @@ class TestWebServerEndpoints:
 
         assert data["name"] == "backup"
         assert captured["name"] == "backup"
-        assert captured["args"] == ["backup", str(archive)]
+        assert captured["args"] == ["backup", "-o", str(archive)]
         assert archive.parent == get_hermes_home() / "backups"
         assert archive.name.startswith("hermes-backup-")
         assert archive.suffix == ".zip"
@@ -1702,7 +1702,7 @@ class TestWebServerEndpoints:
         archive = Path(resp.json()["archive"])
 
         assert archive.parent == hosted_home / "backups"
-        assert captured["args"] == ["backup", str(archive)]
+        assert captured["args"] == ["backup", "-o", str(archive)]
         assert archive.parent.is_dir()
 
     def test_ops_backup_download_streams_dashboard_backup(self, tmp_path):


### PR DESCRIPTION
## Bug

The dashboard "Full backup" button calls `hermes backup <path>` (output path passed as positional argument), but the `hermes backup` CLI only accepts output paths via `-o/--output`. This causes `hermes: error: unrecognized arguments` when spawning the subprocess.

## Fix

Prepend `-o` to the argument list so the spawned command becomes `hermes backup -o <path>`.

### Changed files

- `hermes_cli/web_server.py` — `args = ["backup"]` → `args = ["backup", "-o"]`
- `tests/hermes_cli/test_web_server.py` — updated assertions to expect `-o` in the args