### PR TITLE
fix(memory): mirror approved writes to providers

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1589,7 +1589,16 @@ class CLICommandsMixin:
         from tools import write_approval as wa
         parts = cmd.strip().split()
         args = parts[1:] if len(parts) > 1 else []
-        store = getattr(self.agent, "_memory_store", None) if getattr(self, "agent", None) else None
+        agent = getattr(self, "agent", None)
+        store = getattr(agent, "_memory_store", None) if agent else None
+        memory_manager = getattr(agent, "_memory_manager", None) if agent else None
+        metadata_builder = None
+        build_metadata = getattr(agent, "_build_memory_write_metadata", None) if agent else None
+        if callable(build_metadata):
+            metadata_builder = lambda: build_metadata(
+                write_origin="memory_approval",
+                execution_context="slash_command",
+            )
         if store is None:
             # No live agent store (e.g. /memory approve invoked from the Desktop
             # GUI, or any context without an active agent). Apply against a freshly
@@ -1604,6 +1613,8 @@ class CLICommandsMixin:
         out = handle_pending_subcommand(
             wa.MEMORY, args,
             memory_store=store,
+            memory_manager=memory_manager,
+            memory_metadata_builder=metadata_builder,
             set_mode_fn=lambda enabled: self._save_write_approval("memory", enabled),
         )
         if out is None:

--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -16,9 +16,12 @@ platform the gateway truncates it and points the user at the dashboard / file.
 from __future__ import annotations
 
 import json
-from typing import List, Optional
+import logging
+from typing import Callable, Dict, List, Optional
 
 from tools import write_approval as wa
+
+logger = logging.getLogger(__name__)
 
 
 def _fmt_state(subsystem: str) -> str:
