### PR TITLE
fix(cli): preserve local-only commits before update reset fallback

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9727,11 +9727,58 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
+                # force-pushed or rebase, or the user committed locally on the
+                # update branch).  Since local changes are already stashed,
+                # reset to match the remote exactly.
+                #
+                # The autostash only preserves UNCOMMITTED changes — local-only
+                # COMMITS would be silently discarded by the reset (reachable
+                # only via reflog, which nobody finds).  Park HEAD on a backup
+                # branch first so committed local work survives the reset and
+                # can be cherry-picked back afterwards.
                 print(
                     "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
                 )
+                ahead_count = 0
+                ahead_result = subprocess.run(
+                    git_cmd + ["rev-list", "--count", f"origin/{branch}..HEAD"],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                )
+                if ahead_result.returncode == 0:
+                    try:
+                        ahead_count = int(ahead_result.stdout.strip())
+                    except ValueError:
+                        ahead_count = 0
+                if ahead_count > 0:
+                    from datetime import datetime, timezone
+
+                    backup_branch = datetime.now(timezone.utc).strftime(
+                        "hermes-local-commits-%Y%m%d-%H%M%S"
+                    )
+                    backup_result = subprocess.run(
+                        git_cmd + ["branch", backup_branch, "HEAD"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if backup_result.returncode == 0:
+                        print(
+                            f"  ✓ {ahead_count} local commit(s) preserved on "
+                            f"branch '{backup_branch}'"
+                        )
+                        print(
+                            "    Restore later with: git cherry-pick "
+                            f"origin/{branch}..{backup_branch}"
+                        )
+                    else:
+                        print(
+                            f"  ⚠ Could not create a backup branch for "
+                            f"{ahead_count} local commit(s); they stay "
+                            f"reachable via 'git reflog' (pre-reset HEAD: "
+                            f"{pre_pull_sha or 'unknown'})."
+                        )
                 reset_result = subprocess.run(
                     git_cmd + ["reset", "--hard", f"origin/{branch}"],
                     cwd=PROJECT_ROOT,

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -673,6 +673,96 @@ class TestCmdUpdateBranchFlag:
         assert "nonexistent" in out
 
 
+class TestCmdUpdateDivergedLocalCommitBackup:
+    """When ``git pull --ff-only`` fails, the update falls back to
+    ``git reset --hard origin/<branch>`` — which silently discards local-only
+    COMMITS (the autostash only covers uncommitted changes).  A backup branch
+    must be created at the pre-reset HEAD first so committed local work
+    survives (real incident: a live install carrying local gateway fixes as
+    commits on main would have lost them all to the reset fallback)."""
+
+    @staticmethod
+    def _diverged_side_effect(ahead_count="2", branch_create_rc=0):
+        """Simulate a checkout that is behind origin AND has local commits."""
+
+        def side_effect(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+
+            if "rev-parse" in joined and "--abbrev-ref" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+            if "rev-parse" in joined and "--verify" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            # Ahead check: local-only commits on top of origin/main.
+            if "rev-list" in joined and "origin/main..HEAD" in joined:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout=f"{ahead_count}\n", stderr=""
+                )
+            # Behind check: updates are available.
+            if "rev-list" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="3\n", stderr="")
+            if "pull" in joined and "--ff-only" in joined:
+                return subprocess.CompletedProcess(
+                    cmd, 128, stdout="", stderr="fatal: Not possible to fast-forward\n"
+                )
+            if "branch" in joined and "hermes-local-commits-" in joined:
+                return subprocess.CompletedProcess(
+                    cmd, branch_create_rc, stdout="", stderr=""
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        return side_effect
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_backup_branch_created_before_reset(self, mock_run, _mock_which, capsys):
+        mock_run.side_effect = self._diverged_side_effect(ahead_count="2")
+        cmd_update(SimpleNamespace())
+
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+
+        backup_idx = next(
+            (i for i, c in enumerate(commands) if "branch" in c and "hermes-local-commits-" in c),
+            None,
+        )
+        reset_idx = next(
+            (i for i, c in enumerate(commands) if "reset" in c and "--hard" in c and "origin/main" in c),
+            None,
+        )
+        assert backup_idx is not None, commands
+        assert reset_idx is not None, commands
+        assert backup_idx < reset_idx, "backup branch must exist before the destructive reset"
+
+        out = capsys.readouterr().out
+        assert "2 local commit(s) preserved on branch" in out
+        assert "git cherry-pick origin/main..hermes-local-commits-" in out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_no_backup_branch_when_nothing_ahead(self, mock_run, _mock_which, capsys):
+        mock_run.side_effect = self._diverged_side_effect(ahead_count="0")
+        cmd_update(SimpleNamespace())
+
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        assert not any("hermes-local-commits-" in c for c in commands), commands
+        # The reset fallback itself must still run.
+        assert any("reset" in c and "--hard" in c for c in commands), commands
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_failed_backup_branch_prints_reflog_guidance(self, mock_run, _mock_which, capsys):
+        mock_run.side_effect = self._diverged_side_effect(
+            ahead_count="2", branch_create_rc=1
+        )
+        cmd_update(SimpleNamespace())
+
+        out = capsys.readouterr().out
+        assert "Could not create a backup branch" in out
+        assert "git reflog" in out
+        # The reset must proceed anyway — a failed backup must not brick the update.
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        assert any("reset" in c and "--hard" in c for c in commands), commands
+
+
 class TestCmdUpdateCheckBranchFlag:
     """``hermes update --check --branch <name>`` honors the branch override.
 


### PR DESCRIPTION
## Problem

When `git pull --ff-only` fails during `hermes update` (diverged history — upstream force-push/rebase, or the user committed locally on the update branch), the code falls back to `git reset --hard origin/<branch>`.

The pre-update autostash only preserves **uncommitted** changes. Local-only **commits** are silently discarded by the reset — after it, they are reachable only via `git reflog`, which most users never find. On a live install carrying local fixes as commits on `main`, one `hermes update` would silently destroy them all.

## Fix

Before the destructive reset in `_cmd_update_impl`:

1. Count commits ahead of `origin/<branch>` via `git rev-list --count origin/<branch>..HEAD`.
2. If any exist, create a timestamped backup branch (`hermes-local-commits-YYYYMMDD-HHMMSS`) at the pre-reset HEAD and print a `git cherry-pick` one-liner to restore them.
3. If backup-branch creation fails, print reflog guidance with the pre-reset SHA and proceed — a failed backup must never brick the update.

Behavior when there are no local commits is unchanged.

## Tests

New `TestCmdUpdateDivergedLocalCommitBackup` class in `tests/hermes_cli/test_cmd_update.py`:

- backup branch is created **before** the `reset --hard` (order asserted)
- no backup branch when nothing is ahead
- failed backup prints reflog guidance and the reset still proceeds

`python -m pytest tests/hermes_cli/test_cmd_update.py` — 30 passed (27 existing + 3 new).
`python -m py_compile` passes for both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)