### PR TITLE
fix(gateway): preserve depth-capped interrupt follow-ups

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8347,6 +8347,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return text
         return (enriched_text or text).strip()
 
+    def _requeue_interrupt_depth_pending(
+        self,
+        session_key: str,
+        source,
+        *,
+        adapter: Any,
+        pending_event: Optional[MessageEvent],
+        pending_text: Optional[str],
+        event_message_id: Optional[str],
+        channel_prompt: Optional[str],
+    ) -> bool:
+        """Park the next interrupt follow-up when recursive drain hits its cap."""
+        if not adapter or not session_key:
+            return False
+
+        queued_event = pending_event
+        if queued_event is None and pending_text:
+            queued_event = MessageEvent(
+                text=pending_text,
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id=event_message_id,
+                channel_prompt=channel_prompt,
+            )
+
+        pending_slot = getattr(adapter, "_pending_messages", None)
+        if queued_event is not None and pending_slot is not None:
+            if getattr(queued_event, "source", None) is None:
+                queued_event.source = source
+            self._enqueue_fifo(session_key, queued_event, adapter)
+            return True
+
+        if pending_text and hasattr(adapter, "queue_message"):
+            adapter.queue_message(session_key, pending_text)
+            return True
+        return False
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -24292,10 +24329,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _interrupt_depth, session_key,
                     )
                     adapter = self._adapter_for_source(source)
-                    if adapter and pending_event:
-                        merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
-                    elif adapter and hasattr(adapter, 'queue_message'):
-                        adapter.queue_message(session_key, pending)
+                    self._requeue_interrupt_depth_pending(
+                        session_key,
+                        source,
+                        adapter=adapter,
+                        pending_event=pending_event,
+                        pending_text=pending,
+                        event_message_id=event_message_id,
+                        channel_prompt=channel_prompt,
+                    )
                     return result_holder[0] or {"final_response": response, "messages": history}
 
                 was_interrupted = result.get("interrupted")

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -169,6 +169,74 @@ class TestQueueConsumptionAfterCompletion:
         # gets the next-in-line item.
         assert adapter._pending_messages[session_key].text == "Q2"
 
+    def test_interrupt_depth_requeues_plain_interrupt_text_as_event(self):
+        """Depth-capped interrupt strings must not require adapter.queue_message()."""
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._queued_events = {}
+        adapter = _StubAdapter()
+        session_key = "telegram:user:voice-depth"
+        source = MagicMock(chat_id="123", platform=Platform.TELEGRAM, profile=None)
+
+        stored = runner._requeue_interrupt_depth_pending(
+            session_key,
+            source,
+            adapter=adapter,
+            pending_event=None,
+            pending_text='"transcribed voice follow-up"',
+            event_message_id="voice-1",
+            channel_prompt="voice-channel",
+        )
+
+        assert stored is True
+        queued = adapter._pending_messages[session_key]
+        assert queued.text == '"transcribed voice follow-up"'
+        assert queued.message_type == MessageType.TEXT
+        assert queued.source is source
+        assert queued.message_id == "voice-1"
+        assert queued.channel_prompt == "voice-channel"
+        assert runner._queued_events == {}
+
+    def test_interrupt_depth_requeues_event_behind_existing_slot(self):
+        """Depth-capped full events should preserve FIFO ordering."""
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._queued_events = {}
+        adapter = _StubAdapter()
+        session_key = "telegram:user:voice-depth-fifo"
+        source = MagicMock(chat_id="123", platform=Platform.TELEGRAM, profile=None)
+
+        adapter._pending_messages[session_key] = MessageEvent(
+            text="already queued",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="text-1",
+        )
+        voice_event = MessageEvent(
+            text="",
+            message_type=MessageType.VOICE,
+            source=source,
+            message_id="voice-2",
+            media_urls=["/tmp/voice-2.ogg"],
+            media_types=["audio/ogg"],
+        )
+
+        stored = runner._requeue_interrupt_depth_pending(
+            session_key,
+            source,
+            adapter=adapter,
+            pending_event=voice_event,
+            pending_text=None,
+            event_message_id=None,
+            channel_prompt=None,
+        )
+
+        assert stored is True
+        assert adapter._pending_messages[session_key].text == "already queued"
+        assert runner._queued_events[session_key] == [voice_event]
+
 
 class TestBusyInputModeQueueFifo:
     """Regression coverage for issue #28503.
@@ -218,5 +286,4 @@ class TestBusyInputModeQueueFifo:
             "five",
         ]
         assert runner._queue_depth(session_key, adapter=adapter) == len(texts)
-
 


### PR DESCRIPTION
## Summary

Fixes #61008.

When an interrupt-drain chain reaches `_MAX_INTERRUPT_DEPTH`, the gateway currently tries to park a remaining string `interrupt_message` via `adapter.queue_message(...)`. Normal gateway adapters use `_pending_messages` and do not implement that legacy method, so a transcribed voice follow-up can be dropped exactly when the recursion guard fires.

This patch adds a shared `GatewayRunner._requeue_interrupt_depth_pending()` helper that:
- requeues a full pending `MessageEvent` through the existing FIFO pending-event path,
- converts a plain interrupt transcript string into a real `MessageEvent` when no full event remains,
- preserves FIFO ordering when another pending slot is already occupied,
- keeps the legacy `queue_message()` fallback only for non-standard adapters without `_pending_messages`.

## Validation

- `uv run --extra dev pytest tests/gateway/test_queue_consumption.py -q` — 16 passed
- `uv run --extra dev pytest tests/gateway/test_stt_config.py tests/gateway/test_telegram_audio_vs_voice.py -q` — 12 passed
- `uv run --extra dev pytest tests/gateway/test_busy_session_ack.py -q` — 26 passed
- `uv run --extra dev pytest tests/gateway/test_run_progress_interrupt.py tests/gateway/test_pending_drain_no_recursion.py tests/gateway/test_internal_event_never_interrupts_busy_session.py -q` — 10 passed
- `uv run --extra dev pytest tests/gateway/test_queue_command.py tests/gateway/test_busy_session_auth_bypass.py tests/gateway/test_subagent_protection_30170.py -q` — 26 passed
- `uv run --extra dev pytest tests/gateway -q -k "queue or interrupt or voice"` — 442 passed, 7 skipped, 8515 deselected
- `uv run --extra dev ruff check gateway/run.py tests/gateway/test_queue_consumption.py` — passed
- `python -m py_compile gateway/run.py tests/gateway/test_queue_consumption.py` — passed
- `git diff --check origin/main..HEAD` — passed
- `gitleaks git --log-opts='origin/main..HEAD' --redact .` — no leaks found

## Duplicate / overlap check

- Exact open PR search for `61008 in:title,body` returned no results immediately before push.
- `preflight_issue.py 61008 --keyword interrupt_depth --keyword _MAX_INTERRUPT_DEPTH --keyword queue_message --keyword voice-interrupt` warned on broad queue/interrupt work only.
- Manually checked the closest overlaps:
  - #39126 is hook start/end symmetry on interrupt drain turns.
  - #58039 is goal-continuation labeling and queue notices.
  - #54917 is a TUI voice transcript requeue loop.
  - #58780 is a broader Telegram feature request for auto-queueing out-of-band messages.

Those do not preserve a depth-capped gateway interrupt transcript as a pending turn.
