### PR TITLE
feat(skills): add aiops-agent optional skill

### DIFF
--- a/optional-skills/devops/aiops-agent/SKILL.md
+++ b/optional-skills/devops/aiops-agent/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: aiops-agent
+description: Triage service incidents from logs, alerts, and metrics.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [aiops, incident-response, logs, monitoring, observability, sre, triage]
+    category: devops
+    requires_toolsets: [terminal]
+    related_skills: [watchers, docker-management]
+---
+
+# AIOps Agent
+
+An AIOps agent turns raw signal (logs, alerts, metrics) into a diagnosis and a
+remediation plan. This skill is the on-demand triage runbook: gather evidence
+with `terminal`, summarize and fingerprint errors with the bundled
+`log_triage.py`, correlate against recent changes, and propose remediation —
+safe steps first, destructive steps only with explicit confirmation.
+
+## When to Use
+
+- User reports a service/system is degraded, erroring, or down and wants root cause
+- User pastes or points at a log dump and asks "what's wrong here?"
+- User wants a recurring class of incident turned into an automated check
+- Don't use for: continuously polling a feed/API when nothing is wrong yet — use the `watchers` skill for that
+- Don't use for: container lifecycle management with no incident involved — use the `docker-management` skill for that
+
+## Prerequisites
+
+- `terminal` toolset enabled (required)
+- Read access to the relevant log source for the target platform: `journalctl`,
+  `docker logs`, `kubectl logs`, Windows Event Log, or the macOS unified log
+- Optional: `docker`/`kubectl` CLI configured if triaging containerized workloads
+- Python 3 available to run `scripts/log_triage.py` (stdlib only, no extra installs)
+
+## Quick Reference
+
+| Task | Command |
+|---|---|
+| Tail a systemd service's logs (Linux) | `journalctl -u <service> -n 200 --no-pager` |
+| Follow a container's logs | `docker logs --tail 200 -f <container>` |
+| Tail a Kubernetes pod's logs | `kubectl logs <pod> -n <namespace> --tail=200` |
+| Logs from a pod's previous (crashed) instance | `kubectl logs <pod> -n <namespace> --previous` |
+| Recent Windows Event Log errors | `Get-WinEvent -LogName System -MaxEvents 200 \| Where-Object LevelDisplayName -eq 'Error'` |
+| macOS unified log, last hour | `log show --predicate 'eventMessage contains "error"' --last 1h` |
+| Host resource snapshot (Linux/macOS) | `uptime; free -h; df -h` |
+| Host resource snapshot (Windows) | `Get-CimInstance Win32_OperatingSystem \| Select-Object FreePhysicalMemory; Get-PSDrive` |
+| Recent deploys/changes in a repo | `git log --oneline --since="2 hours ago"` |
+| Summarize + fingerprint a log dump | `python scripts/log_triage.py --file app.log` |
+
+## Procedure
+
+1. **Scope the incident.** Done when you can state the affected service, the
+   time window, and the user-visible symptom in one sentence.
+2. **Collect evidence.** Pull logs from the relevant surface (systemd/docker/
+   kubectl/cloud) plus a change timeline (deploys, config edits, dependency
+   bumps) for the same window. Done when you have raw log text and a change
+   timeline covering the incident window.
+3. **Run `log_triage.py`** on the collected logs to get severity counts, a
+   ranked list of error signatures, and spike detection. Done when you have
+   the ranked signature list in hand.
+4. **Correlate.** Check whether the top signature's onset lines up with an
+   entry in the change timeline. Done when you can name a leading hypothesis
+   or explicitly state that nothing correlates.
+5. **Verify the hypothesis** with a targeted check — reproduce it, read the
+   failing code path, or check a dependency's status page. Done when the
+   hypothesis is confirmed, refuted, or escalated with evidence either way.
+6. **Propose remediation**, splitting steps into **safe** (restart a crashed
+   pod, roll back a bad config, clear a full disk's temp files) and
+   **destructive** (force-delete data, drop a database, kill unrelated
+   processes). Destructive steps always require explicit user confirmation
+   before execution. Done when every step in the plan is labeled.
+7. **Execute approved steps one at a time**, re-checking the original symptom
+   after each. Done when the symptom is cleared and re-verified, or you
+   escalate because it isn't.
+8. **Document and close the loop.** Record root cause, timeline, and the fix
+   in a short incident summary. If this is a recurring failure class, propose
+   a `watchers` job or a `cronjob` health check to catch it earlier next
+   time. Done when the summary is written and any follow-up monitor is
+   proposed.
+
+## Common Pitfalls
+
+| Problem | Cause | Fix |
+|---|---|---|
+| Chasing every WARN line | Warn-level noise dominates volume | Filter to ERROR/CRITICAL first — `log_triage.py`'s counts show the split |
+| False "spike" from a restart burst | App logs a burst of startup errors on boot | Exclude the first N seconds after a known restart from the analysis window |
+| Auto-restarting in a crash loop | Remediation restarts blindly on every failure | Cap restart attempts; if it crashes again within minutes, stop and escalate |
+| Pasting raw logs with secrets into chat/tickets | Logs often carry tokens, connection strings, or PII | Redact example lines before sharing; don't forward raw log dumps verbatim |
+| Treating correlation as root cause | Deploy timing coincidence isn't causation | Confirm with a targeted reproduction or code read before declaring root cause |
+
+## Verification Checklist
+
+- [ ] Affected service, time window, and symptom stated in one sentence
+- [ ] Logs and a change timeline collected for the incident window
+- [ ] `log_triage.py` run and top error signatures reviewed
+- [ ] Hypothesis confirmed or refuted with concrete evidence
+- [ ] Remediation steps labeled safe/destructive; destructive steps confirmed with the user
+- [ ] Symptom re-checked after remediation and confirmed resolved
+- [ ] Root cause and fix documented; recurring-failure follow-up proposed if relevant

--- a/optional-skills/devops/aiops-agent/scripts/log_triage.py
+++ b/optional-skills/devops/aiops-agent/scripts/log_triage.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Summarize a log dump: severity counts, top error signatures, and spike detection.
+
+Stdlib only, no network calls. Reads a log file or stdin and prints a JSON
+summary suitable for incident triage:
+
+    {
+      "total_lines": int,
+      "counts": {"ERROR": int, "WARN": int, ...},
+      "top_signatures": [{"signature": str, "count": int, "level": str, "example": str}, ...],
+      "spike": {"detected": bool, "recent_rate": float, "baseline_rate": float, "ratio": float|None}
+    }
+
+Usage:
+    python log_triage.py --file app.log
+    cat app.log | python log_triage.py
+    python log_triage.py --selftest
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+LEVEL_KEYWORDS = [
+    ("CRITICAL", re.compile(r"\b(CRITICAL|FATAL|PANIC(?:KED)?)\b", re.IGNORECASE)),
+    ("ERROR", re.compile(r"\b(ERRORS?|ERR|EXCEPTIONS?|TRACEBACKS?|FAILED)\b", re.IGNORECASE)),
+    ("WARN", re.compile(r"\bWARN(?:ING)?S?\b", re.IGNORECASE)),
+    ("INFO", re.compile(r"\b(INFO|DEBUG)\b", re.IGNORECASE)),
+]
+
+# Timestamp patterns tried in order; first match wins.
+_TS_ISO = re.compile(
+    r"(?P<ts>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)"
+)
+_TS_SYSLOG = re.compile(r"(?P<ts>[A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})")
+TIMESTAMP_PATTERNS = [_TS_ISO, _TS_SYSLOG]
+
+# Tokens normalized away when building a "signature" so similar lines group together.
+_NORMALIZERS = [
+    (
+        re.compile(
+            r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+        ),
+        "<uuid>",
+    ),
+    (re.compile(r"\b0x[0-9a-fA-F]+\b"), "<hex>"),
+    (re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b"), "<ip>"),
+    (
+        re.compile(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?"),
+        "<ts>",
+    ),
+    (re.compile(r"\b\d+\b"), "<n>"),
+]
+
+_CRITICAL_WORDS = ("CRITICAL", "FATAL", "PANIC")
+
+
+def classify_level(line: str) -> str:
+    """Return the highest-severity level keyword found in a log line, or OTHER."""
+    for level, pattern in LEVEL_KEYWORDS:
+        if pattern.search(line):
+            return level
+    return "OTHER"
+
+
+def extract_timestamp(line: str):
+    for pattern in TIMESTAMP_PATTERNS:
+        m = pattern.search(line)
+        if m:
+            return m.group("ts")
+    return None
+
+
+def _parse_dt(ts: str, now_year: int):
+    """Best-effort parse of a matched timestamp string to a naive UTC datetime, or None."""
+    ts_norm = ts.replace("Z", "+00:00")
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z"):
+        try:
+            dt = datetime.strptime(ts_norm, fmt)
+            return dt.astimezone(timezone.utc).replace(tzinfo=None)
+        except ValueError:
+            continue
+    for fmt in (
+        "%Y-%m-%d %H:%M:%S.%f",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S.%f",
+        "%Y-%m-%dT%H:%M:%S",
+    ):
+        try:
+            return datetime.strptime(ts_norm, fmt)
+        except ValueError:
+            continue
+    try:
+        # syslog timestamps have no year — assume current year.
+        return datetime.strptime(f"{now_year} {ts}", "%Y %b %d %H:%M:%S")
+    except ValueError:
+        return None
+
+
+def fingerprint(line: str) -> str:
+    """Normalize volatile tokens (ids, ips, numbers, timestamps) so similar errors group together."""
+    sig = line.strip()
+    for pattern, placeholder in _NORMALIZERS:
+        sig = pattern.sub(placeholder, sig)
+    return sig[:200]
+
+
+def _detect_spike(timestamps, window_minutes: int) -> dict:
+    """Compare the error rate in the most recent window against the rest of the span."""
+    if len(timestamps) < 2:
+        return {"detected": False, "recent_rate": 0.0, "baseline_rate": 0.0, "ratio": 0.0}
+
+    timestamps = sorted(timestamps)
+    latest = timestamps[-1]
+    window = timedelta(minutes=window_minutes)
+    recent = [t for t in timestamps if t > latest - window]
+    baseline = [t for t in timestamps if t <= latest - window]
+
+    recent_rate = len(recent) / max(window_minutes, 1)
+    total_span_minutes = max((timestamps[-1] - timestamps[0]).total_seconds() / 60.0, 1e-9)
+    baseline_minutes = max(total_span_minutes - window_minutes, window_minutes)
+    baseline_rate = (len(baseline) / baseline_minutes) if baseline else 0.0
+
+    if baseline_rate > 0:
+        ratio = recent_rate / baseline_rate
+    else:
+        ratio = float("inf") if recent_rate > 0 else 0.0
+
+    detected = bool(baseline) and ratio >= 3.0 and recent_rate > 0
+    # No usable baseline (all errors fall in the recent window) — fall back to an
+    # absolute-count heuristic so a genuine burst of new errors still flags.
+    if not baseline and len(recent) >= 5:
+        detected = True
+
+    return {
+        "detected": detected,
+        "recent_rate": round(recent_rate, 3),
+        "baseline_rate": round(baseline_rate, 3),
+        "ratio": None if ratio == float("inf") else round(ratio, 3),
+    }
+
+
+def analyze(text: str, window_minutes: int = 5, top: int = 10) -> dict:
+    lines = [line for line in text.splitlines() if line.strip()]
+    counts = Counter()
+    signatures = Counter()
+    examples = {}
+    error_timestamps = []
+    now_year = datetime.now(timezone.utc).year
+
+    for line in lines:
+        level = classify_level(line)
+        counts[level] += 1
+        if level in ("ERROR", "CRITICAL"):
+            sig = fingerprint(line)
+            signatures[sig] += 1
+            examples.setdefault(sig, line.strip())
+            ts_raw = extract_timestamp(line)
+            if ts_raw:
+                dt = _parse_dt(ts_raw, now_year)
+                if dt:
+                    error_timestamps.append(dt)
+
+    top_signatures = [
+        {
+            "signature": sig,
+            "count": count,
+            "level": "CRITICAL"
+            if any(w in examples[sig].upper() for w in _CRITICAL_WORDS)
+            else "ERROR",
+            "example": examples[sig],
+        }
+        for sig, count in signatures.most_common(top)
+    ]
+
+    return {
+        "total_lines": len(lines),
+        "counts": dict(counts),
+        "top_signatures": top_signatures,
+        "spike": _detect_spike(error_timestamps, window_minutes),
+    }
+
+
+_SELFTEST_LOG = """\
+2026-07-08T10:00:00Z INFO service started
+2026-07-08T10:01:00Z INFO handled request 1 from 10.0.0.5
+2026-07-08T10:15:00Z WARNING disk usage at 80% on /data
+2026-07-08T10:30:00Z ERROR request 123 failed for user 45 at 10.0.0.5
+2026-07-08T10:31:00Z ERROR request 124 failed for user 46 at 10.0.0.6
+2026-07-08T10:31:05Z ERROR request 125 failed for user 47 at 10.0.0.7
+2026-07-08T10:31:10Z ERROR request 126 failed for user 48 at 10.0.0.8
+2026-07-08T10:31:20Z ERROR request 127 failed for user 49 at 10.0.0.9
+2026-07-08T10:31:30Z CRITICAL out of memory, restarting worker
+"""
+
+
+def _selftest() -> int:
+    result = analyze(_SELFTEST_LOG)
+    assert result["total_lines"] == 9
+    assert result["counts"].get("ERROR", 0) == 5
+    assert result["counts"].get("CRITICAL", 0) == 1
+    assert result["counts"].get("WARN", 0) == 1
+    assert result["top_signatures"], "expected at least one error signature"
+    assert result["top_signatures"][0]["count"] == 5
+    assert result["spike"]["detected"] is True
+    print(json.dumps({"selftest": "ok"}))
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--file", help="Path to a log file. Reads stdin if omitted.")
+    parser.add_argument(
+        "--window-minutes", type=int, default=5, help="Recent window size for spike detection."
+    )
+    parser.add_argument(
+        "--top", type=int, default=10, help="Number of top error signatures to report."
+    )
+    parser.add_argument("--selftest", action="store_true", help="Run an internal self-test and exit.")
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        return _selftest()
+
+    if args.file:
+        with open(args.file, "r", encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    else:
+        text = sys.stdin.read()
+
+    result = analyze(text, window_minutes=args.window_minutes, top=args.top)
+    print(json.dumps(result, indent=2))
+
+    has_errors = result["counts"].get("ERROR", 0) or result["counts"].get("CRITICAL", 0)
+    return 1 if (has_errors or result["spike"]["detected"]) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_aiops_agent_skill.py
+++ b/tests/skills/test_aiops_agent_skill.py
@@ -1,0 +1,179 @@
+"""Tests for optional-skills/devops/aiops-agent/scripts/log_triage.py"""
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "devops"
+    / "aiops-agent"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import log_triage as lt
+
+
+class TestClassifyLevel:
+    def test_error_keyword(self):
+        assert lt.classify_level("2026-07-08T10:00:00Z ERROR request failed") == "ERROR"
+
+    def test_critical_keyword_outranks_error(self):
+        # A line mentioning both should be classified by the level-keyword search order.
+        assert lt.classify_level("CRITICAL: out of memory") == "CRITICAL"
+
+    def test_warn_keyword(self):
+        assert lt.classify_level("WARNING disk usage high") == "WARN"
+
+    def test_info_keyword(self):
+        assert lt.classify_level("INFO service started") == "INFO"
+
+    def test_no_keyword_is_other(self):
+        assert lt.classify_level("plain text with no level marker") == "OTHER"
+
+    def test_err_does_not_match_inside_error(self):
+        # "ERR" must not falsely match as a substring of "ERROR" via bad word boundaries.
+        assert lt.classify_level("a line about ERRORS in general") == "ERROR"
+
+    def test_plural_warnings_matches_warn(self):
+        assert lt.classify_level("multiple warnings detected during startup") == "WARN"
+
+    def test_plural_exceptions_matches_error(self):
+        assert lt.classify_level("3 unhandled exceptions found") == "ERROR"
+
+
+class TestFingerprint:
+    def test_numbers_normalized(self):
+        a = lt.fingerprint("request 123 failed for user 45")
+        b = lt.fingerprint("request 999 failed for user 2")
+        assert a == b
+
+    def test_ip_normalized(self):
+        a = lt.fingerprint("connection from 10.0.0.5 refused")
+        b = lt.fingerprint("connection from 192.168.1.20 refused")
+        assert a == b
+
+    def test_uuid_normalized(self):
+        a = lt.fingerprint("job 550e8400-e29b-41d4-a716-446655440000 failed")
+        b = lt.fingerprint("job 123e4567-e89b-12d3-a456-426614174000 failed")
+        assert a == b
+
+    def test_timestamp_normalized(self):
+        a = lt.fingerprint("2026-07-08T10:00:00Z ERROR boom")
+        b = lt.fingerprint("2026-07-08T11:30:05Z ERROR boom")
+        assert a == b
+
+    def test_distinct_messages_stay_distinct(self):
+        a = lt.fingerprint("ERROR disk full")
+        b = lt.fingerprint("ERROR connection refused")
+        assert a != b
+
+
+class TestAnalyze:
+    LOG = "\n".join(
+        [
+            "2026-07-08T10:00:00Z INFO service started",
+            "2026-07-08T10:15:00Z WARNING disk usage at 80% on /data",
+            "2026-07-08T10:30:00Z ERROR request 123 failed for user 45 at 10.0.0.5",
+            "2026-07-08T10:30:10Z ERROR request 124 failed for user 46 at 10.0.0.6",
+        ]
+    )
+
+    def test_total_lines(self):
+        assert lt.analyze(self.LOG)["total_lines"] == 4
+
+    def test_counts(self):
+        counts = lt.analyze(self.LOG)["counts"]
+        assert counts["INFO"] == 1
+        assert counts["WARN"] == 1
+        assert counts["ERROR"] == 2
+
+    def test_top_signature_groups_similar_errors(self):
+        sigs = lt.analyze(self.LOG)["top_signatures"]
+        assert len(sigs) == 1
+        assert sigs[0]["count"] == 2
+
+    def test_blank_lines_ignored(self):
+        assert lt.analyze("\n\n  \n").get("total_lines") == 0
+
+    def test_signature_level_marked_critical(self):
+        log = "2026-07-08T10:00:00Z CRITICAL out of memory, restarting"
+        sigs = lt.analyze(log)["top_signatures"]
+        assert sigs[0]["level"] == "CRITICAL"
+
+
+class TestSpikeDetection:
+    def test_burst_of_recent_errors_detected(self):
+        result = lt.analyze(lt._SELFTEST_LOG)
+        assert result["spike"]["detected"] is True
+
+    def test_no_spike_with_too_few_errors(self):
+        log = "2026-07-08T10:00:00Z ERROR only one error here"
+        assert lt.analyze(log)["spike"]["detected"] is False
+
+    def test_steady_low_rate_no_spike(self):
+        lines = [
+            f"2026-07-08T10:{minute:02d}:00Z ERROR steady failure {minute}"
+            for minute in range(0, 60, 10)
+        ]
+        result = lt.analyze("\n".join(lines), window_minutes=5)
+        assert result["spike"]["detected"] is False
+
+    def test_no_timestamps_no_crash(self):
+        log = "ERROR something broke\nERROR something broke again"
+        result = lt.analyze(log)
+        assert result["spike"]["detected"] is False
+
+
+class TestSelftest:
+    def test_selftest_exits_zero(self):
+        assert lt.main(["--selftest"]) == 0
+
+    def test_selftest_prints_ok(self, capsys):
+        lt.main(["--selftest"])
+        out = json.loads(capsys.readouterr().out)
+        assert out == {"selftest": "ok"}
+
+
+class TestCli:
+    def test_stdin_with_errors_exits_one(self, capsys):
+        with mock.patch.object(sys.stdin, "read", return_value=TestAnalyze.LOG):
+            rc = lt.main([])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 1
+        assert out["counts"]["ERROR"] == 2
+
+    def test_stdin_clean_log_exits_zero(self, capsys):
+        clean = "2026-07-08T10:00:00Z INFO all good\n2026-07-08T10:01:00Z INFO still good"
+        with mock.patch.object(sys.stdin, "read", return_value=clean):
+            rc = lt.main([])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert out["counts"].get("ERROR", 0) == 0
+
+    def test_file_argument(self, tmp_path, capsys):
+        log_file = tmp_path / "app.log"
+        log_file.write_text(TestAnalyze.LOG, encoding="utf-8")
+        rc = lt.main(["--file", str(log_file)])
+        out = json.loads(capsys.readouterr().out)
+        assert rc == 1
+        assert out["total_lines"] == 4
+
+    def test_top_flag_limits_signatures(self, capsys):
+        # Distinct non-numeric words keep each line a separate signature after
+        # fingerprint() normalizes away the timestamp (numbers are normalized too).
+        words = ["alpha", "beta", "gamma", "delta", "epsilon"]
+        lines = [f"2026-07-08T10:00:00Z ERROR distinct failure {word}" for word in words]
+        with mock.patch.object(sys.stdin, "read", return_value="\n".join(lines)):
+            lt.main(["--top", "2"])
+        out = json.loads(capsys.readouterr().out)
+        assert len(out["top_signatures"]) <= 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Context

Your messages in this session were "ta boa a mensagem?" and "AIOps agent" — both very short, and I couldn't find any existing "message" in the repo/session to review (clean working tree, no open PR, no draft anywhere). Since you were unavailable to clarify, I made an autonomous call: treat "AIOps agent" as a request to add an AIOps capability to Hermes, scoped as a **skill** (lowest-footprint option per this repo's Footprint Ladder) rather than a new core tool or plugin.

**Please sanity-check this interpretation** — if you meant something else entirely, this PR is easy to close/redo.

## What this adds

`optional-skills/devops/aiops-agent/` — an on-demand incident-triage skill, following the conventions of the neighboring `watchers` and `docker-management` skills:

- **`SKILL.md`** — a triage runbook: scope → collect evidence → run the log summarizer → correlate against recent changes → verify hypothesis → propose remediation (safe steps vs. destructive steps, the latter requiring explicit user confirmation) → execute → document. Includes a quick-reference table of log commands across systemd/journalctl, Docker, kubectl, Windows Event Log, and macOS unified log.
- **`scripts/log_triage.py`** — stdlib-only (no deps, no network), so it runs anywhere Python 3 does:
  - Classifies log lines by severity (CRITICAL/ERROR/WARN/INFO)
  - Fingerprints errors by normalizing volatile tokens (UUIDs, IPs, timestamps, numbers) so repeated errors group together instead of each looking unique
  - Detects error-rate spikes (recent window vs. baseline)
  - CLI: `--file`/stdin input, JSON output, exit code reflects whether anomalies were found, `--selftest` for a quick smoke check
- **`tests/skills/test_aiops_agent_skill.py`** — 28 tests (classification, fingerprinting, spike detection, CLI behavior). Caught and fixed a real regex bug during testing: the severity classifier didn't recognize plural forms like "3 errors occurred" or "multiple warnings detected" due to overly strict word boundaries.

`related_skills` points to `watchers` (continuous polling/detection) and `docker-management` (container lifecycle) with "don't use for" notes in both directions to avoid overlap.

## Verification

- Frontmatter validated against `hermes-agent-skill-authoring` standards (description 56/60 chars, name/size limits, required fields) — all pass.
- `scripts/run_tests.sh tests/skills/test_aiops_agent_skill.py -q` → 28/28 passed.
- Ran `log_triage.py --selftest` standalone on native Windows Python too.

## Not done (flagging, not assuming)

- Didn't touch `website/docs/reference/optional-skills-catalog.md` (and its i18n copies) — that catalog didn't have an obvious generator script wired to CI in this checkout, and translations looked maintained separately.
- Didn't wire this into the docs site nav.

If this isn't the direction you wanted, no worries — happy to redo based on what you actually meant by "AIOps agent."