### PR TITLE
fix: tolerate closed event loop during MCP cleanup

### DIFF
--- a/tests/tools/test_mcp_reconnect_retry_reset.py
+++ b/tests/tools/test_mcp_reconnect_retry_reset.py
@@ -5,8 +5,70 @@ reconnection, so transient blips do not accumulate toward permanent parking.
 """
 
 import asyncio
+from typing import cast
 
 import pytest
+
+
+class _FakeLoop:
+    def __init__(self, closed):
+        self._closed = closed
+
+    def is_closed(self):
+        return self._closed
+
+
+class _FakeTask:
+    def __init__(self, *, done=False, loop_closed=False, cancel_exc=None):
+        self._done = done
+        self._loop = _FakeLoop(loop_closed)
+        self._cancel_exc = cancel_exc
+        self.cancel_called = 0
+        self.awaited = False
+
+    def done(self):
+        return self._done
+
+    def get_loop(self):
+        return self._loop
+
+    def cancel(self):
+        self.cancel_called += 1
+        if self._cancel_exc is not None:
+            raise self._cancel_exc
+
+    def __await__(self):
+        async def _inner():
+            self.awaited = True
+            raise asyncio.CancelledError()
+
+        return _inner().__await__()
+
+
+@pytest.mark.no_isolate
+def test_cancel_pending_task_skips_cancel_when_loop_already_closed(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.mcp_tool import _cancel_pending_task
+
+    task = _FakeTask(loop_closed=True)
+    asyncio.run(_cancel_pending_task(cast(asyncio.Task, task)))
+
+    assert task.cancel_called == 0
+    assert not task.awaited
+
+
+@pytest.mark.no_isolate
+def test_cancel_pending_task_swallows_event_loop_closed_from_cancel(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.mcp_tool import _cancel_pending_task
+
+    task = _FakeTask(cancel_exc=RuntimeError("Event loop is closed"))
+    asyncio.run(_cancel_pending_task(cast(asyncio.Task, task)))
+
+    assert task.cancel_called == 1
+    assert not task.awaited
 
 
 @pytest.mark.no_isolate

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1505,6 +1505,41 @@ class ElicitationHandler:
 # Server task -- each MCP server lives in one long-lived asyncio Task
 # ---------------------------------------------------------------------------
 
+
+async def _cancel_pending_task(task: asyncio.Task) -> None:
+    """Cancel a pending asyncio task, tolerating loop-shutdown races.
+
+    During CLI teardown or MCP reloads, a parked server task can still be in
+    ``_wait_for_reconnect_or_shutdown()`` while the owning event loop is already
+    closing. ``task.cancel()`` then raises ``RuntimeError('Event loop is closed')``
+    and emits a noisy "Exception ignored" traceback even though the MCP request
+    itself already completed successfully.
+
+    Treat that specific loop-shutdown race as benign teardown noise.
+    """
+    if task.done():
+        return
+
+    try:
+        loop = task.get_loop()
+    except Exception:
+        loop = None
+
+    if loop is not None and loop.is_closed():
+        return
+
+    try:
+        task.cancel()
+    except RuntimeError as exc:
+        if "Event loop is closed" in str(exc):
+            return
+        raise
+
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
 class MCPServerTask:
     """Manages a single MCP server connection in a dedicated asyncio Task.
 
@@ -1993,12 +2028,7 @@ class MCPServerTask:
             )
         finally:
             for t in (shutdown_task, reconnect_task):
-                if not t.done():
-                    t.cancel()
-                    try:
-                        await t
-                    except (asyncio.CancelledError, Exception):
-                        pass
+                await _cancel_pending_task(t)
         if self._shutdown_event.is_set():
             return "shutdown"
         self._reconnect_event.clear()


### PR DESCRIPTION
## Bug Description

When an MCP server is parked and the CLI tears down or reloads MCP connections, `_wait_for_reconnect_or_shutdown()` may still hold pending asyncio tasks. If the owning event loop has already closed by the time cleanup tries `task.cancel()`, Hermes emits a noisy `RuntimeError: Event loop is closed` traceback even though the MCP operation already succeeded.

## Root Cause

The parked-server cleanup path cancelled pending `shutdown_task` / `reconnect_task` unconditionally. `asyncio.Task.cancel()` can raise `RuntimeError("Event loop is closed")` during teardown races when the task's loop is already closed.

## Fix

- add `_cancel_pending_task()` helper for MCP cleanup
- skip cancel entirely when the task loop is already closed
- swallow the specific `RuntimeError("Event loop is closed")` race during cancellation
- cover both teardown-race paths with regression tests

## How to Verify

1. Configure an MCP server and force a parked/reload/teardown path.
2. Run a CLI command that uses the MCP tool successfully.
3. Confirm Hermes exits/reloads without printing `RuntimeError: Event loop is closed`.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification of the fix

Manual / automated checks run:
- `uv run --python /usr/local/bin/python3.13 --extra dev python -m pytest tests/tools/test_mcp_reconnect_retry_reset.py -q`
- `uv run --python /usr/local/bin/python3.13 --extra dev python -m pytest tests/tools/test_mcp_tool.py -q -k "MCPServerTask or mcp"`
- `hermes chat -q "Use the MCP tool mcp_flowise_rag_rag_status and return only the stack_dir value." --yolo -Q`

## Risk Assessment

Low — the change is scoped to MCP teardown cleanup and only relaxes cancellation behavior for tasks that are already done, already on a closed loop, or fail with the specific loop-closed race during shutdown.
