### PR TITLE
fix(browser): kill persistent agent-browser host process on cleanup (Windows resource leak)

### DIFF
--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -1,6 +1,6 @@
 """Regression tests for browser session cleanup and screenshot recovery."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 
 class TestScreenshotPathRecovery:
@@ -138,3 +138,68 @@ class TestBrowserCleanup:
         assert browser_tool._session_last_activity == {}
         assert browser_tool._recording_sessions == set()
         assert browser_tool._cleanup_done is True
+
+
+class TestWindowsAgentBrowserHostCleanup:
+    socket_a = r"C:\\Temp\\agent-browser-a"
+    socket_b = r"C:\\Temp\\agent-browser-b"
+
+    def _proc(self, env=None, error=None):
+        proc = Mock(pid=123)
+        proc.name.side_effect = error or (lambda: "agent-browser-win32-x64.exe")
+        proc.cmdline.side_effect = error or (lambda: [])
+        proc.environ.side_effect = error or (lambda: env or {})
+        return proc
+
+    def _run(self, monkeypatch, processes, start=101, terminate=None):
+        import psutil
+        from tools import browser_tool
+        from tools.process_registry import ProcessRegistry
+        monkeypatch.setattr(browser_tool.sys, "platform", "win32")
+        monkeypatch.setattr(psutil, "process_iter", lambda _attrs: processes)
+        monkeypatch.setattr("gateway.status.get_process_start_time", lambda _pid: start)
+        terminate = terminate or Mock()
+        monkeypatch.setattr(ProcessRegistry, "_terminate_host_pid", terminate)
+        browser_tool._cleanup_windows_agent_browser_host(self.socket_a)
+        return terminate
+
+    def test_per_session_cleanup_invokes_host_cleanup(self, monkeypatch):
+        from tools import browser_tool
+        browser_tool._active_sessions["task"] = {"session_name": "a", "bb_session_id": None}
+        helper = Mock()
+        monkeypatch.setattr(browser_tool, "_cleanup_windows_agent_browser_host", helper)
+        with (patch("tools.browser_tool._maybe_stop_recording"),
+              patch("tools.browser_tool._run_browser_command"),
+              patch("tools.browser_tool.os.path.exists", return_value=True),
+              patch("tools.browser_tool.os.path.isfile", return_value=False),
+              patch("tools.browser_tool.shutil.rmtree")):
+            browser_tool.cleanup_browser("task")
+        helper.assert_called_once()
+
+    def test_matching_binding_terminates_with_start_token(self, monkeypatch):
+        proc = self._proc({"AGENT_BROWSER_SOCKET_DIR": self.socket_a})
+        self._run(monkeypatch, [proc]).assert_called_once_with(123, expected_start=101)
+
+    def test_different_binding_is_preserved(self, monkeypatch):
+        self._run(monkeypatch, [self._proc({"AGENT_BROWSER_SOCKET_DIR": self.socket_b})]).assert_not_called()
+
+    def test_missing_binding_is_preserved(self, monkeypatch):
+        self._run(monkeypatch, [self._proc()]).assert_not_called()
+
+    def test_missing_start_token_is_skipped(self, monkeypatch):
+        self._run(monkeypatch, [self._proc({"AGENT_BROWSER_SOCKET_DIR": self.socket_a})], start=None).assert_not_called()
+
+    def test_recycled_pid_is_rejected_by_registry(self, monkeypatch):
+        from tools import process_registry
+        from tools.process_registry import ProcessRegistry
+        monkeypatch.setattr(process_registry, "_IS_WINDOWS", True)
+        monkeypatch.setattr(ProcessRegistry, "_is_host_pid_alive", lambda _pid: True)
+        monkeypatch.setattr(ProcessRegistry, "_safe_host_start_time", lambda _pid: 202)
+        taskkill = Mock()
+        monkeypatch.setattr(process_registry.subprocess, "run", taskkill)
+        self._run(monkeypatch, [self._proc({"AGENT_BROWSER_SOCKET_DIR": self.socket_a})], terminate=ProcessRegistry._terminate_host_pid)
+        taskkill.assert_not_called()
+
+    def test_inaccessible_process_does_not_crash(self, monkeypatch):
+        import psutil
+        self._run(monkeypatch, [self._proc(error=psutil.AccessDenied(pid=123))])

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4282,6 +4282,59 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
         _last_active_session_key.pop(bare_task_id, None)
 
 
+def _cleanup_windows_agent_browser_host(socket_dir: str) -> None:
+    """Best-effort cleanup of the agent-browser host bound to one session."""
+    if sys.platform != "win32":
+        return
+    try:
+        import psutil
+        from gateway.status import get_process_start_time
+        from tools.process_registry import ProcessRegistry
+    except Exception:
+        return
+
+    target_socket = os.path.normcase(os.path.normpath(socket_dir))
+    try:
+        processes = psutil.process_iter(["pid", "name", "cmdline"])
+    except Exception:
+        return
+
+    for proc in processes:
+        try:
+            pid = proc.pid
+            name = (proc.name() or "").lower()
+            argv = [str(arg) for arg in (proc.cmdline() or [])]
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            continue
+        if "agent-browser" not in name and not any("agent-browser" in arg.lower() for arg in argv):
+            continue
+
+        argv_bound = False
+        for arg in argv:
+            value = arg.split("=", 1)[1] if arg.startswith("--") and "=" in arg else arg
+            if value and os.path.normcase(os.path.normpath(value.strip("\"'"))) == target_socket:
+                argv_bound = True
+                break
+        try:
+            env_socket = (proc.environ() or {}).get("AGENT_BROWSER_SOCKET_DIR", "")
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            continue
+        env_bound = bool(env_socket) and os.path.normcase(os.path.normpath(env_socket)) == target_socket
+        if not argv_bound and not env_bound:
+            continue
+
+        try:
+            start_time = get_process_start_time(pid)
+        except Exception:
+            continue
+        if start_time is None:
+            continue
+        try:
+            ProcessRegistry._terminate_host_pid(pid, expected_start=start_time)
+        except (ProcessLookupError, PermissionError, OSError):
+            continue
+
+
 def _cleanup_single_browser_session(task_id: str) -> None:
     """Internal: reap a single browser session by its exact session key."""
     # Stop the CDP supervisor for this task FIRST so we close our WebSocket
@@ -4342,6 +4395,7 @@ def _cleanup_single_browser_session(task_id: str) -> None:
         if session_name:
             socket_dir = os.path.join(_socket_safe_tmpdir(), f"agent-browser-{session_name}")
             if os.path.exists(socket_dir):
+                _cleanup_windows_agent_browser_host(socket_dir)
                 # agent-browser writes {session}.pid in the socket dir
                 pid_file = os.path.join(socket_dir, f"{session_name}.pid")
                 if os.path.isfile(pid_file):
@@ -4377,58 +4431,7 @@ def cleanup_all_browsers() -> None:
     except Exception:
         pass
 
-    # Windows: kill orphaned agent-browser host processes that survive
-    # per-session daemon cleanup.  agent-browser-win32-x64.exe is a
-    # persistent host binary that stays alive between sessions and
-    # accumulates over time, eventually causing WinError 1450
-    # ("Insufficient system resources") after many browser sessions.
-    # Only targets processes with "agent-browser" and "chrome" in their
-    # command line — never touches msedgewebview2.exe (Hermes UI).
-    if sys.platform == "win32":
-        try:
-            from hermes_cli._subprocess_compat import (
-                windows_hide_flags,
-            )  # type: ignore[import-not-found]
 
-            _no_window = {"creationflags": windows_hide_flags()}
-            if shutil.which("wmic"):
-                _kill_result = subprocess.run(
-                    [
-                        shutil.which("wmic"),
-                        "process",
-                        "where",
-                        "commandline like '%agent-browser%chrome%'",
-                        "delete",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="ignore",
-                    timeout=15,
-                    **_no_window,
-                )
-            else:
-                # wmic removed on modern Windows — fall back to PowerShell
-                ps_path = shutil.which("powershell") or shutil.which("pwsh")
-                if ps_path:
-                    _kill_result = subprocess.run(
-                        [
-                            ps_path,
-                            "-NoProfile",
-                            "-Command",
-                            "Get-CimInstance Win32_Process -Filter \"CommandLine like '%agent-browser%chrome%'\" | Remove-CimInstance",
-                        ],
-                        capture_output=True,
-                        text=True,
-                        encoding="utf-8",
-                        errors="ignore",
-                        timeout=15,
-                        **_no_window,
-                    )
-        except Exception:
-            pass  # best-effort cleanup; never crash the shutdown path
-
-    # Reset cached lookups so they are re-evaluated on next use.
     global _cached_agent_browser, _agent_browser_resolved
     global _cached_command_timeout, _command_timeout_resolved
     global _cached_chromium_installed

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4377,6 +4377,57 @@ def cleanup_all_browsers() -> None:
     except Exception:
         pass
 
+    # Windows: kill orphaned agent-browser host processes that survive
+    # per-session daemon cleanup.  agent-browser-win32-x64.exe is a
+    # persistent host binary that stays alive between sessions and
+    # accumulates over time, eventually causing WinError 1450
+    # ("Insufficient system resources") after many browser sessions.
+    # Only targets processes with "agent-browser" and "chrome" in their
+    # command line — never touches msedgewebview2.exe (Hermes UI).
+    if sys.platform == "win32":
+        try:
+            from hermes_cli._subprocess_compat import (
+                windows_hide_flags,
+            )  # type: ignore[import-not-found]
+
+            _no_window = {"creationflags": windows_hide_flags()}
+            if shutil.which("wmic"):
+                _kill_result = subprocess.run(
+                    [
+                        shutil.which("wmic"),
+                        "process",
+                        "where",
+                        "commandline like '%agent-browser%chrome%'",
+                        "delete",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="ignore",
+                    timeout=15,
+                    **_no_window,
+                )
+            else:
+                # wmic removed on modern Windows — fall back to PowerShell
+                ps_path = shutil.which("powershell") or shutil.which("pwsh")
+                if ps_path:
+                    _kill_result = subprocess.run(
+                        [
+                            ps_path,
+                            "-NoProfile",
+                            "-Command",
+                            "Get-CimInstance Win32_Process -Filter \"CommandLine like '%agent-browser%chrome%'\" | Remove-CimInstance",
+                        ],
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        errors="ignore",
+                        timeout=15,
+                        **_no_window,
+                    )
+        except Exception:
+            pass  # best-effort cleanup; never crash the shutdown path
+
     # Reset cached lookups so they are re-evaluated on next use.
     global _cached_agent_browser, _agent_browser_resolved
     global _cached_command_timeout, _command_timeout_resolved


### PR DESCRIPTION
## Summary

Fixes a Windows resource leak where a persistent `agent-browser-win32-x64.exe` host can survive normal browser-session cleanup and accumulate across sessions.

## Root cause

The per-session cleanup path removed the daemon recorded in the session PID file, but could leave a session-bound agent-browser host process alive. The original PR used a global WMIC/PowerShell process sweep, which could affect unrelated sessions or processes.

## Fix

- Removes the global WMIC/PowerShell cleanup sweep.
- Adds a Windows-only, best-effort host cleanup helper invoked from `_cleanup_single_browser_session()`, so it runs through normal `cleanup_browser(task_id)` and inactivity cleanup.
- A process is terminated only when all checks pass:
  1. Its name or command line identifies `agent-browser`.
  2. Its argv or `AGENT_BROWSER_SOCKET_DIR` environment value exactly matches the session socket directory being cleaned.
  3. `gateway.status.get_process_start_time(pid)` returns a canonical start token.
  4. The token is passed to `ProcessRegistry._terminate_host_pid(pid, expected_start=...)` for PID-reuse protection.
- Any unreadable metadata, inaccessible/vanished process, missing token, or cleanup error fails closed and does not interrupt browser cleanup.

## Scope

Windows-only. This PR intentionally does not globally kill `chrome.exe`, Edge, Hermes UI processes, unrelated Node processes, or another Hermes session's agent-browser host.

## Validation

```text
scripts/run_tests.sh tests/tools/test_browser_cleanup.py tests/tools/test_browser_orphan_reaper.py -q
39 passed, 0 failed

git diff --check
passed
```

Native Windows two-session smoke test:

- Created two real `agent-browser-win32-x64.exe` hosts with distinct `AGENT_BROWSER_SOCKET_DIR` bindings.
- Ran the real `cleanup_browser(task_id)` path for session A.
- Session A host count became zero.
- Session B host remained alive and bound to its own socket directory.

```text
ASSERT_A_ZERO=True
ASSERT_B_UNTOUCHED=True
```

## Related

This addresses the persistent host-process layer. Detached/reparented `chrome.exe` orphan cleanup is a related but separate issue.