### PR TITLE
fix(tools): flush budget-enforced tool results

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -13,6 +13,7 @@ extracted functions reach back through the ``run_agent`` module via
 from __future__ import annotations
 
 import concurrent.futures
+import copy
 import json
 from pathlib import Path
 import logging
@@ -130,6 +131,36 @@ def _flush_session_db_after_tool_progress(
         agent._flush_messages_to_session_db(messages)
     except Exception as exc:
         logger.warning("Incremental tool-call persistence failed after %s: %s", stage, exc)
+
+
+def _enforce_turn_budget_and_persist_changes(
+    agent,
+    tool_messages: list[dict],
+    *,
+    effective_task_id: str,
+    config: BudgetConfig,
+) -> None:
+    before_contents = [copy.deepcopy(msg.get("content")) for msg in tool_messages]
+    enforce_turn_budget(
+        tool_messages,
+        env=get_active_env(effective_task_id),
+        config=config,
+    )
+    changed_messages = [
+        msg
+        for msg, before in zip(tool_messages, before_contents)
+        if msg.get("content") != before
+    ]
+    if not changed_messages:
+        return
+
+    try:
+        agent._rewrite_persisted_tool_results(changed_messages)
+    except Exception as exc:
+        logger.warning(
+            "Incremental tool-call persistence failed after turn budget enforcement: %s",
+            exc,
+        )
 
 
 def _ra():
@@ -1014,7 +1045,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     num_tools = len(parsed_calls)
     if finalize and num_tools > 0:
         turn_tool_msgs = messages[-num_tools:]
-        enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id), config=_tool_budget)
+        _enforce_turn_budget_and_persist_changes(
+            agent,
+            turn_tool_msgs,
+            effective_task_id=effective_task_id,
+            config=_tool_budget,
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # Append any pending user steer text to the last tool result so the
@@ -1728,7 +1764,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # ── Per-turn aggregate budget enforcement ─────────────────────────
     num_tools_seq = len(assistant_message.tool_calls)
     if finalize and num_tools_seq > 0:
-        enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id), config=_tool_budget)
+        _enforce_turn_budget_and_persist_changes(
+            agent,
+            messages[-num_tools_seq:],
+            effective_task_id=effective_task_id,
+            config=_tool_budget,
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # See _execute_tool_calls_parallel for the rationale. Same hook,
@@ -1786,9 +1827,10 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
     total_tools = len(assistant_message.tool_calls)
     if total_tools > 0:
         _tool_budget = _budget_for_agent(agent)
-        enforce_turn_budget(
+        _enforce_turn_budget_and_persist_changes(
+            agent,
             messages[-total_tools:],
-            env=get_active_env(effective_task_id),
+            effective_task_id=effective_task_id,
             config=_tool_budget,
         )
         agent._apply_pending_steer_to_tool_results(messages, total_tools)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4270,6 +4270,45 @@ class SessionDB:
 
         return self._execute_write(_do)
 
+    def update_active_tool_result_contents(
+        self,
+        session_id: str,
+        updates: List[Tuple[str, str]],
+    ) -> int:
+        """Rewrite already-persisted active tool results by tool-call ID.
+
+        Incremental persistence writes each result before the next tool starts.
+        Turn-level output budgeting may subsequently replace one or more of
+        those in-memory contents with persisted-output references. Update the
+        existing rows atomically so the durable transcript mirrors the final
+        messages without appending duplicates.
+        """
+        normalized = [
+            (str(tool_call_id), self._encode_content(content))
+            for tool_call_id, content in updates
+            if tool_call_id
+        ]
+        if not normalized:
+            return 0
+
+        def _do(conn):
+            updated = 0
+            for tool_call_id, stored_content in normalized:
+                cursor = conn.execute(
+                    """UPDATE messages SET content = ?
+                       WHERE id = (
+                           SELECT id FROM messages
+                           WHERE session_id = ? AND role = 'tool'
+                             AND tool_call_id = ? AND active = 1
+                           ORDER BY id DESC LIMIT 1
+                       )""",
+                    (stored_content, session_id, tool_call_id),
+                )
+                updated += cursor.rowcount
+            return updated
+
+        return self._execute_write(_do)
+
     def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
         """Insert *messages* as fresh active rows for *session_id*.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1822,6 +1822,34 @@ class AIAgent:
         with persist_lock:
             return self._flush_messages_to_session_db_unlocked(messages, conversation_history)
 
+    def _rewrite_persisted_tool_results(self, messages: List[Dict]) -> int:
+        """Persist in-place rewrites of tool rows already flushed this turn."""
+        if getattr(self, "_persist_disabled", False) or not self._session_db:
+            return 0
+
+        updates = [
+            (msg.get("tool_call_id"), msg.get("content"))
+            for msg in messages
+            if isinstance(msg, dict)
+            and msg.get("role") == "tool"
+            and msg.get(_DB_PERSISTED_MARKER)
+            and msg.get("tool_call_id")
+        ]
+        if not updates:
+            return 0
+
+        persist_lock = getattr(self, "_session_persist_lock", None)
+        if persist_lock is None:
+            return self._session_db.update_active_tool_result_contents(
+                self.session_id,
+                updates,
+            )
+        with persist_lock:
+            return self._session_db.update_active_tool_result_contents(
+                self.session_id,
+                updates,
+            )
+
     def _flush_messages_to_session_db_unlocked(
         self,
         messages: List[Dict],

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -29,6 +29,7 @@ import tempfile
 from unittest.mock import MagicMock, patch
 
 from agent.tool_dispatch_helpers import make_tool_result_message
+from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
@@ -250,3 +251,145 @@ def test_execute_tool_calls_concurrent_flushes_each_tool_result_in_order():
     # production flush call breaks one of these assertions.
     assert flushed_tool_ids == ["c1", "c2"]
     assert flush_lengths == [1, 2]
+
+
+def _attach_real_session_db(agent, tmp_path, session_id: str) -> SessionDB:
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session(session_id=session_id, source="cli")
+    agent._session_db = db
+    agent._session_db_created = True
+    agent.session_id = session_id
+    return db
+
+
+def _assert_stored_tool_contents(db, session_id: str, expected: list[str]) -> None:
+    stored = [
+        msg for msg in db.get_messages(session_id)
+        if msg["role"] == "tool"
+    ]
+    assert [msg["content"] for msg in stored] == expected
+    assert len({msg["tool_call_id"] for msg in stored}) == len(expected)
+
+
+def test_execute_tool_calls_sequential_rewrites_budgeted_results_in_session_db(tmp_path):
+    agent = _make_agent()
+    db = _attach_real_session_db(agent, tmp_path, "sequential-budget")
+    tool_calls = [
+        _mock_tool_call(name="web_search", call_id="c1"),
+        _mock_tool_call(name="web_search", call_id="c2"),
+    ]
+    messages: list = []
+    assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
+
+    def _fake_budget(tool_messages, **kwargs):
+        tool_messages[0]["content"] = "<persisted-output>\ntrimmed c1\n</persisted-output>"
+        return tool_messages
+
+    with (
+        patch(
+            "run_agent.handle_function_call",
+            side_effect=lambda *args, tool_call_id, **kwargs: f"raw-{tool_call_id}",
+        ),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+        patch("agent.tool_executor.enforce_turn_budget", side_effect=_fake_budget),
+    ):
+        agent._execute_tool_calls_sequential(assistant_message, messages, "task-1")
+
+    assert messages[0]["content"].startswith("<persisted-output>")
+    _assert_stored_tool_contents(
+        db,
+        "sequential-budget",
+        ["<persisted-output>\ntrimmed c1\n</persisted-output>", "raw-c2"],
+    )
+
+
+def test_execute_tool_calls_concurrent_rewrites_budgeted_results_in_session_db(tmp_path):
+    agent = _make_agent()
+    db = _attach_real_session_db(agent, tmp_path, "concurrent-budget")
+    tool_calls = [
+        _mock_tool_call(name="web_search", call_id="c1"),
+        _mock_tool_call(name="web_search", call_id="c2"),
+    ]
+    messages: list = []
+    assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
+
+    def _fake_budget(tool_messages, **kwargs):
+        tool_messages[1]["content"] = "<persisted-output>\ntrimmed c2\n</persisted-output>"
+        return tool_messages
+
+    def _fake_invoke(function_name, function_args, effective_task_id, tool_call_id, **kwargs):
+        return f"raw-result-{tool_call_id}"
+
+    with (
+        patch.object(agent, "_invoke_tool", side_effect=_fake_invoke),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+        patch("agent.tool_executor.enforce_turn_budget", side_effect=_fake_budget),
+    ):
+        agent._execute_tool_calls_concurrent(assistant_message, messages, "task-1")
+
+    assert messages[1]["content"].startswith("<persisted-output>")
+    _assert_stored_tool_contents(
+        db,
+        "concurrent-budget",
+        ["raw-result-c1", "<persisted-output>\ntrimmed c2\n</persisted-output>"],
+    )
+
+
+def test_execute_tool_calls_segmented_rewrites_budgeted_results_in_session_db(tmp_path):
+    from agent.tool_executor import execute_tool_calls_segmented
+
+    agent = _make_agent()
+    db = _attach_real_session_db(agent, tmp_path, "segmented-budget")
+    c1 = _mock_tool_call(name="web_search", call_id="c1")
+    c2 = _mock_tool_call(name="web_search", call_id="c2")
+    messages: list = []
+    assistant_message = SimpleNamespace(content="", tool_calls=[c1, c2])
+
+    def _fake_budget(tool_messages, **kwargs):
+        tool_messages[0]["content"] = "<persisted-output>\ntrimmed c1\n</persisted-output>"
+        return tool_messages
+
+    def _fake_invoke(
+        function_name,
+        function_args,
+        effective_task_id,
+        tool_call_id,
+        **kwargs,
+    ):
+        return f"raw-{tool_call_id}"
+
+    with (
+        patch(
+            "run_agent.handle_function_call",
+            side_effect=lambda *args, tool_call_id, **kwargs: f"raw-{tool_call_id}",
+        ),
+        patch.object(
+            agent,
+            "_invoke_tool",
+            side_effect=_fake_invoke,
+        ),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+        patch("agent.tool_executor.enforce_turn_budget", side_effect=_fake_budget),
+    ):
+        execute_tool_calls_segmented(
+            agent,
+            assistant_message,
+            messages,
+            "task-1",
+            segments=[("sequential", [c1]), ("parallel", [c2])],
+        )
+
+    _assert_stored_tool_contents(
+        db,
+        "segmented-budget",
+        ["<persisted-output>\ntrimmed c1\n</persisted-output>", "raw-c2"],
+    )


### PR DESCRIPTION
## What changed

- Add a transactional SessionDB API that updates already-persisted active tool-result rows by `session_id + tool_call_id`.
- After turn-level budget enforcement mutates a tool result, reconcile the existing row instead of invoking the append-only flush or creating a duplicate.
- Serialize rewrites through the agent's existing persistence lock.
- Apply the behavior to sequential, concurrent, and mixed segmented tool execution.
- Replace mocked post-budget assertions with real SQLite regressions that verify raw flush -> budget mutation -> one updated stored row.

## Why

Each tool result is flushed before the next tool starts and receives `_db_persisted`. Turn-level budget enforcement can later replace that content with a `<persisted-output>` reference. A second ordinary flush cannot persist the replacement because marked messages are intentionally skipped; the existing row must be updated.

## Tests

- incremental persistence + full SessionDB suites: `388 passed`
- `python -m ruff check` on changed Python files
- `git diff --check`