### PR TITLE
perf(dashboard): aggregate session stats by source in SQL

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9514,13 +9514,14 @@ async def get_session_stats(profile: Optional[str] = None):
         active_store = db.session_count(include_archived=False)
         archived = db.session_count(archived_only=True)
         messages = db.message_count()
-        by_source: Dict[str, int] = {}
         try:
-            for s in db.list_sessions_rich(limit=10000, include_archived=True, compact_rows=True):
-                src = str(s.get("source") or "cli")
-                by_source[src] = by_source.get(src, 0) + 1
+            by_source = db.session_count_by_source(
+                include_archived=True,
+                exclude_children=True,
+                limit=100,
+            )
         except Exception:
-            pass
+            by_source = {}
         return {
             "total": total,
             "active_store": active_store,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4975,6 +4975,47 @@ class SessionDB:
             cursor = self._conn.execute(f"SELECT COUNT(*) FROM sessions s{where_sql}", params)
             return cursor.fetchone()[0]
 
+    def session_count_by_source(
+        self,
+        *,
+        include_archived: bool = False,
+        archived_only: bool = False,
+        exclude_children: bool = False,
+        limit: int = 100,
+    ) -> Dict[str, int]:
+        """Count sessions grouped by source without materialising rich rows.
+
+        ``exclude_children=True`` mirrors ``list_sessions_rich`` visibility:
+        roots plus branch sessions, excluding sub-agent runs, delegates, and
+        compression continuations. Use that when the source badges accompany
+        list-style session stats.
+        """
+        where_clauses = []
+        params = []
+
+        if exclude_children:
+            where_clauses.append(_LISTABLE_CHILD_SQL)
+            where_clauses.append(f"{_delegate_from_json('s.model_config')} IS NULL")
+        if archived_only:
+            where_clauses.append("s.archived = 1")
+        elif not include_archived:
+            where_clauses.append("s.archived = 0")
+
+        where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+        safe_limit = max(1, min(int(limit or 100), 1000))
+
+        with self._lock:
+            if self._conn is None:
+                raise RuntimeError("SessionDB connection is closed")
+            rows = self._conn.execute(
+                "SELECT COALESCE(s.source, 'cli') AS source, COUNT(*) AS count "
+                f"FROM sessions s{where_sql} "
+                "GROUP BY COALESCE(s.source, 'cli') "
+                "ORDER BY count DESC LIMIT ?",
+                params + [safe_limit],
+            ).fetchall()
+        return {str(row["source"]): int(row["count"] or 0) for row in rows}
+
     def message_count(self, session_id: str = None) -> int:
         """Count messages, optionally for a specific session."""
         with self._lock:

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -460,6 +460,34 @@ class TestSessionManagementEndpoints:
         assert {"total", "active_store", "archived", "messages", "by_source"} <= set(body)
         assert body["total"] >= 1
 
+    def test_stats_source_counts_use_direct_aggregate(self, monkeypatch):
+        """Source badges should not materialise rich session rows.
+
+        Large stores can have thousands of sessions. The stats endpoint only
+        needs grouped counts, so it should not call ``list_sessions_rich`` and
+        build preview/last-active rows just to count source labels.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="sess-discord", source="discord")
+            db.create_session(session_id="sess-cron", source="cron")
+        finally:
+            db.close()
+
+        def fail_list_sessions_rich(self, *args, **kwargs):
+            raise AssertionError("stats should use grouped source counts")
+
+        monkeypatch.setattr(SessionDB, "list_sessions_rich", fail_list_sessions_rich)
+
+        r = self.client.get("/api/sessions/stats")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["by_source"]["cli"] == 1
+        assert body["by_source"]["discord"] == 1
+        assert body["by_source"]["cron"] == 1
+
     def test_rename(self):
         r = self.client.patch("/api/sessions/sess-x", json={"title": "Renamed"})
         assert r.status_code == 200 and r.json()["title"] == "Renamed"


### PR DESCRIPTION
## Summary
- add `SessionDB.session_count_by_source()` so source badges can be counted with a grouped SQL aggregate
- switch `/api/sessions/stats` to use that aggregate instead of materializing up to 10k `list_sessions_rich()` rows
- keep the existing `active_store` semantics and API shape unchanged

## Why
`/api/sessions/stats` only needs grouped source counts for small dashboard badges. Before this change it built rich session-list rows — including preview/last-active projection and compression-tip handling — just to count `source` labels.

That is unnecessary work on large stores. On one real store with 24,691 session rows, the old path took a median ~665ms and also only counted the first 10k materialized rows. The direct aggregate took ~29ms and counts the full listable store. On a 9,009-row profile, the old path was ~883ms vs ~17ms for the aggregate.

This PR deliberately does **not** change `active_store`; the existing field continues to mean the current non-archived store count. If the dashboard wants a separate open/unclosed-session metric later, that should be an explicit additive API/UI decision rather than hidden inside this perf fix.

## Duplicate check
Searched open and closed PRs/issues in `NousResearch/hermes-agent` for:
- `active_store sessions stats`
- `"Active in store"`
- `"sessions/stats" "by_source"`
- `"end_reason IS NULL" "sessions" "stats"`
- `"unarchived" "sessions/stats"`

No duplicate PRs or issues found.

## Validation
- `python -m py_compile hermes_state.py hermes_cli/web_server.py tests/hermes_cli/test_dashboard_admin_endpoints.py`
- `pytest tests/hermes_cli/test_dashboard_admin_endpoints.py::TestSessionManagementEndpoints::test_stats_not_shadowed_by_session_id_route tests/hermes_cli/test_dashboard_admin_endpoints.py::TestSessionManagementEndpoints::test_stats_source_counts_use_direct_aggregate -q -o 'addopts='` → 2 passed
- `pytest tests/hermes_cli/test_dashboard_admin_endpoints.py -q -o 'addopts='` → 74 passed
- `pytest tests/test_hermes_state.py -q -o 'addopts='` → 339 passed
- `ruff check hermes_state.py hermes_cli/web_server.py tests/hermes_cli/test_dashboard_admin_endpoints.py` → clean
- `git diff --check` → clean
