### PR TITLE
fix(titles): sanitize generated session titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -5,6 +5,7 @@ adds latency to the user-facing reply.
 """
 
 import logging
+import re
 import threading
 from typing import Callable, Optional
 
@@ -20,18 +21,32 @@ FailureCallback = Callable[[str, BaseException], None]
 TitleCallback = Callable[[str], None]
 
 _TITLE_PROMPT = (
-    "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
-    "following exchange. The title should capture the main topic or intent. "
+    "Generate a short title for this chat, like a messenger thread header. "
+    "The title should reflect the user's question; use the assistant response only as context "
+    "when the request is too short or ambiguous. "
+    "Use 3-7 words, one line, no longer than 40 characters. "
     "Write the title in the same language the user is writing in. "
-    "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
+    "Prefer specific titles over generic ones. Do not use empty placeholders like "
+    "New Chat, Новый чат, Chat, Dialog, or Help. Return ONLY the title text: no quotes, no prefixes, "
+    "no JSON, and no explanation."
 )
 
 _TITLE_PROMPT_PINNED_LANGUAGE = (
-    "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
-    "following exchange. The title should capture the main topic or intent. "
+    "Generate a short title for this chat, like a messenger thread header. "
+    "The title should reflect the user's question; use the assistant response only as context "
+    "when the request is too short or ambiguous. "
+    "Use 3-7 words, one line, no longer than 40 characters. "
     "Write the title in {language}. "
-    "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
+    "Prefer specific titles over generic ones. Do not use empty placeholders like "
+    "New Chat, Новый чат, Chat, Dialog, or Help. Return ONLY the title text: no quotes, no prefixes, "
+    "no JSON, and no explanation."
 )
+
+_DEFAULT_CHAT_NAMES = frozenset({"Новый чат", "New Chat"})
+_DEFAULT_CHAT_NAMES_CASEFOLD = frozenset(name.casefold() for name in _DEFAULT_CHAT_NAMES)
+_TITLE_SIZE = 40
+_TITLE_PROMPT_USER_MAX = 512
+_TITLE_PROMPT_ASSISTANT_MAX = 200
 
 
 def _title_language() -> str:
@@ -46,6 +61,28 @@ def _title_language() -> str:
         ).strip()
     except Exception:
         return ""
+
+
+def _sanitize_generated_title(raw_title: str) -> Optional[str]:
+    """Clean generated title text using the same conservative rules as chat rename."""
+    title = (raw_title or "").strip().split("\n", 1)[0].strip()
+    title = title.replace("\u200b", "").replace("\ufeff", "")
+    title = "".join(char for char in title if ord(char) >= 32 or char.isspace())
+    title = re.sub(r"^(?:название|title)\s*:\s*", "", title, flags=re.IGNORECASE)
+    title = re.sub(r"^[\"'«»]+|[\"'«»]+$", "", title)
+    title = re.sub(r"\s+", " ", title).strip()
+    if not title:
+        return None
+    if title.casefold() in _DEFAULT_CHAT_NAMES_CASEFOLD:
+        return None
+    if len(title) > _TITLE_SIZE:
+        content_limit = _TITLE_SIZE - len("...")
+        boundary = title[: content_limit + 1].rfind(" ")
+        if boundary > 0:
+            title = title[:boundary].rstrip() + "..."
+        else:
+            title = title[:content_limit].rstrip() + "..."
+    return title or None
 
 
 def generate_title(
@@ -66,9 +103,10 @@ def generate_title(
     ``AIAgent._emit_auxiliary_failure`` so the user sees a warning instead
     of silently accumulating untitled sessions.
     """
-    # Truncate long messages to keep the request small
-    user_snippet = user_message[:500] if user_message else ""
-    assistant_snippet = assistant_response[:500] if assistant_response else ""
+    # Truncate long messages to keep the request small; the assistant response
+    # is context only, so keep it shorter than the user's request.
+    user_snippet = user_message[:_TITLE_PROMPT_USER_MAX] if user_message else ""
+    assistant_snippet = assistant_response[:_TITLE_PROMPT_ASSISTANT_MAX] if assistant_response else ""
 
     language = _title_language()
     prompt = _TITLE_PROMPT_PINNED_LANGUAGE.format(language=language) if language else _TITLE_PROMPT
