### PR TITLE
fix(titles): scope title uniqueness and resolution by source

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -951,7 +951,10 @@ def compress_context(
                     # Auto-number the title for the continuation session
                     if old_title:
                         try:
-                            new_title = agent._session_db.get_next_title_in_lineage(old_title)
+                            new_title = agent._session_db.get_next_title_in_lineage(
+                                old_title,
+                                source=getattr(agent, "platform", None) or "cli",
+                            )
                             agent._session_db.set_session_title(agent.session_id, new_title)
                         except (ValueError, Exception) as e:
                             logger.debug("Could not propagate title on compression: %s", e)

--- a/cli.py
+++ b/cli.py
@@ -8590,7 +8590,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         else:
                             # Session not created yet — defer the title
                             # Check uniqueness proactively with the sanitized title
-                            existing = self._session_db.get_session_by_title(new_title)
+                            existing = self._session_db.get_session_by_title(
+                                new_title,
+                                source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                            )
                             if existing:
                                 _cprint(f"  Title '{new_title}' is already in use by session {existing['id']}")
                             else:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2030,7 +2030,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if title is None:
             base = source.get("title") or "fork"
             try:
-                title = db.get_next_title_in_lineage(base)
+                title = db.get_next_title_in_lineage(base, source="api_server")
             except Exception:
                 title = f"{base} fork"
         try:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3616,7 +3616,10 @@ class GatewaySlashCommandsMixin:
             if session:
                 target_id = session["id"]
             else:
-                target_id = await self._session_db.resolve_session_by_title(name)
+                target_id = await self._session_db.resolve_session_by_title(
+                    name,
+                    source=source.platform.value if source.platform else None,
+                )
         if not target_id:
             return t("gateway.resume.not_found", name=name)
         # Compression creates child continuations that hold the live transcript.
@@ -3811,7 +3814,10 @@ class GatewaySlashCommandsMixin:
         else:
             current_title = await self._session_db.get_session_title(current_entry.session_id)
             base = current_title or "branch"
-            branch_title = await self._session_db.get_next_title_in_lineage(base)
+            branch_title = await self._session_db.get_next_title_in_lineage(
+                base,
+                source=source.platform.value if source.platform else None,
+            )
 
         parent_session_id = current_entry.session_id
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -882,6 +882,7 @@ class CLICommandsMixin:
         timestamp_str = now.strftime("%Y%m%d_%H%M%S")
         short_uuid = uuid.uuid4().hex[:6]
         new_session_id = f"{timestamp_str}_{short_uuid}"
+        session_source = os.environ.get("HERMES_SESSION_SOURCE", "cli")
 
         # Determine branch title
         if branch_name:
@@ -892,7 +893,9 @@ class CLICommandsMixin:
             if self._session_db:
                 current_title = self._session_db.get_session_title(self.session_id)
             base = current_title or "branch"
-            branch_title = self._session_db.get_next_title_in_lineage(base)
+            branch_title = self._session_db.get_next_title_in_lineage(
+                base, source=session_source
+            )
 
         # Save the current session's state before branching
         parent_session_id = self.session_id
@@ -920,7 +923,7 @@ class CLICommandsMixin:
         try:
             self._session_db.create_session(
                 session_id=new_session_id,
-                source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                source=session_source,
                 model=self.model,
                 model_config={
                     "max_iterations": self.max_turns,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1308,7 +1308,10 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
             resolved_id = session["id"]
         else:
             # Try as title (with auto-latest for lineage)
-            resolved_id = db.resolve_session_by_title(name_or_id)
+            resolved_id = db.resolve_session_by_title(
+                name_or_id,
+                source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+            )
 
         if resolved_id:
             # Project forward through compression chain so resumes land on

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1710,11 +1710,13 @@ class SessionDB:
                     (SCHEMA_VERSION,),
                 )
 
-        # Unique title index — always ensure it exists
+        # Unique title index — title names are user-facing handles inside a
+        # source namespace (cli, telegram, api_server, ...), not globally.
         try:
+            cursor.execute("DROP INDEX IF EXISTS idx_sessions_title_unique")
             cursor.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_title_unique "
-                "ON sessions(title) WHERE title IS NOT NULL"
+                "ON sessions(source, title) WHERE title IS NOT NULL"
             )
         except sqlite3.OperationalError:
             pass  # Index already exists
@@ -3059,11 +3061,17 @@ class SessionDB:
         """
         title = self.sanitize_title(title)
         def _do(conn):
+            session_row = conn.execute(
+                "SELECT source FROM sessions WHERE id = ?", (session_id,)
+            ).fetchone()
+            if not session_row:
+                return 0
+            source = session_row["source"]
             if title:
                 # Check uniqueness (allow the same session to keep its own title)
                 cursor = conn.execute(
-                    "SELECT id FROM sessions WHERE title = ? AND id != ?",
-                    (title, session_id),
+                    "SELECT id FROM sessions WHERE source = ? AND title = ? AND id != ?",
+                    (source, title, session_id),
                 )
                 conflict = cursor.fetchone()
                 if conflict:
@@ -3157,16 +3165,23 @@ class SessionDB:
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
-    def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
+    def get_session_by_title(
+        self, title: str, *, source: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""
+        query = "SELECT * FROM sessions WHERE title = ?"
+        params: list[Any] = [title]
+        if source is not None:
+            query += " AND source = ?"
+            params.append(source)
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT * FROM sessions WHERE title = ?", (title,)
-            )
+            cursor = self._conn.execute(query, params)
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def resolve_session_by_title(self, title: str) -> Optional[str]:
+    def resolve_session_by_title(
+        self, title: str, *, source: Optional[str] = None
+    ) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
         If the exact title exists, returns that session's ID.
@@ -3175,17 +3190,22 @@ class SessionDB:
         latest numbered variant (the most recent continuation).
         """
         # First try exact match
-        exact = self.get_session_by_title(title)
+        exact = self.get_session_by_title(title, source=source)
 
         # Also search for numbered variants: "title #2", "title #3", etc.
         # Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        query = (
+            "SELECT id, title, started_at FROM sessions "
+            "WHERE title LIKE ? ESCAPE '\\'"
+        )
+        params: list[Any] = [f"{escaped} #%"]
+        if source is not None:
+            query += " AND source = ?"
+            params.append(source)
+        query += " ORDER BY started_at DESC"
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT id, title, started_at FROM sessions "
-                "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
-                (f"{escaped} #%",),
-            )
+            cursor = self._conn.execute(query, params)
             numbered = cursor.fetchall()
 
         if numbered:
