### PR TITLE
fix(cli): re-detect auto-detected local model on model swap (#54454)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -15,8 +15,16 @@ loaded) so this module never imports ``cli`` at import time -> no import cycle.
 from __future__ import annotations
 
 import sys
+import time
 
 from rich.markup import escape as _escape
+
+
+# How long (seconds) to trust a previously auto-detected local model before
+# re-probing the server. Keeps the per-turn cost to at most one cheap
+# ``GET /v1/models`` every few seconds while still reflecting a mid-session
+# model swap (e.g. loading a different model in LM Studio). See #54454.
+LOCAL_MODEL_REDETECT_TTL_SECONDS = 3.0
 
 
 class CLIAgentSetupMixin:
@@ -163,13 +171,67 @@ class CLIAgentSetupMixin:
         # models when provider is openai-codex).  Fixes #651.
         model_changed = self._normalize_model_for_provider(resolved_provider)
 
+        # Re-detect the loaded model for an auto-detected local endpoint so a
+        # mid-session model swap (e.g. switching the loaded model in LM Studio)
+        # is reflected instead of continuing to report the model that was
+        # loaded when the session started.  Fixes #54454.
+        local_model_changed = self._maybe_refresh_local_model()
+
         # AIAgent/OpenAI client holds auth at init time, so rebuild if key,
         # routing, or the effective model changed.
-        if (credentials_changed or routing_changed or model_changed) and self.agent is not None:
+        if (
+            credentials_changed or routing_changed or model_changed or local_model_changed
+        ) and self.agent is not None:
             self.agent = None
             self._active_agent_route_signature = None
 
         return True
+
+    def _maybe_refresh_local_model(self) -> bool:
+        """Re-detect the loaded model for an auto-detected local endpoint.
+
+        Only acts when the model was auto-detected (never explicitly chosen by
+        the user) *and* the resolved endpoint is local — otherwise it is a
+        no-op.  A short TTL keeps the cost to at most one cheap
+        ``GET /v1/models`` every few seconds.  Returns ``True`` when the
+        detected model differs from the current one (so the caller can rebuild
+        the agent), ``False`` otherwise.  Never raises — detection failures
+        leave the current model untouched.
+
+        Fixes #54454 (LM Studio model swapped mid-session was not reflected).
+        """
+        # Respect an explicit user choice — only refresh the auto-detected case.
+        if not getattr(self, "_model_is_default", False):
+            return False
+
+        base_url = getattr(self, "base_url", "") or ""
+        if "localhost" not in base_url and "127.0.0.1" not in base_url:
+            return False
+
+        now = time.monotonic()
+        last_probe = getattr(self, "_local_model_last_probe", 0.0)
+        if last_probe and (now - last_probe) < LOCAL_MODEL_REDETECT_TTL_SECONDS:
+            return False
+        self._local_model_last_probe = now
+
+        try:
+            from hermes_cli.runtime_provider import _auto_detect_local_model
+            detected = _auto_detect_local_model(base_url)
+        except Exception:
+            return False
+
+        if detected and detected != self.model:
+            try:
+                from cli import logger
+                logger.info(
+                    "Local inference model changed on %s: %s -> %s",
+                    base_url, self.model or "(none)", detected,
+                )
+            except Exception:
+                pass
+            self.model = detected
+            return True
+        return False
 
     def _resolve_turn_agent_config(self, user_message: str) -> dict:
         """Build the effective model/runtime config for a single user turn.

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -200,6 +200,80 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.api_mode == "codex_responses"
 
 
+def test_local_model_redetect_rebuilds_agent_on_model_swap(monkeypatch):
+    """Auto-detected local model is re-detected each turn and rebuilds the
+    agent when the loaded model changes mid-session (#54454)."""
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openai",
+            "api_mode": "chat_completions",
+            "base_url": "http://localhost:1234/v1",
+            "api_key": "no-key-required",
+            "source": "config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+
+    detected = {"model": "gemma-4"}
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._auto_detect_local_model",
+        lambda base_url: detected["model"],
+    )
+
+    # No explicit model -> auto-detect path (_model_is_default is True).
+    shell = cli.HermesCLI(compact=True, max_turns=1)
+    assert shell._model_is_default is True
+
+    # First turn resolves the currently-loaded local model.
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.model == "gemma-4"
+
+    # User swaps the loaded model in LM Studio; an agent already exists.
+    shell.agent = object()
+    shell._local_model_last_probe = 0.0  # bypass the re-probe TTL for the test
+    detected["model"] = "qwen-3.6"
+
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.model == "qwen-3.6"
+    assert shell.agent is None  # rebuilt so the swapped model is used
+
+
+def test_local_model_redetect_left_alone_for_explicit_model(monkeypatch):
+    """An explicitly chosen model is never overridden by local re-detection."""
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openai",
+            "api_mode": "chat_completions",
+            "base_url": "http://localhost:1234/v1",
+            "api_key": "no-key-required",
+            "source": "config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+
+    probes = {"count": 0}
+
+    def _detect(base_url):
+        probes["count"] += 1
+        return "qwen-3.6"
+
+    monkeypatch.setattr("hermes_cli.runtime_provider._auto_detect_local_model", _detect)
+
+    # Explicit --model means _model_is_default is False.
+    shell = cli.HermesCLI(model="my-pinned-model", compact=True, max_turns=1)
+    assert shell._model_is_default is False
+
+    assert shell._ensure_runtime_credentials() is True
+    assert shell.model == "my-pinned-model"
+    assert probes["count"] == 0  # never probed for an explicit choice
+
+
 def test_cli_turn_routing_uses_primary_when_disabled(monkeypatch):
     cli = _import_cli()
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)

