### PR TITLE
fix(memory): sanitize synced message context

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -625,6 +625,46 @@ class MemoryManager:
             return True
         return "messages" in signature.parameters
 
+    @classmethod
+    def _strip_skill_scaffolding_from_messages(
+        cls,
+        messages: Optional[List[Dict[str, Any]]],
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Return a messages payload safe to expose to memory providers.
+
+        ``sync_all`` already strips the primary user text before fan-out, but
+        providers that opt into the optional ``messages=`` context can otherwise
+        receive earlier slash-skill-expanded user messages verbatim. Strip the
+        same scaffolding there too, while leaving the caller-owned transcript
+        objects untouched.
+        """
+        if messages is None:
+            return None
+
+        cleaned: List[Dict[str, Any]] = []
+        changed = False
+        for message in messages:
+            if not isinstance(message, dict):
+                cleaned.append(message)
+                continue
+
+            content = message.get("content")
+            if message.get("role") != "user" or not isinstance(content, str):
+                cleaned.append(message)
+                continue
+
+            stripped = cls._strip_skill_scaffolding(content)
+            if stripped is None:
+                changed = True
+                continue
+            if stripped != content:
+                message = dict(message)
+                message["content"] = stripped
+                changed = True
+            cleaned.append(message)
+
+        return cleaned if changed else messages
+
     def sync_all(
         self,
         user_content: str,
@@ -658,16 +698,17 @@ class MemoryManager:
         if not clean_user_content:
             return
         user_content = clean_user_content
+        sync_messages = self._strip_skill_scaffolding_from_messages(messages)
 
         def _run() -> None:
             for provider in providers:
                 try:
-                    if messages is not None and self._provider_sync_accepts_messages(provider):
+                    if sync_messages is not None and self._provider_sync_accepts_messages(provider):
                         provider.sync_turn(
                             user_content,
                             assistant_content,
                             session_id=session_id,
-                            messages=messages,
+                            messages=sync_messages,
                         )
                     else:
                         provider.sync_turn(

--- a/tests/agent/test_memory_skill_scaffolding.py
+++ b/tests/agent/test_memory_skill_scaffolding.py
@@ -51,6 +51,7 @@ class _RecordingProvider(MemoryProvider):
         self.prefetched = []
         self.queued = []
         self.synced = []
+        self.synced_messages = []
 
     @property
     def name(self) -> str:
@@ -74,6 +75,8 @@ class _RecordingProvider(MemoryProvider):
 
     def sync_turn(self, user_content, assistant_content, *, session_id: str = "", messages=None) -> None:
         self.synced.append(user_content)
+        if messages is not None:
+            self.synced_messages.append(messages)
 
     def get_tool_schemas(self):
         return []
@@ -147,6 +150,40 @@ class TestMemoryManagerStripsScaffolding:
         mgr.sync_all(_SINGLE_SKILL_TURN, "Done.")
         mgr.flush_pending(timeout=5.0)
         assert provider.synced == ["make a skill for release triage"]
+
+    def test_sync_all_strips_skill_scaffolding_from_messages_payload(self):
+        mgr, provider = _manager_with_recorder()
+        messages = [
+            {"role": "user", "content": _SINGLE_SKILL_TURN},
+            {"role": "assistant", "content": "Done."},
+        ]
+
+        mgr.sync_all(_SINGLE_SKILL_TURN, "Done.", messages=messages)
+        mgr.flush_pending(timeout=5.0)
+
+        assert provider.synced == ["make a skill for release triage"]
+        assert provider.synced_messages == [[
+            {"role": "user", "content": "make a skill for release triage"},
+            {"role": "assistant", "content": "Done."},
+        ]]
+        assert messages[0]["content"] == _SINGLE_SKILL_TURN
+
+    def test_sync_all_drops_bare_skill_turns_from_messages_payload(self):
+        mgr, provider = _manager_with_recorder()
+        messages = [
+            {"role": "user", "content": _BARE_SKILL_TURN},
+            {"role": "assistant", "content": "Loaded."},
+            {"role": "user", "content": "now use that skill"},
+        ]
+
+        mgr.sync_all("now use that skill", "Done.", messages=messages)
+        mgr.flush_pending(timeout=5.0)
+
+        assert provider.synced == ["now use that skill"]
+        assert provider.synced_messages == [[
+            {"role": "assistant", "content": "Loaded."},
+            {"role": "user", "content": "now use that skill"},
+        ]]
 
     def test_sync_all_skips_bare_skill(self):
         mgr, provider = _manager_with_recorder()


### PR DESCRIPTION
## What changed

- Sanitize the optional `messages=` payload passed to memory providers that opt into completed-turn context.
- Replace slash-skill-expanded user messages with the extracted user instruction.
- Drop bare skill-scaffolding user messages when no user instruction is present.
- Preserve caller-owned transcript objects by copying only changed message dictionaries.

## Why

`MemoryManager.sync_all()` already sanitized primary `user_content`, but opted-in providers still received raw expanded `SKILL.md` bodies through the transcript payload. That can pollute external memory or vector stores with implementation scaffolding instead of the user's request.

## Tests

- memory skill-scaffolding + provider suites: `116 passed`
- `python -m ruff check agent/memory_manager.py tests/agent/test_memory_skill_scaffolding.py`
- `git diff --check`