### PR TITLE
fix(desktop): avoid local profile REST backend spawns

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -36,6 +36,7 @@ import {
   profileRemoteOverride,
   profileSshOverride,
   resolveAuthMode,
+  resolveProfileApiRequest,
   resolveProfileBackendRoute,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
@@ -222,10 +223,40 @@ const ROUTES = [
     expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
   },
   {
-    name: 'a local non-primary profile gets its own pooled backend',
+    name: 'an unscoped local profile request keeps its pooled backend',
     profile: 'coder',
-    opts: { primaryProfile: 'default', globalRemote: false, profileRemoteOverride: false },
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'POST',
+      requestPath: '/api/memory/reset'
+    },
     expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
+  },
+  {
+    name: 'a profile-aware local REST request reuses the primary backend',
+    profile: 'coder',
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'GET',
+      requestPath: '/api/config'
+    },
+    expected: { backend: 'primary', descriptorProfile: 'coder', scopePath: true }
+  },
+  {
+    name: 'a profile-management request uses the primary without a query scope',
+    profile: 'coder',
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'DELETE',
+      requestPath: '/api/profiles/worker'
+    },
+    expected: { backend: 'primary', descriptorProfile: null, scopePath: false }
   }
 ]
 
@@ -307,6 +338,27 @@ test('pathWithGlobalRemoteProfile skips local and per-profile remote override pa
   )
 })
 
+test('pathWithGlobalRemoteProfile appends local-primary profile scope only for eligible routes', () => {
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/config', 'iris', {
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'GET',
+      requestPath: '/api/config'
+    }),
+    '/api/config?profile=iris'
+  )
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/memory/reset', 'iris', {
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'POST',
+      requestPath: '/api/memory/reset'
+    }),
+    '/api/memory/reset'
+  )
+})
+
 test('pathWithGlobalRemoteProfile skips empty profile/path safely', () => {
   assert.equal(
     pathWithGlobalRemoteProfile('/api/model/info', '', {
@@ -321,6 +373,116 @@ test('pathWithGlobalRemoteProfile skips empty profile/path safely', () => {
       profileRemoteOverride: false
     }),
     ''
+  )
+})
+
+// --- resolveProfileApiRequest ---
+
+test('resolveProfileApiRequest keeps eligible local REST on the primary backend', () => {
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/config?view=desktop', {
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: null,
+      requestPath: '/api/config?view=desktop&profile=iris'
+    }
+  )
+})
+
+test('resolveProfileApiRequest keeps unscoped destructive routes on the profile backend', () => {
+  for (const [method, path] of [
+    ['POST', '/api/memory/reset'],
+    ['POST', '/api/curator/run'],
+    ['PUT', '/api/curator/paused'],
+    ['POST', '/api/webhooks']
+  ]) {
+    assert.deepEqual(
+      resolveProfileApiRequest('iris', path, {
+        globalRemote: false,
+        profileRemoteOverride: false,
+        requestMethod: method
+      }),
+      { backendProfile: 'iris', requestPath: path }
+    )
+  }
+})
+
+test('resolveProfileApiRequest uses exact method and path eligibility for mixed families', () => {
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/skills', {
+      requestMethod: 'GET'
+    }),
+    { backendProfile: null, requestPath: '/api/skills?profile=iris' }
+  )
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/skills', {
+      requestMethod: 'POST'
+    }),
+    { backendProfile: 'iris', requestPath: '/api/skills' }
+  )
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/config/defaults', {
+      requestMethod: 'GET'
+    }),
+    { backendProfile: 'iris', requestPath: '/api/config/defaults' }
+  )
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/model/recommended-default?provider=nous', {
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: 'iris',
+      requestPath: '/api/model/recommended-default?provider=nous'
+    }
+  )
+})
+
+test('resolveProfileApiRequest scopes complete safe families according to their contracts', () => {
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/tools/toolsets/image_gen/config', {
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: null,
+      requestPath: '/api/tools/toolsets/image_gen/config?profile=iris'
+    }
+  )
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/profiles/worker', {
+      requestMethod: 'DELETE'
+    }),
+    {
+      backendProfile: null,
+      requestPath: '/api/profiles/worker'
+    }
+  )
+})
+
+test('resolveProfileApiRequest preserves remote routing precedence', () => {
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/memory/reset', {
+      globalRemote: true,
+      profileRemoteOverride: false,
+      requestMethod: 'POST'
+    }),
+    {
+      backendProfile: null,
+      requestPath: '/api/memory/reset?profile=iris'
+    }
+  )
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/config', {
+      globalRemote: true,
+      profileRemoteOverride: true,
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: 'iris',
+      requestPath: '/api/config'
+    }
   )
 })
 

