### PR TITLE
Recover missing llmwiki_hermes package for wiki memory provider

### DIFF
--- a/llmwiki_hermes/LICENSE
+++ b/llmwiki_hermes/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/llmwiki_hermes/__init__.py
+++ b/llmwiki_hermes/__init__.py
@@ -1,0 +1,5 @@
+"""LLM-Wiki on Hermes."""
+
+__all__ = ["__version__"]
+
+__version__ = "1.0.0"

--- a/llmwiki_hermes/cli.py
+++ b/llmwiki_hermes/cli.py
@@ -1,0 +1,13 @@
+"""Standalone CLI entrypoint."""
+
+from llmwiki_hermes.provider.cli import app
+
+
+def main() -> None:
+    """Run the wiki CLI."""
+
+    app(prog_name="llmwiki-hermes")
+
+
+if __name__ == "__main__":
+    main()

--- a/llmwiki_hermes/compiler/__init__.py
+++ b/llmwiki_hermes/compiler/__init__.py
@@ -1,0 +1,5 @@
+"""Compile source material into notes."""
+
+from llmwiki_hermes.compiler.service import CompilerService
+
+__all__ = ["CompilerService"]

--- a/llmwiki_hermes/compiler/classify.py
+++ b/llmwiki_hermes/compiler/classify.py
@@ -1,0 +1,63 @@
+"""Deterministic classification heuristics."""
+
+from __future__ import annotations
+
+import re
+
+SEMANTIC_HINTS = (
+    "definition",
+    "stable facts",
+    "principle",
+    "rule",
+    "concept",
+    "是什么",
+    "定义",
+)
+
+EPISODIC_HINTS = (
+    "meeting",
+    "kickoff",
+    "decision",
+    "project",
+    "transcript",
+    "讨论",
+    "会议",
+    "项目",
+)
+
+SEMANTIC_SECONDARY_HINTS = ("decision", "scope", "principle", "rule", "决定", "范围", "原则")
+
+DATE_PATTERN = re.compile(r"\b\d{4}[-/]\d{1,2}[-/]\d{1,2}\b")
+
+
+def classify_text(content: str, source_type: str | None = None) -> dict[str, bool]:
+    """Classify content as semantic, episodic, or both."""
+
+    lowered = content.lower()
+    semantic = any(token in lowered for token in SEMANTIC_HINTS)
+    episodic = any(token in lowered for token in EPISODIC_HINTS) or bool(
+        DATE_PATTERN.search(content)
+    )
+    if not semantic and any(token in lowered for token in SEMANTIC_SECONDARY_HINTS):
+        semantic = True
+
+    if source_type:
+        lowered_type = source_type.lower()
+        if lowered_type in {"meeting", "transcript", "chat", "project"}:
+            episodic = True
+        if lowered_type in {"concept", "note", "research"}:
+            semantic = True
+
+    if not semantic and not episodic:
+        semantic = True
+
+    return {"semantic": semantic, "episodic": episodic}
+
+
+def detect_date(content: str) -> str | None:
+    """Extract an ISO-like date from text when present."""
+
+    match = DATE_PATTERN.search(content)
+    if not match:
+        return None
+    return match.group(0).replace("/", "-")

--- a/llmwiki_hermes/compiler/episodic.py
+++ b/llmwiki_hermes/compiler/episodic.py
@@ -1,0 +1,283 @@
+"""Episodic note synthesis."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date
+from pathlib import Path
+
+from llmwiki_hermes.compiler.classify import detect_date
+from llmwiki_hermes.compiler.sections import (
+    merge_line_blocks,
+    normalize_heading,
+    parse_markdown_sections,
+    render_markdown_note,
+    section_content,
+)
+from llmwiki_hermes.constants import CURRENT_SCHEMA_VERSION
+from llmwiki_hermes.schemas.notes import (
+    EpisodicNoteFrontmatter,
+    SourceNoteFrontmatter,
+    is_unsupported_schema,
+)
+from llmwiki_hermes.storage.frontmatter import load_note, write_note
+from llmwiki_hermes.storage.vault import VaultService
+from llmwiki_hermes.templates import render_template
+from llmwiki_hermes.utils.slug import build_note_id, slugify
+from llmwiki_hermes.utils.time import today_utc
+
+logger = logging.getLogger(__name__)
+
+PROJECT_PATTERN = re.compile(r"\bproject\s+([a-z0-9][a-z0-9_-]*)\b", re.IGNORECASE)
+EPISODIC_SECTION_ORDER = (
+    "What Happened",
+    "Decisions",
+    "Open Questions",
+    "Derived Semantic Updates",
+)
+
+
+def _bulletize(text: str, fallback: str) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    bullets = [line for line in lines if line.startswith(("-", "*"))]
+    if bullets:
+        return "\n".join(bullets[:5])
+    if lines:
+        return "\n".join(f"- {line.lstrip('-* ').strip()}" for line in lines[:5])
+    return f"- {fallback}"
+
+
+def extract_section_lines(
+    content: str,
+    section_headers: tuple[str, ...],
+    markers: tuple[str, ...],
+    fallback: str,
+) -> str:
+    """Extract bullets from explicit sections, then marker matches, then fallback."""
+
+    explicit = section_content(content, *section_headers)
+    if explicit:
+        return _bulletize(explicit, fallback=fallback)
+
+    picked = [
+        line.strip()
+        for line in content.splitlines()
+        if any(marker in line.lower() for marker in markers)
+    ]
+    if picked:
+        return "\n".join(f"- {line.lstrip('-* ').strip()}" for line in picked[:5])
+    return f"- {fallback}"
+
+
+def extract_project(title: str, content: str) -> str | None:
+    """Extract a stable project key when one is explicitly present."""
+
+    for candidate in (title, content):
+        match = PROJECT_PATTERN.search(candidate)
+        if match:
+            return slugify(match.group(1))
+    return None
+
+
+def build_episodic_title_key(title: str) -> str:
+    """Normalize an episodic title for strong-match dedupe."""
+
+    return slugify(title.replace("_", "-"))
+
+
+def render_episodic_note(
+    title: str,
+    content: str,
+    source_note: SourceNoteFrontmatter,
+) -> tuple[EpisodicNoteFrontmatter, str, str]:
+    """Create episodic note frontmatter and body."""
+
+    parsed_date = detect_date(content)
+    event_date = date.fromisoformat(parsed_date) if parsed_date else today_utc()
+    note_id = build_note_id("epi", title, event_date.isoformat())
+    fallback_line = (
+        content.splitlines()[0].strip() if content.splitlines() else "No summary extracted."
+    )
+    project = extract_project(title, content)
+    frontmatter = EpisodicNoteFrontmatter(
+        schema_version=CURRENT_SCHEMA_VERSION,
+        id=note_id,
+        title=title,
+        date=event_date,
+        participants=[],
+        project=project,
+        source_refs=[source_note.id],
+        entity_refs=[],
+        tags=["meeting", "project"] if project else ["event"],
+    )
+    body = render_template(
+        "episodic_note.md.j2",
+        {
+            "title": title,
+            "what_happened": extract_section_lines(
+                content,
+                section_headers=("What Happened",),
+                markers=("happened", "discuss", "讨论", "meeting", "project"),
+                fallback=fallback_line,
+            ),
+            "decisions": extract_section_lines(
+                content,
+                section_headers=("Decisions",),
+                markers=("decision", "decide", "决定", "scope", "先做"),
+                fallback="No explicit decisions extracted.",
+            ),
+            "open_questions": extract_section_lines(
+                content,
+                section_headers=("Open Questions",),
+                markers=("question", "todo", "unknown", "待定", "open"),
+                fallback="No open questions extracted.",
+            ),
+            "derived_semantic_updates": extract_section_lines(
+                content,
+                section_headers=("Derived Semantic Updates",),
+                markers=("semantic", "concept", "derived"),
+                fallback="No derived semantic updates extracted.",
+            ),
+        },
+    )
+    filename = f"{slugify(note_id.replace('_', '-'))}.md"
+    return frontmatter, body, filename
+
+
+def _resolve_existing_episodic_path(
+    vault_service: VaultService,
+    new_frontmatter: EpisodicNoteFrontmatter,
+) -> Path | None:
+    matches: list[Path] = []
+    for path in sorted(vault_service.episodic_dir.glob("*.md")):
+        try:
+            document = load_note(path)
+            frontmatter = EpisodicNoteFrontmatter.model_validate(document.frontmatter)
+        except Exception:
+            continue
+        if frontmatter.date != new_frontmatter.date:
+            continue
+        if build_episodic_title_key(frontmatter.title) != build_episodic_title_key(
+            new_frontmatter.title
+        ):
+            continue
+        same_project = bool(
+            frontmatter.project
+            and new_frontmatter.project
+            and slugify(frontmatter.project) == slugify(new_frontmatter.project)
+        )
+        shared_source = bool(set(frontmatter.source_refs) & set(new_frontmatter.source_refs))
+        if same_project or shared_source:
+            matches.append(path)
+    return matches[0] if len(matches) == 1 else None
+
+
+def _merge_episodic_body(existing_body: str, new_body: str, title: str) -> str:
+    existing = parse_markdown_sections(existing_body)
+    incoming = parse_markdown_sections(new_body)
+
+    existing_sections = {header: content for header, content in existing.sections}
+    incoming_sections = {header: content for header, content in incoming.sections}
+    managed = [
+        (
+            "What Happened",
+            merge_line_blocks(
+                existing_sections.get("What Happened", ""),
+                incoming_sections.get("What Happened", ""),
+            ),
+        ),
+        (
+            "Decisions",
+            merge_line_blocks(
+                existing_sections.get("Decisions", ""),
+                incoming_sections.get("Decisions", ""),
+            ),
+        ),
+        (
+            "Open Questions",
+            merge_line_blocks(
+                existing_sections.get("Open Questions", ""),
+                incoming_sections.get("Open Questions", ""),
+            ),
+        ),
+        (
+            "Derived Semantic Updates",
+            merge_line_blocks(
+                existing_sections.get("Derived Semantic Updates", ""),
+                incoming_sections.get("Derived Semantic Updates", ""),
+            ),
+        ),
+    ]
+    extra_sections = [
+        (header, content)
+        for header, content in existing.sections
+        if normalize_heading(header)
+        not in {normalize_heading(item) for item in EPISODIC_SECTION_ORDER}
+    ]
+    return render_markdown_note(title, existing.lead_lines, managed, extra_sections)
+
+
+def _disambiguate_episodic_identity(
+    frontmatter: EpisodicNoteFrontmatter,
+    source_note: SourceNoteFrontmatter,
+) -> tuple[EpisodicNoteFrontmatter, str]:
+    note_id = build_note_id(
+        "epi",
+        frontmatter.title,
+        f"{frontmatter.date.isoformat()}-{source_note.id}",
+    )
+    updated = frontmatter.model_copy(update={"id": note_id})
+    filename = f"{slugify(note_id.replace('_', '-'))}.md"
+    return updated, filename
+
+
+def create_or_append_episodic_note(
+    vault_service: VaultService,
+    title: str,
+    content: str,
+    source_note: SourceNoteFrontmatter,
+    dry_run: bool = False,
+) -> str | None:
+    """Create or append to an episodic note."""
+
+    frontmatter, body, filename = render_episodic_note(title, content, source_note)
+    existing_path = _resolve_existing_episodic_path(vault_service, frontmatter)
+    path = existing_path or (vault_service.episodic_dir / filename)
+    if existing_path is None and path.exists():
+        frontmatter, filename = _disambiguate_episodic_identity(frontmatter, source_note)
+        path = vault_service.episodic_dir / filename
+    if path.exists():
+        existing = load_note(path)
+        if is_unsupported_schema(existing.frontmatter):
+            logger.warning(
+                (
+                    "Skipping episodic auto-append for %s because %s uses "
+                    "unsupported schema_version %s."
+                ),
+                title,
+                path,
+                existing.frontmatter.get("schema_version"),
+            )
+            return None
+        existing_frontmatter = EpisodicNoteFrontmatter.model_validate(existing.frontmatter)
+        merged_frontmatter = EpisodicNoteFrontmatter.model_validate(
+            {
+                **existing.frontmatter,
+                "schema_version": CURRENT_SCHEMA_VERSION,
+                "project": existing_frontmatter.project or frontmatter.project,
+                "source_refs": sorted(set(existing_frontmatter.source_refs) | {source_note.id}),
+                "participants": sorted(
+                    set(existing_frontmatter.participants) | set(frontmatter.participants)
+                ),
+                "entity_refs": sorted(
+                    set(existing_frontmatter.entity_refs) | set(frontmatter.entity_refs)
+                ),
+                "tags": sorted(set(existing_frontmatter.tags) | set(frontmatter.tags)),
+            }
+        )
+        frontmatter = merged_frontmatter
+        body = _merge_episodic_body(existing.body, body, existing_frontmatter.title)
+    if not dry_run:
+        write_note(path, frontmatter.model_dump(mode="json"), body)
+    return str(path)

--- a/llmwiki_hermes/compiler/ingest.py
+++ b/llmwiki_hermes/compiler/ingest.py
@@ -1,0 +1,81 @@
+"""Ingest pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llmwiki_hermes.compiler.service import CompilerService, normalize_text
+from llmwiki_hermes.schemas.cli import CommandOutput
+from llmwiki_hermes.settings import WikiSettings
+from llmwiki_hermes.storage.ingest_inputs import IngestInputLoader, flatten_json_text
+from llmwiki_hermes.storage.sqlite_index import IndexService
+from llmwiki_hermes.storage.vault import VaultService
+
+__all__ = ["IngestService", "normalize_text", "flatten_json_text"]
+
+
+class IngestService:
+    """Compile raw source material into notes and index entries."""
+
+    def __init__(self, settings: WikiSettings) -> None:
+        self.settings = settings
+        self.vault_service = VaultService(settings.vault_path)
+        self.index_service = IndexService(self.vault_service)
+        self.compiler_service = CompilerService(self.vault_service, self.index_service)
+        self.input_loader = IngestInputLoader()
+
+    @classmethod
+    def from_settings(cls, settings: WikiSettings) -> "IngestService":
+        return cls(settings)
+
+    def ingest(
+        self,
+        path: Path | None,
+        stdin: bool,
+        recursive: bool,
+        tags: list[str],
+        source_type: str | None,
+        dry_run: bool,
+    ) -> CommandOutput:
+        """Ingest a file, directory, or STDIN payload."""
+
+        self.vault_service.ensure_initialized()
+        inputs = self.input_loader.resolve(path=path, stdin=stdin, recursive=recursive)
+        created: list[str] = []
+        for loaded_input in inputs.loaded_inputs:
+            effective_source_type = source_type or loaded_input.detected_source_type
+            created.extend(
+                self.compiler_service.ingest_input(
+                    input_path=loaded_input.path,
+                    raw_content=loaded_input.raw_content,
+                    source_type=effective_source_type,
+                    tags=tags,
+                    dry_run=dry_run,
+                )
+            )
+        if not dry_run and inputs.loaded_inputs:
+            self.compiler_service.reindex()
+        failed_inputs = [failure.as_dict() for failure in inputs.failed_inputs]
+        processed_inputs = inputs.processed_inputs
+        successful_inputs = len(inputs.loaded_inputs)
+        failed_count = len(failed_inputs)
+        if failed_count == 0:
+            message = f"Ingested {successful_inputs} input(s)."
+        elif successful_inputs > 0:
+            message = (
+                f"Ingested {successful_inputs} of {processed_inputs} input(s); "
+                f"{failed_count} failed."
+            )
+        else:
+            message = f"Failed to ingest {processed_inputs} input(s)."
+        return CommandOutput(
+            ok=successful_inputs > 0 or processed_inputs == 0,
+            message=message,
+            data={
+                "created_or_updated": created,
+                "dry_run": dry_run,
+                "processed_inputs": processed_inputs,
+                "successful_inputs": successful_inputs,
+                "failed_inputs": failed_inputs,
+            },
+        )

