### PR TITLE
fix(gateway): honor checkpoints.enabled from config in gateway-spawned agents

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2409,6 +2409,32 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _resolve_checkpoint_kwargs(config: dict | None = None) -> dict:
+    """Resolve filesystem-checkpoint AIAgent kwargs from config.yaml.
+
+    Mirrors the CLI lane's semantics (``HermesCLI.__init__`` in cli.py): the
+    root-level ``checkpoints`` block may be a bool shorthand or a mapping;
+    when the block is absent checkpoints stay disabled (AIAgent's own
+    default). Without this, ``checkpoints: {enabled: true}`` in config.yaml
+    was honored by ``hermes chat`` but silently ignored by every
+    gateway-spawned agent.
+
+    Returns a dict suitable for ``AIAgent(**kwargs)`` expansion.
+    """
+    cfg = config if config is not None else _load_gateway_config()
+    cp_cfg = cfg.get("checkpoints", {}) if isinstance(cfg, dict) else {}
+    if isinstance(cp_cfg, bool):
+        cp_cfg = {"enabled": cp_cfg}
+    if not isinstance(cp_cfg, dict):
+        cp_cfg = {}
+    return {
+        "checkpoints_enabled": bool(cp_cfg.get("enabled", False)),
+        "checkpoint_max_snapshots": cp_cfg.get("max_snapshots", 20),
+        "checkpoint_max_total_size_mb": cp_cfg.get("max_total_size_mb", 500),
+        "checkpoint_max_file_size_mb": cp_cfg.get("max_file_size_mb", 10),
+    }
+
+
 def _channel_override_lookup_keys(
     chat_id: str,
     *,
@@ -13177,6 +13203,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     provider_sort=pr.get("sort"),
                     provider_require_parameters=pr.get("require_parameters", False),
                     provider_data_collection=pr.get("data_collection"),
+                    **_resolve_checkpoint_kwargs(user_config),
                     session_id=task_id,
                     platform=platform_key,
                     user_id=source.user_id,
@@ -18037,6 +18064,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     provider_sort=pr.get("sort"),
                     provider_require_parameters=pr.get("require_parameters", False),
                     provider_data_collection=pr.get("data_collection"),
+                    **_resolve_checkpoint_kwargs(user_config),
                     session_id=session_id,
                     platform=platform_key,
                     user_id=source.user_id,

--- a/tests/gateway/test_checkpoint_config_propagation.py
+++ b/tests/gateway/test_checkpoint_config_propagation.py
@@ -1,0 +1,164 @@
+"""Regression tests for checkpoint config propagation to gateway agents.
+
+``checkpoints: {enabled: true}`` in config.yaml was honored by the CLI lane
+(``HermesCLI.__init__`` reads the block and passes ``checkpoints_enabled`` to
+AIAgent) but silently ignored by every gateway-spawned agent:
+``gateway/run.py`` never read the block, so AIAgent's ``checkpoints_enabled``
+default (False) always won and filesystem checkpoints stayed OFF in
+long-running gateways even when the user's config promised them.
+
+``_resolve_checkpoint_kwargs`` mirrors the CLI semantics:
+    mapping block -> its ``enabled``/limits; bool shorthand -> enabled flag;
+    absent/malformed block -> disabled with default limits.
+"""
+
+import importlib
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a writable config.yaml and a clean module cache.
+
+    Mirrors tests/gateway/test_max_tokens_propagation.py: re-import
+    ``hermes_cli`` / ``gateway`` so each config write is read fresh, and
+    restore the pre-test module snapshot on teardown so sibling test files
+    keep their import-time mocks.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _saved = {
+        k: v
+        for k, v in sys.modules.items()
+        if k.startswith(("hermes_cli", "gateway"))
+    }
+
+    def write_cfg(body: str) -> None:
+        (hermes_home / "config.yaml").write_text(textwrap.dedent(body))
+
+    def fresh_gateway():
+        for mod in list(sys.modules.keys()):
+            if mod.startswith(("hermes_cli", "gateway")):
+                del sys.modules[mod]
+        return importlib.import_module("gateway.run")
+
+    try:
+        yield write_cfg, fresh_gateway
+    finally:
+        for k in list(sys.modules.keys()):
+            if k.startswith(("hermes_cli", "gateway")):
+                del sys.modules[k]
+        sys.modules.update(_saved)
+
+
+# ---------------------------------------------------------------------------
+# Pure resolver semantics (explicit config dicts)
+# ---------------------------------------------------------------------------
+
+
+def _resolver():
+    from gateway.run import _resolve_checkpoint_kwargs
+
+    return _resolve_checkpoint_kwargs
+
+
+def test_config_on():
+    kw = _resolver()({"checkpoints": {"enabled": True}})
+    assert kw["checkpoints_enabled"] is True
+    assert kw["checkpoint_max_snapshots"] == 20
+    assert kw["checkpoint_max_total_size_mb"] == 500
+    assert kw["checkpoint_max_file_size_mb"] == 10
+
+
+def test_config_off():
+    kw = _resolver()({"checkpoints": {"enabled": False}})
+    assert kw["checkpoints_enabled"] is False
+
+
+def test_config_absent():
+    """No checkpoints block -> disabled (AIAgent's own default preserved)."""
+    kw = _resolver()({})
+    assert kw["checkpoints_enabled"] is False
+    assert kw["checkpoint_max_snapshots"] == 20
+
+
+def test_bool_shorthand():
+    """``checkpoints: true`` shorthand matches the CLI lane's bool handling."""
+    assert _resolver()({"checkpoints": True})["checkpoints_enabled"] is True
+    assert _resolver()({"checkpoints": False})["checkpoints_enabled"] is False
+
+
+def test_malformed_block_disables():
+    """A non-dict, non-bool block must not crash agent construction."""
+    kw = _resolver()({"checkpoints": "yes please"})
+    assert kw["checkpoints_enabled"] is False
+    assert kw["checkpoint_max_snapshots"] == 20
+
+
+def test_limits_pass_through():
+    kw = _resolver()(
+        {
+            "checkpoints": {
+                "enabled": True,
+                "max_snapshots": 7,
+                "max_total_size_mb": 123,
+                "max_file_size_mb": 4,
+            }
+        }
+    )
+    assert kw == {
+        "checkpoints_enabled": True,
+        "checkpoint_max_snapshots": 7,
+        "checkpoint_max_total_size_mb": 123,
+        "checkpoint_max_file_size_mb": 4,
+    }
+
+
+def test_kwargs_match_aiagent_signature():
+    """Every resolved key must be a real AIAgent constructor parameter."""
+    import inspect
+
+    from run_agent import AIAgent
+
+    params = set(inspect.signature(AIAgent.__init__).parameters)
+    kw = _resolver()({"checkpoints": {"enabled": True}})
+    missing = set(kw) - params
+    assert not missing, f"resolved kwargs not accepted by AIAgent: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Real config path (config.yaml -> _load_gateway_config -> resolver)
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_via_real_config_load(isolated_home):
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(
+        """
+        checkpoints:
+          enabled: true
+          max_snapshots: 5
+        """
+    )
+    grun = fresh_gateway()
+    kw = grun._resolve_checkpoint_kwargs()
+    assert kw["checkpoints_enabled"] is True
+    assert kw["checkpoint_max_snapshots"] == 5
+
+
+def test_absent_via_real_config_load(isolated_home):
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(
+        """
+        model:
+          default: glm-5.1
+        """
+    )
+    grun = fresh_gateway()
+    kw = grun._resolve_checkpoint_kwargs()
+    assert kw["checkpoints_enabled"] is False


### PR DESCRIPTION
## Summary

`config.yaml` can promise filesystem checkpoints:

```yaml
checkpoints:
  enabled: true
```

The CLI lane keeps that promise — `HermesCLI.__init__` (cli.py:3878-3884 at base) reads the
block and passes `checkpoints_enabled` + the three size limits into `AIAgent`. The messaging
gateway does not: neither `AIAgent` construction site in `gateway/run.py` (the per-session
agent and the background-task agent) reads the block, so `AIAgent`'s `checkpoints_enabled`
default (`False`, agent/agent_init.py:327) always wins and checkpoints are silently OFF for
every gateway-spawned agent — precisely the long-running surfaces where post-hoc file rollback
matters most.

## Config promise vs. behavior (evidence at base `ac6dd598a`)

| Lane | Reads `checkpoints` block? | Effective with `enabled: true` |
| --- | --- | --- |
| CLI (`hermes chat`) | yes — cli.py:3878-3884 | ON |
| Gateway per-session agent — gateway/run.py:18021 (base) | no | OFF (silent) |
| Gateway background-task agent — gateway/run.py:13163 (base) | no | OFF (silent) |

The gateway does read the same root-level block for checkpoint *auto-prune* maintenance
(gateway/run.py:3074 at base), so the config key is already gateway-visible — only agent
construction ignored it.

## Change

- New module-level `_resolve_checkpoint_kwargs(config=None)` in `gateway/run.py`, next to the
  other config resolvers (`_resolve_gateway_model`), mirroring the CLI semantics exactly:
  mapping block → its `enabled` + limits; bool shorthand (`checkpoints: true`) → enabled flag;
  absent or malformed block → disabled with default limits (20 snapshots / 500 MB total /
  10 MB per file — same defaults as cli.py and agent_init.py).
- Expanded (`**`) at both gateway construction sites from the `user_config` already loaded in
  scope — no extra config read, no signature changes.

Net diff: +28 lines in `gateway/run.py`, one new test file.

## Deliberately NOT wired (and why)

- **Session-hygiene compression agent** (run.py:11070 at base) and **`/compress` tmp agent**
  (slash_commands.py:3184 at base): memory-only toolsets (`enabled_toolsets=["memory"]`),
  never mutate files — checkpointing is meaningless there.
- **api_server platform agent** (gateway/platforms/api_server.py:1345 at base): out of scope
  for the minimal fix to the messaging-gateway seam this PR targets; trivially wireable with
  the same helper as a follow-up if maintainers want it.

## Behavior notes

- Users without a `checkpoints` block: no behavior change (resolver returns the same defaults
  AIAgent already used).
- Cached session agents: `checkpoints_enabled` is constructor-baked (agent_init.py builds the
  `CheckpointManager` at init). A config flip therefore applies to newly built agents — on
  config-signature change, cache eviction, or gateway restart — same propagation class as the
  other constructor kwargs (e.g. toolsets).
- Disk growth is bounded by the existing `checkpoints.auto_prune` maintenance the gateway
  already runs.

## Tests

`tests/gateway/test_checkpoint_config_propagation.py` (conventions copied from
`tests/gateway/test_max_tokens_propagation.py`):

- config-on / config-off / config-absent
- bool shorthand (`checkpoints: true|false`)
- malformed block (string) → disabled, no crash
- limit pass-through
- every resolved kwarg is a real `AIAgent.__init__` parameter (signature guard)
- real path: config.yaml → `_load_gateway_config()` → resolver, in an isolated `HERMES_HOME`

Results (hermes-agent venv, Python 3.11.11):

- new file: **9/9 passed**
- neighbors: `test_max_tokens_propagation.py` + `test_agent_cache.py` → **84/84 passed**
- `test_background_command.py`: 21 passed, 1 failed
  (`TestRunBackgroundTask::test_media_files_routed_by_type`) — **pre-existing at clean
  `origin/main` base** (fails identically with the patch stashed); unrelated to this change.
- `python -m compileall gateway/run.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
