### PR TITLE
fix(acp): bound resource file reads to session cwd

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -186,6 +186,53 @@ def _path_from_file_uri(uri: str) -> Path | None:
     return Path(path_text)
 
 
+def _blocked_resource_part(
+    *,
+    uri: str,
+    body: str,
+    name: str | None = None,
+    title: str | None = None,
+) -> list[dict[str, Any]]:
+    return [{
+        "type": "text",
+        "text": _format_resource_text(
+            uri=uri,
+            name=name,
+            title=title,
+            body=body,
+        ),
+    }]
+
+
+def _resolve_resource_path_for_read(
+    path: Path,
+    *,
+    allowed_root: str | Path | None,
+) -> tuple[Path | None, str | None]:
+    """Resolve an ACP file resource and keep host reads inside the session root."""
+    if allowed_root is None:
+        return path, None
+
+    try:
+        root = Path(allowed_root).expanduser().resolve(strict=True)
+    except OSError:
+        return None, "[Blocked attached file because the ACP session workspace is unavailable.]"
+
+    read_path = path.expanduser()
+    if not read_path.is_absolute():
+        read_path = root / read_path
+
+    try:
+        resolved = read_path.resolve(strict=True)
+    except OSError as exc:
+        return None, f"[Could not read attached file: {exc}]"
+
+    if not resolved.is_relative_to(root):
+        return None, "[Blocked attached file outside the ACP session workspace.]"
+
+    return resolved, None
+
+
 def _decode_text_bytes(data: bytes, mime_type: str | None) -> str | None:
     """Decode resource bytes if they are probably text; return None for binary."""
     if b"\x00" in data and not _is_text_resource(mime_type):