--- a/llmwiki_hermes/compiler/sections.py
+++ b/llmwiki_hermes/compiler/sections.py
@@ -1,0 +1,132 @@
+"""Markdown section parsing and merge helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ParsedMarkdownNote:
+    """Structured view of a note body."""
+
+    title: str
+    lead_lines: list[str]
+    sections: list[tuple[str, str]]
+
+
+def normalize_heading(value: str) -> str:
+    """Normalize a section heading for deterministic lookup."""
+
+    return " ".join(value.strip().lower().split())
+
+
+def parse_markdown_sections(body: str) -> ParsedMarkdownNote:
+    """Parse a Markdown note into title, lead-in lines, and H2 sections."""
+
+    lines = body.rstrip().splitlines()
+    title = ""
+    start = 0
+    if lines and lines[0].startswith("# "):
+        title = lines[0][2:].strip()
+        start = 1
+
+    lead_lines: list[str] = []
+    sections: list[tuple[str, str]] = []
+    current_header: str | None = None
+    current_lines: list[str] = []
+
+    def flush_current() -> None:
+        nonlocal current_header, current_lines
+        if current_header is None:
+            return
+        sections.append((current_header, "\n".join(current_lines).strip()))
+        current_header = None
+        current_lines = []
+
+    for line in lines[start:]:
+        if line.startswith("## "):
+            flush_current()
+            current_header = line[3:].strip()
+            current_lines = []
+            continue
+        if current_header is None:
+            lead_lines.append(line.rstrip())
+        else:
+            current_lines.append(line.rstrip())
+
+    flush_current()
+    return ParsedMarkdownNote(title=title, lead_lines=lead_lines, sections=sections)
+
+
+def section_content(body: str, *headings: str) -> str:
+    """Return the first matching H2 section content."""
+
+    parsed = parse_markdown_sections(body)
+    wanted = {normalize_heading(item) for item in headings}
+    for header, content in parsed.sections:
+        if normalize_heading(header) in wanted:
+            return content.strip()
+    return ""
+
+
+def merge_line_blocks(existing: str, new: str) -> str:
+    """Merge two line-oriented blocks while preserving order."""
+
+    merged: list[str] = []
+    seen: set[str] = set()
+    for raw in (*existing.splitlines(), *new.splitlines()):
+        line = raw.rstrip()
+        if not line.strip():
+            continue
+        if line in seen:
+            continue
+        seen.add(line)
+        merged.append(line)
+    return "\n".join(merged)
+
+
+def merge_paragraph_blocks(existing: str, new: str) -> str:
+    """Merge paragraph blocks while preserving order."""
+
+    def collect(text: str) -> list[str]:
+        blocks: list[str] = []
+        current: list[str] = []
+        for line in text.splitlines():
+            if line.strip():
+                current.append(line.rstrip())
+                continue
+            if current:
+                blocks.append("\n".join(current).strip())
+                current = []
+        if current:
+            blocks.append("\n".join(current).strip())
+        return blocks
+
+    merged: list[str] = []
+    seen: set[str] = set()
+    for block in (*collect(existing), *collect(new)):
+        if not block or block in seen:
+            continue
+        seen.add(block)
+        merged.append(block)
+    return "\n\n".join(merged)
+
+
+def render_markdown_note(
+    title: str,
+    lead_lines: list[str],
+    ordered_sections: list[tuple[str, str]],
+    extra_sections: list[tuple[str, str]],
+) -> str:
+    """Render a note body from ordered managed sections and preserved extra sections."""
+
+    lines: list[str] = [f"# {title}", ""]
+    if any(line.strip() for line in lead_lines):
+        lines.extend(lead_lines)
+        lines.append("")
+    for header, content in [*ordered_sections, *extra_sections]:
+        lines.append(f"## {header}")
+        if content.strip():
+            lines.extend(content.rstrip().splitlines())
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/llmwiki_hermes/compiler/semantic.py
+++ b/llmwiki_hermes/compiler/semantic.py
@@ -1,0 +1,516 @@
+"""Semantic note synthesis and maintenance."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from llmwiki_hermes.compiler.sections import (
+    merge_line_blocks,
+    merge_paragraph_blocks,
+    normalize_heading,
+    parse_markdown_sections,
+    render_markdown_note,
+    section_content,
+)
+from llmwiki_hermes.constants import CURRENT_SCHEMA_VERSION
+from llmwiki_hermes.schemas.cli import CommandOutput
+from llmwiki_hermes.schemas.notes import (
+    EpisodicNoteFrontmatter,
+    SemanticNoteFrontmatter,
+    SourceNoteFrontmatter,
+    is_unsupported_schema,
+    validate_note_frontmatter,
+)
+from llmwiki_hermes.settings import WikiSettings
+from llmwiki_hermes.storage.frontmatter import load_note, write_note
+from llmwiki_hermes.storage.vault import VaultService
+from llmwiki_hermes.templates import render_template
+from llmwiki_hermes.utils.slug import build_note_id, slugify
+from llmwiki_hermes.utils.time import today_utc
+
+logger = logging.getLogger(__name__)
+
+SEMANTIC_SECTION_ORDER = ("Definition", "Stable Facts", "Relations", "Source Notes")
+EPISODIC_SECTION_ORDER = (
+    "What Happened",
+    "Decisions",
+    "Open Questions",
+    "Derived Semantic Updates",
+)
+
+
+def _bulletize(text: str, fallback: str) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    bullets = [line for line in lines if line.startswith(("-", "*"))]
+    if bullets:
+        return "\n".join(bullets[:5])
+    if lines:
+        return "\n".join(f"- {line.lstrip('-* ').strip()}" for line in lines[:5])
+    return f"- {fallback}"
+
+
+def extract_definition(content: str) -> str:
+    """Pick a short definition paragraph."""
+
+    explicit = section_content(content, "Definition")
+    if explicit:
+        return explicit.strip()
+    lines = [line.strip() for line in content.splitlines() if line.strip()]
+    if not lines:
+        return "No definition extracted yet."
+    first = lines[0].lstrip("#").strip()
+    return first if len(first) <= 240 else f"{first[:237]}..."
+
+
+def extract_bullets(content: str) -> str:
+    """Promote explicit stable facts or synthesize fallback bullets."""
+
+    explicit = section_content(content, "Stable Facts")
+    if explicit:
+        return _bulletize(explicit, fallback="No stable facts extracted yet.")
+    definition = extract_definition(content)
+    return _bulletize(content, fallback=definition)
+
+
+def extract_relations(content: str) -> str:
+    """Extract relation lines from explicit sections or fallback heuristics."""
+
+    explicit = section_content(content, "Relations")
+    if explicit:
+        return _bulletize(explicit, fallback="related_to: source-derived")
+    lines = [
+        line.strip()
+        for line in content.splitlines()
+        if "related_to" in line.lower() or "contrasted_with" in line.lower()
+    ]
+    if lines:
+        return _bulletize("\n".join(lines), fallback="related_to: source-derived")
+    return "- related_to: source-derived"
+
+
+def render_semantic_note(
+    title: str,
+    content: str,
+    source_note: SourceNoteFrontmatter,
+    existing_path: Path | None = None,
+) -> tuple[SemanticNoteFrontmatter, str, str]:
+    """Create or update a semantic note."""
+
+    note_id = build_note_id("sem", title)
+    frontmatter = SemanticNoteFrontmatter(
+        schema_version=CURRENT_SCHEMA_VERSION,
+        id=note_id,
+        title=title,
+        aliases=[],
+        entity_refs=[],
+        source_refs=[source_note.id],
+        updated_at=today_utc(),
+        confidence="medium",
+        tags=["concept"],
+    )
+    body = render_template(
+        "semantic_note.md.j2",
+        {
+            "title": title,
+            "definition": extract_definition(content),
+            "stable_facts": extract_bullets(content),
+            "relations": extract_relations(content),
+            "source_notes": f"- [[{source_note.id}]]",
+        },
+    )
+    filename = (
+        existing_path.name
+        if existing_path is not None
+        else f"{slugify(note_id.replace('_', '-'))}.md"
+    )
+    return frontmatter, body, filename
+
+
+def _semantic_identity_key(value: str) -> str:
+    return slugify(value.replace("_", "-"))
+
+
+def _semantic_identity_tokens(note: dict[str, Any]) -> set[str]:
+    tokens = {_semantic_identity_key(note["title"])}
+    tokens.update(_semantic_identity_key(alias) for alias in note.get("aliases", []) if alias)
+    return {token for token in tokens if token}
+
+
+def _resolve_existing_semantic_path(vault_service: VaultService, title: str) -> Path | None:
+    target_id = build_note_id("sem", title)
+    target_key = _semantic_identity_key(title)
+    id_matches: list[Path] = []
+    title_matches: list[Path] = []
+    alias_matches: list[Path] = []
+
+    for path in sorted(vault_service.semantic_dir.glob("*.md")):
+        try:
+            document = load_note(path)
+            frontmatter = validate_note_frontmatter(document.frontmatter)
+        except Exception:
+            continue
+        if not isinstance(frontmatter, SemanticNoteFrontmatter):
+            continue
+        if frontmatter.id == target_id:
+            id_matches.append(path)
+            continue
+        if _semantic_identity_key(frontmatter.title) == target_key:
+            title_matches.append(path)
+            continue
+        alias_keys = {_semantic_identity_key(alias) for alias in frontmatter.aliases}
+        if target_key in alias_keys:
+            alias_matches.append(path)
+
+    for matches in (id_matches, title_matches, alias_matches):
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            return None
+    return None
+
+
+def _merge_semantic_body(existing_body: str, new_body: str, title: str) -> str:
+    existing = parse_markdown_sections(existing_body)
+    incoming = parse_markdown_sections(new_body)
+
+    existing_sections = {header: content for header, content in existing.sections}
+    incoming_sections = {header: content for header, content in incoming.sections}
+    managed = [
+        (
+            "Definition",
+            merge_paragraph_blocks(
+                existing_sections.get("Definition", ""),
+                incoming_sections.get("Definition", ""),
+            ),
+        ),
+        (
+            "Stable Facts",
+            merge_line_blocks(
+                existing_sections.get("Stable Facts", ""),
+                incoming_sections.get("Stable Facts", ""),
+            ),
+        ),
+        (
+            "Relations",
+            merge_line_blocks(
+                existing_sections.get("Relations", ""),
+                incoming_sections.get("Relations", ""),
+            ),
+        ),
+        (
+            "Source Notes",
+            merge_line_blocks(
+                existing_sections.get("Source Notes", ""),
+                incoming_sections.get("Source Notes", ""),
+            ),
+        ),
+    ]
+    extra_sections = [
+        (header, content)
+        for header, content in existing.sections
+        if normalize_heading(header)
+        not in {normalize_heading(item) for item in SEMANTIC_SECTION_ORDER}
+    ]
+    return render_markdown_note(title, existing.lead_lines, managed, extra_sections)
+
+
+def _disambiguate_semantic_identity(
+    frontmatter: SemanticNoteFrontmatter,
+    source_note: SourceNoteFrontmatter,
+) -> tuple[SemanticNoteFrontmatter, str]:
+    note_id = build_note_id("sem", frontmatter.title, source_note.id)
+    updated = frontmatter.model_copy(update={"id": note_id})
+    filename = f"{slugify(note_id.replace('_', '-'))}.md"
+    return updated, filename
+
+
+def _canonical_note(notes: list[dict[str, Any]]) -> dict[str, Any]:
+    return sorted(notes, key=lambda note: (note["id"], note["path"]))[0]
+
+
+def _build_semantic_merge_preview(notes: list[dict[str, Any]]) -> dict[str, Any]:
+    canonical = _canonical_note(notes)
+    return {
+        "target_path": canonical["path"],
+        "merged_source_refs": sorted(
+            {source_ref for note in notes for source_ref in note.get("source_refs", [])}
+        ),
+        "merged_aliases": sorted(
+            {
+                alias
+                for note in notes
+                for alias in [note["title"], *note.get("aliases", [])]
+                if _semantic_identity_key(alias) != _semantic_identity_key(canonical["title"])
+            }
+        ),
+        "merged_tags": sorted({tag for note in notes for tag in note.get("tags", [])}),
+    }
+
+
+def _build_episodic_merge_preview(notes: list[dict[str, Any]]) -> dict[str, Any]:
+    canonical = _canonical_note(notes)
+    return {
+        "target_path": canonical["path"],
+        "merged_source_refs": sorted(
+            {source_ref for note in notes for source_ref in note.get("source_refs", [])}
+        ),
+        "merged_participants": sorted(
+            {participant for note in notes for participant in note.get("participants", [])}
+        ),
+        "merged_entity_refs": sorted(
+            {entity_ref for note in notes for entity_ref in note.get("entity_refs", [])}
+        ),
+        "project": canonical.get("project"),
+    }
+
+
+class SemanticMaintenanceService:
+    """Reports potential duplicate semantic pages."""
+
+    def __init__(self, vault_service: VaultService) -> None:
+        self.vault_service = vault_service
+
+    @classmethod
+    def from_settings(cls, settings: WikiSettings) -> "SemanticMaintenanceService":
+        return cls(VaultService(settings.vault_path))
+
+    def compact_report(self) -> CommandOutput:
+        semantic_notes = self._load_semantic_notes()
+        episodic_notes = self._load_episodic_notes()
+
+        duplicate_candidates = list(self._find_semantic_duplicates(semantic_notes).values())
+        source_conflict_candidates = list(self._find_source_conflicts(semantic_notes).values())
+        episodic_near_duplicates = list(
+            self._find_episodic_near_duplicates(episodic_notes).values()
+        )
+
+        total_groups = (
+            len(duplicate_candidates)
+            + len(source_conflict_candidates)
+            + len(episodic_near_duplicates)
+        )
+        summary = {
+            "total_groups": total_groups,
+            "semantic_duplicate_groups": len(duplicate_candidates),
+            "semantic_source_conflict_groups": len(source_conflict_candidates),
+            "episodic_near_duplicate_groups": len(episodic_near_duplicates),
+        }
+        return CommandOutput(
+            message=(
+                "No maintenance candidates found. Dry-run only."
+                if total_groups == 0
+                else (
+                    f"Found {total_groups} candidate maintenance group(s): "
+                    f"{summary['semantic_duplicate_groups']} semantic duplicate, "
+                    f"{summary['semantic_source_conflict_groups']} semantic source conflict, "
+                    f"{summary['episodic_near_duplicate_groups']} episodic near-duplicate. "
+                    "Dry-run only."
+                )
+            ),
+            data={
+                "dry_run": True,
+                "summary": summary,
+                "semantic_duplicate_candidates": duplicate_candidates,
+                "semantic_source_conflict_candidates": source_conflict_candidates,
+                "episodic_near_duplicate_candidates": episodic_near_duplicates,
+            },
+        )
+
+    def _load_semantic_notes(self) -> list[dict[str, Any]]:
+        notes: list[dict[str, Any]] = []
+        for path in sorted(self.vault_service.semantic_dir.glob("*.md")):
+            try:
+                document = load_note(path)
+                frontmatter = validate_note_frontmatter(document.frontmatter)
+                if not isinstance(frontmatter, SemanticNoteFrontmatter):
+                    continue
+                notes.append(
+                    {
+                        "id": frontmatter.id,
+                        "title": frontmatter.title,
+                        "path": str(path),
+                        "aliases": frontmatter.aliases,
+                        "tags": frontmatter.tags,
+                        "source_refs": frontmatter.source_refs,
+                        "entity_refs": frontmatter.entity_refs,
+                        "schema_version": document.frontmatter.get("schema_version"),
+                    }
+                )
+            except Exception:
+                continue
+        return notes
+
+    def _load_episodic_notes(self) -> list[dict[str, Any]]:
+        notes: list[dict[str, Any]] = []
+        for path in sorted(self.vault_service.episodic_dir.glob("*.md")):
+            try:
+                document = load_note(path)
+                frontmatter = validate_note_frontmatter(document.frontmatter)
+                if not isinstance(frontmatter, EpisodicNoteFrontmatter):
+                    continue
+                notes.append(
+                    {
+                        "id": frontmatter.id,
+                        "title": frontmatter.title,
+                        "path": str(path),
+                        "date": frontmatter.date.isoformat(),
+                        "source_refs": frontmatter.source_refs,
+                        "participants": frontmatter.participants,
+                        "project": frontmatter.project,
+                        "entity_refs": frontmatter.entity_refs,
+                    }
+                )
+            except Exception:
+                continue
+        return notes
+
+    def _find_semantic_duplicates(
+        self, semantic_notes: list[dict[str, Any]]
+    ) -> dict[str, dict[str, Any]]:
+        groups: dict[str, dict[str, Any]] = {}
+        for note in semantic_notes:
+            for token in _semantic_identity_tokens(note):
+                groups.setdefault(token, {"key": token, "notes": []})["notes"].append(note)
+
+        deduped: dict[frozenset[str], tuple[str, dict[str, Any]]] = {}
+        for token, group in sorted(groups.items()):
+            if len(group["notes"]) < 2:
+                continue
+            note_set = frozenset(note["id"] for note in group["notes"])
+            deduped.setdefault(note_set, (token, group))
+
+        result: dict[str, dict[str, Any]] = {}
+        for token, group in (item for item in deduped.values()):
+            canonical = _canonical_note(group["notes"])
+            result[token] = {
+                "key": token,
+                "canonical_note_id": canonical["id"],
+                "match_reason": "shared_identity_token",
+                "merge_preview": _build_semantic_merge_preview(group["notes"]),
+                "requires_manual_review": True,
+                "notes": group["notes"],
+            }
+        return result
+
+    def _find_source_conflicts(
+        self, semantic_notes: list[dict[str, Any]]
+    ) -> dict[str, dict[str, Any]]:
+        groups: dict[str, dict[str, Any]] = {}
+        for note in semantic_notes:
+            for source_ref in note["source_refs"]:
+                groups.setdefault(source_ref, {"source_ref": source_ref, "notes": []})[
+                    "notes"
+                ].append(note)
+
+        result: dict[str, dict[str, Any]] = {}
+        for source_ref, group in groups.items():
+            if len(group["notes"]) < 2:
+                continue
+            canonical = _canonical_note(group["notes"])
+            result[source_ref] = {
+                "source_ref": source_ref,
+                "canonical_note_id": canonical["id"],
+                "match_reason": "shared_source_ref",
+                "merge_preview": _build_semantic_merge_preview(group["notes"]),
+                "requires_manual_review": True,
+                "notes": group["notes"],
+            }
+        return result
+
+    def _find_episodic_near_duplicates(
+        self, episodic_notes: list[dict[str, Any]]
+    ) -> dict[str, dict[str, Any]]:
+        groups: dict[str, dict[str, Any]] = {}
+        for note in episodic_notes:
+            title_key = self._near_duplicate_title_key(note["title"])
+            key = f"{note['date']}::{title_key}"
+            groups.setdefault(key, {"date": note["date"], "title_key": title_key, "notes": []})[
+                "notes"
+            ].append(note)
+
+        result: dict[str, dict[str, Any]] = {}
+        for key, group in groups.items():
+            if len(group["notes"]) < 2:
+                continue
+            canonical = _canonical_note(group["notes"])
+            result[key] = {
+                "date": group["date"],
+                "title_key": group["title_key"],
+                "canonical_note_id": canonical["id"],
+                "match_reason": "same_date_title_key",
+                "merge_preview": _build_episodic_merge_preview(group["notes"]),
+                "requires_manual_review": True,
+                "notes": group["notes"],
+            }
+        return result
+
+    def _near_duplicate_title_key(self, title: str) -> str:
+        tokens = [token for token in slugify(title).split("-") if token]
+        if not tokens:
+            return "note"
+        return "-".join(tokens[:2])
+
+
+def upsert_semantic_note(
+    vault_service: VaultService,
+    title: str,
+    content: str,
+    source_note: SourceNoteFrontmatter,
+    dry_run: bool = False,
+) -> str | None:
+    """Create or update a semantic note from source content."""
+
+    existing_path = _resolve_existing_semantic_path(vault_service, title)
+    frontmatter, body, filename = render_semantic_note(
+        title,
+        content,
+        source_note,
+        existing_path=existing_path,
+    )
+    path = existing_path or (vault_service.semantic_dir / filename)
+    if existing_path is None and path.exists():
+        frontmatter, filename = _disambiguate_semantic_identity(frontmatter, source_note)
+        path = vault_service.semantic_dir / filename
+
+    if path.exists():
+        existing = load_note(path)
+        if is_unsupported_schema(existing.frontmatter):
+            logger.warning(
+                (
+                    "Skipping semantic auto-merge for %s because %s uses "
+                    "unsupported schema_version %s."
+                ),
+                title,
+                path,
+                existing.frontmatter.get("schema_version"),
+            )
+            return None
+        existing_frontmatter = SemanticNoteFrontmatter.model_validate(existing.frontmatter)
+        merged_aliases = sorted(
+            {
+                *existing_frontmatter.aliases,
+                *(
+                    [title]
+                    if _semantic_identity_key(title)
+                    != _semantic_identity_key(existing_frontmatter.title)
+                    else []
+                ),
+            }
+        )
+        merged_frontmatter = SemanticNoteFrontmatter.model_validate(
+            {
+                **existing.frontmatter,
+                "schema_version": CURRENT_SCHEMA_VERSION,
+                "aliases": merged_aliases,
+                "source_refs": sorted(set(existing_frontmatter.source_refs) | {source_note.id}),
+                "tags": sorted(set(existing_frontmatter.tags) | set(frontmatter.tags)),
+                "updated_at": str(today_utc()),
+            }
+        )
+        frontmatter = merged_frontmatter
+        body = _merge_semantic_body(existing.body, body, existing_frontmatter.title)
+    if not dry_run:
+        write_note(path, frontmatter.model_dump(mode="json"), body)
+    return str(path)