@@ -3195,7 +3215,9 @@ class SessionDB:
             return exact["id"]
         return None
 
-    def get_next_title_in_lineage(self, base_title: str) -> str:
+    def get_next_title_in_lineage(
+        self, base_title: str, *, source: Optional[str] = None
+    ) -> str:
         """Generate the next title in a lineage (e.g., "my session" → "my session #2").
 
         Strips any existing " #N" suffix to find the base name, then finds
@@ -3211,11 +3233,13 @@ class SessionDB:
         # Find all existing numbered variants
         # Escape SQL LIKE wildcards (%, _) in the base to prevent false matches
         escaped = base.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        query = "SELECT title FROM sessions WHERE (title = ? OR title LIKE ? ESCAPE '\\')"
+        params: list[Any] = [base, f"{escaped} #%"]
+        if source is not None:
+            query += " AND source = ?"
+            params.append(source)
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT title FROM sessions WHERE title = ? OR title LIKE ? ESCAPE '\\'",
-                (base, f"{escaped} #%"),
-            )
+            cursor = self._conn.execute(query, params)
             existing = [row["title"] for row in cursor.fetchall()]
 
         if not existing:

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -123,6 +123,22 @@ class TestBranchCommandCLI:
         title = session_db.get_session_title(cli_instance.session_id)
         assert title == "My Coding Session #2"
 
+    def test_branch_auto_title_uses_configured_source(
+        self, cli_instance, session_db, monkeypatch
+    ):
+        """Custom CLI sources must number titles inside their own namespace."""
+        custom_source = "third-party-tool"
+        monkeypatch.setenv("HERMES_SESSION_SOURCE", custom_source)
+        session_db.create_session("custom-existing", custom_source)
+        session_db.set_session_title("custom-existing", "My Coding Session #2")
+
+        HermesCLI = __import__("cli").HermesCLI
+        HermesCLI._handle_branch_command(cli_instance, "/branch")
+
+        created = session_db.get_session(cli_instance.session_id)
+        assert created["source"] == custom_source
+        assert created["title"] == "My Coding Session #3"
+
     def test_branch_empty_conversation(self, cli_instance, session_db):
         """Branching with no history should show an error."""
         from cli import HermesCLI

--- a/tests/gateway/test_matrix_project_context_isolation.py
+++ b/tests/gateway/test_matrix_project_context_isolation.py
@@ -431,7 +431,9 @@ async def test_matrix_resume_quoted_title_same_room():
     )
 
     assert "Resumed session" in result
-    runner._session_db._db.resolve_session_by_title.assert_called_once_with("Project B Plan")
+    runner._session_db._db.resolve_session_by_title.assert_called_once_with(
+        "Project B Plan", source="matrix"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -178,6 +178,32 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_by_name_scoped_to_platform_source(self, tmp_path):
+        """Title resume should not cross platform source namespaces."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("telegram_session", "telegram", user_id="12345", chat_id="67890")
+        db.set_session_title("telegram_session", "Shared Project")
+        db.create_session("discord_session", "discord", user_id="12345", chat_id="67890")
+        db.set_session_title("discord_session", "Shared Project")
+        db.create_session("current_session_001", "telegram", user_id="12345", chat_id="67890")
+
+        event = _make_event(text="/resume Shared Project", platform=Platform.TELEGRAM)
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        runner.session_store.switch_session.assert_called_once()
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "telegram_session"
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_resume_clears_session_model_overrides(self, tmp_path):
         """Resume must not carry a previous session's /model override into the
         restored conversation, while leaving other chats' overrides intact (#10702)."""

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -118,6 +118,34 @@ def test_cmd_chat_tui_resume_resolves_title_before_launch(monkeypatch, main_mod)
     assert captured["resume"] == "20260409_000000_aa11bb"
 
 