--- a/tests/hermes_cli/test_local_model_redetect.py
+++ b/tests/hermes_cli/test_local_model_redetect.py
@@ -1,0 +1,144 @@
+"""Unit tests for CLIAgentSetupMixin._maybe_refresh_local_model (#54454).
+
+An auto-detected local endpoint (e.g. LM Studio with no ``model.default``)
+should re-detect the loaded model each turn so a mid-session model swap is
+reflected — instead of forever reporting the model that was loaded when the
+session started.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from hermes_cli import cli_agent_setup_mixin as mod
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+class _Shell(CLIAgentSetupMixin):
+    """Minimal carrier for the mixin method — only the attributes it reads."""
+
+    def __init__(self, *, model="", base_url="", is_default=True):
+        self.model = model
+        self.base_url = base_url
+        self._model_is_default = is_default
+        self._local_model_last_probe = 0.0
+
+
+@pytest.fixture
+def patch_detect(monkeypatch):
+    """Patch _auto_detect_local_model and count calls."""
+    state = {"detected": "", "calls": 0}
+
+    def _fake(base_url):
+        state["calls"] += 1
+        return state["detected"]
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._auto_detect_local_model", _fake
+    )
+    return state
+
+
+def test_refreshes_when_local_and_auto_detected(patch_detect):
+    shell = _Shell(model="gemma-4", base_url="http://localhost:1234/v1")
+    patch_detect["detected"] = "qwen-3.6"
+
+    changed = shell._maybe_refresh_local_model()
+
+    assert changed is True
+    assert shell.model == "qwen-3.6"
+    assert patch_detect["calls"] == 1
+
+
+def test_no_change_when_same_model(patch_detect):
+    shell = _Shell(model="gemma-4", base_url="http://127.0.0.1:1234/v1")
+    patch_detect["detected"] = "gemma-4"
+
+    changed = shell._maybe_refresh_local_model()
+
+    assert changed is False
+    assert shell.model == "gemma-4"
+
+
+def test_skips_when_model_explicitly_chosen(patch_detect):
+    shell = _Shell(
+        model="gpt-5.3", base_url="http://localhost:1234/v1", is_default=False
+    )
+    patch_detect["detected"] = "qwen-3.6"
+
+    changed = shell._maybe_refresh_local_model()
+
+    assert changed is False
+    assert shell.model == "gpt-5.3"
+    assert patch_detect["calls"] == 0  # no probe for an explicit choice
+
+
+def test_skips_when_endpoint_is_not_local(patch_detect):
+    shell = _Shell(model="gemma-4", base_url="https://openrouter.ai/api/v1")
+    patch_detect["detected"] = "qwen-3.6"
+
+    changed = shell._maybe_refresh_local_model()
+
+    assert changed is False
+    assert shell.model == "gemma-4"
+    assert patch_detect["calls"] == 0  # no probe for a remote endpoint
+
+
+def test_ttl_skips_reprobe_within_window(patch_detect):
+    shell = _Shell(model="gemma-4", base_url="http://localhost:1234/v1")
+    patch_detect["detected"] = "qwen-3.6"
+
+    # A very recent probe means the next call is inside the TTL window.
+    shell._local_model_last_probe = time.monotonic()
+
+    changed = shell._maybe_refresh_local_model()
+
+    assert changed is False
+    assert shell.model == "gemma-4"
+    assert patch_detect["calls"] == 0
+
+
+def test_reprobe_after_ttl_expires(patch_detect, monkeypatch):
+    shell = _Shell(model="gemma-4", base_url="http://localhost:1234/v1")
+    patch_detect["detected"] = "qwen-3.6"
+
+    base = time.monotonic()
+    shell._local_model_last_probe = base
+    # Advance the clock past the TTL.
+    monkeypatch.setattr(
+        mod.time, "monotonic", lambda: base + mod.LOCAL_MODEL_REDETECT_TTL_SECONDS + 1
+    )
+
+    changed = shell._maybe_refresh_local_model()
+
+    assert changed is True
+    assert shell.model == "qwen-3.6"
+    assert patch_detect["calls"] == 1
+
+
+def test_detection_failure_is_safe(monkeypatch):
+    shell = _Shell(model="gemma-4", base_url="http://localhost:1234/v1")
+
+    def _boom(base_url):
+        raise RuntimeError("server down")
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider._auto_detect_local_model", _boom
+    )
+
+    changed = shell._maybe_refresh_local_model()
+
+    assert changed is False
+    assert shell.model == "gemma-4"  # unchanged, no exception
+
+
+def test_empty_detection_leaves_model_untouched(patch_detect):
+    shell = _Shell(model="gemma-4", base_url="http://localhost:1234/v1")
+    patch_detect["detected"] = ""  # server returned 0 or >1 models
+
+    changed = shell._maybe_refresh_local_model()
+
+    assert changed is False
+    assert shell.model == "gemma-4"


### PR DESCRIPTION
## What does this PR do?

Fixes #54454 — with a local, auto-detected model (e.g. LM Studio / llama.cpp
and no `model.default` configured), swapping the loaded model **mid-session**
was not reflected: Hermes kept reporting (and sending) the model that was
loaded when the session started. Starting a new session was the only
workaround.

**Root cause:** the local model name is auto-detected once, in
`HermesCLI.__init__`, via `GET /v1/models` and stored on the session. Nothing
re-detects it afterward, so a model swap in LM Studio leaves the session
pointing at the old model.

**Fix:** re-detect the local model at the start of each turn inside
`_ensure_runtime_credentials` (which already runs every turn to pick up
credential/routing changes), and fold the result into the **existing**
agent-rebuild trigger so a changed model transparently rebuilds the agent with
the new name.

The refresh is tightly guarded so it can't disturb anything else:

- **only when auto-detected** (`_model_is_default`) — an explicit `--model` or
  `model.default` is never overridden;
- **only for local endpoints** (`localhost` / `127.0.0.1`);
- **rate-limited by a short TTL** (`LOCAL_MODEL_REDETECT_TTL_SECONDS = 3s`), so
  the per-turn cost is at most one cheap `GET /v1/models` every few seconds;
- **fail-safe** — any detection error leaves the current model untouched.

## Related Issue

Fixes #54454

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cli_agent_setup_mixin.py`
  - add `_maybe_refresh_local_model()` (guarded, TTL-rate-limited, fail-safe);
  - call it in `_ensure_runtime_credentials` and include its result in the
    existing `credentials_changed / routing_changed / model_changed` rebuild
    condition;
  - add `LOCAL_MODEL_REDETECT_TTL_SECONDS`.
- `tests/hermes_cli/test_local_model_redetect.py` — 8 isolated unit tests for
  the new method (local/remote, auto/explicit, same-model, TTL window, TTL
  expiry, detection failure, empty detection).
- `tests/cli/test_cli_provider_resolution.py` — 2 end-to-end tests through
  `_ensure_runtime_credentials`: agent rebuilds on a model swap; explicit model
  is never probed/overridden.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_local_model_redetect.py tests/cli/test_cli_provider_resolution.py -q` → all pass.
2. Manual repro (matches the issue): start LM Studio serving model A with no
   `model.default`; `hermes chat`; ask which model → reports A. Switch LM Studio
   to model B; ask again → now reports B (previously stayed A until a new
   session).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (no PR referenced #54454)
- [x] My PR contains **only** changes related to this fix
- [x] Affected test modules pass — `test_local_model_redetect.py` (8) + `test_cli_provider_resolution.py` (33 total incl. new). Adjacent suites (`test_runtime_provider_resolution.py`, `test_cli_active_agent_ref_wiring.py`, 140) also pass. The full 17k-test suite wasn't run locally.
- [x] I've added tests (8 unit + 2 integration)
- [x] I've tested on my platform: Ubuntu (WSL2)

### Documentation & Housekeeping

- [x] Behavior is documented in docstrings/comments; no user-facing docs affected — N/A
- [x] No config keys changed (TTL is an internal constant) — N/A for `cli-config.yaml.example`
- [x] No architecture/workflow change — N/A for `CONTRIBUTING.md`/`AGENTS.md`
- [x] No tool schema/description change — N/A
