### PR TITLE
fix(dingtalk): add timeout to subprocess.check_call in QR code install

### DIFF
--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -169,10 +169,12 @@ def _ensure_qrcode_installed() -> bool:
         [sys.executable, "-m", "pip", "install", "-q", "qrcode"],
     ):
         try:
-            subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.check_call(
+                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=120
+            )
             import qrcode  # noqa: F401,F811
             return True
-        except (subprocess.CalledProcessError, ImportError, FileNotFoundError):
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ImportError, FileNotFoundError):
             continue
     return False
 


### PR DESCRIPTION
## Summary

Add ``timeout=120`` to ``subprocess.check_call()`` in ``_ensure_qrcode_installed()``.

## Problem

``subprocess.check_call(cmd)`` without a ``timeout`` parameter in ``hermes_cli/dingtalk_auth.py:172`` can block indefinitely when ``uv pip install`` or ``pip install`` hangs due to network issues, unreachable registries, or dependency resolution delays. Since this function can be invoked during agent startup (QR code rendering), a hang here blocks the entire agent turn.

## Fix

- Added ``timeout=120`` to the ``subprocess.check_call()`` call (120s is generous for a small package install).
- Added ``subprocess.TimeoutExpired`` to the caught exceptions so the timeout failure falls through to the next installer (uv -> pip) just like ``CalledProcessError``.

## Testing

- Syntax check passed (py_compile)
- No behavior change for successful installs (120s is more than enough for ``qrcode``)
- Timeout failure gracefully falls through to next installer or returns False