+def test_title_resolution_uses_configured_session_source(monkeypatch, main_mod):
+    calls = []
+
+    class _DB:
+        def get_session(self, _value):
+            return None
+
+        def resolve_session_by_title(self, title, *, source=None):
+            calls.append((title, source))
+            return "custom-session"
+
+        def get_compression_tip(self, session_id):
+            return session_id
+
+        def close(self):
+            return None
+
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "third-party-tool")
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_state",
+        types.SimpleNamespace(SessionDB=lambda: _DB()),
+    )
+
+    assert main_mod._resolve_session_by_name_or_id("Shared Project") == "custom-session"
+    assert calls == [("Shared Project", "third-party-tool")]
+
+
 def test_cmd_chat_tui_passes_model_and_provider(monkeypatch, main_mod):
     captured = {}
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3762,6 +3762,20 @@ class TestTitleUniqueness:
         with pytest.raises(ValueError, match="already in use"):
             db.set_session_title("s2", "my project")
 
+    def test_duplicate_title_allowed_across_sources(self, db):
+        """Different platforms have independent title namespaces."""
+        db.create_session("cli-session", "cli")
+        db.create_session("telegram-session", "telegram")
+
+        assert db.set_session_title("cli-session", "shared project") is True
+        assert db.set_session_title("telegram-session", "shared project") is True
+
+        assert db.get_session_by_title("shared project", source="cli")["id"] == "cli-session"
+        assert (
+            db.get_session_by_title("shared project", source="telegram")["id"]
+            == "telegram-session"
+        )
+
     def test_same_session_can_keep_title(self, db):
         """A session can re-set its own title without error."""
         db.create_session("s1", "cli")
