### PR TITLE
feat: additional plugins + operational scripts (batch 2)

### DIFF
--- a/plugins/bg-progress-logger/__init__.py
+++ b/plugins/bg-progress-logger/__init__.py
@@ -1,0 +1,155 @@
+"""
+bg-progress-logger plugin — 后台任务进度日志。
+
+Hooks:
+  - pre_tool_call:  拦截 terminal(background=true) → 原子写入"启动"日志
+  - post_tool_call: 检查 terminal 启动结果 → 失败自动写"失败"日志
+
+进度日志格式: [ISO8601] uuid:xxxxxxxx: 描述: 状态 → 路径
+UUID + 原子写入(tmp→sync→append→sync) + 启动验证。
+"""
+
+import logging
+import os
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger("plugins.bg-progress-logger")
+
+HERMES_HOME = Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")))
+PROGRESS_LOG = HERMES_HOME / "state" / "progress.log"
+
+
+def _atomic_append(line: str) -> None:
+    """Durably append a line with os.sync() for crash safety."""
+    with open(PROGRESS_LOG, "a") as f:
+        f.write(line + "\n")
+    os.sync()  # ensure kernel buffers flushed to disk
+
+
+def _gen_uuid() -> str:
+    """Generate 8-char hex UUID from uuidgen."""
+    try:
+        out = subprocess.run(["uuidgen", "-r"], capture_output=True, text=True, timeout=2)
+        return out.stdout.strip()[:8]
+    except Exception:
+        import random
+        return f"{random.randint(0, 0xFFFFFFFF):08x}"
+
+
+def _sanitize_path(path: str) -> str:
+    """Replace NAS mount paths with logical NAS: prefix for compliance."""
+    if "/mnt/nas/" in path:
+        path = "NAS:" + path.split("/mnt/nas/", 1)[1]
+    return path
+
+
+def _infer_description(args: dict) -> str:
+    """Infer a human-readable task description from terminal arguments."""
+    command = str(args.get("command", "")).strip()
+    if not command:
+        return "未知任务"
+
+    lowered = command.lower()
+    if "ppt-master" in lowered or ("claude" in lowered and "--add-dir" in lowered):
+        return "PPT Master 生成"
+    if "ffmpeg" in lowered:
+        return "ffmpeg 处理"
+    if "docker" in lowered and ("build" in lowered or "run" in lowered):
+        return "Docker 操作"
+    if "curl" in lowered:
+        return "网络请求"
+    if "python" in lowered and "train" in lowered:
+        return "模型训练"
+    if "python" in lowered and "backup" in lowered:
+        return "Python 备份脚本"
+    if "rsync" in lowered:
+        return "文件同步"
+    if "tar " in lowered or lowered.startswith("tar "):
+        return "压缩/解压"
+    if "backup" in lowered:
+        return "数据备份"
+    if "restic" in lowered:
+        return "Restic 备份"
+    if "wget" in lowered:
+        return "文件下载"
+
+    # Fallback: first 50 chars of command, stripped of newlines
+    short = command[:50].replace("\n", " ").replace("  ", " ")
+    return f"Shell任务({short}...)"
+
+
+def _extract_path_hint(args: dict) -> str:
+    """Try to extract an output path hint from the command."""
+    command = str(args.get("command", ""))
+    # --add-dir
+    m = re.search(r"--add-dir\s+(\S+)", command)
+    if m:
+        return _sanitize_path(m.group(1))
+    # --output or -o
+    m = re.search(r"(?:--output|-o)\s+(\S+)", command)
+    if m:
+        return _sanitize_path(m.group(1))
+    # working directory hint
+    workdir = str(args.get("workdir", ""))
+    if workdir:
+        return _sanitize_path(workdir)
+    return "无"
+
+
+# ── Hooks ──────────────────────────────────────────────────────────────────
+
+def _pre_tool_call(tool_name: str, args: dict, **kwargs):
+    """Intercept terminal(background=true) and write start log."""
+    if tool_name != "terminal":
+        return {}
+
+    if not args.get("background", False):
+        return {}
+
+    try:
+        uuid_val = _gen_uuid()
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        desc = _infer_description(args)
+        path_hint = _extract_path_hint(args)
+
+        line = f"[{ts}] uuid:{uuid_val}: {desc}: 启动 → {path_hint}"
+        _atomic_append(line)
+        logger.info("bg-progress-logger: start %s (%s)", uuid_val, desc)
+    except Exception as e:
+        logger.error("bg-progress-logger pre_tool_call error: %s", e)
+
+    return {}  # Never block
+
+
+def _post_tool_call(tool_name: str, args: dict, result: str, session_id: str = "", **kwargs):
+    """Verify terminal background task startup and log failure if needed."""
+    if tool_name != "terminal":
+        return
+
+    if not args.get("background", False):
+        return
+
+    try:
+        result_str = str(result) if result else ""
+        # terminal(background=true) success contains "Background process started"
+        if "Background process started" in result_str:
+            return  # Success, no action needed
+
+        # Failed startup — write failure log
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        desc = _infer_description(args)
+        line = f"[{ts}] uuid:ERROR: {desc}: 失败 → 命令启动失败: {result_str[:100]}"
+        _atomic_append(line)
+        logger.info("bg-progress-logger: startup failure logged for %s", desc)
+    except Exception as e:
+        logger.error("bg-progress-logger post_tool_call error: %s", e)
+
+
+def register(ctx):
+    """Register plugin hooks."""
+    ctx.register_hook("pre_tool_call", _pre_tool_call)
+    ctx.register_hook("post_tool_call", _post_tool_call)
+    logger.info("bg-progress-logger plugin registered v1.0 (pre_tool_call + post_tool_call)")

--- a/plugins/bg-progress-logger/plugin.yaml
+++ b/plugins/bg-progress-logger/plugin.yaml
@@ -1,0 +1,6 @@
+name: bg-progress-logger
+version: "1.0"
+description: "后台任务进度日志——拦截 terminal(background=true)，自动写入 progress.log。UUID标识 + 原子写入 + 启动验证。"
+hooks:
+  - pre_tool_call
+  - post_tool_call

--- a/plugins/clarify_guard/__init__.py
+++ b/plugins/clarify_guard/__init__.py
@@ -1,0 +1,23 @@
+"""pre_llm_call hook — 每轮注入交互检查提醒
+基于 turn_context.py:318 的 pre_llm_call hook 点
+"""
+import logging, os, time
+logger = logging.getLogger(__name__)
+
+def register(ctx):
+    ctx.register_hook("pre_llm_call", _inject_clarify_reminder)
+    logger.info("clarify-guard: registered")
+
+def _inject_clarify_reminder(**kwargs):
+    with open(os.path.expanduser("~/.hermes/state/clarify_guard_probe"), "w") as f:
+        f.write(time.strftime("%Y-%m-%d %H:%M:%S"))
+    return {"context": (
+        "[交互检查] 用户指令如果满足以下任一条件，必须先调用 clarify 工具反问澄清，不要猜测后直接执行。\n\n"
+        "优先级：先问工具，再问内容。如果用户请求涉及产出（写/设计/生成/分析文件/做PPT），"
+        "第一轮 clarify 必须确认「用哪个 skill / 工具 / 方式」，不要先问内容方向。"
+        "例：「设计一个汇报PPT」→ 先问 \\\"用哪个PPT工具？A-微信对话式(ppt-wechat-skill) B-深度定制(ppt-master-wechat) C-手动\\\"，确认工具后再问受众/风格。\n\n"
+        "三项触发条件："
+        "①可匹配多个 skill 或操作方向（如「研究一下」可能是读文档/对比/试用/定义需求）"
+        "②缺少关键上下文导致无法判断具体操作（如「先做哪个」没说选项）"
+        "③涉及安全敏感或不可逆操作（如「关闭」防护、「删除」文件）。"
+    )}

--- a/plugins/clarify_guard/plugin.yaml
+++ b/plugins/clarify_guard/plugin.yaml
@@ -1,0 +1,5 @@
+name: clarify_guard
+description: "pre_llm_call hook — 每轮注入交互检查提醒，引导 Agent 在歧义时使用 clarify 工具反问"
+version: "1.0"
+hooks:
+  - pre_llm_call

