### PR TITLE
fix(tools): bound fuzzy matching on large files

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -429,6 +429,19 @@ class TestExpensiveFuzzyGuards:
         assert err == "Could not find a match for old_string in the file"
         assert CountingSequenceMatcher.calls <= 5
 
+    def test_block_anchor_skips_oversized_middle_comparison(self, monkeypatch):
+        class ForbiddenSequenceMatcher:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("SequenceMatcher should not run for oversized block-anchor middle")
+
+        monkeypatch.setattr(fm, "_SEQUENCE_MATCHER_MAX_PAIR_CHAR_PRODUCT", 100)
+        monkeypatch.setattr(fm, "SequenceMatcher", ForbiddenSequenceMatcher)
+
+        content = "anchor start\n" + ("content middle " * 20) + "\nanchor end"
+        pattern = "anchor start\n" + ("pattern middle " * 20) + "\nanchor end"
+
+        assert fm._strategy_block_anchor(content, pattern) == []
+
 
 class TestStrategyNameSurfaced:
     """Tests for the strategy name in the 4-tuple return (Bug 6)."""

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -1,5 +1,6 @@
 """Tests for the fuzzy matching module."""
 
+import tools.fuzzy_match as fm
 from tools.fuzzy_match import fuzzy_find_and_replace
 
 
@@ -357,6 +358,78 @@ class TestBlockAnchorThreshold:
         )
 
 
+class TestExpensiveFuzzyGuards:
+    """Regression tests for large-file fuzzy matching bounds."""
+
+    def test_large_file_miss_skips_expensive_sequence_matcher(self, monkeypatch):
+        class ForbiddenSequenceMatcher:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("SequenceMatcher should not run for large-file miss")
+
+        monkeypatch.setattr(fm, "_EXPENSIVE_FUZZY_MAX_CONTENT_CHARS", 100)
+        monkeypatch.setattr(fm, "_EXPENSIVE_FUZZY_MAX_CONTENT_LINES", 20)
+        monkeypatch.setattr(fm, "SequenceMatcher", ForbiddenSequenceMatcher)
+
+        content = "\n".join(f"line {i}: stable content" for i in range(50))
+        new, count, strategy, err = fm.fuzzy_find_and_replace(
+            content,
+            "missing header\nmissing footer",
+            "replacement",
+        )
+
+        assert new == content
+        assert count == 0
+        assert strategy is None
+        assert err == "Could not find a match for old_string in the file"
+
+    def test_unicode_strategy_still_runs_before_large_file_guard(self, monkeypatch):
+        monkeypatch.setattr(fm, "_EXPENSIVE_FUZZY_MAX_CONTENT_CHARS", 100)
+        monkeypatch.setattr(fm, "_EXPENSIVE_FUZZY_MAX_CONTENT_LINES", 20)
+
+        content = ("padding line\n" * 30) + "return value\u2014fallback\n"
+        new, count, strategy, err = fm.fuzzy_find_and_replace(
+            content,
+            "return value--fallback",
+            "return value--replacement",
+        )
+
+        assert err is None
+        assert count == 1
+        assert strategy == "unicode_normalized"
+        assert "return value\u2014replacement" in new
+
+    def test_context_aware_sequence_matcher_calls_are_bounded(self, monkeypatch):
+        from difflib import SequenceMatcher as RealSequenceMatcher
+
+        class CountingSequenceMatcher:
+            calls = 0
+
+            def __init__(self, *args, **kwargs):
+                CountingSequenceMatcher.calls += 1
+                self._matcher = RealSequenceMatcher(*args, **kwargs)
+
+            def ratio(self):
+                return self._matcher.ratio()
+
+        monkeypatch.setattr(fm, "_EXPENSIVE_FUZZY_MAX_CONTENT_CHARS", 10_000)
+        monkeypatch.setattr(fm, "_EXPENSIVE_FUZZY_MAX_CONTENT_LINES", 10_000)
+        monkeypatch.setattr(fm, "_SEQUENCE_MATCHER_MAX_CALLS", 5)
+        monkeypatch.setattr(fm, "SequenceMatcher", CountingSequenceMatcher)
+
+        content = "\n".join(f"candidate line {i}" for i in range(50))
+        new, count, strategy, err = fm.fuzzy_find_and_replace(
+            content,
+            "missing alpha\nmissing beta",
+            "replacement",
+        )
+
+        assert new == content
+        assert count == 0
+        assert strategy is None
+        assert err == "Could not find a match for old_string in the file"
+        assert CountingSequenceMatcher.calls <= 5
+
+
 class TestStrategyNameSurfaced:
     """Tests for the strategy name in the 4-tuple return (Bug 6)."""
 
