### PR TITLE
fix(kanban): surface active PR respawn guards

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1235,13 +1235,19 @@ class GatewayKanbanWatchersMixin:
                 results = await asyncio.to_thread(_tick_once)
                 any_spawned = False
                 for slug, res in (results or []):
-                    if res is not None and getattr(res, "spawned", None):
+                    if res is None:
+                        continue
+                    respawn_guarded = getattr(res, "respawn_guarded", []) or []
+                    if getattr(res, "spawned", None):
                         any_spawned = True
+                    if getattr(res, "spawned", None) or respawn_guarded:
                         # Quiet by default — only log when something actually
-                        # happened, so an idle gateway stays silent.
+                        # happened, including review/respawn gates that explain
+                        # why a ready task was deliberately not spawned.
                         logger.info(
                             "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
+                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d "
+                            "respawn_guarded=%d",
                             slug,
                             len(res.spawned),
                             res.reclaimed,
@@ -1249,7 +1255,15 @@ class GatewayKanbanWatchersMixin:
                             len(res.timed_out) if hasattr(res.timed_out, "__len__") else 0,
                             res.promoted,
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
+                            len(respawn_guarded),
                         )
+                        for tid, reason in respawn_guarded:
+                            logger.info(
+                                "kanban dispatcher [%s]: respawn_guarded task=%s reason=%s",
+                                slug,
+                                tid,
+                                reason,
+                            )
                 # Health telemetry (aggregate across boards)
                 ready_pending = await asyncio.to_thread(_ready_nonempty)
                 if ready_pending and not any_spawned:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2180,6 +2180,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
+            "respawn_guarded": [
+                {"task_id": tid, "reason": reason}
+                for (tid, reason) in res.respawn_guarded
+            ],
             "auto_assigned_default": res.auto_assigned_default,
         }, indent=2))
         return 0
@@ -2218,6 +2222,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    if res.respawn_guarded:
+        for tid, reason in res.respawn_guarded:
+            print(f"Skipped (respawn guard: {reason}): {tid}")
     return 0
 
 
@@ -2317,7 +2324,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             return
         did_work = (
             res.reclaimed or res.crashed or res.timed_out or res.promoted
-            or res.spawned or res.auto_blocked or res.stale
+            or res.spawned or res.auto_blocked or res.stale or res.respawn_guarded
         )
         if did_work:
             print(
@@ -2325,9 +2332,16 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
                 f"reclaimed={res.reclaimed} crashed={len(res.crashed)} "
                 f"timed_out={len(res.timed_out)} stale={len(res.stale)} "
                 f"promoted={res.promoted} spawned={len(res.spawned)} "
-                f"auto_blocked={len(res.auto_blocked)}",
+                f"auto_blocked={len(res.auto_blocked)} "
+                f"respawn_guarded={len(res.respawn_guarded)}",
                 flush=True,
             )
+            for tid, reason in res.respawn_guarded:
+                print(
+                    f"[{_fmt_ts(int(time.time()))}] "
+                    f"respawn_guarded task={tid} reason={reason}",
+                    flush=True,
+                )
 
     def _ready_queue_nonempty() -> bool:
         """Cheap probe — is there at least one ready+assigned+unclaimed

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6874,7 +6874,8 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
 def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
-    whose assignee maps to a real Hermes profile.
+    whose assignee maps to a real Hermes profile and is not currently parked
+    by a respawn guard.
 
     Used by the gateway- and CLI-embedded dispatchers' health telemetry to
     decide whether ``0 spawned`` is a "stuck" condition (real spawnable
@@ -6887,7 +6888,7 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     the warning still fires in degraded environments.
     """
     rows = conn.execute(
-        "SELECT DISTINCT assignee FROM tasks "
+        "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND assignee IS NOT NULL "
         "    AND claim_lock IS NULL"
     ).fetchall()
@@ -6899,7 +6900,10 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
         # Can't introspect — assume spawnable, preserve legacy behavior.
         return True
     for row in rows:
-        if profile_exists(row["assignee"]):
+        if (
+            profile_exists(row["assignee"])
+            and check_respawn_guard(conn, row["id"]) is None
+        ):
             return True
     return False
 

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -8,6 +8,7 @@ operator footgun that only manifests in long-running setups.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 import tempfile
@@ -92,6 +93,32 @@ def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypat
     assert captured.get("max_spawn") == 2, (
         f"CLI --max=2 must override config kanban.max_spawn=10; got {captured.get('max_spawn')!r}"
     )