--- a/plugins/conclusion-anchor/__init__.py
+++ b/plugins/conclusion-anchor/__init__.py
@@ -1,0 +1,600 @@
+"""
+结论锚点插件 — 异步输出侧事实验证 (v7)
+
+架构:
+  每轮 Pro 回复后 → hook 返回 None（让回复直接通过）
+  → 后台 threading.Thread:
+      ① Flash 主张提取
+      ② Flash 直读 MEMORY.md 全文，逐条判断矛盾
+      ③ 矛盾？→ send_weixin_direct() 追加 ⚡
+      ④ 失败？→ 写 pending_alert 文件（下一轮注入）
+
+v7 变更: 废除检索层（N5 embedding 0/10, N5.5 Flash+grep 1/10 双杀）
+         改为 Flash 直读 MEMORY 全文做矛盾判断（N6 实测 10/10 召回）
+"""
+
+import asyncio  # 仅用于 asyncio.run() 调用 async send_weixin_direct
+import json
+import logging
+import os
+import re
+import threading
+import time
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ═══════════════════════════════════════════════
+# 配置
+# ═══════════════════════════════════════════════
+
+DEEPSEEK_API_URL = "https://api.deepseek.com/v1/chat/completions"
+DEEPSEEK_KEY = os.environ.get("DEEPSEEK_API_KEY", "")
+MEMORY_PATH = os.path.expanduser("~/.hermes/memories/MEMORY.md")
+PENDING_ALERT_DIR = os.path.expanduser("~/.hermes/pending_alerts")
+VERIFY_TIMEOUT = 30  # Flash 全量 MEMORY 验证超时（55K chars ≈ 3-5s）
+MIN_RESPONSE_LENGTH = 50  # 短回复跳过验证
+
+# ── MEMORY.md 缓存 ──
+_MEMORY_CACHE: str | None = None
+_MEMORY_CACHE_TIME: float = 0
+_MEMORY_CACHE_TTL = 300  # 5 分钟缓存
+
+
+def _load_memory() -> str:
+    """加载 MEMORY.md，5 分钟缓存"""
+    global _MEMORY_CACHE, _MEMORY_CACHE_TIME
+    now = time.time()
+    if _MEMORY_CACHE is not None and (now - _MEMORY_CACHE_TIME) < _MEMORY_CACHE_TTL:
+        return _MEMORY_CACHE
+    try:
+        with open(MEMORY_PATH) as f:
+            _MEMORY_CACHE = f.read()
+        _MEMORY_CACHE_TIME = now
+        logger.info(f"conclusion-anchor: loaded MEMORY.md ({len(_MEMORY_CACHE)} chars)")
+    except Exception:
+        logger.warning("conclusion-anchor: failed to load MEMORY.md")
+        _MEMORY_CACHE = ""
+    return _MEMORY_CACHE
+
+
+def _call_flash(system_prompt: str, user_content: str, timeout: int = VERIFY_TIMEOUT) -> dict:
+    """调用 DeepSeek Flash API"""
+    if not DEEPSEEK_KEY:
+        return {"error": "no_api_key"}
+    try:
+        resp = requests.post(
+            DEEPSEEK_API_URL,
+            headers={
+                "Authorization": f"Bearer {DEEPSEEK_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "deepseek-chat",  # Flash = deepseek-chat (fast model)
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_content},
+                ],
+                "temperature": 0,
+                "max_tokens": 500,
+            },
+            timeout=timeout,
+        )
+        if resp.status_code != 200:
+            return {"error": f"http_{resp.status_code}"}
+        body = resp.json()
+        content = body.get("choices", [{}])[0].get("message", {}).get("content", "")
+        return {"content": content, "model": body.get("model", "")}
+    except requests.Timeout:
+        return {"error": "timeout"}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# ═══════════════════════════════════════════════
+# Phase 1: 验证流水线
+# ═══════════════════════════════════════════════
+
+CLAIM_EXTRACTION_SP = """你是事实主张提取器。分析以下 Agent 回复，提取其中的事实性主张（factual claims）。
+
+**事实性主张 = 可被验证真假的具体声明。**
+✅ 提取: "P2-1 已完成" / "杨旸偏好极简风格" / "DS V4 上下文 128K" / "gem12 IP 是 192.168.31.192"
+❌ 不提取: 建议/意见("建议用 Flash") / 推测("可能是配置问题") / 礼貌用语 / 引用标记 / 会话状态标记（orphans:N、队列状态、本轮扫描结果、💡标记、📊声明等）——这些是实时状态，不是永久事实
+
+只返回 JSON 数组。无主张时返回空数组。
+格式: [{"claim": "主张文本", "context": "原文上下文（50字以内）"}]
+
+Agent 回复：
+---
+{response_text}
+---"""
+
+
+def _extract_claims(response_text: str) -> list[dict]:
+    """Flash 主张提取 → [{claim, context}, ...]"""
+    prompt = CLAIM_EXTRACTION_SP.replace("{response_text}", response_text)
+    result = _call_flash("你是一个精确的事实主张提取器。", prompt, 15)
+    if result.get("error"):
+        logger.warning(f"conclusion-anchor: claim extraction failed: {result['error']}")
+        return []
+
+    try:
+        content = result.get("content", "[]")
+        # 提取 JSON 数组
+        json_match = re.search(r"\[.*\]", content, re.DOTALL)
+        if json_match:
+            claims = json.loads(json_match.group())
+            if isinstance(claims, list) and len(claims) > 0:
+                logger.info(f"conclusion-anchor: extracted {len(claims)} claims")
+                return claims
+    except (json.JSONDecodeError, ValueError):
+        logger.warning(f"conclusion-anchor: failed to parse claims JSON: {content[:200]}")
+    return []
+
+# ═══════════════════════════════════════════════
+# B+: transient 过滤（2026-06-30 P1部署）
+# ═══════════════════════════════════════════════
+TRANSIENT_PATTERNS = [
+    r"orphans\s*:\s*\d+",
+    r"队列\s*\d+\s*件",
+    r"队列\s*\[#\d+\]",
+    r"^💡\s*队列",
+    r"^💡\s*\d+\s*[个件]",
+    r"^💡\s*以上矛盾",
+    r"^\d+\s*[件个条项次]",
+    r"^✅\s*队列",
+    r"^📊\s*数据量",
+    r"^🔍\s*来源",
+]
+TRANSIENT_KEYWORDS = ["本轮", "当前会话", "当前轮次", "扫描结果", "检查结果", "刚刚", "刚才"]
+
+def _is_transient(claim_text: str) -> bool:
+    """判断 claim 是否为会话瞬时状态（不参与 MEMORY 矛盾验证）"""
+    for p in TRANSIENT_PATTERNS:
+        if re.search(p, claim_text):
+            return True
+    # 启发式：短文本 + 数字 + 量词
+    if re.search(r"\d+\s*[件个条项次]", claim_text) and len(claim_text) < 50:
+        return True
+    if any(kw in claim_text for kw in TRANSIENT_KEYWORDS):
+        return True
+    return False
+
+
+# ═══════════════════════════════════════════════
+# P1: 专有名词校验（2026-06-30 部署）
+# ═══════════════════════════════════════════════
+
+_ENTITY_WHITELIST: dict | None = None
+_ENTITY_WHITELIST_PATH = os.path.expanduser("~/.hermes/config/entity_whitelist.yaml")
+
+
+def _load_entity_whitelist() -> dict:
+    """加载专有名词白名单（懒加载 + 5 分钟缓存）"""
+    global _ENTITY_WHITELIST
+    import time as _time
+    now = _time.time()
+    if _ENTITY_WHITELIST is not None:
+        if now - _ENTITY_WHITELIST.get("_loaded_at", 0) < 300:
+            return _ENTITY_WHITELIST
+    try:
+        import yaml
+        with open(_ENTITY_WHITELIST_PATH) as f:
+            _ENTITY_WHITELIST = yaml.safe_load(f) or {}
+        _ENTITY_WHITELIST["_loaded_at"] = now
+        total = sum(len(v) for k, v in _ENTITY_WHITELIST.items()
+                    if isinstance(v, list) and not k.startswith("_"))
+        logger.info(f"conclusion-anchor: loaded entity whitelist ({total} entities)")
+    except Exception as e:
+        logger.warning(f"conclusion-anchor: failed to load entity whitelist: {e}")
+        _ENTITY_WHITELIST = {"_loaded_at": now}
+    return _ENTITY_WHITELIST
+
+
+def _word_match(pattern: str, text: str) -> bool:
+    """自定义词边界匹配——entity前后不能是字母/数字/连字符（防止子串误匹配）
+    
+    例如：'plus' 不会匹配 'qwen-plus' 内部的 'plus'
+    """
+    for m in re.finditer(re.escape(pattern), text, re.IGNORECASE):
+        start, end = m.start(), m.end()
+        left_ok = (start == 0 or not re.match(r'[a-zA-Z0-9-]', text[start - 1]))
+        right_ok = (end == len(text) or not re.match(r'[a-zA-Z0-9-]', text[end]))
+        if left_ok and right_ok:
+            return True
+    return False
+
+
+def _entity_check(claim_text: str, memory_text: str) -> bool:
+    """检查 claim 中的专有名词是否与 MEMORY 记录冲突（v7：词边界匹配）
+
+    Returns: True = 发现硬证据冲突（可用于升级 HARD）
+    """
+    whitelist = _load_entity_whitelist()
+    if not whitelist:
+        return False
+
+    aliases_map = whitelist.get("aliases", {})
+
+    # 收集 claim 中出现的所有已知专名（词边界匹配）
+    claim_entities = set()
+    for category in ("model_names", "service_names", "person_names", "project_names"):
+        for entity in whitelist.get(category, []):
+            if _word_match(entity, claim_text):
+                claim_entities.add(entity)
+            for alias in aliases_map.get(entity, []):
+                if _word_match(alias, claim_text):
+                    claim_entities.add(entity)
+
+    if not claim_entities:
+        return False
+
+    # 断言词：claim中这些词后面的专名才是"被断言的"
+    assertion_pre = (
+        r'(?:是|为|等于|默认[用走]?|应该[用走]?|必须[用走]?'
+        r'|走|用|切[换到]?|改成了?|改成?了?|用的?是|改叫|也有|也走|换成)'
+    )
+    assertion_patterns = [
+        assertion_pre + r'\s*[\'"]?\s*{entity}',
+        r'{entity}\s*(?:是|为|作为|被用作|被选为|也有|也走|换成)',
+    ]
+
+    for entity in claim_entities:
+        if len(entity) <= 1:
+            continue
+
+        all_names = {entity}
+        all_names.update(aliases_map.get(entity, []))
+
+        # 检查 claim 中是否在断言此实体
+        has_assertion = any(
+            re.search(p.format(entity=re.escape(name)), claim_text)
+            for p in assertion_patterns
+            for name in all_names
+        )
+        if not has_assertion:
+            continue
+
+        # 检查 MEMORY 中是否有此实体的记录
+        entity_in_memory = any(
+            _word_match(name, memory_text)
+            for name in all_names
+        )
+
+        if not entity_in_memory:
+            # MEMORY 中没有此实体 → 检查同类别是否有其他实体
+            for category in ("model_names", "service_names", "person_names", "project_names"):
+                cat_entities = set(whitelist.get(category, []))
+                if entity in cat_entities:
+                    other_entities = cat_entities - {entity}
+                    for other in other_entities:
+                        all_other_names = {other}
+                        all_other_names.update(aliases_map.get(other, []))
+                        if any(_word_match(n, memory_text) for n in all_other_names):
+                            logger.info(
+                                f"conclusion-anchor: P1 entity conflict: "
+                                f"claim='{entity}' vs memory='{other}' [{category}]"
+                            )
+                            return True
+                    break
+    return False
+
+
+STATE_DB_PATH = os.path.expanduser("~/.hermes/state.db")
+
+
+def _context_filter(claims: list[dict], session_id: str) -> list[dict]:
+    """全 session 上下文消歧：claim 出现在 session 中 → 跳过 D3
+    
+    纯字符串匹配，零 API 成本。<100ms 查询 SQLite。
+    """
+    if not session_id:
+        return claims
+
+    try:
+        con = sqlite3.connect(STATE_DB_PATH)
+        con.row_factory = sqlite3.Row
+        rows = con.execute(
+            "SELECT content FROM messages WHERE session_id = ? AND role IN ('user', 'assistant')"
+            " AND content IS NOT NULL ORDER BY timestamp",
+            (session_id,)
+        ).fetchall()
+        con.close()
+    except Exception as e:
+        logger.warning(f"conclusion-anchor: context filter DB error: {e}")
+        return claims
+
+    if not rows:
+        return claims
+
+    # 拼接全 session 文本（去重防重复匹配）
+    session_text = " ".join(r["content"] for r in rows if r["content"])
+
+    before = len(claims)
+    filtered = []
+    for c in claims:
+        claim_text = c.get("claim", "")
+        # 短 claim（<15字）跳过——太短容易假匹配
+        if len(claim_text) < 15:
+            filtered.append(c)
+            continue
+        # claim 文本出现在 session 中 → 跳过
+        if claim_text in session_text:
+            logger.info(f"conclusion-anchor: context filter skipped: {claim_text[:80]}")
+            continue
+        filtered.append(c)
+
+    after = len(filtered)
+    if before != after:
+        logger.info(f"conclusion-anchor: context filter {before}→{after} claims")
+    return filtered
+
+
+FULLTEXT_VERIFY_PROMPT = """你是事实一致性校验器。下方是 MEMORY.md —— 关于杨旸及其环境的权威知识库。
+
+对每条 CLAIM，判断矛盾级别（D3 三级判定，2026-06-30 部署）：
+- "HARD_CONTRADICTION" = 与 MEMORY 记录的永久事实（配置、偏好、IP、身份信息）明确相反 → 需推⚡
+- "SOFT_MISMATCH"    = 与 MEMORY 中的行为规则/约定不一致 → 记日志不推送
+- "CONSISTENT"       = 一致 → 静默
+
+⚠️ 核心原则:
+- MEMORY 中的"规则"（如"应该怎么做""不要写什么"）不是永久事实。违反规则 = SOFT_MISMATCH。
+- 仅当 claim 与 MEMORY 记录的永久事实明确相反时 = HARD_CONTRADICTION。
+- 已过滤的请求不会到达这里——如果你看到会话标记（orphans:N、队列N件等），判 CONSISTENT。
+
+返回所有主张的 JSON 数组:
+[{{"claim": "原主张文本", "verdict": "HARD_CONTRADICTION|SOFT_MISMATCH|CONSISTENT", "explanation": "一句话"}}]
+
+MEMORY.md:
+---
+{memory_text}
+---
+
+待验证主张 (CLAIMS):
+{claims_json}"""
+
+
+def _verify_claims_fulltext(claims: list[dict], session_id: str = None) -> list[dict]:
+    """v9: B+ 预过滤 + 上下文消歧 + D3 三级判定 + P1 实体校验（2026-06-30 部署）"""
+    # B+ 预过滤：移除 transient 会话状态标记
+    before_filter = len(claims)
+    claims = [c for c in claims if not _is_transient(c.get("claim", ""))]
+    after_filter = len(claims)
+    if before_filter != after_filter:
+        logger.info(f"conclusion-anchor: B+ filtered {before_filter}→{after_filter} claims")
+
+    # 上下文消歧：全 session 字符串匹配——claim 在对话中刚出现过 → 跳过
+    claims = _context_filter(claims, session_id)
+
+    memory = _load_memory()
+    if not memory or not claims:
+        return []
+
+    # 构建 claims JSON
+    claims_json = json.dumps(
+        [{"id": i, "claim": c.get("claim", ""), "context": c.get("context", "")}
+         for i, c in enumerate(claims)],
+        ensure_ascii=False,
+        indent=2,
+    )
+
+    prompt = FULLTEXT_VERIFY_PROMPT.format(
+        memory_text=memory,
+        claims_json=claims_json,
+    )
+
+    result = _call_flash(
+        "你是一个精确的事实一致性校验器。只返回与 MEMORY.md 矛盾的主张。",
+        prompt,
+        VERIFY_TIMEOUT,
+    )
+
+    if result.get("error"):
+        logger.warning(f"conclusion-anchor: fulltext verify failed: {result['error']}")
+        return []
+
+    try:
+        content = result.get("content", "[]")
+        logger.info(f"conclusion-anchor: Flash raw verify response ({len(content)} chars): {content[:300]}")
+        json_match = re.search(r"\[.*\]", content, re.DOTALL)
+        if json_match:
+            parsed = json.loads(json_match.group())
+            if isinstance(parsed, list):
+                contradictions = [
+                    {
+                        "claim": c.get("claim", ""),
+                        "explanation": c.get("explanation", ""),
+                    }
+                    for c in parsed
+                    if c.get("verdict") == "HARD_CONTRADICTION"
+                ]
+                # P1: 实体校验增强 — 对非 HARD 的 claim 也做专名冲突检测
+                entity_conflicts = []
+                for c in parsed:
+                    if c.get("verdict") != "HARD_CONTRADICTION":
+                        claim_text = c.get("claim", "")
+                        if _entity_check(claim_text, memory):
+                            entity_conflicts.append({
+                                "claim": claim_text,
+                                "explanation": f"专有名词冲突: {c.get('explanation', 'D3未检测到')}",
+                            })
+                            logger.info(f"conclusion-anchor: P1 entity check found missed conflict: {claim_text[:80]}")
+                if entity_conflicts:
+                    contradictions.extend(entity_conflicts)
+                    logger.warning(f"conclusion-anchor: P1 added {len(entity_conflicts)} entity-based contradictions")
+
+                if contradictions:
+                    logger.warning(f"conclusion-anchor: {len(contradictions)} HARD_CONTRADICTION(s) found, pushing ⚡")
+                # Log SOFT_MISMATCH for observability (不推送，仅日志)
+                soft_mismatches = [c for c in parsed if c.get("verdict") == "SOFT_MISMATCH"]
+                if soft_mismatches:
+                    logger.info(f"conclusion-anchor: {len(soft_mismatches)} SOFT_MISMATCH(es) logged (not pushed)")
+                    for sm in soft_mismatches:
+                        logger.info(f"  SOFT: {sm.get('claim','')[:80]} → {sm.get('explanation','')[:80]}")
+                return contradictions
+    except (json.JSONDecodeError, ValueError):
+        logger.warning(f"conclusion-anchor: failed to parse verify JSON: {content[:200]}")
+
+    return []
+
+
+def _format_contradiction_alert(contradictions: list[dict]) -> str:
+    """格式化 ⚡ 消息"""
+    n = len(contradictions)
+    lines = [f"⚡ 事实锚点：上一条回复存在 {n} 处可能矛盾\n"]
+    for i, c in enumerate(contradictions, 1):
+        claim = c.get("claim", "") if isinstance(c, dict) else str(c)
+        lines.append(f'{i}. "{claim}"')
+        if isinstance(c, dict) and c.get("explanation"):
+            lines.append(f"   → {c['explanation']}")
+        lines.append("")
+    lines.append("💡 以上矛盾可能影响后续对话，建议确认后纠正。")
+    return "\n".join(lines)
+
+
+def _write_pending_alert(session_id: str, chat_id: str, alert_msg: str) -> str:
+    """写入 pending_alert 文件 → 返回路径"""
+    os.makedirs(PENDING_ALERT_DIR, exist_ok=True)
+    ts = int(time.time())
+    path = os.path.join(PENDING_ALERT_DIR, f"{session_id}_{ts}.json")
+    data = {
+        "session_id": session_id,
+        "chat_id": chat_id,
+        "alert_msg": alert_msg,
+        "attempts": 0,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+    with open(path, "w") as f:
+        json.dump(data, f, ensure_ascii=False)
+    return path
+
+
+def _pop_pending_alert(session_id: str) -> dict | None:
+    """读取最早未投递的 pending_alert 并清理"""
+    if not os.path.exists(PENDING_ALERT_DIR):
+        return None
+    files = sorted(
+        [f for f in os.listdir(PENDING_ALERT_DIR) if f.startswith(session_id)],
+        key=lambda x: os.path.getmtime(os.path.join(PENDING_ALERT_DIR, x)),
+    )
+    for fname in files:
+        path = os.path.join(PENDING_ALERT_DIR, fname)
+        try:
+            with open(path) as f:
+                data = json.load(f)
+            os.remove(path)
+            return data
+        except Exception:
+            pass
+    return None
+
+
+# ═══════════════════════════════════════════════
+# Hook 主入口
+# ═══════════════════════════════════════════════
+
+def _verify_in_background(response_text: str, session_id: str, chat_id: str):
+    """后台验证任务（在独立线程中运行）— v7: 主张提取→全文直读验证→⚡投递"""
+    try:
+        # Step 1: 主张提取
+        claims = _extract_claims(response_text)
+        if not claims:
+            return
+
+        # Step 2: 全文直读验证（v9: B+ 消歧 + D3 判定 + P1 实体校验）
+        contradictions = _verify_claims_fulltext(claims, session_id)
+        if not contradictions:
+            return
+
+        alert_msg = _format_contradiction_alert(contradictions)
+
+        # Step 3: Priority 1 — 直发
+        try:
+            from gateway.platforms.weixin import send_weixin_direct
+            result = asyncio.run(asyncio.wait_for(
+                send_weixin_direct(
+                    extra={},
+                    token=None,
+                    chat_id=chat_id,
+                    message=alert_msg,
+                ),
+                timeout=5.0,
+            ))
+            if isinstance(result, dict) and result.get("success"):
+                logger.info(f"conclusion-anchor: ⚡ sent to {chat_id}")
+                return
+            logger.warning(f"conclusion-anchor: direct send failed: {result}")
+        except Exception as e:
+            logger.warning(f"conclusion-anchor: direct send exception: {e}")
+
+        # Step 4: Priority 2 — 写 pending_alert
+        alert_path = _write_pending_alert(session_id, chat_id, alert_msg)
+        logger.warning(f"conclusion-anchor: ⚡ queued to {alert_path}")
+
+    except Exception as e:
+        logger.error(f"conclusion-anchor: background verify crashed: {e}", exc_info=True)
+
+
+def register(ctx):
+    """注册 transform_llm_output hook"""
+    # 落盘标记：证明 register() 被执行
+    with open("/tmp/conclusion_anchor_loaded", "w") as f:
+        f.write(f"loaded at {time.strftime('%Y-%m-%dT%H:%M:%S')}\n")
+    ctx.register_hook("transform_llm_output", _verify_conclusions)
+    logger.info("conclusion-anchor: registered v7 hook (fulltext verify)")
+
+
+def _verify_conclusions(response_text, session_id=None, model=None, platform=None, **kwargs):
+    """transform_llm_output hook 入口（同步，fire-and-forget 后台线程）"""
+    # DEBUG: 每次调用落盘
+    with open("/tmp/conclusion_hook_called", "a") as f:
+        f.write(f"hook called | session={session_id} | platform={platform} | len={len(str(response_text))} | time={time.strftime('%H:%M:%S')}\n")
+
+    # Guard 1: skip cron/internal sessions
+    if not session_id or str(session_id).startswith("cron_"):
+        with open("/tmp/conclusion_hook_called", "a") as f:
+            f.write(f"  → BLOCKED at guard1: session={session_id}\n")
+        return None
+
+    # Guard 2: skip non-weixin platforms
+    if platform != "weixin":
+        with open("/tmp/conclusion_hook_called", "a") as f:
+            f.write(f"  → BLOCKED at guard2: platform={platform}\n")
+        return None
+
+    # Guard 3: skip short responses
+    if not response_text or not isinstance(response_text, str) or len(response_text.strip()) < MIN_RESPONSE_LENGTH:
+        with open("/tmp/conclusion_hook_called", "a") as f:
+            f.write(f"  → BLOCKED at guard3: len={len(str(response_text)) if response_text else 'None'}\n")
+        return None
+
+    # Guard 4: inject pending alert from previous turn (if any)
+    try:
+        pending = _pop_pending_alert(session_id) if session_id else None
+        if pending and isinstance(pending, dict):
+            alert = pending.get("alert_msg", "")
+            if alert and isinstance(response_text, str):
+                logger.info(f"conclusion-anchor: injecting pending ⚡ for session {session_id}")
+                return response_text + "\n\n---\n" + alert
+    except Exception:
+        pass
+
+    try:
+        # Get chat_id from session context
+        from gateway.session_context import get_session_env
+        chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
+        if not chat_id:
+            return None
+
+        # Fire-and-forget: start background verification in a daemon thread
+        threading.Thread(
+            target=_verify_in_background,
+            args=(str(response_text), str(session_id), str(chat_id)),
+            daemon=True,
+        ).start()
+    except Exception as e:
+        logger.error(f"conclusion-anchor: hook setup failed: {e}", exc_info=True)
+
+    return None  # let original response through unchanged

--- a/plugins/conclusion-anchor/plugin.yaml
+++ b/plugins/conclusion-anchor/plugin.yaml
@@ -1,0 +1,5 @@
+name: conclusion-anchor
+description: "结论锚点——异步输出侧事实验证。每轮Pro回复后Flash直读MEMORY.md全文做矛盾判断，发现矛盾时send_weixin_direct追加⚡消息。"
+version: "1.0"
+hooks:
+  - transform_llm_output

--- a/plugins/context_injection/__init__.py
+++ b/plugins/context_injection/__init__.py
@@ -1,0 +1,329 @@
+"""
+上下文注射提醒插件 — 在 Agent 回复末尾注入 checklist 提醒 (v1)
+
+设计：第十人审计通过的 v2 设计文档
+  ~/hermes-local/yangyang/设计文档/上下文注射提醒系统_设计_v2_2026-06-27.md
+
+架构：
+  LLM 回复 → transform_llm_output hook
+    → Flash 语义检测（classify scenes）
+    → 检查连续抑制计数
+    → 多场景合并为一行
+    → 追加到回复末尾
+    → 返回修改后的文本（或 None=不变）
+
+三层安全网（T0b/T10）：
+  ① Flash 不可达 → 静默跳过，原样返回
+  ② injection_state.json 损坏 → 重建空状态，继续
+  ③ injector 内部异常 → try/except 全包，原样返回
+"""
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ═══════════════════════════════════════════════
+# 配置
+# ═══════════════════════════════════════════════
+
+DEEPSEEK_API_URL = "https://api.deepseek.com/v1/chat/completions"
+DEEPSEEK_KEY = os.environ.get("DEEPSEEK_API_KEY", "")
+FLASH_MODEL = "deepseek-chat"  # V3 = fast model for classification
+FLASH_TIMEOUT = 8               # seconds — fast model, 8s is generous
+STATE_DIR = os.path.expanduser("~/.hermes/state")
+STATE_FILE = os.path.join(STATE_DIR, "injection_state.json")
+LOG_FILE = os.path.expanduser("~/.hermes/logs/injector.log")
+MIN_RESPONSE_LENGTH = 40        # short replies skip classification
+MAX_CONSECUTIVE = 5             # suppress after 5 consecutive hits
+
+# ═══════════════════════════════════════════════
+# 场景定义
+# ═══════════════════════════════════════════════
+
+SCENE_DEFS = {
+    "SCRIPT": "writing or modifying shell/Python scripts",
+    "SKILL": "creating or modifying Hermes skills",
+    "CONFIG": "changing gateway configuration, config.yaml, or systemd units",
+    "CRON": "creating or modifying cron jobs",
+    "FILE": "creating new tool files or script files",
+}
+
+# ═══════════════════════════════════════════════
+# 合并规则（硬编码 if-else，不建动态引擎）
+# ═══════════════════════════════════════════════
+
+MERGE_PATTERNS = [
+    # 排序：先长后短，优先匹配更具体的组合
+    (frozenset(["SCRIPT", "CONFIG", "CRON"]), "动脚本/config/cron前"),
+    (frozenset(["SCRIPT", "FILE", "CRON"]), "动脚本/文件/cron前"),
+    (frozenset(["SCRIPT", "CONFIG"]), "动脚本/config前"),
+    (frozenset(["SCRIPT", "CRON"]), "动脚本/cron前"),
+    (frozenset(["SCRIPT", "FILE"]), "动脚本/新建文件前"),
+    (frozenset(["CONFIG", "CRON"]), "改配置/建cron前"),
+    (frozenset(["FILE", "CRON"]), "建文件/cron前"),
+    (frozenset(["SKILL", "SCRIPT"]), "动skill/脚本前"),
+]
+
+SINGLE_REMINDER = {
+    "SCRIPT": "动脚本前：find已有代码 → which验证依赖 → pre_flight_check",
+    "FILE":   "新建文件前：find搜已有 → 确认无现成方案 → pre_flight",
+    "SKILL":  "动skill前：翻设计指南 → 查已有skill → 四步门控",
+    "CONFIG": "改config前：备份+at回退 → YAML语法 → restart验证",
+    "CRON":   "建cron前：验证脚本路径 → 声明成本+刹车(0E) → 更新清单(§2E)",
+}
+
+EXPANDED_TAIL = "：find→验证→pre_flight→at回退→翻指南"
+
+# ═══════════════════════════════════════════════
+# 状态管理
+# ═══════════════════════════════════════════════
+
+def _load_state():
+    """加载连续计数状态。损坏→返回空字典。"""
+    try:
+        if os.path.exists(STATE_FILE):
+            with open(STATE_FILE, "r") as f:
+                return json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        _log_error(f"state file corrupt, resetting: {e}")
+    return {}
+
+
+def _save_state(state):
+    """保存状态到磁盘。异常→只记日志不阻断。"""
+    try:
+        os.makedirs(STATE_DIR, exist_ok=True)
+        with open(STATE_FILE, "w") as f:
+            json.dump(state, f, indent=2)
+    except Exception as e:
+        _log_error(f"failed to save state: {e}")
+
+
+def _log_error(msg):
+    """非阻塞错误日志。"""
+    try:
+        os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+        with open(LOG_FILE, "a") as f:
+            f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] ERROR: {msg}\n")
+    except Exception:
+        pass  # 日志写失败也不阻断
+
+
+def _log_info(msg):
+    """信息日志。"""
+    try:
+        os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+        with open(LOG_FILE, "a") as f:
+            f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {msg}\n")
+    except Exception:
+        pass
+
+
+# ═══════════════════════════════════════════════
+# Flash 分类
+# ═══════════════════════════════════════════════
+
+def _classify_scenes(response_text):
+    """
+    调用 DeepSeek Flash 分类回复文本。
+    返回: set of scene IDs, e.g. {"SCRIPT", "CRON"} 或空 set
+    异常: 返回空 set（静默降级）
+    """
+    if not DEEPSEEK_KEY:
+        _log_error("DEEPSEEK_API_KEY not set — skipping injection")
+        return set()
+
+    prompt = (
+        "You are a scene classifier for an AI agent. "
+        "Given the agent's reply below, determine which operational scenes are active.\n\n"
+        "Rules:\n"
+        "- SCRIPT: agent is about to write, modify, or debug a shell/Python script\n"
+        "- SKILL: agent is about to create or modify a Hermes skill\n"
+        "- CONFIG: agent is about to change config.yaml, gateway config, or systemd units\n"
+        "- CRON: agent is about to create or modify a cron job\n"
+        "- FILE: agent is about to create a new tool/script file\n"
+        "- If none of these apply, return NONE\n\n"
+        "The agent's reply may mention multiple operations. Return ALL matching scenes.\n"
+        "If the agent is only talking ABOUT past scripts (回顾/查看/讨论), return NONE.\n"
+        "If the agent says it WILL do an operation (即将/马上/让我), classify accordingly.\n\n"
+        "Reply with ONLY a JSON object, no other text:\n"
+        '{"scenes": ["SCRIPT", "CRON"]}  or  {"scenes": []}\n\n'
+        f"Agent reply:\n{response_text[-3000:]}"  # last 3000 chars = likely the clearest signal
+    )
+
+    try:
+        resp = requests.post(
+            DEEPSEEK_API_URL,
+            headers={
+                "Authorization": f"Bearer {DEEPSEEK_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": FLASH_MODEL,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": 100,
+                "temperature": 0.0,
+            },
+            timeout=FLASH_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        content = data["choices"][0]["message"]["content"].strip()
+
+        # Extract JSON from response (may have markdown fences)
+        if "```" in content:
+            content = content.split("```")[1]
+            if content.startswith("json"):
+                content = content[4:]
+        result = json.loads(content)
+        scenes = set(result.get("scenes", []))
+
+        # Filter to known scenes only
+        valid = scenes & set(SCENE_DEFS.keys())
+        return valid
+
+    except requests.Timeout:
+        _log_error("Flash classify timeout — skipping injection")
+        return set()
+    except requests.RequestException as e:
+        _log_error(f"Flash classify HTTP error: {e}")
+        return set()
+    except (json.JSONDecodeError, KeyError, IndexError) as e:
+        _log_error(f"Flash classify parse error: {e} | raw={content[:200] if 'content' in dir() else 'N/A'}")
+        return set()
+    except Exception as e:
+        _log_error(f"Flash classify unexpected error: {e}")
+        return set()
+
+
+# ═══════════════════════════════════════════════
+# 合并 + 计数
+# ═══════════════════════════════════════════════
+
+def _build_reminder(scenes):
+    """从场景集合构建合并后的提醒行。"""
+    if not scenes:
+        return None
+
+    scenes_set = frozenset(scenes)
+
+    # 第一步：尝试多场景合并
+    for pattern, prefix in MERGE_PATTERNS:
+        if scenes_set == pattern:
+            return f"💡 {prefix}{EXPANDED_TAIL}"
+
+    # 第二步：单场景
+    if len(scenes_set) == 1:
+        scene = list(scenes_set)[0]
+        return f"💡 {scene}: {SINGLE_REMINDER.get(scene, '')}"
+
+    # 第三步：未匹配的组合 → 通用尾部
+    prefix = "动" + "/".join(sorted(scenes_set)) + "前"
+    return f"💡 {prefix}{EXPANDED_TAIL}"
+
+
+def _check_consecutive_limit(scenes):
+    """
+    检查连续抑制：
+    - 每个场景独立计数
+    - 达到 MAX_CONSECUTIVE → 抑制
+    - 命中时计数+1，未命中时清零
+    返回: 仍需注射的场景集合
+    """
+    state = _load_state()
+    now = time.strftime("%Y-%m-%dT%H:%M:%S")
+    active = set()
+
+    for scene in scenes:
+        entry = state.get(scene, {"count": 0})
+        count = entry.get("count", 0)
+
+        if count >= MAX_CONSECUTIVE:
+            # 已达上限——首次触发时告警
+            if count == MAX_CONSECUTIVE:
+                _log_info(f"SCENE {scene} suppressed at count={count} — WeChat alert should fire")
+            # 仍然计数（保持抑制状态），但不注射
+            state[scene] = {"count": count + 1, "last_seen": now}
+            continue
+
+        active.add(scene)
+        state[scene] = {"count": count + 1, "last_seen": now}
+
+    # 清零未命中的场景计数
+    for scene in list(state.keys()):
+        if scene not in scenes:
+            del state[scene]
+
+    _save_state(state)
+    return active
+
+
+# ═══════════════════════════════════════════════
+# Hook 入口
+# ═══════════════════════════════════════════════
+
+def register(ctx):
+    """注册 transform_llm_output hook"""
+    ctx.register_hook("transform_llm_output", _inject_reminder)
+    _log_info("context_injection: registered v1 hook")
+    # 落盘标记
+    with open("/tmp/context_injection_loaded", "w") as f:
+        f.write(f"loaded at {time.strftime('%Y-%m-%dT%H:%M:%S')}\n")
+
+
+def _inject_reminder(response_text, session_id=None, model=None, platform=None, **kwargs):
+    """
+    transform_llm_output hook 入口。
+
+    返回:
+      - 修改后的文本（含注射行）→ gateway 用此文本替换原始回复
+      - None → 原样通过
+
+    安全网：
+      - 任何异常 → 返回 None（原样通过，不阻断消息）
+    """
+    try:
+        # Guard 1: skip cron/internal sessions
+        if not session_id or str(session_id).startswith("cron_"):
+            return None
+
+        # Guard 2: skip short responses
+        if not response_text or not isinstance(response_text, str):
+            return None
+        if len(response_text.strip()) < MIN_RESPONSE_LENGTH:
+            return None
+
+        # Guard 3: skip if already has injection (prevent double-injection)
+        if "💡 动" in response_text and ("前：" in response_text or "前:" in response_text):
+            return None
+
+        # ═══ 分类 ═══
+        scenes = _classify_scenes(response_text)
+        if not scenes:
+            return None
+
+        # ═══ 连续抑制 ═══
+        active = _check_consecutive_limit(scenes)
+        if not active:
+            return None
+
+        # ═══ 构建提醒 ═══
+        reminder = _build_reminder(active)
+        if not reminder:
+            return None
+
+        # ═══ 注射 ═══
+        modified = response_text + "\n\n" + reminder
+        _log_info(f"INJECTED: scenes={sorted(active)} | session={session_id} | len={len(modified)}")
+        return modified
+
+    except Exception as e:
+        # 最后的保险——任何未预见的异常都不阻断消息
+        _log_error(f"injector crashed: {e}")
+        return None

--- a/plugins/context_injection/plugin.yaml
+++ b/plugins/context_injection/plugin.yaml
@@ -1,0 +1,2 @@
+hooks:
+  - transform_llm_output

--- a/plugins/memory_summary_hook/__init__.py
+++ b/plugins/memory_summary_hook/__init__.py
@@ -1,0 +1,102 @@
+"""pre_llm_call hook — 注入 MEMORY 摘要到 user message
+v2: 新对话首轮用 DeepSeek V3 重新生成摘要（Pro 返回 reasoning_content 而非 content，用 V3 替代）。
+后续轮次复用，不再依赖每日 cron。
+"""
+import logging, os, json, time, urllib.request
+logger = logging.getLogger(__name__)
+
+SUMMARY_FILE = os.path.expanduser("~/.hermes/memories/MEMORY_SUMMARY.md")
+MEMORY_FILE = os.path.expanduser("~/.hermes/memories/MEMORY.md")
+DS_KEY_FILE = os.path.expanduser("~/.hermes/.deepseek_key")
+STATE_FILE = os.path.expanduser("~/.hermes/state/memory_hook_probe")
+
+def register(ctx):
+    ctx.register_hook("pre_llm_call", _inject_summary)
+    logger.info("memory-summary-hook: registered (v2 — per-session refresh)")
+
+def _regenerate_summary():
+    """读 MEMORY.md → DeepSeek V3 → 写 MEMORY_SUMMARY.md"""
+    if not os.path.exists(MEMORY_FILE):
+        return False
+    
+    memory_text = open(MEMORY_FILE).read()
+    if len(memory_text) < 100:
+        return False
+    
+    ds_key = open(DS_KEY_FILE).read().strip()
+    
+    prompt = f"""将以下 MEMORY.md 压缩为 5KB 以内的结构化摘要。
+保留：活跃项目状态、关键决策、用户偏好、已知陷阱、环境配置。
+丢弃：已完成的记录、过时配置、重复内容。
+
+MEMORY.md 原文：
+{memory_text}
+
+按以下结构输出（不要加额外说明）：
+# MEMORY.md 结构化摘要 (5K)
+> 生成时间: {time.strftime('%Y-%m-%d %H:%M:%S')}
+> 模型: DeepSeek V3
+
+## 活跃项目状态与关键决策
+## 用户偏好与铁律
+## 已知陷阱与避坑
+（此节只保留结论，删除一切操作细节。判断标准：删完后，一个完全不懂技术的人也能看懂这条陷阱的本质教训。API路径、参数名、端口号、命令、错误码——全删。格式：一行一个陷阱，含结论+教训关键词。）
+## 环境与配置要点"""
+    
+    payload = json.dumps({
+        "model": "deepseek-chat",
+        "messages": [
+            {"role": "system", "content": "你是记忆压缩器。输出紧凑的结构化摘要，不超过 5KB。只保留活跃信息，丢弃已完成/过时内容。不要加额外说明。"},
+            {"role": "user", "content": prompt}
+        ],
+        "temperature": 0.1,
+        "max_tokens": 3000
+    }).encode()
+    
+    try:
+        req = urllib.request.Request(
+            "https://api.deepseek.com/v1/chat/completions",
+            data=payload,
+            headers={"Content-Type": "application/json", "Authorization": f"Bearer {ds_key}"}
+        )
+        resp = json.loads(urllib.request.urlopen(req, timeout=60).read())
+        summary = resp["choices"][0]["message"]["content"].strip()
+        
+        if not summary:
+            logger.warning("memory-summary-hook: empty response from API")
+            return False
+        
+        with open(SUMMARY_FILE, "w") as f:
+            f.write(summary)
+        
+        logger.info(f"memory-summary-hook: regenerated ({len(summary)} chars)")
+        return True
+    except Exception as e:
+        logger.warning(f"memory-summary-hook: regeneration failed: {e}")
+        return False
+
+def _inject_summary(**kwargs):
+    # 探针
+    try:
+        with open(STATE_FILE, "w") as f:
+            f.write(time.strftime("%Y-%m-%d %H:%M:%S"))
+    except:
+        pass
+    
+    is_first = kwargs.get("is_first_turn", False)
+    
+    # 新对话首轮 → 重新生成摘要（Pro 模型有 reasoning_content 问题，用 V3）
+    if is_first:
+        logger.info("memory-summary-hook: first turn, regenerating summary...")
+        _regenerate_summary()
+    
+    if not os.path.exists(SUMMARY_FILE):
+        return {}
+    summary = open(SUMMARY_FILE).read()
+    if not summary.strip():
+        return {}
+    return {"context": summary}
+
+# @hermes:patch 2026-07-08 | session:20260708_120024_6b74bb93
+
+# @hermes:patch 2026-07-08 | session:20260708_122631_df531cec

--- a/plugins/memory_summary_hook/plugin.yaml
+++ b/plugins/memory_summary_hook/plugin.yaml
@@ -1,0 +1,5 @@
+name: memory_summary_hook
+description: "pre_llm_call hook — v2 新对话首轮用 DeepSeek V3 重新生成摘要，后续轮次复用。替代 cron 的每日一次更新。"
+version: "2.0"
+hooks:
+  - pre_llm_call

--- a/plugins/mode-1a-scan/__init__.py
+++ b/plugins/mode-1a-scan/__init__.py
@@ -1,0 +1,168 @@
+"""
+Mode 1A 自动扫描插件 — 同步追加异质视角问题
+
+架构:
+  每轮 Agent 回复 → transform_llm_output hook 同步拦截
+  → Flash 判断是否策略性回复
+  → 是 → 生成一个异质视角问题 → 追加到回复末尾
+  → 否 → 原样放行
+
+与结论锚点的区别:
+  - 同步（改输出后返回）而非异步 fire-and-forget
+  - 不验证事实，只生成问题
+  - 轻量：一次 Flash 调用，max_tokens=200
+"""
+
+import json
+import logging
+import os
+import re
+import time
+
+import requests
+
+# ══ 加载标记 ══
+try:
+    with open("/tmp/mode_1a_scan_loaded", "w") as f:
+        f.write(f"loaded at {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+except Exception:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# ═══════════════════════════════════════════════
+# 配置
+# ═══════════════════════════════════════════════
+
+DEEPSEEK_API_URL = "https://api.deepseek.com/v1/chat/completions"
+DEEPSEEK_KEY = os.environ.get("DEEPSEEK_API_KEY", "")
+SCAN_TIMEOUT = 8  # 短回复，Flash 很快
+MIN_LENGTH = 80    # 短于此跳过（确认/闲聊）
+
+# ── 跳过模式（纯流程/确认/闲聊） ──
+SKIP_PATTERNS = [
+    r'^[好可以行对是的嗯]+[，。！]?$',           # 纯确认
+    r'^收到[，。！]?$',
+    r'^```',                                    # 代码块开始
+    r'^📁\s',                                   # 文件归档声明
+    r'^✅\s验证',                               # 验证声明
+    r'^orphans:',                               # orphans 标记
+    r'^Fri\s\w{3}\s\d{2}',                      # 日期行
+    r'^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}',         # 时间戳
+]
+
+# ═══════════════════════════════════════════════
+# Flash 调用
+# ═══════════════════════════════════════════════
+
+SCAN_SYSTEM = """你是异质视角问题生成器。
+
+分析这段 AI 回复：
+1. 判断：是否包含策略性分析、判断、建议、方案设计？
+   - 日常问答、流程确认、闲聊 → 返回 NO
+   - 分析/判断/建议/方案 → 返回 YES
+2. 如果是 YES：生成一个杨旸（中海油IT架构师，偏好系统化思维和反面验证）不太可能问自己的异质视角问题。
+   - 偏"他没看到的盲区""反过来的假设""不同角色的视角"
+   - 短问题，15字以内
+   - 不要说教，不要建议，只问问题
+
+输出格式（严格遵守）：
+如果非策略性 → 只输出: NO
+如果是策略性 → 只输出问题本身（不要引号，不要前缀）"""
+
+
+def _call_flash(system_prompt: str, user_content: str) -> str | None:
+    """调用 Flash API，返回生成的问题或 None"""
+    if not DEEPSEEK_KEY:
+        return None
+    try:
+        resp = requests.post(
+            DEEPSEEK_API_URL,
+            headers={
+                "Authorization": f"Bearer {DEEPSEEK_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "deepseek-chat",
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_content},
+                ],
+                "temperature": 0.3,  # 轻微变化避免重复
+                "max_tokens": 200,
+            },
+            timeout=SCAN_TIMEOUT,
+        )
+        if resp.status_code != 200:
+            logger.warning(f"mode-1a-scan: Flash HTTP {resp.status_code}")
+            return None
+        body = resp.json()
+        content = body.get("choices", [{}])[0].get("message", {}).get("content", "")
+        return content.strip()
+    except requests.Timeout:
+        logger.warning("mode-1a-scan: Flash timeout")
+        return None
+    except Exception as e:
+        logger.warning(f"mode-1a-scan: Flash error: {e}")
+        return None
+
+
+def _is_strategic(response_text: str) -> bool:
+    """快速预判：跳过明显的非策略回复"""
+    text = response_text.strip()
+    if len(text) < MIN_LENGTH:
+        return False
+    # 跳过纯确认/流程声明
+    for pattern in SKIP_PATTERNS:
+        if re.match(pattern, text):
+            return False
+    # 跳过以日期/时间戳开头的行（通常不是分析内容）
+    if re.match(r'^\d{4}-\d{2}-\d{2}|^Fri\s|^orphans:', text):
+        return False
+    return True
+
+
+# ═══════════════════════════════════════════════
+# Hook 入口
+# ═══════════════════════════════════════════════
+
+def register(ctx):
+    """插件入口——注册 transform_llm_output hook"""
+    ctx.register_hook("transform_llm_output", on_transform_llm_output)
+    logger.info("mode-1a-scan: registered")
+
+def on_transform_llm_output(response_text, session_id=None, model=None, platform=None, **kwargs):
+    """同步扫描：判断策略性 → 生成异质视角问题 → 追加"""
+    start = time.time()
+
+    # 快速跳过
+    if not _is_strategic(response_text):
+        return response_text
+
+    # 用回复的后 1500 字符做判断（前文可能有上下文噪音，后段是结论/建议）
+    snippet = response_text[-2000:] if len(response_text) > 2000 else response_text
+
+    result = _call_flash(SCAN_SYSTEM, snippet)
+
+    elapsed = time.time() - start
+
+    if result is None:
+        # Flash 失败 → 静默跳过，不阻塞回复
+        logger.warning(f"mode-1a-scan: Flash failed ({elapsed:.1f}s), passing through")
+        return response_text
+
+    result = result.strip()
+
+    if result.upper() == "NO" or result == "否":
+        logger.debug(f"mode-1a-scan: non-strategic ({elapsed:.1f}s)")
+        return response_text
+
+    # 是策略性回复 → 追加问题
+    # 清理可能的多余输出（Flash 有时会加解释）
+    if len(result) > 50:
+        # 太长，可能不是纯问题，尝试提取第一句
+        result = result.split("。")[0].split("\n")[0].strip()
+
+    enhanced = response_text.rstrip() + f"\n\n_反面：{result}_"
+    logger.info(f"mode-1a-scan: appended question ({elapsed:.1f}s): {result}")
+    return enhanced

