### PR TITLE
feat(titles): show provisional chat title before LLM refinement

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1640,6 +1640,7 @@ class HermesACPAgent(acp.Agent):
                         and getattr(state.agent, "provider", None) == _title_provider
                     ),
                     title_callback=_notify_title_update,
+                    provisional_title_callback=_notify_title_update,
                 )
             except Exception:
                 logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -5,6 +5,7 @@ adds latency to the user-facing reply.
 """
 
 import logging
+import re
 import threading
 from typing import Callable, Optional
 
@@ -38,6 +39,39 @@ _TITLE_PROMPT_PINNED_LANGUAGE = (
     "Write the title in {language}. "
     "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
 )
+
+
+def provisional_title_from_message(
+    message: str,
+    max_length: int = 80,
+) -> Optional[str]:
+    """Derive an immediate local title from the first meaningful line."""
+    if not message:
+        return None
+
+    for line in str(message).splitlines():
+        candidate = re.sub(r"\s+", " ", line).strip()
+        if not candidate:
+            continue
+        candidate = re.sub(
+            r"^(user|human|prompt|question)\s*:\s*",
+            "",
+            candidate,
+            flags=re.I,
+        )
+        candidate = candidate.strip("`\"'[](){} ")
+        if candidate:
+            break
+    else:
+        return None
+
+    if len(candidate) <= max_length:
+        return candidate
+
+    shortened = candidate[:max_length].rstrip()
+    if " " in shortened:
+        shortened = shortened.rsplit(" ", 1)[0].rstrip()
+    return (shortened or candidate[:max_length]).rstrip(" .,;:!?") + "..."
 
 
 def _title_language() -> str:
@@ -160,26 +194,35 @@ def generate_title(
         return None
 
 
-def _persist_session_title(session_db, session_id, title):
+def _persist_session_title(
+    session_db,
+    session_id,
+    title,
+    *,
+    expected_title: Optional[str] = None,
+):
     """Persist a generated title, recovering from duplicate-title collisions.
 