--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -41,6 +41,7 @@ import {
   profileSshOverride,
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
+  resolveProfileApiRequest,
   resolveProfileBackendRoute,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
@@ -342,9 +343,15 @@ const ROUTES = [
     expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
   },
   {
-    name: 'a local non-primary profile gets its own pooled backend',
+    name: 'an unscoped local profile request keeps its pooled backend',
     profile: 'coder',
-    opts: { primaryProfile: 'default', globalRemote: false, profileRemoteOverride: false },
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'POST',
+      requestPath: '/api/memory/reset'
+    },
     expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
   },
   {
@@ -368,6 +375,44 @@ const ROUTES = [
       profileRemoteOverride: false,
       primaryRemoteActive: true,
       ownEntry: true
+    },
+    expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
+  },
+  {
+    name: 'a profile-aware local REST request reuses the primary backend',
+    profile: 'coder',
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'GET',
+      requestPath: '/api/config'
+    },
+    expected: { backend: 'primary', descriptorProfile: 'coder', scopePath: true }
+  },
+  {
+    name: 'a profile-management request uses the primary without a query scope',
+    profile: 'coder',
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'DELETE',
+      requestPath: '/api/profiles/worker'
+    },
+    expected: { backend: 'primary', descriptorProfile: null, scopePath: false }
+  },
+  {
+    name: 'a stored local profile never reuses a remote primary for an eligible REST route',
+    profile: 'coder',
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      primaryRemoteActive: true,
+      ownEntry: true,
+      requestMethod: 'GET',
+      requestPath: '/api/config'
     },
     expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
   }
@@ -535,6 +580,27 @@ test('translateSelfProfileQuery no-ops when alias and backend profile agree or a
   assert.equal(translateSelfProfileQuery('/api/cron/jobs?profile=mara', '', 'default'), '/api/cron/jobs?profile=mara')
 })
 