+
+
+def test_cli_dispatch_json_reports_respawn_guarded(
+    isolated_kanban_home, monkeypatch, capsys
+):
+    """Dry-run JSON must expose tasks parked by respawn guards.
+
+    Without this field, operators see ``spawned: []`` but not the active PR or
+    recent-success reason that explains why dispatch skipped a ready card.
+    """
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"kanban": {}})
+
+    result = kanban_db.DispatchResult()
+    result.respawn_guarded.append(("t_pr173", "active_pr"))
+    monkeypatch.setattr(kanban_db, "dispatch_once", lambda conn, **kw: result)
+
+    args = argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=True)
+    assert kb_cli._cmd_dispatch(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["respawn_guarded"] == [
+        {"task_id": "t_pr173", "reason": "active_pr"}
+    ]
 
 
 def test_cli_invalid_max_in_progress_silently_disables(isolated_kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1703,6 +1703,30 @@ def test_has_spawnable_ready_true_when_real_profile_present(kanban_home, monkeyp
         assert kb.has_spawnable_ready(conn) is True
 
 
+def test_has_spawnable_ready_false_when_only_ready_task_has_active_pr(
+    kanban_home, monkeypatch
+):
+    """A ready task parked behind the active_pr respawn guard is not spawnable.
+
+    Gateway/daemon stuck telemetry calls ``has_spawnable_ready`` after a tick with
+    0 spawned workers. If active-PR review gates still count as spawnable, the
+    board looks broken even though dispatch correctly refused to respawn.
+    """
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="has-pr", assignee="daily")
+        kb.add_comment(
+            conn,
+            t,
+            "worker",
+            "Opened https://github.com/NousResearch/hermes-agent/pull/173",
+        )
+
+        assert kb.has_spawnable_ready(conn) is False
+
+
 def test_has_spawnable_ready_false_on_empty_queue(kanban_home):
     """Empty queue is the trivial false case — no ready tasks at all."""
     with kb.connect() as conn:

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -365,7 +365,7 @@ Every profile that works kanban tasks automatically gets the worker lifecycle �
 1. On spawn, call `kanban_show()` to read title + body + parent handoffs + prior attempts + full comment thread.
 2. `cd $HERMES_KANBAN_WORKSPACE` (via the terminal tool) and do the work there.
 3. Call `kanban_heartbeat(note="...")` every few minutes during long operations. **If your work may run longer than 1 hour, call `kanban_heartbeat` at least once an hour** — the dispatcher reclaims tasks that have been running past `kanban.dispatch_stale_timeout_seconds` (default 4 h) with no heartbeat in the last hour, on the assumption the worker crashed without cleanup. A reclaim is benign (the task goes back to `ready` for re-dispatch without a failure-counter tick) but you lose your current run's progress.
-4. Complete with `kanban_complete(summary="...", metadata={...})`, or `kanban_block(reason="...")` if stuck.
+4. Complete with `kanban_complete(summary="...", metadata={...})`, or `kanban_block(reason="...")` if stuck. For code changes that have opened a PR but still need human eyes, prefer `kanban_comment(...)` with the review handoff, then `kanban_block(reason="review-required: ...")` so the card parks in an explicit human-review state instead of sitting in `ready` behind the `active_pr` respawn guard.
 
 That final `kanban_complete` / `kanban_block` call is part of the worker
 protocol. If the worker process exits with status 0 while the task is still
@@ -375,6 +375,13 @@ of respawning it into the same loop. This usually means the model wrote a
 plain-text answer and exited without using the Kanban tool surface.
 
 The lifecycle plus the load-bearing reference details (workspace kinds, deliverable `artifacts`, claiming created cards) ship in that system-prompt block, so every worker has them regardless of which profile it runs under — no per-profile skill setup required.
+
+If a legacy or non-compliant worker leaves a PR URL in comments and exits without
+blocking/completing, the dispatcher treats the ready card as protected by the
+`active_pr` respawn guard. Dispatch telemetry (`hermes kanban dispatch --json`,
+daemon/gateway logs, and task events) reports `respawn_guarded` with the guard
+reason so operators see that the card is waiting on review rather than silently
+idle.
 
 ### Pinning extra skills to a specific task
 


### PR DESCRIPTION
## Summary
- exclude active-PR guarded ready tasks from spawnable-ready telemetry
- surface respawn_guarded task/reason entries in dispatch JSON, CLI, daemon, and gateway logs
- document blocking review-required PR handoffs to avoid ready+active_pr limbo

## Test Plan
- scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -k 'has_spawnable_ready or respawn_guard' -v
- scripts/run_tests.sh tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py -v
- scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_core_functionality.py -k 'kanban or gateway_dispatcher or dispatch'
- python3 -m compileall -q gateway/kanban_watchers.py hermes_cli/kanban.py hermes_cli/kanban_db.py