### PR TITLE
perf(web): split dashboard routes

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { act, type ReactNode, useEffect } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,253 @@
+import { act, type ReactNode, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const chatPageMock = vi.hoisted(() => {
+  let resolve!: (module: { default: (props: { isActive?: boolean }) => ReactNode }) => void;
+  const promise = new Promise<{ default: (props: { isActive?: boolean }) => ReactNode }>((done) => {
+    resolve = done;
+  });
+
+  return {
+    mountCount: 0,
+    promise,
+    resolve,
+    unmountCount: 0,
+  };
+});
+
+vi.mock("@/pages/ChatPage", () => chatPageMock.promise);
+
+vi.mock("@/pages/SessionsPage", () => ({
+  default: () => <div data-testid="sessions-page">Sessions page</div>,
+}));
+
+vi.mock("@/pages/FilesPage", () => ({ default: () => <div>FilesPage</div> }));
+vi.mock("@/pages/AnalyticsPage", () => ({ default: () => <div>AnalyticsPage</div> }));
+vi.mock("@/pages/ModelsPage", () => ({ default: () => <div>ModelsPage</div> }));
+vi.mock("@/pages/LogsPage", () => ({ default: () => <div>LogsPage</div> }));
+vi.mock("@/pages/CronPage", () => ({ default: () => <div>CronPage</div> }));
+vi.mock("@/pages/SkillsPage", () => ({ default: () => <div>SkillsPage</div> }));
+vi.mock("@/pages/PluginsPage", () => ({ default: () => <div>PluginsPage</div> }));
+vi.mock("@/pages/McpPage", () => ({ default: () => <div>McpPage</div> }));
+vi.mock("@/pages/PairingPage", () => ({ default: () => <div>PairingPage</div> }));
+vi.mock("@/pages/ChannelsPage", () => ({ default: () => <div>ChannelsPage</div> }));
+vi.mock("@/pages/WebhooksPage", () => ({ default: () => <div>WebhooksPage</div> }));
+vi.mock("@/pages/SystemPage", () => ({ default: () => <div>SystemPage</div> }));
+vi.mock("@/pages/ProfilesPage", () => ({ default: () => <div>ProfilesPage</div> }));
+vi.mock("@/pages/ProfileBuilderPage", () => ({ default: () => <div>ProfileBuilderPage</div> }));
+vi.mock("@/pages/ConfigPage", () => ({ default: () => <div>ConfigPage</div> }));
+vi.mock("@/pages/EnvPage", () => ({ default: () => <div>EnvPage</div> }));
+vi.mock("@/pages/DocsPage", () => ({ default: () => <div>DocsPage</div> }));
+
+vi.mock("@nous-research/ui/ui/components/button", () => ({
+  Button: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
+}));
+vi.mock("@nous-research/ui/ui/components/selection-switcher", () => ({
+  SelectionSwitcher: () => null,
+}));
+vi.mock("@nous-research/ui/ui/components/spinner", () => ({
+  Spinner: () => <span data-testid="spinner" />,
+}));
+vi.mock("@nous-research/ui/ui/components/typography/index", () => ({
+  Typography: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+vi.mock("@nous-research/ui/ui/components/confirm-dialog", () => ({
+  ConfirmDialog: () => null,
+}));
+vi.mock("@nous-research/ui/hooks/use-below-breakpoint", () => ({
+  useBelowBreakpoint: () => false,
+}));
+
+vi.mock("@/components/AuthWidget", () => ({ AuthWidget: () => null }));
+vi.mock("@/components/LanguageSwitcher", () => ({ LanguageSwitcher: () => null }));
+vi.mock("@/components/ProfileScopeBanner", () => ({ ProfileScopeBanner: () => null }));
+vi.mock("@/components/ProfileSwitcher", () => ({ ProfileSwitcher: () => null }));
+vi.mock("@/components/SidebarFooter", () => ({ SidebarFooter: () => null }));
+vi.mock("@/components/SidebarStatusStrip", () => ({
+  SidebarStatusStrip: () => null,
+  gatewayLine: () => ({ label: "Running", tone: "ok" }),
+}));
+vi.mock("@/components/ThemeSwitcher", () => ({ ThemeSwitcher: () => null }));
+vi.mock("@/contexts/PageHeaderProvider", () => ({
+  PageHeaderProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/contexts/ProfileProvider", () => ({
+  ProfileProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/contexts/useProfileScope", () => ({
+  useProfileScope: () => ({
+    currentProfile: "default",
+    profile: "",
+    profiles: ["default"],
+    setProfile: vi.fn(),
+  }),
+}));
+vi.mock("@/contexts/useSystemActions", () => ({
+  useSystemActions: () => ({
+    activeAction: null,
+    isBusy: false,
+    isRunning: false,
+    pendingAction: null,
+    runAction: vi.fn(),
+  }),
+}));
+vi.mock("@/hooks/useSidebarStatus", () => ({
+  useSidebarStatus: () => null,
+}));
+vi.mock("@/i18n", () => ({
+  useI18n: () => ({
+    t: {
+      app: {
+        activeSessionsLabel: "Active sessions",
+        brand: "Hermes",
+        closeNavigation: "Close navigation",
+        gatewayStrip: {
+          failed: "Failed",
+          off: "Off",
+          running: "Running",
+          starting: "Starting",
+          stopped: "Stopped",
+        },
+        gatewayStatusLabel: "Gateway",
+        nav: {
+          analytics: "Analytics",
+          chat: "Chat",
+          channels: "Channels",
+          config: "Config",
+          cron: "Cron",
+          docs: "Docs",
+          env: "Env",
+          files: "Files",
+          logs: "Logs",
+          mcp: "MCP",
+          models: "Models",
+          pairing: "Pairing",
+          plugins: "Plugins",
+          profiles: "Profiles",
+          sessions: "Sessions",
+          skills: "Skills",
+          system: "System",
+          webhooks: "Webhooks",
+        },
+        navigation: "Navigation",
+        openNavigation: "Open navigation",
+        pluginNavSection: "Plugins",
+        statusOverview: "Status",
+        system: "System",
+      },
+      common: {
+        cancel: "Cancel",
+        collapse: "Collapse",
+        expand: "Expand",
+        loading: "Loading",
+      },
+      language: {
+        switchTo: "Switch language",
+      },
+      status: {
+        restartGateway: "Restart gateway",
+        restartingGateway: "Restarting gateway",
+        updateHermes: "Update Hermes",
+        updatingHermes: "Updating Hermes",
+      },
+      theme: {
+        switchTheme: "Switch theme",
+      },
+    },
+  }),
+}));
+vi.mock("@/lib/api", () => ({
+  HERMES_BASE_PATH: "",
+  api: {
+    checkHermesUpdate: vi.fn(),
+    getConfig: vi.fn().mockResolvedValue({ dashboard: {} }),
+  },
+}));
+vi.mock("@/plugins", () => ({
+  PluginPage: () => <div data-testid="plugin-page" />,
+  PluginSlot: () => null,
+  usePlugins: () => ({ loading: false, manifests: [], plugins: [] }),
+}));
+vi.mock("@/themes", () => ({
+  useTheme: () => ({ theme: { layoutVariant: "standard" } }),
+}));
+
+import App from "./App";
+
+function ChatPage({ isActive = true }: { isActive?: boolean }) {
+  useEffect(() => {
+    chatPageMock.mountCount += 1;
+
+    return () => {
+      chatPageMock.unmountCount += 1;
+    };
+  }, []);
+
+  return <div data-testid="chat-page" data-active={String(isActive)} />;
+}
+
+describe("App persistent chat route", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    chatPageMock.mountCount = 0;
+    chatPageMock.unmountCount = 0;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({
+        addEventListener: vi.fn(),
+        matches: false,
+        removeEventListener: vi.fn(),
+      })),
+    });
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the lazy chat host mounted after first /chat navigation", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/chat"]}>
+          <App />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("Loading chat");
+    expect(container.querySelector('[data-testid="chat-page"]')).toBeNull();
+
+    await act(async () => {
+      chatPageMock.resolve({ default: ChatPage });
+      await chatPageMock.promise;
+    });
+
+    const chatPage = container.querySelector('[data-testid="chat-page"]') as HTMLElement;
+    expect(chatPage).not.toBeNull();
+    expect(chatPage.dataset.active).toBe("true");
+    expect(chatPageMock.mountCount).toBe(1);
+
+    const sessionsLink = container.querySelector('a[href="/sessions"]') as HTMLAnchorElement;
+    expect(sessionsLink).not.toBeNull();
+
+    await act(async () => {
+      sessionsLink.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(container.querySelector('[data-testid="sessions-page"]')).not.toBeNull();
+    expect(container.querySelector('[data-chat-active="false"] [data-testid="chat-page"]')).not.toBeNull();
+    expect(chatPageMock.mountCount).toBe(1);
+    expect(chatPageMock.unmountCount).toBe(0);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,11 @@
 import {
   useCallback,
   useEffect,
+  lazy,
   useMemo,
   useRef,
   useState,
+  Suspense,
   type ComponentType,
   type FocusEvent,
   type MouseEvent,
@@ -72,25 +74,7 @@ import { ProfileSwitcher } from "@/components/ProfileSwitcher";
 import { ProfileScopeBanner } from "@/components/ProfileScopeBanner";
 import { useSystemActions } from "@/contexts/useSystemActions";
 import type { SystemAction } from "@/contexts/system-actions-context";
-import ConfigPage from "@/pages/ConfigPage";
-import DocsPage from "@/pages/DocsPage";
-import EnvPage from "@/pages/EnvPage";
-import FilesPage from "@/pages/FilesPage";
 import SessionsPage from "@/pages/SessionsPage";
-import LogsPage from "@/pages/LogsPage";
-import AnalyticsPage from "@/pages/AnalyticsPage";
-import ModelsPage from "@/pages/ModelsPage";
-import CronPage from "@/pages/CronPage";
-import ProfilesPage from "@/pages/ProfilesPage";
-import ProfileBuilderPage from "@/pages/ProfileBuilderPage";
-import SkillsPage from "@/pages/SkillsPage";
-import PluginsPage from "@/pages/PluginsPage";
-import McpPage from "@/pages/McpPage";
-import PairingPage from "@/pages/PairingPage";
-import ChannelsPage from "@/pages/ChannelsPage";
-import WebhooksPage from "@/pages/WebhooksPage";
-import SystemPage from "@/pages/SystemPage";
-import ChatPage from "@/pages/ChatPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -99,6 +83,7 @@ import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
 import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
+import { shouldRenderPersistentChatHost } from "@/lib/dashboard-chat-host";
 import { api } from "@/lib/api";
 import type { StatusResponse, UpdateCheckResponse } from "@/lib/api";
 
@@ -113,6 +98,40 @@ function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
   }
   return <Navigate to="/sessions" replace />;
 }
+
+function LoadingFallback({ label = "Loading…" }: { label?: string }) {
+  return (
+    <div
+      className="flex min-h-64 min-w-0 flex-1 items-center justify-center"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Spinner />
+        <span>{label}</span>
+      </div>
+    </div>
+  );
+}
+
+const FilesPage = lazy(() => import("@/pages/FilesPage"));
+const AnalyticsPage = lazy(() => import("@/pages/AnalyticsPage"));
+const ModelsPage = lazy(() => import("@/pages/ModelsPage"));
+const LogsPage = lazy(() => import("@/pages/LogsPage"));
+const CronPage = lazy(() => import("@/pages/CronPage"));
+const SkillsPage = lazy(() => import("@/pages/SkillsPage"));
+const PluginsPage = lazy(() => import("@/pages/PluginsPage"));
+const McpPage = lazy(() => import("@/pages/McpPage"));
+const PairingPage = lazy(() => import("@/pages/PairingPage"));
+const ChannelsPage = lazy(() => import("@/pages/ChannelsPage"));
+const WebhooksPage = lazy(() => import("@/pages/WebhooksPage"));
+const SystemPage = lazy(() => import("@/pages/SystemPage"));
+const ProfilesPage = lazy(() => import("@/pages/ProfilesPage"));
+const ProfileBuilderPage = lazy(() => import("@/pages/ProfileBuilderPage"));
+const ConfigPage = lazy(() => import("@/pages/ConfigPage"));
+const EnvPage = lazy(() => import("@/pages/EnvPage"));
+const DocsPage = lazy(() => import("@/pages/DocsPage"));
+const ChatPage = lazy(() => import("@/pages/ChatPage"));
 
 const CHAT_NAV_ITEM: NavItem = {
   path: "/chat",
@@ -130,26 +149,26 @@ const CHAT_NAV_ITEM: NavItem = {
  * Routing still owns the URL so /chat deep-links, browser back/forward,
  * and nav highlight keep working.
  */
-const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
-  "/": RootRedirect,
-  "/sessions": SessionsPage,
-  "/files": FilesPage,
-  "/analytics": AnalyticsPage,
-  "/models": ModelsPage,
-  "/logs": LogsPage,
-  "/cron": CronPage,
-  "/skills": SkillsPage,
-  "/plugins": PluginsPage,
-  "/mcp": McpPage,
-  "/pairing": PairingPage,
-  "/channels": ChannelsPage,
-  "/webhooks": WebhooksPage,
-  "/system": SystemPage,
-  "/profiles": ProfilesPage,
-  "/profiles/new": ProfileBuilderPage,
-  "/config": ConfigPage,
-  "/env": EnvPage,
-  "/docs": DocsPage,
+const BUILTIN_ROUTES_CORE: Record<string, ReactNode> = {
+  "/": <RootRedirect />,
+  "/sessions": <SessionsPage />,
+  "/files": <FilesPage />,
+  "/analytics": <AnalyticsPage />,
+  "/models": <ModelsPage />,
+  "/logs": <LogsPage />,
+  "/cron": <CronPage />,
+  "/skills": <SkillsPage />,
+  "/plugins": <PluginsPage />,
+  "/mcp": <McpPage />,
+  "/pairing": <PairingPage />,
+  "/channels": <ChannelsPage />,
+  "/webhooks": <WebhooksPage />,
+  "/system": <SystemPage />,
+  "/profiles": <ProfilesPage />,
+  "/profiles/new": <ProfileBuilderPage />,
+  "/config": <ConfigPage />,
+  "/env": <EnvPage />,
+  "/docs": <DocsPage />,
 };
 
 // Route placeholder for /chat.  The persistent ChatPage host (rendered
@@ -282,7 +301,7 @@ function partitionSidebarNav(
 }
 
 function buildRoutes(
-  builtinRoutes: Record<string, ComponentType>,
+  builtinRoutes: Record<string, ReactNode>,
   manifests: PluginManifest[],
 ): Array<{
   key: string;
@@ -306,7 +325,7 @@ function buildRoutes(
     element: ReactNode;
   }> = [];
 
-  for (const [path, Component] of Object.entries(builtinRoutes)) {
+  for (const [path, element] of Object.entries(builtinRoutes)) {
     const om = byOverride.get(path);
     if (om) {
       routes.push({
@@ -315,7 +334,7 @@ function buildRoutes(
         element: <PluginPage name={om.name} />,
       });
     } else {
-      routes.push({ key: `builtin:${path}`, path, element: <Component /> });
+      routes.push({ key: `builtin:${path}`, path, element });
     }
   }
 
@@ -378,6 +397,7 @@ export default function App() {
   const normalizedPath = pathname.replace(/\/$/, "") || "/";
   const isChatRoute = normalizedPath === "/chat";
   const embeddedChat = isDashboardEmbeddedChatEnabled();
+  const [chatHostMounted, setChatHostMounted] = useState(isChatRoute);
 
   // `dashboard.show_token_analytics` gates the Analytics nav item.  The
   // page itself remains reachable by URL (it renders an explanation when
@@ -395,6 +415,14 @@ export default function App() {
       })
       .catch(() => setShowTokenAnalytics(false));
   }, []);
+
+  useEffect(() => {
+    if (isChatRoute) setChatHostMounted(true);
+  }, [isChatRoute]);
+  const shouldRenderChatHost = shouldRenderPersistentChatHost(
+    chatHostMounted,
+    isChatRoute,
+  );
 
   // A plugin can replace the built-in /chat page via `tab.override: "/chat"`
   // in its manifest.  When one does, `buildRoutes` already swaps the route
@@ -421,7 +449,7 @@ export default function App() {
   const builtinRoutes = useMemo(
     () => ({
       ...BUILTIN_ROUTES_CORE,
-      ...(embeddedChat ? { "/chat": ChatRouteSink } : {}),
+      ...(embeddedChat ? { "/chat": <ChatRouteSink /> } : {}),
     }),
     [embeddedChat],
   );
@@ -737,17 +765,19 @@ export default function App() {
                 )}
               >
                 <ProfileKeyedRoutes>
-                  <Routes>
-                    {routes.map(({ key, path, element }) => (
-                      <Route key={key} path={path} element={element} />
-                    ))}
-                    <Route
-                      path="*"
-                      element={
-                        <UnknownRouteFallback pluginsLoading={pluginsLoading} />
-                      }
-                    />
-                  </Routes>
+                  <Suspense fallback={<LoadingFallback />}>
+                    <Routes>
+                      {routes.map(({ key, path, element }) => (
+                        <Route key={key} path={path} element={element} />
+                      ))}
+                      <Route
+                        path="*"
+                        element={
+                          <UnknownRouteFallback pluginsLoading={pluginsLoading} />
+                        }
+                      />
+                    </Routes>
+                  </Suspense>
                 </ProfileKeyedRoutes>
 
                 {embeddedChat &&
@@ -765,7 +795,7 @@ export default function App() {
                         </div>
                       </div>
                     ) : null
-                  ) : (
+                  ) : shouldRenderChatHost ? (
                     <div
                       data-chat-active={isChatRoute ? "true" : "false"}
                       className={cn(
@@ -774,9 +804,17 @@ export default function App() {
                       )}
                       aria-hidden={!isChatRoute}
                     >
-                      <ChatPage isActive={isChatRoute} />
+                      <Suspense
+                        fallback={
+                          isChatRoute ? (
+                            <LoadingFallback label="Loading chat…" />
+                          ) : null
+                        }
+                      >
+                        <ChatPage isActive={isChatRoute} />
+                      </Suspense>
                     </div>
-                  ))}
+                  ) : null)}
               </div>
               <PluginSlot name="post-main" />
             </div>