@@ -82,8 +120,8 @@ def generate_title(
         response = call_llm(
             task="title_generation",
             messages=messages,
-            max_tokens=500,
-            temperature=0.3,
+            max_tokens=80,
+            temperature=0.1,
             timeout=timeout,
             main_runtime=main_runtime,
         )
@@ -95,14 +133,7 @@ def generate_title(
         # tag variants (unterminated blocks, orphan closes, mixed case)
         # are handled, not just a single literal <think> pair.
         from agent.agent_runtime_helpers import strip_think_blocks
-        title = strip_think_blocks(None, content).strip()
-        # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
-        title = title.strip('"\'')
-        if title.lower().startswith("title:"):
-            title = title[6:].strip()
-        # Enforce reasonable length
-        if len(title) > 80:
-            title = title[:77] + "..."
+        title = _sanitize_generated_title(strip_think_blocks(None, content))
         return title if title else None
     except Exception as e:
         # Log at WARNING so this shows up in agent.log without debug mode.

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -74,6 +74,8 @@ class TestGenerateTitle:
 
         assert captured_kwargs["task"] == "title_generation"
         assert captured_kwargs["timeout"] is None
+        assert captured_kwargs["max_tokens"] == 80
+        assert captured_kwargs["temperature"] == 0.1
 
     def test_explicit_timeout_still_overrides_config(self):
         captured_kwargs = {}
@@ -89,6 +91,25 @@ class TestGenerateTitle:
             assert generate_title("question", "answer", timeout=123.0) == "Explicit Timeout"
 
         assert captured_kwargs["timeout"] == 123.0
+
+    def test_truncates_user_and_assistant_context_for_prompt(self):
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Short Title"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("u" * 600, "a" * 300) == "Short Title"
+
+        user_prompt = captured_kwargs["messages"][1]["content"]
+        assert "u" * 512 in user_prompt
+        assert "u" * 513 not in user_prompt
+        assert "a" * 200 in user_prompt
+        assert "a" * 201 not in user_prompt
 
     def test_strips_quotes(self):
         mock_response = MagicMock()
@@ -139,15 +160,62 @@ class TestGenerateTitle:
             title = generate_title("my pod keeps crashing", "Let me look...")
             assert title == "Kubernetes Pod Debugging"
 
-    def test_truncates_long_titles(self):
+    def test_strips_russian_title_prefix(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Название: Починка падающих CI тестов"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("тесты падают", "Посмотрим CI")
+            assert title == "Починка падающих CI тестов"
+
+    def test_strips_guillemet_quotes_and_control_chars(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "\ufeff«Debug\u0007 failing CI tests»\u200b"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("tests are failing", "Let's inspect CI")
+            assert title == "Debug failing CI tests"
+
+    def test_normalizes_whitespace_control_chars(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Debug\tCI\rPipeline"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("tests are failing", "Let's inspect CI")
+            assert title == "Debug CI Pipeline"
+
+    def test_rejects_placeholder_title_output(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "New Chat"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("hello", "hi") is None
+
+    def test_truncates_long_titles_at_word_boundary(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            "Investigate failing integration tests after provider routing changes"
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("question", "answer")
+            assert title == "Investigate failing integration tests..."
+            assert title.endswith("...")
+
+    def test_truncates_unbroken_title_to_inclusive_limit(self):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "A" * 100
 
         with patch("agent.title_generator.call_llm", return_value=mock_response):
             title = generate_title("question", "answer")
-            assert len(title) == 80
-            assert title.endswith("...")
+            assert title == "A" * 37 + "..."
+            assert len(title) == 40
 
     def test_returns_none_on_empty_response(self):
         mock_response = MagicMock()


### PR DESCRIPTION
## What changed

- Tighten the title prompt around a short, specific messenger-thread title in the user's language.
- Bound the auxiliary request with shorter snippets, `max_tokens=80`, and `temperature=0.1`.
- Sanitize generated output at the storage boundary:
  - keep one line;
  - remove zero-width/BOM characters and normalize whitespace controls;
  - strip `Title:` / `Название:` prefixes and wrapping quotes;
  - reject empty/default `New Chat` placeholders;
  - enforce an inclusive 40-character limit for both word-delimited and unbroken output.
- Keep the existing asynchronous first-exchange trigger unchanged.

## Why

The model is instructed to return only a title, but provider output can still contain formatting artifacts. The persistence boundary should enforce the title contract before SessionDB stores the value.

## Tests

- `PYTHONPYCACHEPREFIX=/private/tmp/hermes-pycache python -m pytest -p no:cacheprovider tests/agent/test_title_generator.py -q` (33 passed)
- `PYTHONPYCACHEPREFIX=/private/tmp/hermes-pycache python -m py_compile agent/title_generator.py tests/agent/test_title_generator.py`
- `git diff --check`