### PR TITLE
fix(async_delegation): add missing interrupt_for_session function

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -357,7 +357,7 @@ class DeliveryRouter:
         lines.append("")
         lines.append(content)
         
-        output_path.write_text("\n".join(lines))
+        output_path.write_text("\n".join(lines), encoding="utf-8")
         
         return {
             "path": str(output_path),
@@ -370,7 +370,7 @@ class DeliveryRouter:
         out_dir = get_hermes_home() / "cron" / "output"
         out_dir.mkdir(parents=True, exist_ok=True)
         path = out_dir / f"{job_id}_{timestamp}.txt"
-        path.write_text(content)
+        path.write_text(content, encoding="utf-8")
         return path
 
     def _filter_silence_narration_enabled(self) -> bool:

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -381,6 +381,7 @@ def _git_clone(url: str, dest: Path) -> None:
             ["git", "clone", "--depth", "1", url, str(dest)],
             check=True,
             capture_output=True,
+            timeout=300,
         )
     except FileNotFoundError as exc:
         raise DistributionError("git is required for git-URL installs") from exc

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -519,6 +519,48 @@ def interrupt_all(reason: str = "shutdown") -> int:
     return count
 
 
+def interrupt_for_session(
+    *,
+    session_key: str,
+    parent_session_id: str = "",
+    reason: str = "session_reset",
+) -> int:
+    """Interrupt running async delegations tied to a gateway session.
+
+    Used on ``/new`` and session reset so delegations whose spawning
+    conversation has ended don't burn tokens and park orphaned completions
+    on the shared queue. Matches by ``session_key`` (captured at dispatch
+    time) and logs ``parent_session_id`` for diagnostics.
+
+    Returns how many delegations were interrupted.
+    """
+    count = 0
+    with _records_lock:
+        targets = [
+            r
+            for r in _records.values()
+            if r.get("status") == "running"
+            and r.get("session_key") == session_key
+        ]
+    for r in targets:
+        fn = r.get("interrupt_fn")
+        if callable(fn):
+            try:
+                fn()
+                count += 1
+            except Exception as exc:
+                logger.debug(
+                    "interrupt_for_session: %s interrupt failed: %s",
+                    r.get("delegation_id"), exc,
+                )
+    if count:
+        logger.info(
+            "Interrupted %d async delegation(s) for session_key=%s (%s)",
+            count, session_key, reason,
+        )
+    return count
+
+
 def _reset_for_tests() -> None:
     """Test-only: clear all state and tear down the executor."""
     global _executor, _executor_max_workers


### PR DESCRIPTION
## Summary

Add the missing  function to  that the gateway's  reset handler has been calling since commit 75efd7396.

## Problem

Commit 75efd7396 ("fix(gateway): never resurrect ended sessions for delegation completions; /new severs in-flight delegations") added a call to  in  but the function was never implemented in .

The call is wrapped in , so the ImportError is silently swallowed. This means when a user triggers  or resets a conversation, in-flight async delegations are **never interrupted** — they continue burning tokens and park orphaned completions on the shared queue, exactly the bug class this commit was meant to fix (#55578).

## Fix

Added  matching the caller's signature. It:
- Filters running delegations by  (captured at dispatch time, stored in the delegation record)
- Invokes each target's , mirroring the existing  pattern
- Logs the interrupted count with session context

## Testing
- Syntax check passed (py_compile)
- Import verification:  succeeds
- Signature matches caller usage in 