@@ -56,6 +59,8 @@ def handle_pending_subcommand(
     args: List[str],
     *,
     memory_store=None,
+    memory_manager=None,
+    memory_metadata_builder: Optional[Callable[[], Dict[str, object]]] = None,
     set_mode_fn=None,
 ) -> Optional[str]:
     """Dispatch a /memory or /skills subcommand.
@@ -66,6 +71,11 @@ def handle_pending_subcommand(
         memory_store: live MemoryStore for applying approved memory writes
             (CLI passes ``self.agent._memory_store``; gateway applies against a
             freshly loaded store).
+        memory_manager: optional live MemoryManager used to mirror approved
+            memory writes to external providers, matching the foreground
+            built-in memory tool path.
+        memory_metadata_builder: optional callable that returns provenance
+            metadata for mirrored memory writes.
         set_mode_fn: optional callable ``(enabled: bool) -> None`` that
             persists the new write_approval boolean to config (gateway provides
             this; CLI uses its own ``save_config_value`` and passes a closure).
@@ -85,7 +95,7 @@ def handle_pending_subcommand(
         return _fmt_pending_list(subsystem)
 
     if sub in {"approve", "apply"}:
-        return _approve(subsystem, rest, memory_store)
+        return _approve(subsystem, rest, memory_store, memory_manager, memory_metadata_builder)
 
     if sub in {"reject", "deny", "drop"}:
         return _reject(subsystem, rest)
@@ -105,7 +115,13 @@ def _resolve_one(subsystem: str, rest: List[str]):
     return rest[0], None
 
 
-def _approve(subsystem: str, rest: List[str], memory_store) -> str:
+def _approve(
+    subsystem: str,
+    rest: List[str],
+    memory_store,
+    memory_manager=None,
+    memory_metadata_builder: Optional[Callable[[], Dict[str, object]]] = None,
+) -> str:
     target, err = _resolve_one(subsystem, rest)
     if err or target is None:
         return err or f"Usage: /{subsystem} approve <id>"
@@ -124,7 +140,7 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
 
     applied, failed = 0, []
     for rec in targets:
-        ok, msg = _apply_one(subsystem, rec, memory_store)
+        ok, msg = _apply_one(subsystem, rec, memory_store, memory_manager, memory_metadata_builder)
         if ok:
             wa.discard_pending(subsystem, rec["id"])
             applied += 1
@@ -138,7 +154,31 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
     return "\n".join(out)
 
 
-def _apply_one(subsystem: str, rec, memory_store):
+def _mirror_approved_memory_write(
+    memory_manager,
+    result,
+    payload,
+    memory_metadata_builder,
+) -> None:
+    if memory_manager is None:
+        return
+    try:
+        memory_manager.notify_memory_tool_write(
+            result,
+            payload,
+            build_metadata=memory_metadata_builder,
+        )
+    except Exception as e:
+        logger.debug("approved memory write mirror failed: %s", e)
+
+
+def _apply_one(
+    subsystem: str,
+    rec,
+    memory_store,
+    memory_manager=None,
+    memory_metadata_builder: Optional[Callable[[], Dict[str, object]]] = None,
+):
     payload = rec.get("payload", {})
     try:
         if subsystem == wa.MEMORY:
@@ -146,7 +186,15 @@ def _apply_one(subsystem: str, rec, memory_store):
                 return False, "memory store unavailable"
             from tools.memory_tool import apply_memory_pending
             result = apply_memory_pending(payload, memory_store)
-            return bool(result.get("success")), result.get("error", "")
+            ok = bool(result.get("success"))
+            if ok:
+                _mirror_approved_memory_write(
+                    memory_manager,
+                    result,
+                    payload,
+                    memory_metadata_builder,
+                )
+            return ok, result.get("error", "")
         else:
             from tools.skill_manager_tool import apply_skill_pending
             result = json.loads(apply_skill_pending(payload))

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -11,6 +11,7 @@ import json
 import os
 import tempfile
 import shutil
+from types import SimpleNamespace
 
 import pytest
 
@@ -30,6 +31,34 @@ def _set_approval(subsystem, enabled):
     c = cfg.load_config()
     c.setdefault(subsystem, {})["write_approval"] = enabled
     cfg.save_config(c)
+
+
+class _RecordingMemoryProvider:
+    """Minimal external memory provider used by approval bridge tests."""
+
+    name = "recording"
+
+    def get_tool_schemas(self):
+        return []
+
+    def on_memory_write(self, action, target, content, metadata=None):
+        self.calls.append({
+            "action": action,
+            "target": target,
+            "content": content,
+            "metadata": dict(metadata or {}),
+        })
+
+    def __init__(self):
+        self.calls = []
+
+
+def _memory_manager_with_recording_provider():
+    from agent.memory_manager import MemoryManager
+    provider = _RecordingMemoryProvider()
+    manager = MemoryManager()
+    manager.add_provider(provider)
+    return manager, provider
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +164,47 @@ def test_cli_memory_approve_without_live_agent_uses_fresh_store(hermes_home, cap
     # The approved write landed in a freshly loaded on-disk store (MEMORY.md).
     reloaded = MemoryStore(); reloaded.load_from_disk()
     assert any("remember the launch date" in e for e in reloaded.memory_entries)
+
+
+def test_cli_memory_approve_with_live_agent_mirrors_to_memory_manager(hermes_home, capsys):
+    """Approved staged writes should use the same MemoryManager bridge as
+    committed foreground memory tool writes, so external providers stay in sync.
+    """
+    from tools.memory_tool import memory_tool, MemoryStore
+    from tools import write_approval as wa
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    _set_approval("memory", True)
+    store = MemoryStore(); store.load_from_disk()
+    r = json.loads(memory_tool("add", "user", "approved provider fact", store=store))
+    assert r.get("pending_id"), r
+
+    manager, provider = _memory_manager_with_recording_provider()
+    handler = CLICommandsMixin.__new__(CLICommandsMixin)
+    handler.agent = SimpleNamespace(
+        _memory_store=store,
+        _memory_manager=manager,
+        _build_memory_write_metadata=lambda **kwargs: {
+            "write_origin": kwargs.get("write_origin"),
+            "execution_context": kwargs.get("execution_context"),
+        },
+    )
+    handler._handle_memory_command(f"/memory approve {r['pending_id']}")
+
+    out = capsys.readouterr().out
+    assert "Approved 1" in out, out
+    assert wa.pending_count("memory") == 0
+    assert provider.calls == [
+        {
+            "action": "add",
+            "target": "user",
+            "content": "approved provider fact",
+            "metadata": {
+                "write_origin": "memory_approval",
+                "execution_context": "slash_command",
+            },
+        }
+    ]
 
 
 def test_load_on_disk_store_honors_configured_char_limits(hermes_home, monkeypatch):
@@ -261,6 +331,34 @@ def test_handle_approve_all(hermes_home):
     assert "Approved 2" in out
     assert wa.pending_count("memory") == 0
     assert len(store.user_entries) == 2
+
+
+def test_handle_approve_mirrors_memory_write_to_manager(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools.memory_tool import MemoryStore
+    from tools import write_approval as wa
+
+    store = MemoryStore(); store.load_from_disk()
+    rec = wa.stage_write("memory", {"action": "add", "target": "memory", "content": "synced"},
+                         summary="synced", origin="foreground")
+    manager, provider = _memory_manager_with_recording_provider()
+
+    out = handle_pending_subcommand(
+        wa.MEMORY, ["approve", rec["id"]],
+        memory_store=store,
+        memory_manager=manager,
+        memory_metadata_builder=lambda: {"write_origin": "approval-test"},
+    )
+
+    assert "Approved 1" in out
+    assert provider.calls == [
+        {
+            "action": "add",
+            "target": "memory",
+            "content": "synced",
+            "metadata": {"write_origin": "approval-test"},
+        }
+    ]
 
 
 def test_handle_reject(hermes_home):


### PR DESCRIPTION
## What changed

- Thread the live `MemoryManager` through the CLI `/memory approve` path.
- After a staged write is successfully applied, reuse `MemoryManager.notify_memory_tool_write(...)` with the original pending payload.
- Preserve provider lifecycle boundaries: approval without a live agent still updates the built-in on-disk store and does not fabricate a provider manager.
- Add shared-handler and live-CLI regressions with a recording provider.

## Why

Foreground committed memory writes notify configured external providers. With write approval enabled, the foreground call is staged, and the later approval previously updated only `MEMORY.md` / `USER.md`, leaving provider-backed memory stale.

The approval path now reuses the existing bridge, including its success, batch, mutating-action, and metadata filtering.

## Tests

- `HERMES_HOME=/private/tmp/hermes-61090-home PYTHONPYCACHEPREFIX=/private/tmp/hermes-pycache python -m pytest -p no:cacheprovider tests/tools/test_write_approval.py -q` (36 passed)
- `python -m ruff check hermes_cli/cli_commands_mixin.py hermes_cli/write_approval_commands.py tests/tools/test_write_approval.py`
- `git diff --check`