### PR TITLE
fix(gateway): respect session_reset.mode=none for resume_pending freshness gate

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1774,18 +1774,29 @@ class SessionStore:
                         # and return the existing entry so the transcript reloads
                         # intact, but still honour normal daily/idle reset policy.
                         #
-                        # Freshness gate (#46934): the idle/daily policy checks
-                        # ``updated_at``, which is bumped to ``now`` on every
-                        # message — so a zombie session that keeps receiving
-                        # messages never trips it and would resume stale context
-                        # forever.  ``last_resume_marked_at`` is set once when
-                        # resume was marked and never bumped per-message, so it
-                        # correctly measures how long resume has been pending.
-                        # If that exceeds the auto-continue freshness window, the
-                        # recovery turn either never ran or failed — treat the
-                        # session as a zombie and fall through to auto-reset.
+                        # ``mode == "none"`` is an explicit opt-out: the user asked
+                        # Hermes not to auto-reset the session, so resume_pending
+                        # freshness gating must not override that choice.
                         reset_reason = self._should_reset(entry, source)
                         if not reset_reason:
+                            policy = self.config.get_reset_policy(
+                                platform=source.platform,
+                                session_type=source.chat_type,
+                            )
+                            if policy.mode == "none":
+                                entry.updated_at = now
+                                self._save()
+                                return entry
+                            # Freshness gate (#46934): the idle/daily policy checks
+                            # ``updated_at``, which is bumped to ``now`` on every
+                            # message — so a zombie session that keeps receiving
+                            # messages never trips it and would resume stale context
+                            # forever.  ``last_resume_marked_at`` is set once when
+                            # resume was marked and never bumped per-message, so it
+                            # correctly measures how long resume has been pending.
+                            # If that exceeds the auto-continue freshness window, the
+                            # recovery turn either never ran or failed — treat the
+                            # session as a zombie and fall through to auto-reset.
                             _fw = auto_continue_freshness_window()
                             _ref_time = entry.last_resume_marked_at or entry.updated_at
                             if _fw > 0 and (now - _ref_time).total_seconds() > _fw:

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
-from gateway.config import GatewayConfig, Platform
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
 from gateway.session import SessionSource, SessionStore
 
 
@@ -274,7 +274,7 @@ class TestResumePendingFreshnessGate:
         return entry
 
     def test_fresh_resume_pending_returns_same_session(self, tmp_path):
-        store = _make_store(tmp_path)
+        store = _make_store(tmp_path, policy=SessionResetPolicy(mode="both"))
         source = _make_source()
         entry = self._mark_resume_pending(store, source)
 
@@ -285,7 +285,7 @@ class TestResumePendingFreshnessGate:
 
     def test_stale_resume_pending_falls_through_to_reset(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "3600")
-        store = _make_store(tmp_path)
+        store = _make_store(tmp_path, policy=SessionResetPolicy(mode="both"))
         source = _make_source()
         entry = self._mark_resume_pending(store, source)
 
@@ -305,12 +305,29 @@ class TestResumePendingFreshnessGate:
     def test_freshness_gate_disabled_returns_stale_session(self, tmp_path, monkeypatch):
         # Opt-out: window <= 0 restores the pre-fix "always fresh" behaviour.
         monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "0")
-        store = _make_store(tmp_path)
+        store = _make_store(tmp_path, policy=SessionResetPolicy(mode="both"))
         source = _make_source()
         entry = self._mark_resume_pending(store, source)
 
         with store._lock:
             entry.last_resume_marked_at = datetime.now() - timedelta(seconds=999999)
+            entry.updated_at = datetime.now()
+            store._save()
+
+        refreshed = store.get_or_create_session(source)
+        assert refreshed.session_id == entry.session_id
+        assert refreshed.resume_pending
+
+
+    def test_mode_none_bypasses_freshness_gate(self, tmp_path, monkeypatch):
+        # Explicit no-reset policy should win over resume_pending freshness gating.
+        monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "3600")
+        store = _make_store(tmp_path, policy=SessionResetPolicy(mode="none"))
+        source = _make_source()
+        entry = self._mark_resume_pending(store, source)
+
+        with store._lock:
+            entry.last_resume_marked_at = datetime.now() - timedelta(seconds=7200)
             entry.updated_at = datetime.now()
             store._save()
 


### PR DESCRIPTION
## Summary
- respect `session_reset.mode = none` for `resume_pending` freshness gating
- keep the existing `resume_pending` session instead of auto-resetting it into `resume_pending_expired`
- add a regression test for the explicit opt-out behavior

## Why
The freshness gate was added to prevent zombie sessions from resuming stale context forever after a gateway interruption.

But it also overrode an explicit user choice:
- `session_reset.mode: none`

With the current behavior, a restart-interrupted session can still auto-reset after `agent.gateway_auto_continue_freshness` elapses, even though normal reset policy says “do not auto-reset”.

## Changes
- if `_should_reset(...)` returns no reset reason and the resolved reset policy mode is `none`, return the existing `resume_pending` session
- leave the freshness gate unchanged for finite reset modes (`idle`, `daily`, `both`)
- update the existing freshness-gate tests to pin a finite reset policy explicitly
- add a regression test proving that `mode=none` bypasses the freshness gate

## Testing
- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest -q tests/gateway/test_clean_shutdown_marker.py`
