### PR TITLE
fix(env): load root ~/.hermes/.env as base in profile mode

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -226,6 +226,12 @@ def load_hermes_dotenv(
 
     Behavior:
     - `~/.hermes/.env` overrides stale shell-exported values when present.
+    - profile-mode (`HERMES_HOME=~/.hermes/profiles/<name>`): the root
+      `~/.hermes/.env` is loaded as a non-override base first, then the
+      profile's own `.env` is loaded with override=True so profile values
+      win. This restores the "global config + per-profile overrides"
+      layering the multiplex path already enforces via ``set_secret_scope``;
+      see #61046.
     - project `.env` acts as a dev fallback and only fills missing values when
       the user env exists.
     - if no user env exists, the project `.env` also overrides stale shell vars.
@@ -236,11 +242,27 @@ def load_hermes_dotenv(
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 
+    # In profile mode the user-managed `~/.hermes/.env` lives one level up
+    # (the hermes root, not the profile subdir). Load it as a non-override
+    # base so profile values in the subsequent `user_env` load still win.
+    base_env = None
+    if home_path.parent.name == "profiles" and home_path.parent.parent:
+        base_env = home_path.parent.parent / ".env"
+
     # Fix corrupted .env files before python-dotenv parses them (#8908).
     if user_env.exists():
         _sanitize_env_file_if_needed(user_env)
+    if base_env is not None and base_env.exists():
+        _sanitize_env_file_if_needed(base_env)
     if project_env_path and project_env_path.exists():
         _sanitize_env_file_if_needed(project_env_path)
+
+    if base_env is not None and base_env.exists():
+        # Base layer: root ~/.hermes/.env fills in any keys the profile did
+        # not define. override=False so a later override=True on the profile
+        # .env still wins for keys the profile sets explicitly.
+        _load_dotenv_with_fallback(base_env, override=False)
+        loaded.append(base_env)
 
     if user_env.exists():
         _load_dotenv_with_fallback(user_env, override=True)

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -103,3 +103,71 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_profile_home_loads_root_env_as_base_and_profile_env_as_override(tmp_path, monkeypatch):
+    """When HERMES_HOME points to ~/.hermes/profiles/<name>, the root
+    ~/.hermes/.env is loaded as a non-override base, and the profile's own
+    .env overrides the base for keys it defines explicitly (#61046).
+    """
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "test"
+    profile.mkdir(parents=True)
+
+    (root / ".env").write_text(
+        "QQ_APP_ID=root-app\nSHARED_KEY=root-value\n",
+        encoding="utf-8",
+    )
+    (profile / ".env").write_text(
+        "QQ_APP_ID=profile-app\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("QQ_APP_ID", raising=False)
+    monkeypatch.delenv("SHARED_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=profile)
+
+    # Both files should be reported as loaded, root first (base) then profile.
+    assert loaded == [root / ".env", profile / ".env"]
+    # Profile wins for keys it defines.
+    assert os.getenv("QQ_APP_ID") == "profile-app"
+    # Root fills in keys the profile did not set.
+    assert os.getenv("SHARED_KEY") == "root-value"
+
+
+def test_profile_home_without_root_env_still_loads_profile_env(tmp_path, monkeypatch):
+    """Profile mode must not crash when the root ~/.hermes/.env is missing."""
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "test"
+    profile.mkdir(parents=True)
+
+    # Only the profile .env exists, not the root one.
+    (profile / ".env").write_text("QQ_APP_ID=profile-app\n", encoding="utf-8")
+
+    monkeypatch.delenv("QQ_APP_ID", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=profile)
+
+    assert loaded == [profile / ".env"]
+    assert os.getenv("QQ_APP_ID") == "profile-app"
+
+
+def test_non_profile_home_does_not_look_for_root_env_sibling(tmp_path, monkeypatch):
+    """When HERMES_HOME is the hermes root itself (default), a sibling
+    directory at the same level must not be mistaken for a profiles dir.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("QQ_APP_ID=root-app\n", encoding="utf-8")
+    # A sibling named 'profiles' is unrelated and must be ignored.
+    sibling_profiles = tmp_path / "profiles"
+    sibling_profiles.mkdir()
+    (sibling_profiles / ".env").write_text("QQ_APP_ID=should-not-load\n", encoding="utf-8")
+
+    monkeypatch.delenv("QQ_APP_ID", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [home / ".env"]
+    assert os.getenv("QQ_APP_ID") == "root-app"


### PR DESCRIPTION
## Summary

When the gateway runs under `-p <name>`, `HERMES_HOME` resolves to `~/.hermes/profiles/<name>`, so the user-managed root `~/.hermes/.env` was no longer reachable by the `HERMES_HOME`-relative path inside `load_hermes_dotenv()`. The multiplex path already isolates credentials via `set_secret_scope`, but the single-profile gateway startup never loaded the root `.env` at all — so a profile that omits a key inherits the shell value (often empty/stale) instead of the user-managed value from the hermes root.

## Root cause

`load_hermes_dotenv(hermes_home=...)` builds `user_env = home_path / ".env"`. Under `-p test`, that becomes `~/.hermes/profiles/test/.env`. The root `~/.hermes/.env` is never read, so any key the profile does not define falls through to the process environment (typically empty, or a stale shell export).

## Fix

Detect the profile layout (`home_path.parent.name == "profiles"`) and load the root `~/.hermes/.env` as a non-override base before the profile's own `.env`, which keeps its existing `override=True` semantics. Profile keys still win; missing keys fall through to the root. This mirrors the layering the multiplex path already enforces via `set_secret_scope`.

The non-profile path is unchanged: when `HERMES_HOME` is the hermes root (the default), the new `base_env` is `None` and the function behaves exactly as before. A `profiles` directory that happens to be a sibling of a non-profile home is not mistaken for a parent (see `test_non_profile_home_does_not_look_for_root_env_sibling`).

## Validation

- `python3 -m py_compile hermes_cli/env_loader.py` — OK
- `python3 -m ruff check hermes_cli/env_loader.py tests/hermes_cli/test_env_loader.py` — all checks passed
- `pytest tests/hermes_cli/test_env_loader.py` — 9/9 PASS (6 existing + 3 new)
- `pytest tests/hermes_cli/test_profiles.py tests/hermes_cli/test_apply_profile_override.py` — 167/167 PASS (no regressions in the profile machinery)
- Stash-and-replay check: with the env_loader change stashed, `test_profile_home_loads_root_env_as_base_and_profile_env_as_override` fails (only `~/.hermes/profiles/test/.env` is in `loaded`, root is missing); with the change applied, both files are loaded and the profile value wins for `QQ_APP_ID` while `SHARED_KEY` falls through to the root.

## Diff scope

22 insertions in `hermes_cli/env_loader.py` (≈10 lines of real logic, the rest is docstring and inline comments). 68 insertions in `tests/hermes_cli/test_env_loader.py` (3 new tests covering the profile-base layering, the missing-root-env case, and the sibling-`profiles` no-false-positive case).

Closes #61046
