### PR TITLE
fix(delegate): narrow leaf child toolsets

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -31,6 +31,7 @@ from tools.delegate_tool import (
     _build_child_progress_callback,
     _build_child_system_prompt,
     _extract_output_tail,
+    _strip_blocked_tool_definitions,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
@@ -199,6 +200,155 @@ class TestStripBlockedTools(unittest.TestCase):
                     f"Toolset {name!r} (tools={tools}) is fully blocked "
                     f"but was not stripped",
                 )
+
+
+def _fake_tool_schema(name):
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"{name} test schema",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _fake_child_with_tools(tool_names):
+    child = MagicMock()
+    child.tools = [_fake_tool_schema(name) for name in tool_names]
+    child.valid_tool_names = set(tool_names)
+    return child
+
+
+def _schema_names(child):
+    return {
+        tool["function"]["name"]
+        for tool in child.tools
+        if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
+    }
+
+
+class TestChildToolSchemaNarrowing(unittest.TestCase):
+    def test_leaf_coding_parent_uses_default_child_toolsets(self):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["coding"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = _fake_child_with_tools(
+                ["terminal", "read_file", "web_search"]
+            )
+
+            _build_child_agent(
+                task_index=0,
+                goal="Narrow default",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(
+            MockAgent.call_args[1]["enabled_toolsets"],
+            ["terminal", "file", "web"],
+        )
+
+    def test_leaf_child_prunes_blocked_tools_from_explicit_composite_schema(self):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["coding"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            child = _fake_child_with_tools(
+                [
+                    "terminal",
+                    "read_file",
+                    "delegate_task",
+                    "execute_code",
+                    "memory",
+                    "clarify",
+                ]
+            )
+            MockAgent.return_value = child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Explicit composite",
+                context=None,
+                toolsets=["coding"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        names = _schema_names(child)
+        self.assertIn("terminal", names)
+        self.assertIn("read_file", names)
+        self.assertTrue(
+            names.isdisjoint(
+                {"delegate_task", "execute_code", "memory", "clarify"}
+            )
+        )
+        self.assertTrue(child.valid_tool_names.isdisjoint(DELEGATE_BLOCKED_TOOLS))
+
+    @patch("tools.delegate_tool._load_config", return_value={"max_spawn_depth": 2})
+    def test_orchestrator_keeps_delegate_but_prunes_other_blocked_composite_tools(
+        self, mock_cfg
+    ):
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["coding"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            child = _fake_child_with_tools(
+                [
+                    "terminal",
+                    "read_file",
+                    "delegate_task",
+                    "execute_code",
+                    "memory",
+                    "clarify",
+                ]
+            )
+            MockAgent.return_value = child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Coordinate workers",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                role="orchestrator",
+            )
+
+        self.assertIn("delegation", MockAgent.call_args[1]["enabled_toolsets"])
+        names = _schema_names(child)
+        self.assertIn("delegate_task", names)
+        self.assertTrue(names.isdisjoint({"execute_code", "memory", "clarify"}))
+        self.assertEqual(child._delegate_role, "orchestrator")
+
+    def test_strip_blocked_tool_definitions_allows_delegate_only_for_orchestrator(self):
+        schemas = [
+            _fake_tool_schema(name)
+            for name in ["terminal", "delegate_task", "execute_code", "memory"]
+        ]
+
+        leaf_names = {
+            tool["function"]["name"]
+            for tool in _strip_blocked_tool_definitions(schemas, role="leaf")
+        }
+        orchestrator_names = {
+            tool["function"]["name"]
+            for tool in _strip_blocked_tool_definitions(
+                schemas, role="orchestrator"
+            )
+        }
+
+        self.assertEqual(leaf_names, {"terminal"})
+        self.assertEqual(orchestrator_names, {"terminal", "delegate_task"})
 
 
 class TestDelegateTask(unittest.TestCase):
@@ -1857,6 +2007,31 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         self.assertEqual(
             MockAgent.call_args[1]["enabled_toolsets"],
             ["web", "browser", "mcp-MiniMax"],
+        )
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_default_leaf_child_preserves_mcp_toolsets_by_default(self, mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["terminal", "file", "web", "mcp-MiniMax"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test default leaf toolsets",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(
+            MockAgent.call_args[1]["enabled_toolsets"],
+            ["terminal", "file", "web", "mcp-MiniMax"],
         )
 
     @patch(

--- a/tests/tools/test_delegate_composite_toolsets.py
+++ b/tests/tools/test_delegate_composite_toolsets.py
@@ -17,6 +17,14 @@ class TestExpandParentToolsets(unittest.TestCase):
         # Original composite is preserved
         self.assertIn("hermes-cli", expanded)
 
+    def test_composite_includes_are_expanded(self):
+        """Composites that use includes (e.g. safe -> web) expand too."""
+        expanded = _expand_parent_toolsets({"safe"})
+        self.assertIn("web", expanded)
+        self.assertIn("vision", expanded)
+        self.assertIn("image_gen", expanded)
+        self.assertIn("safe", expanded)
+
     def test_individual_toolset_unchanged(self):
         """When parent already uses individual toolsets, expansion keeps them."""
         expanded = _expand_parent_toolsets({"web", "terminal"})

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -30,7 +30,7 @@ from concurrent.futures import (
 )
 from typing import Any, Dict, List, Optional
 
-from toolsets import TOOLSETS
+from toolsets import TOOLSETS, resolve_toolset
 
 # Sentinel value used by the runtime provider system for providers that are
 # not natively known (named custom providers, third-party aggregators, etc.).
@@ -555,9 +555,12 @@ def _expand_parent_toolsets(parent_toolsets: set) -> set:
     """
     parent_tool_names: set = set()
     for ts_name in parent_toolsets:
-        ts_def = TOOLSETS.get(ts_name)
-        if ts_def:
-            parent_tool_names.update(ts_def.get("tools", []))
+        try:
+            parent_tool_names.update(resolve_toolset(ts_name))
+        except Exception:
+            ts_def = TOOLSETS.get(ts_name)
+            if ts_def:
+                parent_tool_names.update(ts_def.get("tools", []))
 
     if not parent_tool_names:
         return set(parent_toolsets)
@@ -581,6 +584,21 @@ def _preserve_parent_mcp_toolsets(
         if _is_mcp_toolset_name(toolset_name) and toolset_name not in preserved:
             preserved.append(toolset_name)
     return preserved
+
+
+def _default_leaf_child_toolsets(parent_toolsets: set[str]) -> List[str]:
+    """Return the narrow default toolsets a leaf child should receive.
+
+    Leaf subagents are usually delegated focused repo/research work, so they
+    should not inherit broad parent postures such as ``coding`` or
+    ``hermes-cli`` by default.  Intersect the small child default with the
+    parent's expanded capability set so a parent that disabled web/terminal/etc.
+    does not accidentally grant it back to the child.
+    """
+    if not parent_toolsets:
+        return list(DEFAULT_TOOLSETS)
+    expanded_parent = _expand_parent_toolsets(parent_toolsets)
+    return [name for name in DEFAULT_TOOLSETS if name in expanded_parent]
 
 
 DEFAULT_MAX_ITERATIONS = 50
@@ -781,6 +799,79 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
         or all(t in DELEGATE_BLOCKED_TOOLS for t in defn.get("tools", []))
     }
     return [t for t in toolsets if t not in blocked_toolset_names]
+
+
+def _blocked_tool_names_for_child_role(role: str) -> set[str]:
+    """Return individual tool names a child role may not see or call."""
+    blocked = set(DELEGATE_BLOCKED_TOOLS)
+    if role == "orchestrator":
+        # Orchestrators are the only children allowed to call delegate_task.
+        # They still cannot use memory, clarify, execute_code, send_message,
+        # cronjob, or any other explicitly blocked tool.
+        blocked.discard("delegate_task")
+    return blocked
+
+
+def _tool_schema_name(tool_def: Any) -> Optional[str]:
+    """Extract a function/tool name from OpenAI-format or raw schema dicts."""
+    if not isinstance(tool_def, dict):
+        return None
+    function = tool_def.get("function")
+    if isinstance(function, dict):
+        name = function.get("name")
+        return str(name) if name else None
+    name = tool_def.get("name")
+    return str(name) if name else None
+
+
+def _strip_blocked_tool_definitions(
+    tool_defs: Any,
+    *,
+    role: str = "leaf",
+) -> Any:
+    """Remove blocked individual tool schemas from a child's tool list.
+
+    Toolset-name stripping is not enough for composite toolsets like
+    ``coding`` or ``hermes-cli`` because they embed individual blocked tools.
+    This schema-level pass is the child security backstop.
+    """
+    if not isinstance(tool_defs, list):
+        return tool_defs
+    blocked = _blocked_tool_names_for_child_role(role)
+    return [
+        tool_def
+        for tool_def in tool_defs
+        if _tool_schema_name(tool_def) not in blocked
+    ]
+
+
+def _apply_child_tool_schema_restrictions(child: Any, *, role: str) -> None:
+    """Synchronize a constructed child's schemas and executable tool names."""
+    blocked = _blocked_tool_names_for_child_role(role)
+
+    tools = getattr(child, "tools", None)
+    if isinstance(tools, list):
+        filtered_tools = _strip_blocked_tool_definitions(tools, role=role)
+        child.tools = filtered_tools
+        filtered_names = [
+            name
+            for tool_def in filtered_tools
+            if (name := _tool_schema_name(tool_def))
+        ]
+        child.valid_tool_names = set(filtered_names)
+        try:
+            import model_tools
+
+            model_tools._last_resolved_tool_names = list(filtered_names)
+        except Exception:
+            pass
+        return
+
+    valid_tool_names = getattr(child, "valid_tool_names", None)
+    if isinstance(valid_tool_names, set):
+        child.valid_tool_names = valid_tool_names - blocked
+    elif isinstance(valid_tool_names, (list, tuple)):
+        child.valid_tool_names = set(valid_tool_names) - blocked
 
 
 def _emit_parent_console(parent_agent, line: str) -> None:
@@ -1127,6 +1218,13 @@ def _build_child_agent(
                 child_toolsets, parent_toolsets
             )
         child_toolsets = _strip_blocked_tools(child_toolsets)
+    elif effective_role == "leaf":
+        child_toolsets = _default_leaf_child_toolsets(parent_toolsets)
+        if _get_inherit_mcp_toolsets():
+            child_toolsets = _preserve_parent_mcp_toolsets(
+                child_toolsets, parent_toolsets
+            )
+        child_toolsets = _strip_blocked_tools(child_toolsets)
     elif parent_agent and parent_enabled is not None:
         child_toolsets = _strip_blocked_tools(parent_enabled)
     elif parent_toolsets:
@@ -1330,6 +1428,7 @@ def _build_child_agent(
         tool_progress_callback=child_progress_cb,
         iteration_budget=None,  # fresh budget per subagent
     )
+    _apply_child_tool_schema_restrictions(child, role=effective_role)
     child._print_fn = getattr(parent_agent, "_print_fn", None)
     # Now the child exists, its session id can ride on every relayed event
     # (including the spawn_requested below — first emit happens after this).
@@ -2489,8 +2588,9 @@ def delegate_task(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
-                # Subagents always inherit the parent's toolsets; the model
-                # cannot choose or narrow them (no model-facing toolsets arg).
+                # The model cannot choose or narrow child toolsets (no
+                # model-facing toolsets arg). _build_child_agent applies the
+                # role-specific default, intersected with parent capabilities.
                 toolsets=None,
                 model=creds["model"],
                 max_iterations=effective_max_iter,


### PR DESCRIPTION
## What does this PR do?

Narrows default leaf subagent tool exposure and prevents blocked individual tools from leaking through composite toolsets.

Leaf children now default to the small `terminal`, `file`, and `web` toolsets, intersected with the parent's expanded capabilities. Orchestrator children keep delegation behavior. Explicit composite toolsets are still allowed, but blocked tool schemas such as `delegate_task`, `execute_code`, `memory`, and `clarify` are pruned for leaf children.

## Related Issue

Partially addresses #11431. This PR only targets oversized/default child tool schemas and blocked-tool leakage; it does not attempt the separate stuck-child shutdown, compaction, or session-persistence work described in that issue.

Related: #37188 also touches delegate router/toolset scoping, so this PR is intentionally limited to leaf child schema size and blocked-tool pruning.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Expanded parent toolsets through `resolve_toolset()` so composites with `includes` are handled consistently.
- Added a narrow default for leaf child agents, intersected with parent capabilities.
- Preserved parent MCP toolsets on the new default leaf path when `delegation.inherit_mcp_toolsets` is enabled, matching the existing explicit-toolsets behavior.
- Added schema-level blocked-tool pruning for child agent tools.
- Preserved orchestrator access to `delegate_task` while pruning other blocked tools.
- Added regression tests for default leaf narrowing, MCP preservation, explicit composite pruning, orchestrator behavior, and composite include expansion.

## Impact

Local schema estimate for a `coding` parent leaf child; numbers are environment-dependent because unavailable tool checks can prune schemas:

- Before: 24 tool schemas, 43,159 serialized schema chars, about 10,789 rough tokens; blocked tools present: `clarify`, `delegate_task`, `execute_code`, `memory`
- After: 6 tool schemas, 12,581 serialized schema chars, about 3,145 rough tokens; blocked tools present: none
- Reduction: 30,578 chars, about 7,644 rough tokens, roughly 71%

Rough tokens are estimated as serialized schema chars / 4, not model-provider billing output.

## How to Test

1. `python -m pytest tests/tools/test_delegate.py tests/tools/test_delegate_composite_toolsets.py -q`
2. `uv tool run ruff check .`
3. `python scripts/check-windows-footguns.py --all`
4. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.13 local environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation passed locally; full test suite was not run.