@@ -3819,6 +3833,22 @@ class TestTitleLineage:
         # Resolving "my project" should return s3 (latest numbered variant)
         assert db.resolve_session_by_title("my project") == "s3"
 
+    def test_resolve_title_scoped_to_source(self, db):
+        """A numbered title in another source must not win this source's resume."""
+        import time
+
+        db.create_session("cli-root", "cli")
+        db.set_session_title("cli-root", "my project")
+        time.sleep(0.01)
+        db.create_session("telegram-child", "telegram")
+        db.set_session_title("telegram-child", "my project #2")
+
+        assert db.resolve_session_by_title("my project", source="cli") == "cli-root"
+        assert (
+            db.resolve_session_by_title("my project", source="telegram")
+            == "telegram-child"
+        )
+
     def test_resolve_exact_numbered(self, db):
         """Resolving an exact numbered title returns that specific session."""
         db.create_session("s1", "cli")
@@ -3859,6 +3889,22 @@ class TestTitleLineage:
         db.set_session_title("s2", "my project #2")
         # Even when called with "my project #2", it should return #3
         assert db.get_next_title_in_lineage("my project #2") == "my project #3"
+
+    def test_next_title_lineage_scoped_to_source(self, db):
+        """Branch/compression title numbering is independent per source."""
+        db.create_session("cli-root", "cli")
+        db.set_session_title("cli-root", "my project")
+        db.create_session("telegram-child", "telegram")
+        db.set_session_title("telegram-child", "my project #2")
+
+        assert (
+            db.get_next_title_in_lineage("my project", source="cli")
+            == "my project #2"
+        )
+        assert (
+            db.get_next_title_in_lineage("my project", source="telegram")
+            == "my project #3"
+        )
 
 
 class TestTitleSqlWildcards:

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -335,12 +335,38 @@ def test_sess_found(server):
 # ── session.resume payload ────────────────────────────────────────────
 
 
+def test_session_resume_title_lookup_uses_surface_source(server, monkeypatch):
+    calls = []
+
+    class _DB:
+        def get_session(self, _sid):
+            return None
+
+        def get_session_by_title(self, title, *, source=None):
+            calls.append((title, source))
+            return None
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_resolve_session_source", lambda _source: "desktop")
+
+    resp = server.handle_request(
+        {
+            "id": "r-title",
+            "method": "session.resume",
+            "params": {"session_id": "Shared Project"},
+        }
+    )
+
+    assert resp["error"]["code"] == 4007
+    assert calls == [("Shared Project", "desktop")]
+
+
 def test_session_resume_returns_hydrated_messages(server, monkeypatch):
     class _DB:
         def get_session(self, _sid):
             return {"id": "20260409_010101_abc123"}
 
-        def get_session_by_title(self, _title):
+        def get_session_by_title(self, _title, *, source=None):
             return None
 
         def reopen_session(self, _sid):
@@ -397,7 +423,7 @@ def test_session_resume_defaults_to_deferred_build(server, monkeypatch):
                 "model_config": {"provider": "vendor"},
             }
 
-        def get_session_by_title(self, _title):
+        def get_session_by_title(self, _title, *, source=None):
             return None
 
         def resolve_resume_session_id(self, sid):
@@ -541,7 +567,7 @@ def test_session_resume_handles_multimodal_list_content(server, monkeypatch):
         def get_session(self, _sid):
             return {"id": "20260502_000000_listcontent"}
 
-        def get_session_by_title(self, _title):
+        def get_session_by_title(self, _title, *, source=None):
             return None
 
         def reopen_session(self, _sid):
