### PR TITLE
fix(error-classifier): don't misclassify 'rate limit exceeded' as billing

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1242,7 +1242,16 @@ def _classify_by_message(
     # surface "usage limit" errors without an HTTP status code.  A transient
     # signal ("try again", "resets at", …) means it's a periodic quota, not
     # billing exhaustion.
-    has_usage_limit = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
+    #
+    # But an unambiguous rate-limit phrase must NOT be captured here: e.g.
+    # "rate limit exceeded" contains the usage-limit substring "limit
+    # exceeded", and with no transient signal it would be misclassified as
+    # permanent billing exhaustion (non-retryable + credential rotation)
+    # instead of a retryable rate limit.  Defer those to the rate-limit check
+    # below by excluding messages that also match a rate-limit pattern.
+    has_usage_limit = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS) and not any(
+        p in error_msg for p in _RATE_LIMIT_PATTERNS
+    )
     if has_usage_limit:
         has_transient_signal = any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS)
         if has_transient_signal:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -410,6 +410,28 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.should_rotate_credential is True
 
+    def test_message_only_rate_limit_exceeded_is_rate_limit_not_billing(self):
+        """A status-less 'rate limit exceeded' (e.g. an SSE error frame with
+        status_code=None) must classify as a retryable rate limit, not
+        permanent billing exhaustion.
+
+        Regression: 'rate limit exceeded' contains the usage-limit substring
+        'limit exceeded', and the usage-limit disambiguation ran before the
+        rate-limit check — so with no transient signal it was routed to
+        billing (non-retryable, rotate credential) instead of rate_limit."""
+        e = MockAPIError("rate limit exceeded")  # no status_code
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_message_only_usage_limit_still_billing(self):
+        """Guard: a genuine status-less 'usage limit exceeded' (no rate-limit
+        wording, no transient signal) must still classify as billing."""
+        e = MockAPIError("usage limit exceeded")  # no status_code
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
     # ── 5xx that are actually request-validation errors ──
     # Some OpenAI-compatible gateways (e.g. codex.nekos.me) return
     # request-validation failures with a 5xx status. These are


### PR DESCRIPTION
## What does this PR do?

Fixes a misclassification where a **status-less** `"rate limit exceeded"` error
was treated as permanent **billing exhaustion** instead of a retryable **rate
limit**.

In `classify_api_error`'s message-only path (`_classify_by_message`, used e.g.
for SSE `type=error` stream frames that carry `status_code=None`), the
usage-limit disambiguation runs **before** the rate-limit check.
`_USAGE_LIMIT_PATTERNS` contains `"limit exceeded"`, which is a substring of
`"rate limit exceeded"`, so with no transient signal ("try again", "resets
at", …) the message was routed to `billing`:

```
classify_api_error(Exception("rate limit exceeded"))
  -> reason=billing, retryable=False, should_rotate_credential=True, should_fallback=True
```

A transient rate limit was thus treated as permanent credit exhaustion — the
loop wouldn't back off and retry; it rotated the credential and fell back.
`"too many requests"` and `"rate limit reached; try again in 20s"` already
classified correctly, which highlighted the inconsistency.

## Fix

Exclude messages that also match a rate-limit pattern from the usage-limit
block, so they fall through to the existing rate-limit check:

```python
has_usage_limit = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS) and not any(
    p in error_msg for p in _RATE_LIMIT_PATTERNS
)
```

Scope: only the **message-only** path. The `402`-status path is intentionally
left untouched — an HTTP 402 (Payment Required) is itself a billing signal.
Genuine usage-limit / quota / `key limit exceeded` / credit messages are
unaffected (verified).

## Related Issue

No existing issue — found via a code audit of the failover classifier.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py` — guard the usage-limit disambiguation in
  `_classify_by_message` against rate-limit phrases.
- `tests/agent/test_error_classifier.py` — regression tests: status-less
  `"rate limit exceeded"` → `rate_limit`/retryable; status-less
  `"usage limit exceeded"` → `billing` (unchanged).

## How to Test

1. `scripts/run_tests.sh tests/agent/test_error_classifier.py -q` → all pass (168).
2. `classify_api_error(Exception("rate limit exceeded")).reason` is
   `FailoverReason.rate_limit` (was `billing`); other billing/quota messages
   are unchanged.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(error-classifier):`)
- [x] I searched for existing PRs (none for this misclassification)
- [x] Only changes related to this fix
- [x] Affected test module passes — `tests/agent/test_error_classifier.py` (168). Full suite not run locally.
- [x] Added regression tests
- [x] Tested on: Ubuntu (WSL2)

### Documentation & Housekeeping

- [x] Behavior-only fix — N/A for docs / config / architecture / tool schemas
