### PR TITLE
fix(gateway): respect session_reset.mode and fix misleading reset notice

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10834,6 +10834,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             reason_text = "previous session was stopped or interrupted"
                         elif reset_reason == "daily":
                             reason_text = f"daily schedule at {policy.at_hour}:00"
+                        elif reset_reason == "resume_pending_expired":
+                            reason_text = "previous session expired after gateway resume timeout"
                         else:
                             hours = policy.idle_minutes // 60
                             mins = policy.idle_minutes % 60

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1786,10 +1786,20 @@ class SessionStore:
                         # session as a zombie and fall through to auto-reset.
                         reset_reason = self._should_reset(entry, source)
                         if not reset_reason:
-                            _fw = auto_continue_freshness_window()
-                            _ref_time = entry.last_resume_marked_at or entry.updated_at
-                            if _fw > 0 and (now - _ref_time).total_seconds() > _fw:
-                                reset_reason = "resume_pending_expired"
+                            # Freshness gate (#46934): only apply if resets are enabled
+                            policy = self.config.get_reset_policy(
+                                platform=source.platform,
+                                session_type=source.chat_type
+                            )
+                            if policy.mode != "none":
+                                _fw = auto_continue_freshness_window()
+                                _ref_time = entry.last_resume_marked_at or entry.updated_at
+                                if _fw > 0 and (now - _ref_time).total_seconds() > _fw:
+                                    reset_reason = "resume_pending_expired"
+                                else:
+                                    entry.updated_at = now
+                                    self._save()
+                                    return entry
                             else:
                                 entry.updated_at = now
                                 self._save()

--- a/tests/gateway/test_61052_resume_expired.py
+++ b/tests/gateway/test_61052_resume_expired.py
@@ -1,0 +1,90 @@
+import pytest
+import shutil
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+from gateway.session import SessionStore, SessionEntry, SessionSource
+from gateway.config import GatewayConfig, SessionResetPolicy, Platform
+
+@pytest.fixture
+def temp_sessions():
+    path = Path("/tmp/hermes_test_sessions")
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True)
+    yield path
+    if path.exists():
+        shutil.rmtree(path)
+
+def test_resume_pending_expired_respects_mode_none(temp_sessions):
+    # 1. Setup config with mode: none
+    policy = SessionResetPolicy(mode="none", idle_minutes=1440)
+    config = GatewayConfig(
+        default_reset_policy=policy
+    )
+    store = SessionStore(sessions_dir=temp_sessions, config=config)
+    store._save = MagicMock() 
+    
+    # 2. Setup source and get its canonical session key
+    source = SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="test_chat",
+        chat_type="dm"
+    )
+    session_key = store._generate_session_key(source)
+    
+    # Create a session entry that is resume_pending and expired
+    now = datetime.now()
+    entry = SessionEntry(
+        session_key=session_key,
+        session_id="test_session",
+        created_at=now,
+        updated_at=now - timedelta(seconds=5000)
+    )
+    entry.last_resume_marked_at = now - timedelta(seconds=5000)
+    entry.resume_pending = True
+    
+    # Inject the entry into the store
+    store._entries[session_key] = entry
+    
+    # 3. Attempt to get session
+    recovered = store.get_or_create_session(source)
+    assert recovered.session_id == "test_session"
+    assert recovered.resume_pending is True
+
+def test_resume_pending_expired_triggers_when_enabled(temp_sessions):
+    # 1. Setup config with mode: idle (resets enabled)
+    policy = SessionResetPolicy(mode="idle", idle_minutes=1440)
+    config = GatewayConfig(
+        default_reset_policy=policy
+    )
+    store = SessionStore(sessions_dir=temp_sessions, config=config)
+    store._save = MagicMock()
+    
+    # 2. Setup source and get its canonical session key
+    source = SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="test_chat",
+        chat_type="dm"
+    )
+    session_key = store._generate_session_key(source)
+    
+    # Create a session entry that is resume_pending and expired
+    now = datetime.now()
+    entry = SessionEntry(
+        session_key=session_key,
+        session_id="test_session",
+        created_at=now,
+        updated_at=now - timedelta(seconds=5000)
+    )
+    entry.last_resume_marked_at = now - timedelta(seconds=5000)
+    entry.resume_pending = True
+    
+    # Inject the entry into the store
+    store._entries[session_key] = entry
+    
+    # 3. Attempt to get session
+    recovered = store.get_or_create_session(source)
+    assert recovered.session_id != "test_session"
+    assert recovered.resume_pending is False
+

--- a/tests/gateway/test_61052_resume_expired.py
+++ b/tests/gateway/test_61052_resume_expired.py
@@ -1,38 +1,21 @@
 import pytest
-import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock
 from gateway.session import SessionStore, SessionEntry, SessionSource
 from gateway.config import GatewayConfig, SessionResetPolicy, Platform
 
-@pytest.fixture
-def temp_sessions():
-    path = Path("/tmp/hermes_test_sessions")
-    if path.exists():
-        shutil.rmtree(path)
-    path.mkdir(parents=True)
-    yield path
-    if path.exists():
-        shutil.rmtree(path)
-
-def test_resume_pending_expired_respects_mode_none(temp_sessions):
+def test_resume_pending_expired_respects_mode_none(tmp_path):
     # 1. Setup config with mode: none
     policy = SessionResetPolicy(mode="none", idle_minutes=1440)
-    config = GatewayConfig(
-        default_reset_policy=policy
-    )
-    store = SessionStore(sessions_dir=temp_sessions, config=config)
-    store._save = MagicMock() 
-    
+    config = GatewayConfig(default_reset_policy=policy)
+    store = SessionStore(sessions_dir=tmp_path, config=config)
+    store._save = MagicMock()
+
     # 2. Setup source and get its canonical session key
