### PR TITLE
fix(cron): accept named months/weekdays and special chars in schedules

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -347,9 +347,16 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     
     # Check for cron expression (5 or 6 space-separated fields)
     # Cron fields: minute hour day month weekday [year]
+    #
+    # Allow the full cron field charset — named months/weekdays
+    # (JAN-DEC, SUN-SAT), step/range/list syntax, and the special chars
+    # ``L`` ``W`` ``#`` ``?`` — and let ``croniter`` below be the
+    # authoritative validator. A digits-only gate here wrongly rejected
+    # valid expressions like ``0 9 * * MON-FRI`` or ``0 0 * * 5#3``,
+    # raising "Invalid schedule" before croniter ever saw them.
     parts = schedule.split()
     if len(parts) >= 5 and all(
-        re.match(r'^[\d\*\-,/]+$', p) for p in parts[:5]
+        re.match(r'^[A-Za-z0-9*,/?#\-]+$', p) for p in parts[:5]
     ):
         if not HAS_CRONITER:
             raise ValueError("Cron expressions require 'croniter' package. Install with: pip install croniter")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -96,6 +96,25 @@ class TestParseSchedule:
         assert result["kind"] == "cron"
         assert result["expr"] == "0 9 * * *"
 
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "0 9 * * MON-FRI",   # named weekday range
+            "0 9 * * mon",       # named weekday, lowercase
+            "0 0 1 JAN *",       # named month
+            "0 0 L * *",         # last-day-of-month
+            "0 0 * * 5#3",       # third Friday
+            "0 0 15 * ? ",       # '?' (no-specific) with trailing space
+        ],
+    )
+    def test_cron_named_and_special_fields(self, expr):
+        """Named months/weekdays and cron special chars (L, #, ?) are valid
+        cron and must not be rejected before croniter validates them."""
+        pytest.importorskip("croniter")
+        result = parse_schedule(expr)
+        assert result["kind"] == "cron"
+        assert result["expr"] == expr.strip()
+
     def test_iso_timestamp(self):
         result = parse_schedule("2030-01-15T14:00:00")
         assert result["kind"] == "once"


### PR DESCRIPTION
## What does this PR do?

`parse_schedule` classified an input as a cron expression only when every one
of the first five fields matched a **digits-only** regex (`^[\d*\-,/]+$`). Any
croniter-valid expression using **named weekdays/months** (`MON-FRI`, `JAN`) or
**special chars** (`L`, `W`, `#`, `?`) failed that gate, was never treated as
cron, fell through the timestamp/duration branches, and hit
`raise ValueError("Invalid schedule ...")`.

So creating a job with textbook cron syntax crashed:

```
parse_schedule("0 9 * * MON-FRI")   # ValueError: Invalid schedule ...
parse_schedule("0 0 L * *")         # ValueError
parse_schedule("0 0 * * 5#3")       # ValueError
```

even though the `croniter(...)` validator six lines below fully supports all of
them (the curated blueprint catalog dodges it only because it uses numeric
forms like `0 9 * * 1-5`).

## Related Issue

No existing issue — found via a code audit; verified croniter accepts these
forms and that the digits-only gate is the sole blocker.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py` — broaden the per-field cron-detection charset to the full
  cron set (letters + `*,/?#-`) and let `croniter` be the authoritative
  validator (it still raises a clear "Invalid cron expression" for genuinely
  bad input).
- `tests/cron/test_jobs.py` — parametrized regression test over named
  weekday/month and `L`/`#`/`?` expressions.

## How to Test

1. `scripts/run_tests.sh tests/cron/test_jobs.py -q` → all pass (requires the
   `croniter` extra; the new cases `importorskip("croniter")`).
2. Pre-fix, the digits-only regex rejects `0 9 * * MON-FRI`, `0 0 L * *`, and
   `0 0 * * 5#3` (all classified as non-cron → ValueError).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(cron):`)
- [x] I searched for existing PRs (none for named-field cron parsing)
- [x] Only changes related to this fix
- [x] Affected test module passes — `tests/cron/test_jobs.py` (109 incl. new). Full suite not run locally.
- [x] Added a regression test
- [x] Tested on: Ubuntu (WSL2)

### Documentation & Housekeeping

- [x] Behavior-only fix — N/A for docs / config / architecture / tool schemas