--- a/llmwiki_hermes/compiler/service.py
+++ b/llmwiki_hermes/compiler/service.py
@@ -1,0 +1,122 @@
+"""Compiler orchestration service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llmwiki_hermes.compiler.classify import classify_text
+from llmwiki_hermes.compiler.episodic import create_or_append_episodic_note
+from llmwiki_hermes.compiler.semantic import upsert_semantic_note
+from llmwiki_hermes.compiler.source import derive_title, render_source_note
+from llmwiki_hermes.errors import IngestInputError
+from llmwiki_hermes.schemas.notes import SourceNoteFrontmatter
+from llmwiki_hermes.storage.frontmatter import load_note, write_note
+from llmwiki_hermes.storage.sqlite_index import IndexService
+from llmwiki_hermes.storage.vault import VaultService
+
+
+def normalize_text(raw: str) -> str:
+    """Normalize ingest input into plain text."""
+
+    normalized = raw.replace("\r\n", "\n").replace("\r", "\n")
+    cleaned = "".join(
+        char for char in normalized if char == "\n" or char == "\t" or ord(char) >= 32
+    )
+    return cleaned.strip()
+
+
+class CompilerService:
+    """Compile normalized input into persisted notes and index updates."""
+
+    def __init__(self, vault_service: VaultService, index_service: IndexService) -> None:
+        self.vault_service = vault_service
+        self.index_service = index_service
+
+    def ingest_input(
+        self,
+        *,
+        input_path: Path | None,
+        raw_content: str,
+        source_type: str,
+        tags: list[str],
+        dry_run: bool,
+    ) -> list[str]:
+        """Compile a single input payload into source, semantic, and episodic notes."""
+
+        normalized = normalize_text(raw_content)
+        if not normalized:
+            raise IngestInputError("Ingest input is empty after normalization.")
+
+        source_frontmatter, source_body, filename = render_source_note(
+            content=normalized,
+            path=input_path,
+            source_type=source_type,
+            tags=tags,
+        )
+        existing_source = self.find_source_by_hash(source_frontmatter.content_hash)
+        source_path = existing_source or self.vault_service.sources_dir / filename
+
+        created_or_updated: list[str] = []
+        source_note = self._persist_source_note(
+            source_path=source_path,
+            existing_source=existing_source,
+            source_frontmatter=source_frontmatter,
+            source_body=source_body,
+            dry_run=dry_run,
+        )
+        if existing_source is None:
+            created_or_updated.append(str(source_path))
+
+        title = derive_title(input_path, normalized)
+        classes = classify_text(normalized, source_type=source_type)
+        if classes["semantic"]:
+            semantic_path = upsert_semantic_note(
+                vault_service=self.vault_service,
+                title=title,
+                content=normalized,
+                source_note=source_note,
+                dry_run=dry_run,
+            )
+            if semantic_path is not None:
+                created_or_updated.append(semantic_path)
+        if classes["episodic"]:
+            episodic_path = create_or_append_episodic_note(
+                vault_service=self.vault_service,
+                title=title,
+                content=normalized,
+                source_note=source_note,
+                dry_run=dry_run,
+            )
+            if episodic_path is not None:
+                created_or_updated.append(episodic_path)
+        return created_or_updated
+
+    def reindex(self) -> None:
+        """Rebuild the SQLite index after successful compilation."""
+
+        self.index_service.reindex()
+
+    def find_source_by_hash(self, content_hash: str) -> Path | None:
+        """Return an existing source note path for a known content hash."""
+
+        for path in self.vault_service.sources_dir.glob("*.md"):
+            document = load_note(path)
+            if document.frontmatter.get("content_hash") == content_hash:
+                return path
+        return None
+
+    def _persist_source_note(
+        self,
+        *,
+        source_path: Path,
+        existing_source: Path | None,
+        source_frontmatter: SourceNoteFrontmatter,
+        source_body: str,
+        dry_run: bool,
+    ) -> SourceNoteFrontmatter:
+        if not dry_run and existing_source is None:
+            write_note(source_path, source_frontmatter.model_dump(mode="json"), source_body)
+            return source_frontmatter
+        if existing_source is not None:
+            return SourceNoteFrontmatter.model_validate(load_note(existing_source).frontmatter)
+        return source_frontmatter

--- a/llmwiki_hermes/compiler/source.py
+++ b/llmwiki_hermes/compiler/source.py
@@ -1,0 +1,63 @@
+"""Source note generation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llmwiki_hermes.constants import CURRENT_SCHEMA_VERSION
+from llmwiki_hermes.schemas.notes import SourceNoteFrontmatter
+from llmwiki_hermes.templates import render_template
+from llmwiki_hermes.utils.hashing import sha256_text
+from llmwiki_hermes.utils.slug import build_note_id, slugify
+from llmwiki_hermes.utils.time import utc_now
+
+
+def derive_title(path: Path | None, content: str) -> str:
+    """Choose a readable title for imported content."""
+
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            return stripped.lstrip("#").strip()
+        if stripped:
+            return stripped[:80]
+    if path is not None:
+        return path.stem.replace("_", " ").replace("-", " ").title()
+    return "Imported Source"
+
+
+def render_source_note(
+    content: str,
+    path: Path | None,
+    source_type: str,
+    tags: list[str],
+) -> tuple[SourceNoteFrontmatter, str, str]:
+    """Create source note frontmatter and body."""
+
+    title = derive_title(path, content)
+    content_hash = sha256_text(content)
+    stem = path.stem if path is not None else title
+    note_id = build_note_id("src", stem, utc_now().date().isoformat())
+    frontmatter = SourceNoteFrontmatter(
+        schema_version=CURRENT_SCHEMA_VERSION,
+        id=note_id,
+        title=title,
+        source_type=source_type,
+        origin="stdin" if path is None else "user_upload",
+        ingested_at=utc_now(),
+        content_hash=content_hash,
+        source_refs=[],
+        tags=sorted(set(tags + ["source", source_type])),
+    )
+    body = render_template(
+        "source_note.md.j2",
+        {
+            "title": frontmatter.title,
+            "origin": frontmatter.origin,
+            "source_type": source_type,
+            "content_hash": content_hash,
+            "extracted_content": content.strip() or "(empty input)",
+        },
+    )
+    filename = f"{slugify(note_id.replace('_', '-'))}.md"
+    return frontmatter, body, filename

--- a/llmwiki_hermes/constants.py
+++ b/llmwiki_hermes/constants.py
@@ -1,0 +1,28 @@
+"""Project-wide constants."""
+
+from pathlib import Path
+
+APP_NAME = "llmwiki-hermes"
+PROVIDER_NAME = "wiki"
+DEFAULT_TOP_K_SEMANTIC = 5
+DEFAULT_TOP_K_EPISODIC = 4
+DEFAULT_RECALL_TOP_K = 8
+DEFAULT_AUTO_WRITEBACK = False
+CURRENT_SCHEMA_VERSION = 1
+VAULT_ROOT_NAME = "LLM-Wiki"
+VAULT_DIRS = (
+    "00_inbox",
+    "10_sources",
+    "20_semantic",
+    "30_episodic",
+    "40_indexes",
+    "90_system",
+    ".wiki",
+)
+INDEX_DB_NAME = "index.sqlite"
+INGEST_LOG_NAME = "ingest.log"
+STATE_FILE_NAME = "state.json"
+SESSION_LOG_DIR = "sessions"
+PRECOMPRESS_DIR = "precompress"
+CONFIG_ENV_VAR = "LLMWIKI_VAULT_PATH"
+DEFAULT_CONFIG_PATH = Path("~/.config/llmwiki-hermes/config.yaml").expanduser()

--- a/llmwiki_hermes/errors.py
+++ b/llmwiki_hermes/errors.py
@@ -1,0 +1,25 @@
+"""Domain-specific exceptions."""
+
+
+class LlmWikiError(Exception):
+    """Base exception for the project."""
+
+
+class VaultNotInitializedError(LlmWikiError):
+    """Raised when a vault is missing required structure."""
+
+
+class InvalidFrontmatterError(LlmWikiError):
+    """Raised when a note's frontmatter cannot be parsed or validated."""
+
+
+class IndexCorruptionError(LlmWikiError):
+    """Raised when the SQLite sidecar index is missing or invalid."""
+
+
+class IngestInputError(LlmWikiError):
+    """Raised when ingest input is missing or malformed."""
+
+
+class ConfigurationError(LlmWikiError):
+    """Raised when required configuration is unavailable."""

--- a/llmwiki_hermes/provider/__init__.py
+++ b/llmwiki_hermes/provider/__init__.py
@@ -1,0 +1,5 @@
+"""Hermes provider integration layer."""
+
+from llmwiki_hermes.provider.plugin import WikiMemoryProvider
+
+__all__ = ["WikiMemoryProvider"]