@@ -591,7 +617,7 @@ def test_session_resume_lazy_registers_watch_session_without_agent(server, monke
         def get_session(self, _sid):
             return {"id": target}
 
-        def get_session_by_title(self, _title):
+        def get_session_by_title(self, _title, *, source=None):
             return None
 
         def reopen_session(self, _sid):
@@ -664,7 +690,7 @@ def test_session_resume_lazy_reports_running_for_inflight_child(server, monkeypa
         def get_session(self, _sid):
             return {"id": target}
 
-        def get_session_by_title(self, _title):
+        def get_session_by_title(self, _title, *, source=None):
             return None
 
         def reopen_session(self, _sid):
@@ -715,7 +741,7 @@ def test_session_resume_lazy_tolerates_missing_row_for_active_child(server, monk
             # Row not flushed yet — the whole point of the race.
             return None
 
-        def get_session_by_title(self, _title):
+        def get_session_by_title(self, _title, *, source=None):
             return None
 
         def reopen_session(self, _sid):
@@ -770,7 +796,7 @@ def test_session_resume_missing_row_non_lazy_still_errors(server, monkeypatch):
         def get_session(self, _sid):
             return None
 
-        def get_session_by_title(self, _title):
+        def get_session_by_title(self, _title, *, source=None):
             return None
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
@@ -812,7 +838,7 @@ def test_session_resume_reuses_existing_live_session(server, monkeypatch):
         def get_session(self, _sid):
             return {"id": target}
 
-        def get_session_by_title(self, _title):
+        def get_session_by_title(self, _title, *, source=None):
             return None
 
         def reopen_session(self, _sid):
@@ -943,7 +969,7 @@ def test_session_resume_reuses_live_agent_after_compression_rotation(server, mon
         def get_session(self, _sid):
             return {"id": target}
 
-        def get_session_by_title(self, _title):
+        def get_session_by_title(self, _title, *, source=None):
             return None
 
         def resolve_resume_session_id(self, _target):
@@ -1029,7 +1055,7 @@ def test_session_resume_live_payload_uses_current_history_with_ancestors(server,
         def get_session(self, _sid):
             return {"id": target}
 
-        def get_session_by_title(self, _title):
+        def get_session_by_title(self, _title, *, source=None):
             return None
 
         def reopen_session(self, _sid):
@@ -1162,12 +1188,14 @@ def test_session_branch_persists_branched_from_marker(server, monkeypatch):
     thing that keeps a TUI branch visible.
     """
     create_calls = []
+    lineage_calls = []
 
     class _DB:
         def get_session_title(self, _key):
             return "parent-title"
 
-        def get_next_title_in_lineage(self, base):
+        def get_next_title_in_lineage(self, base, *, source=None):
+            lineage_calls.append((base, source))
             return f"{base} 2"
 
         def create_session(self, new_key, **kwargs):
@@ -1199,6 +1227,7 @@ def test_session_branch_persists_branched_from_marker(server, monkeypatch):
     parent_key = "20260101_000000_parent"
     server._sessions[parent_sid] = {
         "session_key": parent_key,
+        "source": "desktop",
         "history": [{"role": "user", "content": "hello"}],
         "history_lock": threading.Lock(),
         "cols": 80,
@@ -1213,6 +1242,8 @@ def test_session_branch_persists_branched_from_marker(server, monkeypatch):
     new_key, kwargs = create_calls[0]
     assert new_key == "20260101_000001_child0"
     assert kwargs["parent_session_id"] == parent_key
+    assert kwargs["source"] == "desktop"
+    assert lineage_calls == [("parent-title", "desktop")]
     # The marker — without it the branch is invisible in /resume and /sessions.
     assert kwargs["model_config"] == {"_branched_from": parent_key}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5603,7 +5603,10 @@ def _(rid, params: dict) -> dict:
 
     found = db.get_session(target)
     if not found:
-        found = db.get_session_by_title(target)
+        source = _resolve_session_source(
+            str(params.get("source") or "").strip() or None
+        )
+        found = db.get_session_by_title(target, source=source)
         if found:
             target = found["id"]
         elif is_truthy_value(params.get("lazy", False)) and _child_run_active(target):
@@ -8091,7 +8094,7 @@ def _(rid, params: dict) -> dict:
         else:
             current = db.get_session_title(old_key) or "branch"
             title = (
-                db.get_next_title_in_lineage(current)
+                db.get_next_title_in_lineage(current, source=source)
                 if hasattr(db, "get_next_title_in_lineage")
                 else f"{current} (branch)"
             )

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -67,7 +67,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_title_unique
-    ON sessions(title) WHERE title IS NOT NULL;
+ON sessions(source, title) WHERE title IS NOT NULL;
 ```
 
 ### Messages Table
@@ -142,7 +142,7 @@ The `schema_version` table stores a single integer. Simple column additions are 
 | 1 | Initial schema (sessions, messages, FTS5) |
 | 2 | Add `finish_reason` column to messages |
 | 3 | Add `title` column to sessions |
-| 4 | Add unique index on `title` (NULLs allowed, non-NULL must be unique) |
+| 4 | Add unique index on `(source, title)` (NULL titles allowed) |
 | 5 | Add billing columns: `cache_read_tokens`, `cache_write_tokens`, `reasoning_tokens`, `billing_provider`, `billing_base_url`, `billing_mode`, `estimated_cost_usd`, `actual_cost_usd`, `cost_status`, `cost_source`, `pricing_version` |
 | 6 | Add reasoning columns to messages: `reasoning`, `reasoning_details`, `codex_reasoning_items` |
 | 7 | Add `reasoning_content` column to messages |
@@ -233,7 +233,7 @@ conversation = db.get_messages_as_conversation("sess_abc123")
 ### Session Titles
 
 ```python
-# Set a title (must be unique among non-NULL titles)
+# Set a title (must be unique among non-NULL titles in the same source)
 db.set_session_title("sess_abc123", "Fix Docker Build")
 
 # Resolve by title (returns most recent in lineage)

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -18,7 +18,7 @@ Every conversation — whether from the CLI, Telegram, Discord, Slack, WhatsApp,
 
 The SQLite database stores:
 - Session ID, source platform, user ID
-- **Session title** (unique, human-readable name)
+- **Session title** (human-readable name, unique within its source/platform)
 - Model name and configuration
 - System prompt snapshot
 - Full message history (role, content, tool calls, tool results)
@@ -678,7 +678,7 @@ exists in state.db.
 
 Key tables in `state.db`:
 
-- **sessions** — session metadata (id, source, user_id, model, title, timestamps, token counts). Titles have a unique index (NULL titles allowed, only non-NULL must be unique).
+- **sessions** — session metadata (id, source, user_id, model, title, timestamps, token counts). Non-NULL titles are unique within each source/platform.
 - **messages** — full message history (role, content, tool_calls, tool_name, token_count)
 - **messages_fts** — FTS5 virtual table for full-text search across message content
 


### PR DESCRIPTION
Fixes #60047

## What changed

- Scope non-empty title uniqueness to `(source, title)`.
- Add source filters to exact title lookup, resume resolution, and lineage numbering.
- Thread the effective source through CLI, custom `chat --source`, TUI/Desktop resume and branch flows, gateway resume, compression, and API forks.
- Update session documentation to describe per-source title uniqueness.
- Add regressions for duplicate titles across sources, custom-source CLI branches, TUI/Desktop lookup and numbering, gateway resume isolation, and lineage numbering.

## Why

Titles are user-facing handles inside a source namespace. A Telegram session titled `Project #2` must not affect CLI/TUI numbering or make a different source's `Project` ambiguous.

## Tests

- title/session-state slice: 60 passed
- CLI branch and TUI resume flows: 67 passed
- TUI protocol: 84 passed
- gateway resume/matrix slice: 61 passed
- `python -m ruff check` on changed Python files
- `python -m py_compile` on changed Python files
- `git diff --check`