### PR TITLE
fix(chat): namespace PTY attach token by resume target to fix session switching

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -43,14 +43,21 @@ import { useProfileScope } from "@/contexts/useProfileScope";
 // Stable per-browser token identifying THIS chat tab's keep-alive PTY session.
 // Sent as ?attach=; lets a refresh/disconnect reattach to the same live process
 // instead of spawning a fresh one. Per-localStorage, so other devices can't grab it.
+// The key is namespaced by resume target: switching to a different session
+// changes ``resumeKey``, which changes the storage key, ensuring a different
+// conversation always gets its own PTY rather than reattaching to the
+// previous session's running process.
 // ``rotate`` mints a new token — used when the user explicitly starts a fresh
 // session so the old keep-alive PTY is NOT reattached (the registry reaps it).
 const PTY_ATTACH_TOKEN_KEY = "hermes.pty.token.chat";
-function ptyAttachToken(rotate = false): string {
+function ptyAttachToken(rotate = false, resumeKey = ""): string {
+  const storageKey = resumeKey
+    ? `${PTY_ATTACH_TOKEN_KEY}.${resumeKey}`
+    : PTY_ATTACH_TOKEN_KEY;
   let t = "";
   if (!rotate) {
     try {
-      t = window.localStorage.getItem(PTY_ATTACH_TOKEN_KEY) ?? "";
+      t = window.localStorage.getItem(storageKey) ?? "";
     } catch {
       /* private mode / storage blocked */
     }
@@ -60,7 +67,7 @@ function ptyAttachToken(rotate = false): string {
     crypto.getRandomValues(a);
     t = Array.from(a, (b) => b.toString(16).padStart(2, "0")).join("");
     try {
-      window.localStorage.setItem(PTY_ATTACH_TOKEN_KEY, t);
+      window.localStorage.setItem(storageKey, t);
     } catch {
       /* ignore */
     }
@@ -710,7 +717,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // Keep-alive identity: reattach to this tab's living PTY across
       // refresh/transient drops. A forced-fresh start rotates the token so
       // the previous keep-alive PTY is not reattached (registry reaps it).
-      params.attach = ptyAttachToken(forceFresh);
+      params.attach = ptyAttachToken(forceFresh, resumeParam ?? "");
       // Profile-scoped chat: the PTY child gets HERMES_HOME pointed at the
       // selected profile, so the conversation runs with that profile's model,
       // skills, memory, and sessions (see web_server._resolve_chat_argv).


### PR DESCRIPTION
## Summary

Selecting a previous session from the Chat tab's session list spawned a new terminal in the *old* session's context instead of resuming the selected one.

## Root Cause

`79f4f78fa` introduced PTY keep-alive: the browser stores an attach token in `localStorage["hermes.pty.token.chat"]` and `PTY_REGISTRY.attach_or_spawn()` reuses the existing PTY process when the same token reconnects.

The token key was a single static string regardless of which session was open. When the user clicked a different session:

1. `?resume=<new-id>` changed → channel UUID regenerated → WebSocket effect re-ran
2. `ptyAttachToken(false)` returned the **same** old token from localStorage
3. Server found the existing PTY alive under that token → reattached to it
4. The `resume` param in `_resolve_chat_argv` is only used **when spawning a new PTY** — on reattach it's ignored entirely
5. Result: the old session's terminal appeared regardless of which session was selected

## Fix

Namespace the localStorage key by `resumeParam` so each session ID gets its own stable PTY attach token:

```ts
// before
params.attach = ptyAttachToken(forceFresh);

// after
params.attach = ptyAttachToken(forceFresh, resumeParam ?? "");
```

`ptyAttachToken` now accepts an optional `resumeKey` and uses `hermes.pty.token.chat.<resumeKey>` as the storage key when non-empty. A fresh chat (no resume param) continues to use the bare key as before.

Keep-alive across refresh/transient disconnects is fully preserved — only switching to a *different* session now correctly spawns a new PTY.

## Testing

1. Start a chat session and send a message
2. Navigate to the Sessions page and start another session  
3. Return to the Chat tab and use the session switcher to select the first session
4. ✅ The first session's conversation now resumes correctly instead of opening a new terminal

## Affected version

Introduced in `79f4f78fa feat(chat): persist attach token, reconnect on transient close`
