### PR TITLE
fix(gateway): clarify resume_pending_expired auto-reset notice

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -136,6 +136,58 @@ _GATEWAY_PROVIDER_POLICY_RE = re.compile(
     re.IGNORECASE,
 )
 
+
+
+def _auto_reset_context_note(reset_reason: str) -> str:
+    """Return the assistant-only context note for an auto-reset session."""
+
+    if reset_reason == "suspended":
+        return (
+            "[System note: The user's previous session was stopped and suspended. "
+            "This is a fresh conversation with no prior context.]"
+        )
+    if reset_reason == "daily":
+        return (
+            "[System note: The user's session was automatically reset by the daily "
+            "schedule. This is a fresh conversation with no prior context.]"
+        )
+    if reset_reason == "resume_pending_expired":
+        return (
+            "[System note: The user's previous session expired after a gateway "
+            "resume timeout. This is a fresh conversation with no prior context.]"
+        )
+    return (
+        "[System note: The user's previous session expired due to inactivity. "
+        "This is a fresh conversation with no prior context.]"
+    )
+
+
+def _auto_reset_reason_text(reset_reason: str, policy: Any) -> str:
+    """Return the human-facing auto-reset reason text."""
+
+    if reset_reason == "suspended":
+        return "previous session was stopped or interrupted"
+    if reset_reason == "daily":
+        return f"daily schedule at {policy.at_hour}:00"
+    if reset_reason == "resume_pending_expired":
+        return "previous session expired after gateway resume timeout"
+
+    hours = policy.idle_minutes // 60
+    mins = policy.idle_minutes % 60
+    duration = f"{hours}h" if not mins else f"{hours}h {mins}m" if hours else f"{mins}m"
+    return f"inactive for {duration}"
+
+
+def _auto_reset_adjust_hint(reset_reason: str) -> str:
+    """Return the config hint appended to the user-facing auto-reset notice."""
+
+    if reset_reason == "resume_pending_expired":
+        return (
+            "Adjust gateway resume freshness in config.yaml under "
+            "agent.gateway_auto_continue_freshness."
+        )
+    return "Adjust reset timing in config.yaml under session_reset."
+
 _GATEWAY_AUTH_ERROR_RE = re.compile(
     r"(provider\s+authentication\s+failed|incorrect\s+api\s+key|invalid\s+api\s+key|\b401\b)",
     re.IGNORECASE,
@@ -10801,12 +10853,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # so the agent knows this is a fresh conversation (not an intentional /reset).
         if _was_auto_reset:
             reset_reason = getattr(session_entry, 'auto_reset_reason', None) or 'idle'
-            if reset_reason == "suspended":
-                context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
-            elif reset_reason == "daily":
-                context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
-            else:
-                context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
+            context_note = _auto_reset_context_note(reset_reason)
             context_prompt = context_note + "\n\n" + context_prompt
 
             # Send a user-facing notification explaining the reset, unless:
@@ -10830,20 +10877,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if should_notify:
                     adapter = self._adapter_for_source(source)
                     if adapter:
-                        if reset_reason == "suspended":
-                            reason_text = "previous session was stopped or interrupted"
-                        elif reset_reason == "daily":
-                            reason_text = f"daily schedule at {policy.at_hour}:00"
-                        else:
-                            hours = policy.idle_minutes // 60
-                            mins = policy.idle_minutes % 60
-                            duration = f"{hours}h" if not mins else f"{hours}h {mins}m" if hours else f"{mins}m"
-                            reason_text = f"inactive for {duration}"
+                        reason_text = _auto_reset_reason_text(reset_reason, policy)
+                        adjust_hint = _auto_reset_adjust_hint(reset_reason)
                         notice = (
                             f"◐ Session automatically reset ({reason_text}). "
                             f"Conversation history cleared.\n"
                             f"Use /resume to browse and restore a previous session.\n"
-                            f"Adjust reset timing in config.yaml under session_reset."
+                            f"{adjust_hint}"
                         )
                         try:
                             session_info = await asyncio.to_thread(

--- a/tests/gateway/test_resume_pending_expired_notice.py
+++ b/tests/gateway/test_resume_pending_expired_notice.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from gateway.run import (
+    _auto_reset_adjust_hint,
+    _auto_reset_context_note,
+    _auto_reset_reason_text,
+)
+
+
+def _policy(*, idle_minutes: int = 1440, at_hour: int = 9) -> SimpleNamespace:
+    return SimpleNamespace(idle_minutes=idle_minutes, at_hour=at_hour)
+
+
+def test_resume_pending_expired_has_dedicated_context_note() -> None:
+    note = _auto_reset_context_note("resume_pending_expired")
+    assert "gateway resume timeout" in note
+    assert "inactivity" not in note
+
+
+def test_resume_pending_expired_has_dedicated_reason_text() -> None:
+    text = _auto_reset_reason_text("resume_pending_expired", _policy())
+    assert text == "previous session expired after gateway resume timeout"
+
+
+def test_resume_pending_expired_has_dedicated_config_hint() -> None:
+    hint = _auto_reset_adjust_hint("resume_pending_expired")
+    assert hint == (
+        "Adjust gateway resume freshness in config.yaml under "
+        "agent.gateway_auto_continue_freshness."
+    )
+
+
+def test_idle_reason_text_still_uses_session_reset_idle_minutes() -> None:
+    text = _auto_reset_reason_text("idle", _policy(idle_minutes=90))
+    assert text == "inactive for 1h 30m"
+
+
+def test_daily_reason_text_is_unchanged() -> None:
+    text = _auto_reset_reason_text("daily", _policy(at_hour=6))
+    assert text == "daily schedule at 6:00"
+
+
+def test_non_resume_pending_adjust_hint_stays_on_session_reset() -> None:
+    hint = _auto_reset_adjust_hint("idle")
+    assert hint == "Adjust reset timing in config.yaml under session_reset."


### PR DESCRIPTION
## Summary
- add dedicated notice text for `resume_pending_expired`
- stop labeling that path as generic idle reset / `inactive for 24h`
- point users at `agent.gateway_auto_continue_freshness` for this specific reset path

## Why
`resume_pending_expired` currently falls through the generic idle-reset notice branch, so users can see:

- `Session automatically reset (inactive for 24h)`

…even when the real cause was the gateway resume freshness timeout, not a 24h idle reset.

## Changes
- add `_auto_reset_context_note()` mapping for assistant-side context
- add `_auto_reset_reason_text()` mapping for the user-facing notice
- add `_auto_reset_adjust_hint()` so this path points at the correct config key
- preserve existing idle/daily/suspended wording
- add focused regression tests for the new mappings

## Testing
- `./venv/bin/python -m pytest -q tests/gateway/test_resume_pending_expired_notice.py tests/gateway/test_48031_model_switch_after_auto_reset.py`
