### PR TITLE
chore(models): drop x-ai/grok-4.3 from OpenRouter/Nous curated lists in favor of grok-4.5

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -49,7 +49,6 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("google/gemini-3.5-flash",                ""),
     # xAI
     ("x-ai/grok-4.5",                          ""),
-    ("x-ai/grok-4.3",                          ""),
     # DeepSeek
     ("deepseek/deepseek-v4-pro",               ""),
     ("deepseek/deepseek-v4-flash",             ""),
@@ -195,7 +194,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemini-3.5-flash",
         # xAI
         "x-ai/grok-4.5",
-        "x-ai/grok-4.3",
         # DeepSeek
         "deepseek/deepseek-v4-pro",
         "deepseek/deepseek-v4-flash",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-08T18:59:16Z",
+  "updated_at": "2026-07-08T19:45:27Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -58,10 +58,6 @@
         },
         {
           "id": "x-ai/grok-4.5",
-          "description": ""
-        },
-        {
-          "id": "x-ai/grok-4.3",
           "description": ""
         },
         {
@@ -192,9 +188,6 @@
         },
         {
           "id": "x-ai/grok-4.5"
-        },
-        {
-          "id": "x-ai/grok-4.3"
         },
         {
           "id": "deepseek/deepseek-v4-pro"


### PR DESCRIPTION
## Summary
`x-ai/grok-4.5` is now the single curated Grok entry on the OpenRouter and Nous Portal picker lists; `x-ai/grok-4.3` is removed from those snapshots only.

Follow-up to #60887. grok-4.3 is **not retired upstream** — it remains fully usable by typing the model name, which validates against the live aggregator catalogs (verified live on OpenRouter). No `xai_retirement.py` remap is warranted since xAI still serves the model. The xAI-direct curated list is models.dev-cache-driven and unaffected.

## Changes
- `hermes_cli/models.py`: drop `x-ai/grok-4.3` from `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]`
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py` (manifest sync test enforces this)

## Validation
| Check | Result |
|---|---|
| Curated lists: 4.5 present, 4.3 absent | real-import assert, pass |
| `x-ai/grok-4.3` still on live OpenRouter catalog (typed names keep working) | confirmed live |
| `test_model_catalog` (manifest sync), `test_model_validation`, `test_model_normalize`, `test_run_agent`, `test_codex_transport` | pass |

## Infographic

![grok43-curated-removal](https://v3b.fal.media/files/b/0aa17756/HxGGAMkoVPO6g87FqnVSA_ZlSq5Dn6.png)