--- a/web/src/lib/dashboard-chat-host.test.ts
+++ b/web/src/lib/dashboard-chat-host.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldRenderPersistentChatHost } from "./dashboard-chat-host";
+
+describe("shouldRenderPersistentChatHost", () => {
+  it("renders immediately on the first chat route paint", () => {
+    expect(shouldRenderPersistentChatHost(false, true)).toBe(true);
+  });
+
+  it("keeps the persistent host mounted after the first chat visit", () => {
+    expect(shouldRenderPersistentChatHost(true, false)).toBe(true);
+  });
+
+  it("does not mount chat before it is visited", () => {
+    expect(shouldRenderPersistentChatHost(false, false)).toBe(false);
+  });
+});

--- a/web/src/lib/dashboard-chat-host.ts
+++ b/web/src/lib/dashboard-chat-host.ts
@@ -1,0 +1,6 @@
+export function shouldRenderPersistentChatHost(
+  chatHostMounted: boolean,
+  isChatRoute: boolean,
+) {
+  return chatHostMounted || isChatRoute;
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -86,6 +86,16 @@ export default defineConfig({
   build: {
     outDir: "../hermes_cli/web_dist",
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          const normalized = id.split(path.sep).join("/");
+          if (normalized.includes("/node_modules/@xterm/")) {
+            return "xterm";
+          }
+        },
+      },
+    },
   },
   server: {
     proxy: {


### PR DESCRIPTION
## What does this PR do?

Splits the dashboard's non-initial routes out of the initial bundle while keeping `/sessions` eager.

The dashboard previously statically imported every page module from `App.tsx`, which pulled route-only dependencies such as xterm into the initial `/sessions` bundle. This PR lazy-loads non-initial routes with `React.lazy`/`Suspense` and adds a focused `@xterm/*` manual chunk.

## Related Issue

Refs #25912. This is a scoped route-splitting pass; it does not add bundle analyzer UI, an initial-entry budget, or dashboard bundling docs.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Kept `SessionsPage` eagerly loaded for the default `/sessions` route.
- Lazy-loaded non-initial dashboard pages with `React.lazy` and a shared route `Suspense` fallback.
- Lazy-loaded embedded chat only on first `/chat` visit, then kept it mounted for persistence.
- Added a render-time chat host guard so first navigation to `/chat` shows the lazy fallback instead of a blank frame.
- Added a narrow `@xterm/*` manual chunk in `web/vite.config.ts`.

## Impact

Measured with `npm --prefix web run build` on the same `origin/main` base and this branch:

- Main chunk before: `index-CBTV-n-R.js` 1,957.88 kB, gzip 559.39 kB
- Main chunk after: `index-j09W0UmF.js` 605.01 kB, gzip 182.20 kB
- After initial preloaded JS graph, including shared chunks from `index.html`: about 1,075.74 kB, gzip 333.74 kB
- New async xterm chunk: `xterm-C4C4p9ky.js` 495.62 kB, gzip 129.28 kB
- New async chat chunk: `ChatPage-Dxvkh_DF.js` 28.73 kB, gzip 9.88 kB

The main chunk is still above Vite's 500 kB warning threshold, but the initial entry graph is substantially smaller than the previous single 1,957.88 kB / 559.39 kB bundle.

## How to Test

Tested locally with Node 22.22.2.

1. `npm ci --workspace web --ignore-scripts --no-audit --no-fund`
2. `npm --prefix web run build`
3. `npm --prefix web run typecheck`
4. `npm --prefix web run test`
5. `uv tool run ruff check .`
6. `python scripts/check-windows-footguns.py --all`
7. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Node 22.22.2 local environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted web build/typecheck/tests passed locally; full Python test suite was not run.
