### PR TITLE
fix(agent): route Claude Sonnet through anthropic-codex provider

### DIFF
--- a/agent/tool_output_compressor.py
+++ b/agent/tool_output_compressor.py
@@ -1,0 +1,362 @@
+"""Headroom tool output compression.
+
+Compresses large tool outputs before they enter the conversation context.
+Uses Headroom's SmartCrusher directly (no proxy, no import overhead when
+disabled).  Works with any message format since it operates on the raw
+tool result string before formatting.
+
+Failure mode (prominent): this module is fail-open.  Any error — import
+failure, config error, compression exception — returns None and the
+original output passes through unchanged.  Compression is lossy by design
+(the heuristic text compressor truncates repetitive middle sections).
+
+Why hook inline in ``model_tools.py`` rather than via the existing
+``transform_tool_result`` plugin hook: the plugin hook runs for every tool
+call but is gated by ``has_hook()`` which requires plugin discovery overhead.
+The inline hook has a fast-path that returns before any import when
+``context.headroom.enabled`` is False (the default).  Built-in features
+that need zero-overhead disabled paths hook inline (see approval,
+edit-approval, observability context in the same function).
+
+Config: ``context.headroom`` in config.yaml
+
+    enabled: true/false            (default false)
+    exclude_tools: [tool, ...]     (never compress these)
+    min_chars: 2000                (skip below this length)
+    min_reduction_pct: 20          (skip if compression saves less)
+    max_output_chars: 8000         (hard cap on compressed output)
+    keep_head_lines: 10            (head lines preserved)
+    keep_tail_lines: 5             (tail lines preserved)
+
+Toggle: ``hermes config set context.headroom.enabled true|false``
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import hashlib
+import threading
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config cache — avoids calling load_config_readonly() on every tool call
+# ---------------------------------------------------------------------------
+_config_cache: tuple[float, dict] | None = None
+_CONFIG_TTL = 5.0  # seconds
+
+
+def _config() -> dict:
+    """Read headroom config with safe defaults and TTL-based caching."""
+    global _config_cache
+    now = time.monotonic()
+    if _config_cache and now - _config_cache[0] < _CONFIG_TTL:
+        return _config_cache[1]
+    try:
+        from hermes_cli.config import load_config_readonly
+        raw = load_config_readonly()
+        cfg = raw.get("context", {}).get("headroom", {}) or {}
+    except Exception:
+        cfg = {}
+    _config_cache = (now, cfg)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# SmartCrusher singleton with failed-init sentinel
+# ---------------------------------------------------------------------------
+# Tri-state: None (untried), False (init failed — never retry), or instance
+_crusher = None  # type: ignore[assignment]
+_crusher_lock = threading.Lock()
+
+
+def _get_crusher():
+    """Lazy-init SmartCrusher.  Returns None if headroom-ai not installed."""
+    global _crusher
+    if _crusher is not None:  # True = instance, False = failed sentinel
+        return _crusher if _crusher is not False else None
+    with _crusher_lock:
+        if _crusher is None:
+            try:
+                from headroom import SmartCrusher
+                _crusher = SmartCrusher()
+            except ImportError:
+                _crusher = False  # sentinel: don't retry
+            except Exception as e:
+                logger.debug("Headroom SmartCrusher init failed: %s", e)
+                _crusher = False  # sentinel: don't retry
+    return _crusher if _crusher is not False else None
+
+
+# ---------------------------------------------------------------------------
+# Compression cache — stores originals for future retrieval
+# ---------------------------------------------------------------------------
+_cache: dict[str, str] = {}
+_cache_lock = threading.Lock()
+_CACHE_MAX = 50  # max cached originals per process (FIFO eviction)
+
+
+def compress_tool_result(
+    tool_name: str,
+    result: str,
+    *,
+    config: dict | None = None,
+) -> Optional[str]:
+    """Compress a tool result using Headroom's SmartCrusher.
+
+    Returns the compressed version with a retrieval marker, or None if the
+    original should pass through unchanged.
+
+    Args:
+        tool_name: Tool being called (for exclusion list + logging).
+        result: Raw tool output string.
+        config: Optional config dict (bypasses config read for testing).
+                When None, reads from ``context.headroom`` in config.yaml.
+    """
+    cfg = config or _config()
+    if not cfg.get("enabled", False):
+        return None
+
+    # Env-var escape hatch for CI / debugging
+    if __import__("os").environ.get("HERMES_COMPRESS_DISABLE") == "1":
+        return None
+
+    # Tool exclusion list
+    if tool_name in cfg.get("exclude_tools", []):
+        return None
+
+    # Length gate
+    if len(result) <= cfg.get("min_chars", 2000):
+        return None
+
+    min_reduction = cfg.get("min_reduction_pct", 20)
+
+    # Try SmartCrusher first (excellent for JSON/structured data)
+    # Note: SmartCrusher may be unavailable (headroom-ai not installed) —
+    # heuristic fallback always runs regardless.
+    crusher = _get_crusher()
+    if crusher is not None:
+        try:
+            cr = crusher.crush(result)
+            compressed = cr.compressed
+            if cr.was_modified and len(result) > 0 and len(compressed) > 0:
+                reduction = (1 - len(compressed) / len(result)) * 100
+                if reduction >= min_reduction:
+                    return _build_output(result, compressed, reduction, "smartcrusher")
+        except Exception as e:
+            logger.debug("Headroom SmartCrusher failed for %s: %s", tool_name, e)
+
+    # Fallback: heuristic text compressor for code/plain text
+    # SmartCrusher handles JSON; this handles the rest.
+    # Always runs — doesn't depend on headroom-ai being installed.
+    try:
+        text_compressed = _heuristic_compress(result, cfg)
+        if text_compressed is not None:
+            reduction = (1 - len(text_compressed) / len(result)) * 100
+            if reduction >= min_reduction:
+                return _build_output(result, text_compressed, reduction, "heuristic")
+    except Exception as e:
+        logger.debug("Headroom text compression failed for %s: %s", tool_name, e)
+
+    return None
+
+
+def _heuristic_compress(text: str, cfg: dict) -> Optional[str]:
+    """Heuristic text compressor for code/plain text that SmartCrusher skips.
+
+    Strategy:
+    - Detect line-structured content (code, logs, listings)
+    - Keep first N lines (header/context)
+    - Keep last N lines (trailer/context)
+    - Preserve error-like lines (Traceback, Error, Exception, etc.)
+    - Replace middle with a summary of unique line patterns
+    """
+    lines = text.split("\n")
+    if len(lines) < 50:
+        return None
+
+    max_output = cfg.get("max_output_chars", 8000)
+    keep_head = cfg.get("keep_head_lines", 10)
+    keep_tail = cfg.get("keep_tail_lines", 5)
+
+    # Strip blank lines (they cost tokens but add no info)
+    non_blank = [l for l in lines if l.strip()]
+    if len(non_blank) < 50:
+        return None
+
+    # Detect repetitive/sequential patterns (e.g. file listings, numbered output)
+    patterns = _detect_repetition(non_blank)
+    if patterns is not None:
+        return _collapse_repetition(lines, patterns, keep_head, keep_tail, max_output)
+
+    # General truncation: keep head + tail, summarize middle
+    if len(lines) > 200:
+        return _truncate_middle(lines, keep_head, keep_tail, max_output)
+
+    return None
+
+
+# Lines matching this are preserved even if they fall in the truncated middle.
+# Prevents silent loss of stack traces, error messages, etc.
+_ERROR_LINE_RE = re.compile(
+    r"Traceback|Error|Exception|FAIL|panic|FATAL|CRITICAL|assertion failed|assert\s",
+    re.IGNORECASE,
+)
+
+
+def _detect_repetition(lines: list[str]) -> Optional[dict]:
+    """Detect if lines follow a repetitive pattern."""
+    if len(lines) < 10:
+        return None
+
+    # Count lines that match a simple sequential pattern (e.g. "  N|something")
+    numbered_re = re.compile(r"^\s*\d+\|")
+    numbered_count = sum(1 for l in lines[:min(50, len(lines))] if numbered_re.match(l))
+    if numbered_count > 0.7 * min(50, len(lines)):
+        return {"type": "numbered"}
+
+    # Count lines that are structurally similar (same prefix)
+    if len(lines) < 20:
+        return None
+    prefixes = set()
+    for l in lines[:20]:
+        prefixes.add(l[:30].rstrip())
+    if len(prefixes) < 5:
+        return {"type": "uniform"}
+
+    return None
+
+
+def _collapse_repetition(lines: list[str], patterns: dict, keep_head: int, keep_tail: int,
+                         max_output: int) -> Optional[str]:
+    """Collapse repetitive content into a compact representation."""
+    summary_lines = list(lines[:keep_head])
+    skipped = len(lines) - keep_head - keep_tail
+    summary_lines.append(f" ... {skipped} similar lines omitted ...")
+    summary_lines.extend(lines[-keep_tail:])
+    result = "\n".join(summary_lines)
+    if len(result) < max_output and len(result) < len("\n".join(lines)):
+        return result
+    return None
+
+
+def _truncate_middle(lines: list[str], keep_head: int, keep_tail: int,
+                     max_output: int) -> Optional[str]:
+    """Keep head + tail lines, replace middle with summary.
+
+    Preserves error-like lines (Traceback, Error, Exception, etc.) even
+    when they fall in the truncated middle region, plus 1 line of context
+    before each error line.
+    """
+    if len(lines) < 200:
+        return None
+
+    middle_start = keep_head
+    middle_end = len(lines) - keep_tail
+    middle = lines[middle_start:middle_end]
+
+    # Find error-like lines in the middle
+    error_indices: list[int] = []
+    for i, line in enumerate(middle):
+        if _ERROR_LINE_RE.search(line):
+            error_indices.append(i)
+
+    # Collect unique non-error lines for the summary
+    unique_patterns: set[str] = set()
+    for l in middle[:500]:  # sample first 500
+        if not _ERROR_LINE_RE.search(l):
+            unique_patterns.add(l.strip())
+
+    summary_lines = list(lines[:keep_head])
+    skipped = len(lines) - keep_head - keep_tail
+    skipped_bytes = sum(len(l) + 1 for l in middle)  # +1 for newline
+
+    if error_indices:
+        # Include error lines with context in the compressed output
+        summary_lines.append(
+            f" ... {skipped} lines / {skipped_bytes} bytes omitted "
+            f"({len(unique_patterns)} unique patterns, "
+            f"{len(error_indices)} error lines preserved) ..."
+        )
+        # Add error lines with 1 line of preceding context
+        prev_error_end = 0
+        for idx in error_indices:
+            # Add context line before error
+            ctx_start = max(prev_error_end, idx - 1)
+            for ci in range(ctx_start, idx + 1):
+                if ci < len(middle):
+                    summary_lines.append(middle[ci])
+            prev_error_end = idx + 1
+    else:
+        summary_lines.append(
+            f" ... {skipped} lines / {skipped_bytes} bytes omitted "
+            f"({len(unique_patterns)} unique patterns) ..."
+        )
+
+    summary_lines.extend(lines[-keep_tail:])
+    result = "\n".join(summary_lines)
+    if len(result) < max_output and len(result) < len("\n".join(lines)):
+        return result
+    return None
+
+
+def _build_output(
+    original: str,
+    compressed: str,
+    reduction: float,
+    strategy: str,
+) -> str:
+    """Build the final compressed output with cache marker."""
+    h = hashlib.md5(
+        original.encode("utf-8", errors="replace"),
+        usedforsecurity=False,
+    ).hexdigest()[:12]
+
+    with _cache_lock:
+        # FIFO eviction (dict preserves insertion order in Python 3.7+)
+        if len(_cache) >= _CACHE_MAX:
+            oldest_key = next(iter(_cache))
+            del _cache[oldest_key]
+        _cache[h] = original
+
+    out = (
+        f"[COMPRESSED by headroom ({strategy}): {reduction:.0f}% saved, "
+        f"{len(original):,}→{len(compressed):,} chars]\n"
+        f"{compressed}\n"
+        f"[Full output cached: hash={h}]"
+    )
+
+    logger.debug(
+        "Headroom: compressed %s→%s chars (%.0f%% saved, strategy=%s, hash=%s)",
+        len(original), len(compressed), reduction, strategy, h,
+    )
+    return out
+
+
+def retrieve_cached(h: str) -> Optional[str]:
+    """Retrieve an original tool result from the compression cache."""
+    with _cache_lock:
+        return _cache.get(h)
+
+
+def cache_stats() -> dict:
+    """Return cache statistics."""
+    with _cache_lock:
+        return {"cached_items": len(_cache), "max_cache_size": _CACHE_MAX}
+
+
+def clear_cache():
+    """Clear the compression cache."""
+    with _cache_lock:
+        _cache.clear()
+
+
+def _reset_state():
+    """Reset all module-level state.  For tests."""
+    global _config_cache, _crusher
+    _config_cache = None
+    _crusher = None
+    clear_cache()

--- a/agent/tool_output_compressor.py
+++ b/agent/tool_output_compressor.py
@@ -33,9 +33,12 @@ Toggle: ``hermes config set context.headroom.enabled true|false``
 
 from __future__ import annotations
 
+from collections import OrderedDict
+
 import logging
 import re
 import hashlib
+import json
 import threading
 import time
 from typing import Optional
@@ -93,10 +96,17 @@ def _get_crusher():
 
 # ---------------------------------------------------------------------------
 # Compression cache — stores originals for future retrieval
+# Uses OrderedDict for LRU eviction (most recently retrieved stays)
 # ---------------------------------------------------------------------------
-_cache: dict[str, str] = {}
+_cache: OrderedDict[str, str] = OrderedDict()
 _cache_lock = threading.Lock()
-_CACHE_MAX = 50  # max cached originals per process (FIFO eviction)
+_CACHE_MAX_DEFAULT = 5000  # fallback when config doesn't specify
+
+
+def _cache_max(cfg: dict | None = None) -> int:
+    """Get cache size from config, with sensible default."""
+    c = cfg or _config()
+    return c.get("cache_max", _CACHE_MAX_DEFAULT)
 
 
 def compress_tool_result(
@@ -118,6 +128,11 @@ def compress_tool_result(
     """
     cfg = config or _config()
     if not cfg.get("enabled", False):
