### PR TITLE
fix(docker): reject Windows drive cwd overrides

### DIFF
--- a/tests/tools/test_container_cwd_sanitize.py
+++ b/tests/tools/test_container_cwd_sanitize.py
@@ -20,14 +20,32 @@ behaviour so neither path can regress.
 import tools.terminal_tool as tt
 
 
+def _windows_isabs(path):
+    return (
+        len(path) >= 3
+        and path[1] == ":"
+        and path[2] in ("\\", "/")
+    ) or path.startswith(("\\\\", "//"))
+
+
 class TestIsUnusableContainerCwd:
     def test_windows_backslash_host_path_rejected(self):
         # The exact shape from the bug report: a Windows host cwd reaching a
         # Linux container's -w flag.
         assert tt._is_unusable_container_cwd(r"C:\Users\someuser") is True
+        assert tt._is_unusable_container_cwd(r"E:\Oraca\workspaces\repo") is True
 
     def test_windows_forwardslash_host_path_rejected(self):
         assert tt._is_unusable_container_cwd("C:/Users/someuser") is True
+        assert tt._is_unusable_container_cwd("D:/workspaces/repo") is True
+
+    def test_non_c_windows_drive_rejected_on_native_windows(self, monkeypatch):
+        # On native Windows, os.path.isabs("E:\\...") is True, so the old
+        # relative-path fallback does not catch non-C drive letters.
+        monkeypatch.setattr(tt.os.path, "isabs", _windows_isabs)
+
+        assert tt._is_unusable_container_cwd(r"E:\Oraca\workspaces\repo") is True
+        assert tt._is_unusable_container_cwd("D:/workspaces/repo") is True
 
     def test_posix_home_host_path_rejected(self):
         assert tt._is_unusable_container_cwd("/home/ben/projects") is True
@@ -136,6 +154,14 @@ class TestOverrideCwdSanitizedAtCallSite:
             "It must be sanitized back to config['cwd']."
         )
 
+    def test_non_c_windows_host_override_does_not_reach_container(self, monkeypatch):
+        monkeypatch.setattr(tt.os.path, "isabs", _windows_isabs)
+        cwd = self._run_and_capture_cwd(monkeypatch, r"E:\Oraca\workspaces\repo")
+        assert cwd == "/root", (
+            f"Host-path cwd override leaked to the container builder: {cwd!r}. "
+            "Any Windows drive-letter cwd must be sanitized back to config['cwd']."
+        )
+
     def test_posix_host_override_does_not_reach_container(self, monkeypatch):
         cwd = self._run_and_capture_cwd(monkeypatch, "/home/someuser/project")
         assert cwd == "/root"
@@ -235,6 +261,11 @@ class TestFileOpsCwdSanitizedAtCallSite:
 
     def test_windows_host_override_does_not_reach_container(self, monkeypatch):
         cwd = self._run_and_capture_cwd(monkeypatch, r"C:\Users\someuser")
+        assert cwd == "/workspace"
+
+    def test_non_c_windows_host_override_does_not_reach_container(self, monkeypatch):
+        monkeypatch.setattr(tt.os.path, "isabs", _windows_isabs)
+        cwd = self._run_and_capture_cwd(monkeypatch, r"E:\Oraca\workspaces\repo")
         assert cwd == "/workspace"
 
     def test_relative_cwd_override_does_not_reach_container(self, monkeypatch):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1212,6 +1212,7 @@ def _safe_getcwd() -> str:
 # (``C:\Users\...`` / ``C:/Users/...``) — the latter is how a Windows host's
 # cwd looks when it leaks toward a Linux container's ``-w`` flag.
 _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
+_WINDOWS_DRIVE_CWD_RE = re.compile(r"^[A-Za-z]:[\\/]")
 
 _CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona"})
 
@@ -1245,9 +1246,9 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
         return False
     if any(cwd.startswith(p) for p in _HOST_CWD_PREFIXES):
         return True
-    # Relative paths (".", "src/") can't be a container workdir either. Windows
-    # drive paths are absolute on Windows but os.path.isabs() is False on a
-    # POSIX host, so they're already caught by the prefix check above.
+    if _WINDOWS_DRIVE_CWD_RE.match(cwd):
+        return True
+    # Relative paths (".", "src/") can't be a container workdir either.
     if not os.path.isabs(cwd):
         return True
     return False


### PR DESCRIPTION
Fixes #60962

## What changed

- Treat every Windows drive-letter cwd (`D:/...`, `E:\\...`, etc.) as a host path that cannot be used as a Linux container workdir.
- Preserve existing `C:\\` / `C:/` behavior and valid in-container absolute paths.
- Add native-Windows `os.path.isabs()` regressions for the sanitizer, terminal cwd overrides, and file-operation cwd overrides.

## Why

The existing host-prefix check recognized only `C:`. On native Windows, `os.path.isabs("E:\\...")` is true, so non-C drive overrides bypassed both the host-prefix and relative-path guards and could reach `docker run -w` unchanged.

## Tests

- `HERMES_HOME=/private/tmp/hermes-61053-home PYTHONPYCACHEPREFIX=/private/tmp/hermes-pycache python -m pytest -p no:cacheprovider tests/tools/test_container_cwd_sanitize.py tests/tools/test_modal_sandbox_fixes.py -q` (49 passed)
- `python -m ruff check tools/terminal_tool.py tests/tools/test_container_cwd_sanitize.py`
- `git diff --check`