### PR TITLE
fix(banner): stop fabricating "1 commit behind" on SSH-official remotes

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -202,10 +202,17 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
-        checked = _check_via_rev(head_rev) if head_rev else None
-        if checked == UPDATE_AVAILABLE_NO_COUNT:
-            return 1
-        return checked
+        # ls-remote against the upstream URL only tells us tip SHAs — there
+        # is no local history to count commits against. Return the
+        # UPDATE_AVAILABLE_NO_COUNT sentinel so the banner and CLI renderers
+        # print "update available" instead of fabricating a "1 commit behind"
+        # message. The dashboard's REST /api/hermes/update/check already
+        # treats any nonzero behind as update_available=true (see
+        # hermes_cli/web_server.py::check_hermes_update), and the desktop
+        # store clamps behind<=0 to 0 and reads update_available separately
+        # (apps/desktop/src/store/updates.ts::mapBackendCheck), so no UI
+        # consumer depends on a fabricated count here.
+        return _check_via_rev(head_rev) if head_rev else None
 
     # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
     # clone the history stops at a single commit, so a plain `git fetch` would

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4634,11 +4634,15 @@ def _print_version_info(*, check_updates: bool = True) -> None:
 
     # Show update status (synchronous — acceptable since user asked for version info)
     try:
-        from hermes_cli.banner import check_for_updates
+        from hermes_cli.banner import UPDATE_AVAILABLE_NO_COUNT, check_for_updates
         from hermes_cli.config import recommended_update_command
 
         behind = check_for_updates()