@@ -483,6 +556,18 @@ class TestFindClosestLines:
         result = self.find_closest_lines("def foo():", content)
         # Should include line numbers in format "N| content"
         assert "|" in result
+
+    def test_large_content_skips_hint_similarity_scan(self, monkeypatch):
+        class ForbiddenSequenceMatcher:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("SequenceMatcher should not run for large hint scans")
+
+        monkeypatch.setattr(fm, "_EXPENSIVE_FUZZY_MAX_CONTENT_CHARS", 100)
+        monkeypatch.setattr(fm, "_EXPENSIVE_FUZZY_MAX_CONTENT_LINES", 20)
+        monkeypatch.setattr(fm, "SequenceMatcher", ForbiddenSequenceMatcher)
+
+        content = "\n".join(f"def function_{i}(): pass" for i in range(50))
+        assert self.find_closest_lines("def missing():", content) == ""
 
 
 class TestFormatNoMatchHint:
@@ -665,4 +750,3 @@ class TestEscapeNormalizedNewString:
         assert err is None
         assert count == 1
         assert "return 2" in new
-

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -40,11 +40,52 @@ UNICODE_MAP = {
     "\u2026": "...", "\u00a0": " ", # ellipsis and non-breaking space
 }
 
+_EXPENSIVE_FUZZY_STRATEGIES = frozenset({"block_anchor", "context_aware"})
+_EXPENSIVE_FUZZY_MAX_CONTENT_CHARS = 1_000_000
+_EXPENSIVE_FUZZY_MAX_CONTENT_LINES = 20_000
+_EXPENSIVE_FUZZY_MAX_PATTERN_CHARS = 100_000
+
+_SEQUENCE_MATCHER_MAX_CALLS = 20_000
+_SEQUENCE_MATCHER_MAX_PAIR_CHAR_PRODUCT = 2_000_000
+_SEQUENCE_MATCHER_MAX_TOTAL_CHAR_PRODUCT = 25_000_000
+
 def _unicode_normalize(text: str) -> str:
     """Normalizes Unicode characters to their standard ASCII equivalents."""
     for char, repl in UNICODE_MAP.items():
         text = text.replace(char, repl)
     return text
