### PR TITLE
fix(memory): align background review prompt with disabled memory

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -358,6 +358,42 @@ _COMBINED_REVIEW_PROMPT = (
     "and stop — but don't reach for that conclusion as a default."
 )
 
+_MEMORY_DISABLED_REVIEW_PROMPT = (
+    "Review the conversation above for durable memory-worthy facts, but built-in "
+    "memory is disabled for this profile and no memory write tool is available. "
+    "Do not try to save memory. Just say 'Nothing to save.' and stop."
+)
+
+
+def _memory_review_available(agent: Any) -> bool:
+    return bool(
+        getattr(agent, "_memory_enabled", False)
+        or getattr(agent, "_user_profile_enabled", False)
+    )
+
+
+def _select_review_prompt(
+    agent: Any,
+    *,
+    review_memory: bool,
+    review_skills: bool,
+) -> str:
+    memory_available = _memory_review_available(agent)
+    effective_review_memory = review_memory and memory_available
+
+    if effective_review_memory and review_skills:
+        return getattr(agent, "_COMBINED_REVIEW_PROMPT", _COMBINED_REVIEW_PROMPT)
+    if effective_review_memory:
+        return getattr(agent, "_MEMORY_REVIEW_PROMPT", _MEMORY_REVIEW_PROMPT)
+    if review_skills:
+        return getattr(agent, "_SKILL_REVIEW_PROMPT", _SKILL_REVIEW_PROMPT)
+    if review_memory:
+        return getattr(
+            agent,
+            "_MEMORY_DISABLED_REVIEW_PROMPT",
+            _MEMORY_DISABLED_REVIEW_PROMPT,
+        )
+    return getattr(agent, "_SKILL_REVIEW_PROMPT", _SKILL_REVIEW_PROMPT)
 
 
 def summarize_background_review_actions(
@@ -934,15 +970,14 @@ def spawn_background_review_thread(
     owns the actual ``threading.Thread`` construction so test-level patches
     of ``run_agent.threading.Thread`` keep working.
     """
-    # Pick the right prompt based on which triggers fired.  Allow per-agent
-    # override (the prompts moved to module-level constants but old code paths
-    # that set agent._MEMORY_REVIEW_PROMPT etc. directly keep working).
-    if review_memory and review_skills:
-        prompt = getattr(agent, "_COMBINED_REVIEW_PROMPT", _COMBINED_REVIEW_PROMPT)
-    elif review_memory:
-        prompt = getattr(agent, "_MEMORY_REVIEW_PROMPT", _MEMORY_REVIEW_PROMPT)
-    else:
-        prompt = getattr(agent, "_SKILL_REVIEW_PROMPT", _SKILL_REVIEW_PROMPT)
+    # Pick the right prompt based on which triggers fired and which tools are
+    # actually available to the fork. Per-agent prompt overrides are preserved
+    # for back-compat with older code paths that set prompt attributes directly.
+    prompt = _select_review_prompt(
+        agent,
+        review_memory=review_memory,
+        review_skills=review_skills,
+    )
 
     def _target() -> None:
         _run_review_in_thread(agent, messages_snapshot, prompt)
@@ -954,6 +989,7 @@ __all__ = [
     "_MEMORY_REVIEW_PROMPT",
     "_SKILL_REVIEW_PROMPT",
     "_COMBINED_REVIEW_PROMPT",
+    "_MEMORY_DISABLED_REVIEW_PROMPT",
     "spawn_background_review_thread",
     "summarize_background_review_actions",
     "build_memory_write_metadata",

--- a/run_agent.py
+++ b/run_agent.py
@@ -1552,6 +1552,7 @@ class AIAgent:
         _MEMORY_REVIEW_PROMPT,
         _SKILL_REVIEW_PROMPT,
         _COMBINED_REVIEW_PROMPT,
+        _MEMORY_DISABLED_REVIEW_PROMPT,
     )
 
     @staticmethod

--- a/tests/run_agent/test_review_prompt_class_first.py
+++ b/tests/run_agent/test_review_prompt_class_first.py
@@ -15,6 +15,7 @@ snapshot the full prompt text (change-detector).
 """
 
 from run_agent import AIAgent
+from agent.background_review import spawn_background_review_thread
 
 
 # ---------------------------------------------------------------------------
@@ -233,3 +234,54 @@ def test_memory_review_prompt_still_focused_on_user_facts():
     assert "skills_list" not in prompt
     assert "SURVEY" not in prompt
     assert "memory tool" in prompt
+
+
+def test_memory_disabled_combined_review_uses_skill_prompt_only():
+    """Do not instruct a memory-disabled review fork to call a hidden memory tool."""
+    agent = AIAgent.__new__(AIAgent)
+    agent._memory_enabled = False
+    agent._user_profile_enabled = False
+
+    _target, prompt = spawn_background_review_thread(
+        agent,
+        messages_snapshot=[],
+        review_memory=True,
+        review_skills=True,
+    )
+
+    assert prompt == AIAgent._SKILL_REVIEW_PROMPT
+    assert "**Memory**" not in prompt
+
+
+def test_memory_disabled_memory_only_review_gets_noop_prompt():
+    """A memory-only trigger with memory disabled should not ask for a tool call."""
+    agent = AIAgent.__new__(AIAgent)
+    agent._memory_enabled = False
+    agent._user_profile_enabled = False
+
+    _target, prompt = spawn_background_review_thread(
+        agent,
+        messages_snapshot=[],
+        review_memory=True,
+        review_skills=False,
+    )
+
+    assert "memory is disabled" in prompt
+    assert "no memory write tool is available" in prompt
+    assert "Nothing to save." in prompt
+
+
+def test_user_profile_enabled_keeps_memory_review_prompt_available():
+    """USER.md/profile memory still uses the memory prompt even if memory_enabled is false."""
+    agent = AIAgent.__new__(AIAgent)
+    agent._memory_enabled = False
+    agent._user_profile_enabled = True
+
+    _target, prompt = spawn_background_review_thread(
+        agent,
+        messages_snapshot=[],
+        review_memory=True,
+        review_skills=False,
+    )
+
+    assert prompt == AIAgent._MEMORY_REVIEW_PROMPT


### PR DESCRIPTION
## What changed

- Add a memory-disabled review prompt for memory-only background reviews when no memory write tool is available.
- Select the background review prompt from the effective tool availability, not just from the raw `review_memory` / `review_skills` trigger flags.
- When `memory_enabled=false` and no user profile memory is enabled, combined memory+skills review now uses the skill-only prompt instead of instructing the model to use a hidden memory tool.
- Keep USER.md / user-profile review behavior unchanged: `_user_profile_enabled=True` still uses the memory prompt even when `memory_enabled=false`.
- Add regression coverage for memory-disabled combined review, memory-disabled memory-only review, and user-profile-enabled memory review.

## Why

The runtime whitelist already hides the built-in memory tool when a profile disables memory, but the prompt could still tell the background reviewer to save facts with the memory tool. That mismatch invites denied tool calls or confusing no-op review behavior. The prompt should describe the tools the fork actually has.

## Tests

- `PYTHONPYCACHEPREFIX=/private/tmp/hermes-pycache python -m pytest -p no:cacheprovider tests/run_agent/test_review_prompt_class_first.py tests/run_agent/test_background_review_toolset_restriction.py -q`
- `PYTHONPYCACHEPREFIX=/private/tmp/hermes-pycache python -m py_compile agent/background_review.py run_agent.py`
- `git diff --check`