-    The write goes through ``set_auto_title_if_empty`` (predicate + write in
-    one transaction) so a manual ``/title`` set while LLM generation was in
-    flight is never overwritten — a plain ``set_session_title`` fallback keeps
-    older stores working. ``set_session_title`` raises ValueError when the
-    title would collide with another session (the unique-title index). Rather
-    than swallow it and leave the session untitled (#50537), append a #N
-    suffix via get_next_title_in_lineage() when the store supports lineage
-    dedup; otherwise re-raise so the caller can decide.
+    Without a provisional title, the write uses ``set_auto_title_if_empty``.
+    With one, it uses ``compare_and_set_session_title`` so a concurrent manual
+    rename wins. Duplicate generated titles still retry through lineage
+    numbering before the same predicate is attempted again.
 
     Returns the title actually persisted, or None when a concurrent manual
     title won the race (nothing was written).
     """
-    atomic_fn = getattr(session_db, "set_auto_title_if_empty", None)
+    if expected_title is None:
+        atomic_fn = getattr(session_db, "set_auto_title_if_empty", None)
+    else:
+        atomic_fn = getattr(session_db, "compare_and_set_session_title", None)
 
     def _set(t):
-        if atomic_fn is not None:
-            if not atomic_fn(session_id, t):
+        if callable(atomic_fn):
+            if expected_title is None:
+                stored = atomic_fn(session_id, t)
+            else:
+                stored = atomic_fn(session_id, expected_title, t)
+            if not stored:
                 # Predicate failed: a title appeared while generation was in
                 # flight (manual /title wins), or the session vanished.
                 logger.debug(
@@ -188,6 +231,10 @@ def _persist_session_title(session_db, session_id, title):
                 )
                 return None
             return t
+        if expected_title is not None:
+            # Stores that can persist the provisional title must provide an
+            # atomic replacement primitive before it is safe to refine it.
+            return None
         ok = session_db.set_session_title(session_id, t)
         if ok is False:
             raise RuntimeError(
@@ -216,6 +263,7 @@ def auto_title_session(
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
     runtime_validator: Optional[RuntimeValidator] = None,
+    provisional_title: Optional[str] = None,
 ) -> None:
     """Generate and set a session title if one doesn't already exist.
 
@@ -245,6 +293,7 @@ def auto_title_session(
             main_runtime=main_runtime,
             title_callback=title_callback,
             runtime_validator=runtime_validator,
+            provisional_title=provisional_title,
         )
     except Exception as e:
         # WARNING (not debug) so operators see it in agent.log; the message
@@ -271,6 +320,7 @@ def _auto_title_session(
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
     runtime_validator: Optional[RuntimeValidator] = None,
+    provisional_title: Optional[str] = None,
 ) -> None:
     """Body of :func:`auto_title_session` — see its docstring."""
     if not session_db or not session_id:
@@ -279,7 +329,7 @@ def _auto_title_session(
     # Check if title already exists (user may have set one via /title before first response)
     try:
         existing = session_db.get_session_title(session_id)
-        if existing:
+        if existing != provisional_title:
             return
     except Exception:
         return
@@ -314,7 +364,12 @@ def _auto_title_session(
         return
 
     try:
-        persisted = _persist_session_title(session_db, session_id, title)
+        persisted = _persist_session_title(
+            session_db,
+            session_id,
+            title,
+            expected_title=provisional_title,
+        )
         if persisted is None:
             return
         logger.debug("Auto-generated session title: %s", persisted)
@@ -337,6 +392,7 @@ def maybe_auto_title(
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
     runtime_validator: Optional[RuntimeValidator] = None,
+    provisional_title_callback: Optional[TitleCallback] = None,
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
 
@@ -361,6 +417,24 @@ def maybe_auto_title(
         logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
         return
 
+    provisional_title = None
+    try:
+        candidate = provisional_title_from_message(user_message)
+        set_if_empty = getattr(session_db, "set_auto_title_if_empty", None)
+        if candidate and callable(set_if_empty) and set_if_empty(session_id, candidate):
+            provisional_title = candidate
+            if provisional_title_callback is not None:
+                try:
+                    provisional_title_callback(provisional_title)
+                except Exception:
+                    logger.debug(
+                        "Provisional title callback failed",
+                        exc_info=True,
+                    )
+    except Exception:
+        logger.debug("Could not set provisional session title", exc_info=True)
+        provisional_title = None
+
     thread = threading.Thread(
         target=auto_title_session,
         args=(session_db, session_id, user_message, assistant_response),
@@ -369,6 +443,7 @@ def maybe_auto_title(
             "main_runtime": main_runtime,
             "title_callback": title_callback,
             "runtime_validator": runtime_validator,
+            "provisional_title": provisional_title,
         },
         daemon=True,
         name="auto-title",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3372,6 +3372,39 @@ class SessionDB:
         ).fetchone()
         return row is not None
 
+    def _ensure_session_title_available(
+        self,
+        conn: sqlite3.Connection,
+        session_id: str,
+        title: Optional[str],
+    ) -> None:
+        """Validate title uniqueness inside an active write transaction."""
+        if not title:
+            return
+        conflict = conn.execute(
+            "SELECT id FROM sessions WHERE title = ? AND id != ?",
+            (title, session_id),
+        ).fetchone()
+        if not conflict:
+            return
+
+        conflict_id = conflict["id"]
+        # A compression continuation is the visible head of its hidden
+        # ancestors, so the title may move forward within that lineage.
+        if self._is_compression_ancestor(
+            conn,
+            ancestor_id=conflict_id,
+            descendant_id=session_id,
+        ):
+            conn.execute(
+                "UPDATE sessions SET title = NULL WHERE id = ?",
+                (conflict_id,),
+            )
+            return
+        raise ValueError(
+            f"Title '{title}' is already in use by session {conflict_id}"
+        )
+
     def _set_session_title(
         self,
         session_id: str,
@@ -3390,37 +3423,7 @@ class SessionDB:
                 if current is None or current["title"] is not None:
                     return 0
 
-            if title:
-                # Check uniqueness (allow the same session to keep its own title)
-                cursor = conn.execute(
-                    "SELECT id FROM sessions WHERE title = ? AND id != ?",
-                    (title, session_id),
-                )
-                conflict = cursor.fetchone()
-                if conflict:
-                    conflict_id = conflict["id"]
-                    # A compression continuation is the live, projected-forward
-                    # head of its conversation; its compressed predecessors are
-                    # ended and hidden from the session list (list_sessions_rich
-                    # projects roots → tip). When the title that "conflicts" is
-                    # held by such a hidden ancestor, the user has no way to free
-                    # it — renaming the visible tip back to the base name would
-                    # dead-end with "already in use by <session they can't see>".
-                    # Treat this as a transfer: move the title off the ancestor
-                    # onto the continuation. Uniqueness is preserved (still only
-                    # one session carries the exact title) and the parent-link
-                    # lineage is untouched.
-                    if self._is_compression_ancestor(
-                        conn, ancestor_id=conflict_id, descendant_id=session_id
-                    ):
-                        conn.execute(
-                            "UPDATE sessions SET title = NULL WHERE id = ?",
-                            (conflict_id,),
-                        )
-                    else:
-                        raise ValueError(
-                            f"Title '{title}' is already in use by session {conflict_id}"
-                        )
+            self._ensure_session_title_available(conn, session_id, title)
             predicate = " AND title IS NULL" if only_if_empty else ""
             cursor = conn.execute(
                 f"UPDATE sessions SET title = ? WHERE id = ?{predicate}",
@@ -3449,6 +3452,32 @@ class SessionDB:
         :meth:`set_session_title`.
         """
         return self._set_session_title(session_id, title, only_if_empty=True)
+
+    def compare_and_set_session_title(
+        self,
+        session_id: str,
+        expected_title: Optional[str],
+        title: Optional[str],
+    ) -> bool:
+        """Set a title only while the stored value matches ``expected_title``."""
+        expected_title = self.sanitize_title(expected_title)
+        title = self.sanitize_title(title)
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT title FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is None or row["title"] != expected_title:
+                return 0
+            self._ensure_session_title_available(conn, session_id, title)
+            cursor = conn.execute(
+                "UPDATE sessions SET title = ? WHERE id = ? AND title IS ?",
+                (title, session_id, expected_title),
+            )
+            return cursor.rowcount
+
+        return self._execute_write(_do) > 0
 
     def get_session_title(self, session_id: str) -> Optional[str]:
         """Get the title for a session, or None."""

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1356,6 +1356,10 @@ class TestPrompt:
             "api_mode": "codex_responses",
         }
         assert callable(mock_title.call_args.kwargs["title_callback"])
+        assert (
+            mock_title.call_args.kwargs["provisional_title_callback"]
+            is mock_title.call_args.kwargs["title_callback"]
+        )
 
     @pytest.mark.asyncio
     async def test_prompt_sends_session_info_update_after_auto_title(self, agent):

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -8,6 +8,7 @@ from agent.title_generator import (
     generate_title,
     auto_title_session,
     maybe_auto_title,
+    provisional_title_from_message,
     _title_language,
 )
 from hermes_state import SessionDB
@@ -225,6 +226,30 @@ class TestGenerateTitle:
         mock_call_llm.assert_not_called()
 
 
+class TestProvisionalTitle:
+    """Unit tests for immediate local titles."""
+
+    def test_uses_first_meaningful_line(self):
+        title = provisional_title_from_message(
+            "\n\nQuestion: fix the broken import\nmore detail"
+        )
+        assert title == "fix the broken import"
+
+    def test_strips_common_wrapping(self):
+        title = provisional_title_from_message('  "`Debug this auth failure`"  ')
+        assert title == "Debug this auth failure"
+
+    def test_truncates_at_word_boundary(self):
+        title = provisional_title_from_message(
+            "Investigate the websocket reconnect loop after compression rotates sessions",
+            max_length=42,
+        )
+        assert title == "Investigate the websocket reconnect loop..."
+
+    def test_empty_message_returns_none(self):
+        assert provisional_title_from_message(" \n\t") is None
+
+
 class TestAutoTitleSession:
     """Tests for auto_title_session() — the sync worker function."""
 
@@ -297,6 +322,45 @@ class TestAutoTitleSession:
         with patch("agent.title_generator.generate_title", return_value=None):
             auto_title_session(db, "sess-1", "hi", "hello")
             db.set_auto_title_if_empty.assert_not_called()
+
+    def test_replaces_matching_provisional_title(self):
+        db = MagicMock()
+        db.get_session_title.return_value = "fix import"
+        db.compare_and_set_session_title.return_value = True
+
+        with patch("agent.title_generator.generate_title", return_value="Debugging Imports"):
+            auto_title_session(
+                db,
+                "sess-1",
+                "fix import",
+                "hello",
+                provisional_title="fix import",
+            )
+
+        db.compare_and_set_session_title.assert_called_once_with(
+            "sess-1", "fix import", "Debugging Imports"
+        )
+
+    def test_preserves_manual_rename_after_provisional_title(self):
+        db = MagicMock()
+        db.get_session_title.return_value = "fix import"
+        db.compare_and_set_session_title.return_value = False
+        seen = []
+
+        with patch("agent.title_generator.generate_title", return_value="Debugging Imports"):
+            auto_title_session(
+                db,
+                "sess-1",
+                "fix import",
+                "hello",
+                provisional_title="fix import",
+                title_callback=seen.append,
+            )
+
+        db.compare_and_set_session_title.assert_called_once_with(
+            "sess-1", "fix import", "Debugging Imports"
+        )
+        assert seen == []
 
     def test_never_raises_when_body_throws(self):
         """Daemon-thread target must swallow ALL exceptions (e.g. the
@@ -391,6 +455,7 @@ class TestMaybeAutoTitle:
                 main_runtime=None,
                 title_callback=None,
                 runtime_validator=None,
+                provisional_title="hello",
             )
 
     def test_skips_when_title_generation_disabled(self):
@@ -409,6 +474,7 @@ class TestMaybeAutoTitle:
             maybe_auto_title(db, "sess-1", "hello", "hi there", history)
 
         mock_auto.assert_not_called()
+        db.set_auto_title_if_empty.assert_not_called()
 
     def test_forwards_failure_callback_to_worker(self):
         """maybe_auto_title must forward failure_callback into the thread."""
@@ -437,7 +503,38 @@ class TestMaybeAutoTitle:
                 main_runtime=None,
                 title_callback=None,
                 runtime_validator=None,
+                provisional_title="hello",
             )
+
+    def test_sets_provisional_title_before_background_generation(self):
+        db = MagicMock()
+        db.set_auto_title_if_empty.return_value = True
+        provisional_seen = []
+        final_seen = []
+        history = [
+            {"role": "user", "content": "fix zed titles"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            maybe_auto_title(
+                db,
+                "sess-1",
+                "fix zed titles",
+                "hi there",
+                history,
+                title_callback=final_seen.append,
+                provisional_title_callback=provisional_seen.append,
+            )
+            import time
+            time.sleep(0.3)
+
+        db.set_auto_title_if_empty.assert_called_once_with(
+            "sess-1", "fix zed titles"
+        )
+        assert provisional_seen == ["fix zed titles"]
+        assert final_seen == []
+        assert mock_auto.call_args.kwargs["provisional_title"] == "fix zed titles"
 
     def test_skips_if_no_response(self):
         db = MagicMock()
@@ -510,6 +607,30 @@ class TestAutoTitleDuplicateHandling:
         db.set_auto_title_if_empty.return_value = False
         assert _persist_session_title(db, "sess-1", "Some Title") is None
         db.set_session_title.assert_not_called()
+
+    def test_dedupes_refined_title_without_losing_provisional_guard(self):
+        from agent.title_generator import _persist_session_title
+
+        db = MagicMock()
+        db.compare_and_set_session_title.side_effect = [
+            ValueError("in use"),
+            True,
+        ]
+        db.get_next_title_in_lineage.return_value = "Debugging Import Error #2"
+
+        persisted = _persist_session_title(
+            db,
+            "sess-1",
+            "Debugging Import Error",
+            expected_title="fix import",
+        )
+
+        assert persisted == "Debugging Import Error #2"
+        assert db.compare_and_set_session_title.call_args_list[-1].args == (
+            "sess-1",
+            "fix import",
+            "Debugging Import Error #2",
+        )
 
     def test_not_found_raises_runtime_error_internally(self):
         # Legacy store (no atomic write): set_session_title returning False

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -292,7 +292,9 @@ async def test_run_agent_passes_discord_auto_thread_title_callback(monkeypatch, 
         )
 
     mock_title.assert_called_once()
-    callback = mock_title.call_args.kwargs["title_callback"]
+    kwargs = mock_title.call_args.kwargs
+    assert "provisional_title_callback" not in kwargs
+    callback = kwargs["title_callback"]
     with patch.object(runner, "_schedule_discord_semantic_thread_rename") as mock_schedule:
         callback("Semantic Session Title")
     mock_schedule.assert_called_once()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3940,6 +3940,24 @@ class TestTitleUniqueness:
     def test_get_session_title_nonexistent(self, db):
         assert db.get_session_title("nonexistent") is None
 
+    def test_compare_and_set_title_preserves_concurrent_manual_rename(self, db):
+        """A stale background title write must not overwrite a manual rename."""
+        db.create_session("s1", "cli")
+        assert db.compare_and_set_session_title("s1", None, "provisional") is True
+
+        other = SessionDB(db_path=db.db_path)
+        try:
+            other.set_session_title("s1", "Manual Rename")
+            assert (
+                db.compare_and_set_session_title(
+                    "s1", "provisional", "Generated Title"
+                )
+                is False
+            )
+            assert db.get_session_title("s1") == "Manual Rename"
+        finally:
+            other.close()
+
 
 class TestTitleLineage:
     """Tests for title lineage resolution and auto-numbering."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7921,6 +7921,11 @@ def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
         "api_key": _Agent.api_key,
         "api_mode": "codex_responses",
     }
+    assert callable(mock_title.call_args.kwargs["title_callback"])
+    assert (
+        mock_title.call_args.kwargs["provisional_title_callback"]
+        is mock_title.call_args.kwargs["title_callback"]
+    )
 
 
 def test_prompt_submit_skips_auto_title_when_interrupted(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10245,6 +10245,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     # model changed before it fires (#19027).
                     _title_model = getattr(agent, "model", None)
                     _title_provider = getattr(agent, "provider", None)
+                    _title_update_callback = lambda t, _k=_title_key: _emit(
+                        "session.title",
+                        sid,
+                        {"session_id": _k, "title": t},
+                    )
                     maybe_auto_title(
                         _get_db(),
                         _title_key,
@@ -10269,9 +10274,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         # Push the generated title live so the sidebar renames
                         # without waiting for the next list refresh (the titler
                         # runs async, after this turn's refresh already fired).
-                        title_callback=lambda t, _k=_title_key: _emit(
-                            "session.title", sid, {"session_id": _k, "title": t}
-                        ),
+                        title_callback=_title_update_callback,
+                        provisional_title_callback=_title_update_callback,
                     )
                 except Exception:
                     pass


### PR DESCRIPTION
Fixes #55201

## What changed

- Derive and persist a useful provisional title synchronously from the first meaningful line of the first user message.
- Send the provisional title through the existing live session-update path in TUI and ACP, then replace it with the asynchronous LLM title.
- Keep Discord/Telegram thread renames on the final LLM title only.
- Add atomic `SessionDB.compare_and_set_session_title()` refinement:
  - provisional title writes only while the title is unset;
  - LLM refinement writes only while the title still equals that provisional value.
- Preserve current title lineage de-duplication and runtime validation from `main`.
- Preserve manual or concurrent renames without a read/write race.

## Why

LLM title generation already runs after the first exchange, but clients remain untitled until that background request finishes. A local provisional title makes the session identifiable immediately. The conditional refinement is required so the later LLM result cannot overwrite a title the user changed while generation was in flight.

## Tests

- title generator + full SessionDB suites: `433 passed`
- ACP/TUI/gateway title integration: `4 passed`
- `python -m ruff check` on all changed Python files
- `python -m py_compile` on changed production files
- `git diff --check`