-        if behind and behind > 0:
+        if behind == UPDATE_AVAILABLE_NO_COUNT:
+            print(
+                f"Update available — run '{recommended_update_command()}'"
+            )
+        elif behind and behind > 0:
             commits_word = "commit" if behind == 1 else "commits"
             print(
                 f"Update available: {behind} {commits_word} behind — "

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -124,7 +124,7 @@ def test_check_for_updates_official_ssh_origin_uses_https_probe(tmp_path):
     with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
         result = banner._check_via_local_git(repo_dir)
 
-    assert result == 1
+    assert result == banner.UPDATE_AVAILABLE_NO_COUNT
     assert ["git", "fetch", "origin", "--quiet"] not in calls
 
 
@@ -339,3 +339,52 @@ def test_invalidate_update_cache_no_profiles_dir(tmp_path):
         _invalidate_update_cache()
 
     assert not (default_home / ".update_check").exists()
+
+
+def test_print_version_info_renders_no_count_sentinel(capsys):
+    """`hermes --version` must render UPDATE_AVAILABLE_NO_COUNT (-1) without a
+    fabricated commit count.
+
+    Regression guard for the SSH-official-remote path: `_check_via_local_git`
+    returns the -1 sentinel because `ls-remote` can only tell us tip SHAs, not
+    a real commit count. Previously the SSH branch returned a hard-coded `1`,
+    which the CLI banner rendered as "Update available: 1 commit behind" —
+    misleading and stable even when upstream had accumulated dozens of new
+    commits. This test locks in the correct rendering.
+    """
+    from hermes_cli.banner import UPDATE_AVAILABLE_NO_COUNT
+    from hermes_cli.main import _print_version_info
+
+    with patch("hermes_cli.banner.check_for_updates", return_value=UPDATE_AVAILABLE_NO_COUNT), \
+         patch("hermes_cli.config.recommended_update_command", return_value="hermes update"):
+        _print_version_info(check_updates=True)
+
+    out = capsys.readouterr().out
+    assert "Update available" in out
+    assert "commit behind" not in out
+    assert "commits behind" not in out
+    assert "hermes update" in out
+
+
+def test_print_version_info_renders_exact_count(capsys):
+    """Real commit counts (from non-shallow git clones) still render precisely."""
+    from hermes_cli.main import _print_version_info
+
+    with patch("hermes_cli.banner.check_for_updates", return_value=3), \
+         patch("hermes_cli.config.recommended_update_command", return_value="hermes update"):
+        _print_version_info(check_updates=True)
+
+    out = capsys.readouterr().out
+    assert "3 commits behind" in out
+
+
+def test_print_version_info_up_to_date(capsys):
+    """behind == 0 renders "Up to date"."""
+    from hermes_cli.main import _print_version_info
+
+    with patch("hermes_cli.banner.check_for_updates", return_value=0):
+        _print_version_info(check_updates=True)
+
+    out = capsys.readouterr().out
+    assert "Up to date" in out
+    assert "Update available" not in out


### PR DESCRIPTION
## Problem

The SSH-official-remote branch in `banner._check_via_local_git` was hard-coded to return `1` whenever `_check_via_rev` reported `UPDATE_AVAILABLE_NO_COUNT`, so `hermes --version` and the CLI banner surfaced a stable but false `Update available: 1 commit behind — run hermes update` message.

The count never grew: whether upstream was 1 commit or 100 commits ahead, the banner always said "1 commit behind".

## Root cause

Introduced in #52828 to "align with the desktop client checker". The intent was to give the desktop UI *something* to show, but the change picked the wrong lever: an `ls-remote` probe against the upstream URL can only tell us tip SHAs, not a real commit count. Fabricating `1` in the source path breaks every downstream consumer that renders a count.

The `UPDATE_AVAILABLE_NO_COUNT` sentinel (`-1`) already means "update exists, count unknown" — that's the exact shape this path should return. It's what `check_via_nix_revision` and (via #50784) `check_via_pypi` already do.

## Why no UI consumer needs the fake `1`

- **REST `/api/hermes/update/check`** (`hermes_cli/web_server.py::check_hermes_update`) treats any nonzero `behind` as `update_available=true`, and the docstring explicitly documents `-1` as a legitimate value (`"-1 if behind by an unknown count (nix/pypi)"`).
- **Desktop store** (`apps/desktop/src/store/updates.ts::mapBackendCheck`) already clamps `behind <= 0` to `0` and reads `updateAvailable` as a separate boolean field — so a `-1` payload from the backend renders as `updateAvailable=true, behind=0`, exactly the "yes update, no number" UX the original PR was trying to achieve.

So restoring the sentinel is a strict improvement: the CLI banner and `hermes --version` say "Update available" honestly instead of inventing a count, and every REST/desktop consumer keeps working.

## Changes

- `hermes_cli/banner.py::_check_via_local_git` — drop the `return 1` override in the SSH branch; propagate the sentinel unchanged. Comment explains why every UI consumer already handles `-1` correctly.
- `hermes_cli/main.py::_print_version_info` — render the sentinel as `Update available — run <cmd>` (no count).
- `tests/hermes_cli/test_update_check.py`
  - Update `test_check_for_updates_official_ssh_origin_uses_https_probe` to assert on the sentinel (was asserting on the fabricated `1`).
  - Add three new tests locking in the CLI renderer's three branches: `UPDATE_AVAILABLE_NO_COUNT` → "Update available" without a count; `> 0` → exact-count rendering; `== 0` → "Up to date".

## Test plan

```
$ ./venv/bin/python -m pytest tests/hermes_cli/test_update_check.py \
    tests/gateway/test_version_command.py tests/hermes_cli/test_banner_git_state.py \
    tests/hermes_cli/test_banner_pip_update.py tests/hermes_cli/test_banner_skills.py \
    tests/hermes_cli/test_pip_install_detection.py \
    -o 'addopts=' -q -n 0 --tb=short
51 passed in 8.30s
```

## Repro (before this PR)

Clone `git@github.com:NousResearch/hermes-agent.git` (SSH remote) via the installer (`--depth 1`). Fully update to the latest tag. Run `hermes --version`:

```
Update available: 1 commit behind — run 'hermes update'
```

Now run `hermes update`. It reports `Already up to date`. `hermes --version` still says `1 commit behind`. Rinse and repeat — the message is permanent because the SSH branch never actually counted anything.

After this PR the same environment reports `Up to date` (when caught up) or `Update available — run 'hermes update'` (when upstream is genuinely ahead).