+test('pathWithGlobalRemoteProfile appends local-primary profile scope only for eligible routes', () => {
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/config', 'iris', {
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'GET',
+      requestPath: '/api/config'
+    }),
+    '/api/config?profile=iris'
+  )
+  assert.equal(
+    pathWithGlobalRemoteProfile('/api/memory/reset', 'iris', {
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'POST',
+      requestPath: '/api/memory/reset'
+    }),
+    '/api/memory/reset'
+  )
+})
+
 test('pathWithGlobalRemoteProfile skips empty profile/path safely', () => {
   assert.equal(
     pathWithGlobalRemoteProfile('/api/model/info', '', {
@@ -549,6 +615,130 @@ test('pathWithGlobalRemoteProfile skips empty profile/path safely', () => {
       profileRemoteOverride: false
     }),
     ''
+  )
+})
+
+// --- resolveProfileApiRequest ---
+
+test('resolveProfileApiRequest keeps eligible local REST on the primary backend', () => {
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/config?view=desktop', {
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: null,
+      requestPath: '/api/config?view=desktop&profile=iris'
+    }
+  )
+})
+
+test('resolveProfileApiRequest keeps unscoped destructive routes on the profile backend', () => {
+  for (const [method, path] of [
+    ['POST', '/api/memory/reset'],
+    ['POST', '/api/curator/run'],
+    ['PUT', '/api/curator/paused'],
+    ['POST', '/api/webhooks']
+  ]) {
+    assert.deepEqual(
+      resolveProfileApiRequest('iris', path, {
+        globalRemote: false,
+        profileRemoteOverride: false,
+        requestMethod: method
+      }),
+      { backendProfile: 'iris', requestPath: path }
+    )
+  }
+})
+
+test('resolveProfileApiRequest uses exact method and path eligibility for mixed families', () => {
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/skills', {
+      requestMethod: 'GET'
+    }),
+    { backendProfile: null, requestPath: '/api/skills?profile=iris' }
+  )
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/skills', {
+      requestMethod: 'POST'
+    }),
+    { backendProfile: 'iris', requestPath: '/api/skills' }
+  )
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/config/defaults', {
+      requestMethod: 'GET'
+    }),
+    { backendProfile: 'iris', requestPath: '/api/config/defaults' }
+  )
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/model/recommended-default?provider=nous', {
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: 'iris',
+      requestPath: '/api/model/recommended-default?provider=nous'
+    }
+  )
+})
+
+test('resolveProfileApiRequest scopes complete safe families according to their contracts', () => {
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/tools/toolsets/image_gen/config', {
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: null,
+      requestPath: '/api/tools/toolsets/image_gen/config?profile=iris'
+    }
+  )
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/profiles/worker', {
+      requestMethod: 'DELETE'
+    }),
+    {
+      backendProfile: null,
+      requestPath: '/api/profiles/worker'
+    }
+  )
+})
+
+test('resolveProfileApiRequest preserves remote routing precedence', () => {
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/memory/reset', {
+      globalRemote: true,
+      profileRemoteOverride: false,
+      requestMethod: 'POST'
+    }),
+    {
+      backendProfile: null,
+      requestPath: '/api/memory/reset?profile=iris'
+    }
+  )
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/config', {
+      globalRemote: true,
+      profileRemoteOverride: true,
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: 'iris',
+      requestPath: '/api/config'
+    }
+  )
+})
+
+test('resolveProfileApiRequest keeps a stored local profile off a remote primary', () => {
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/config', {
+      primaryRemoteActive: true,
+      ownEntry: true,
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: 'iris',
+      requestPath: '/api/config'
+    }
   )
 })
 

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -354,6 +354,8 @@ export interface ProfileRouteOptions {
   globalRemote?: boolean
   primaryProfile?: null | string
   profileRemoteOverride?: boolean
+  requestMethod?: null | string
+  requestPath?: null | string
 }
 
 export interface ProfileBackendRoute {
@@ -369,16 +371,81 @@ export interface ProfileBackendRoute {
   scopePath: boolean
 }
 
+const LOCAL_PRIMARY_SCOPED_ROUTES = new Set([
+  'GET /api/config',
+  'PUT /api/config',
+  'GET /api/config/raw',
+  'PUT /api/config/raw',
+  'GET /api/config/schema',
+  'DELETE /api/env',
+  'GET /api/env',
+  'PUT /api/env',
+  'POST /api/env/reveal',
+  'GET /api/model/auxiliary',
+  'GET /api/model/info',
+  'GET /api/model/moa',
+  'PUT /api/model/moa',
+  'GET /api/model/options',
+  'POST /api/model/set',
+  'GET /api/skills',
+  'GET /api/skills/content',
+  'PUT /api/skills/toggle',
+  'POST /api/skills/hub/install',
+  'GET /api/skills/hub/preview',
+  'GET /api/skills/hub/scan',
+  'GET /api/skills/hub/search',
+  'GET /api/skills/hub/sources',
+  'POST /api/skills/hub/uninstall',
+  'POST /api/skills/hub/update'
+])
+
+function localPrimaryRequestScope(opts: ProfileRouteOptions): boolean | null {
+  const rawPath = String(opts.requestPath || '')
+
+  if (!rawPath) {
+    return null
+  }
+
+  let pathname
+
+  try {
+    pathname = new URL(rawPath, 'https://example.invalid').pathname
+  } catch {
+    return null
+  }
+
+  const method = String(opts.requestMethod || 'GET').toUpperCase()
+
+  if (LOCAL_PRIMARY_SCOPED_ROUTES.has(`${method} ${pathname}`)) {
+    return true
+  }
+
+  // Every current /api/tools handler accepts `profile`; every /api/profiles
+  // handler either aggregates profiles or names its target in the path/body.
+  // These are the only whole families safe to route through the primary.
+  if (pathname === '/api/tools' || pathname.startsWith('/api/tools/')) {
+    return true
+  }
+
+  if (pathname === '/api/profiles' || pathname.startsWith('/api/profiles/')) {
+    return false
+  }
+
+  return null
+}
+
 /**
  * The one place that answers "which backend serves profile P, and does its
- * REST path need a profile scope?". Four routes, in precedence order:
+ * REST path need a profile scope?". Five routes, in precedence order:
  *
  *  1. The primary profile owns the window backend outright.
  *  2. A profile with its own remote override gets a pooled descriptor for that
  *     host, which is already scoped to it.
  *  3. A profile inheriting the app-global remote shares the primary backend —
  *     one host serves every profile — so it is scoped per request instead.
- *  4. Any other local profile gets its own pooled backend, spawned with
+ *  4. A local profile REST request that the primary backend can safely scope
+ *     reuses that backend, with `?profile=` when the handler accepts it.
+ *  5. Any other local profile gets its own pooled backend, spawned with
  *     `--profile`, so its `HERMES_HOME` scopes it.
  *
  * Routing used to be spread across three overlapping predicates that each
@@ -399,6 +466,16 @@ function resolveProfileBackendRoute(profile, opts: ProfileRouteOptions = {}): Pr
 
   if (opts.globalRemote) {
     return { backend: 'primary', descriptorProfile: scopedProfile, scopePath: true }
+  }
+
+  const localScope = localPrimaryRequestScope(opts)
+
+  if (localScope !== null) {
+    return {
+      backend: 'primary',
+      descriptorProfile: localScope ? scopedProfile : null,
+      scopePath: localScope
+    }
   }
 
   return { backend: 'pool', descriptorProfile: null, scopePath: false }
@@ -436,6 +513,29 @@ function pathWithGlobalRemoteProfile(path, profile, opts: ProfileRouteOptions = 
   parsed.searchParams.set('profile', scopedProfile)
 
   return `${parsed.pathname}${parsed.search}${parsed.hash}`
+}
+
+export interface ProfileApiRequestRoute {
+  /** Profile passed to ensureBackend; null selects the primary backend. */
+  backendProfile: null | string
+  requestPath: string
+}
+
+/**
+ * Resolve the two decisions made by the `hermes:api` IPC handler from the same
+ * routing table: which backend serves the request, and whether its URL needs a
+ * profile query scope.
+ */
+function resolveProfileApiRequest(profile, path, opts: ProfileRouteOptions = {}): ProfileApiRequestRoute {
+  const scopedProfile = connectionScopeKey(profile)
+  const requestPath = String(path || '')
+  const routeOpts = { ...opts, requestPath }
+  const route = resolveProfileBackendRoute(scopedProfile, routeOpts)
+
+  return {
+    backendProfile: route.backend === 'pool' ? scopedProfile : null,
+    requestPath: pathWithGlobalRemoteProfile(requestPath, scopedProfile, routeOpts)
+  }
 }
 
 function tokenPreview(value) {
@@ -558,6 +658,7 @@ export {
   profileRemoteOverride,
   profileSshOverride,
   resolveAuthMode,
+  resolveProfileApiRequest,
   resolveProfileBackendRoute,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -485,6 +485,8 @@ export interface ProfileRouteOptions {
   primaryRemoteActive?: boolean
   /** A stored per-profile entry exists for this profile (local or remote). */
   ownEntry?: boolean
+  requestMethod?: null | string
+  requestPath?: null | string
 }
 
 export interface ProfileBackendRoute {
@@ -500,16 +502,83 @@ export interface ProfileBackendRoute {
   scopePath: boolean
 }
 
+const LOCAL_PRIMARY_SCOPED_ROUTES = new Set([
+  'GET /api/config',
+  'PUT /api/config',
+  'GET /api/config/raw',
+  'PUT /api/config/raw',
+  'GET /api/config/schema',
+  'DELETE /api/env',
+  'GET /api/env',
+  'PUT /api/env',
+  'POST /api/env/reveal',
+  'GET /api/model/auxiliary',
+  'GET /api/model/info',
+  'GET /api/model/moa',
+  'PUT /api/model/moa',
+  'GET /api/model/options',
+  'POST /api/model/set',
+  'GET /api/skills',
+  'GET /api/skills/content',
+  'PUT /api/skills/toggle',
+  'POST /api/skills/hub/install',
+  'GET /api/skills/hub/preview',
+  'GET /api/skills/hub/scan',
+  'GET /api/skills/hub/search',
+  'GET /api/skills/hub/sources',
+  'POST /api/skills/hub/uninstall',
+  'POST /api/skills/hub/update'
+])
+
+function localPrimaryRequestScope(opts: ProfileRouteOptions): boolean | null {
+  const rawPath = String(opts.requestPath || '')
+
+  if (!rawPath) {
+    return null
+  }
+
+  let pathname
+
+  try {
+    pathname = new URL(rawPath, 'https://example.invalid').pathname
+  } catch {
+    return null
+  }
+
+  const method = String(opts.requestMethod || 'GET').toUpperCase()
+
+  if (LOCAL_PRIMARY_SCOPED_ROUTES.has(`${method} ${pathname}`)) {
+    return true
+  }
+
+  // Every current /api/tools handler accepts `profile`; every /api/profiles
+  // handler either aggregates profiles or names its target in the path/body.
+  // These are the only whole families safe to route through the primary.
+  if (pathname === '/api/tools' || pathname.startsWith('/api/tools/')) {
+    return true
+  }
+
+  if (pathname === '/api/profiles' || pathname.startsWith('/api/profiles/')) {
+    return false
+  }
+
+  return null
+}
+
 /**
  * The one place that answers "which backend serves profile P, and does its
- * REST path need a profile scope?". Four routes, in precedence order:
+ * REST path need a profile scope?". Six routes, in precedence order:
  *
  *  1. The primary profile owns the window backend outright.
  *  2. A profile with its own remote override gets a pooled descriptor for that
  *     host, which is already scoped to it.
  *  3. A profile inheriting the app-global remote shares the primary backend —
  *     one host serves every profile — so it is scoped per request instead.
- *  4. Any other local profile gets its own pooled backend, spawned with
+ *  4. An unknown profile under a remote primary shares that remote backend.
+ *     A stored local profile remains isolated in its own backend.
+ *  5. A local profile REST request that the primary backend can safely scope
+ *     reuses that backend, with `?profile=` when the handler accepts it.
+ *  6. Any other local profile gets its own pooled backend, spawned with
  *     `--profile`, so its `HERMES_HOME` scopes it.
  *
  * Routing used to be spread across three overlapping predicates that each
@@ -532,12 +601,28 @@ function resolveProfileBackendRoute(profile, opts: ProfileRouteOptions = {}): Pr
     return { backend: 'primary', descriptorProfile: scopedProfile, scopePath: true }
   }
 
-  if (opts.primaryRemoteActive && !opts.ownEntry) {
-    // The primary profile's own backend is a remote gateway (per-profile
-    // override or env) and this sub-profile has no stored entry of its own.
-    // Route through that gateway with profile scoping instead of spawning a
-    // fresh local backend that shares nothing but the name (#88296).
-    return { backend: 'primary', descriptorProfile: scopedProfile, scopePath: true }
+  if (opts.primaryRemoteActive) {
+    if (!opts.ownEntry) {
+      // The primary profile's own backend is a remote gateway (per-profile
+      // override or env) and this sub-profile has no stored entry of its own.
+      // Route through that gateway with profile scoping instead of spawning a
+      // fresh local backend that shares nothing but the name (#88296).
+      return { backend: 'primary', descriptorProfile: scopedProfile, scopePath: true }
+    }
+
+    // A stored local profile must not be redirected into the remote primary,
+    // even when its REST endpoint supports profile scoping.
+    return { backend: 'pool', descriptorProfile: null, scopePath: false }
+  }
+
+  const localScope = localPrimaryRequestScope(opts)
+
+  if (localScope !== null) {
+    return {
+      backend: 'primary',
+      descriptorProfile: localScope ? scopedProfile : null,
+      scopePath: localScope
+    }
   }
 
   return { backend: 'pool', descriptorProfile: null, scopePath: false }
@@ -657,6 +742,29 @@ function apiRequestRegistryConnectionId(request): null | string {
   }
 
   return id
+}
+
+export interface ProfileApiRequestRoute {
+  /** Profile passed to ensureBackend; null selects the primary backend. */
+  backendProfile: null | string
+  requestPath: string
+}
+
+/**
+ * Resolve the two decisions made by the `hermes:api` IPC handler from the same
+ * routing table: which backend serves the request, and whether its URL needs a
+ * profile query scope.
+ */
+function resolveProfileApiRequest(profile, path, opts: ProfileRouteOptions = {}): ProfileApiRequestRoute {
+  const scopedProfile = connectionScopeKey(profile)
+  const requestPath = String(path || '')
+  const routeOpts = { ...opts, requestPath }
+  const route = resolveProfileBackendRoute(scopedProfile, routeOpts)
+
+  return {
+    backendProfile: route.backend === 'pool' ? scopedProfile : null,
+    requestPath: pathWithGlobalRemoteProfile(requestPath, scopedProfile, routeOpts)
+  }
 }
 
 function tokenPreview(value) {
@@ -801,6 +909,7 @@ export {
   profileSshOverride,
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
+  resolveProfileApiRequest,
   resolveProfileBackendRoute,
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -59,11 +59,11 @@ import {
   normalizeRemoteBaseUrl,
   normalizeSshConfig,
   normAuthMode,
-  pathWithGlobalRemoteProfile,
   profileHasRemoteConnection,
   profileRemoteOverride,
   profileSshOverride,
   resolveAuthMode,
+  resolveProfileApiRequest,
   resolveProfileBackendRoute,
   resolveTestWsUrl,
   savedProfileSsh,
@@ -7743,11 +7743,13 @@ function primaryProfileKey() {
 }
 
 // Options describing the current connection setup for `resolveProfileBackendRoute`.
-function profileRouteOptions(profile) {
+function profileRouteOptions(profile, request?) {
   return {
     globalRemote: globalRemoteActive(),
     primaryProfile: primaryProfileKey(),
-    profileRemoteOverride: Boolean(profileHasRemoteOverride(profile))
+    profileRemoteOverride: Boolean(profileHasRemoteOverride(profile)),
+    requestMethod: request?.method,
+    requestPath: request?.path
   }
 }
 
@@ -9899,13 +9901,17 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   // backend instead of spawning a fresh pool backend.  A freshly spawned
   // backend calls ensure_hermes_home() which recreates the profile directory,
   // defeating the deletion and leaving a zombie process.
-  const routeProfile = resolveRouteProfile(tornDownProfile, profile)
+  //
+  // Safe local-profile REST calls also stay on the primary dashboard and carry
+  // ?profile=. Endpoints that cannot honor that scope retain their pooled
+  // backend so a destructive call can never fall through to the primary home.
+  const apiRoute = resolveProfileApiRequest(profile, request.path, profileRouteOptions(profile, request))
+  const routeProfile = resolveRouteProfile(tornDownProfile, apiRoute.backendProfile)
+
   const connection = await ensureBackend(routeProfile)
   const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
-  const requestPath = pathWithGlobalRemoteProfile(request.path, profile, profileRouteOptions(profile))
-
-  const url = `${connection.baseUrl}${requestPath}`
+  const url = `${connection.baseUrl}${apiRoute.requestPath}`
 
   // OAuth gateways authenticate REST via EITHER a native bearer token
   // (cookieless RFC 8252 flow) OR the HttpOnly session cookie held in the OAuth

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -85,6 +85,7 @@ import {
   profileSshOverride,
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
+  resolveProfileApiRequest,
   resolveProfileBackendRoute,
   resolveTestWsUrl,
   savedProfileSsh,
@@ -9480,7 +9481,7 @@ function primaryProfileKey() {
 }
 
 // Options describing the current connection setup for `resolveProfileBackendRoute`.
-function profileRouteOptions(profile) {
+function profileRouteOptions(profile, request?) {
   const config = readDesktopConnectionConfig()
   const sshOverride = profileSshOverride(config, profile)
   const key = connectionScopeKey(profile) || primaryProfileKey()
@@ -9498,7 +9499,9 @@ function profileRouteOptions(profile) {
     primaryRemoteActive: primaryBackendIsRemote(),
     // A stored per-profile entry (local or remote) — pins this profile to
     // its own backend; absent entries inherit the primary's remote.
-    ownEntry: Boolean((readDesktopConnectionConfig().profiles || {})[key])
+    ownEntry: Boolean((config.profiles || {})[key]),
+    requestMethod: request?.method,
+    requestPath: request?.path
   }
 }
 
@@ -13148,13 +13151,17 @@ async function handleHermesApiRequest(request) {
   // backend instead of spawning a fresh pool backend.  A freshly spawned
   // backend calls ensure_hermes_home() which recreates the profile directory,
   // defeating the deletion and leaving a zombie process.
-  const routeProfile = resolveRouteProfile(tornDownProfile, profile)
+  //
+  // Safe local-profile REST calls also stay on the primary dashboard and carry
+  // ?profile=. Endpoints that cannot honor that scope retain their pooled
+  // backend so a destructive call can never fall through to the primary home.
+  const apiRoute = resolveProfileApiRequest(profile, request.path, profileRouteOptions(profile, request))
+  const routeProfile = resolveRouteProfile(tornDownProfile, apiRoute.backendProfile)
+
   const connection = await ensureBackend(routeProfile)
   const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
-  const requestPath = pathWithGlobalRemoteProfile(request.path, profile, profileRouteOptions(profile))
-
-  const url = `${connection.baseUrl}${requestPath}`
+  const url = `${connection.baseUrl}${apiRoute.requestPath}`
 
   // OAuth gateways authenticate REST via EITHER a native bearer token
   // (cookieless RFC 8252 flow) OR the HttpOnly session cookie held in the OAuth

--- a/apps/desktop/electron/profile-delete-routing.test.ts
+++ b/apps/desktop/electron/profile-delete-routing.test.ts
@@ -80,3 +80,7 @@ test('resolveRouteProfile passes the requested profile through when nothing was 
 test('resolveRouteProfile passes through undefined when nothing was torn down and no profile was requested', () => {
   assert.equal(resolveRouteProfile(null, undefined), undefined)
 })
+
+test('resolveRouteProfile preserves a primary-backend route from another routing policy', () => {
+  assert.equal(resolveRouteProfile(null, null), null)
+})

--- a/apps/desktop/electron/profile-delete-routing.test.ts
+++ b/apps/desktop/electron/profile-delete-routing.test.ts
@@ -147,3 +147,7 @@ test('localProfilePoolKeys returns every local process scope for one profile', (
   assert.deepEqual(localProfilePoolKeys('Selena'), ['selena', 'conn:local::selena'])
   assert.deepEqual(localProfilePoolKeys(''), [])
 })
+
+test('resolveRouteProfile preserves a primary-backend route from another routing policy', () => {
+  assert.equal(resolveRouteProfile(null, null), null)
+})

--- a/apps/desktop/electron/profile-delete-routing.ts
+++ b/apps/desktop/electron/profile-delete-routing.ts
@@ -89,7 +89,7 @@ export function decideProfileDeleteAction(
  */
 export function resolveRouteProfile(
   tornDownProfile: string | null,
-  profile: string | undefined
+  profile: string | null | undefined
 ): string | null | undefined {
   return tornDownProfile ? null : profile
 }

--- a/apps/desktop/electron/profile-delete-routing.ts
+++ b/apps/desktop/electron/profile-delete-routing.ts
@@ -180,7 +180,7 @@ export function decideProfileDeleteAction(
  */
 export function resolveRouteProfile(
   tornDownProfile: string | null,
-  profile: string | undefined
+  profile: string | null | undefined
 ): string | null | undefined {
   return tornDownProfile ? null : profile
 }

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -249,9 +249,10 @@ export class HermesGateway extends JsonRpcGatewayClient {
 // Profile that profile-scoped REST settings (config/env/skills/tools/model/…)
 // should target. Mirrors $activeGatewayProfile, pushed in from the store via
 // setApiRequestProfile so this module needs no store import (avoids a cycle).
-// Electron main consumes request.profile to pick which backend *process* serves
-// the call; each pooled backend already has its own HERMES_HOME, so no backend
-// change is needed. Null → primary, so single-profile users are unaffected.
+// Electron main consumes request.profile as request scope. Local calls whose
+// REST handlers accept profile reuse the primary dashboard via ?profile=;
+// unscoped handlers retain a profile backend. Remote overrides still route to
+// their owning backend. Null → primary, so single-profile users are unaffected.
 let _apiProfile: null | string = null
 
 export function setApiRequestProfile(profile: null | string): void {
@@ -678,10 +679,8 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
   }
 }
 
-// Mutations take the owning `profile` so Electron routes them to that profile's
-// backend (remote pool or local primary) via request.profile — matching the
-// read path. A remote session's row lives only on its remote host, so a mutation
-// that hit the local primary would no-op or 404. Omit for the current/default.
+// Mutations take the owning `profile` so Electron can route them to the correct
+// remote backend or local profile scope. Omit for the current/default profile.
 export function setSessionArchived(id: string, archived: boolean, profile?: string | null): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
     ...(profile ? { profile } : {}),

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -234,9 +234,10 @@ export class HermesGateway extends JsonRpcGatewayClient {
 // Profile that profile-scoped REST settings (config/env/skills/tools/model/…)
 // should target. Mirrors $activeGatewayProfile, pushed in from the store via
 // setApiRequestProfile so this module needs no store import (avoids a cycle).
-// Electron main consumes request.profile to pick which backend *process* serves
-// the call; each pooled backend already has its own HERMES_HOME, so no backend
-// change is needed. Null → primary, so single-profile users are unaffected.
+// Electron main consumes request.profile as request scope. Local calls whose
+// REST handlers accept profile reuse the primary dashboard via ?profile=;
+// unscoped handlers retain a profile backend. Remote overrides still route to
+// their owning backend. Null → primary, so single-profile users are unaffected.
 let _apiProfile: null | string = null
 
 export function setApiRequestProfile(profile: null | string): void {
@@ -566,10 +567,8 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
   }
 }
 
-// Mutations take the owning `profile` so Electron routes them to that profile's
-// backend (remote pool or local primary) via request.profile — matching the
-// read path. A remote session's row lives only on its remote host, so a mutation
-// that hit the local primary would no-op or 404. Omit for the current/default.
+// Mutations take the owning `profile` so Electron can route them to the correct
+// remote backend or local profile scope. Omit for the current/default profile.
 export function setSessionArchived(id: string, archived: boolean, profile?: string | null): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
     ...(profile ? { profile } : {}),


### PR DESCRIPTION
## Summary

Fixes #61023.

Hermes One can start an extra isolated dashboard backend for a local non-primary profile during startup because the Electron `hermes:api` proxy treated every `request.profile` as a backend-process routing key. Profile-scoped startup/config/session reads then call `ensureBackend(profile)`, which launches a pooled `--profile <name> dashboard/serve` backend even though the primary machine dashboard can serve local profiles through `?profile=`.

This keeps ordinary local-profile REST on the primary backend and appends `?profile=<name>` to the proxied path instead. Per-profile remote overrides and app-global remote mode still route through profile descriptors so remote hosts keep working. Live chat sockets still use the existing lazy secondary backend path; this only changes REST routing.

## Refresh note

Rebased onto current `main` after profile-delete routing moved from source-regex coverage into pure Vitest helpers. The live handler now composes the current `resolveRouteProfile()` deletion guard with this PR's REST routing policy, and the obsolete deleted test file is not restored.

## Duplicate / overlap check

- Exact PR search: `61023 in:title,body` returned no competing open implementation.
- #48652 isolates profile backends after they exist; this PR avoids spawning a local isolated backend for REST in the first place.
- #57810 routes remote/fleet profile roster reads; this PR handles the local-profile REST route in the general IPC proxy.
- #60606 fixes stale dashboard process cleanup after update, not startup routing.

## Verification

- `npm --prefix apps/desktop run test:desktop:platforms` - 37 files passed; 418 tests passed, 1 skipped
- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/desktop run build`
- `git diff --check origin/main...HEAD`
- publish-gate gitleaks scan - no leaks found