@@ -213,7 +260,11 @@ def _format_resource_text(
     return f"{header}\nURI: {uri}\n\n{body}"
 
 
-def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]:
+def _resource_link_to_parts(
+    block: ResourceContentBlock,
+    *,
+    allowed_root: str | Path | None,
+) -> list[dict[str, Any]]:
     """Convert an ACP resource_link block to OpenAI content parts.
 
     Returns a list of {"type": "text", ...} and/or {"type": "image_url", ...}
@@ -231,15 +282,24 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
     path = _path_from_file_uri(uri)
 
     if path is None:
-        return [{
-            "type": "text",
-            "text": _format_resource_text(
-                uri=uri,
-                name=name,
-                title=title,
-                body="[Resource link only; Hermes cannot read non-file ACP resource URIs directly.]",
-            ),
-        }]
+        return _blocked_resource_part(
+            uri=uri,
+            name=name,
+            title=title,
+            body="[Resource link only; Hermes cannot read non-file ACP resource URIs directly.]",
+        )
+
+    path, blocked_reason = _resolve_resource_path_for_read(
+        path,
+        allowed_root=allowed_root,
+    )
+    if path is None:
+        return _blocked_resource_part(
+            uri=uri,
+            name=name,
+            title=title,
+            body=blocked_reason or "[Blocked attached file.]",
+        )
 
     # Image files: emit a short text header + image_url data URL so vision
     # models can see the attachment instead of a "binary omitted" note.
@@ -248,28 +308,22 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
         try:
             size = path.stat().st_size
             if size > _MAX_ACP_RESOURCE_BYTES:
-                return [{
-                    "type": "text",
-                    "text": _format_resource_text(
-                        uri=uri,
-                        name=name,
-                        title=title,
-                        body=f"[Image too large to inline: {size} bytes, cap={_MAX_ACP_RESOURCE_BYTES}]",
-                    ),
-                }]
+                return _blocked_resource_part(
+                    uri=uri,
+                    name=name,
+                    title=title,
+                    body=f"[Image too large to inline: {size} bytes, cap={_MAX_ACP_RESOURCE_BYTES}]",
+                )
             with path.open("rb") as fh:
                 data = fh.read()
         except OSError as exc:
             logger.warning("ACP image resource read failed: %s", uri, exc_info=True)
-            return [{
-                "type": "text",
-                "text": _format_resource_text(
-                    uri=uri,
-                    name=name,
-                    title=title,
-                    body=f"[Could not read attached image: {exc}]",
-                ),
-            }]
+            return _blocked_resource_part(
+                uri=uri,
+                name=name,
+                title=title,
+                body=f"[Could not read attached image: {exc}]",
+            )
         display = _resource_display_name(uri, name=name, title=title)
         return [
             {"type": "text", "text": f"[Attached image: {display}]\nURI: {uri}"},
@@ -283,15 +337,12 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
             data = fh.read(read_size)
         text = _decode_text_bytes(data, mime_type)
         if text is None:
-            return [{
-                "type": "text",
-                "text": _format_resource_text(
-                    uri=uri,
-                    name=name,
-                    title=title,
-                    body=f"[Binary file omitted: {size} bytes, mime={mime_type or 'unknown'}]",
-                ),
-            }]
+            return _blocked_resource_part(
+                uri=uri,
+                name=name,
+                title=title,
+                body=f"[Binary file omitted: {size} bytes, mime={mime_type or 'unknown'}]",
+            )
         note = None
         if size > _MAX_ACP_RESOURCE_BYTES:
             note = f"truncated to {_MAX_ACP_RESOURCE_BYTES} of {size} bytes"
@@ -301,15 +352,12 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
         }]
     except OSError as exc:
         logger.warning("ACP resource read failed: %s", uri, exc_info=True)
-        return [{
-            "type": "text",
-            "text": _format_resource_text(
-                uri=uri,
-                name=name,
-                title=title,
-                body=f"[Could not read attached file: {exc}]",
-            ),
-        }]
+        return _blocked_resource_part(
+            uri=uri,
+            name=name,
+            title=title,
+            body=f"[Could not read attached file: {exc}]",
+        )
 
 
 def _embedded_resource_to_parts(block: EmbeddedResourceContentBlock) -> list[dict[str, Any]]:
@@ -404,6 +452,8 @@ def _content_blocks_to_openai_user_content(
         | ResourceContentBlock
         | EmbeddedResourceContentBlock
     ],
+    *,
+    allowed_root: str | Path | None,
 ) -> str | list[dict[str, Any]]:
     """Convert ACP prompt blocks into a Hermes/OpenAI-compatible user content payload."""
     parts: list[dict[str, Any]] = []
@@ -421,7 +471,10 @@ def _content_blocks_to_openai_user_content(
                 parts.append(image_part)
             continue
         if isinstance(block, ResourceContentBlock):
-            resource_parts = _resource_link_to_parts(block)
+            resource_parts = _resource_link_to_parts(
+                block,
+                allowed_root=allowed_root,
+            )
             for part in resource_parts:
                 parts.append(part)
                 if part.get("type") == "text":
@@ -1312,7 +1365,10 @@ class HermesACPAgent(acp.Agent):
             return PromptResponse(stop_reason="refusal")
 
         user_text = _extract_text(prompt).strip()
-        user_content = _content_blocks_to_openai_user_content(prompt)
+        user_content = _content_blocks_to_openai_user_content(
+            prompt,
+            allowed_root=state.cwd,
+        )
         text_only_prompt = all(isinstance(block, TextContentBlock) for block in prompt)
         has_content = bool(user_text) or (
             isinstance(user_content, list) and bool(user_content)

--- a/tests/acp_adapter/test_acp_images.py
+++ b/tests/acp_adapter/test_acp_images.py
@@ -14,10 +14,13 @@ from acp_adapter.server import HermesACPAgent, _content_blocks_to_openai_user_co
 
 
 def test_acp_image_blocks_convert_to_openai_multimodal_content():
-    content = _content_blocks_to_openai_user_content([
-        TextContentBlock(type="text", text="What is in this image?"),
-        ImageContentBlock(type="image", data="aGVsbG8=", mimeType="image/png"),
-    ])
+    content = _content_blocks_to_openai_user_content(
+        [
+            TextContentBlock(type="text", text="What is in this image?"),
+            ImageContentBlock(type="image", data="aGVsbG8=", mimeType="image/png"),
+        ],
+        allowed_root=None,
+    )
 
     assert content == [
         {"type": "text", "text": "What is in this image?"},
@@ -29,9 +32,12 @@ def test_acp_image_blocks_convert_to_openai_multimodal_content():
 
 
 def test_text_only_acp_blocks_stay_string_for_legacy_prompt_path():
-    content = _content_blocks_to_openai_user_content([
-        TextContentBlock(type="text", text="/help"),
-    ])
+    content = _content_blocks_to_openai_user_content(
+        [
+            TextContentBlock(type="text", text="/help"),
+        ],
+        allowed_root=None,
+    )
 
     assert content == "/help"
 
@@ -40,16 +46,19 @@ def test_acp_resource_link_file_is_inlined_as_text(tmp_path):
     attached = tmp_path / "notes.md"
     attached.write_text("# Notes\n\nAttached file body", encoding="utf-8")
 
-    content = _content_blocks_to_openai_user_content([
-        TextContentBlock(type="text", text="Please read this file"),
-        ResourceContentBlock(
-            type="resource_link",
-            name="notes.md",
-            title="Project notes",
-            uri=attached.as_uri(),
-            mimeType="text/markdown",
-        ),
-    ])
+    content = _content_blocks_to_openai_user_content(
+        [
+            TextContentBlock(type="text", text="Please read this file"),
+            ResourceContentBlock(
+                type="resource_link",
+                name="notes.md",
+                title="Project notes",
+                uri=attached.as_uri(),
+                mimeType="text/markdown",
+            ),
+        ],
+        allowed_root=tmp_path,
+    )
 
     assert content == (
         "Please read this file\n"
@@ -59,17 +68,89 @@ def test_acp_resource_link_file_is_inlined_as_text(tmp_path):
     )
 
 
-def test_acp_embedded_text_resource_is_inlined_as_text():
-    content = _content_blocks_to_openai_user_content([
-        EmbeddedResourceContentBlock(
-            type="resource",
-            resource=TextResourceContents(
-                uri="file:///workspace/todo.txt",
-                mimeType="text/plain",
-                text="first\nsecond",
+def test_acp_resource_link_relative_path_resolves_inside_workspace(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    attached = workspace / "notes.md"
+    attached.write_text("relative body", encoding="utf-8")
+
+    content = _content_blocks_to_openai_user_content(
+        [
+            ResourceContentBlock(
+                type="resource_link",
+                name="notes.md",
+                uri="notes.md",
+                mimeType="text/markdown",
             ),
-        ),
-    ])
+        ],
+        allowed_root=workspace,
+    )
+
+    assert "relative body" in content
+
+
+def test_acp_resource_link_outside_workspace_is_not_inlined(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("outside secret body", encoding="utf-8")
+
+    content = _content_blocks_to_openai_user_content(
+        [
+            ResourceContentBlock(
+                type="resource_link",
+                name="outside-secret.txt",
+                uri=outside.as_uri(),
+                mimeType="text/plain",
+            ),
+        ],
+        allowed_root=workspace,
+    )
+
+    assert "outside secret body" not in content
+    assert "Blocked attached file outside the ACP session workspace" in content
+    assert outside.as_uri() in content
+
+
+def test_acp_resource_link_symlink_escape_is_not_inlined(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("symlink secret body", encoding="utf-8")
+    link = workspace / "linked-secret.txt"
+    link.symlink_to(outside)
+
+    content = _content_blocks_to_openai_user_content(
+        [
+            ResourceContentBlock(
+                type="resource_link",
+                name="linked-secret.txt",
+                uri=link.as_uri(),
+                mimeType="text/plain",
+            ),
+        ],
+        allowed_root=workspace,
+    )
+
+    assert "symlink secret body" not in content
+    assert "Blocked attached file outside the ACP session workspace" in content
+    assert link.as_uri() in content
+
+
+def test_acp_embedded_text_resource_is_inlined_as_text():
+    content = _content_blocks_to_openai_user_content(
+        [
+            EmbeddedResourceContentBlock(
+                type="resource",
+                resource=TextResourceContents(
+                    uri="file:///workspace/todo.txt",
+                    mimeType="text/plain",
+                    text="first\nsecond",
+                ),
+            ),
+        ],
+        allowed_root=None,
+    )
 
     assert content == (
         "[Attached file: todo.txt]\n"
@@ -98,15 +179,18 @@ def test_acp_resource_link_image_file_is_inlined_as_image_url(tmp_path):
     attached = tmp_path / "shot.png"
     attached.write_bytes(_ONE_PX_PNG)
 
-    content = _content_blocks_to_openai_user_content([
-        TextContentBlock(type="text", text="Look at this screenshot"),
-        ResourceContentBlock(
-            type="resource_link",
-            name="shot.png",
-            uri=attached.as_uri(),
-            mimeType="image/png",
-        ),
-    ])
+    content = _content_blocks_to_openai_user_content(
+        [
+            TextContentBlock(type="text", text="Look at this screenshot"),
+            ResourceContentBlock(
+                type="resource_link",
+                name="shot.png",
+                uri=attached.as_uri(),
+                mimeType="image/png",
+            ),
+        ],
+        allowed_root=tmp_path,
+    )
 
     assert isinstance(content, list)
     # [user text, image header, image_url]
@@ -123,13 +207,16 @@ def test_acp_resource_link_image_mime_inferred_from_suffix(tmp_path):
     attached = tmp_path / "pic.jpg"
     attached.write_bytes(_ONE_PX_PNG)  # content doesn't matter for the code path
 
-    content = _content_blocks_to_openai_user_content([
-        ResourceContentBlock(
-            type="resource_link",
-            name="pic.jpg",
-            uri=attached.as_uri(),
-        ),
-    ])
+    content = _content_blocks_to_openai_user_content(
+        [
+            ResourceContentBlock(
+                type="resource_link",
+                name="pic.jpg",
+                uri=attached.as_uri(),
+            ),
+        ],
+        allowed_root=tmp_path,
+    )
 
     assert isinstance(content, list)
     image_parts = [p for p in content if p.get("type") == "image_url"]
@@ -139,16 +226,19 @@ def test_acp_resource_link_image_mime_inferred_from_suffix(tmp_path):
 
 def test_acp_embedded_blob_image_is_inlined_as_image_url():
     b64 = base64.b64encode(_ONE_PX_PNG).decode("ascii")
-    content = _content_blocks_to_openai_user_content([
-        EmbeddedResourceContentBlock(
-            type="resource",
-            resource=BlobResourceContents(
-                uri="file:///tmp/embed.png",
-                mimeType="image/png",
-                blob=b64,
+    content = _content_blocks_to_openai_user_content(
+        [
+            EmbeddedResourceContentBlock(
+                type="resource",
+                resource=BlobResourceContents(
+                    uri="file:///tmp/embed.png",
+                    mimeType="image/png",
+                    blob=b64,
+                ),
             ),
-        ),
-    ])
+        ],
+        allowed_root=None,
+    )
 
     assert isinstance(content, list)
     assert content[0]["type"] == "text"


### PR DESCRIPTION
## Summary

- Resolve ACP `resource_link` file paths before host-side reads and require them to stay under the active ACP session cwd.
- Treat relative resource paths as session-cwd-relative, then block `../` and symlink escapes after resolution.
- Keep legitimate in-workspace text/image attachments working and return a blocked-resource note instead of inlining outside-workspace file contents.

Fixes #53145.

## Duplicate / overlap check

- Exact open-PR search for `53145 in:title,body`: none.
- #23098 previously addressed the same resource-link containment gap, but it is closed unmerged and `origin/main` still lacks the workspace-bound read guard.
- #41754 adds sensitive-path blocking for ACP resource reads via `get_read_block_error()`, but it does not bind arbitrary `file://` resource reads to the ACP session workspace. This PR covers the separate workspace containment boundary.
- #57458 targets ACP edit auto-approval symlink sensitivity (#55367), not ACP resource-link host reads.

## Tests

- `uv run --extra dev --extra acp pytest tests/acp_adapter/test_acp_images.py -q` — 11 passed
- `uv run --extra dev --extra acp pytest tests/acp_adapter tests/acp/test_server.py tests/acp/test_session.py -q` — 147 passed
- `TMPDIR="$PWD/.pytest-tmp" uv run --extra dev --extra acp pytest tests/acp -q` — 302 passed, 7 warnings
- `uv run --extra dev --extra acp ruff check acp_adapter/server.py tests/acp_adapter/test_acp_images.py` — passed
- `python -m py_compile acp_adapter/server.py tests/acp_adapter/test_acp_images.py` — passed
- `git diff --check` — passed
- `gitleaks git --log-opts='origin/main..HEAD' --redact .` — no leaks found

Note: running `tests/acp -q` without `TMPDIR` set failed 3 edit-approval tests locally because macOS placed pytest temp files under `/private/var/.../T`, which this checkout's file-tool policy treats as a sensitive system path. The same failures passed with `TMPDIR` inside the repo.
