### PR TITLE
feat(gateway): add thread-scoped memory injection

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2162,6 +2162,10 @@ def resolve_channel_prompt(
 
     Returns the prompt string, or None if no match is found.  Blank/whitespace-
     only prompts are treated as absent.
+
+    Supports both string values (legacy) and dict values (new format with
+    ``thread_memory: true``).  Dict entries are skipped here — they carry
+    configuration flags, not prompt text.
     """
     prompts = config_extra.get("channel_prompts") or {}
     if not isinstance(prompts, dict):
@@ -2173,10 +2177,31 @@ def resolve_channel_prompt(
         prompt = prompts.get(key)
         if prompt is None:
             continue
+        # Dict values are config objects (e.g. {thread_memory: true}),
+        # not prompt strings — skip them.
+        if isinstance(prompt, dict):
+            continue
         prompt = str(prompt).strip()
         if prompt:
             return prompt
     return None
+
+
+def is_thread_memory_enabled(
+    config_extra: dict,
+    platform_name: str,
+) -> bool:
+    """Check whether thread-scoped memory is enabled for a platform.
+
+    Looks up ``channel_prompts`` in the adapter's ``config.extra`` dict.
+    Returns True when the entry for *platform_name* is a dict with
+    ``thread_memory: true``.
+    """
+    prompts = config_extra.get("channel_prompts") or {}
+    if not isinstance(prompts, dict):
+        return False
+    entry = prompts.get(platform_name)
+    return isinstance(entry, dict) and bool(entry.get("thread_memory"))
 
 
 def resolve_channel_skills(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10675,8 +10675,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
+        # Check if thread-scoped memory is enabled for this channel
+        _thread_memory_enabled = False
+        try:
+            from gateway.platforms.base import is_thread_memory_enabled
+            _platform_cfg = self.config.platforms.get(source.platform)
+            if _platform_cfg:
+                _thread_memory_enabled = is_thread_memory_enabled(
+                    _platform_cfg.extra,
+                    source.platform,
+                )
+        except Exception:
+            pass
+
         # Build the context prompt to inject
-        context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+        context_prompt = build_session_context_prompt(
+            context,
+            redact_pii=_redact_pii,
+            thread_memory_enabled=_thread_memory_enabled,
+        )
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -381,6 +381,7 @@ def build_session_context_prompt(
     context: SessionContext,
     *,
     redact_pii: bool = False,
+    thread_memory_enabled: bool = False,
 ) -> str:
     """
     Build the dynamic system prompt section that tells the agent about its context.
@@ -609,6 +610,42 @@ def build_session_context_prompt(
     # Note about explicit targeting
     lines.append("")
     lines.append("*For explicit targeting, use `\"platform:chat_id\"` format if the user provides a specific chat ID.*")
+
+    # Thread-scoped memory injection
+    if thread_memory_enabled and context.source.thread_id:
+        try:
+            from pathlib import Path
+
+            thread_id = context.source.thread_id
+            thread_memory_dir = Path.home() / ".hermes" / "thread_memory"
+            thread_memory_dir.mkdir(parents=True, exist_ok=True)
+            thread_memory_file = thread_memory_dir / f"{thread_id}.md"
+
+            if thread_memory_file.exists():
+                content = thread_memory_file.read_text(encoding="utf-8").strip()
+                if content:
+                    lines.append("")
+                    lines.append(f"## Thread Memory — {thread_id}")
+                    lines.append(content)
+                    lines.append("")
+                    lines.append("---")
+                    lines.append(
+                        "This is thread-scoped memory for this conversation's topic."
+                    )
+                    lines.append(
+                        f"- Save project context, technical decisions, and session state here using write_file to ~/.hermes/thread_memory/{thread_id}.md"
+                    )
+                    lines.append(
+                        "- Save cross-thread facts (user identity, global preferences, credentials) to the shared memory tool as usual"
+                    )
+                    lines.append(
+                        "- When unsure, default here — this file's scope is this thread only"
+                    )
+                    lines.append(
+                        "- Keep this file under 2200 characters (same limit as shared memory)"
+                    )
+        except Exception as exc:
+            logger.warning("Failed to load thread memory for %s: %s", context.source.thread_id, exc)
 
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary

Allow per-thread memory files to be injected into the agent's ephemeral system prompt, enabling context separation by topic when using platform threads (Telegram, Discord, etc.).

## Motivation

Users who organize conversations by thread (e.g. one thread per project) need the agent to automatically load thread-specific context without being told. This extends the existing  config to support a  flag.

## Config

Platform-wide (recommended — no chat_id needed):

```yaml
channel_prompts:
  telegram:
    thread_memory: true
```

Multiple platforms:

```yaml
channel_prompts:
  telegram:
    thread_memory: true
  discord:
    thread_memory: true
```

## How it works

1. `channel_prompts.<platform>.thread_memory: true` enables the feature
2. On each message, `build_session_context_prompt()` checks if enabled
3. If enabled AND session has a `thread_id`, reads `~/.hermes/thread_memory/{thread_id}.md`
4. Injects the file content into the ephemeral system prompt with agent instructions
5. Agent can update the file using `write_file`

## Changes (80 lines, 3 files)

- **gateway/platforms/base.py** — `resolve_channel_prompt()` skips dict values (backward compatible); new `is_thread_memory_enabled(platform_name)`
- **gateway/run.py** — checks thread_memory config per platform, passes flag to context builder
- **gateway/session.py** — new `thread_memory_enabled` parameter, reads and injects thread memory file content

## Properties

- **Opt-in** — `false` by default, zero behavior change for non-users
- **No new tools** — agent uses existing `write_file` to maintain thread memory files
- **No prompt cache break** — injected via `ephemeral_system_prompt` which is already per-turn
- **No core changes** — does not touch system_prompt.py, memory_manager.py, prompt_builder.py, or agent core
- **Graceful fallback** — missing file = no-op, empty file = instruction block only
- **2200 char limit** — same as shared memory