--- a/llmwiki_hermes/provider/cli.py
+++ b/llmwiki_hermes/provider/cli.py
@@ -1,0 +1,358 @@
+"""Typer app exposed as the Hermes `wiki` subcommand."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import typer
+
+from llmwiki_hermes.constants import PROVIDER_NAME
+from llmwiki_hermes.errors import LlmWikiError
+from llmwiki_hermes.schemas.cli import CommandOutput
+
+if TYPE_CHECKING:
+    from llmwiki_hermes.settings import WikiSettings
+
+app = typer.Typer(help="LLM-Wiki provider commands for Hermes.")
+
+
+def echo_output(output: CommandOutput, as_json: bool = False) -> None:
+    """Render CLI output as either human text or JSON."""
+
+    if as_json:
+        typer.echo(json.dumps(output.model_dump(mode="json"), ensure_ascii=False, indent=2))
+        return
+    typer.echo(render_human_output(output))
+
+
+def render_human_output(output: CommandOutput) -> str:
+    """Render a stable human-readable summary from the JSON payload."""
+
+    lines = [output.message]
+    if _is_ingest_output(output.data):
+        lines.extend(_render_ingest_details(output.data))
+    elif _is_doctor_output(output.data):
+        lines.extend(_render_doctor_details(output.data))
+    elif _is_reindex_output(output.data):
+        lines.extend(_render_reindex_details(output.data))
+    elif _is_compact_output(output.data):
+        lines.extend(_render_compact_details(output.data))
+    return "\n".join(lines)
+
+
+def _is_doctor_output(data: dict[str, Any]) -> bool:
+    return "issues" in data and "stats" in data
+
+
+def _is_ingest_output(data: dict[str, Any]) -> bool:
+    return {
+        "created_or_updated",
+        "processed_inputs",
+        "successful_inputs",
+        "failed_inputs",
+    } <= data.keys()
+
+
+def _is_reindex_output(data: dict[str, Any]) -> bool:
+    return {"note_files", "indexed_notes", "skipped_notes", "failed_notes"} <= data.keys()
+
+
+def _is_compact_output(data: dict[str, Any]) -> bool:
+    return "summary" in data and "semantic_duplicate_candidates" in data
+
+
+def _render_ingest_details(data: dict[str, Any]) -> list[str]:
+    failed_inputs = data.get("failed_inputs", [])
+    lines = [
+        "Summary:",
+        (
+            f"- mode: {'dry-run' if data.get('dry_run') else 'apply'}, "
+            f"processed: {data.get('processed_inputs', 0)}, "
+            f"successful: {data.get('successful_inputs', 0)}, "
+            f"failed: {len(failed_inputs)}"
+        ),
+        f"- created/updated notes: {len(data.get('created_or_updated', []))}",
+    ]
+    if failed_inputs:
+        lines.append("Failures:")
+        for failure in failed_inputs:
+            lines.append(f"- [{failure['code']}] {failure['path']}: {failure['message']}")
+    return lines
+
+
+def _render_doctor_details(data: dict[str, Any]) -> list[str]:
+    stats = data.get("stats", {})
+    issues = data.get("issues", [])
+    severity_counts = data.get("severity_counts", {})
+    lines = [
+        "Summary:",
+        (
+            f"- note files: {stats.get('note_files', 0)} total, "
+            f"{stats.get('valid_notes', 0)} valid, "
+            f"{stats.get('invalid_notes', 0)} invalid, "
+            f"{stats.get('indexed_notes', 0)} indexed"
+        ),
+        (
+            f"- note health: {stats.get('orphan_semantic_notes', 0)} orphan semantic, "
+            f"{stats.get('orphan_episodic_notes', 0)} orphan episodic, "
+            f"{stats.get('duplicate_source_hash_groups', 0)} duplicate source hash group(s)"
+        ),
+        (
+            f"- index health: {stats.get('missing_index_entries', 0)} missing entry, "
+            f"{stats.get('stale_index_entries', 0)} stale entry"
+        ),
+        (
+            f"- schema health: {stats.get('legacy_schema_notes', 0)} legacy note(s), "
+            f"{stats.get('notes_by_schema_version', {})}"
+        ),
+    ]
+    if severity_counts:
+        counts = ", ".join(
+            f"{count} {severity}" for severity, count in sorted(severity_counts.items())
+        )
+        lines.append(f"- issue severity: {counts}")
+    if issues:
+        lines.append("Issues:")
+        for issue in issues:
+            location = issue["path"]
+            lines.append(f"- [{issue['severity']}] {issue['code']} {location}: {issue['message']}")
+        recovery_workflow = data.get("recovery_workflow", [])
+        if recovery_workflow:
+            lines.append(f"Recovery workflow: {' -> '.join(recovery_workflow)}")
+            lines.append(
+                "If issues remain after reindex, inspect the listed files and repair them manually."
+            )
+    return lines
+
+
+def _render_reindex_details(data: dict[str, Any]) -> list[str]:
+    lines = [
+        "Summary:",
+        (
+            f"- files scanned: {data.get('note_files', 0)}, "
+            f"indexed: {data.get('indexed_notes', 0)}, "
+            f"skipped: {data.get('skipped_notes', 0)}"
+        ),
+        (
+            f"- index contents: {data.get('chunk_count', 0)} chunk(s), "
+            f"{data.get('link_count', 0)} link(s)"
+        ),
+        f"- index path: {data.get('index_path', '')}",
+    ]
+    failed_notes = data.get("failed_notes", [])
+    if failed_notes:
+        lines.append("Skipped notes:")
+        for issue in failed_notes:
+            lines.append(f"- [{issue['severity']}] {issue['path']}: {issue['message']}")
+        lines.append("Recommended next step: run doctor after reindex to confirm remaining issues.")
+    else:
+        lines.append("Recommended next step: run doctor after reindex to confirm index health.")
+    return lines
+
+
+def _render_compact_details(data: dict[str, Any]) -> list[str]:
+    summary = data.get("summary", {})
+    lines = [
+        "Summary:",
+        f"- mode: {'dry-run' if data.get('dry_run') else 'apply'}",
+        (
+            f"- candidate groups: {summary.get('total_groups', 0)} total, "
+            f"{summary.get('semantic_duplicate_groups', 0)} semantic duplicate, "
+            f"{summary.get('semantic_source_conflict_groups', 0)} semantic source conflict, "
+            f"{summary.get('episodic_near_duplicate_groups', 0)} episodic near-duplicate"
+        ),
+    ]
+    candidate_lines = _compact_candidate_lines(data)
+    if candidate_lines:
+        lines.append("Candidates:")
+        lines.extend(candidate_lines)
+        lines.append("Review candidate notes manually before making any content changes.")
+    else:
+        lines.append("No candidate groups detected. No manual cleanup is suggested right now.")
+    return lines
+
+
+def _compact_candidate_lines(data: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    for candidate in data.get("semantic_duplicate_candidates", []):
+        note_ids = ", ".join(note["id"] for note in candidate.get("notes", []))
+        lines.append(
+            "- semantic duplicate "
+            f"{candidate.get('key', 'group')}: {note_ids} "
+            f"(canonical: {candidate.get('canonical_note_id', 'n/a')}, "
+            f"reason: {candidate.get('match_reason', 'n/a')})"
+        )
+    for candidate in data.get("semantic_source_conflict_candidates", []):
+        note_ids = ", ".join(note["id"] for note in candidate.get("notes", []))
+        lines.append(
+            "- semantic source conflict "
+            f"{candidate.get('source_ref', 'source')}: {note_ids} "
+            f"(canonical: {candidate.get('canonical_note_id', 'n/a')}, "
+            f"reason: {candidate.get('match_reason', 'n/a')})"
+        )
+    for candidate in data.get("episodic_near_duplicate_candidates", []):
+        note_ids = ", ".join(note["id"] for note in candidate.get("notes", []))
+        lines.append(
+            f"- episodic near-duplicate {candidate.get('date', 'date')} / "
+            f"{candidate.get('title_key', 'title')}: {note_ids} "
+            f"(canonical: {candidate.get('canonical_note_id', 'n/a')}, "
+            f"reason: {candidate.get('match_reason', 'n/a')})"
+        )
+    return lines
+
+
+def abort_on_error(exc: Exception) -> None:
+    """Convert domain exceptions into user-facing CLI failures."""
+
+    typer.echo(f"Error: {exc}", err=True)
+    raise typer.Exit(code=1) from exc
+
+
+def load_settings(vault: Path | None) -> "WikiSettings":
+    """Load settings from CLI args, then Hermes profile config, then defaults."""
+
+    from llmwiki_hermes.settings import WikiSettings
+
+    config_path = None
+    hermes_home = os.getenv("HERMES_HOME")
+    if not hermes_home:
+        try:
+            from hermes_constants import get_hermes_home  # type: ignore[import-untyped]
+        except ImportError:
+            hermes_home = None
+        else:
+            hermes_home = str(get_hermes_home())
+    if hermes_home:
+        candidate = Path(hermes_home) / PROVIDER_NAME / "config.yaml"
+        if candidate.exists():
+            config_path = candidate
+    return WikiSettings.load(vault_path=vault, config_path=config_path)
+
+
+@app.command()
+def init(
+    vault: Path = typer.Option(..., help="Base path that will contain the LLM-Wiki vault."),
+    force: bool = typer.Option(False, help="Overwrite system files if they already exist."),
+    json_output: bool = typer.Option(False, "--json", help="Render output as JSON."),
+) -> None:
+    """Initialize a new vault."""
+
+    from llmwiki_hermes.storage.vault import VaultService
+
+    try:
+        service = VaultService.from_user_path(vault)
+        output = service.initialize(force=force)
+        echo_output(output, as_json=json_output)
+    except (LlmWikiError, FileNotFoundError, OSError) as exc:
+        abort_on_error(exc)
+
+
+@app.command()
+def ingest(
+    path: Path | None = typer.Argument(None, help="Path to a file or directory to ingest."),
+    vault: Path | None = typer.Option(None, help="Existing LLM-Wiki vault path."),
+    stdin: bool = typer.Option(False, help="Read content from STDIN."),
+    recursive: bool = typer.Option(False, help="Recurse into directories."),
+    tags: str = typer.Option("", help="Comma-separated tags."),
+    source_type: str | None = typer.Option(None, help="Explicit source type."),
+    dry_run: bool = typer.Option(False, help="Preview outputs without writing notes."),
+    json_output: bool = typer.Option(False, "--json", help="Render output as JSON."),
+) -> None:
+    """Ingest source material into the vault."""
+
+    from llmwiki_hermes.compiler.ingest import IngestService
+
+    try:
+        settings = load_settings(vault)
+        service = IngestService.from_settings(settings)
+        output = service.ingest(
+            path=path,
+            stdin=stdin,
+            recursive=recursive,
+            tags=[item.strip() for item in tags.split(",") if item.strip()],
+            source_type=source_type,
+            dry_run=dry_run,
+        )
+        echo_output(output, as_json=json_output)
+        if not output.ok:
+            raise typer.Exit(code=1)
+    except (LlmWikiError, FileNotFoundError, OSError, ValueError) as exc:
+        abort_on_error(exc)
+
+
+@app.command()
+def reindex(
+    vault: Path | None = typer.Option(None, help="Existing LLM-Wiki vault path."),
+    json_output: bool = typer.Option(False, "--json", help="Render output as JSON."),
+) -> None:
+    """Rebuild the SQLite sidecar index."""
+
+    from llmwiki_hermes.storage.sqlite_index import IndexService
+    from llmwiki_hermes.storage.vault import VaultService
+
+    try:
+        settings = load_settings(vault)
+        output = IndexService(VaultService(settings.vault_path)).reindex()
+        echo_output(output, as_json=json_output)
+    except (LlmWikiError, FileNotFoundError, OSError) as exc:
+        abort_on_error(exc)
+
+
+@app.command()
+def recall(
+    query: str = typer.Option(..., "--query", "-q", help="Query text."),
+    vault: Path | None = typer.Option(None, help="Existing LLM-Wiki vault path."),
+    memory_type: str = typer.Option("auto", help="auto|semantic|episodic"),
+    top_k: int = typer.Option(8, help="Max result count."),
+    json_output: bool = typer.Option(False, "--json", help="Render output as JSON."),
+) -> None:
+    """Explicitly search the knowledge base."""
+
+    from llmwiki_hermes.recall.search import RecallService
+
+    try:
+        settings = load_settings(vault)
+        service = RecallService.from_settings(settings)
+        output = service.recall_cli(query=query, memory_type=memory_type, top_k=top_k)
+        echo_output(output, as_json=json_output)
+    except (LlmWikiError, FileNotFoundError, OSError, ValueError) as exc:
+        abort_on_error(exc)
+
+
+@app.command()
+def doctor(
+    vault: Path | None = typer.Option(None, help="Existing LLM-Wiki vault path."),
+    json_output: bool = typer.Option(False, "--json", help="Render output as JSON."),
+) -> None:
+    """Validate the vault and index."""
+
+    from llmwiki_hermes.storage.vault import VaultService
+
+    try:
+        settings = load_settings(vault)
+        service = VaultService(settings.vault_path)
+        service.ensure_initialized()
+        output = service.doctor()
+        echo_output(output, as_json=json_output)
+    except (LlmWikiError, FileNotFoundError, OSError) as exc:
+        abort_on_error(exc)
+
+
+@app.command()
+def compact(
+    vault: Path | None = typer.Option(None, help="Existing LLM-Wiki vault path."),
+    json_output: bool = typer.Option(False, "--json", help="Render output as JSON."),
+) -> None:
+    """Report potential semantic duplicates and conflicts."""
+
+    from llmwiki_hermes.compiler.semantic import SemanticMaintenanceService
+
+    try:
+        settings = load_settings(vault)
+        output = SemanticMaintenanceService.from_settings(settings).compact_report()
+        echo_output(output, as_json=json_output)
+    except (LlmWikiError, FileNotFoundError, OSError) as exc:
+        abort_on_error(exc)

--- a/llmwiki_hermes/provider/plugin.py
+++ b/llmwiki_hermes/provider/plugin.py
@@ -1,0 +1,249 @@
+"""Thin Hermes-compatible provider wrapper."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from llmwiki_hermes.constants import PROVIDER_NAME
+from llmwiki_hermes.provider.tools import ProviderTools
+from llmwiki_hermes.provider.writeback import SessionWritebackService
+from llmwiki_hermes.recall.search import RecallService
+from llmwiki_hermes.settings import WikiSettings
+from llmwiki_hermes.storage.vault import VaultService
+
+if TYPE_CHECKING:
+
+    class HermesMemoryProviderBase:
+        """Typed fallback used during static analysis."""
+
+        def system_prompt_block(self) -> str: ...
+
+        def queue_prefetch(self, query: str, *, session_id: str = "") -> None: ...
+
+        def on_turn_start(self, turn_number: int, message: str, **kwargs: Any) -> None: ...
+else:
+    try:
+        from agent.memory_provider import MemoryProvider as HermesMemoryProviderBase
+    except ImportError:
+
+        class HermesMemoryProviderBase:
+            """Fallback base class when Hermes is not installed."""
+
+            def system_prompt_block(self) -> str:
+                return ""
+
+            def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+                return None
+
+            def on_turn_start(self, turn_number: int, message: str, **kwargs: Any) -> None:
+                return None
+
+
+logger = logging.getLogger(__name__)
+
+
+class WikiMemoryProvider(HermesMemoryProviderBase):
+    """Runtime adapter with the shape Hermes expects."""
+
+    def __init__(self) -> None:
+        self.session_id: str | None = None
+        self.settings: WikiSettings | None = None
+        self.vault_service: VaultService | None = None
+        self.recall_service: RecallService | None = None
+        self.tools: ProviderTools | None = None
+        self.writeback_service: SessionWritebackService | None = None
+
+    @property
+    def name(self) -> str:
+        return PROVIDER_NAME
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        try:
+            vault_path = kwargs.get("vault_path")
+            config_path = kwargs.get("config_path")
+            hermes_home = kwargs.get("hermes_home")
+            if config_path is None and hermes_home:
+                config_path = Path(str(hermes_home)) / PROVIDER_NAME / "config.yaml"
+            self.session_id = session_id
+            settings = WikiSettings.load(
+                vault_path=Path(vault_path) if vault_path else None,
+                config_path=Path(config_path) if config_path else None,
+            )
+            overrides = {
+                key: kwargs[key]
+                for key in ("top_k_semantic", "top_k_episodic", "auto_writeback")
+                if key in kwargs
+            }
+            self.settings = settings.model_copy(update=overrides)
+            self.vault_service = VaultService(self.settings.vault_path)
+            self.vault_service.ensure_initialized()
+            self.recall_service = RecallService.from_settings(self.settings)
+            self.tools = ProviderTools(self.recall_service, self.vault_service)
+            self.writeback_service = SessionWritebackService(self.vault_service)
+            logger.info(
+                "Initialized provider %s for session %s with vault %s.",
+                self.name,
+                session_id,
+                self.settings.vault_path,
+            )
+        except Exception:
+            logger.exception(
+                "Provider %s failed to initialize for session %s.",
+                self.name,
+                session_id,
+            )
+            raise
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "wiki_recall",
+                "description": "Search the local knowledge base.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "memory_type": {
+                            "type": "string",
+                            "enum": ["auto", "semantic", "episodic"],
+                            "default": "auto",
+                        },
+                        "top_k": {"type": "integer", "default": 8, "minimum": 1, "maximum": 20},
+                    },
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "wiki_get_note",
+                "description": "Read a full Markdown note by id or slug.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"id_or_slug": {"type": "string"}},
+                    "required": ["id_or_slug"],
+                },
+            },
+        ]
+
+    def handle_tool_call(self, name: str, args: dict[str, Any], **kwargs: Any) -> str:
+        if self.tools is None:
+            raise RuntimeError("Provider must be initialized before tool calls.")
+        result: dict[str, Any]
+        if name == "wiki_recall":
+            result = self.tools.wiki_recall(
+                query=str(args["query"]),
+                memory_type=str(args.get("memory_type", "auto")),
+                top_k=int(args.get("top_k", 8)),
+            )
+        elif name == "wiki_get_note":
+            result = self.tools.wiki_get_note(id_or_slug=str(args["id_or_slug"]))
+        else:
+            raise ValueError(f"Unknown tool: {name}")
+        return json.dumps(result, ensure_ascii=False)
+
+    def get_config_schema(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "vault_path",
+                "description": "Path to the LLM-Wiki vault root.",
+                "required": True,
+            },
+            {
+                "key": "top_k_semantic",
+                "description": "Default semantic recall result count.",
+                "required": False,
+                "default": 5,
+            },
+            {
+                "key": "top_k_episodic",
+                "description": "Default episodic recall result count.",
+                "required": False,
+                "default": 4,
+            },
+            {
+                "key": "auto_writeback",
+                "description": "Persist session summaries back into the vault.",
+                "required": False,
+                "default": False,
+                "choices": [True, False],
+            },
+        ]
+
+    def save_config(self, values: dict[str, Any], hermes_home: str | Path) -> None:
+        config_dir = Path(hermes_home) / PROVIDER_NAME
+        config_dir.mkdir(parents=True, exist_ok=True)
+        config_path = config_dir / "config.yaml"
+        config_path.write_text(yaml.safe_dump(values, sort_keys=False), encoding="utf-8")
+        logger.info("Saved provider %s config to %s.", self.name, config_path)
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self.recall_service is None:
+            logger.warning("Prefetch requested before provider %s was initialized.", self.name)
+            return ""
+        try:
+            result = self.recall_service.recall(query=query, memory_type="auto", top_k=8)
+            logger.debug(
+                "Prefetch for provider %s returned %s result(s).",
+                self.name,
+                len(result.results),
+            )
+            return result.recall_block
+        except Exception:
+            logger.exception("Recall prefetch failed for provider %s.", self.name)
+            return ""
+
+    def sync_turn(self, user: str, assistant: str, *, session_id: str = "") -> None:
+        effective_session_id = session_id or self.session_id
+        if self.writeback_service is None or effective_session_id is None:
+            return
+        try:
+            self.writeback_service.sync_turn(effective_session_id, user, assistant)
+            logger.debug("Synced turn for session %s.", effective_session_id)
+        except Exception:
+            logger.exception("Session sync failed for session %s.", effective_session_id)
+
+    def on_pre_compress(self, messages: list[dict[str, Any]]) -> None:
+        if self.writeback_service is None or self.session_id is None:
+            return
+        try:
+            self.writeback_service.on_pre_compress(self.session_id, messages)
+            logger.debug("Stored pre-compress snapshot for session %s.", self.session_id)
+        except Exception:
+            logger.exception("Pre-compress snapshot failed for session %s.", self.session_id)
+
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
+        if (
+            self.writeback_service is None
+            or self.vault_service is None
+            or self.settings is None
+            or self.session_id is None
+        ):
+            return
+        try:
+            self.writeback_service.on_session_end(
+                session_id=self.session_id,
+                messages=messages,
+                auto_writeback=self.settings.auto_writeback,
+            )
+            logger.debug("Completed session end writeback for session %s.", self.session_id)
+        except Exception:
+            logger.exception("Session writeback failed for session %s.", self.session_id)
+            self.vault_service.write_session_summary(self.session_id, messages)
+
+    def shutdown(self) -> None:
+        self.writeback_service = None
+        self.tools = None
+        self.recall_service = None
+        self.vault_service = None
+        self.settings = None
+        self.session_id = None
+
+    def as_json(self) -> str:
+        return json.dumps({"name": self.name})

--- a/llmwiki_hermes/provider/tools.py
+++ b/llmwiki_hermes/provider/tools.py
@@ -1,0 +1,32 @@
+"""Read-only tool implementations exposed to Hermes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llmwiki_hermes.recall.search import RecallService
+from llmwiki_hermes.storage.vault import VaultService
+
+
+class ProviderTools:
+    """Thin wrappers around recall and note retrieval."""
+
+    def __init__(self, recall_service: RecallService, vault_service: VaultService) -> None:
+        self.recall_service = recall_service
+        self.vault_service = vault_service
+
+    def wiki_recall(
+        self,
+        query: str,
+        memory_type: str = "auto",
+        top_k: int = 8,
+    ) -> dict[str, Any]:
+        return self.recall_service.recall(
+            query=query,
+            memory_type=memory_type,
+            top_k=top_k,
+        ).model_dump(mode="json")
+
+    def wiki_get_note(self, id_or_slug: str) -> dict[str, Any]:
+        document = self.vault_service.get_note(id_or_slug=id_or_slug)
+        return document.model_dump(mode="json")

--- a/llmwiki_hermes/provider/writeback.py
+++ b/llmwiki_hermes/provider/writeback.py
@@ -1,0 +1,86 @@
+"""Session writeback orchestration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from llmwiki_hermes.compiler.episodic import create_or_append_episodic_note
+from llmwiki_hermes.compiler.source import render_source_note
+from llmwiki_hermes.storage.frontmatter import write_note
+from llmwiki_hermes.storage.sqlite_index import IndexService
+from llmwiki_hermes.storage.vault import VaultService
+from llmwiki_hermes.utils.slug import slugify
+
+logger = logging.getLogger(__name__)
+
+
+class SessionWritebackService:
+    """Persist session lifecycle artifacts without blocking the caller."""
+
+    def __init__(self, vault_service: VaultService) -> None:
+        self.vault_service = vault_service
+        self.index_service = IndexService(vault_service)
+
+    def sync_turn(self, session_id: str, user: str, assistant: str) -> None:
+        """Append a single turn to the session log."""
+
+        self.vault_service.append_session_turn(session_id, {"user": user, "assistant": assistant})
+        logger.debug("Appended session turn for %s.", session_id)
+
+    def on_pre_compress(self, session_id: str, messages: list[dict[str, Any]]) -> None:
+        """Persist the tail of the conversation before compression."""
+
+        preview = [item for item in messages[-4:]]
+        self.vault_service.write_precompress_snapshot(session_id, preview)
+        logger.debug("Persisted %s pre-compress message(s) for %s.", len(preview), session_id)
+
+    def on_session_end(
+        self,
+        session_id: str,
+        messages: list[dict[str, Any]],
+        auto_writeback: bool,
+    ) -> None:
+        """Persist a session transcript as source and episodic memory."""
+
+        if not auto_writeback:
+            logger.debug("Auto writeback disabled for session %s.", session_id)
+            return
+
+        transcript = "\n".join(
+            f"{item.get('role', 'message')}: {item.get('content', '')}" for item in messages
+        ).strip()
+        if not transcript:
+            logger.debug(
+                "Skipping writeback for session %s because transcript is empty.",
+                session_id,
+            )
+            return
+
+        session_name = session_id or "session"
+        title = f"Session {session_name}"
+        source_frontmatter, source_body, filename = render_source_note(
+            content=transcript,
+            path=None,
+            source_type="chat",
+            tags=["session"],
+        )
+        source_path = self.vault_service.sources_dir / f"src-{slugify(session_name)}-{filename}"
+        write_note(source_path, source_frontmatter.model_dump(mode="json"), source_body)
+        episodic_path = create_or_append_episodic_note(
+            vault_service=self.vault_service,
+            title=title,
+            content=transcript,
+            source_note=source_frontmatter,
+            dry_run=False,
+        )
+        if episodic_path is None:
+            logger.warning(
+                (
+                    "Skipped episodic session writeback for %s because the matched "
+                    "note uses an unsupported schema."
+                ),
+                session_id,
+            )
+        self.index_service.reindex()
+        logger.info("Persisted session writeback artifacts for %s.", session_id)

--- a/llmwiki_hermes/recall/__init__.py
+++ b/llmwiki_hermes/recall/__init__.py
@@ -1,0 +1,1 @@
+"""Recall services."""

--- a/llmwiki_hermes/recall/format.py
+++ b/llmwiki_hermes/recall/format.py
@@ -1,0 +1,50 @@
+"""Formatting helpers for recall output."""
+
+from __future__ import annotations
+
+from llmwiki_hermes.schemas.cli import RecallHit
+from llmwiki_hermes.types import NoteKind
+
+
+def format_recall_block(results: list[RecallHit]) -> str:
+    """Build the compact provider prefetch block."""
+
+    semantic = [hit for hit in results if hit.kind == NoteKind.SEMANTIC]
+    episodic = [hit for hit in results if hit.kind == NoteKind.EPISODIC]
+    source = [hit for hit in results if hit.kind == NoteKind.SOURCE]
+    source_refs = sorted({ref for hit in results for ref in hit.source_refs})
+
+    lines: list[str] = ["[Semantic Recall]"]
+    if semantic:
+        for index, hit in enumerate(semantic, start=1):
+            lines.append(f"{index}. {hit.id} — {hit.title}")
+            lines.append(f"   {hit.snippet}")
+    else:
+        lines.append("None")
+
+    lines.append("")
+    lines.append("[Episodic Recall]")
+    if episodic:
+        for index, hit in enumerate(episodic, start=1):
+            lines.append(f"{index}. {hit.id} — {hit.title}")
+            lines.append(f"   {hit.snippet}")
+    else:
+        lines.append("None")
+
+    lines.append("")
+    lines.append("[Source Recall]")
+    if source:
+        for index, hit in enumerate(source, start=1):
+            lines.append(f"{index}. {hit.id} — {hit.title}")
+            lines.append(f"   {hit.snippet}")
+    else:
+        lines.append("None")
+
+    lines.append("")
+    lines.append("[Source Refs]")
+    if source_refs:
+        lines.extend(f"- {item}" for item in source_refs)
+    else:
+        lines.append("- none")
+
+    return "\n".join(lines).strip()

