### PR TITLE
feat(desktop): route agent lanes and keep Slack sessions visible

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
@@ -9,10 +9,14 @@ import { useLiveCompletionAdapter } from './use-live-completion-adapter'
 
 const KIND_RE = /^@(file|folder|url|image|tool|git):(.*)$/
 const REF_STARTERS = new Set(['file', 'folder', 'url', 'image', 'tool', 'git'])
+const AGENT_STARTERS = new Set(['claude', 'codex', 'gemini'])
 
 const STARTER_META: Record<string, string> = {
+  claude: 'Start a Claude Code lane',
+  codex: 'Start a Codex lane',
   file: 'Attach a file reference',
   folder: 'Attach a folder reference',
+  gemini: 'Start a Gemini CLI lane',
   url: 'Attach a URL reference',
   image: 'Attach an image reference',
   tool: 'Attach a tool reference',
@@ -21,12 +25,12 @@ const STARTER_META: Record<string, string> = {
 
 function starterEntries(query: string): CompletionEntry[] {
   const q = normalize(query)
-  const kinds = Array.from(REF_STARTERS)
+  const kinds = [...Array.from(AGENT_STARTERS), ...Array.from(REF_STARTERS)]
   const filtered = q ? kinds.filter(kind => kind.startsWith(q)) : kinds
 
   return filtered.map(kind => ({
-    text: `@${kind}:`,
-    display: `@${kind}:`,
+    text: REF_STARTERS.has(kind) ? `@${kind}:` : `@${kind}`,
+    display: REF_STARTERS.has(kind) ? `@${kind}:` : `@${kind}`,
     meta: STARTER_META[kind] || ''
   }))
 }

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -120,6 +120,7 @@ import {
   useRepoWorktreeMap
 } from './projects'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
+import { shouldShowMessagingSections } from './sidebar-visibility'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 
 // Non-session groups (messaging platforms) stay compact: show a few rows up
@@ -1331,8 +1332,7 @@ export function ChatSidebar({
               />
             )}
 
-            {!trimmedQuery &&
-              !worktreeGroupingActive &&
+            {shouldShowMessagingSections({ searchActive: Boolean(trimmedQuery), workspaceGroupingActive: worktreeGroupingActive }) &&
               messagingGroups.map(group => {
                 const visible = messagingVisible[group.sourceId] ?? NON_SESSION_INITIAL_ROWS
                 const shownSessions = group.sessions.slice(0, visible)

--- a/apps/desktop/src/app/chat/sidebar/sidebar-visibility.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/sidebar-visibility.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldShowMessagingSections } from './sidebar-visibility'
+
+describe('shouldShowMessagingSections', () => {
+  it('keeps messaging sections visible while workspace grouping is active', () => {
+    expect(shouldShowMessagingSections({ searchActive: false, workspaceGroupingActive: true })).toBe(true)
+  })
+
+  it('keeps messaging sections visible in the flat recents view', () => {
+    expect(shouldShowMessagingSections({ searchActive: false, workspaceGroupingActive: false })).toBe(true)
+  })
+
+  it('hides messaging sections during search results', () => {
+    expect(shouldShowMessagingSections({ searchActive: true, workspaceGroupingActive: true })).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/sidebar-visibility.ts
+++ b/apps/desktop/src/app/chat/sidebar/sidebar-visibility.ts
@@ -1,0 +1,14 @@
+export interface SidebarAuxiliarySectionVisibility {
+  searchActive: boolean
+  workspaceGroupingActive: boolean
+}
+
+/**
+ * Messaging-platform sections are auxiliary navigation, not a replacement for
+ * Recents/Projects. They must remain visible while workspace grouping is active
+ * so Slack/Telegram/etc. conversations do not disappear behind the Projects
+ * toggle.
+ */
+export function shouldShowMessagingSections({ searchActive }: SidebarAuxiliarySectionVisibility): boolean {
+  return !searchActive
+}

--- a/apps/desktop/src/app/right-sidebar/terminal/instance.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/instance.tsx
@@ -82,14 +82,15 @@ export function TerminalInstance({ id, active, cwd, onAddSelectionToChat, revive
 
 interface AgentTerminalInstanceProps {
   active: boolean
+  canWrite?: boolean
   id: string
+  ownerSessionId?: string
   procId: string
 }
 
-/** Read-only mirror of an agent background process — a write-only xterm streamed
- *  live from the backend output (no PTY, no input). */
-export function AgentTerminalInstance({ active, id, procId }: AgentTerminalInstanceProps) {
-  const { hostRef } = useAgentTerminal({ active, id, procId })
+/** Mirror of an agent background process. PTY-backed lanes can receive input. */
+export function AgentTerminalInstance({ active, canWrite, id, ownerSessionId, procId }: AgentTerminalInstanceProps) {
+  const { hostRef } = useAgentTerminal({ active, canWrite, id, ownerSessionId, procId })
 
   return (
     <div

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
@@ -27,6 +27,10 @@ export interface TerminalEntry {
   /** `user` = interactive PTY shell. `agent` = read-only mirror of an agent
    *  background process (`terminal(background=true)`), keyed by `procId`. */
   kind: 'user' | 'agent'
+  /** Agent PTY mirrors can be writable (Claude/Codex/Gemini auth prompts, etc.). */
+  canWrite?: boolean
+  /** Runtime session id that owns this process, required to scope write RPCs. */
+  ownerSessionId?: string
   procId?: string
 }
 
@@ -164,12 +168,41 @@ const surfacedProcs = new Set<string>()
 
 const findByProc = (procId: string) => $terminals.get().find(term => term.procId === procId)
 
+interface AgentTerminalOptions {
+  canWrite?: boolean
+  ownerSessionId?: string
+}
+
+function agentTerminalEntry(procId: string, title: string, options: AgentTerminalOptions = {}): TerminalEntry {
+  return {
+    id: newId(),
+    title: title || 'agent',
+    auto: false,
+    cwd: '',
+    kind: 'agent',
+    procId,
+    ...(options.canWrite ? { canWrite: true } : {}),
+    ...(options.ownerSessionId ? { ownerSessionId: options.ownerSessionId } : {})
+  }
+}
+
 /** Auto-surface an agent background process as a read-only tab — once. Returns
  *  the tab id, or null if it was already surfaced and the user has since closed it. */
-export function ensureAgentTerminal(procId: string, title: string): string | null {
+export function ensureAgentTerminal(procId: string, title: string, options: AgentTerminalOptions = {}): string | null {
   const existing = findByProc(procId)
 
   if (existing) {
+    const nextCanWrite = Boolean(existing.canWrite || options.canWrite)
+    const nextOwner = options.ownerSessionId || existing.ownerSessionId
+
+    if (nextCanWrite !== Boolean(existing.canWrite) || nextOwner !== existing.ownerSessionId) {
+      $terminals.set(
+        $terminals.get().map(term =>
+          term.id === existing.id ? { ...term, canWrite: nextCanWrite, ownerSessionId: nextOwner } : term
+        )
+      )
+    }
+
     return existing.id
   }
 
@@ -178,22 +211,35 @@ export function ensureAgentTerminal(procId: string, title: string): string | nul
   }
 
   surfacedProcs.add(procId)
-  const id = newId()
-  $terminals.set([...$terminals.get(), { id, title: title || 'agent', auto: false, cwd: '', kind: 'agent', procId }])
+  const entry = agentTerminalEntry(procId, title, options)
+  $terminals.set([...$terminals.get(), entry])
 
-  return id
+  return entry.id
 }
 
 /** Open + focus an agent process's tab (the status-stack link), recreating it if
  *  the user had closed it. Opens the pane. */
-export function openAgentTerminal(procId: string, title: string): void {
+export function openAgentTerminal(procId: string, title: string, options: AgentTerminalOptions = {}): void {
   surfacedProcs.add(procId)
   seedAgentTerminalCommand(procId, title)
   let id = findByProc(procId)?.id
 
   if (!id) {
-    id = newId()
-    $terminals.set([...$terminals.get(), { id, title: title || 'agent', auto: false, cwd: '', kind: 'agent', procId }])
+    const entry = agentTerminalEntry(procId, title, options)
+    id = entry.id
+    $terminals.set([...$terminals.get(), entry])
+  } else if (options.canWrite || options.ownerSessionId) {
+    $terminals.set(
+      $terminals.get().map(term =>
+        term.id === id
+          ? {
+              ...term,
+              ...(options.canWrite ? { canWrite: true } : {}),
+              ...(options.ownerSessionId ? { ownerSessionId: options.ownerSessionId } : {})
+            }
+          : term
+      )
+    )
   }
 
   $activeTerminalId.set(id)

--- a/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
@@ -6,15 +6,28 @@ import { Terminal } from '@xterm/xterm'
 import { useEffect, useRef } from 'react'
 
 import { useTheme } from '@/themes/context'
+import { $gateway } from '@/store/gateway'
 
 import { registerAgentTerminalWriter } from './agent-terminal-stream'
 import { makeTerminalReader, registerTerminalReader } from './buffer'
 import { resolveSurfaceColor, terminalTheme } from './selection'
 
-// Read-only terminal for an agent background process: a write-only xterm (no PTY,
-// no input) fed live by the backend output stream, keyed by process id. Shares
-// the user terminal's look so the two read as one surface.
-export function useAgentTerminal({ active, id, procId }: { active: boolean; id: string; procId: string }) {
+// Terminal mirror for an agent background process. Most background tabs are
+// output-only, but PTY-backed Claude/Codex/Gemini lanes expose stdin so auth
+// prompts and interactive TUIs can be answered in place.
+export function useAgentTerminal({
+  active,
+  canWrite = false,
+  id,
+  ownerSessionId,
+  procId
+}: {
+  active: boolean
+  canWrite?: boolean
+  id: string
+  ownerSessionId?: string
+  procId: string
+}) {
   const { renderedMode, theme, themeName } = useTheme()
   const hostRef = useRef<HTMLDivElement | null>(null)
   const termRef = useRef<Terminal | null>(null)
@@ -39,8 +52,8 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
       allowProposedApi: true,
       allowTransparency: false,
       convertEol: true,
-      cursorBlink: false,
-      disableStdin: true,
+      cursorBlink: canWrite,
+      disableStdin: !canWrite,
       fontFamily: "'JetBrains Mono', 'Cascadia Code', 'SF Mono', Menlo, Consolas, monospace",
       fontSize: 11,
       fontWeight: 'normal',
@@ -89,17 +102,30 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
     // Stream live output straight into the terminal (replays backlog on attach).
     const unregister = registerAgentTerminalWriter(procId, chunk => term.write(chunk))
     const unregisterReader = registerTerminalReader(id, makeTerminalReader(term))
+    const disposableInput = term.onData(data => {
+      if (!canWrite || !ownerSessionId) {
+        return
+      }
+
+      const gateway = $gateway.get()
+
+      if (!gateway) {
+        return
+      }
+
+      void gateway.request('process.write', { data, process_id: procId, session_id: ownerSessionId })
+    })
 
     return () => {
       unregister()
       unregisterReader()
+      disposableInput.dispose()
       observer.disconnect()
       term.dispose()
       termRef.current = null
       webglRef.current = null
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [canWrite, id, ownerSessionId, procId])
 
   useEffect(() => {
     const term = termRef.current

--- a/apps/desktop/src/app/right-sidebar/terminal/workspace.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/workspace.tsx
@@ -35,9 +35,9 @@ export function TerminalWorkspace({ onAddSelectionToChat }: TerminalWorkspacePro
   // Live chunks stream via agent.terminal.output; the process-list snapshot also
   // seeds/falls back so the tab never stays blank if the stream races startup.
   useEffect(() => {
-    for (const list of Object.values(background)) {
+    for (const [sessionId, list] of Object.entries(background)) {
       for (const item of list) {
-        ensureAgentTerminal(item.id, item.title)
+        ensureAgentTerminal(item.id, item.title, { canWrite: item.canWrite, ownerSessionId: sessionId })
         seedAgentTerminalCommand(item.id, item.title)
         syncAgentTerminalSnapshot(item.id, item.output ?? '')
       }
@@ -48,7 +48,14 @@ export function TerminalWorkspace({ onAddSelectionToChat }: TerminalWorkspacePro
     <>
       {terminals.map(term =>
         term.kind === 'agent' ? (
-          <AgentTerminalInstance active={term.id === activeId} id={term.id} key={term.id} procId={term.procId!} />
+          <AgentTerminalInstance
+            active={term.id === activeId}
+            canWrite={Boolean(term.canWrite)}
+            id={term.id}
+            key={term.id}
+            ownerSessionId={term.ownerSessionId}
+            procId={term.procId!}
+          />
         ) : (
           <TerminalInstance
             active={term.id === activeId}

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -17,6 +17,14 @@ vi.mock('@/hermes', () => ({
   transcribeAudio: vi.fn()
 }))
 
+const { openAgentTerminal } = vi.hoisted(() => ({
+  openAgentTerminal: vi.fn()
+}))
+
+vi.mock('@/app/right-sidebar/terminal/terminals', () => ({
+  openAgentTerminal
+}))
+
 // The active id the desktop holds is the *runtime* session id from
 // session.create — deliberately distinct from the stored DB id here, because
 // that mismatch is the bug: the REST renameSession endpoint resolves against
@@ -225,7 +233,51 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
   afterEach(() => {
     cleanup()
     $busy.set(false)
+    openAgentTerminal.mockClear()
     vi.restoreAllMocks()
+  })
+
+  it('routes leading agent mentions to agent.start instead of prompt.submit', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const states: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'agent.start') {
+        return { can_write: true, process_id: 'proc-gemini', title: 'Gemini: review repo' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('@gemini review repo')
+
+    expect(calls.map(c => c.method)).toEqual(['agent.start'])
+    expect(calls[0]?.params).toEqual({
+      lane: 'gemini',
+      prompt: 'review repo',
+      session_id: RUNTIME_SESSION_ID
+    })
+    expect(openAgentTerminal).toHaveBeenCalledWith('proc-gemini', 'Gemini: review repo', {
+      canWrite: true,
+      ownerSessionId: RUNTIME_SESSION_ID
+    })
+    expect(states.at(-1)?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'system', parts: [expect.objectContaining({ text: 'Started Gemini lane in the terminal.' })] })
+      ])
+    )
   })
 
   it('submits /goal send directives returned directly by slash.exec instead of rendering no output', async () => {
@@ -1239,7 +1291,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
     expect(ok).toBe(true)
     expect(calls.map(c => c.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
-    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID })
+    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID, source: 'desktop' })
     expect(calls[2]?.params).toEqual({
       session_id: RECOVERED_SESSION_ID,
       text: 'message during starved loop'

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -7,6 +7,7 @@ import { useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
 import { branchGroupForUser, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
 import { pathLabel, SLASH_COMMAND_RE } from '@/lib/chat-runtime'
+import { agentLaneTitle, parseAgentTagPrompt } from '@/lib/agent-lanes'
 import { triggerHaptic } from '@/lib/haptics'
 import { setMutableRef } from '@/lib/mutable-ref'
 import { normalize } from '@/lib/text'
@@ -24,6 +25,8 @@ import { clearAllPrompts } from '@/store/prompts'
 import { $busy, $connection, $messages, setAwaitingResponse, setBusy, setMessages } from '@/store/session'
 import { clearSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
+
+import { openAgentTerminal } from '@/app/right-sidebar/terminal/terminals'
 
 import type {
   ClientSessionState,
@@ -463,6 +466,59 @@ export function usePromptActions({
       const visibleText = rawText.trim()
       const attachments = options?.attachments ?? $composerAttachments.get()
 
+      const agentPrompt = !attachments.length ? parseAgentTagPrompt(visibleText) : null
+
+      if (agentPrompt) {
+        if (!agentPrompt.prompt) {
+          notify({
+            kind: 'error',
+            message: `Write a prompt after @${agentPrompt.lane}`,
+            title: `${agentLaneTitle(agentPrompt.lane)} needs a prompt`
+          })
+
+          return false
+        }
+
+        try {
+          const sessionId = activeSessionIdRef.current || (await createBackendSessionForSend(visibleText))
+
+          if (!sessionId) {
+            notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
+
+            return false
+          }
+
+          const result = await requestGateway<{
+            can_write?: boolean
+            command?: string
+            process_id?: string
+            title?: string
+          }>('agent.start', {
+            lane: agentPrompt.lane,
+            prompt: agentPrompt.prompt,
+            session_id: sessionId
+          })
+          const processId = result.process_id || ''
+
+          if (!processId) {
+            throw new Error('agent.start did not return a process id')
+          }
+
+          const title = result.title || `${agentLaneTitle(agentPrompt.lane)}: ${agentPrompt.prompt}`
+          openAgentTerminal(processId, title, {
+            canWrite: result.can_write !== false,
+            ownerSessionId: sessionId
+          })
+          appendSessionTextMessage(sessionId, 'system', `Started ${agentLaneTitle(agentPrompt.lane)} lane in the terminal.`)
+
+          return true
+        } catch (err) {
+          notifyError(err, `Could not start ${agentLaneTitle(agentPrompt.lane)}`)
+
+          return false
+        }
+      }
+
       if (!attachments.length && SLASH_COMMAND_RE.test(visibleText)) {
         triggerHaptic('selection')
         await executeSlashCommand(visibleText)
@@ -472,7 +528,7 @@ export function usePromptActions({
 
       return await submitPromptText(rawText, options)
     },
-    [executeSlashCommand, submitPromptText]
+    [activeSessionIdRef, appendSessionTextMessage, copy, createBackendSessionForSend, executeSlashCommand, requestGateway, submitPromptText]
   )
 
   const transcribeVoiceAudio = useCallback(

--- a/apps/desktop/src/lib/agent-lanes.test.ts
+++ b/apps/desktop/src/lib/agent-lanes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { agentLaneTitle, parseAgentTagPrompt } from './agent-lanes'
+
+describe('agent lane tags', () => {
+  it('parses leading Claude, Codex, and Gemini mentions', () => {
+    expect(parseAgentTagPrompt('@claude fix this')).toEqual({ lane: 'claude', prompt: 'fix this' })
+    expect(parseAgentTagPrompt('@codex\nreview diff')).toEqual({ lane: 'codex', prompt: 'review diff' })
+    expect(parseAgentTagPrompt('@Gemini explain repo')).toEqual({ lane: 'gemini', prompt: 'explain repo' })
+  })
+
+  it('ignores non-agent refs', () => {
+    expect(parseAgentTagPrompt('@file:README.md')).toBeNull()
+    expect(parseAgentTagPrompt('hello @gemini')).toBeNull()
+  })
+
+  it('renders lane titles', () => {
+    expect(agentLaneTitle('claude')).toBe('Claude')
+    expect(agentLaneTitle('codex')).toBe('Codex')
+    expect(agentLaneTitle('gemini')).toBe('Gemini')
+  })
+})

--- a/apps/desktop/src/lib/agent-lanes.ts
+++ b/apps/desktop/src/lib/agent-lanes.ts
@@ -1,0 +1,34 @@
+export type AgentLane = 'claude' | 'codex' | 'gemini'
+
+export interface ParsedAgentPrompt {
+  lane: AgentLane
+  prompt: string
+}
+
+const AGENT_TAG_RE = /^@(claude|codex|gemini)(?:\s+([\s\S]*))?$/i
+
+export const AGENT_LANES: readonly AgentLane[] = ['claude', 'codex', 'gemini']
+
+export function parseAgentTagPrompt(text: string): ParsedAgentPrompt | null {
+  const match = AGENT_TAG_RE.exec(text.trim())
+
+  if (!match) {
+    return null
+  }
+
+  return {
+    lane: match[1]!.toLowerCase() as AgentLane,
+    prompt: (match[2] ?? '').trim()
+  }
+}
+
+export function agentLaneTitle(lane: AgentLane): string {
+  switch (lane) {
+    case 'claude':
+      return 'Claude'
+    case 'codex':
+      return 'Codex'
+    case 'gemini':
+      return 'Gemini'
+  }
+}

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -14,6 +14,8 @@ export type StatusItemState = 'done' | 'failed' | 'running'
 export type StatusItemType = 'background' | 'subagent' | 'todo'
 
 export interface ComposerStatusItem {
+  /** background: PTY stdin is available for interactive CLIs. */
+  canWrite?: boolean
   /** background: non-zero exit shown inline when failed. */
   exitCode?: number
   /** subagent: active tool label shown on the right. */
@@ -180,6 +182,7 @@ const writeBackground = (sid: string, items: ComposerStatusItem[]) => {
 
 // `tui_gateway` process.list entry (tools/process_registry.list_sessions + output_tail).
 interface GatewayProcessEntry {
+  can_write?: boolean
   command?: string
   exit_code?: number
   output_tail?: string
@@ -193,6 +196,7 @@ const toBackgroundItem = (proc: GatewayProcessEntry): ComposerStatusItem => {
 
   return {
     exitCode,
+    canWrite: Boolean(proc.can_write),
     id: proc.session_id ?? '',
     output: proc.output_tail || undefined,
     state: exited ? (exitCode ? 'failed' : 'done') : 'running',
@@ -202,7 +206,11 @@ const toBackgroundItem = (proc: GatewayProcessEntry): ComposerStatusItem => {
 }
 
 const sameItem = (a: ComposerStatusItem, b: ComposerStatusItem) =>
-  a.state === b.state && a.title === b.title && a.output === b.output && a.exitCode === b.exitCode
+  a.state === b.state &&
+  a.title === b.title &&
+  a.output === b.output &&
+  a.exitCode === b.exitCode &&
+  a.canWrite === b.canWrite
 
 /**
  * Layout-stable sync of the registry snapshot into the store: existing rows

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -89,6 +89,79 @@ def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
         server._sessions.pop(sid, None)
 
 
+def test_agent_start_launches_pty_lane(monkeypatch, tmp_path):
+    import tools.terminal_tool as terminal_tool_mod
+
+    sid = "agent-start-sid"
+    session_key = "agent-start-key"
+    calls = {}
+    server._sessions[sid] = {"session_key": session_key, "cwd": str(tmp_path)}
+
+    def fake_terminal_tool(command, **kwargs):
+        calls["command"] = command
+        calls["kwargs"] = kwargs
+        return json.dumps({"error": None, "session_id": "proc-claude"})
+
+    monkeypatch.setattr(server, "_wire_agent_terminal_output", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda _key: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(terminal_tool_mod, "terminal_tool", fake_terminal_tool)
+
+    try:
+        result = server._methods["agent.start"](
+            "r1", {"session_id": sid, "lane": "claude", "prompt": "hola"}
+        )
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert result["result"] == {
+        "can_write": True,
+        "command": "claude --dangerously-skip-permissions hola",
+        "lane": "claude",
+        "process_id": "proc-claude",
+        "title": "Claude: hola",
+    }
+    assert calls["kwargs"] == {
+        "background": True,
+        "force": True,
+        "notify_on_complete": False,
+        "pty": True,
+        "session_id": session_key,
+        "task_id": session_key,
+        "workdir": str(tmp_path),
+    }
+
+
+def test_process_write_is_scoped_to_session_owner(monkeypatch):
+    from tools.process_registry import process_registry
+
+    sid = "write-sid"
+    server._sessions[sid] = {"session_key": "owner-key"}
+    writes = []
+
+    monkeypatch.setattr(
+        process_registry,
+        "get",
+        lambda proc_id: types.SimpleNamespace(session_key="owner-key") if proc_id == "proc-1" else None,
+    )
+    monkeypatch.setattr(
+        process_registry,
+        "write_stdin",
+        lambda proc_id, data: writes.append((proc_id, data)) or {"status": "ok", "bytes_written": len(data)},
+    )
+
+    try:
+        result = server._methods["process.write"](
+            "r1", {"session_id": sid, "process_id": "proc-1", "data": "y\r"}
+        )
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert result["result"] == {"status": "ok", "bytes_written": 2}
+    assert writes == [("proc-1", "y\r")]
+
+
 def test_handoff_fail_marks_only_inflight_rows(monkeypatch):
     class DbContext:
         def __init__(self, db):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import queue
+import shlex
 import subprocess
 import sys
 import threading
@@ -317,6 +318,8 @@ class _SlashWorker:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
             cwd=os.getcwd(),
             env=env,
@@ -11402,6 +11405,113 @@ def _(rid, params: dict) -> dict:
 # ── Methods: tools & system ──────────────────────────────────────────
 
 
+_AGENT_LANE_TITLES = {
+    "claude": "Claude",
+    "codex": "Codex",
+    "gemini": "Gemini",
+}
+
+
+def _agent_lane_command(lane: str, prompt: str) -> str:
+    quoted_prompt = shlex.quote(prompt)
+    if lane == "claude":
+        return f"claude --dangerously-skip-permissions {quoted_prompt}"
+    if lane == "codex":
+        return f"codex --dangerously-bypass-approvals-and-sandbox {quoted_prompt}"
+    if lane == "gemini":
+        return (
+            "GOOGLE_GENAI_USE_GCA=true npx -y @google/gemini-cli "
+            f"--skip-trust --approval-mode yolo --prompt-interactive {quoted_prompt}"
+        )
+    raise ValueError(f"unknown agent lane: {lane}")
+
+
+@method("agent.start")
+def _(rid, params: dict) -> dict:
+    """Start a PTY-backed Claude/Codex/Gemini CLI lane for the desktop app."""
+    session, err = _sess(params, rid)
+    if err:
+        return err
+
+    lane = str(params.get("lane") or "").strip().lower()
+    prompt = str(params.get("prompt") or "").strip()
+    if lane not in _AGENT_LANE_TITLES:
+        return _err(rid, 4004, "lane must be one of: claude, codex, gemini")
+    if not prompt:
+        return _err(rid, 4004, "prompt required")
+
+    session_key = str(session.get("session_key") or "")
+    if not session_key:
+        return _err(rid, 4001, "no session key")
+
+    command = _agent_lane_command(lane, prompt)
+    title = f"{_AGENT_LANE_TITLES[lane]}: {prompt[:80]}{'…' if len(prompt) > 80 else ''}"
+    approval_token = None
+    session_tokens = []
+    home_token = None
+
+    try:
+        _wire_agent_terminal_output()
+
+        from tools.approval import reset_current_session_key, set_current_session_key
+        from tools.terminal_tool import terminal_tool
+
+        approval_token = set_current_session_key(session_key)
+        session_tokens = _set_session_context(session_key)
+        profile_home = session.get("profile_home")
+        if profile_home:
+            home_token = set_hermes_home_override(profile_home)
+
+        cwd = _session_cwd(session)
+        _register_session_cwd(session)
+        raw = terminal_tool(
+            command,
+            background=True,
+            force=True,
+            notify_on_complete=False,
+            pty=True,
+            session_id=session_key,
+            task_id=session_key,
+            workdir=cwd,
+        )
+        data = json.loads(raw) if isinstance(raw, str) else {}
+    except Exception as exc:
+        return _err(rid, 5010, str(exc))
+    finally:
+        if home_token is not None:
+            try:
+                reset_hermes_home_override(home_token)
+            except Exception:
+                pass
+        if session_tokens:
+            try:
+                _clear_session_context(session_tokens)
+            except Exception:
+                pass
+        if approval_token is not None:
+            try:
+                reset_current_session_key(approval_token)
+            except Exception:
+                pass
+
+    if data.get("error"):
+        return _err(rid, 5010, str(data.get("error")))
+    process_id = str(data.get("session_id") or "")
+    if not process_id:
+        return _err(rid, 5010, "agent lane did not start")
+
+    return _ok(
+        rid,
+        {
+            "can_write": True,
+            "command": command,
+            "lane": lane,
+            "process_id": process_id,
+            "title": title,
+        },
+    )
+
+
 @method("process.stop")
 def _(rid, params: dict) -> dict:
     try:
@@ -11425,6 +11535,7 @@ def _session_processes(session: dict) -> list:
         # The 200-char list preview is too thin for the desktop's inline
         # terminal viewer — ship a real tail alongside it.
         entry["output_tail"] = (proc.output_buffer or "")[-4000:]
+        entry["can_write"] = bool(not proc.exited and getattr(proc, "_pty", None))
         owned.append(entry)
     return owned
 
@@ -11460,6 +11571,38 @@ def _(rid, params: dict) -> dict:
         ):
             return _err(rid, 4044, f"no such process: {proc_id}")
         return _ok(rid, process_registry.kill_process(proc_id))
+    except Exception as e:
+        return _err(rid, 5010, str(e))
+
+
+@method("process.write")
+def _(rid, params: dict) -> dict:
+    """Write raw stdin to a session-owned PTY background process."""
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    proc_id = str(params.get("process_id") or "")
+    if not proc_id:
+        return _err(rid, 4012, "process_id required")
+    data = params.get("data", "")
+    if not isinstance(data, str):
+        return _err(rid, 4004, "data must be a string")
+    try:
+        from tools.process_registry import process_registry
+
+        proc = process_registry.get(proc_id)
+        if proc is None or str(getattr(proc, "session_key", "") or "") != str(
+            session.get("session_key") or ""
+        ):
+            return _err(rid, 4044, f"no such process: {proc_id}")
+        result = process_registry.write_stdin(proc_id, data)
+        if result.get("status") != "ok":
+            return _err(
+                rid,
+                5010,
+                str(result.get("error") or result.get("status") or "write failed"),
+            )
+        return _ok(rid, result)
     except Exception as e:
         return _err(rid, 5010, str(e))
 
@@ -14297,7 +14440,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
         r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
+            cmd, shell=True, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30, cwd=os.getcwd(),
             stdin=subprocess.DEVNULL,
         )
         return _ok(


### PR DESCRIPTION
## Summary
- Route Desktop `@claude` / `@codex` / `@gemini` prompts into dedicated writable agent terminal lanes.
- Scope `agent.start` and `process.write` to the selected desktop session so lane input reaches the right PTY.
- Keep messaging-platform sections, including Slack, visible while the sidebar is in Projects/worktree grouping mode.

## Test plan
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run test:ui -- src/lib/agent-lanes.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx src/app/right-sidebar/terminal/terminals.test.ts`
- `npm --workspace apps/desktop run test:ui -- src/app/chat/sidebar/sidebar-visibility.test.ts src/app/chat/sidebar/projects/workspace-groups.test.ts src/app/right-sidebar/terminal/terminals.test.ts`
- focused pytest for `tests/test_tui_gateway_server.py::test_agent_start_launches_pty_lane` and `tests/test_tui_gateway_server.py::test_process_write_is_scoped_to_session_owner`
- `npm --workspace apps/desktop run build`