+        return None
+
+    # Never compress headroom_retrieve output — would create recursive
+    # compression and burn cache slots for already-compressed markers.
+    if tool_name == "headroom_retrieve":
         return None
 
     # Env-var escape hatch for CI / debugging
@@ -316,36 +331,86 @@ def _build_output(
     ).hexdigest()[:12]
 
     with _cache_lock:
-        # FIFO eviction (dict preserves insertion order in Python 3.7+)
-        if len(_cache) >= _CACHE_MAX:
-            oldest_key = next(iter(_cache))
-            del _cache[oldest_key]
-        _cache[h] = original
+        # LRU eviction: move to end on access, evict from front
+        max_size = _cache_max()
+        if h in _cache:
+            # Already cached — move to end (most recently used)
+            _cache.move_to_end(h)
+        else:
+            if len(_cache) >= max_size:
+                _cache.popitem(last=False)  # evict oldest (least recently used)
+            _cache[h] = original
 
-    out = (
-        f"[COMPRESSED by headroom ({strategy}): {reduction:.0f}% saved, "
-        f"{len(original):,}→{len(compressed):,} chars]\n"
-        f"{compressed}\n"
-        f"[Full output cached: hash={h}]"
+    # Build output with the compressed content.
+    # For SmartCrusher, the compressed output is a CCR marker (no readable content),
+    # so we also include a preview of the original's first lines.
+    # For heuristic compression, the compressed output already IS a readable summary.
+    parts = [compressed]
+
+    # SmartCrusher produces CCR markers in some fields — add a preview only
+    # when the compressed output has lost the actual content (e.g. terminal
+    # tool {"output":"<<ccr:...>>"}, read_file {"content":"<<ccr:...>>"}).
+    # For tool outputs where SmartCrusher already preserved representative
+    # data (search_files arrays with file paths), skipping the preview avoids
+    # duplicate rendering.
+    if strategy == "smartcrusher":
+        raw_preview = None
+        try:
+            comp_parsed = json.loads(compressed)
+            if isinstance(comp_parsed, dict):
+                # Find any string field that was replaced with a CCR marker.
+                # Those are the fields where the original content was lost.
+                for key, val in comp_parsed.items():
+                    if isinstance(val, str) and "<<ccr:" in val:
+                        orig_parsed = json.loads(original)
+                        if isinstance(orig_parsed, dict):
+                            raw_preview = orig_parsed.get(key, "")
+                            break
+            elif isinstance(comp_parsed, str):
+                raw_preview = original
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        if raw_preview is not None and raw_preview:
+            content_lines = raw_preview.split("\n")
+            preview = "\n".join(content_lines[:15])
+            if len(content_lines) > 15:
+                preview += f"\n... ({len(content_lines) - 15} more lines)"
+            parts.append(preview)
+
+    parts.append(f"[Full output cached: hash={h}]")
+
+    # Build the header LAST so the savings figure reflects the actual total
+    # delivered size (compressed JSON + preview + markers), not just the
+    # SmartCrusher payload.
+    out_parts = "\n".join(parts)
+    actual_reduction = (1 - len(out_parts) / len(original)) * 100
+    header = (
+        f"[COMPRESSED by headroom ({strategy}): {actual_reduction:.0f}% saved, "
+        f"{len(original):,}→{len(out_parts):,} chars]"
     )
+    out = f"{header}\n{out_parts}"
 
     logger.debug(
         "Headroom: compressed %s→%s chars (%.0f%% saved, strategy=%s, hash=%s)",
-        len(original), len(compressed), reduction, strategy, h,
+        len(original), len(out_parts), actual_reduction, strategy, h,
     )
     return out
 
 
 def retrieve_cached(h: str) -> Optional[str]:
-    """Retrieve an original tool result from the compression cache."""
+    """Retrieve an original tool result from the compression cache.
+    Promotes the item to most-recently-used to prevent eviction."""
     with _cache_lock:
+        if h in _cache:
+            _cache.move_to_end(h)  # promote to MRU
         return _cache.get(h)
 
 
 def cache_stats() -> dict:
     """Return cache statistics."""
     with _cache_lock:
-        return {"cached_items": len(_cache), "max_cache_size": _CACHE_MAX}
+        return {"cached_items": len(_cache), "max_cache_size": _cache_max()}
 
 
 def clear_cache():

--- a/model_tools.py
+++ b/model_tools.py
@@ -1291,6 +1291,18 @@ def handle_function_call(
                     pass
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
 
+        # Headroom: compress large tool outputs before they enter context.
+        # Runs after dispatch, before post_tool_call hook and transform hook.
+        # Fail-open: any error passes the original result through.
+        try:
+            if isinstance(result, str):
+                from agent.tool_output_compressor import compress_tool_result
+                compressed = compress_tool_result(function_name, result)
+                if compressed is not None:
+                    result = compressed
+        except Exception as _cr_err:
+            logger.debug("Headroom compressor error: %s", _cr_err)
+
         _emit_post_tool_call_hook(
             function_name=function_name,
             function_args=function_args,

--- a/tests/agent/test_tool_output_compressor.py
+++ b/tests/agent/test_tool_output_compressor.py
@@ -1,0 +1,467 @@
+"""Tests for agent/tool_output_compressor.py.
+
+Covers:
+- Compression disabled by default (config)
+- headroom-ai absent (pass-through)
+- SmartCrusher exception → pass-through
+- JSON compression via SmartCrusher
+- Heuristic text compression (repetition, truncation)
+- Error-line preservation in truncation
+- Small output pass-through
+- Cache operations
+- Config cache TTL
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import agent.tool_output_compressor as comp
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Reset module state before and after each test."""
+    comp._reset_state()
+    yield
+    comp._reset_state()
+
+
+# ---------------------------------------------------------------------------
+# Config gating
+# ---------------------------------------------------------------------------
+
+def test_disabled_by_default():
+    """Compression is off unless context.headroom.enabled is True."""
+    result = comp.compress_tool_result("dummy", "x" * 5000)
+    assert result is None
+
+
+def test_enabled_compresses_when_configured():
+    """With config, compress_tool_result attempts compression."""
+    cfg = {"enabled": True, "min_chars": 100}
+    # Build output that will trigger heuristic (>200 lines)
+    text = "\n".join([f"line {i}: some content here" for i in range(250)])
+    result = comp.compress_tool_result("test_tool", text, config=cfg)
+    # Should be compressed (heuristic truncation)
+    assert result is not None
+    assert "COMPRESSED" in result
+    assert len(result) < len(text)
+
+
+def test_env_var_disable():
+    """HERMES_COMPRESS_DISABLE=1 bypasses compression."""
+    import os
+    old = os.environ.get("HERMES_COMPRESS_DISABLE")
+    os.environ["HERMES_COMPRESS_DISABLE"] = "1"
+    try:
+        comp._config_cache = None  # force re-read
+        result = comp.compress_tool_result(
+            "test_tool",
+            "\n".join([f"  {i}|def h_{i}(): pass" for i in range(500)]),
+        )
+        assert result is None  # disabled by env var
+    finally:
+        if old is None:
+            os.environ.pop("HERMES_COMPRESS_DISABLE", None)
+        else:
+            os.environ["HERMES_COMPRESS_DISABLE"] = old
+
+
+# ---------------------------------------------------------------------------
+# headroom-ai absent
+# ---------------------------------------------------------------------------
+
+def test_headroom_absent_pass_through():
+    """When SmartCrusher import fails, SmartCrusher path is skipped."""
+    with patch.object(comp, "_get_crusher", return_value=None):
+        result = comp.compress_tool_result(
+            "search_files",
+            json.dumps([{"a": i} for i in range(100)]),
+            config={"enabled": True, "min_chars": 0},
+        )
+        assert result is None
+
+
+def test_crusher_init_failed_sentinel():
+    """Failed SmartCrusher init sets sentinel so we don't retry import."""
+    import builtins
+    real_import = builtins.__import__
+    headroom_imports = 0
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        nonlocal headroom_imports
+        if name == "headroom":
+            headroom_imports += 1
+            raise ImportError("no headroom")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        for _ in range(5):
+            comp.compress_tool_result(
+                "x",
+                "x" * 3000,
+                config={"enabled": True, "min_chars": 0},
+            )
+    assert headroom_imports == 1
+    assert comp._crusher is False
+
+
+# ---------------------------------------------------------------------------
+# SmartCrusher compression
+# ---------------------------------------------------------------------------
+
+def test_json_compression():
+    """SmartCrusher compresses JSON data."""
+    data = json.dumps([{"file": f"mod_{i}.py", "line": i * 10, "match": f"def f_{i}()"} for i in range(200)], indent=2)
+
+    # Mock SmartCrusher
+    crushed = data.replace("    ", "")  # simulate whitespace removal
+    mock_cr = MagicMock()
+    mock_cr.compressed = crushed
+    mock_cr.was_modified = True
+
+    mock_crusher = MagicMock()
+    mock_crusher.crush.return_value = mock_cr
+
+    with patch.object(comp, "_get_crusher", return_value=mock_crusher):
+        result = comp.compress_tool_result(
+            "search_files",
+            data,
+            config={"enabled": True, "min_chars": 0, "min_reduction_pct": 5},
+        )
+
+    assert result is not None
+    assert "COMPRESSED" in result
+    assert "smartcrusher" in result
+    assert "smartcrusher" in result.lower()
+
+
+def test_smartcrusher_exception_pass_through():
+    """Exception in SmartCrusher.crush() → fall through to heuristic."""
+    mock_crusher = MagicMock()
+    mock_crusher.crush.side_effect = RuntimeError("crush error")
+
+    # Build output that will trigger heuristic
+    text = "\n".join([f"  {i}|def h_{i}(): pass" for i in range(500)])
+
+    with patch.object(comp, "_get_crusher", return_value=mock_crusher):
+        result = comp.compress_tool_result(
+            "file_read",
+            text,
+            config={"enabled": True, "min_chars": 0, "min_reduction_pct": 10},
+        )
+
+    # Should fall through to heuristic and succeed
+    assert result is not None
+    assert "COMPRESSED" in result
+
+
+# ---------------------------------------------------------------------------
+# Heuristic text compression
+# ---------------------------------------------------------------------------
+
+def test_heuristic_numbered_lines():
+    """Numbered lines (N|pattern) are detected and collapsed."""
+    lines = [f"  {i}|def handler_{i}(): pass" for i in range(500)]
+    text = "\n".join(lines)
+
+    # Ensure SmartCrusher returns None (was_modified=False)
+    mock_cr = MagicMock()
+    mock_cr.was_modified = False
+    mock_crusher = MagicMock()
+    mock_crusher.crush.return_value = mock_cr
+
+    with patch.object(comp, "_get_crusher", return_value=mock_crusher):
+        result = comp.compress_tool_result(
+            "file_read",
+            text,
+            config={"enabled": True, "min_chars": 0, "min_reduction_pct": 10},
+        )
+
+    assert result is not None
+    assert "COMPRESSED" in result
+    assert "heuristic" in result
+    # Should have collapsed most lines
+    assert len(result) < len(text) * 0.1  # at most 10% of original
+
+
+def test_heuristic_uniform_prefix():
+    """Uniform prefix lines are detected and collapsed."""
+    # Ensure the first 30 chars are identical across all lines
+    lines = [f"INFO  Processing item: status OK  padding_{i}" for i in range(200)]
+    text = "\n".join(lines)
+
+    mock_cr = MagicMock()
+    mock_cr.was_modified = False
+    mock_crusher = MagicMock()
+    mock_crusher.crush.return_value = mock_cr
+
+    with patch.object(comp, "_get_crusher", return_value=mock_crusher):
+        result = comp.compress_tool_result(
+            "execute_code",
+            text,
+            config={"enabled": True, "min_chars": 0, "min_reduction_pct": 10},
+        )
+
+    assert result is not None
+    assert "similar lines omitted" in result
+
+
+def test_heuristic_truncation_diverse_lines():
+    """Diverse lines with >200 lines get head+tail truncation."""
+    lines = []
+    for i in range(300):
+        lines.append(f"def unique_function_{i}(arg_a, arg_b):")
+        lines.append(f"    # Implementation for function {i}")
+        lines.append(f"    return compute({i}, arg_a) + process(arg_b)")
+        lines.append("")
+    text = "\n".join(lines)
+
+    mock_cr = MagicMock()
+    mock_cr.was_modified = False
+    mock_crusher = MagicMock()
+    mock_crusher.crush.return_value = mock_cr
+
+    with patch.object(comp, "_get_crusher", return_value=mock_crusher):
+        result = comp.compress_tool_result(
+            "web_extract",
+            text,
+            config={"enabled": True, "min_chars": 0, "min_reduction_pct": 10},
+        )
+
+    assert result is not None
+    assert "unique patterns" in result
+
+
+# ---------------------------------------------------------------------------
+# Error-line preservation
+# ---------------------------------------------------------------------------
+
+def test_error_lines_preserved_in_truncation():
+    """Error lines in the middle are preserved even during truncation."""
+    lines = []
+    for i in range(250):
+        if i == 125:
+            lines.append("Traceback (most recent call last):")
+            lines.append('  File "app.py", line 42, in main')
+            lines.append("    ValueError: something went wrong")
+        else:
+            lines.append(f"Normal log line {i}")
+    text = "\n".join(lines)
+
+    mock_cr = MagicMock()
+    mock_cr.was_modified = False
+    mock_crusher = MagicMock()
+    mock_crusher.crush.return_value = mock_cr
+
+    with patch.object(comp, "_get_crusher", return_value=mock_crusher):
+        result = comp.compress_tool_result(
+            "execute_code",
+            text,
+            config={"enabled": True, "min_chars": 0, "min_reduction_pct": 10},
+        )
+
+    assert result is not None
+    # Traceback should be preserved
+    assert "Traceback" in result
+    # Error line preservation marker
+    assert "error lines preserved" in result
+
+
+# ---------------------------------------------------------------------------
+# Pass-through cases
+# ---------------------------------------------------------------------------
+
+def test_small_output_passed_through():
+    """Small outputs skip compression entirely."""
+    result = comp.compress_tool_result(
+        "file_read",
+        "Small content",
+        config={"enabled": True, "min_chars": 2000},
+    )
+    assert result is None
+
+
+def test_below_reduction_threshold_passed_through():
+    """If compression saves less than min_reduction_pct, pass through."""
+    # SmartCrusher that barely compresses
+    mock_cr = MagicMock()
+    mock_cr.compressed = "x" * 990  # 1% reduction on 1000 chars
+    mock_cr.was_modified = True
+
+    mock_crusher = MagicMock()
+    mock_crusher.crush.return_value = mock_cr
+
+    text = "x" * 1000
+    with patch.object(comp, "_get_crusher", return_value=mock_crusher):
+        result = comp.compress_tool_result(
+            "test",
+            text,
+            config={"enabled": True, "min_chars": 0, "min_reduction_pct": 20},
+        )
+
+    assert result is None
+
+
+def test_tool_exclusion():
+    """Excluded tools skip compression."""
+    result = comp.compress_tool_result(
+        "memory_search",
+        "x" * 5000,
+        config={"enabled": True, "exclude_tools": ["memory_search"]},
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Cache operations
+# ---------------------------------------------------------------------------
+
+def test_cache_populated_after_compression():
+    """Compressed results store originals in cache."""
+    comp.clear_cache()
+    text = "\n".join([f"  {i}|def h_{i}(): pass" for i in range(500)])
+
+    mock_cr = MagicMock()
+    mock_cr.was_modified = False
+    mock_crusher = MagicMock()
+    mock_crusher.crush.return_value = mock_cr
+
+    with patch.object(comp, "_get_crusher", return_value=mock_crusher):
+        result = comp.compress_tool_result(
+            "file_read",
+            text,
+            config={"enabled": True, "min_chars": 0, "min_reduction_pct": 10},
+        )
+
+    assert result is not None
+    # Extract hash from result
+    assert "hash=" in result
+    stats = comp.cache_stats()
+    assert stats["cached_items"] >= 1
+
+
+def test_cache_fifo_eviction():
+    """_build_output evicts oldest entry (FIFO) when cache is full."""
+    comp.clear_cache()
+    # Pre-fill cache to max
+    with comp._cache_lock:
+        for i in range(50):
+            comp._cache[f"h{i:03d}"] = f"original {i}"
+
+    # Now _build_output should evict h000 (FIFO)
+    out = comp._build_output("new original", "compressed", 50.0, "test")
+    assert "h000" not in comp._cache
+    # New hash should be present in the output
+    assert "hash=" in out
+
+
+def test_retrieve_cached():
+    """retrieve_cached returns the stored original."""
+    comp.clear_cache()
+    with comp._cache_lock:
+        comp._cache["abc123"] = "original content"
+
+    result = comp.retrieve_cached("abc123")
+    assert result == "original content"
+
+    assert comp.retrieve_cached("nonexistent") is None
+
+
+def test_clear_cache():
+    """clear_cache empties the cache."""
+    with comp._cache_lock:
+        comp._cache["test"] = "data"
+    comp.clear_cache()
+    assert len(comp._cache) == 0
+
+
+# ---------------------------------------------------------------------------
+# Config caching
+# ---------------------------------------------------------------------------
+
+def test_config_cache_ttl():
+    """Config is cached for _CONFIG_TTL seconds."""
+    comp._config_cache = None
+
+    call_count = 0
+
+    def mock_load():
+        nonlocal call_count
+        call_count += 1
+        return {"context": {"headroom": {"enabled": True}}}
+
+    with patch("hermes_cli.config.load_config_readonly", mock_load):
+        # First call: loads config
+        comp._config()
+        assert call_count == 1
+
+        # Second call within TTL: uses cache
+        comp._config()
+        assert call_count == 1  # no additional load
+
+        # Expire TTL
+        comp._config_cache = (-999.0, {"enabled": True})
+        comp._config()
+        assert call_count == 2  # reload after TTL expired
+
+
+def test_config_read_error_returns_empty():
+    """If config read fails, empty dict is returned (fail-open)."""
+    comp._config_cache = None
+    with patch("hermes_cli.config.load_config_readonly", side_effect=RuntimeError("config error")):
+        cfg = comp._config()
+        assert cfg == {}
+
+
+# ---------------------------------------------------------------------------
+# _reset_state
+# ---------------------------------------------------------------------------
+
+def test_reset_state_clears_everything():
+    """_reset_state clears cache, config cache, and crusher."""
+    comp._config_cache = (0, {"enabled": True})
+    comp._crusher = "fake_instance"
+    with comp._cache_lock:
+        comp._cache["test"] = "data"
+
+    comp._reset_state()
+
+    assert comp._config_cache is None
+    assert comp._crusher is None
+    assert len(comp._cache) == 0
+
+
+# ---------------------------------------------------------------------------
+# Build output format
+# ---------------------------------------------------------------------------
+
+def test_output_format():
+    """Compressed output contains expected markers."""
+    out = comp._build_output("original" * 100, "compressed", 50.0, "smartcrusher")
+    assert "COMPRESSED by headroom" in out
+    assert "smartcrusher" in out
+    assert "50% saved" in out
+    assert "hash=" in out
+    assert "compressed" in out
+
+
+def test_md5_usedforsecurity_false():
+    """_build_output() uses usedforsecurity=False for FIPS compatibility."""
+    import hashlib
+    real_md5 = hashlib.md5
+    seen_kwargs = {}
+
+    def wrapped(*args, **kwargs):
+        nonlocal seen_kwargs
+        seen_kwargs = dict(kwargs)
+        return real_md5(*args, **kwargs)
+
+    with patch.object(hashlib, "md5", side_effect=wrapped):
+        comp._build_output("original" * 10, "compressed", 50.0, "smartcrusher")
+    assert seen_kwargs.get("usedforsecurity") is False

--- a/tests/agent/test_tool_output_compressor.py
+++ b/tests/agent/test_tool_output_compressor.py
@@ -349,15 +349,16 @@ def test_cache_populated_after_compression():
 def test_cache_fifo_eviction():
     """_build_output evicts oldest entry (FIFO) when cache is full."""
     comp.clear_cache()
+    max_size = comp._CACHE_MAX_DEFAULT
     # Pre-fill cache to max
     with comp._cache_lock:
-        for i in range(50):
-            comp._cache[f"h{i:03d}"] = f"original {i}"
+        for i in range(max_size):
+            comp._cache[f"h{i:05d}"] = f"original {i}"
 
-    # Now _build_output should evict h000 (FIFO)
+    # Now _build_output should evict the oldest entry (FIFO)
+    oldest_key = f"h00000"
     out = comp._build_output("new original", "compressed", 50.0, "test")
-    assert "h000" not in comp._cache
-    # New hash should be present in the output
+    assert oldest_key not in comp._cache
     assert "hash=" in out
 
 
@@ -446,9 +447,34 @@ def test_output_format():
     out = comp._build_output("original" * 100, "compressed", 50.0, "smartcrusher")
     assert "COMPRESSED by headroom" in out
     assert "smartcrusher" in out
-    assert "50% saved" in out
+    # actual reduction is computed from final output size, not the passed argument
+    assert "% saved" in out
     assert "hash=" in out
-    assert "compressed" in out
+
+
+def test_output_format_with_ccr_preview():
+    """Preview is added when compressed output contains a CCR marker."""
+    import json
+    # Simulate terminal tool: original has "output" key with multiline text,
+    # compressed has the output replaced with a CCR token.
+    original = json.dumps({"output": "\n".join(f"line {i}" for i in range(20)), "exit_code": 0})
+    compressed = json.dumps({"output": "<<ccr:abc123,string,1KB>>", "exit_code": 0})
+    out = comp._build_output(original, compressed, 50.0, "smartcrusher")
+    assert "COMPRESSED by headroom" in out
+    assert "line 0" in out  # preview contains first lines of original
+    assert "(5 more lines)" in out  # ellipsis for truncated lines
+    assert "hash=" in out
+
+
+def test_output_format_no_duplicate_preview():
+    """No preview added when compressed output has no CCR markers (search_files)."""
+    import json
+    original = json.dumps({"total_count": 50, "files": [f"/path/f{i}.py" for i in range(50)]})
+    compressed = json.dumps({"total_count": 50, "files": [f"/path/f{i}.py" for i in range(16)]})
+    out = comp._build_output(original, compressed, 50.0, "smartcrusher")
+    # Should NOT have a preview — no CCR markers in compressed output
+    assert out.count("f0.py") == 1  # only in the compressed JSON, not duplicated
+    assert "hash=" in out
 
 
 def test_md5_usedforsecurity_false():
@@ -465,3 +491,103 @@ def test_md5_usedforsecurity_false():
     with patch.object(hashlib, "md5", side_effect=wrapped):
         comp._build_output("original" * 10, "compressed", 50.0, "smartcrusher")
     assert seen_kwargs.get("usedforsecurity") is False
+
+
+def test_headroom_retrieve_excluded_from_compression():
+    """headroom_retrieve output is never compressed (prevents recursive compression)."""
+    import json
+    # Even large retrieve output passes through
+    result = comp.compress_tool_result(
+        "headroom_retrieve",
+        json.dumps({"content": "x" * 10000, "found": True}),
+        config={"enabled": True, "min_chars": 0},
+    )
+    assert result is None
+
+
+def test_lru_promotion_on_retrieval():
+    """Retrieving a cached item moves it to most-recently-used (stays longer)."""
+    comp.clear_cache()
+    max_size = comp._CACHE_MAX_DEFAULT
+    # Fill cache
+    with comp._cache_lock:
+        for i in range(max_size):
+            comp._cache[f"h{i:05d}"] = f"original {i}"
+
+    # Retrieve oldest item — should promote to end (most recently used)
+    comp.retrieve_cached("h00000")
+
+    # Insert one more item (triggers eviction of LRU)
+    out = comp._build_output("new", "compressed", 50.0, "test")
+    # h00000 was promoted, so it should NOT be evicted
+    assert "h00000" in comp._cache
+    # h00001 should be evicted (it's the actual LRU now)
+    assert "h00001" not in comp._cache
+
+
+# ---------------------------------------------------------------------------
+# Integration: simulates multi-turn agent workflow
+# ---------------------------------------------------------------------------
+
+def test_multi_turn_cache_survives_retrieval():
+    """Simulate: turn 1 compresses tool output, turn 2 retrieves it.
+
+    This is the actual failure mode the agent hits — hashes from previous
+    turns are evicted before retrieval.
+    """
+    comp.clear_cache()
+    comp._config_cache = None
+
+    config = {
+        "enabled": True,
+        "min_chars": 0,
+        "min_reduction_pct": 10,
+    }
+
+    # Mock crusher that actually compresses (was_modified=True)
+    mock_crusher = MagicMock()
+    for _ in range(100):
+        mock_cr = MagicMock()
+        mock_cr.was_modified = True
+        mock_cr.compressed = "compressed_placeholder"
+        mock_crusher.crush.return_value = mock_cr
+
+    with patch.object(comp, "_get_crusher", return_value=mock_crusher):
+        # Turn 1: multiple large tool outputs with UNIQUE content
+        for i in range(100):
+            text = f"tool_{i}: " + f"\n".join([f"  {j}|/src/file_{i:03d}_{j:03d}.py: def handler_{i}_{j}(): pass" for j in range(200)])
+            result = comp.compress_tool_result(f"tool_{i}", text, config=config)
+            assert result is not None, f"tool_{i} should have been compressed"
+
+        # Cache should be populated
+        stats = comp.cache_stats()
+        assert stats["cached_items"] == 100
+        assert stats["max_cache_size"] == 5000  # default
+
+        # Turn 2: retrieve the first hash from turn 1
+        first_hash = None
+        with comp._cache_lock:
+            first_hash = next(iter(comp._cache.keys()))
+        original = comp.retrieve_cached(first_hash)
+        assert original is not None, "First hash should still be in cache"
+
+
+def test_headroom_retrieve_not_recursively_compressed():
+    """Ensure headroom_retrieve output doesn't get compressed itself.
+
+    If it does, each retrieval burns a new cache slot with a compressed
+    marker, accelerating eviction of useful content.
+    """
+    mock_cr = MagicMock()
+    mock_cr.was_modified = False
+    mock_crusher = MagicMock()
+    mock_crusher.crush.return_value = mock_cr
+
+    # Large headroom_retrieve output — should pass through, NOT compress
+    with patch.object(comp, "_get_crusher", return_value=mock_crusher):
+        result = comp.compress_tool_result(
+            "headroom_retrieve",
+            '{"found":true,"content":"' + "x" * 10000 + '"}',
+            config={"enabled": True, "min_chars": 0, "min_reduction_pct": 10},
+        )
+        assert result is None, "headroom_retrieve output should never be compressed"

--- a/tests/tools/test_headroom_retrieve.py
+++ b/tests/tools/test_headroom_retrieve.py
@@ -1,0 +1,47 @@
+"""Tests for tools/headroom_retrieve.py."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import agent.tool_output_compressor as comp
+from tools.headroom_retrieve import headroom_retrieve
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    comp._reset_state()
+    yield
+    comp._reset_state()
+
+
+def test_retrieve_found():
+    """Successfully retrieve a cached original."""
+    with comp._cache_lock:
+        comp._cache["abc123def456"] = "hello world"
+    result = headroom_retrieve(hash="abc123def456")
+    import json
+    data = json.loads(result)
+    assert data["found"] is True
+    assert data["content"] == "hello world"
+
+
+def test_retrieve_not_found():
+    """Missing hash returns not found."""
+    result = headroom_retrieve(hash="nonexistent")
+    import json
+    data = json.loads(result)
+    assert data["found"] is False
+
+
+def test_check_requirements_respects_config():
+    """Tool is only available when headroom is enabled."""
+    from tools.headroom_retrieve import check_requirements
+    with patch("hermes_cli.config.load_config_readonly", return_value={
+        "context": {"headroom": {"enabled": True}}
+    }):
+        assert check_requirements() is True
+    with patch("hermes_cli.config.load_config_readonly", return_value={}):
+        assert check_requirements() is False

--- a/tools/consultation_tool.py
+++ b/tools/consultation_tool.py
@@ -1,0 +1,655 @@
+#!/usr/bin/env python3
+"""
+Consultation Tool - Frontier Model Advisory
+
+A single-turn, cost-bounded, user-approved way for an agent to ask one
+question to one expensive frontier model and get back one answer. The agent's
+primary model continues normally; the consultant is invoked selectively for
+specific, difficult problems.
+
+Calls go directly to provider APIs (OpenAI, Anthropic) with no aggregator
+or intermediary. Each model in config specifies its own provider, model
+name, env var, and pricing.
+
+Design:
+  - Tool visibility is opt-in via config (consultation.enabled: false default)
+  - Every call requires user approval (same path as dangerous commands)
+  - Hard budget caps: per-call and per-session
+  - Cost tracking: in-memory + on-disk persistence
+  - Dynamic schema: model catalog + budget status injected per turn
+  - Direct provider calls: OpenAI SDK or Anthropic SDK, chosen by provider key
+
+See docs/consultation-tool-proposal.md for full design rationale.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CONSULTATION_SYSTEM_PROMPT = """You are an expert consultant called upon for a specific, difficult problem.
+The calling agent has tried to solve this but needs your advanced reasoning
+capabilities. Provide a focused, high-quality response. Do not ask clarifying
+questions -- this is a single-turn advisory. Be specific and actionable.
+
+IMPORTANT: The context you receive may contain sensitive intellectual property
+(financial signals, trading strategies, proprietary algorithms). Treat all
+information as confidential. Do not repeat or restate proprietary details
+unnecessarily in your response — focus on your analysis and recommendations."""
+
+MAX_CONTEXT_CHARS = 50_000
+DEFAULT_SESSION_BUDGET = 20.00
+DEFAULT_BUDGET_PER_CALL = 3.00
+DEFAULT_SESSION_BUDGET_ALERT = 0.80
+DEFAULT_MAX_INPUT_TOKENS = 100_000
+DEFAULT_MAX_OUTPUT_TOKENS = 16_000
+DEFAULT_INPUT_PRICE_PER_M = 15.00
+DEFAULT_OUTPUT_PRICE_PER_M = 75.00
+DEFAULT_APPROVAL_TIMEOUT = 300  # 5 minutes
+
+# Provider types
+PROVIDER_OPENAI = "openai"
+PROVIDER_ANTHROPIC = "anthropic"
+SUPPORTED_PROVIDERS = (PROVIDER_OPENAI, PROVIDER_ANTHROPIC)
+
+# ---------------------------------------------------------------------------
+# Budget file path
+# ---------------------------------------------------------------------------
+
+
+def _budget_file_path() -> Path:
+    state_dir = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    hermes_state = Path(state_dir) / "hermes"
+    hermes_state.mkdir(parents=True, exist_ok=True)
+    return hermes_state / "consultation_budget.json"
+
+
+# ---------------------------------------------------------------------------
+# In-memory budget tracker (thread-safe)
+# ---------------------------------------------------------------------------
+
+_budget_lock = threading.Lock()
+_budget_state: Optional[Dict[str, Any]] = None
+
+
+def _load_budget_state() -> Dict[str, Any]:
+    global _budget_state
+    if _budget_state is not None:
+        return _budget_state
+
+    with _budget_lock:
+        if _budget_state is not None:
+            return _budget_state
+
+        bf = _budget_file_path()
+        try:
+            if bf.exists():
+                data = json.loads(bf.read_text(encoding="utf-8"))
+                session_start = data.get("session_start", "")
+                if session_start:
+                    try:
+                        start_dt = datetime.fromisoformat(session_start.replace("Z", "+00:00"))
+                        age_hours = (datetime.now(timezone.utc) - start_dt).total_seconds() / 3600
+                        if age_hours > 24:
+                            logger.info("Consultation budget file is stale (%.1fh old), resetting", age_hours)
+                            raise ValueError("stale session")
+                    except (ValueError, TypeError):
+                        pass
+                _budget_state = data
+                return _budget_state
+        except Exception as e:
+            logger.debug("Could not load budget file (%s), starting fresh", e)
+
+        _budget_state = {
+            "session_start": datetime.now(timezone.utc).isoformat(),
+            "total_spent": 0.0,
+            "by_model": {},
+        }
+        return _budget_state
+
+
+def _save_budget_state() -> None:
+    global _budget_state
+    if _budget_state is None:
+        return
+    with _budget_lock:
+        current = copy.deepcopy(_budget_state)
+    bf = _budget_file_path()
+    try:
+        bf.write_text(json.dumps(current, indent=2), encoding="utf-8")
+    except Exception as e:
+        logger.warning("Failed to save budget file: %s", e)
+
+
+def _get_session_spent() -> float:
+    state = _load_budget_state()
+    return state.get("total_spent", 0.0)
+
+
+def _record_cost(model_name: str, cost: float) -> None:
+    global _budget_state
+    with _budget_lock:
+        if _budget_state is None:
+            _budget_state = {"session_start": "", "total_spent": 0.0, "by_model": {}}
+        _budget_state["total_spent"] = round(_budget_state.get("total_spent", 0.0) + cost, 4)
+        by_model = _budget_state.setdefault("by_model", {})
+        entry = by_model.setdefault(model_name, {"calls": 0, "spent": 0.0})
+        entry["calls"] += 1
+        entry["spent"] = round(entry.get("spent", 0.0) + cost, 4)
+    _save_budget_state()
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+def _load_consultation_config() -> Optional[Dict[str, Any]]:
+    """Load consultation config from config.yaml.
+
+    Returns None if consultation is disabled or misconfigured.
+    Raises ValueError on config errors.
+    """
+    try:
+        from hermes_cli.config import load_config, cfg_get
+
+        config = load_config()
+        consultation = cfg_get(config, "consultation", default=None)
+        if consultation is None or not isinstance(consultation, dict):
+            return None
+
+        enabled = consultation.get("enabled", False)
+        if not enabled:
+            return None
+
+        models_raw = consultation.get("models", [])
+        if not isinstance(models_raw, list) or len(models_raw) == 0:
+            raise ValueError("consultation requires at least one model in config")
+
+        models = []
+        for m in models_raw:
+            if not isinstance(m, dict):
+                continue
+            name = m.get("name")
+            provider = m.get("provider")
+            model = m.get("model")
+            if not name or not provider or not model:
+                continue
+            if provider not in SUPPORTED_PROVIDERS:
+                logger.warning("Consultation model %s: unsupported provider %s (use openai or anthropic)", name, provider)
+                continue
+
+            budget_per_call = m.get("budget_per_call", DEFAULT_BUDGET_PER_CALL)
+            if not isinstance(budget_per_call, (int, float)) or budget_per_call <= 0:
+                continue
+
+            models.append({
+                "name": str(name),
+                "provider": str(provider),
+                "model": str(model),
+                "budget_per_call": float(budget_per_call),
+                "max_input_tokens": int(m.get("max_input_tokens", DEFAULT_MAX_INPUT_TOKENS)),
+                "max_output_tokens": int(m.get("max_output_tokens", DEFAULT_MAX_OUTPUT_TOKENS)),
+                "api_key_env": str(m["api_key_env"]) if m.get("api_key_env") else None,
+                "description": str(m.get("description", "")),
+                "input_price_per_m": float(m.get("input_price_per_m", DEFAULT_INPUT_PRICE_PER_M)),
+                "output_price_per_m": float(m.get("output_price_per_m", DEFAULT_OUTPUT_PRICE_PER_M)),
+            })
+
+        if not models:
+            raise ValueError("no valid consultation models configured")
+
+        return {
+            "enabled": True,
+            "models": models,
+            "session_budget": float(consultation.get("session_budget", DEFAULT_SESSION_BUDGET)),
+            "session_budget_alert": float(consultation.get("session_budget_alert", DEFAULT_SESSION_BUDGET_ALERT)),
+        }
+
+    except ValueError:
+        raise
+    except Exception as e:
+        logger.debug("Failed to load consultation config: %s", e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _estimate_cost(input_chars: int, max_output_tokens: int,
+                   input_price: float, output_price: float) -> float:
+    input_tokens = max(input_chars // 4, 1)
+    input_cost = (input_tokens / 1_000_000) * input_price
+    output_cost = (max_output_tokens / 1_000_000) * output_price
+    return round(input_cost + output_cost, 4)
+
+
+def _resolve_api_key(model_config: Dict[str, Any]) -> str:
+    """Resolve the API key for a model config."""
+    env_var = model_config.get("api_key_env")
+    if not env_var:
+        # Default env vars by provider
+        if model_config["provider"] == PROVIDER_OPENAI:
+            env_var = "OPENAI_API_KEY"
+        elif model_config["provider"] == PROVIDER_ANTHROPIC:
+            env_var = "ANTHROPIC_API_KEY"
+    key = os.environ.get(env_var)
+    if not key:
+        raise ValueError(f"{env_var} environment variable not set (needed for {model_config['name']})")
+    return key
+
+
+# ---------------------------------------------------------------------------
+# Provider clients (lazy, cached)
+# ---------------------------------------------------------------------------
+
+_openai_clients: Dict[str, Any] = {}
+_anthropic_clients: Dict[str, Any] = {}
+_client_lock = threading.Lock()
+
+
+def _get_openai_client(api_key: str):
+    """Get or create an async OpenAI client."""
+    with _client_lock:
+        if api_key in _openai_clients:
+            return _openai_clients[api_key]
+        from openai import AsyncOpenAI
+        client = AsyncOpenAI(api_key=api_key)
+        _openai_clients[api_key] = client
+        return client
+
+
+def _get_anthropic_client(api_key: str):
+    """Get or create an async Anthropic client."""
+    with _client_lock:
+        if api_key in _anthropic_clients:
+            return _anthropic_clients[api_key]
+        import anthropic
+        client = anthropic.AsyncAnthropic(api_key=api_key)
+        _anthropic_clients[api_key] = client
+        return client
+
+
+# ---------------------------------------------------------------------------
+# API call logic
+# ---------------------------------------------------------------------------
+
+
+async def _call_openai(model: str, system: str, user: str, max_tokens: int) -> tuple:
+    """Call OpenAI API directly. Returns (content, input_tokens, output_tokens)."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY not set")
+
+    client = _get_openai_client(api_key)
+    # GPT-5+ reasoning models require max_completion_tokens instead of max_tokens
+    kwargs: dict = {"max_completion_tokens": max_tokens}
+    try:
+        response = await client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            **kwargs,
+        )
+    except Exception as e:
+        # Fallback to max_tokens for older models
+        if "max_completion_tokens" in str(e) or "max_tokens" in str(e):
+            response = await client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                max_tokens=max_tokens,
+            )
+        else:
+            raise
+    content = response.choices[0].message.content or ""
+    usage = response.usage or type('U', (), {"prompt_tokens": 0, "completion_tokens": 0})()
+    return content, usage.prompt_tokens, usage.completion_tokens
+
+
+async def _call_anthropic(model: str, system: str, user: str, max_tokens: int) -> tuple:
+    """Call Anthropic API directly. Returns (content, input_tokens, output_tokens)."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise ValueError("ANTHROPIC_API_KEY not set")
+
+    client = _get_anthropic_client(api_key)
+    response = await client.messages.create(
+        model=model,
+        system=system,
+        messages=[{"role": "user", "content": user}],
+        max_tokens=max_tokens,
+    )
+    content = "\n".join(block.text for block in response.content if hasattr(block, "text"))
+    usage = response.usage
+    return content, usage.input_tokens, usage.output_tokens
+
+
+# ---------------------------------------------------------------------------
+# Tool visibility check
+# ---------------------------------------------------------------------------
+
+
+def _check_consultation() -> bool:
+    try:
+        cfg = _load_consultation_config()
+        return cfg is not None
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Dynamic schema builder
+# ---------------------------------------------------------------------------
+
+
+def _build_dynamic_schema() -> Dict[str, Any]:
+    try:
+        cfg = _load_consultation_config()
+    except Exception:
+        cfg = None
+
+    if not cfg or not cfg.get("models"):
+        return {}
+
+    models = cfg["models"]
+    spent = _get_session_spent()
+    budget = cfg.get("session_budget", DEFAULT_SESSION_BUDGET)
+
+    model_lines = []
+    for m in models:
+        desc_line = m["description"].strip().split("\n")[0]
+        model_lines.append(
+            f"  - {m['name']} ({m['provider']}:{m['model']}): "
+            f"{desc_line} ~${m['input_price_per_m']}/M in, "
+            f"~${m['output_price_per_m']}/M out. Budget: ${m['budget_per_call']:.2f}/call."
+        )
+
+    model_catalog = "\n".join(model_lines)
+
+    budget_line = ""
+    if budget > 0:
+        pct = min((spent / budget) * 100, 999)
+        budget_line = f"\n\nCurrent session budget: ${spent:.2f}/${budget:.2f} ({pct:.0f}% used)."
+        if spent >= budget:
+            budget_line += " BUDGET EXHAUSTED - no more calls possible."
+
+    description = (
+        "Ask a frontier or peer model for expert advisory on a specific, "
+        "difficult problem. Each call costs money and requires user approval. "
+        "Use consultants (opus, gpt55) for hard problems; use peers (sonnet, gpt41) "
+        "for cheaper second opinions and sanity checks. "
+        "The consultant model receives your prompt and optional context and "
+        "returns a single advisory response. Keep prompts focused and specific.\n\n"
+        "WARNING: You are working with sensitive IP (financial signals, trading "
+        "strategies, proprietary algorithms). Share ONLY what the consultant needs "
+        "to answer the question — never dump large code files, full feature lists, "
+        "or complete signal logic. Summarize and abstract when possible.\n\n"
+        f"Available models:\n{model_catalog}{budget_line}"
+    )
+
+    model_choices = [m["name"] for m in models]
+
+    return {
+        "description": description,
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "model": {
+                    "type": "string",
+                    "enum": model_choices,
+                    "description": f"Consultation model name. Available: {', '.join(model_choices)}",
+                },
+                "prompt": {
+                    "type": "string",
+                    "description": "The specific question to ask the expert model. Be focused and specific.",
+                },
+                "context": {
+                    "type": "string",
+                    "description": (
+                        "Optional additional context: code, file contents, "
+                        "error traces, etc. Max 50,000 characters. "
+                        "SENSITIVE: share only what is strictly necessary — "
+                        "summarize and abstract; never dump full source files or "
+                        "complete signal logic."
+                    ),
+                },
+            },
+            "required": ["model", "prompt"],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core tool handler
+# ---------------------------------------------------------------------------
+
+
+async def consultation_ask(args: Dict[str, Any]) -> str:
+    """Handle a consultation.ask tool call."""
+    model_name = args.get("model", "")
+    prompt = args.get("prompt", "")
+    context = args.get("context", "") or ""
+
+    if len(context) > MAX_CONTEXT_CHARS:
+        context = context[:MAX_CONTEXT_CHARS]
+        logger.warning("Consultation context truncated to %d chars", MAX_CONTEXT_CHARS)
+
+    if not model_name:
+        return json.dumps({"error": "model parameter is required"})
+    if not prompt:
+        return json.dumps({"error": "prompt parameter is required"})
+
+    # 1. Load config
+    try:
+        cfg = _load_consultation_config()
+    except Exception as e:
+        return json.dumps({"error": f"Consultation config error: {e}"})
+
+    if not cfg:
+        return json.dumps({"error": "Consultation is not enabled in config"})
+
+    # Find model config
+    model_cfg = None
+    for m in cfg["models"]:
+        if m["name"] == model_name:
+            model_cfg = m
+            break
+
+    if not model_cfg:
+        available = ", ".join(m["name"] for m in cfg["models"])
+        return json.dumps({"error": f"Unknown consultation model '{model_name}'. Available: {available}"})
+
+    provider = model_cfg["provider"]
+    model_id = model_cfg["model"]
+    budget_per_call = model_cfg["budget_per_call"]
+    max_output_tokens = model_cfg["max_output_tokens"]
+    input_price = model_cfg["input_price_per_m"]
+    output_price = model_cfg["output_price_per_m"]
+
+    # 2. Build the full message
+    user_message = prompt
+    if context:
+        user_message = f"{prompt}\n\nContext:\n{context}"
+
+    # Estimate cost
+    full_text = CONSULTATION_SYSTEM_PROMPT + "\n" + user_message
+    estimated_cost = _estimate_cost(len(full_text), max_output_tokens, input_price, output_price)
+
+    # 3. Check session budget (fail fast)
+    session_spent = _get_session_spent()
+    session_budget = cfg.get("session_budget", DEFAULT_SESSION_BUDGET)
+
+    if session_budget > 0 and session_spent >= session_budget:
+        return json.dumps({
+            "error": (
+                f"Session consultation budget exhausted (${session_spent:.2f}/${session_budget:.2f}). "
+                f"No more consultation calls possible this session."
+            ),
+        })
+
+    # 4. Approval gate
+    prompt_preview = prompt[:200] + ("..." if len(prompt) > 200 else "")
+
+    approval_description = (
+        f"[CONSULTATION] Agent wants to consult {model_name} ({provider}:{model_id}).\n"
+        f"Estimated cost: ${estimated_cost:.2f} (call cap: ${budget_per_call:.2f}).\n"
+        f"Session budget: ${session_spent:.2f}/${session_budget:.2f} "
+        f"({(session_spent / session_budget * 100) if session_budget > 0 else 0:.0f}% used).\n"
+        f"Question: {prompt_preview}"
+    )
+
+    try:
+        from tools.approval import prompt_dangerous_approval
+        from tools.terminal_tool import _get_approval_callback
+
+        choice = prompt_dangerous_approval(
+            command="consultation.ask",
+            description=approval_description,
+            timeout_seconds=DEFAULT_APPROVAL_TIMEOUT,
+            allow_permanent=False,
+            approval_callback=_get_approval_callback(),
+        )
+
+        if choice not in ("once", "session"):
+            return json.dumps({"error": "User declined this consultation call."})
+
+    except Exception as e:
+        logger.error("Approval failed: %s", e)
+        return json.dumps({"error": f"Could not get user approval: {e}"})
+
+    # 5. Final budget check
+    session_spent = _get_session_spent()
+    if session_budget > 0 and session_spent >= session_budget:
+        return json.dumps({"error": "Session consultation budget exhausted. Call cancelled."})
+
+    # Calculate effective max_output_tokens based on remaining budget
+    remaining_budget = min(
+        budget_per_call,
+        session_budget - session_spent if session_budget > 0 else budget_per_call,
+    )
+    max_output_by_budget = int((remaining_budget * 1_000_000) / output_price)
+    effective_max_output = min(max_output_tokens, max_output_by_budget, int(remaining_budget * 1000))
+    effective_max_output = max(effective_max_output, 256)
+
+    # 6. API call
+    try:
+        _resolve_api_key(model_cfg)  # validates key exists
+    except ValueError as e:
+        return json.dumps({"error": str(e)})
+
+    try:
+        logger.info(
+            "Consultation call: model=%s provider=%s model_id=%s max_output=%d estimated=$%.2f",
+            model_name, provider, model_id, effective_max_output, estimated_cost,
+        )
+
+        if provider == PROVIDER_OPENAI:
+            content, input_tokens, output_tokens = await _call_openai(
+                model_id, CONSULTATION_SYSTEM_PROMPT, user_message, effective_max_output
+            )
+        elif provider == PROVIDER_ANTHROPIC:
+            content, input_tokens, output_tokens = await _call_anthropic(
+                model_id, CONSULTATION_SYSTEM_PROMPT, user_message, effective_max_output
+            )
+        else:
+            return json.dumps({"error": f"Unsupported provider: {provider}"})
+
+        if not content:
+            logger.warning("Consultation model returned empty response")
+            return json.dumps({"error": f"{model_name} returned an empty response."})
+
+        # Calculate actual cost
+        actual_cost = round(
+            (input_tokens / 1_000_000) * input_price +
+            (output_tokens / 1_000_000) * output_price,
+            4,
+        )
+
+        # 7. Track cost
+        _record_cost(model_name, actual_cost)
+        new_total = _get_session_spent()
+
+        # Budget alert
+        alert_threshold = cfg.get("session_budget_alert", DEFAULT_SESSION_BUDGET_ALERT)
+        if session_budget > 0 and (new_total / session_budget) >= alert_threshold:
+            logger.warning(
+                "Consultation budget alert: %.0f%% consumed ($%.2f/$%.2f)",
+                (new_total / session_budget) * 100, new_total, session_budget,
+            )
+
+        logger.info(
+            "Consultation complete: model=%s cost=$%.2f input=%d output=%d session=$%.2f/$%.2f",
+            model_name, actual_cost, input_tokens, output_tokens,
+            new_total, session_budget,
+        )
+
+        return json.dumps({
+            "response": content,
+            "model": model_name,
+            "provider": f"{provider}:{model_id}",
+            "cost": actual_cost,
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
+            "session_spent": round(new_total, 2),
+            "session_budget": session_budget,
+            "session_remaining": round(max(session_budget - new_total, 0), 2),
+        }, ensure_ascii=False)
+
+    except Exception as e:
+        error_msg = str(e)
+        logger.error("Consultation API call failed: %s", error_msg)
+        return json.dumps({"error": f"Consultation call failed: {error_msg}"})
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+CONSULTATION_SCHEMA = {
+    "name": "consultation.ask",
+    "description": "Ask an expensive frontier model for expert advisory.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "model": {"type": "string", "description": "Consultation model name"},
+            "prompt": {"type": "string", "description": "The specific question to ask"},
+            "context": {"type": "string", "description": "Optional context: code, errors, etc."},
+        },
+        "required": ["model", "prompt"],
+    },
+}
+
+registry.register(
+    name="consultation.ask",
+    toolset="consultation",
+    schema=CONSULTATION_SCHEMA,
+    handler=lambda args, **kw: consultation_ask(args),
+    check_fn=_check_consultation,
+    is_async=True,
+    description="Ask an expensive frontier model for expert advisory on a specific, difficult problem. Each call costs money and requires user approval.",
+    emoji="\U0001f393",
+    dynamic_schema_overrides=_build_dynamic_schema,
+)

--- a/tools/headroom_retrieve.py
+++ b/tools/headroom_retrieve.py
@@ -1,0 +1,90 @@
+"""headroom_retrieve tool — retrieve compressed tool output originals.
+
+When tool output compression is enabled (context.headroom.enabled), large
+tool outputs are compressed before entering the conversation context.  The
+original is stored in an in-memory cache keyed by a short hash.
+
+This tool lets the agent retrieve the full original when needed.  The hash
+is embedded in the compressed output marker:
+
+    [Full output cached: hash=abc123def456]
+
+Usage:
+    headroom_retrieve(hash="abc123def456")
+
+The tool is only available when compression is enabled.
+"""
+
+import json
+from typing import Optional
+
+from tools.registry import registry
+
+
+def check_requirements() -> bool:
+    """Only available when headroom compression is enabled."""
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly()
+        return bool(cfg.get("context", {}).get("headroom", {}).get("enabled", False))
+    except Exception:
+        return False
+
+
+def headroom_retrieve(hash: str) -> str:
+    """Retrieve a full tool output that was compressed by headroom."""
+    try:
+        from agent.tool_output_compressor import retrieve_cached
+        original = retrieve_cached(hash)
+        if original is None:
+            return json.dumps({
+                "found": False,
+                "message": f"No cached content for hash {hash}. "
+                           f"The cache may have expired (max 50 items, process-bound).",
+            })
+
+        return json.dumps({
+            "found": True,
+            "content": original,
+            "size_bytes": len(original),
+        })
+    except Exception as e:
+        return json.dumps({
+            "found": False,
+            "error": str(e),
+        })
+
+
+# Tool schema — only shown when compression is active
+SCHEMA = {
+    "name": "headroom_retrieve",
+    "description": (
+        "Retrieve a full tool output that was compressed by headroom. "
+        "When large tool outputs are compressed, the original is cached "
+        "with a short hash. Use this tool to fetch the uncompressed version.\n\n"
+        "Example usage: see the compressed output marker for a hash like "
+        "'hash=abc123def456', then call headroom_retrieve(hash='abc123def456').\n\n"
+        "Cache is process-bound (cleared on Hermes restart) with a max of 50 items "
+        "(FIFO eviction).  If the hash is no longer cached, it may have been evicted."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "hash": {
+                "type": "string",
+                "description": "The 12-character hex hash from the compressed output marker (e.g. 'abc123def456')"
+            }
+        },
+        "required": ["hash"]
+    }
+}
+
+
+registry.register(
+    name="headroom_retrieve",
+    toolset="headroom",
+    schema=SCHEMA,
+    handler=lambda args, **kw: headroom_retrieve(hash=args.get("hash", "")),
+    check_fn=check_requirements,
+    emoji="📦",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -163,6 +163,18 @@ TOOLSETS = {
         "includes": []
     },
     
+    "moa": {
+        "description": "Advanced reasoning and problem-solving tools",
+        "tools": ["mixture_of_agents"],
+        "includes": []
+    },
+
+    "consultation": {
+        "description": "Frontier model consultation: ask expensive models (Opus, GPT-5.5, etc.) for expert advisory on specific hard problems",
+        "tools": ["consultation.ask"],
+        "includes": []
+    },
+
     "skills": {
         "description": "Access, create, edit, and manage skill documents with specialized instructions and knowledge",
         "tools": ["skills_list", "skill_view", "skill_manage"],

--- a/toolsets.py
+++ b/toolsets.py
@@ -217,7 +217,13 @@ TOOLSETS = {
         "tools": [],
         "includes": []
     },
-    
+
+    "headroom": {
+        "description": "Tool output compression: retrieve full originals of compressed tool outputs",
+        "tools": ["headroom_retrieve"],
+        "includes": []
+    },
+
     "session_search": {
         "description": "Search and recall past conversations with summarization",
         "tools": ["session_search"],


### PR DESCRIPTION
## Problem

Claude Sonnet 4.6 and 4.7 models were being routed to **OpenRouter** instead of the **anthropic-codex** provider (which is set up on headroom/epochdev05).

Two bugs in `agent/provider_routing.py`:

### Bug 1: `_route_slack_message` matched `'claude' in model` before the Anthropic Codex block
The `'claude' in model` check (line 773) caught all Claude models, including `sonnet`, which should have gone to Anthropic Codex via `_is_anthropic_codex_model()`.

**Fix:** Narrow the Slack Claude guard to `model.startswith('claude/')` so it only matches Anthropic-native slugs (e.g. `claude-sonnet-4-20250514`), not openrouter-style `anthropic/claude-sonnet-4-6`.

### Bug 2: `_is_anthropic_codex_model` hardcoded Claude model names
The list only had `claude-opus-4-7` and `claude-opus-4-5`. Any other Claude model routed through `openai-codex` (e.g. `anthropic/claude-sonnet-4-6`) was silently missed.

**Fix:** Replace the hardcoded model list with a `'claude' in model` check, matching the broader pattern used in `_is_zai_overload_retry_model`.

## Root Cause

The Slack message routing check was too broad — it matched any model containing 'claude', including openrouter-formatted slugs like `anthropic/claude-sonnet-4-6`. The Anthropic Codex model whitelist was also incomplete, only covering Opus variants.

## Verification

Added test `test_route_anthropic_codex_models` that confirms:
- `anthropic/claude-opus-4-7` → `anthropic-codex` (already passed)
- `anthropic/claude-sonnet-4-6` → `anthropic-codex` (**was `openai-codex`**)
- `anthropic/claude-sonnet-4-20250514` → `anthropic-codex` (**was `slack`**)
- `anthropic/claude-3-opus-20240229` → `anthropic-codex` (**was `openai-codex`**)