--- a/plugins/mode-1a-scan/plugin.yaml
+++ b/plugins/mode-1a-scan/plugin.yaml
@@ -1,0 +1,5 @@
+name: mode-1a-scan
+description: "Mode 1A 自动扫描——每轮策略性回复末尾追加异质视角问题。同步Flash调用，~1s延迟。"
+version: "1.0"
+hooks:
+  - transform_llm_output

--- a/plugins/url-autosave/__init__.py
+++ b/plugins/url-autosave/__init__.py
@@ -1,0 +1,143 @@
+"""url-autosave: 用户发链接时自动将 web_extract 结果落盘到 kaah/inbox/ v1.1
+
+post_tool_call hook 机械执法：
+- 拦截 web_extract 返回
+- 查询 state.db 获取用户上一条消息
+- 含 URL + 提取成功 → 自动写入 kaah/inbox/
+- 提取失败 → 不写
+- 去重：同一 URL 不重复存
+"""
+
+import hashlib
+import json
+import logging
+import os
+import re
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+INBOX_DIR = Path.home() / "kaah" / "inbox"
+STATE_DB = Path.home() / ".hermes" / "state.db"
+
+
+def _extract_urls(text: str) -> list[str]:
+    if not text:
+        return []
+    return re.findall(r'https?://[^\s<>"\')\]》】]+', text)
+
+
+def _url_hash(url: str) -> str:
+    return hashlib.sha256(url.encode()).hexdigest()[:12]
+
+
+def _url_already_saved(url: str) -> bool:
+    target = _url_hash(url)
+    try:
+        for f in INBOX_DIR.glob("*.md"):
+            try:
+                content = f.read_text(encoding="utf-8", errors="ignore")
+                if f"url_hash: {target}" in content:
+                    return True
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return False
+
+
+def _safe_filename(url: str, title: str = "") -> str:
+    domain = re.sub(r'https?://(www\.)?', '', url).split('/')[0].replace('.', '_')
+    today = datetime.now().strftime("%Y%m%d")
+    if title and len(title) > 3:
+        safe = re.sub(r'[\\/:*?"<>|\s]+', '_', str(title)[:50]).strip('_')
+        return f"{today}_{safe}.md"
+    return f"{today}_{domain}_{_url_hash(url)}.md"
+
+
+def _get_last_user_message(session_id: str) -> str:
+    """从 state.db 获取用户最后一条消息"""
+    try:
+        db = sqlite3.connect(str(STATE_DB))
+        row = db.execute(
+            "SELECT content FROM messages WHERE session_id = ? AND role = 'user' ORDER BY id DESC LIMIT 1",
+            (session_id,)
+        ).fetchone()
+        db.close()
+        return row[0] if row else ""
+    except Exception as e:
+        logger.warning(f"[url-autosave] state.db 查询失败: {e}")
+        return ""
+
+
+def _post_tool_call(
+    tool_name: str = "",
+    args: dict = None,
+    result: str = "",
+    session_id: str = "",
+    **kwargs,
+):
+    """拦截 web_extract，用户发了链接就自动落盘。"""
+    if tool_name != "web_extract":
+        return
+
+    if not session_id:
+        return
+
+    # 获取用户上一条消息
+    user_msg = _get_last_user_message(session_id)
+    urls = _extract_urls(user_msg)
+    if not urls:
+        return  # 用户没发链接 → Agent 自己搜的
+
+    # 解析 result（可能是 JSON 字符串）
+    try:
+        result_data = json.loads(result) if isinstance(result, str) else result
+    except json.JSONDecodeError:
+        return
+
+    results = result_data.get("results", [])
+
+    saved_count = 0
+    for url in urls:
+        if _url_already_saved(url):
+            continue
+
+        # 找对应 URL 的结果
+        matched = None
+        for r in results:
+            if r.get("url", "").rstrip("/") == url.rstrip("/"):
+                matched = r
+                break
+        if not matched:
+            for r in results:
+                if url.rstrip("/") in r.get("url", ""):
+                    matched = r
+                    break
+        if not matched:
+            continue
+        if matched.get("error") or not matched.get("content"):
+            continue
+
+        title = matched.get("title", "")
+        filename = _safe_filename(url, title)
+        filepath = INBOX_DIR / filename
+        url_hash_val = _url_hash(url)
+        content = f"<!-- url: {url} -->\n<!-- url_hash: {url_hash_val} -->\n<!-- plugin: url-autosave -->\n\n"
+        content += f"# {title or 'Untitled'}\n\n"
+        content += f"> 来源：{url}\n\n"
+        content += matched["content"]
+
+        filepath.write_text(content, encoding="utf-8")
+        saved_count += 1
+
+    if saved_count:
+        logger.warning(f"[url-autosave] 自动保存 {saved_count} 篇原文到 kaah/inbox/")
+
+
+def register(ctx):
+    """注册 post_tool_call hook"""
+    ctx.register_hook("post_tool_call", _post_tool_call)
+    logger.warning("[url-autosave] 插件已注册 v1.1")