--- a/llmwiki_hermes/recall/rank.py
+++ b/llmwiki_hermes/recall/rank.py
@@ -1,0 +1,125 @@
+"""Ranking utilities for recall results."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import date, datetime
+from typing import Any
+
+from llmwiki_hermes.types import MemoryType, NoteKind
+from llmwiki_hermes.utils.slug import slugify
+
+SEMANTIC_QUERY_HINTS = ("what", "define", "definition", "是什么", "定义")
+EPISODIC_QUERY_HINTS = ("when", "meeting", "project", "case", "讨论", "会议", "项目", "何时")
+DATE_PATTERN = re.compile(r"\b\d{4}-\d{1,2}-\d{1,2}\b")
+
+
+def classify_query_bias(query: str) -> str:
+    """Choose which memory type should receive a default boost."""
+
+    lowered = query.lower()
+    if any(token in lowered for token in SEMANTIC_QUERY_HINTS):
+        return MemoryType.SEMANTIC.value
+    if any(token in lowered for token in EPISODIC_QUERY_HINTS):
+        return MemoryType.EPISODIC.value
+    return MemoryType.AUTO.value
+
+
+def recency_bonus(raw_value: str) -> float:
+    """Return a small positive score for recent content."""
+
+    if not raw_value:
+        return 0.0
+    try:
+        parsed = datetime.fromisoformat(raw_value).date()
+    except ValueError:
+        try:
+            parsed = date.fromisoformat(raw_value)
+        except ValueError:
+            return 0.0
+    days_old = max((date.today() - parsed).days, 0)
+    return max(0.0, 1.0 - min(days_old, 365) / 365)
+
+
+def _normalized_text(value: str) -> str:
+    return slugify(value.replace("_", "-"))
+
+
+def _contains_query(candidate: str, query: str) -> bool:
+    query_key = _normalized_text(query)
+    candidate_key = _normalized_text(candidate)
+    return bool(query_key and candidate_key and query_key in candidate_key)
+
+
+def _overlap_bonus(query: str, candidate: str) -> float:
+    query_tokens = {token for token in _normalized_text(query).split("-") if token}
+    candidate_tokens = {token for token in _normalized_text(candidate).split("-") if token}
+    if not query_tokens or not candidate_tokens:
+        return 0.0
+    overlap = len(query_tokens & candidate_tokens)
+    return min(overlap * 0.2, 0.6)
+
+
+def _metadata_bonus(row: dict[str, Any], query: str) -> float:
+    bonus = 0.0
+    project = str(row.get("project") or "")
+    if project and _contains_query(query, project):
+        bonus += 0.8
+
+    query_date = DATE_PATTERN.search(query)
+    row_date = str(row.get("date") or "")
+    if query_date and row_date == query_date.group(0):
+        bonus += 0.8
+
+    source_refs = json.loads(row.get("source_refs_json") or "[]")
+    if any(_contains_query(query, str(source_ref)) for source_ref in source_refs):
+        bonus += 0.4
+    return bonus
+
+
+def score_row(row: dict[str, Any], query: str, memory_type: str) -> float:
+    """Compute a deterministic score for a search row."""
+
+    bias = classify_query_bias(query)
+    title_key = _normalized_text(str(row["title"]))
+    query_key = _normalized_text(query)
+    title_hit = (
+        2.0 if title_key == query_key else 1.0 if _contains_query(row["title"], query) else 0.0
+    )
+    title_hit += _overlap_bonus(query, str(row["title"]))
+
+    alias_hit = 0.0
+    for alias in json.loads(row.get("aliases_json") or "[]"):
+        alias_text = str(alias)
+        alias_key = _normalized_text(alias_text)
+        if alias_key == query_key:
+            alias_hit = max(alias_hit, 1.25)
+        elif _contains_query(alias_text, query):
+            alias_hit = max(alias_hit, 0.75)
+        alias_hit = max(alias_hit, _overlap_bonus(query, alias_text))
+
+    fts_score = float(row.get("fts_score") or 0.0)
+    fts_bonus = 1.0 / (1.0 + max(fts_score, 0.0))
+    kind_bonus = 0.0
+    if memory_type == MemoryType.SEMANTIC.value and row["kind"] == NoteKind.SEMANTIC.value:
+        kind_bonus += 2.0
+    if memory_type == MemoryType.EPISODIC.value and row["kind"] == NoteKind.EPISODIC.value:
+        kind_bonus += 2.0
+    if memory_type == MemoryType.AUTO.value:
+        if bias == MemoryType.SEMANTIC.value and row["kind"] == NoteKind.SEMANTIC.value:
+            kind_bonus += 1.5
+        if bias == MemoryType.EPISODIC.value and row["kind"] == NoteKind.EPISODIC.value:
+            kind_bonus += 1.5
+        if bias == MemoryType.AUTO.value and row["kind"] == NoteKind.SEMANTIC.value:
+            kind_bonus += 0.5
+
+    return round(
+        title_hit
+        + alias_hit
+        + fts_bonus
+        + kind_bonus
+        + _metadata_bonus(row, query)
+        + recency_bonus(str(row.get("updated_at", ""))),
+        5,
+    )

--- a/llmwiki_hermes/recall/search.py
+++ b/llmwiki_hermes/recall/search.py
@@ -1,0 +1,135 @@
+"""Recall service built on the SQLite sidecar index."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+from llmwiki_hermes.recall.format import format_recall_block
+from llmwiki_hermes.recall.rank import score_row
+from llmwiki_hermes.schemas.cli import CommandOutput, RecallHit, RecallResponse
+from llmwiki_hermes.settings import WikiSettings
+from llmwiki_hermes.storage.sqlite_index import IndexService
+from llmwiki_hermes.storage.vault import VaultService
+
+logger = logging.getLogger(__name__)
+
+ENGLISH_STOPWORDS = {
+    "a",
+    "an",
+    "are",
+    "be",
+    "can",
+    "could",
+    "did",
+    "do",
+    "does",
+    "for",
+    "how",
+    "i",
+    "in",
+    "is",
+    "it",
+    "me",
+    "of",
+    "on",
+    "please",
+    "tell",
+    "the",
+    "this",
+    "to",
+    "was",
+    "we",
+    "what",
+    "when",
+    "where",
+    "which",
+    "who",
+    "why",
+    "you",
+}
+
+
+def normalize_query(query: str) -> str:
+    """Normalize natural-language input into an FTS-safe query."""
+
+    tokens = re.findall(r"\w+(?:[-']\w+)*", query, flags=re.UNICODE)
+    filtered = [
+        token for token in tokens if not (token.isascii() and token.lower() in ENGLISH_STOPWORDS)
+    ]
+    normalized = filtered or tokens
+    return " ".join(normalized).strip()
+
+
+class RecallService:
+    """Search, rank, and format knowledge recall."""
+
+    def __init__(self, settings: WikiSettings) -> None:
+        self.settings = settings
+        self.vault_service = VaultService(settings.vault_path)
+        self.index_service = IndexService(self.vault_service)
+
+    @classmethod
+    def from_settings(cls, settings: WikiSettings) -> "RecallService":
+        return cls(settings)
+
+    def recall(self, query: str, memory_type: str, top_k: int) -> RecallResponse:
+        """Search and rank notes."""
+
+        normalized = normalize_query(query)
+        if not normalized:
+            logger.warning("Recall query normalized to empty input.")
+            return RecallResponse(
+                query="",
+                memory_type=memory_type,
+                results=[],
+                recall_block=format_recall_block([]),
+            )
+        kind_filter = None if memory_type == "auto" else memory_type
+        try:
+            rows = self.index_service.search(query=normalized, kind=kind_filter, top_k=top_k)
+        except Exception:
+            logger.exception(
+                "Recall search failed for query %r with memory_type=%s.",
+                normalized,
+                memory_type,
+            )
+            raise
+
+        best_by_note: dict[str, RecallHit] = {}
+        for row in rows:
+            hit = RecallHit(
+                id=row["id"],
+                title=row["title"],
+                kind=row["kind"],
+                path=row["path"],
+                snippet=(
+                    (row.get("snippet") or row.get("heading") or "").strip()[:280] or row["title"]
+                ),
+                score=score_row(row, normalized, memory_type),
+                source_refs=json.loads(row["source_refs_json"] or "[]"),
+            )
+            existing = best_by_note.get(hit.id)
+            if existing is None or hit.score > existing.score:
+                best_by_note[hit.id] = hit
+        ranked = sorted(best_by_note.values(), key=lambda item: item.score, reverse=True)[:top_k]
+        logger.debug(
+            "Recall returned %s note(s) for query %r with memory_type=%s.",
+            len(ranked),
+            normalized,
+            memory_type,
+        )
+        return RecallResponse(
+            query=normalized,
+            memory_type=memory_type,
+            results=ranked,
+            recall_block=format_recall_block(ranked),
+        )
+
+    def recall_cli(self, query: str, memory_type: str, top_k: int) -> CommandOutput:
+        response = self.recall(query=query, memory_type=memory_type, top_k=top_k)
+        return CommandOutput(
+            message=response.recall_block,
+            data=response.model_dump(mode="json"),
+        )

--- a/llmwiki_hermes/schemas/__init__.py
+++ b/llmwiki_hermes/schemas/__init__.py
@@ -1,0 +1,25 @@
+"""Pydantic schemas for notes and CLI payloads."""
+
+from llmwiki_hermes.schemas.cli import CommandOutput, RecallHit, RecallResponse
+from llmwiki_hermes.schemas.diagnostics import DiagnosticIssue, DiagnosticReport, DiagnosticSeverity
+from llmwiki_hermes.schemas.notes import (
+    EpisodicNoteFrontmatter,
+    NoteDocument,
+    SemanticNoteFrontmatter,
+    SourceNoteFrontmatter,
+    validate_note_frontmatter,
+)
+
+__all__ = [
+    "CommandOutput",
+    "RecallHit",
+    "RecallResponse",
+    "DiagnosticIssue",
+    "DiagnosticReport",
+    "DiagnosticSeverity",
+    "NoteDocument",
+    "SourceNoteFrontmatter",
+    "SemanticNoteFrontmatter",
+    "EpisodicNoteFrontmatter",
+    "validate_note_frontmatter",
+]

--- a/llmwiki_hermes/schemas/cli.py
+++ b/llmwiki_hermes/schemas/cli.py
@@ -1,0 +1,38 @@
+"""Schemas used by CLI and provider responses."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from llmwiki_hermes.types import NoteKind
+
+
+class CommandOutput(BaseModel):
+    """Standard CLI payload."""
+
+    ok: bool = True
+    message: str
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class RecallHit(BaseModel):
+    """Single recall result."""
+
+    id: str
+    title: str
+    kind: NoteKind
+    path: str
+    snippet: str
+    score: float
+    source_refs: list[str] = Field(default_factory=list)
+
+
+class RecallResponse(BaseModel):
+    """Recall response payload."""
+
+    query: str
+    memory_type: str
+    results: list[RecallHit]
+    recall_block: str

--- a/llmwiki_hermes/schemas/diagnostics.py
+++ b/llmwiki_hermes/schemas/diagnostics.py
@@ -1,0 +1,34 @@
+"""Schemas for diagnostic and maintenance reports."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class DiagnosticSeverity(StrEnum):
+    """Supported issue severities."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class DiagnosticIssue(BaseModel):
+    """A single actionable issue discovered during validation."""
+
+    code: str
+    severity: DiagnosticSeverity = DiagnosticSeverity.ERROR
+    path: str
+    message: str
+    note_id: str | None = None
+
+
+class DiagnosticReport(BaseModel):
+    """Structured validation output."""
+
+    issues: list[DiagnosticIssue] = Field(default_factory=list)
+    stats: dict[str, int | dict[str, int]] = Field(default_factory=dict)
+    severity_counts: dict[str, int] = Field(default_factory=dict)
+    recovery_workflow: list[str] = Field(default_factory=list)

--- a/llmwiki_hermes/schemas/notes.py
+++ b/llmwiki_hermes/schemas/notes.py
@@ -1,0 +1,115 @@
+"""Structured note schemas."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Mapping
+
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+from llmwiki_hermes.constants import CURRENT_SCHEMA_VERSION
+from llmwiki_hermes.errors import InvalidFrontmatterError
+from llmwiki_hermes.types import NoteKind
+
+
+class NoteFrontmatterBase(BaseModel):
+    """Fields shared by all note types."""
+
+    schema_version: int = CURRENT_SCHEMA_VERSION
+    id: str
+    kind: NoteKind
+    title: str
+    source_refs: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+
+    @field_validator("id", "title")
+    @classmethod
+    def validate_non_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("Field cannot be empty.")
+        return value.strip()
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("schema_version must be zero or greater.")
+        return value
+
+
+class SourceNoteFrontmatter(NoteFrontmatterBase):
+    """Frontmatter for source notes."""
+
+    kind: NoteKind = NoteKind.SOURCE
+    source_type: str = "text"
+    origin: str = "user_upload"
+    ingested_at: datetime
+    content_hash: str
+
+
+class SemanticNoteFrontmatter(NoteFrontmatterBase):
+    """Frontmatter for semantic notes."""
+
+    kind: NoteKind = NoteKind.SEMANTIC
+    aliases: list[str] = Field(default_factory=list)
+    entity_refs: list[str] = Field(default_factory=list)
+    updated_at: date
+    confidence: str = "medium"
+
+
+class EpisodicNoteFrontmatter(NoteFrontmatterBase):
+    """Frontmatter for episodic notes."""
+
+    kind: NoteKind = NoteKind.EPISODIC
+    date: date
+    participants: list[str] = Field(default_factory=list)
+    project: str | None = None
+    entity_refs: list[str] = Field(default_factory=list)
+
+
+class NoteDocument(BaseModel):
+    """In-memory representation of a Markdown note."""
+
+    frontmatter: dict[str, Any]
+    body: str
+    path: str
+
+
+FRONTMATTER_MODELS: dict[str, type[NoteFrontmatterBase]] = {
+    NoteKind.SOURCE.value: SourceNoteFrontmatter,
+    NoteKind.SEMANTIC.value: SemanticNoteFrontmatter,
+    NoteKind.EPISODIC.value: EpisodicNoteFrontmatter,
+}
+
+
+def parse_schema_version(frontmatter: Mapping[str, Any]) -> int | None:
+    """Parse a note schema version when present and integer-like."""
+
+    raw_value = frontmatter.get("schema_version")
+    if raw_value is None or not str(raw_value).strip():
+        return None
+    try:
+        return int(raw_value)
+    except (TypeError, ValueError):
+        return None
+
+
+def is_unsupported_schema(frontmatter: Mapping[str, Any]) -> bool:
+    """Return whether a note uses a schema version newer than the current code supports."""
+
+    parsed = parse_schema_version(frontmatter)
+    return parsed is not None and parsed > CURRENT_SCHEMA_VERSION
+
+
+def validate_note_frontmatter(frontmatter: dict[str, Any]) -> NoteFrontmatterBase:
+    """Validate frontmatter based on the note kind."""
+
+    raw_kind = frontmatter.get("kind")
+    kind = raw_kind.value if isinstance(raw_kind, NoteKind) else str(raw_kind or "").strip()
+    model_cls = FRONTMATTER_MODELS.get(kind)
+    if model_cls is None:
+        raise InvalidFrontmatterError(f"Unsupported note kind: {raw_kind!r}")
+    try:
+        return model_cls.model_validate(frontmatter)
+    except ValidationError as exc:
+        raise InvalidFrontmatterError(str(exc)) from exc

--- a/llmwiki_hermes/settings.py
+++ b/llmwiki_hermes/settings.py
@@ -1,0 +1,75 @@
+"""Configuration loading for LLM-Wiki on Hermes."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+from llmwiki_hermes.constants import (
+    CONFIG_ENV_VAR,
+    DEFAULT_AUTO_WRITEBACK,
+    DEFAULT_CONFIG_PATH,
+    DEFAULT_TOP_K_EPISODIC,
+    DEFAULT_TOP_K_SEMANTIC,
+)
+from llmwiki_hermes.errors import ConfigurationError
+
+
+class WikiSettings(BaseModel):
+    """Persisted runtime configuration."""
+
+    vault_path: Path
+    top_k_semantic: int = Field(default=DEFAULT_TOP_K_SEMANTIC, ge=1, le=50)
+    top_k_episodic: int = Field(default=DEFAULT_TOP_K_EPISODIC, ge=1, le=50)
+    auto_writeback: bool = DEFAULT_AUTO_WRITEBACK
+
+    @classmethod
+    def load(
+        cls,
+        vault_path: Path | None = None,
+        config_path: Path | None = None,
+    ) -> "WikiSettings":
+        """Load settings from explicit args, config file, env, and defaults."""
+
+        resolved_path = config_path or DEFAULT_CONFIG_PATH
+        data: dict[str, Any] = {}
+        if resolved_path.exists():
+            raw = yaml.safe_load(resolved_path.read_text(encoding="utf-8")) or {}
+            if isinstance(raw, dict):
+                data = raw
+        effective_vault = vault_path
+        if effective_vault is None and data.get("vault_path"):
+            effective_vault = Path(str(data["vault_path"]))
+        if effective_vault is None:
+            raw_env = os.environ.get(CONFIG_ENV_VAR)
+            if raw_env:
+                effective_vault = Path(raw_env)
+        if effective_vault is None:
+            raise ConfigurationError(
+                "Vault path is required. Pass --vault or set LLMWIKI_VAULT_PATH."
+            )
+        merged = {
+            "vault_path": effective_vault,
+            "top_k_semantic": data.get("top_k_semantic", DEFAULT_TOP_K_SEMANTIC),
+            "top_k_episodic": data.get("top_k_episodic", DEFAULT_TOP_K_EPISODIC),
+            "auto_writeback": data.get("auto_writeback", DEFAULT_AUTO_WRITEBACK),
+        }
+        return cls.model_validate(merged)
+
+    def save(self, config_path: Path | None = None) -> Path:
+        """Persist settings to YAML."""
+
+        path = config_path or DEFAULT_CONFIG_PATH
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "vault_path": str(self.vault_path),
+            "top_k_semantic": self.top_k_semantic,
+            "top_k_episodic": self.top_k_episodic,
+            "auto_writeback": self.auto_writeback,
+        }
+        path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+        return path

--- a/llmwiki_hermes/storage/__init__.py
+++ b/llmwiki_hermes/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Storage services for filesystem and SQLite."""