-    source = SessionSource(
-        platform=Platform.LOCAL,
-        chat_id="test_chat",
-        chat_type="dm"
-    )
+    source = SessionSource(platform=Platform.LOCAL, chat_id="test_chat", chat_type="dm")
     session_key = store._generate_session_key(source)
-    
+
     # Create a session entry that is resume_pending and expired
     now = datetime.now()
     entry = SessionEntry(
@@ -43,32 +26,26 @@ def test_resume_pending_expired_respects_mode_none(temp_sessions):
     )
     entry.last_resume_marked_at = now - timedelta(seconds=5000)
     entry.resume_pending = True
-    
+
     # Inject the entry into the store
     store._entries[session_key] = entry
-    
+
     # 3. Attempt to get session
     recovered = store.get_or_create_session(source)
     assert recovered.session_id == "test_session"
     assert recovered.resume_pending is True
 
-def test_resume_pending_expired_triggers_when_enabled(temp_sessions):
+def test_resume_pending_expired_triggers_when_enabled(tmp_path):
     # 1. Setup config with mode: idle (resets enabled)
     policy = SessionResetPolicy(mode="idle", idle_minutes=1440)
-    config = GatewayConfig(
-        default_reset_policy=policy
-    )
-    store = SessionStore(sessions_dir=temp_sessions, config=config)
+    config = GatewayConfig(default_reset_policy=policy)
+    store = SessionStore(sessions_dir=tmp_path, config=config)
     store._save = MagicMock()
-    
+
     # 2. Setup source and get its canonical session key
-    source = SessionSource(
-        platform=Platform.LOCAL,
-        chat_id="test_chat",
-        chat_type="dm"
-    )
+    source = SessionSource(platform=Platform.LOCAL, chat_id="test_chat", chat_type="dm")
     session_key = store._generate_session_key(source)
-    
+
     # Create a session entry that is resume_pending and expired
     now = datetime.now()
     entry = SessionEntry(
@@ -79,13 +56,37 @@ def test_resume_pending_expired_triggers_when_enabled(temp_sessions):
     )
     entry.last_resume_marked_at = now - timedelta(seconds=5000)
     entry.resume_pending = True
-    
+
     # Inject the entry into the store
     store._entries[session_key] = entry
-    
+
     # 3. Attempt to get session
     recovered = store.get_or_create_session(source)
     assert recovered.session_id != "test_session"
     assert recovered.resume_pending is False
 
 
+def test_resume_pending_expired_sets_correct_reason(tmp_path):
+    # Setup config with mode: idle
+    policy = SessionResetPolicy(mode="idle", idle_minutes=1440)
+    config = GatewayConfig(default_reset_policy=policy)
+    store = SessionStore(sessions_dir=tmp_path, config=config)
+    store._save = MagicMock()
+
+    source = SessionSource(platform=Platform.LOCAL, chat_id="test_chat", chat_type="dm")
+    session_key = store._generate_session_key(source)
+
+    now = datetime.now()
+    entry = SessionEntry(
+        session_key=session_key,
+        session_id="test_session",
+        created_at=now,
+        updated_at=now - timedelta(seconds=5000)
+    )
+    entry.last_resume_marked_at = now - timedelta(seconds=5000)
+    entry.resume_pending = True
+
+    store._entries[session_key] = entry
+
+    recovered = store.get_or_create_session(source)
+    assert recovered.auto_reset_reason == "resume_pending_expired"

--- a/tests/gateway/test_61052_resume_expired.py
+++ b/tests/gateway/test_61052_resume_expired.py
@@ -88,3 +88,4 @@ def test_resume_pending_expired_triggers_when_enabled(temp_sessions):
     assert recovered.session_id != "test_session"
     assert recovered.resume_pending is False
 
+

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
-from gateway.config import GatewayConfig, Platform
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
 from gateway.session import SessionSource, SessionStore
 
 
@@ -274,7 +274,7 @@ class TestResumePendingFreshnessGate:
         return entry
 
     def test_fresh_resume_pending_returns_same_session(self, tmp_path):
-        store = _make_store(tmp_path)
+        store = _make_store(tmp_path, policy=SessionResetPolicy(mode="both"))
         source = _make_source()
         entry = self._mark_resume_pending(store, source)
 
@@ -285,7 +285,7 @@ class TestResumePendingFreshnessGate:
 
     def test_stale_resume_pending_falls_through_to_reset(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "3600")
-        store = _make_store(tmp_path)
+        store = _make_store(tmp_path, policy=SessionResetPolicy(mode="both"))
         source = _make_source()
         entry = self._mark_resume_pending(store, source)
 
@@ -305,7 +305,7 @@ class TestResumePendingFreshnessGate:
     def test_freshness_gate_disabled_returns_stale_session(self, tmp_path, monkeypatch):
         # Opt-out: window <= 0 restores the pre-fix "always fresh" behaviour.
         monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "0")
-        store = _make_store(tmp_path)
+        store = _make_store(tmp_path, policy=SessionResetPolicy(mode="both"))
         source = _make_source()
         entry = self._mark_resume_pending(store, source)
 


### PR DESCRIPTION
Fixes #61052.

Two distinct issues were addressed:
1. Logic Bug: The 'resume_pending' freshness gate in gateway/session.py was ignoring the session_reset.mode: none policy, causing auto-resets even when disabled.
2. UX Bug: The reset notification in gateway/run.py incorrectly fell back to an idle-based duration message for resume_pending_expired resets.

Changes:
- Updated gateway/session.py to gate the freshness-reset path behind the reset policy mode.
- Updated gateway/run.py to provide a specific, accurate notification for 'resume_pending_expired' resets.
- Added a reproduction test in tests/gateway/test_61052_resume_expired.py.

Verified with targeted tests.