### PR TITLE
fix(desktop): preserve local dashboard session token

### DIFF
--- a/apps/desktop/electron/desktop-backend-auth.test.cjs
+++ b/apps/desktop/electron/desktop-backend-auth.test.cjs
@@ -1,0 +1,64 @@
+/**
+ * Regression coverage for the Desktop-owned local backend auth handshake.
+ *
+ * Run with: node --test electron/desktop-backend-auth.test.cjs
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const mainPath = path.join(__dirname, 'main.cjs')
+const source = fs.readFileSync(mainPath, 'utf8')
+
+function functionSource(functionName, followingFunctionName) {
+  const start = source.indexOf(`async function ${functionName}`)
+  assert.notEqual(start, -1, `main.cjs should define ${functionName}`)
+  const end = source.indexOf(`function ${followingFunctionName}`, start)
+  assert.notEqual(end, -1, `${functionName} should be followed by ${followingFunctionName}`)
+  return source.slice(start, end)
+}
+
+function assertAdoptsBeforeReadiness(body, label) {
+  const adoptIndex = body.indexOf('const authToken = await adoptServedDashboardToken(baseUrl, token')
+  const waitWithAuthIndex = body.indexOf('waitForHermes(baseUrl, authToken)')
+
+  assert.notEqual(adoptIndex, -1, `${label} should adopt the served dashboard token`)
+  assert.notEqual(waitWithAuthIndex, -1, `${label} should probe readiness with authToken`)
+  assert.ok(
+    adoptIndex < waitWithAuthIndex,
+    `${label} token adoption must happen before the readiness API probe`
+  )
+  assert.doesNotMatch(
+    body,
+    /waitForHermes\(baseUrl,\s*token\)/,
+    `${label} must not probe with the pre-adoption spawn token`
+  )
+}
+
+test('primary desktop backend starts isolated to avoid unified-dashboard token drift', () => {
+  const body = functionSource('startHermes()', 'wireCommonWindowHandlers')
+  assert.match(
+    body,
+    /const backendArgs = \['serve', '--host', '127\.0\.0\.1', '--port', '0', '--isolated'\]/,
+    'desktop-spawned serve backend should pass --isolated'
+  )
+})
+
+test('primary desktop backend adopts served dashboard token before readiness API probe', () => {
+  assertAdoptsBeforeReadiness(functionSource('startHermes()', 'wireCommonWindowHandlers'), 'startHermes()')
+})
+
+test('profile pool backend starts isolated to avoid unified-dashboard token drift', () => {
+  const body = functionSource('spawnPoolBackend(profile, entry)', 'stopPoolBackend')
+  assert.match(
+    body,
+    /const backendArgs = \['--profile', profile, 'serve', '--host', '127\.0\.0\.1', '--port', '0', '--isolated'\]/,
+    'profile pool serve backend should pass --isolated'
+  )
+})
+
+test('profile pool backend adopts served dashboard token before readiness API probe', () => {
+  assertAdoptsBeforeReadiness(functionSource('spawnPoolBackend(profile, entry)', 'stopPoolBackend'), 'spawnPoolBackend()')
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5358,7 +5358,9 @@ async function spawnPoolBackend(profile, entry) {
   // --profile wins over the inherited HERMES_HOME env (see _apply_profile_override
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
   // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
-  const backendArgs = ['--profile', profile, 'serve', '--host', '127.0.0.1', '--port', '0']
+  // --isolated keeps the desktop-owned profile backend from routing into a unified
+  // machine dashboard whose session token can differ from the desktop token.
+  const backendArgs = ['--profile', profile, 'serve', '--host', '127.0.0.1', '--port', '0', '--isolated']
   const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
   backend.args = getBackendArgsForRuntime(backend)
@@ -5426,13 +5428,13 @@ async function spawnPoolBackend(profile, entry) {
   entry.port = port
 
   const baseUrl = `http://127.0.0.1:${port}`
-  await Promise.race([waitForHermes(baseUrl, token), startFailed])
-  ready = true
   const authToken = await adoptServedDashboardToken(baseUrl, token, {
     childAlive: () => child.exitCode === null && !child.killed,
     label: `Hermes backend for profile "${profile}"`,
     rememberLog
   })
+  await Promise.race([waitForHermes(baseUrl, authToken), startFailed])
+  ready = true
   entry.token = authToken
 
   return {
@@ -5570,7 +5572,9 @@ async function startHermes() {
 
     const token = crypto.randomBytes(32).toString('base64url')
     // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
-    const backendArgs = ['serve', '--host', '127.0.0.1', '--port', '0']
+    // --isolated keeps the desktop-owned backend from routing into a unified
+    // machine dashboard whose session token can differ from the desktop token.
+    const backendArgs = ['serve', '--host', '127.0.0.1', '--port', '0', '--isolated']
     // Pin the desktop's chosen profile via the global --profile flag. This is
     // deterministic (it wins over the sticky ~/.hermes/active_profile file) and
     // resolves HERMES_HOME the same way `hermes -p <name>` does on the CLI. An
@@ -5680,14 +5684,21 @@ async function startHermes() {
 
     const baseUrl = `http://127.0.0.1:${port}`
     await advanceBootProgress('backend.wait', 'Waiting for Hermes backend to become ready', 90)
-    await Promise.race([waitForHermes(baseUrl, token), backendStartFailed])
-    backendReady = true
-    backendStartFailure = null
+
+    // Post-update fix (2026-07-07): adopt served token *before* readiness probe.
+    // The original spawn token can be rejected if the dashboard regenerates it.
+    // This prevents the first `waitForHermes` (and subsequent hermes:api calls)
+    // from hitting 401 Unauthorized.
     const authToken = await adoptServedDashboardToken(baseUrl, token, {
       // The exit/error handlers null hermesProcess when the child dies.
       childAlive: () => hermesProcess !== null && hermesProcess.exitCode === null && !hermesProcess.killed,
       rememberLog
     })
+
+    await Promise.race([waitForHermes(baseUrl, authToken), backendStartFailed])
+    backendReady = true
+    backendStartFailure = null
+
     updateBootProgress({
       phase: 'backend.ready',
       message: 'Hermes backend is ready. Finalizing desktop startup',

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -512,12 +512,26 @@ def _apply_profile_override() -> None:
 
 _apply_profile_override()
 
+# Desktop-spawned local backends mint a fresh per-process dashboard session
+# token and pass it through the environment. The normal env loader intentionally
+# lets ~/.hermes/.env override stale shell exports, but that would replace the
+# Desktop token with any stable remote-dashboard token saved in .env and make
+# Electron's X-Hermes-Session-Token calls 401. Capture and restore this one
+# in-process secret after dotenv loading; never log or persist it.
+_desktop_session_token_override = (
+    os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN")
+    if os.environ.get("HERMES_DESKTOP") == "1"
+    else None
+)
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.config import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
 
 load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
+if _desktop_session_token_override:
+    os.environ["HERMES_DASHBOARD_SESSION_TOKEN"] = _desktop_session_token_override
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at

--- a/tests/hermes_cli/test_desktop_session_token.py
+++ b/tests/hermes_cli/test_desktop_session_token.py
@@ -1,0 +1,99 @@
+"""Regression coverage for Desktop's ephemeral dashboard session token.
+
+Desktop launches ``hermes serve`` with a freshly generated
+HERMES_DASHBOARD_SESSION_TOKEN. A user's ~/.hermes/.env may also contain a
+stable dashboard token for remote-dashboard workflows. The normal env loader
+lets .env override shell exports, but Desktop's per-process token must win or
+Electron's local API calls 401.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import secrets
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def _request_status(port: int, token: str | None) -> int:
+    headers = {}
+    if token is not None:
+        headers["X-Hermes-Session-Token"] = token
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/api/sessions?limit=1",
+        headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            resp.read()
+            return resp.status
+    except urllib.error.HTTPError as exc:
+        exc.read()
+        return exc.code
+
+
+def test_desktop_session_token_survives_dotenv_override(tmp_path: Path):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text(
+        f"HERMES_DASHBOARD_SESSION_TOKEN={secrets.token_urlsafe(32)}\n",
+        encoding="utf-8",
+    )
+
+    desktop_token = secrets.token_urlsafe(32)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HERMES_HOME": str(hermes_home),
+            "HERMES_DESKTOP": "1",
+            "HERMES_DASHBOARD_SESSION_TOKEN": desktop_token,
+        }
+    )
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+            "--isolated",
+        ],
+        cwd=str(Path(__file__).resolve().parents[2]),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        port = None
+        output: list[str] = []
+        deadline = time.time() + 25
+        assert proc.stdout is not None
+        while time.time() < deadline and port is None:
+            line = proc.stdout.readline()
+            if line:
+                output.append(line.rstrip())
+                match = re.search(r"HERMES_BACKEND_READY port=(\d+)", line)
+                if match:
+                    port = int(match.group(1))
+            elif proc.poll() is not None:
+                break
+
+        assert port is not None, "backend did not become ready: " + " | ".join(output[-8:])
+        assert _request_status(port, None) == 401
+        assert _request_status(port, desktop_token) == 200
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
## Summary
- launch Desktop-owned `hermes serve` backends with `--isolated` so they do not attach to a unified dashboard with a different session token
- adopt the served dashboard token before the readiness probe for both primary and profile-pool Desktop backends
- preserve Desktop-spawned `HERMES_DASHBOARD_SESSION_TOKEN` across `.env` loading when `HERMES_DESKTOP=1`
- add Electron and Python regression coverage for the local Desktop 401/session-token mismatch

## Verification
- `node --test electron/dashboard-token.test.cjs electron/desktop-backend-auth.test.cjs`
- `/Users/carl/.hermes/bin/uv run --with pytest pytest tests/hermes_cli/test_desktop_session_token.py -q`
- `/Users/carl/.hermes/bin/uv run --with pytest pytest tests/hermes_cli/test_web_server.py -k SessionTokenInjection -q`
- `/Users/carl/.hermes/bin/uv run --with pytest pytest tests/hermes_cli/test_dashboard_auth_gate.py -q`
- `git diff --check -- apps/desktop/electron/main.cjs hermes_cli/main.py apps/desktop/electron/desktop-backend-auth.test.cjs tests/hermes_cli/test_desktop_session_token.py`

## Notes
This fixes a local Desktop auth loop where Electron API calls could repeatedly return `401 Unauthorized` after Desktop generated a fresh local dashboard token but the backend loaded a stable token from `~/.hermes/.env`.

Only the Desktop 401 fix files are included; unrelated local dirty working-tree files were intentionally excluded.