--- a/llmwiki_hermes/storage/frontmatter.py
+++ b/llmwiki_hermes/storage/frontmatter.py
@@ -1,0 +1,48 @@
+"""Minimal YAML frontmatter handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from llmwiki_hermes.errors import InvalidFrontmatterError
+from llmwiki_hermes.schemas.notes import NoteDocument
+
+
+def split_frontmatter(content: str) -> tuple[dict[str, Any], str]:
+    """Split a Markdown document into frontmatter and body."""
+
+    if not content.startswith("---\n"):
+        raise InvalidFrontmatterError("Document is missing YAML frontmatter.")
+    parts = content.split("\n---\n", 1)
+    if len(parts) != 2:
+        raise InvalidFrontmatterError("Document has malformed YAML frontmatter delimiters.")
+    raw_frontmatter = parts[0][4:]
+    body = parts[1].lstrip("\n")
+    data = yaml.safe_load(raw_frontmatter) or {}
+    if not isinstance(data, dict):
+        raise InvalidFrontmatterError("YAML frontmatter must decode to an object.")
+    return data, body
+
+
+def dump_frontmatter(frontmatter: dict[str, Any], body: str) -> str:
+    """Serialize frontmatter and body into Markdown."""
+
+    raw_yaml = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()
+    return f"---\n{raw_yaml}\n---\n\n{body.rstrip()}\n"
+
+
+def load_note(path: Path) -> NoteDocument:
+    """Read a note from disk."""
+
+    frontmatter, body = split_frontmatter(path.read_text(encoding="utf-8"))
+    return NoteDocument(frontmatter=frontmatter, body=body, path=str(path))
+
+
+def write_note(path: Path, frontmatter: dict[str, Any], body: str) -> None:
+    """Persist a note document."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dump_frontmatter(frontmatter, body), encoding="utf-8")

--- a/llmwiki_hermes/storage/ingest_inputs.py
+++ b/llmwiki_hermes/storage/ingest_inputs.py
@@ -1,0 +1,207 @@
+"""Input loading and file conversion for ingest."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from llmwiki_hermes.errors import IngestInputError
+
+NATIVE_SOURCE_TYPES: dict[str, str] = {
+    ".md": "markdown",
+    ".txt": "text",
+    ".json": "json",
+}
+
+MARKITDOWN_SOURCE_TYPES: dict[str, str] = {
+    ".pdf": "pdf",
+    ".docx": "docx",
+    ".pptx": "pptx",
+    ".xlsx": "xlsx",
+    ".html": "html",
+    ".htm": "html",
+    ".csv": "csv",
+    ".xml": "xml",
+}
+
+SUPPORTED_SOURCE_TYPES = NATIVE_SOURCE_TYPES | MARKITDOWN_SOURCE_TYPES
+
+
+def flatten_json_text(raw: str) -> str:
+    """Render JSON deterministically for downstream note generation."""
+
+    payload = json.loads(raw)
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+@dataclass(frozen=True)
+class LoadedIngestInput:
+    """A single ingest payload that has already been converted to text."""
+
+    path: Path | None
+    raw_content: str
+    detected_source_type: str
+
+
+@dataclass(frozen=True)
+class FailedIngestInput:
+    """A single ingest payload that could not be loaded."""
+
+    path: str
+    source_type: str
+    code: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "path": self.path,
+            "source_type": self.source_type,
+            "code": self.code,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedIngestInputs:
+    """A batch of ingest inputs with partial-success reporting."""
+
+    loaded_inputs: list[LoadedIngestInput]
+    failed_inputs: list[FailedIngestInput]
+
+    @property
+    def processed_inputs(self) -> int:
+        return len(self.loaded_inputs) + len(self.failed_inputs)
+
+
+class IngestInputLoader:
+    """Resolve files or stdin into normalized text inputs for the compiler."""
+
+    def resolve(
+        self,
+        *,
+        path: Path | None,
+        stdin: bool,
+        recursive: bool,
+    ) -> ResolvedIngestInputs:
+        if stdin:
+            return ResolvedIngestInputs(
+                loaded_inputs=[
+                    LoadedIngestInput(
+                        path=None,
+                        raw_content=sys.stdin.read(),
+                        detected_source_type="text",
+                    )
+                ],
+                failed_inputs=[],
+            )
+        if path is None:
+            raise IngestInputError("Pass a path or use --stdin.")
+
+        resolved = path.expanduser().resolve()
+        if resolved.is_dir():
+            pattern = "**/*" if recursive else "*"
+            paths = [item for item in sorted(resolved.glob(pattern)) if item.is_file()]
+            return self._resolve_paths(paths)
+        return self._resolve_paths([resolved])
+
+    def _resolve_paths(self, paths: list[Path]) -> ResolvedIngestInputs:
+        loaded_inputs: list[LoadedIngestInput] = []
+        failed_inputs: list[FailedIngestInput] = []
+
+        for input_path in paths:
+            loaded, failed = self._load_path(input_path)
+            if loaded is not None:
+                loaded_inputs.append(loaded)
+            if failed is not None:
+                failed_inputs.append(failed)
+
+        return ResolvedIngestInputs(loaded_inputs=loaded_inputs, failed_inputs=failed_inputs)
+
+    def _load_path(self, path: Path) -> tuple[LoadedIngestInput | None, FailedIngestInput | None]:
+        suffix = path.suffix.lower()
+        source_type = SUPPORTED_SOURCE_TYPES.get(suffix)
+        if source_type is None:
+            return None, FailedIngestInput(
+                path=str(path),
+                source_type="unknown",
+                code="unsupported_input_type",
+                message=f"Unsupported ingest input type: {suffix or '<no suffix>'}.",
+            )
+
+        if suffix in NATIVE_SOURCE_TYPES:
+            raw_content = path.read_text(encoding="utf-8")
+            if suffix == ".json":
+                raw_content = flatten_json_text(raw_content)
+            return (
+                LoadedIngestInput(
+                    path=path,
+                    raw_content=raw_content,
+                    detected_source_type=source_type,
+                ),
+                None,
+            )
+
+        try:
+            raw_content = self._convert_with_markitdown(path)
+        except _MarkItDownImportError as exc:
+            return None, FailedIngestInput(
+                path=str(path),
+                source_type=source_type,
+                code="markitdown_not_installed",
+                message=str(exc),
+            )
+        except _MarkItDownConversionError as exc:
+            return None, FailedIngestInput(
+                path=str(path),
+                source_type=source_type,
+                code=exc.code,
+                message=str(exc),
+            )
+
+        return (
+            LoadedIngestInput(
+                path=path,
+                raw_content=raw_content,
+                detected_source_type=source_type,
+            ),
+            None,
+        )
+
+    def _convert_with_markitdown(self, path: Path) -> str:
+        try:
+            from markitdown import MarkItDown, MissingDependencyException
+        except ImportError as exc:  # pragma: no cover - covered via monkeypatch in tests
+            raise _MarkItDownImportError(
+                "MarkItDown support is not installed. Install llmwiki-hermes[markitdown]."
+            ) from exc
+
+        try:
+            result = MarkItDown(enable_plugins=False).convert(path)
+        except MissingDependencyException as exc:
+            raise _MarkItDownConversionError(
+                "markitdown_not_installed",
+                (
+                    f"MarkItDown is installed but missing converters for {path.suffix.lower()}. "
+                    "Install llmwiki-hermes[markitdown]."
+                ),
+            ) from exc
+        except Exception as exc:
+            raise _MarkItDownConversionError(
+                "markitdown_conversion_failed",
+                f"MarkItDown failed to convert {path}: {exc}",
+            ) from exc
+        return result.text_content
+
+
+class _MarkItDownImportError(Exception):
+    """Raised when the MarkItDown dependency is unavailable."""
+
+
+class _MarkItDownConversionError(Exception):
+    """Raised when MarkItDown cannot convert a supported file."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code

--- a/llmwiki_hermes/storage/links.py
+++ b/llmwiki_hermes/storage/links.py
@@ -1,0 +1,13 @@
+"""Wikilink extraction."""
+
+from __future__ import annotations
+
+import re
+
+WIKILINK_PATTERN = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+def extract_links(body: str) -> list[str]:
+    """Extract simple wikilinks."""
+
+    return [match.strip() for match in WIKILINK_PATTERN.findall(body) if match.strip()]

