### PR TITLE
fix(agent): guard response.text access in _summarize_api_error against httpx.ResponseNotRead

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2143,7 +2143,10 @@ class AIAgent:
         # widens exposure vs the old empty-body "HTTP 400" string).
         response = getattr(error, "response", None)
         if response is not None:
-            snippet = (getattr(response, "text", None) or "").strip()
+            try:
+                snippet = (getattr(response, "text", None) or "").strip()
+            except Exception:
+                snippet = ""
             if snippet:
                 status_code = getattr(error, "status_code", None)
                 prefix = f"HTTP {status_code}: " if status_code else ""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -59,6 +59,7 @@ AUTHOR_MAP = {
     "m888.braun@hotmail.com": "ManniBr",  # PR #57417 partial salvage (gateway: fail-closed adapter resolution for unregistered secondary profiles)
     "austin@openvm067.space": "austinlaw076",  # PR #57563 partial salvage (auth: lazy per-profile Anthropic OAuth file; gateway: whatsapp_cloud/line added to port-binding platform set)
     "sunsky.lau@gmail.com": "liuhao1024",  # PR #56993 salvage (gateway: process-level HERMES_HOME for pid/lock/status identity files; #56986)
+    "gauravsaxena.jaipur@gmail.com": "gauravsaxena1997",  # PR #59868 partial salvage (agent: guard response.text against httpx.ResponseNotRead in _summarize_api_error; #59769)
     "blueirobin02@gmail.com": "irresi",  # PR #59048 salvage (gateway: scope reset banners' session info to the serving profile; #59003)
     "jashlee+microsoft@microsoft.com": "s905060",  # PR #57943 salvage (photon: auto-reinstall stale sidecar node_modules when lockfile is newer than npm's install marker; #59169)
     "lohinth25@proton.me": "l0h1nth",  # PR #32210 salvage (mattermost: accept leading-space slash commands from mobile clients; #25184)

--- a/tests/run_agent/test_summarize_api_error.py
+++ b/tests/run_agent/test_summarize_api_error.py
@@ -12,6 +12,10 @@ provider error. This is a diagnostic improvement and is platform-agnostic.
 
 from types import SimpleNamespace
 
+from typing import Any
+
+import httpx
+
 from run_agent import AIAgent
 
 
@@ -53,4 +57,26 @@ def test_empty_body_fallback_redacts_secrets(monkeypatch):
     )
     summary = AIAgent._summarize_api_error(err)
     assert "sk-proj-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdef" not in summary
+
+
+def test_unread_streaming_response_does_not_crash_and_falls_back_to_exception_message():
+    """Unread streaming responses must not replace the real provider error."""
+
+    class _StreamingError(Exception):
+        def __init__(self):
+            super().__init__("Gemini HTTP 429: quota exceeded")
+            self.status_code = 429
+            self.response: Any = None
+
+    err = _StreamingError()
+
+    class _UnreadStreamingResponse:
+        @property
+        def text(self):
+            raise httpx.ResponseNotRead()
+
+    err.response = _UnreadStreamingResponse()
+    summary = AIAgent._summarize_api_error(err)
+    assert "HTTP 429" in summary
+    assert "Gemini HTTP 429: quota exceeded" in summary
 

--- a/tests/run_agent/test_summarize_api_error.py
+++ b/tests/run_agent/test_summarize_api_error.py
@@ -11,7 +11,6 @@ provider error. This is a diagnostic improvement and is platform-agnostic.
 """
 
 from types import SimpleNamespace
-
 from typing import Any
 
 import httpx


### PR DESCRIPTION
## Summary
`_summarize_api_error()` no longer crashes with `httpx.ResponseNotRead` when the error carries a streaming `httpx.Response` whose body was consumed via `iter_bytes()` — the real provider error message (e.g. Gemini 429 free-tier quota guidance) now surfaces instead of the generic "Attempted to access streaming response content" message on every turn.

Root cause: `agent/gemini_native_adapter.py`'s streaming error path reads the error body via the bounded reader and raises `GeminiAPIError` with a fully-formed message, but does not set `.body` on the exception. `_summarize_api_error()` fell through to `response.text` on the same consumed/closed streaming response, which raises `httpx.ResponseNotRead`; the secondary exception replaced the original error.

## Changes
- `run_agent.py::_summarize_api_error()`: wrap the `response.text` access in try/except; on failure degrade to an empty snippet, falling through to the `str(error)` fallback (which carries the full original message). Mirrors the existing guards in `agent/error_classifier.py::_extract_error_body()` and `agent/gemini_native_adapter.py::gemini_http_error()`.
- `tests/run_agent/test_summarize_api_error.py`: regression test — a response whose `.text` raises `httpx.ResponseNotRead` must not crash the summarizer, and the real 429 message must survive into the summary. Fails on unfixed main.
- `scripts/release.py`: AUTHOR_MAP entry for @gauravsaxena1997.

## Validation
| | Before | After |
|---|---|---|
| Consumed streaming response (real httpx, body via `iter_bytes()`) | `httpx.ResponseNotRead` propagates, real error lost | `HTTP 429: Gemini HTTP 429 (RESOURCE_EXHAUSTED): ...` preserved |
| Readable response, empty SDK body (#36109 path) | works | unchanged (`HTTP 429: quota exceeded`) |
| Cloudflare HTML / body-dict branches | work | unchanged |
| `tests/run_agent/` + `tests/agent/test_error_classifier.py` | — | 2125 passed, 0 failed |

## Credit
Salvaged from #59868 by @gauravsaxena1997 (guard + regression test), cherry-picked with authorship preserved.

**What was NOT taken (and why):** #59868 also bundles an unrelated desktop Ctrl-C fix (`hermes_cli/main.py` `cmd_gui` KeyboardInterrupt handling + test). That change is out of scope for #59769 and was dropped from this salvage; it deserves its own PR/triage.

Four other PRs fix the same issue: #59774 (@liuhao1024, first submitted), #59791 and #60192 (@webtecnica), #59971 (@AlexFucuson9). This salvage uses #59868's version because it was the only one shipping a regression test; the guard code is functionally identical across all five. #60192 additionally carries a destructive stale-base hunk deleting an unrelated skill file.

Fixes #59769

Closes #59868
