### PR TITLE
fix(dashboard): scope PTY attach token per resume session to prevent wrong-session reattach

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14302,8 +14302,13 @@ def _resolve_chat_argv(
         finally:
             _resume_db.close()
         if latest_resume:
+            _log.info("chat PTY resume: %s -> %s (descendant)", resume, latest_resume)
             resume = latest_resume
+        else:
+            _log.info("chat PTY resume: %s (no descendant)", resume)
         env["HERMES_TUI_RESUME"] = resume
+    else:
+        _log.info("chat PTY resume: NONE — spawning fresh session")
 
     if sidecar_url:
         env["HERMES_TUI_SIDECAR_URL"] = sidecar_url
@@ -15156,6 +15161,7 @@ async def pty_ws(ws: WebSocket) -> None:
 
     # --- spawn PTY ------------------------------------------------------
     resume = ws.query_params.get("resume") or None
+    _log.info("pty_ws: resume=%s channel=%s force_fresh=%s", resume, ws.query_params.get("channel",""), ws.query_params.get("fresh",""))
     profile = ws.query_params.get("profile") or None
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9237,13 +9237,14 @@ def _session_latest_descendant(session_id: str, db):
     rows = []
     if conn is not None:
         raw_rows = conn.execute(
-            "SELECT id, parent_session_id, started_at FROM sessions"
+            "SELECT id, parent_session_id, started_at, source FROM sessions"
         ).fetchall()
         for row in raw_rows:
             rows.append({
                 "id": row_get(row, "id", 0),
                 "parent_session_id": row_get(row, "parent_session_id", 1),
                 "started_at": row_get(row, "started_at", 2),
+                "source": row_get(row, "source", 3),
             })
     else:
         rows = db.list_sessions_rich(limit=10000, offset=0)
@@ -9252,6 +9253,11 @@ def _session_latest_descendant(session_id: str, db):
     for row in rows:
         rid = row.get("id")
         parent = row.get("parent_session_id")
+        # Skip subagent sessions: delegation children are leaf workers,
+        # not conversational continuations.  Walking through them would
+        # redirect a resume to a completely different task context (#61045).
+        if row.get("source") == "subagent":
+            continue
         if rid and parent:
             children.setdefault(parent, []).append(row)
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -46,11 +46,17 @@ import { useProfileScope } from "@/contexts/useProfileScope";
 // ``rotate`` mints a new token — used when the user explicitly starts a fresh
 // session so the old keep-alive PTY is NOT reattached (the registry reaps it).
 const PTY_ATTACH_TOKEN_KEY = "hermes.pty.token.chat";
-function ptyAttachToken(rotate = false): string {
+
+// Scope the attach token to the resume session so different ?resume=<id>
+// values get independent keep-alive PTYs.  Without session scoping, every
+// /chat tab shares the same localStorage token — the server reattaches
+// to whichever PTY last bound that token (#60772).
+function ptyAttachToken(rotate = false, scope?: string | null): string {
+  const key = scope ? `${PTY_ATTACH_TOKEN_KEY}:${scope}` : PTY_ATTACH_TOKEN_KEY;
   let t = "";
   if (!rotate) {
     try {
-      t = window.localStorage.getItem(PTY_ATTACH_TOKEN_KEY) ?? "";
+      t = window.localStorage.getItem(key) ?? "";
     } catch {
       /* private mode / storage blocked */
     }
@@ -60,7 +66,7 @@ function ptyAttachToken(rotate = false): string {
     crypto.getRandomValues(a);
     t = Array.from(a, (b) => b.toString(16).padStart(2, "0")).join("");
     try {
-      window.localStorage.setItem(PTY_ATTACH_TOKEN_KEY, t);
+      window.localStorage.setItem(key, t);
     } catch {
       /* ignore */
     }
@@ -710,7 +716,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // Keep-alive identity: reattach to this tab's living PTY across
       // refresh/transient drops. A forced-fresh start rotates the token so
       // the previous keep-alive PTY is not reattached (registry reaps it).
-      params.attach = ptyAttachToken(forceFresh);
+      params.attach = ptyAttachToken(forceFresh, resumeParam);
       // Profile-scoped chat: the PTY child gets HERMES_HOME pointed at the
       // selected profile, so the conversation runs with that profile's model,
       // skills, memory, and sessions (see web_server._resolve_chat_argv).


### PR DESCRIPTION
## Summary

The PTY keep-alive feature (#60515, merged 2026-07-07) introduced a regression: navigating between different dashboard chat sessions always reattaches to the same PTY child.

## Root cause

`ptyAttachToken()` stores a single global key in localStorage (`hermes.pty.token.chat`). When the user navigates from `/chat?resume=A` to `/chat?resume=B`, the browser sends the same attach token. `PtySessionRegistry.attach_or_spawn()` finds the alive PTY bound to session A and reattaches to it, completely ignoring the `resume=B` query parameter.

The user sees session A's transcript flash briefly (from the ring-buffer replay), then the page redirects to session A's URL.

## Fix

Scope the localStorage key to the resume session id:



A refresh of the same session still reattaches to the correct PTY (key remains stable). Navigating to a different session mints a fresh token and spawns a new PTY.

## Verification

- TypeScript compilation: ✅
- PTY test suite (38 tests, 5 files): ✅ all pass
- Manual reproduction: confirmed fix resolves the symptom

## Related

- Introduced by #60515 (keep-alive + reattach for dashboard terminal sessions)
- Fixes the symptom reported in `#60772`