### PR TITLE
fix(memory): preserve Hindsight embedded hardening config

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1033,10 +1033,15 @@ class HindsightMemoryProvider(MemoryProvider):
                     llm_provider = "openai"
                 logger.debug("Creating HindsightEmbedded client (profile=%s, provider=%s)",
                              self._config.get("profile", "hermes"), llm_provider)
+                llm_api_key = (
+                    self._config.get("llmApiKey")
+                    or self._config.get("llm_api_key")
+                    or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
+                )
                 kwargs = dict(
                     profile=self._config.get("profile", "hermes"),
                     llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
+                    llm_api_key=llm_api_key,
                     llm_model=self._config.get("llm_model", ""),
                 )
                 if self._llm_base_url:
@@ -1050,6 +1055,14 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._idle_timeout = idle_timeout
                 kwargs["idle_timeout"] = idle_timeout
                 self._client = HindsightEmbedded(**kwargs)
+                # HindsightEmbedded builds its daemon config from constructor
+                # kwargs. Keep that config aligned with Hermes' existing profile
+                # env generation before _ensure_started() can materialize it.
+                client_config = getattr(self._client, "config", None)
+                if isinstance(client_config, dict):
+                    client_config.update(
+                        _build_embedded_profile_env(self._config, llm_api_key=llm_api_key or None)
+                    )
             else:
                 _ensure_cloud_client_dependency()
                 from hindsight_client import Hindsight
@@ -1431,6 +1444,10 @@ class HindsightMemoryProvider(MemoryProvider):
                             client._manager.stop(profile)
 
                     client._ensure_started()
+                    # Some Hindsight daemon-manager paths rewrite the profile env
+                    # during ensure/start from their internal config. Re-materialize
+                    # from Hermes' existing profile env generation afterward.
+                    _materialize_embedded_profile_env(self._config)
                     with open(log_path, "a", encoding="utf-8") as f:
                         f.write("\n=== Daemon started successfully ===\n")
                 except Exception as e:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -423,6 +423,7 @@ class TestConfig:
         class FakeHindsightEmbedded:
             def __init__(self, **kwargs):
                 captured.update(kwargs)
+                self.config = {}
 
         monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
         monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
@@ -442,6 +443,37 @@ class TestConfig:
 
         assert captured["idle_timeout"] == 0
         assert captured["llm_provider"] == "openai"
+
+    def test_get_client_updates_embedded_daemon_config_from_existing_profile_env(self, monkeypatch):
+        captured = {}
+
+        class FakeHindsightEmbedded:
+            def __init__(self, **kwargs):
+                self.config = {"HINDSIGHT_API_LLM_MODEL": "narrow"}
+                captured["config"] = self.config
+
+        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
+        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = {
+            "profile": "hermes",
+            "llm_provider": "openai_compatible",
+            "llm_api_key": "test-key",
+            "llm_model": "gpt-4.1-nano",
+            "llm_base_url": "http://localhost:11434/v1",
+            "idle_timeout": 0,
+        }
+        p._llm_base_url = "http://localhost:11434/v1"
+
+        p._get_client()
+
+        assert captured["config"]["HINDSIGHT_API_LLM_PROVIDER"] == "openai"
+        assert captured["config"]["HINDSIGHT_API_LLM_API_KEY"] == "test-key"
+        assert captured["config"]["HINDSIGHT_API_LLM_MODEL"] == "gpt-4.1-nano"
+        assert captured["config"]["HINDSIGHT_API_LLM_BASE_URL"] == "http://localhost:11434/v1"
+        assert captured["config"]["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "0"
 
 
 class TestPostSetup:


### PR DESCRIPTION
## Summary

- keep `HindsightEmbedded.config` aligned with Hermes' existing embedded profile env generation before daemon startup/materialization
- re-materialize the embedded profile env from Hermes' existing config after daemon startup, because Hindsight's daemon manager can rewrite it from a narrower constructor-derived config
- add focused regression coverage using only existing Hindsight config fields and existing generated env keys

## Why

Hermes already has code that materializes the embedded Hindsight profile env from existing config such as `llm_provider`, `llm_api_key`, `llm_model`, `llm_base_url`, and `idle_timeout`.

However, `HindsightEmbedded` also builds an internal daemon config from constructor kwargs, and daemon startup can rewrite the profile env from that narrower internal config. This can make the profile env drift away from Hermes' existing profile-env generation even when Hermes config itself is correct.

This patch keeps the embedded client's internal config synchronized with the existing profile-env generation and re-materializes the profile env after daemon startup.

## Scope note

This PR intentionally does **not** introduce new Hermes config knobs, schema entries, defaults, or new env-var names. It only preserves existing config/functionality already present in the provider.

Verified in the PR diff:

- no added `get_config_schema()` entries
- no added `_DEFAULT_*` constants
- no new `HINDSIGHT_*` env strings beyond strings already present upstream
- no hidden retain/model/concurrency/observations/worker-slot config keys

## Testing

- `python -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py -q`
  - `117 passed in 0.74s`
