### PR TITLE
fix(memory): feed pre-compress provider context to summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1748,6 +1748,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         self,
         turns_to_summarize: List[Dict[str, Any]],
         focus_topic: Optional[str] = None,
+        pre_compress_context: Optional[str] = None,
     ) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
@@ -1776,6 +1777,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
         content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+        provider_context = (pre_compress_context or "").strip()
 
         # Current date for temporal anchoring (see ## Temporal Anchoring below).
         # Date-only granularity matches system_prompt.py:337 (PR #20451) and the
@@ -1901,6 +1903,13 @@ Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command out
 {_temporal_anchoring_rule}
 Write only the summary body. Do not include any preamble or prefix."""
 
+        provider_context_block = (
+            "\n\nMemory Provider Pre-Compression Context:\n"
+            f"{provider_context}\n"
+            if provider_context
+            else ""
+        )
+
         if self._previous_summary:
             # Iterative update: preserve existing info, add new progress
             prompt = f"""{_summarizer_preamble}
@@ -1911,7 +1920,7 @@ PREVIOUS SUMMARY:
 {self._previous_summary}
 
 NEW TURNS TO INCORPORATE:
-{content_to_summarize}
+{content_to_summarize}{provider_context_block}
 
 Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
 
@@ -1923,7 +1932,7 @@ Update the summary using this exact structure. PRESERVE all existing information
 Create a structured checkpoint summary for the conversation after earlier turns are compacted. The summary should preserve enough detail for continuity without re-reading the original turns.
 
 TURNS TO SUMMARIZE:
-{content_to_summarize}
+{content_to_summarize}{provider_context_block}
 
 Use this exact structure:
 
@@ -2790,7 +2799,14 @@ This compaction should PRIORITISE preserving all information related to the focu
     # Main compression entry point
     # ------------------------------------------------------------------
 
-    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False) -> List[Dict[str, Any]]:
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: int = None,
+        focus_topic: str = None,
+        force: bool = False,
+        pre_compress_context: str | None = None,
+    ) -> List[Dict[str, Any]]:
         """Compress conversation messages by summarizing middle turns.
 
         Algorithm:
@@ -2932,7 +2948,11 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         # Phase 3: Generate structured summary
         summary_focus_topic = focus_topic or self._derive_auto_focus_topic(messages)
-        summary = self._generate_summary(turns_to_summarize, focus_topic=summary_focus_topic)
+        summary = self._generate_summary(
+            turns_to_summarize,
+            focus_topic=summary_focus_topic,
+            pre_compress_context=pre_compress_context,
+        )
 
         # If summary generation failed, behavior splits on
         # ``abort_on_summary_failure`` (config: compression.abort_on_summary_failure):

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -628,15 +628,24 @@ def compress_context(
             except Exception as _rel_err:
                 logger.debug("compression lock release failed: %s", _rel_err)
 
-    # Notify external memory provider before compression discards context
+    # Notify external memory providers before compression discards context.
+    # Providers may return distilled facts/insights that should survive the
+    # compaction boundary; pass those through to the summarizer prompt below.
+    pre_compress_context = ""
     if agent._memory_manager:
         try:
-            agent._memory_manager.on_pre_compress(messages)
+            pre_compress_context = agent._memory_manager.on_pre_compress(messages) or ""
         except Exception:
             pass
 
     try:
-        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
+        compressed = agent.context_compressor.compress(
+            messages,
+            current_tokens=approx_tokens,
+            focus_topic=focus_topic,
+            force=force,
+            pre_compress_context=pre_compress_context,
+        )
     except TypeError:
         # Plugin context engine with strict signature that doesn't accept
         # focus_topic / force — fall back to calling without them.

--- a/tests/agent/test_compression_pre_compress_context.py
+++ b/tests/agent/test_compression_pre_compress_context.py
@@ -1,0 +1,66 @@
+"""Pre-compression memory-provider context wiring."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.conversation_compression import compress_context
+
+
+def test_pre_compress_provider_context_reaches_compressor():
+    """MemoryProvider.on_pre_compress() output is fed into compression."""
+    messages = [
+        {"role": "user", "content": "summarize this long session"},
+        {"role": "assistant", "content": "working"},
+        {"role": "user", "content": "tail"},
+    ]
+
+    memory_manager = MagicMock()
+    memory_manager.on_pre_compress.return_value = "provider extracted: project=alpha"
+
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "user", "content": "tail"},
+    ]
+    compressor._last_compress_aborted = False
+    compressor._last_summary_error = None
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    compressor.compression_count = 1
+
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        _memory_manager=memory_manager,
+        context_compressor=compressor,
+        _compression_feasibility_checked=True,
+        _session_db=None,
+        session_id="s1",
+        compression_in_place=False,
+        model="test/model",
+        platform="cli",
+        tools=None,
+        _todo_store=SimpleNamespace(format_for_injection=lambda: ""),
+        _cached_system_prompt=None,
+        _last_compaction_in_place=False,
+        _emit_status=lambda *_args, **_kwargs: None,
+        _emit_warning=lambda *_args, **_kwargs: None,
+        _invalidate_system_prompt=lambda: None,
+        _build_system_prompt=lambda system_message: f"rebuilt: {system_message}",
+        event_callback=None,
+    )
+
+    compressed, new_prompt = compress_context(
+        agent,
+        messages,
+        "system prompt",
+        approx_tokens=120_000,
+    )
+
+    assert compressed == compressor.compress.return_value
+    assert new_prompt == "rebuilt: system prompt"
+    memory_manager.on_pre_compress.assert_called_once_with(messages)
+    assert compressor.compress.call_args.kwargs["pre_compress_context"] == (
+        "provider extracted: project=alpha"
+    )

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -518,6 +518,30 @@ class TestTailBudgetCodexReplayFields:
 class TestGenerateSummaryNoneContent:
     """Regression: content=None (from tool-call-only assistant messages) must not crash."""
 
+    def test_pre_compress_context_is_included_in_summary_prompt(self):
+        """Provider pre-compress insights must reach the summarizer prompt."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary body"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "do the migration"},
+            {"role": "assistant", "content": "working"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_call:
+            c._generate_summary(
+                messages,
+                pre_compress_context="Provider extracted durable fact: migration target is v2.",
+            )
+
+        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        assert "Provider extracted durable fact: migration target is v2." in prompt
+        assert "Memory Provider Pre-Compression Context" in prompt
+
     def test_none_content_does_not_crash(self):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]


### PR DESCRIPTION
Fixes a memory-provider contract gap: `MemoryProvider.on_pre_compress()` returned provider-extracted context, but `compress_context()` discarded it before invoking the summarizer.

## What changed
- Capture `MemoryManager.on_pre_compress()` output before compaction.
- Pass it into `ContextCompressor.compress()`.
- Include it in both first-pass and iterative summary prompts under `Memory Provider Pre-Compression Context`.
- Keep the existing fallback behavior for plugin compressors with strict signatures.

## Why
Provider hooks can extract facts or insights from context that is about to be compacted. Dropping the returned text made those hooks observational only, despite the interface contract saying their output can be included in the compression summary.

## Tests
- `PYTHONPYCACHEPREFIX=/private/tmp/hermes-pycache python -m pytest -p no:cacheprovider tests/agent/test_context_compressor.py::TestGenerateSummaryNoneContent::test_pre_compress_context_is_included_in_summary_prompt tests/agent/test_compression_pre_compress_context.py tests/agent/test_memory_provider.py::TestMemoryManager::test_on_pre_compress -q`