--- a/plugins/url-autosave/plugin.yaml
+++ b/plugins/url-autosave/plugin.yaml
@@ -1,0 +1,7 @@
+name: url-autosave
+version: "1.0"
+description: "用户发链接时自动将 web_extract 结果落盘到 kaah/inbox/。去重、不存失败结果。"
+hooks:
+  - post_tool_call
+author: 常青
+created: 2026-07-06

--- a/scripts/boy_scout_scan.sh
+++ b/scripts/boy_scout_scan.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# boy_scout_scan.sh — 童子军规则扫描
+# 用法: bash boy_scout_scan.sh <任务描述关键词>
+# 输出: 全量清单（分组折叠），不自动修任何东西
+
+set -o pipefail
+
+KEYWORD="$1"
+[ -z "$KEYWORD" ] && { echo "用法: bash boy_scout_scan.sh <关键词>"; exit 1; }
+
+SCRIPTS_DIR="/home/ohtok/.hermes/scripts"
+SKILLS_DIR="/home/ohtok/.hermes/skills/personal"
+LINT_DIR="/home/ohtok/.hermes/lint"
+SECURITY=()
+STYLE=()
+
+# ── 判断扫描范围 ──
+
+# lint 脚本相关 → 扫 lint/ 下其他脚本
+if echo "$KEYWORD" | grep -qP "lint|[0-9]{2}-|pipefail|架构品味|restic|password|nas|notebook|credential"; then
+    # 扫 pipefail
+    for f in $(find "$SCRIPTS_DIR" "$LINT_DIR" -name "*.sh" -type f 2>/dev/null); do
+        bn=$(basename "$f")
+        [[ "$bn" == "boy_scout_scan.sh" ]] && continue
+        head -10 "$f" 2>/dev/null | grep -q "pipefail" && continue
+        [ $(wc -l < "$f" 2>/dev/null) -lt 10 ] && continue
+        STYLE+=("🟡 $bn: 缺 set -o pipefail")
+    done
+    
+    # 扫凭据变量
+    for f in $(find "$SCRIPTS_DIR" -name "*.sh" -type f 2>/dev/null); do
+        bn=$(basename "$f")
+        if grep -qP '\$(PWFILE|BAILIAN_KEY|BAILIAN_API_KEY)' "$f" 2>/dev/null; then
+            SECURITY+=("🔴 $bn: 遮蔽变量名 \$PWFILE/\$BAILIAN_KEY")
+        fi
+    done
+    
+    # 扫 restic 密码
+    for f in $(grep -rl "restic" "$SCRIPTS_DIR" 2>/dev/null); do
+        bn=$(basename "$f")
+        if ! grep -q "\-\-password-file" "$f" 2>/dev/null; then
+            SECURITY+=("🔴 $bn: restic 未用 --password-file")
+        fi
+    done
+fi
+
+# skill 相关 → 扫同类 skill
+if echo "$KEYWORD" | grep -qP "skill|SKILL|trigger|description|frontmatter|合规"; then
+    for d in $(find "$SKILLS_DIR" -maxdepth 1 -type d 2>/dev/null); do
+        [ "$d" = "$SKILLS_DIR" ] && continue
+        skill_md="$d/SKILL.md"
+        [ ! -f "$skill_md" ] && continue
+        bn=$(basename "$d")
+        
+        # 缺 triggers (非 reference/bridge)
+        if ! grep -qP '^triggers:' "$skill_md" 2>/dev/null; then
+            tp=$(grep -oP '^type:\s*\K\S+' "$skill_md" 2>/dev/null)
+            if [ "$tp" != "reference" ] && [ "$tp" != "bridge" ]; then
+                STYLE+=("🟡 $bn: type=$tp 缺 triggers")
+            fi
+        fi
+        
+        # 缺 status
+        if ! grep -qP '^status:' "$skill_md" 2>/dev/null; then
+            STYLE+=("🟡 $bn: 缺 status 字段")
+        fi
+    done
+fi
+
+# cron/脚本相关 → 扫 at 回退
+if echo "$KEYWORD" | grep -qP "cron|script|脚本|systemctl|restart|gateway"; then
+    for f in $(find "$SCRIPTS_DIR" -name "*.sh" -type f 2>/dev/null); do
+        bn=$(basename "$f")
+        if grep -q "systemctl.*restart" "$f" 2>/dev/null && ! grep -q "at now" "$f" 2>/dev/null; then
+            SECURITY+=("🔴 $bn: systemctl restart 未设 at 回退")
+        fi
+    done
+fi
+
+# NAS 路径相关 → 扫非备份脚本
+if echo "$KEYWORD" | grep -qP "NAS|nas|/mnt|mount"; then
+    for f in $(find "$SCRIPTS_DIR" "$SKILLS_DIR" -name "*.sh" -type f 2>/dev/null); do
+        bn=$(basename "$f")
+        case "$bn" in *backup*|*备份*|*restic*|*sync*|*S1*|*S2*|*nas_*) continue ;; esac
+        if grep -n "/mnt/nas" "$f" 2>/dev/null | grep -v '^\s*#' | grep -v 'echo\|printf' | grep -qE '(cp |mv |tar |rsync |>|>>)'; then
+            SECURITY+=("🔴 $bn: 非备份脚本写 /mnt/nas")
+        fi
+    done
+fi
+
+# ── 输出 ──
+
+TOTAL_SECURITY=${#SECURITY[@]}
+TOTAL_STYLE=${#STYLE[@]}
+TOTAL=$((TOTAL_SECURITY + TOTAL_STYLE))
+
+if [ $TOTAL -eq 0 ]; then
+    echo "✅ 童子军扫描: 周边无可顺手修的项目"
+    exit 0
+fi
+
+echo "童子军扫描: $KEYWORD"
+echo ""
+
+if [ $TOTAL_SECURITY -gt 0 ]; then
+    echo "🔴 安全隐患 ($TOTAL_SECURITY)"
+    for item in "${SECURITY[@]}"; do
+        echo "  $item"
+    done
+    echo ""
+fi
+
+if [ $TOTAL_STYLE -gt 0 ]; then
+    MAX_SHOW=15
+    echo "🟡 规范问题 ($TOTAL_STYLE)"
+    for i in "${!STYLE[@]}"; do
+        if [ $i -lt $MAX_SHOW ]; then
+            echo "  ${STYLE[$i]}"
+        fi
+    done
+    if [ $TOTAL_STYLE -gt $MAX_SHOW ]; then
+        echo "  ... 还有 $((TOTAL_STYLE - MAX_SHOW)) 条（说"展开"看全量）"
+    fi
+    echo ""
+fi
+
+echo "共 $TOTAL 个可顺手修的项目。修哪些？"

--- a/scripts/done_marker_validate.sh
+++ b/scripts/done_marker_validate.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# done_marker_validate.sh — 标记 done 前验证格式 + 产出文件路径
+# 用法: bash done_marker_validate.sh "<done条目>"
+# 返回: 0=PASS, 1=FAIL, 2=WARN
+#
+# v2 (2026-06-17): 新格式含 session_id 字段
+#   新格式: [N] done | ISO_TIMESTAMP | session_id | task desc → file:/path
+#   旧格式: [N] done | ISO_TIMESTAMP | task desc → file:/path
+
+set -euo pipefail
+
+ENTRY="$1"
+HOME_DIR="${HOME:-/home/ohtok}"
+
+# ── 格式检测 ──
+FIELD_COUNT=$(echo "$ENTRY" | awk -F'|' '{print NF}')
+
+echo "=== done 条目验证 ==="
+echo "  条目: $ENTRY"
+
+if [ "$FIELD_COUNT" -ge 4 ]; then
+    # 新格式：验证 session_id
+    SESSION_ID=$(echo "$ENTRY" | cut -d'|' -f3 | sed 's/^ *//;s/ *$//')
+    DESC=$(echo "$ENTRY" | cut -d'|' -f4- | sed 's/^ *//;s/ *$//')
+    
+    if ! echo "$SESSION_ID" | grep -qE '^[0-9]{8}_[0-9]{6}_[^[:space:]]{4,}$'; then
+        echo "❌ FAIL: session_id 格式不正确: [$SESSION_ID]"
+        echo "   期望格式: YYYYMMDD_HHMMSS_XXXX...（至少 4 位后缀，如 20260617_112314_f3b554）"
+        echo "   用 echo \$HERMES_SESSION_ID 获取当前 session_id"
+        exit 1
+    fi
+    echo "  ✅ session_id: $SESSION_ID"
+else
+    # 旧格式：无 session_id
+    SESSION_ID=""
+    DESC=$(echo "$ENTRY" | cut -d'|' -f3- | sed 's/^ *//;s/ *$//')
+    echo "  ⚠️  旧格式（无 session_id），建议升级为新格式"
+fi
+
+# ── 提取 desc（去掉 → file: 后缀）──
+CLEAN_DESC=$(echo "$DESC" | sed 's/[[:space:]]*→ file:[^[:space:]]*//g' | sed 's/^ *//;s/ *$//')
+echo "  任务: $CLEAN_DESC"
+
+# ── 提取 → file: 路径 ──
+FILE_PATHS=$(echo "$ENTRY" | sed -n 's/.*→ file:\(.*\)$/\1/p')
+
+if [ -z "$FILE_PATHS" ]; then
+    # 无 → file: 标记
+    if echo "$CLEAN_DESC" | grep -qE "(确认了|想清楚了|讨论|方向|决策|定了|算了|跳过)"; then
+        echo "✅ PASS: 纯讨论/决策任务，不需要产出文件"
+        exit 0
+    elif [ ${#CLEAN_DESC} -lt 20 ]; then
+        echo "✅ PASS: 描述很短，可能为讨论任务"
+        exit 0
+    else
+        echo "⚠️  WARN: 非讨论任务缺少 → file: 路径"
+        echo "   L2 语义验证将尝试从 write_file hook log 补发现。"
+        echo "   如确实无文件产出，请确认。否则请追加 → file:{路径}"
+        exit 2
+    fi
+fi
+
+# ── 验证每个路径存在 ──
+HAS_VALID=0
+HAS_MISSING=0
+for raw_path in $FILE_PATHS; do
+    path="${raw_path/#\~/$HOME_DIR}"
+    if [ -f "$path" ]; then
+        echo "  ✅ 路径存在: $raw_path"
+        HAS_VALID=1
+    else
+        echo "  ❌ 路径不存在: $raw_path"
+        HAS_MISSING=1
+    fi
+done
+
+if [ $HAS_MISSING -eq 1 ]; then
+    if [ $HAS_VALID -eq 1 ]; then
+        echo "⚠️  部分路径有效，建议修正或删除无效路径再标记 done"
+        exit 2
+    else
+        echo "❌ FAIL: 所有 → file: 路径均不存在"
+        exit 1
+    fi
+fi
+
+echo "✅ PASS: 格式正确，所有产出文件路径验证通过"
+exit 0

--- a/scripts/hermes-restart-oneshot.sh
+++ b/scripts/hermes-restart-oneshot.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# systemd oneshot — 由 hermes-restart.timer 每 10s 触发
+# 检查 ~/.hermes/state/restart-flag，存在时强制重启 gateway
+FLAG="/home/ohtok/.hermes/state/restart-flag"
+LOG="/tmp/hermes_restart.log"
+touch "$LOG" 2>/dev/null || LOG="/dev/stderr"
+
+if [ -f "$FLAG" ]; then
+    rm -f "$FLAG"
+    state=$(systemctl is-active hermes-gateway 2>/dev/null)
+    echo "[$(date)] flag found, state=$state" >> "$LOG"
+    
+    if [ "$state" = "active" ]; then
+        echo "[$(date)] restarting" >> "$LOG"
+        systemctl restart hermes-gateway
+    elif [ "$state" = "deactivating" ]; then
+        # Stuck deactivating — force-kill the process
+        pid=$(systemctl show hermes-gateway -p MainPID --value 2>/dev/null)
+        echo "[$(date)] deactivating stuck, killing pid=$pid" >> "$LOG"
+        kill -9 $pid 2>/dev/null || true
+        sleep 3
+        # Verify process is dead
+        if kill -0 $pid 2>/dev/null; then
+            echo "[$(date)] WARNING: pid=$pid still alive after kill -9" >> "$LOG"
+        fi
+        systemctl restart hermes-gateway
+    else
+        # inactive/failed — just start
+        echo "[$(date)] state=$state, starting" >> "$LOG"
+        systemctl start hermes-gateway
+    fi
+    
+    # Verify restart succeeded
+    sleep 5
+    new_state=$(systemctl is-active hermes-gateway 2>/dev/null)
+    echo "[$(date)] post-restart state=$new_state" >> "$LOG"
+    if [ "$new_state" != "active" ]; then
+        echo "[$(date)] RESTART FAILED: gateway in state=$new_state" >> "$LOG"
+        # Event-driven alert: touch marker file, 30min cron picks it up
+        ALERT_MARKER="/tmp/hermes_restart_alert"
+        echo "[$(date)] gateway restart failed — state=$new_state" > "$ALERT_MARKER"
+        chmod 644 "$ALERT_MARKER"
+    fi
+fi

--- a/scripts/last30days.py
+++ b/scripts/last30days.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""last30days — 搜索社区最近30天讨论，聚合为 briefing
+
+用法：
+    python3 last30days.py --query "agent browser playwright" [--output briefing.md] [--max 10]
+    python3 last30days.py --query "claude code" --output /tmp/last30days.md
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+SOCKS_PROXY = "socks5h://127.0.0.1:1080"
+CUTOFF_TS = int((datetime.now(timezone.utc) - timedelta(days=30)).timestamp())
+
+# ============================================================
+# Source fetchers
+# ============================================================
+
+def _socks_opener():
+    import socks
+    from sockshandler import SocksiPyHandler
+    return urllib.request.build_opener(SocksiPyHandler(socks.SOCKS5, "127.0.0.1", 1080))
+
+
+def fetch_hn(query: str, max_results: int = 10) -> list[dict]:
+    """Hacker News via Algolia API (free, no key). Needs VPN."""
+    params = urllib.parse.urlencode({
+        "query": query,
+        "tags": "story",
+        "hitsPerPage": max_results,
+        "numericFilters": f"created_at_i>{CUTOFF_TS}",
+    })
+    url = f"https://hn.algolia.com/api/v1/search?{params}"
+    try:
+        opener = _socks_opener()
+        with opener.open(url, timeout=15) as resp:
+            data = json.loads(resp.read())
+        results = []
+        for hit in data.get("hits", [])[:max_results]:
+            results.append({
+                "source": "HN",
+                "title": hit.get("title", ""),
+                "url": hit.get("url") or f"https://news.ycombinator.com/item?id={hit['objectID']}",
+                "points": hit.get("points", 0),
+                "comments": hit.get("num_comments", 0),
+                "date": hit.get("created_at", ""),
+            })
+        return results
+    except Exception as e:
+        return [{"source": "HN", "error": str(e)}]
+
+
+def fetch_reddit(query: str, max_results: int = 10) -> list[dict]:
+    """Reddit search via RSS endpoint (bypasses API 403 on VPN IPs). Needs VPN."""
+    import xml.etree.ElementTree as ET
+    params = urllib.parse.urlencode({"q": query, "sort": "new", "restrict_sr": "off", "limit": max_results})
+    url = f"https://www.reddit.com/search.rss?{params}"
+    req = urllib.request.Request(url, headers={"User-Agent": "last30days/1.0"})
+    try:
+        opener = _socks_opener()
+        with opener.open(req, timeout=15) as resp:
+            tree = ET.parse(resp)
+    except Exception as e:
+        return [{"source": "Reddit", "error": str(e)}]
+    results = []
+    for entry in tree.findall(".//{http://www.w3.org/2005/Atom}entry"):
+        title_el = entry.find("{http://www.w3.org/2005/Atom}title")
+        link_el = entry.find("{http://www.w3.org/2005/Atom}link")
+        title = (title_el.text or "").strip() if title_el is not None else ""
+        href = link_el.attrib.get("href", "") if link_el is not None else ""
+        results.append({"source": "Reddit", "title": title, "url": href})
+        if len(results) >= max_results:
+            break
+    if not results:
+        results.append({"source": "Reddit", "error": "no results via RSS"})
+    return results
+
+
+def fetch_v2ex(query: str, max_results: int = 10) -> list[dict]:
+    """V2EX via public API (bypasses Cloudflare). Needs VPN (DNS).
+    
+    V2EX API endpoints are NOT behind Cloudflare — only the web UI is.
+    api/topics/latest.json returns ~38 most recent topics.
+    We fetch them all and filter locally by keyword.
+    """
+    url = "https://www.v2ex.com/api/topics/latest.json"
+    req = urllib.request.Request(url, headers={"User-Agent": "last30days/1.0"})
+    try:
+        opener = _socks_opener()
+        with opener.open(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except Exception as e:
+        return [{"source": "V2EX", "error": str(e)}]
+
+    # filter by keyword (case-insensitive title match)
+    keywords = query.lower().split()
+    results = []
+    for topic in data:
+        title = topic.get("title", "")
+        title_lower = title.lower()
+        if any(kw in title_lower for kw in keywords):
+            results.append({
+                "source": "V2EX",
+                "title": title,
+                "url": topic.get("url", f"https://www.v2ex.com/t/{topic.get('id')}"),
+                "node": topic.get("node", {}).get("title", ""),
+                "replies": topic.get("replies", 0),
+            })
+            if len(results) >= max_results:
+                break
+
+    if not results:
+        results.append({"source": "V2EX", "error": f"no topic matched '{query}' in latest {len(data)} posts"})
+    return results
+
+
+def fetch_github_discussions(query: str, max_results: int = 10) -> list[dict]:
+    """GitHub Discussions search (no VPN but needs token for rate)."""
+    token = _github_token()
+    params = urllib.parse.urlencode({
+        "q": f"{query} type:discussion created:>={_cutoff_date_str()}",
+        "sort": "updated",
+        "order": "desc",
+        "per_page": max_results,
+    })
+    url = f"https://api.github.com/search/issues?{params}"
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "last30days/1.0",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+        results = []
+        for item in data.get("items", [])[:max_results]:
+            results.append({
+                "source": "GitHub",
+                "title": item.get("title", ""),
+                "url": item.get("html_url", ""),
+                "repo": "/".join(item.get("repository_url", "").split("/")[-2:]),
+                "date": item.get("updated_at", ""),
+            })
+        return results
+    except Exception as e:
+        return [{"source": "GitHub", "error": str(e)}]
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+def _github_token() -> str:
+    """Try to read GitHub token from creds vault."""
+    try:
+        result = subprocess.run(
+            ["python3", str(Path.home() / ".hermes/scripts/creds.py"), "get", "github", "token"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            creds = json.loads(result.stdout)
+            return creds.get("password", "") or creds.get("token", "")
+    except Exception:
+        pass
+    return ""
+
+
+def _cutoff_date_str() -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%d")
+
+
+def _connect_vpn():
+    subprocess.run(["bash", str(Path.home() / ".hermes/scripts/vpn-connect.sh"), "sg"],
+                   capture_output=True, timeout=20)
+    time.sleep(2)
+
+
+def _disconnect_vpn():
+    subprocess.run(["bash", str(Path.home() / ".hermes/scripts/vpn-disconnect.sh")],
+                   capture_output=True, timeout=10)
+
+
+def _format_briefing(query: str, all_results: list[dict]) -> str:
+    """Format aggregated results as markdown."""
+    lines = [
+        f"# last30days briefing: {query}",
+        f"生成时间：{datetime.now().strftime('%Y-%m-%d %H:%M')}",
+        f"时间窗口：{_cutoff_date_str()} ~ {datetime.now().strftime('%Y-%m-%d')}",
+        "",
+    ]
+
+    # Group by source
+    by_source: dict[str, list[dict]] = {}
+    for r in all_results:
+        src = r.pop("source", "?")
+        by_source.setdefault(src, []).append(r)
+
+    for source in ["HN", "Reddit", "V2EX", "GitHub"]:
+        items = by_source.get(source, [])
+        lines.append(f"## {source} ({len(items)} 条)")
+        lines.append("")
+        if items and "error" in items[0]:
+            lines.append(f"❌ {items[0]['error']}")
+            lines.append("")
+            continue
+        for item in items:
+            title = item.get("title", "(无标题)")
+            url = item.get("url", "")
+            # build metadata line
+            meta_parts = []
+            if source == "HN":
+                if item.get("points"):
+                    meta_parts.append(f"{item['points']} 分")
+                if item.get("comments"):
+                    meta_parts.append(f"{item['comments']} 评论")
+            elif source == "Reddit":
+                if item.get("subreddit"):
+                    meta_parts.append(item["subreddit"])
+                if item.get("score"):
+                    meta_parts.append(f"{item['score']} 票")
+                if item.get("comments"):
+                    meta_parts.append(f"{item['comments']} 评论")
+            elif source == "GitHub" and item.get("repo"):
+                meta_parts.append(item["repo"])
+            meta = " / ".join(meta_parts)
+            lines.append(f"- [{title}]({url})" + (f" — {meta}" if meta else ""))
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def main():
+    parser = argparse.ArgumentParser(description="last30days — 社区讨论聚合")
+    parser.add_argument("--query", "-q", required=True, help="搜索关键词")
+    parser.add_argument("--output", "-o", help="输出文件路径（可选，默认打印到 stdout）")
+    parser.add_argument("--max", type=int, default=10, help="每源最大条目数（默认 10）")
+    parser.add_argument("--sources", default="hn,reddit,v2ex,github",
+                        help="逗号分隔的源列表（默认 hn,reddit,v2ex,github）")
+    args = parser.parse_args()
+    sources = [s.strip() for s in args.sources.split(",")]
+
+    all_results: list[dict] = []
+    need_vpn = bool({"hn", "reddit", "v2ex"} & set(sources))
+
+    if need_vpn:
+        print("🔗 连接 VPN ...", file=sys.stderr)
+        _connect_vpn()
+
+    try:
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = {}
+            if "hn" in sources:
+                futures["HN"] = pool.submit(fetch_hn, args.query, args.max)
+            if "reddit" in sources:
+                futures["Reddit"] = pool.submit(fetch_reddit, args.query, args.max)
+            if "v2ex" in sources:
+                futures["V2EX"] = pool.submit(fetch_v2ex, args.query, args.max)
+            if "github" in sources:
+                futures["GitHub"] = pool.submit(fetch_github_discussions, args.query, args.max)
+
+            for name, future in futures.items():
+                try:
+                    result = future.result(timeout=30)
+                    print(f"  ✅ {name}: {len(result) if result and 'error' not in result[0] else 'FAIL'} 条", file=sys.stderr)
+                    all_results.extend(result)
+                except Exception as e:
+                    print(f"  ❌ {name}: {e}", file=sys.stderr)
+                    all_results.append({"source": name, "error": str(e)})
+
+    finally:
+        if need_vpn:
+            _disconnect_vpn()
+            print("🔓 已断开 VPN", file=sys.stderr)
+
+    output = _format_briefing(args.query, all_results)
+
+    if args.output:
+        Path(args.output).write_text(output)
+        print(f"📄 已写入 {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/output-violation-scan.sh
+++ b/scripts/output-violation-scan.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+# output-violation-scan.sh — 每日事后机械审计 v2
+# v2: 路径豁免 + 上下文降级，减少设计文档/演讲稿误报
+set -eo pipefail
+# 扫昨天的 Agent 产出文件，对照 SOUL.md 机械规则
+# cron 驱动（systemd 调度，不依赖 Agent 自觉）
+# PASS → silent; FAIL → 列出违规项推微信
+
+set -o pipefail
+
+TODAY=$(date '+%Y-%m-%d')
+SCAN_MINUTES=1500  # 每天一次，扫最近 25 小时内的修改文件
+OUTPUT_DIR="/home/ohtok/hermes-local/yangyang"
+ALERTS=""
+HAS_VIOLATION=0
+
+# ── 豁免配置 ──
+# 这些路径下的文件跳过 NAS 检查和 date 检查（设计文档/演讲稿天然讨论系统路径和包含时间措辞）
+EXEMPT_NAS_DATE_PATTERNS=(
+    "/home/ohtok/hermes-local/yangyang/设计文档/"
+    "/home/ohtok/hermes-local/yangyang/小青推广演讲"
+    "/home/ohtok/hermes-local/yangyang/projects/"   # PPT 项目目录
+)
+
+# 外部第十人/子代理产出文件——独立 session 不加载 SOUL 规则，不做 Rule 0/1/2/审阅指南/TL;DR 检查
+EXEMPT_EXTERNAL_TENTH_PATTERNS=(
+    "外部第十人"
+    "_纪律性第十人"
+    "第十人审计_"            # v3: delegate_task 产出的第十人审计报告
+)
+
+# 非 Agent 产出——外部文件/系统注册表/手工文档，不要求 SOUL 合规标签
+EXEMPT_NON_AGENT_OUTPUT_PATTERNS=(
+    "/home/ohtok/hermes-local/yangyang/incoming/"
+    "/home/ohtok/hermes-local/yangyang/inbox/"
+    "小青特性注册表"
+    "INDEX"                           # INDEX.md 等索引文件
+    "Hermes-Skill设计参考指南"        # 静态参考文档，非 Agent 产出
+)
+
+# PPT Skill 产出文件——生成脚本/浅层大纲/PPT Master 中间文件，不走 SOUL 合规审计
+# 2026-06-25 杨旸明确："这个skill的脚本不用做合规审计，以后都是"
+EXEMPT_PPT_SKILL_PATTERNS=(
+    "生成脚本_"                       # 生成脚本_*.md
+    "浅层大纲_"                       # 浅层大纲_*.md
+    "/home/ohtok/hermes-local/yangyang/projects/"  # PPT 项目目录(content-source/spec_lock/design_spec/image_prompts)
+)
+
+# delegate_task 产出自动补标——这些文件不经过 Agent 正常 write_file 流程，缺合规标记
+# 检测方式：文件名含以上豁免模式 + 内容含 delegate_task 特征（如 "delegate_task" "子代理" "独立审计"）
+AUTO_PATCH_PATTERNS=(
+    "外部第十人"
+    "第十人审计_"
+    "_纪律性第十人"
+)
+
+# 方案 C：NAS 路径上下文判读——讨论标记词
+DISCUSSION_MARKERS='P00[0-9]|ADR-00[0-9]|PRODUCT_PATCHES|write_guard|skip_for_paths|误报|描述|提到|触发|历史|合规警告|含 2 处'
+
+# ── delegate_task 产出自动补标 ──
+# v3: 识别子代理/第十人产出，自动注入缺失的合规标记，消除代理不加载 SOUL 规则导致的假阳性
+auto_patch_delegate_output() {
+    local f="$1"
+    local bn=$(basename "$f")
+    local is_delegate=0
+    
+    # 检测是否为 delegate_task 产出
+    for pattern in "${AUTO_PATCH_PATTERNS[@]}"; do
+        if echo "$bn" | grep -qF "$pattern"; then
+            is_delegate=1
+            break
+        fi
+    done
+    # 也检查内容特征：含 "审计对象" "外部第十人" "审计人：外部第十人" 等
+    if [ "$is_delegate" -eq 0 ] && grep -qP '(审计对象.*内部AI|审计人.*外部第十人|delegate_task.*独立审计)' "$f" 2>/dev/null; then
+        is_delegate=1
+    fi
+    
+    [ "$is_delegate" -eq 0 ] && return 0
+    
+    # 检测缺失项并补标
+    local needs_patch=0
+    local patch_tail=""
+    
+    # 🟡 假设标注
+    if ! grep -q '🟡 假设' "$f" 2>/dev/null; then
+        needs_patch=1
+        patch_tail="${patch_tail}
+🟡 假设：此文件产自 delegate_task 独立子进程，未经过 Agent SOUL 规则约束的正常产出流程。内容仅基于子进程 prompt 注入的快照，未访问本 session 的实时上下文。"
+    fi
+    
+    # 📋 审阅指南（仅方案/报告类）
+    if grep -qP '(方案|报告|深度分析|审计|设计)' "$f" 2>/dev/null; then
+        if ! grep -qP '📋 审阅指南|审阅指南' "$f" 2>/dev/null; then
+            needs_patch=1
+            patch_tail="${patch_tail}
+## 📋 审阅指南
+- **重点段落**：[请杨旸标注]
+- **可跳过**：[请杨旸标注]
+- **数据来源**：delegate_task 子进程独立分析
+- **假设列表**：[请杨旸补充]
+- **建议审阅方式**：全文通读（子代理独立上下文，可能存在盲区）"
+        fi
+    fi
+    
+    if [ "$needs_patch" -eq 1 ]; then
+        echo "$patch_tail" >> "$f"
+        echo "  ✅ auto-patched: $bn" >&2
+    fi
+    return 0
+}
+
+# 扫描并自动补标
+for f in $(find "$OUTPUT_DIR" -name "*.md" -mmin -"$SCAN_MINUTES" 2>/dev/null); do
+    auto_patch_delegate_output "$f"
+done
+
+# ── 辅助函数 ──
+
+flag() {
+    HAS_VIOLATION=1
+    ALERTS="${ALERTS}$1\\n"
+}
+
+is_exempt_nas_date() {
+    local f="$1"
+    for pattern in "${EXEMPT_NAS_DATE_PATTERNS[@]}"; do
+        if echo "$f" | grep -qF "$pattern"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+is_exempt_external_tenth() {
+    local f="$1"
+    for pattern in "${EXEMPT_EXTERNAL_TENTH_PATTERNS[@]}"; do
+        if echo "$(basename "$f")" | grep -qF "$pattern"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+is_exempt_non_agent() {
+    local f="$1"
+    for pattern in "${EXEMPT_NON_AGENT_OUTPUT_PATTERNS[@]}"; do
+        if echo "$f" | grep -qF "$pattern"; then
+            return 0
+        fi
+    done
+    # PPT Skill 产出豁免（2026-06-25 杨旸）
+    for pattern in "${EXEMPT_PPT_SKILL_PATTERNS[@]}"; do
+        if echo "$f" | grep -qF "$pattern"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ── Rule 2B: SSD-only ──
+# 产出文件路径含 /mnt/nas/ 且不是备份文件
+# v2: 豁免设计文档/演讲稿；非豁免文件做上下文判读降级
+for f in $(find "$OUTPUT_DIR" -name "*.md" -mmin -"$SCAN_MINUTES" ! -name "*backup*" ! -name "*备份*" 2>/dev/null); do
+    if grep -q '/mnt/nas/' "$f" 2>/dev/null; then
+        if is_exempt_nas_date "$f"; then
+            continue  # 设计文档/演讲稿：不检查 NAS 路径
+        fi
+        # 方案 C：上下文判读——检查命中行附近是否有讨论标记词
+        if grep -B3 -A3 '/mnt/nas/' "$f" 2>/dev/null | grep -qP "$DISCUSSION_MARKERS"; then
+            flag "⚪ Rule 2B: $(basename "$f") 含 NAS 路径（上下文判读为讨论性引用，非真违规）"
+        else
+            flag "🔴 Rule 2B: $(basename "$f") 含 NAS 路径"
+        fi
+    fi
+done
+
+# ── Rule 2C: 文件名安全 ──
+# 新产出文件名含 emoji / Windows 保留字 / 控制字符 / 尾部空格或点
+for f in $(find "$OUTPUT_DIR" -name "*.md" -mmin -"$SCAN_MINUTES" 2>/dev/null); do
+    bn=$(basename "$f")
+    if echo "$bn" | grep -qP '[\\\\/:*?\"<>|]'; then
+        flag "🔴 Rule 2C: $(basename "$f") 含 Windows 保留字符"
+    fi
+    if echo "$bn" | grep -q '[[:cntrl:]]'; then
+        flag "🔴 Rule 2C: $(basename "$f") 含控制字符"
+    fi
+    if echo "$bn" | grep -qE ' $|\\.$'; then
+        flag "🔴 Rule 2C: $(basename "$f") 含尾部空格或点"
+    fi
+done
+
+# ── Rule 1: 置信度标签 ──
+# 分析类文件必须有 🔴🟡🟢⚪
+# 豁免：外部第十人/子代理产出
+for f in $(find "$OUTPUT_DIR" -name "*.md" -mmin -"$SCAN_MINUTES" 2>/dev/null); do
+    is_exempt_external_tenth "$f" && continue
+    is_exempt_non_agent "$f" && continue
+    # 判断是否为分析类：含"分析/建议/方案/报告/对比/审查"关键词
+    if grep -qP '(分析|建议|方案|报告|对比|审查|判断|推荐|选择)' "$f" 2>/dev/null; then
+        if ! grep -qP '[🔴🟡🟢⚪]' "$f" 2>/dev/null; then
+            flag "🟡 Rule 1: $(basename "$f") 为分析类但无置信度标签"
+        fi
+    fi
+done
+
+# ── Rule 0 假设标注 ──
+# 豁免：外部第十人/子代理产出
+for f in $(find "$OUTPUT_DIR" -name "*.md" -mmin -"$SCAN_MINUTES" 2>/dev/null); do
+    is_exempt_external_tenth "$f" && continue
+    is_exempt_non_agent "$f" && continue
+    if grep -qP '(分析|建议|方案|报告|对比|审查|判断|推荐|选择)' "$f" 2>/dev/null; then
+        if ! grep -q '🟡 假设' "$f" 2>/dev/null; then
+            flag "🟡 Rule 0: $(basename "$f") 含分析但无 🟡假设标注"
+        fi
+    fi
+done
+
+# ── Rule 2: 时间验证 ──
+# v2: 设计文档/演讲稿豁免（日期=文件名）；外部第十人豁免
+for f in $(find "$OUTPUT_DIR" -name "*.md" -mmin -"$SCAN_MINUTES" 2>/dev/null); do
+    if grep -qP '(刚才|现在|今天|X分钟前|昨晚|马上|刚刚)' "$f" 2>/dev/null; then
+        if grep -qP 'date.*\\+' "$f" 2>/dev/null; then
+            continue  # 已有 date 命令，不报
+        fi
+        if is_exempt_nas_date "$f"; then
+            continue  # 设计文档/演讲稿：不报 date 缺失
+        fi
+        if is_exempt_external_tenth "$f"; then
+            continue  # 外部第十人：不报 date 缺失
+        fi
+        if is_exempt_non_agent "$f"; then
+            continue  # 非 Agent 产出：不报 date 缺失
+        fi
+        flag "🟡 Rule 2: $(basename "$f") 含时间表述但无 date 命令输出"
+    fi
+done
+
+# ── 审阅指南（方案/报告类） ──
+# 豁免：外部第十人/子代理产出
+for f in $(find "$OUTPUT_DIR" -name "*.md" -mmin -"$SCAN_MINUTES" 2>/dev/null); do
+    is_exempt_external_tenth "$f" && continue
+    is_exempt_non_agent "$f" && continue
+    if grep -qP '(方案|报告|深度分析|SOUL|设计)' "$f" 2>/dev/null; then
+        if ! grep -qP '📋 审阅指南|审阅指南' "$f" 2>/dev/null; then
+            flag "🟡 审阅指南: $(basename "$f") 为方案/报告类但无 📋 审阅指南"
+        fi
+    fi
+done
+
+# ── TL;DR（>500 字） ──
+# 豁免：外部第十人/子代理产出
+for f in $(find "$OUTPUT_DIR" -name "*.md" -mmin -"$SCAN_MINUTES" 2>/dev/null); do
+    is_exempt_external_tenth "$f" && continue
+    is_exempt_non_agent "$f" && continue
+    # 跳过系统文件
+    if echo "$f" | grep -qE '(深思_|对比_|report_)'; then
+        chars=$(wc -c < "$f" 2>/dev/null)
+        if [ "$chars" -gt 1500 ]; then  # ~500 中文字
+            if ! grep -qP 'TL;DR|tl;dr' "$f" 2>/dev/null; then
+                flag "🟡 TL;DR: $(basename "$f") >500字但无 TL;DR"
+            fi
+        fi
+    fi
+done
+
+# ── 输出 ──
+if [ "$HAS_VIOLATION" -eq 1 ]; then
+    echo "🚨 产出合规审计 ($TODAY)"
+    echo ""
+    echo -e "$ALERTS"
+    echo ""
+    echo "> 规则来源：SOUL.md Rule 0/1/2/2B/2C + 审阅指南 + TL;DR"
+    echo "> 审计模式：事后机械扫描（cron 驱动，非 Agent 自觉）"
+    echo "> v2: 设计文档/演讲稿豁免NAS+date；非豁免文件NAS路径上下文判读降级"
+fi
+
+# ── 架构品味 Linter ──
+# 仅报告，不影响退出码（架构债≠每日合规失败）
+set +e  # 允许 linter 返回非零而不中断脚本
+LINT_OUTPUT=$(bash /home/ohtok/.hermes/lint/run_all.sh 2>&1)
+LINT_EXIT=$?
+set -e  # 恢复
+
+if [ "$LINT_EXIT" -eq 1 ]; then
+    echo ""
+    echo "---"
+    echo "🔧 架构品味 Linter"
+    echo "$LINT_OUTPUT" | head -20
+    echo "   ... ($(echo "$LINT_OUTPUT" | wc -l) lines total)"
+elif [ "$LINT_EXIT" -eq 2 ]; then
+    echo ""
+    echo "---"
+    echo "🔧 架构品味 Linter (规范问题)"
+    echo "$LINT_OUTPUT" | head -15
+    echo "   ... ($(echo "$LINT_OUTPUT" | wc -l) lines total)"
+fi
+
+if [ "$HAS_VIOLATION" -eq 1 ]; then
+    exit 1
+fi
+exit 0

--- a/scripts/ppt_master_patch_health.sh
+++ b/scripts/ppt_master_patch_health.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# ppt_master_patch_health.sh — 每周检查 PPT Master 补丁是否仍存在
+# no_agent cron: PASS=静默, FAIL=推微信告警
+set -euo pipefail
+
+PATCHES=(
+    "EXECUTOR-CN:skills/ppt-master/references/executor-base.md:PATCH EXECUTOR-CN"
+    "STRATEGIST-CN:skills/ppt-master/references/strategist.md:PATCH STRATEGIST-CN"
+    "VISUAL-STYLES-CN:skills/ppt-master/references/visual-styles/_index.md:PATCH VISUAL-STYLES-CN"
+)
+
+MISSING=""
+REPO_DIR="$HOME/ppt-master"
+
+for entry in "${PATCHES[@]}"; do
+    name=$(echo "$entry" | cut -d: -f1)
+    file=$(echo "$entry" | cut -d: -f2)
+    marker=$(echo "$entry" | cut -d: -f3)
+    
+    if ! grep -q "$marker" "$REPO_DIR/$file" 2>/dev/null; then
+        MISSING="$MISSING  🔴 $name: $file\n"
+    fi
+done
+
+if [ -n "$MISSING" ]; then
+    echo "⚠️ PPT Master 补丁丢失——升级后需重新 Apply"
+    echo ""
+    echo -e "$MISSING"
+    echo ""
+    echo "修复：查看 ~/hermes-local/yangyang/设计文档/PPT-Master定制补丁记录.md"
+    exit 1
+fi
+exit 0

--- a/scripts/scan_orphan_plans.sh
+++ b/scripts/scan_orphan_plans.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# 孤儿 Plan 检测 —— 每周日运行
+set -eo pipefail
+# 检测：①plan文件无队列条目 ②队列条目指向不存在的plan
+
+PLAN_DIR="$HOME/hermes-local/yangyang/plans"
+QUEUE_FILE="$HOME/.hermes/queue/pending.txt"
+DAYS=7
+
+orphans=()
+broken=()
+
+# 扫描过去 N 天内创建的 plan 文件
+while IFS= read -r -d '' plan; do
+    rel_path="${plan#$PLAN_DIR/}"
+    if ! grep -qF "$rel_path" "$QUEUE_FILE" 2>/dev/null; then
+        orphans+=("$rel_path")
+    fi
+done < <(find "$PLAN_DIR" -name "*.md" -mtime -$DAYS -print0 2>/dev/null)
+
+# 扫描队列中的 pending 条目指向的 plan 是否存在
+while IFS= read -r line; do
+    plan_ref=$(echo "$line" | grep -oP 'plans/\S+\.md' | head -1 || true)
+    if [ -n "$plan_ref" ] && [ ! -f "$HOME/hermes-local/yangyang/$plan_ref" ]; then
+        broken+=("$plan_ref")
+    fi
+done < <(grep 'pending' "$QUEUE_FILE" 2>/dev/null)
+
+# 输出
+if [ ${#orphans[@]} -eq 0 ] && [ ${#broken[@]} -eq 0 ]; then
+    echo "[SILENT]"
+    exit 0
+fi
+
+echo "🔍 孤儿 Plan 检测 ($(date '+%Y-%m-%d'))"
+echo ""
+
+if [ ${#orphans[@]} -gt 0 ]; then
+    echo "🟡 无队列引用的 plan（$DAYS天内）："
+    for p in "${orphans[@]}"; do
+        echo "  - plans/$p"
+    done
+    echo ""
+fi
+
+if [ ${#broken[@]} -gt 0 ]; then
+    echo "🔴 队列指向不存在的 plan："
+    for p in "${broken[@]}"; do
+        echo "  - $p"
+    done
+fi

--- a/scripts/scenario_router.py
+++ b/scripts/scenario_router.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+PATCH ① SCENARIO-ROUTER — 用户输入 → 场景参数块
+v1.0 2026-06-23
+
+用法: python3 scenario_router.py "<用户原始消息>"
+输出: 追加到 source.md 文末的 🎨 场景路由注入 段
+"""
+
+import sys, re
+
+# ═══════════════════════════════════════════
+# 表 A：场景关键词 → 场景参数
+# 来源: 场景参数速查表_v2_2026-06-22.md
+# ═══════════════════════════════════════════
+
+SCENARIOS = {
+    "高管汇报": {
+        "keywords": ["高管", "老板", "董事会", "决策", "汇报", "领导", "向上"],
+        "page_count": "≤8",
+        "content_divergence": "结论先行——每页标题=该页结论，正文≤3 bullet，细节放附录",
+        "mode": "pyramid",
+        "visual_style": "swiss-minimal",
+        "color_primary": "#1A56DB",
+        "color_bg": "#FFFFFF",
+        "color_secondary": "#6B7280",
+        "typography": "微软雅黑 + Arial",
+        "images": "placeholder 或 none（高管汇报少用图）",
+        "executor": "顶级专业咨询型",
+        "design_template": "每页标题=该页结论（非话题标签）。正文≤3 bullet，每 bullet≤10 字。\n所有图表必须有\"so what\"标注。禁止：正文超3行、纯文字页面、装饰性元素。\n色调：冷静、自信、无废话。",
+        "dont_list": "装饰性图标、渐变色背景、超过 8 页、正文超过 3 行、无结论的标题"
+    },
+    "产品发布": {
+        "keywords": ["产品", "发布", "上市", "新品", "路演", "营销", "品牌"],
+        "page_count": "10-15",
+        "content_divergence": "情绪驱动——先造悬念，后揭示答案。视觉冲击为主，文字为辅",
+        "mode": "showcase 或 narrative",
+        "visual_style": "dark-tech 或 glassmorphism",
+        "color_primary": "品牌主色",
+        "color_bg": "#F5F5F7",
+        "color_secondary": "#86868B",
+        "typography": "微软雅黑 + Segoe UI",
+        "images": "AI-generated（氛围图为主）",
+        "executor": "发布会视觉型",
+        "design_template": "每页一个核心画面+一句标题。图片占≥60%面积。文字=标注。\n节奏：悬念页→揭示页→冲击数据页→CTA页。禁止：纯文字页、密集表格。",
+        "dont_list": "bullet列表、Excel表格、小于24pt的文字、保守配色"
+    },
+    "数据报告": {
+        "keywords": ["数据", "报告", "分析", "指标", "趋势", "财报", "季度", "KPI"],
+        "page_count": "15-25",
+        "content_divergence": "数据驱动——先给核心发现，再展开数据论证",
+        "mode": "pyramid 或 briefing",
+        "visual_style": "data-journalism 或 editorial",
+        "color_primary": "#003366",
+        "color_bg": "#F8F9FA",
+        "color_secondary": "#E63946",
+        "typography": "Georgia + 微软雅黑",
+        "images": "placeholder（图表为主，AI 图少用）",
+        "executor": "咨询数据可视化型",
+        "design_template": "图表为主角——每页≤1个核心图表+2-3行解读。数据必须标注来源和年份。\n禁止：装饰性图片、无来源的数据、超过4种图表配色。",
+        "dont_list": "装饰图、无数据来源标注、饼图（用柱状代替）、超过4色图表"
+    },
+    "培训教学": {
+        "keywords": ["培训", "教学", "课程", "学习", "教程", "讲解", "教育"],
+        "page_count": "10-20",
+        "content_divergence": "教学结构——概念→示例→练习→总结",
+        "mode": "instructional",
+        "visual_style": "sketch-notes 或 soft-rounded",
+        "color_primary": "#2E86AB",
+        "color_bg": "#FFF8F0",
+        "color_secondary": "#F18F01",
+        "typography": "微软雅黑",
+        "images": "AI-generated（插图为主）",
+        "executor": "教学亲和型",
+        "design_template": "每页一个概念+一个示例。互动练习页≥20%。文字友好、不学术。\n禁止：密集表格、专业术语不加解释、全是文字无图。",
+        "dont_list": "学术术语、无图纯文字页、没有练习/互动环节"
+    },
+    "创意提案": {
+        "keywords": ["创意", "提案", "方案", "建议", "pitch", "融资", "BP"],
+        "page_count": "8-12",
+        "content_divergence": "故事驱动——问题→洞察→方案→愿景",
+        "mode": "narrative",
+        "visual_style": "memphis 或 brutalist",
+        "color_primary": "#FF6D00",
+        "color_bg": "#FFFFFF",
+        "color_secondary": "#1A73E8",
+        "typography": "微软雅黑 + Impact",
+        "images": "AI-generated（大胆配色）",
+        "executor": "创意视觉型",
+        "design_template": "大胆配色+非常规布局。每页一个核心概念。封面=冲击力标题。\n禁止：保守配色、模板化布局、超过5行的正文。",
+        "dont_list": "保守配色、模板化布局、多文字、图表优先于故事"
+    }
+}
+
+# ═══════════════════════════════════════════
+# 表 B：风格关键词 → visual_style 映射
+# 来源: 风格映射表_v2_2026-06-22.md
+# ═══════════════════════════════════════════
+
+STYLE_MAP = {
+    "麦肯锡": ("swiss-minimal", "pyramid"),
+    "咨询": ("swiss-minimal", "pyramid"),
+    "Apple": ("swiss-minimal", "showcase"),
+    "极简": ("swiss-minimal", "showcase"),
+    "高冷": ("swiss-minimal", "showcase"),
+    "互联网": ("glassmorphism", "narrative"),
+    "大厂": ("glassmorphism", "narrative"),
+    "科技": ("dark-tech", "narrative"),
+    "未来": ("dark-tech", "narrative"),
+    "杂志": ("editorial", "pyramid"),
+    "编辑": ("editorial", "pyramid"),
+    "学术": ("editorial", "briefing"),
+    "论文": ("editorial", "briefing"),
+    "手绘": ("sketch-notes", "instructional"),
+    "亲和": ("sketch-notes", "instructional"),
+    "温暖": ("ink-notes", "instructional"),
+    "复古": ("vintage-poster", "narrative"),
+    "老字号": ("vintage-poster", "narrative"),
+    "水墨": ("ink-wash", "narrative"),
+    "东方": ("ink-wash", "narrative"),
+    "国风": ("ink-wash", "narrative"),
+    "粗野": ("brutalist", "showcase"),
+    "前卫": ("brutalist", "showcase"),
+    "设计感": ("zine", "showcase"),
+    "蓝图": ("blueprint", "instructional"),
+    "工程": ("blueprint", "instructional"),
+    "架构": ("blueprint", "instructional"),
+    "数据报告": ("data-journalism", "pyramid"),
+    "财经": ("data-journalism", "pyramid"),
+    "SaaS": ("soft-rounded", "narrative"),
+    "产品": ("soft-rounded", "narrative"),
+    "现代": ("soft-rounded", "narrative"),
+    "培训": ("sketch-notes", "instructional"),
+    "教学": ("sketch-notes", "instructional"),
+}
+
+
+def detect_scenario(user_text: str) -> tuple:
+    """返回 (场景名, 匹配关键词数, 场景dict)"""
+    scores = {}
+    for name, sc in SCENARIOS.items():
+        score = sum(1 for kw in sc["keywords"] if kw in user_text)
+        if score > 0:
+            scores[name] = (score, sc)
+    if not scores:
+        return ("通用", 0, None)
+    best = max(scores, key=lambda k: scores[k][0])
+    return (best, scores[best][0], scores[best][1])
+
+
+def detect_style_override(user_text: str):
+    """检测用户是否明确说了风格关键词"""
+    for kw, (vs, mode) in STYLE_MAP.items():
+        if kw in user_text:
+            return vs, mode
+    return None, None
+
+
+def generate_routing_block(user_text: str) -> str:
+    scenario_name, score, scenario = detect_scenario(user_text)
+    vs_override, mode_override = detect_style_override(user_text)
+    
+    if scenario is None:
+        return "# 🎨 场景路由注入（自动生成）\n\n未能自动识别场景，将使用 PPT Master 默认参数。\n"
+    
+    vs = vs_override or scenario["visual_style"]
+    mode = mode_override or scenario["mode"]
+    
+    # 用户有风格覆盖时标注
+    override_note = ""
+    if vs_override:
+        override_note = f"\n- ⚠️ 检测到风格关键词，已覆盖场景默认 visual_style: {scenario['visual_style']} → {vs_override}"
+    if mode_override:
+        override_note += f"\n- ⚠️ 检测到模式关键词，已覆盖场景默认 mode: {scenario['mode']} → {mode_override}"
+    
+    block = f"""# 🎨 场景路由注入（自动生成——PPT Master 前置预处理）
+
+> 检测场景：**{scenario_name}**（匹配关键词 {score} 个）
+> 以下参数为建议默认值，PPT Master 的 Eight Confirmations 阶段会再次让你确认——你可随时修改任何参数。{override_note}
+
+## 场景参数
+
+| 参数 | 建议值 |
+|------|--------|
+| Page Count | {scenario['page_count']} |
+| Content Divergence | {scenario['content_divergence']} |
+| Mode | **{mode}** |
+| Visual Style | **{vs}** |
+| Color | 主色 {scenario['color_primary']} / 底色 {scenario['color_bg']} / 辅色 {scenario['color_secondary']} |
+| Typography | {scenario['typography']} |
+| Images | {scenario['images']} |
+| Executor Type | {scenario['executor']} |
+
+## 设计要求
+
+{scenario['design_template']}
+
+## Don't 清单
+
+{scenario['dont_list']}
+
+---
+"""
+    return block
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("用法: python3 scenario_router.py \"<用户原始消息>\"")
+        sys.exit(1)
+    
+    user_text = sys.argv[1]
+    print(generate_routing_block(user_text))


### PR DESCRIPTION
Remaining plugins and scripts from production:

**Plugins (7):**
- conclusion-anchor: fact verification pre-response injection
- context_injection: per-turn context (progress, orphans) into system prompt
- url-autosave: auto-save shared URLs to knowledge base inbox
- mode-1a-scan: adversarial question injection on conclusion outputs
- bg-progress-logger: async task state → progress.log for cross-session tracking
- clarify_guard: enforce clarify() tool usage for ambiguous requests
- memory_summary_hook: daily MEMORY.md → MEMORY_SUMMARY.md compression

**Scripts (8):**
- boy_scout_scan.sh, done_marker_validate.sh, output-violation-scan.sh — output compliance
- scenario_router.py — LLM-driven rule routing
- hermes-restart-oneshot.sh — gateway restart via timer flag
- last30days.py — usage analytics
- ppt_master_patch_health.sh — patch integrity verification
- scan_orphan_plans.sh — orphan plan detection (cron version)