+
+
+class _SequenceMatcherBudget:
+    """Best-effort work budget for expensive fuzzy similarity checks."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.char_product = 0
+        self.exhausted = False
+
+    def ratio(self, a: str, b: str) -> Optional[float]:
+        pair_work = len(a) * len(b)
+        if (
+            self.calls >= _SEQUENCE_MATCHER_MAX_CALLS
+            or pair_work > _SEQUENCE_MATCHER_MAX_PAIR_CHAR_PRODUCT
+            or self.char_product + pair_work > _SEQUENCE_MATCHER_MAX_TOTAL_CHAR_PRODUCT
+        ):
+            self.exhausted = True
+            return None
+
+        self.calls += 1
+        self.char_product += pair_work
+        return SequenceMatcher(None, a, b).ratio()
+
+
+def _should_skip_expensive_fuzzy_matching(content: str, pattern: str) -> bool:
+    """Return True when deep fuzzy matching is too costly to try safely."""
+    if len(content) > _EXPENSIVE_FUZZY_MAX_CONTENT_CHARS:
+        return True
+    if len(pattern) > _EXPENSIVE_FUZZY_MAX_PATTERN_CHARS:
+        return True
+    return content.count("\n") + 1 > _EXPENSIVE_FUZZY_MAX_CONTENT_LINES
 
 
 def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
@@ -83,6 +124,16 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
     ]
 
     for strategy_name, strategy_fn in strategies:
+        # Keep the cheap deterministic strategies available for large files:
+        # exact, whitespace/indent/escape normalization, boundary trim, and
+        # unicode normalization are all tried before this guard. Only the deep
+        # fuzzy strategies below use SequenceMatcher in broad loops.
+        if (
+            strategy_name in _EXPENSIVE_FUZZY_STRATEGIES
+            and _should_skip_expensive_fuzzy_matching(content, old_string)
+        ):
+            break
+
         matches = strategy_fn(content, old_string)
 
         if matches:
@@ -673,6 +724,7 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
     # Previous values (0.10 / 0.30) were dangerously loose — a 10% middle-section
     # similarity could match completely unrelated blocks.
     threshold = 0.50 if candidate_count == 1 else 0.70
+    budget = _SequenceMatcherBudget()
 
     for i in potential_matches:
         if pattern_line_count <= 2:
@@ -681,7 +733,9 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
             # Compare normalized middle sections
             content_middle = '\n'.join(norm_content_lines[i+1:i+pattern_line_count-1])
             pattern_middle = '\n'.join(pattern_lines[1:-1])
-            similarity = SequenceMatcher(None, content_middle, pattern_middle).ratio()
+            similarity = budget.ratio(content_middle, pattern_middle)
+            if similarity is None:
+                return []
         
         if similarity >= threshold:
             # Calculate positions using ORIGINAL lines to ensure correct character offsets in the file
@@ -707,6 +761,7 @@ def _strategy_context_aware(content: str, pattern: str) -> List[Tuple[int, int]]
     
     matches = []
     pattern_line_count = len(pattern_lines)
+    budget = _SequenceMatcherBudget()
     
     for i in range(len(content_lines) - pattern_line_count + 1):
         block_lines = content_lines[i:i + pattern_line_count]
@@ -714,7 +769,9 @@ def _strategy_context_aware(content: str, pattern: str) -> List[Tuple[int, int]]
         # Calculate line-by-line similarity
         high_similarity_count = 0
         for p_line, c_line in zip(pattern_lines, block_lines):
-            sim = SequenceMatcher(None, p_line.strip(), c_line.strip()).ratio()
+            sim = budget.ratio(p_line.strip(), c_line.strip())
+            if sim is None:
+                return []
             if sim >= 0.80:
                 high_similarity_count += 1
         
@@ -881,6 +938,8 @@ def find_closest_lines(old_string: str, content: str, context_lines: int = 2, ma
 
     if not old_lines or not content_lines:
         return ""
+    if _should_skip_expensive_fuzzy_matching(content, old_string):
+        return ""
 
     # Use first line of old_string as anchor for search
     anchor = old_lines[0].strip()
@@ -893,11 +952,14 @@ def find_closest_lines(old_string: str, content: str, context_lines: int = 2, ma
 
     # Score each line in content by similarity to anchor
     scored = []
+    budget = _SequenceMatcherBudget()
     for i, line in enumerate(content_lines):
         stripped = line.strip()
         if not stripped:
             continue
-        ratio = SequenceMatcher(None, anchor, stripped).ratio()
+        ratio = budget.ratio(anchor, stripped)
+        if ratio is None:
+            return ""
         if ratio > 0.3:
             scored.append((ratio, i))
 


### PR DESCRIPTION
## What does this PR do?

Bounds the expensive fuzzy matching fallback paths used by patch/file replacement when they run against large files or large multi-line patterns.

The exact and cheap normalization strategies still run first. Only the broad `SequenceMatcher`-based `block_anchor`, `context_aware`, and no-match hint scans get size/work budgets so large misses fail quickly instead of hanging the patch tool.

## Related Issue

Fixes #20173. This is a narrower replacement for the closed timeout-guard attempt in #20181.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added explicit work budgets around expensive fuzzy similarity checks in `tools/fuzzy_match.py`.
- Skipped only the expensive fuzzy fallbacks for very large content/patterns; exact, whitespace, indentation, escape, boundary, and Unicode-normalized matching still run before the guard.
- Added regression tests for large-file miss behavior, bounded `SequenceMatcher` calls, Unicode matching before the guard, and large no-match hint scans.

## Impact

Local microbenchmarks on the same synthetic inputs, comparing `origin/main` to this branch:

- 20,001-line miss:
  - `fuzzy_find_and_replace`: 2.507s -> 0.039s
  - `format_no_match_hint`: 0.611s -> 0.001s
- 98KB / 2,342-line adversarial anchored pattern:
  - before: timed out after 5.004s
  - after: 0.016s graceful no-match

Tradeoff: very large/adversarial inputs can now return no-match after the cheap deterministic strategies instead of continuing deep fuzzy search indefinitely.

## How to Test

1. `python -m pytest tests/tools/test_fuzzy_match.py tests/tools/test_patch_parser.py tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py -q`
2. `uv tool run ruff check .`
3. `python scripts/check-windows-footguns.py --all`
4. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.13 local environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation passed locally; full test suite was not run.