--- a/llmwiki_hermes/storage/sqlite_index.py
+++ b/llmwiki_hermes/storage/sqlite_index.py
@@ -1,0 +1,376 @@
+"""SQLite FTS5 index management."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from llmwiki_hermes.errors import IndexCorruptionError
+from llmwiki_hermes.schemas.cli import CommandOutput
+from llmwiki_hermes.schemas.diagnostics import DiagnosticIssue, DiagnosticSeverity
+from llmwiki_hermes.schemas.notes import validate_note_frontmatter
+from llmwiki_hermes.storage.frontmatter import load_note
+from llmwiki_hermes.storage.links import extract_links
+from llmwiki_hermes.storage.vault import VaultService
+
+logger = logging.getLogger(__name__)
+
+
+def chunk_markdown(body: str) -> list[dict[str, str]]:
+    """Split a Markdown body by headings into simple searchable chunks."""
+
+    chunks: list[dict[str, str]] = []
+    current_heading = ""
+    current_lines: list[str] = []
+    for raw_line in body.splitlines():
+        if raw_line.startswith("#"):
+            if current_lines:
+                chunks.append(
+                    {"heading": current_heading, "text": "\n".join(current_lines).strip()}
+                )
+                current_lines = []
+            current_heading = raw_line.lstrip("#").strip()
+            continue
+        current_lines.append(raw_line)
+    if current_lines:
+        chunks.append({"heading": current_heading, "text": "\n".join(current_lines).strip()})
+    return [chunk for chunk in chunks if chunk["text"]]
+
+
+def build_fts_match_query(query: str) -> str:
+    """Quote non-word tokens so SQLite FTS5 does not misparse them."""
+
+    terms: list[str] = []
+    for token in query.split():
+        escaped = token.replace('"', '""')
+        if all(character == "_" or character.isalnum() for character in token):
+            terms.append(token)
+        else:
+            terms.append(f'"{escaped}"')
+    return " ".join(terms)
+
+
+class IndexService:
+    """Manage the sidecar SQLite database."""
+
+    def __init__(self, vault_service: VaultService) -> None:
+        self.vault_service = vault_service
+
+    def connect(self) -> sqlite3.Connection:
+        """Open the SQLite database."""
+
+        self.vault_service.hidden_dir.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(self.vault_service.index_db_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def create_schema(self) -> None:
+        """Create the required SQLite tables."""
+
+        with self.connect() as connection:
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS notes (
+                  id TEXT PRIMARY KEY,
+                  schema_version INTEGER,
+                  kind TEXT NOT NULL,
+                  title TEXT NOT NULL,
+                  path TEXT NOT NULL UNIQUE,
+                  updated_at TEXT,
+                  aliases_json TEXT,
+                  entity_refs_json TEXT,
+                  confidence TEXT,
+                  date TEXT,
+                  project TEXT,
+                  tags_json TEXT,
+                  source_refs_json TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS chunks (
+                  id INTEGER PRIMARY KEY AUTOINCREMENT,
+                  note_id TEXT NOT NULL,
+                  ord INTEGER NOT NULL,
+                  heading TEXT,
+                  text TEXT NOT NULL,
+                  FOREIGN KEY(note_id) REFERENCES notes(id)
+                );
+
+                CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+                  text,
+                  content='chunks',
+                  content_rowid='id'
+                );
+
+                CREATE TABLE IF NOT EXISTS links (
+                  src_note_id TEXT NOT NULL,
+                  dst_note_id TEXT NOT NULL,
+                  relation TEXT DEFAULT 'wikilink'
+                );
+                """
+            )
+
+    def reset_schema(self) -> None:
+        """Drop and recreate the SQLite schema."""
+
+        with self.connect() as connection:
+            connection.executescript(
+                """
+                DROP TABLE IF EXISTS links;
+                DROP TABLE IF EXISTS chunks_fts;
+                DROP TABLE IF EXISTS chunks;
+                DROP TABLE IF EXISTS notes;
+                """
+            )
+        self.create_schema()
+
+    def reindex(self) -> CommandOutput:
+        """Rebuild all index tables from the Markdown file tree."""
+
+        self.vault_service.ensure_initialized()
+        self.reset_schema()
+        note_paths = list(self.vault_service.iter_note_paths())
+        failed_notes: list[DiagnosticIssue] = []
+        indexed = 0
+        chunk_count = 0
+        link_count = 0
+        logger.info(
+            "Reindexing %s note file(s) into %s.",
+            len(note_paths),
+            self.vault_service.index_db_path,
+        )
+        with self.connect() as connection:
+            for path in note_paths:
+                try:
+                    document = load_note(path)
+                    frontmatter = validate_note_frontmatter(document.frontmatter)
+                    raw_schema_version = document.frontmatter.get("schema_version")
+                    schema_version = (
+                        int(raw_schema_version)
+                        if raw_schema_version is not None and str(raw_schema_version).strip()
+                        else None
+                    )
+                    note_id = str(frontmatter.id)
+                    updated_at = getattr(frontmatter, "updated_at", None) or getattr(
+                        frontmatter, "date", ""
+                    )
+                    connection.execute(
+                        """
+                        INSERT INTO notes (
+                          id,
+                          schema_version,
+                          kind,
+                          title,
+                          path,
+                          updated_at,
+                          aliases_json,
+                          entity_refs_json,
+                          confidence,
+                          date,
+                          project,
+                          tags_json,
+                          source_refs_json
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            note_id,
+                            schema_version,
+                            frontmatter.kind.value,
+                            frontmatter.title,
+                            str(path),
+                            str(updated_at),
+                            json.dumps(
+                                getattr(frontmatter, "aliases", []),
+                                ensure_ascii=False,
+                            ),
+                            json.dumps(
+                                getattr(frontmatter, "entity_refs", []),
+                                ensure_ascii=False,
+                            ),
+                            getattr(frontmatter, "confidence", None),
+                            str(getattr(frontmatter, "date", "") or ""),
+                            getattr(frontmatter, "project", None),
+                            json.dumps(frontmatter.tags, ensure_ascii=False),
+                            json.dumps(frontmatter.source_refs, ensure_ascii=False),
+                        ),
+                    )
+                    for order, chunk in enumerate(chunk_markdown(document.body), start=1):
+                        fts_text = (
+                            f"{chunk['heading']}\n{chunk['text']}".strip()
+                            if chunk["heading"]
+                            else chunk["text"]
+                        )
+                        cursor = connection.execute(
+                            """
+                            INSERT INTO chunks (note_id, ord, heading, text)
+                            VALUES (?, ?, ?, ?)
+                            """,
+                            (note_id, order, chunk["heading"], chunk["text"]),
+                        )
+                        connection.execute(
+                            "INSERT INTO chunks_fts(rowid, text) VALUES (?, ?)",
+                            (cursor.lastrowid, fts_text),
+                        )
+                        chunk_count += 1
+                    for link in extract_links(document.body):
+                        connection.execute(
+                            (
+                                "INSERT INTO links "
+                                "(src_note_id, dst_note_id, relation) VALUES (?, ?, ?)"
+                            ),
+                            (note_id, link, "wikilink"),
+                        )
+                        link_count += 1
+                    indexed += 1
+                except Exception as exc:
+                    logger.warning("Skipping invalid note during reindex: %s (%s)", path, exc)
+                    failed_notes.append(
+                        DiagnosticIssue(
+                            code="reindex_skipped_note",
+                            severity=DiagnosticSeverity.WARNING,
+                            path=str(path),
+                            message=str(exc),
+                        )
+                    )
+                    continue
+        skipped_notes = len(failed_notes)
+        logger.info(
+            "Reindex finished for %s: %s indexed, %s skipped, %s chunks, %s links.",
+            self.vault_service.index_db_path,
+            indexed,
+            skipped_notes,
+            chunk_count,
+            link_count,
+        )
+        message = (
+            (f"Reindexed {indexed} note(s), built {chunk_count} chunk(s) and {link_count} link(s).")
+            if not failed_notes
+            else (
+                f"Reindexed {indexed} of {len(note_paths)} note(s), built {chunk_count} chunk(s), "
+                f"{link_count} link(s), skipped {skipped_notes} note(s)."
+            )
+        )
+        return CommandOutput(
+            message=message,
+            data={
+                "note_files": len(note_paths),
+                "indexed_notes": indexed,
+                "skipped_notes": skipped_notes,
+                "failed_notes": [issue.model_dump(mode="json") for issue in failed_notes],
+                "link_count": link_count,
+                "chunk_count": chunk_count,
+                "index_path": str(self.vault_service.index_db_path),
+            },
+        )
+
+    def search(
+        self,
+        query: str,
+        kind: str | None = None,
+        top_k: int = 8,
+    ) -> list[dict[str, Any]]:
+        """Search indexed note chunks using FTS5."""
+
+        if not self.vault_service.index_db_path.exists():
+            raise IndexCorruptionError("SQLite index does not exist. Run reindex first.")
+        fts_query = build_fts_match_query(query)
+        sql = """
+            SELECT
+              notes.id,
+              notes.schema_version,
+              notes.kind,
+              notes.title,
+              notes.path,
+              notes.updated_at,
+              notes.aliases_json,
+              notes.entity_refs_json,
+              notes.confidence,
+              notes.date,
+              notes.project,
+              notes.tags_json,
+              notes.source_refs_json,
+              chunks.heading,
+              snippet(chunks_fts, 0, '[', ']', '...', 18) AS snippet,
+              bm25(chunks_fts) AS fts_score
+            FROM chunks_fts
+            JOIN chunks ON chunks_fts.rowid = chunks.id
+            JOIN notes ON notes.id = chunks.note_id
+            WHERE chunks_fts MATCH ?
+        """
+        params: list[Any] = [fts_query]
+        if kind:
+            sql += " AND notes.kind = ?"
+            params.append(kind)
+        sql += " ORDER BY bm25(chunks_fts) LIMIT ?"
+        params.append(top_k * 3)
+        metadata_sql = """
+            SELECT
+              notes.id,
+              notes.schema_version,
+              notes.kind,
+              notes.title,
+              notes.path,
+              notes.updated_at,
+              notes.aliases_json,
+              notes.entity_refs_json,
+              notes.confidence,
+              notes.date,
+              notes.project,
+              notes.tags_json,
+              notes.source_refs_json,
+              '' AS heading,
+              notes.title AS snippet,
+              0.0 AS fts_score
+            FROM notes
+            WHERE (
+              lower(notes.title) LIKE ?
+              OR lower(notes.aliases_json) LIKE ?
+              OR lower(COALESCE(notes.project, '')) LIKE ?
+              OR COALESCE(notes.date, '') = ?
+              OR lower(notes.source_refs_json) LIKE ?
+            )
+        """
+        metadata_query = f"%{query.lower()}%"
+        metadata_params: list[Any] = [
+            metadata_query,
+            metadata_query,
+            metadata_query,
+            query,
+            metadata_query,
+        ]
+        if kind:
+            metadata_sql += " AND notes.kind = ?"
+            metadata_params.append(kind)
+        metadata_sql += " LIMIT ?"
+        metadata_params.append(top_k * 3)
+        with self.connect() as connection:
+            rows = connection.execute(sql, params).fetchall()
+            metadata_rows = connection.execute(metadata_sql, metadata_params).fetchall()
+        return [dict(row) for row in [*rows, *metadata_rows]]
+
+    def note_count(self) -> int:
+        """Count indexed notes."""
+
+        if not self.vault_service.index_db_path.exists():
+            return 0
+        with self.connect() as connection:
+            row = connection.execute("SELECT COUNT(*) AS count FROM notes").fetchone()
+        return int(row["count"] if row else 0)
+
+    def note_rows(self) -> list[dict[str, Any]]:
+        """Return indexed note ids and paths for diagnostics."""
+
+        if not self.vault_service.index_db_path.exists():
+            return []
+        with self.connect() as connection:
+            rows = connection.execute("SELECT id, path FROM notes").fetchall()
+        return [dict(row) for row in rows]
+
+    def validate(self) -> None:
+        """Raise when the index is unavailable."""
+
+        if not Path(self.vault_service.index_db_path).exists():
+            raise IndexCorruptionError("SQLite index does not exist.")

--- a/llmwiki_hermes/storage/vault.py
+++ b/llmwiki_hermes/storage/vault.py
@@ -1,0 +1,490 @@
+"""Vault filesystem service."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable
+
+from llmwiki_hermes.constants import (
+    CURRENT_SCHEMA_VERSION,
+    INDEX_DB_NAME,
+    INGEST_LOG_NAME,
+    PRECOMPRESS_DIR,
+    SESSION_LOG_DIR,
+    STATE_FILE_NAME,
+    VAULT_DIRS,
+    VAULT_ROOT_NAME,
+)
+from llmwiki_hermes.errors import ConfigurationError, VaultNotInitializedError
+from llmwiki_hermes.schemas.cli import CommandOutput
+from llmwiki_hermes.schemas.diagnostics import DiagnosticIssue, DiagnosticReport, DiagnosticSeverity
+from llmwiki_hermes.schemas.notes import NoteDocument, validate_note_frontmatter
+from llmwiki_hermes.storage.frontmatter import load_note
+from llmwiki_hermes.storage.links import extract_links
+from llmwiki_hermes.utils.slug import slugify
+
+logger = logging.getLogger(__name__)
+NOTE_ID_PREFIXES = ("src-", "sem-", "epi-")
+
+
+def _normalize_lookup_value(value: str) -> str:
+    return slugify(value.replace("_", "-"))
+
+
+def _strip_note_prefix(value: str) -> str:
+    for prefix in NOTE_ID_PREFIXES:
+        if value.startswith(prefix):
+            return value[len(prefix) :]
+    return value
+
+
+class VaultService:
+    """Encapsulates all vault path logic."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root.expanduser().resolve()
+        self.sources_dir = self.root / "10_sources"
+        self.semantic_dir = self.root / "20_semantic"
+        self.episodic_dir = self.root / "30_episodic"
+        self.system_dir = self.root / "90_system"
+        self.hidden_dir = self.root / ".wiki"
+        self.index_db_path = self.hidden_dir / INDEX_DB_NAME
+        self.ingest_log_path = self.hidden_dir / INGEST_LOG_NAME
+        self.state_path = self.hidden_dir / STATE_FILE_NAME
+
+    @classmethod
+    def from_user_path(cls, base_path: Path) -> "VaultService":
+        """Create a service from the user-facing init path."""
+
+        resolved = base_path.expanduser().resolve()
+        root = resolved if resolved.name == VAULT_ROOT_NAME else resolved / VAULT_ROOT_NAME
+        return cls(root)
+
+    def initialize(self, force: bool = False) -> CommandOutput:
+        """Create the vault directory structure."""
+
+        if self.root.exists() and not force and any(self.root.iterdir()):
+            raise ConfigurationError(f"Vault already exists: {self.root}")
+        for name in VAULT_DIRS:
+            (self.root / name).mkdir(parents=True, exist_ok=True)
+        self.ingest_log_path.touch(exist_ok=True)
+        if force or not self.state_path.exists():
+            self.state_path.write_text(json.dumps({"version": "1.0.0"}, indent=2), encoding="utf-8")
+        from llmwiki_hermes.storage.sqlite_index import IndexService
+
+        IndexService(self).create_schema()
+        return CommandOutput(
+            message=f"Initialized vault at {self.root}",
+            data={"vault_path": str(self.root), "index_path": str(self.index_db_path)},
+        )
+
+    def ensure_initialized(self) -> None:
+        """Validate required directories exist."""
+
+        if not self.root.exists():
+            raise VaultNotInitializedError(f"Vault does not exist: {self.root}")
+        missing = [name for name in VAULT_DIRS if not (self.root / name).exists()]
+        if missing:
+            raise VaultNotInitializedError(
+                f"Vault is missing required paths: {', '.join(sorted(missing))}"
+            )
+
+    def iter_note_paths(self) -> Iterable[Path]:
+        """Yield all managed note paths."""
+
+        self.ensure_initialized()
+        for directory in (self.sources_dir, self.semantic_dir, self.episodic_dir):
+            yield from sorted(directory.glob("*.md"))
+
+    def get_note(self, id_or_slug: str) -> NoteDocument:
+        """Resolve a note by id, slug, or filename stem."""
+
+        target = _normalize_lookup_value(id_or_slug)
+        title_match: NoteDocument | None = None
+        for path in self.iter_note_paths():
+            path_key = _normalize_lookup_value(path.stem)
+            if path_key == target or _strip_note_prefix(path_key) == target:
+                return load_note(path)
+            document = load_note(path)
+            note_id = str(document.frontmatter.get("id", ""))
+            note_id_key = _normalize_lookup_value(note_id)
+            if (
+                note_id == id_or_slug
+                or note_id_key == target
+                or _strip_note_prefix(note_id_key) == target
+            ):
+                return document
+            title_key = _normalize_lookup_value(str(document.frontmatter.get("title", "")))
+            if title_key == target and title_match is None:
+                title_match = document
+        if title_match is not None:
+            return title_match
+        raise FileNotFoundError(f"Note not found: {id_or_slug}")
+
+    def doctor(self) -> CommandOutput:
+        """Check directory structure and note readability."""
+
+        issues: list[DiagnosticIssue] = []
+        initialized = True
+        try:
+            self.ensure_initialized()
+        except VaultNotInitializedError as exc:
+            issues.append(
+                DiagnosticIssue(
+                    code="vault_not_initialized",
+                    severity=DiagnosticSeverity.ERROR,
+                    path=str(self.root),
+                    message=str(exc),
+                )
+            )
+            initialized = False
+        note_paths = list(self.iter_note_paths()) if self.root.exists() and initialized else []
+        valid_notes: list[tuple[Path, NoteDocument, Any]] = []
+        legacy_schema_notes = 0
+        notes_by_schema_version: dict[str, int] = {}
+
+        for path in note_paths:
+            try:
+                document = load_note(path)
+            except Exception as exc:
+                logger.warning("Doctor failed to parse frontmatter for %s: %s", path, exc)
+                issues.append(
+                    DiagnosticIssue(
+                        code="frontmatter_parse_error",
+                        severity=DiagnosticSeverity.ERROR,
+                        path=str(path),
+                        message=str(exc),
+                    )
+                )
+                continue
+
+            raw_note_id = str(document.frontmatter.get("id", "")) or None
+            raw_schema_version = document.frontmatter.get("schema_version")
+            if raw_schema_version is None:
+                legacy_schema_notes += 1
+                notes_by_schema_version["legacy"] = notes_by_schema_version.get("legacy", 0) + 1
+                issues.append(
+                    DiagnosticIssue(
+                        code="missing_schema_version",
+                        severity=DiagnosticSeverity.WARNING,
+                        path=str(path),
+                        message="Note is missing schema_version and is treated as a legacy note.",
+                        note_id=raw_note_id,
+                    )
+                )
+            else:
+                try:
+                    parsed_schema_version = int(raw_schema_version)
+                except (TypeError, ValueError):
+                    parsed_schema_version = None
+                if parsed_schema_version is not None:
+                    key = str(parsed_schema_version)
+                    notes_by_schema_version[key] = notes_by_schema_version.get(key, 0) + 1
+                    if parsed_schema_version < CURRENT_SCHEMA_VERSION:
+                        legacy_schema_notes += 1
+                        issues.append(
+                            DiagnosticIssue(
+                                code="outdated_schema_version",
+                                severity=DiagnosticSeverity.WARNING,
+                                path=str(path),
+                                message=(
+                                    "Note uses outdated schema_version "
+                                    f"{parsed_schema_version}; current is {CURRENT_SCHEMA_VERSION}."
+                                ),
+                                note_id=raw_note_id,
+                            )
+                        )
+                    if parsed_schema_version > CURRENT_SCHEMA_VERSION:
+                        issues.append(
+                            DiagnosticIssue(
+                                code="unsupported_schema_version",
+                                severity=DiagnosticSeverity.ERROR,
+                                path=str(path),
+                                message=(
+                                    "Note uses unsupported schema_version "
+                                    f"{parsed_schema_version}; current is {CURRENT_SCHEMA_VERSION}."
+                                ),
+                                note_id=raw_note_id,
+                            )
+                        )
+            for field in ("id", "kind", "title"):
+                if field not in document.frontmatter:
+                    issues.append(
+                        DiagnosticIssue(
+                            code="missing_required_field",
+                            severity=DiagnosticSeverity.ERROR,
+                            path=str(path),
+                            message=f"Frontmatter is missing required field: {field}",
+                            note_id=raw_note_id,
+                        )
+                    )
+            if (
+                document.frontmatter.get("kind") == "episodic"
+                and "date" not in document.frontmatter
+            ):
+                issues.append(
+                    DiagnosticIssue(
+                        code="episodic_missing_date",
+                        severity=DiagnosticSeverity.ERROR,
+                        path=str(path),
+                        message="Episodic note is missing required field: date",
+                        note_id=raw_note_id,
+                    )
+                )
+
+            try:
+                frontmatter = validate_note_frontmatter(document.frontmatter)
+            except Exception as exc:
+                logger.warning("Doctor failed to validate frontmatter for %s: %s", path, exc)
+                issues.append(
+                    DiagnosticIssue(
+                        code="frontmatter_validation_error",
+                        severity=DiagnosticSeverity.ERROR,
+                        path=str(path),
+                        message=str(exc),
+                        note_id=raw_note_id,
+                    )
+                )
+                continue
+
+            note_id = str(frontmatter.id)
+            if frontmatter.kind.value == "semantic" and not frontmatter.source_refs:
+                issues.append(
+                    DiagnosticIssue(
+                        code="semantic_missing_source_refs",
+                        severity=DiagnosticSeverity.ERROR,
+                        path=str(path),
+                        message="Semantic note must retain at least one source_ref.",
+                        note_id=note_id,
+                    )
+                )
+
+            valid_notes.append((path, document, frontmatter))
+
+        source_note_ids: set[str] = set()
+        source_hash_groups: dict[str, list[tuple[str, str]]] = {}
+        orphan_semantic_notes = 0
+        orphan_episodic_notes = 0
+        note_ids_by_path: dict[str, str] = {}
+
+        for path, _document, frontmatter in valid_notes:
+            note_id = str(frontmatter.id)
+            note_ids_by_path[str(path)] = note_id
+            if frontmatter.kind.value != "source":
+                continue
+            source_note_ids.add(note_id)
+            content_hash = getattr(frontmatter, "content_hash", "")
+            if content_hash:
+                source_hash_groups.setdefault(str(content_hash), []).append((str(path), note_id))
+
+        for path, _document, frontmatter in valid_notes:
+            missing_source_refs = [
+                source_ref
+                for source_ref in frontmatter.source_refs
+                if source_ref not in source_note_ids
+            ]
+            if frontmatter.kind.value == "semantic" and missing_source_refs:
+                orphan_semantic_notes += 1
+                issues.append(
+                    DiagnosticIssue(
+                        code="orphan_semantic_note",
+                        severity=DiagnosticSeverity.WARNING,
+                        path=str(path),
+                        message=(
+                            "Semantic note references missing source note(s): "
+                            f"{', '.join(sorted(missing_source_refs))}"
+                        ),
+                        note_id=str(frontmatter.id),
+                    )
+                )
+            if frontmatter.kind.value == "episodic" and (
+                not frontmatter.source_refs or missing_source_refs
+            ):
+                orphan_episodic_notes += 1
+                message = (
+                    "Episodic note does not reference any source note."
+                    if not frontmatter.source_refs
+                    else (
+                        "Episodic note references missing source note(s): "
+                        f"{', '.join(sorted(missing_source_refs))}"
+                    )
+                )
+                issues.append(
+                    DiagnosticIssue(
+                        code="orphan_episodic_note",
+                        severity=DiagnosticSeverity.WARNING,
+                        path=str(path),
+                        message=message,
+                        note_id=str(frontmatter.id),
+                    )
+                )
+
+        duplicate_source_hash_groups = 0
+        for content_hash, members in sorted(source_hash_groups.items()):
+            if len(members) < 2:
+                continue
+            duplicate_source_hash_groups += 1
+            member_ids = [note_id for _path, note_id in members]
+            for member_path, note_id in members:
+                duplicate_peers = [item for item in member_ids if item != note_id]
+                issues.append(
+                    DiagnosticIssue(
+                        code="duplicate_source_content_hash",
+                        severity=DiagnosticSeverity.WARNING,
+                        path=member_path,
+                        message=(
+                            f"Source note shares content_hash {content_hash} with: "
+                            f"{', '.join(sorted(duplicate_peers))}"
+                        ),
+                        note_id=note_id,
+                    )
+                )
+
+        known_targets: set[str] = set()
+        for path, _document, frontmatter in valid_notes:
+            known_targets.update(
+                {
+                    path.stem,
+                    slugify(path.stem.replace("_", "-")),
+                    str(frontmatter.id),
+                    slugify(str(frontmatter.id).replace("_", "-")),
+                }
+            )
+
+        for path, document, frontmatter in valid_notes:
+            for link in extract_links(document.body):
+                normalized_link = slugify(link.replace("_", "-"))
+                if link not in known_targets and normalized_link not in known_targets:
+                    issues.append(
+                        DiagnosticIssue(
+                            code="broken_link",
+                            severity=DiagnosticSeverity.WARNING,
+                            path=str(path),
+                            message=f"Broken wikilink target: {link}",
+                            note_id=str(frontmatter.id),
+                        )
+                    )
+
+        if not self.index_db_path.exists():
+            issues.append(
+                DiagnosticIssue(
+                    code="missing_index",
+                    severity=DiagnosticSeverity.ERROR,
+                    path=str(self.index_db_path),
+                    message=f"Missing SQLite index: {self.index_db_path}",
+                )
+            )
+            indexed_notes = 0
+            missing_index_entries = 0
+            stale_index_entries = 0
+        else:
+            from llmwiki_hermes.storage.sqlite_index import IndexService
+
+            index_service = IndexService(self)
+            indexed_rows = index_service.note_rows()
+            indexed_notes = len(indexed_rows)
+            indexed_paths = {str(row["path"]): str(row["id"]) for row in indexed_rows}
+            valid_paths = {str(path) for path, _document, _frontmatter in valid_notes}
+            missing_paths = sorted(valid_paths - set(indexed_paths))
+            stale_paths = sorted(set(indexed_paths) - valid_paths)
+            missing_index_entries = len(missing_paths)
+            stale_index_entries = len(stale_paths)
+            if indexed_notes != len(note_paths):
+                logger.warning(
+                    "Doctor detected index/file count mismatch for %s: %s indexed vs %s files",
+                    self.index_db_path,
+                    indexed_notes,
+                    len(note_paths),
+                )
+                issues.append(
+                    DiagnosticIssue(
+                        code="index_note_count_mismatch",
+                        severity=DiagnosticSeverity.WARNING,
+                        path=str(self.index_db_path),
+                        message=(
+                            "Index note count does not match the file tree count: "
+                            f"{indexed_notes} indexed vs {len(note_paths)} files"
+                        ),
+                    )
+                )
+            for missing_path in missing_paths:
+                issues.append(
+                    DiagnosticIssue(
+                        code="missing_index_entry",
+                        severity=DiagnosticSeverity.WARNING,
+                        path=missing_path,
+                        message="Valid note is missing from the SQLite index.",
+                        note_id=note_ids_by_path.get(missing_path),
+                    )
+                )
+            for stale_path in stale_paths:
+                issues.append(
+                    DiagnosticIssue(
+                        code="stale_index_entry",
+                        severity=DiagnosticSeverity.WARNING,
+                        path=stale_path,
+                        message="SQLite index contains a note path that no longer exists.",
+                        note_id=indexed_paths.get(stale_path),
+                    )
+                )
+
+        report = DiagnosticReport(
+            issues=issues,
+            stats={
+                "note_files": len(note_paths),
+                "valid_notes": len(valid_notes),
+                "invalid_notes": max(len(note_paths) - len(valid_notes), 0),
+                "indexed_notes": indexed_notes,
+                "orphan_semantic_notes": orphan_semantic_notes,
+                "orphan_episodic_notes": orphan_episodic_notes,
+                "duplicate_source_hash_groups": duplicate_source_hash_groups,
+                "missing_index_entries": missing_index_entries,
+                "stale_index_entries": stale_index_entries,
+                "legacy_schema_notes": legacy_schema_notes,
+                "notes_by_schema_version": notes_by_schema_version,
+            },
+            severity_counts={
+                severity.value: sum(1 for issue in issues if issue.severity == severity)
+                for severity in DiagnosticSeverity
+                if any(issue.severity == severity for issue in issues)
+            },
+            recovery_workflow=["doctor", "reindex", "doctor"] if issues else [],
+        )
+        message = (
+            "Vault passed checks."
+            if not report.issues
+            else f"Detected {len(report.issues)} issue(s)."
+        )
+        return CommandOutput(
+            ok=not report.issues,
+            message=message,
+            data=report.model_dump(mode="json"),
+        )
+
+    def append_session_turn(self, session_id: str, payload: dict[str, Any]) -> None:
+        """Append a JSONL session turn log."""
+
+        session_dir = self.hidden_dir / SESSION_LOG_DIR
+        session_dir.mkdir(parents=True, exist_ok=True)
+        with (session_dir / f"{session_id}.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+    def write_precompress_snapshot(self, session_id: str, messages: list[dict[str, Any]]) -> None:
+        """Persist a pre-compression snapshot."""
+
+        snapshot_dir = self.hidden_dir / PRECOMPRESS_DIR
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        (snapshot_dir / f"{session_id}.json").write_text(
+            json.dumps(messages, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def write_session_summary(self, session_id: str, messages: list[dict[str, Any]]) -> None:
+        """Persist a raw session summary for later episodic compilation."""
+
+        summary_path = self.system_dir / f"session-{slugify(session_id)}.json"
+        summary_path.write_text(
+            json.dumps(messages, ensure_ascii=False, indent=2), encoding="utf-8"
+        )

--- a/llmwiki_hermes/templates/__init__.py
+++ b/llmwiki_hermes/templates/__init__.py
@@ -1,0 +1,13 @@
+"""Template loading and rendering."""
+
+from __future__ import annotations
+
+from importlib import resources
+from string import Template
+
+
+def render_template(name: str, values: dict[str, str]) -> str:
+    """Render a bundled template with string.Template semantics."""
+
+    raw = resources.files("llmwiki_hermes.templates").joinpath(name).read_text(encoding="utf-8")
+    return Template(raw).safe_substitute(values).rstrip() + "\n"

--- a/llmwiki_hermes/templates/episodic_note.md.j2
+++ b/llmwiki_hermes/templates/episodic_note.md.j2
@@ -1,0 +1,13 @@
+# $title
+
+## What Happened
+$what_happened
+
+## Decisions
+$decisions
+
+## Open Questions
+$open_questions
+
+## Derived Semantic Updates
+$derived_semantic_updates

--- a/llmwiki_hermes/templates/index_note.md.j2
+++ b/llmwiki_hermes/templates/index_note.md.j2
@@ -1,0 +1,4 @@
+# $title
+
+## Notes
+$notes

--- a/llmwiki_hermes/templates/semantic_note.md.j2
+++ b/llmwiki_hermes/templates/semantic_note.md.j2
@@ -1,0 +1,13 @@
+# $title
+
+## Definition
+$definition
+
+## Stable Facts
+$stable_facts
+
+## Relations
+$relations
+
+## Source Notes
+$source_notes

--- a/llmwiki_hermes/templates/source_note.md.j2
+++ b/llmwiki_hermes/templates/source_note.md.j2
@@ -1,0 +1,9 @@
+# $title
+
+## Metadata
+- origin: $origin
+- type: $source_type
+- hash: $content_hash
+
+## Extracted Content
+$extracted_content

--- a/llmwiki_hermes/types.py
+++ b/llmwiki_hermes/types.py
@@ -1,0 +1,15 @@
+"""Shared enums and type aliases."""
+
+from enum import StrEnum
+
+
+class NoteKind(StrEnum):
+    SOURCE = "source"
+    SEMANTIC = "semantic"
+    EPISODIC = "episodic"
+
+
+class MemoryType(StrEnum):
+    AUTO = "auto"
+    SEMANTIC = "semantic"
+    EPISODIC = "episodic"

--- a/llmwiki_hermes/utils/__init__.py
+++ b/llmwiki_hermes/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers."""

--- a/llmwiki_hermes/utils/hashing.py
+++ b/llmwiki_hermes/utils/hashing.py
@@ -1,0 +1,12 @@
+"""Hashing utilities."""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def sha256_text(value: str) -> str:
+    """Hash normalized text."""
+
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"

--- a/llmwiki_hermes/utils/slug.py
+++ b/llmwiki_hermes/utils/slug.py
@@ -1,0 +1,24 @@
+"""Slug and identifier helpers."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+
+def slugify(value: str) -> str:
+    """Create a filesystem-safe slug."""
+
+    normalized = unicodedata.normalize("NFKD", value).strip().lower()
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    collapsed = re.sub(r"[^a-z0-9]+", "-", ascii_text).strip("-")
+    return collapsed or "note"
+
+
+def build_note_id(prefix: str, title: str, suffix: str | None = None) -> str:
+    """Create a stable note identifier."""
+
+    parts = [prefix, slugify(title)]
+    if suffix:
+        parts.append(slugify(suffix))
+    return "_".join(part for part in parts if part)

--- a/llmwiki_hermes/utils/time.py
+++ b/llmwiki_hermes/utils/time.py
@@ -1,0 +1,17 @@
+"""Time helpers."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+
+def utc_now() -> datetime:
+    """Current UTC timestamp."""
+
+    return datetime.now(timezone.utc)
+
+
+def today_utc() -> date:
+    """Current UTC date."""
+
+    return utc_now().date()

--- a/plugins/memory/wiki/README.md
+++ b/plugins/memory/wiki/README.md
@@ -1,0 +1,5 @@
+# Wiki Memory Provider
+
+This directory is a thin Hermes-compatible wrapper around the main
+`llmwiki_hermes` package. All storage, indexing, ingest, and recall
+logic lives under `src/llmwiki_hermes/`.

--- a/plugins/memory/wiki/__init__.py
+++ b/plugins/memory/wiki/__init__.py
@@ -1,0 +1,12 @@
+"""Hermes plugin wrapper for the wiki memory provider."""
+
+from llmwiki_hermes.provider.plugin import WikiMemoryProvider
+
+
+def register(ctx) -> None:
+    """Register the wiki memory provider with Hermes."""
+
+    ctx.register_memory_provider(WikiMemoryProvider())
+
+
+__all__ = ["WikiMemoryProvider", "register"]

--- a/plugins/memory/wiki/cli.py
+++ b/plugins/memory/wiki/cli.py
@@ -1,0 +1,122 @@
+"""Hermes plugin CLI wrapper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llmwiki_hermes.provider import cli as provider_cli
+
+
+def wiki_command(args) -> None:
+    """Dispatch the active ``hermes wiki`` subcommand."""
+
+    command = getattr(args, "wiki_command", None)
+    if command == "init":
+        provider_cli.init(
+            vault=Path(args.vault),
+            force=bool(args.force),
+            json_output=bool(args.json_output),
+        )
+        return
+    if command == "ingest":
+        provider_cli.ingest(
+            path=Path(args.path) if args.path else None,
+            vault=Path(args.vault) if args.vault else None,
+            stdin=bool(args.stdin),
+            recursive=bool(args.recursive),
+            tags=str(args.tags or ""),
+            source_type=args.source_type,
+            dry_run=bool(args.dry_run),
+            json_output=bool(args.json_output),
+        )
+        return
+    if command == "reindex":
+        provider_cli.reindex(
+            vault=Path(args.vault) if args.vault else None,
+            json_output=bool(args.json_output),
+        )
+        return
+    if command == "recall":
+        provider_cli.recall(
+            query=str(args.query),
+            vault=Path(args.vault) if args.vault else None,
+            memory_type=str(args.memory_type),
+            top_k=int(args.top_k),
+            json_output=bool(args.json_output),
+        )
+        return
+    if command == "doctor":
+        provider_cli.doctor(
+            vault=Path(args.vault) if args.vault else None,
+            json_output=bool(args.json_output),
+        )
+        return
+    if command == "compact":
+        provider_cli.compact(
+            vault=Path(args.vault) if args.vault else None,
+            json_output=bool(args.json_output),
+        )
+        return
+    raise SystemExit("Unknown wiki command.")
+
+
+def register_cli(subparser) -> None:
+    """Build the ``hermes wiki`` argparse tree."""
+
+    subs = subparser.add_subparsers(dest="wiki_command")
+
+    init_parser = subs.add_parser("init", help="Initialize a new LLM-Wiki vault")
+    init_parser.add_argument("--vault", required=True, help="Base path that will contain the vault")
+    init_parser.add_argument("--force", action="store_true", help="Overwrite system files")
+    init_parser.add_argument(
+        "--json", dest="json_output", action="store_true", help="Render output as JSON"
+    )
+
+    ingest_parser = subs.add_parser("ingest", help="Ingest source material into the vault")
+    ingest_parser.add_argument("path", nargs="?", help="Path to a file or directory to ingest")
+    ingest_parser.add_argument("--vault", help="Existing LLM-Wiki vault path")
+    ingest_parser.add_argument("--stdin", action="store_true", help="Read content from STDIN")
+    ingest_parser.add_argument("--recursive", action="store_true", help="Recurse into directories")
+    ingest_parser.add_argument("--tags", default="", help="Comma-separated tags")
+    ingest_parser.add_argument("--source-type", dest="source_type", help="Explicit source type")
+    ingest_parser.add_argument("--dry-run", action="store_true", help="Preview without writing")
+    ingest_parser.add_argument(
+        "--json", dest="json_output", action="store_true", help="Render output as JSON"
+    )
+
+    reindex_parser = subs.add_parser("reindex", help="Rebuild the SQLite sidecar index")
+    reindex_parser.add_argument("--vault", help="Existing LLM-Wiki vault path")
+    reindex_parser.add_argument(
+        "--json", dest="json_output", action="store_true", help="Render output as JSON"
+    )
+
+    recall_parser = subs.add_parser("recall", help="Search the knowledge base")
+    recall_parser.add_argument("-q", "--query", required=True, help="Query text")
+    recall_parser.add_argument("--vault", help="Existing LLM-Wiki vault path")
+    recall_parser.add_argument(
+        "--memory-type",
+        default="auto",
+        choices=("auto", "semantic", "episodic"),
+        help="Memory type bias",
+    )
+    recall_parser.add_argument("--top-k", type=int, default=8, help="Max result count")
+    recall_parser.add_argument(
+        "--json", dest="json_output", action="store_true", help="Render output as JSON"
+    )
+
+    doctor_parser = subs.add_parser("doctor", help="Validate the vault and index")
+    doctor_parser.add_argument("--vault", help="Existing LLM-Wiki vault path")
+    doctor_parser.add_argument(
+        "--json", dest="json_output", action="store_true", help="Render output as JSON"
+    )
+
+    compact_parser = subs.add_parser("compact", help="Report maintenance candidates")
+    compact_parser.add_argument("--vault", help="Existing LLM-Wiki vault path")
+    compact_parser.add_argument(
+        "--json", dest="json_output", action="store_true", help="Render output as JSON"
+    )
+
+    subparser.set_defaults(func=wiki_command)
+
+
+__all__ = ["register_cli", "wiki_command"]

--- a/plugins/memory/wiki/plugin.yaml
+++ b/plugins/memory/wiki/plugin.yaml
@@ -1,0 +1,8 @@
+name: wiki
+version: 1.0.0
+summary: LLM-Wiki memory provider for Hermes Agent
+description: LLM-Wiki memory provider for Hermes Agent
+provider_type: memory
+hooks:
+  - on_session_end
+  - on_pre_compress

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,12 @@ honcho = ["honcho-ai==2.0.1"]
 # can't break fresh installs.
 supermemory = ["supermemory==3.50.0"]
 mem0 = ["mem0ai==2.0.10"]
+# LLM-Wiki memory provider (memory.wiki). Vendored under `llmwiki_hermes/`.
+# Core runtime needs `typer` (its provider CLI imports it at module load);
+# `pydantic` and `pyyaml` are already core dependencies. `markitdown` is only
+# needed to ingest non-markdown source files (pdf/docx/…) and stays optional.
+wiki = ["typer>=0.12,<1.0"]
+wiki-markitdown = ["markitdown[pdf,docx,pptx,xlsx]>=0.1.0,<0.2.0"]
 # Image resize recovery for the vision tools. Pillow is now a CORE dependency
 # (see the main `dependencies` list) since the byte/pixel shrink paths are on
 # the default vision-embed path and the mid-session lazy install deadlocked the
@@ -354,7 +360,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "llmwiki_hermes", "llmwiki_hermes.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_wiki_provider_guard.py
+++ b/tests/test_wiki_provider_guard.py
@@ -1,0 +1,73 @@
+"""Regression guard for the `wiki` memory provider (llmwiki_hermes recovery).
+
+The wiki provider is a thin wrapper (`plugins/memory/wiki/`) over the
+vendored top-level `llmwiki_hermes` package. A profile with
+`memory.provider: wiki` is dead in the water if that package goes missing
+or the wrapper stops registering `WikiMemoryProvider` — exactly the outage
+this recovery fixed. These tests fail loudly if that regresses, so CI
+catches it before a `provider: wiki` profile does at runtime.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_llmwiki_hermes_package_importable():
+    """The vendored backing package must import (no ModuleNotFoundError)."""
+    mod = importlib.import_module("llmwiki_hermes")
+    assert mod is not None
+
+
+def test_wiki_provider_class_conforms_to_memory_provider_abc():
+    """WikiMemoryProvider must instantiate as the current MemoryProvider ABC."""
+    from agent.memory_provider import MemoryProvider
+    from llmwiki_hermes.provider.plugin import WikiMemoryProvider
+
+    provider = WikiMemoryProvider()
+    assert isinstance(provider, MemoryProvider)
+    assert provider.name == "wiki"
+    # Lifecycle hooks the plugin manifest declares must exist.
+    assert hasattr(provider, "on_session_end")
+    assert hasattr(provider, "on_pre_compress")
+
+
+def test_wiki_plugin_wrapper_registers_provider():
+    """`register(ctx)` must hand a WikiMemoryProvider to the plugin context."""
+    from plugins.memory.wiki import register
+
+    captured = []
+
+    class _Ctx:
+        def register_memory_provider(self, provider):
+            captured.append(provider)
+
+    register(_Ctx())
+    assert len(captured) == 1
+    assert type(captured[0]).__name__ == "WikiMemoryProvider"
+
+
+def test_wiki_discoverable_and_loadable_by_hermes():
+    """Hermes-native discovery/load must surface and construct `wiki`."""
+    from plugins.memory import discover_memory_providers, load_memory_provider
+
+    names = {row[0] for row in discover_memory_providers()}
+    assert "wiki" in names, f"'wiki' not discovered; found {sorted(names)}"
+
+    provider = load_memory_provider("wiki")
+    assert provider is not None
+    assert type(provider).__name__ == "WikiMemoryProvider"
+
+
+def test_wiki_provider_cli_exposes_expected_commands():
+    """The provider CLI must expose the subcommands the wrapper dispatches."""
+    from llmwiki_hermes.provider import cli as provider_cli
+
+    for command in ("init", "ingest", "reindex", "recall", "doctor", "compact"):
+        assert hasattr(provider_cli, command), f"provider CLI missing {command!r}"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Root cause

The active memory provider is configured as `provider: wiki`, but only the thin four-file wrapper under `plugins/memory/wiki/` was ever committed to the repo. Its backing package — `llmwiki_hermes` — was never committed and is absent from the tree and the environment. As a result the wrapper's `from llmwiki_hermes ... import ...` fails with `ModuleNotFoundError`, so the configured provider cannot load.

The wiki *vault* (markdown notes) keeps growing via cron/skills that write files directly, which masked the problem — the on-disk knowledge base looked healthy while the in-agent read/write hookup was silently disconnected.

## Recovery approach

Vendor the package into the repo as a **top-level `llmwiki_hermes/` package**. This matches the existing wrapper-over-library pattern already used by `memory.mem0` (→ `mem0ai`) and `memory.supermemory` (→ `supermemory`), where the plugin is a thin wrapper over a top-level importable library. The only difference is that `llmwiki_hermes` is not published to PyPI, so it is vendored rather than pip-installed.

`providers/` was ruled out (it is the model-provider registry); self-contained memory plugins like `holographic` keep code inline with relative imports precisely because they have no standalone library — `wiki` does.

Changes in this PR:
- Add top-level `llmwiki_hermes/` package — 38 `.py` modules + 4 Jinja templates + the upstream MIT `LICENSE` — copied verbatim from LLM-Wiki-on-Hermes @ `35663ff`.
- Register it in `[tool.setuptools.packages.find].include`.
- Declare its `typer` runtime dependency via a new `wiki` extra; `markitdown` (needed only to ingest non-markdown source files) stays optional via a `wiki-markitdown` extra.
- The existing `plugins/memory/wiki/` wrapper is byte-identical to upstream and is committed unchanged.

No adapter was required: `WikiMemoryProvider` already subclasses the current `agent.memory_provider.MemoryProvider` (via an internal alias with an import-guarded fallback for when Hermes isn't installed).

## Verification performed

- **Imports** — `llmwiki_hermes`, `provider.plugin`, `provider.cli`, and the wrapper all import cleanly; the provider CLI exposes `init/ingest/reindex/recall/doctor/compact`.
- **ABC conformance / registration** — `WikiMemoryProvider` is a real `agent.memory_provider.MemoryProvider`, instantiates, `name="wiki"`, `is_available()` → True; `register(ctx)` registers it.
- **Hermes-native discovery** — `discover_memory_providers()` lists `wiki` among all 9 providers; `load_memory_provider("wiki")` returns a working `WikiMemoryProvider`.
- **Live vault** — `wiki doctor` and `wiki recall` (queries `HOA`, `lease`) run end-to-end against a real 400-note vault, returning ranked semantic/episodic/source hits with scores.
- **Unit tests** — 58 passed (`test_project_metadata`, `test_packaging_metadata`, `test_plugin_utils`, `test_plugin_skills`).
- **Lint** — `ruff check llmwiki_hermes plugins/memory/wiki` → all checks passed.

## Remaining vault-data issues (data, not code)

`wiki doctor` surfaced 14 pre-existing issues in the local vault. These are **data-quality problems in the notes, independent of this code recovery**, and are intentionally **not** addressed in this PR:

- Frontmatter validation errors — e.g. a source note missing `content_hash`, a semantic note missing `updated_at`.
- SQLite index out of sync — 393 indexed vs 400 files on disk; a `wiki reindex` would reconcile.
- A few orphan / broken `source_ref` links between semantic and source notes.

Suggested follow-up (separate change): `wiki reindex` + a frontmatter backfill pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
