### PR TITLE
fix(matrix): refresh stale peer device lists before encrypted sends

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2505,6 +2505,7 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in rooms
         "free_response_rooms": "",     # Comma-separated room IDs where bot responds without mention
         "allowed_rooms": "",           # If set, bot ONLY responds in these room IDs (whitelist)
+        "device_refresh_seconds": 300, # Min seconds between proactive peer device-list refreshes before encrypted sends (0 disables)
     },
 
     # Approval mode for dangerous commands:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -46,6 +46,10 @@ Environment variables:
                               when requester metadata is available (default: true)
     MATRIX_APPROVAL_TIMEOUT_SECONDS
                               Reaction approval/model-picker timeout (default: 300)
+    MATRIX_DEVICE_REFRESH_SECONDS
+                              Min seconds between proactive peer device-list
+                              refreshes before encrypted sends (default: 300,
+                              0 disables; alias of matrix.device_refresh_seconds)
 """
 
 from __future__ import annotations
@@ -827,6 +831,18 @@ class MatrixAdapter(BasePlatformAdapter):
         self._clock_skew_warned: bool = False
         self._last_sync_ts: float = 0.0
 
+        # Throttle state for proactive per-room device-list refresh before
+        # encrypted sends — see _refresh_encrypted_room_devices().
+        # config.yaml: matrix.device_refresh_seconds (0 disables).
+        self._device_refresh_ts: Dict[str, float] = {}
+        device_refresh_raw = config.extra.get("device_refresh_seconds")
+        if device_refresh_raw is None:
+            device_refresh_raw = os.getenv("MATRIX_DEVICE_REFRESH_SECONDS", "300")
+        try:
+            self._device_refresh_interval = float(device_refresh_raw)
+        except (TypeError, ValueError):
+            self._device_refresh_interval = 300.0
+
         # Cache: room_id → bool (is DM)
         self._dm_rooms: Dict[str, bool] = {}
         self._room_identities: Dict[str, MatrixRoomIdentity] = {}
@@ -1575,6 +1591,103 @@ class MatrixAdapter(BasePlatformAdapter):
 
         logger.info("Matrix: disconnected")
 
+    async def _refresh_encrypted_room_devices(self, room_id: str) -> None:
+        """Proactively re-fetch device lists for members of an encrypted room.
+
+        mautrix only invalidates its cached device list for another user when
+        the homeserver reports that user in ``device_lists.changed`` in a /sync
+        response (OlmMachine.handle_device_lists) — there is no catch-up
+        (``/keys/changes``) or manual invalidation path. When that signal is
+        missed (gateway downtime during a peer's device rotation, crypto-store
+        recreation, or homeservers that fail to emit it — the Conduit family:
+        legacy Conduit, unmaintained conduwuit, Tuwunel < 1.6.1), the cache is
+        stale forever: outbound megolm sessions are shared only to the peer's
+        dead device and the peer can never decrypt ("No one-time keys nor
+        device keys got when trying to share keys" on their side). Own-device
+        recovery (_verify_device_keys_on_server) doesn't cover this — the
+        failing direction is encrypting TO a rotated peer.
+
+        This forces a throttled ``/keys/query`` (crypto._fetch_keys) for the
+        room's members before an encrypted send. If any device changed,
+        mautrix's _process_fetched_keys → on_devices_changed drops the
+        outbound group session, so the next send re-shares to the current
+        device set. Same class of fix as matrix-rust-sdk's
+        mark_all_tracked_users_as_dirty (matrix-rust-sdk#3965). Failures here
+        must never block the actual send.
+        """
+        if not self._encryption or self._device_refresh_interval <= 0:
+            return
+        client = self._client
+        crypto = getattr(client, "crypto", None) if client else None
+        if crypto is None or not hasattr(crypto, "_fetch_keys"):
+            return
+        # Throttle: at most one refresh per room per interval.
+        now = time.monotonic()
+        last = self._device_refresh_ts.get(room_id, 0.0)
+        if now - last < self._device_refresh_interval:
+            return
+        try:
+            state_store = getattr(client, "state_store", None)
+            if state_store is not None and hasattr(state_store, "is_encrypted"):
+                if not await state_store.is_encrypted(RoomID(room_id)):
+                    self._device_refresh_ts[room_id] = now
+                    return
+            # Resolve member user IDs (state store first, API fallback).
+            members: list = []
+            if state_store is not None:
+                try:
+                    members = list(await state_store.get_members(RoomID(room_id)) or [])
+                except Exception:
+                    members = []
+            if not members and hasattr(client, "get_joined_members"):
+                try:
+                    members = list((await client.get_joined_members(RoomID(room_id))).keys())
+                except Exception:
+                    members = []
+            # Only refresh *other* users; our own device changes are handled
+            # by _verify_device_keys_on_server and the self-share path.
+            members = [m for m in members if m and m != self._user_id]
+            if not members:
+                self._device_refresh_ts[room_id] = now
+                return
+            # Hold the OlmMachine's fetch-keys lock (the same guard its own
+            # handle_device_lists uses) so this out-of-band query cannot race
+            # a sync-driven one — the spec allows one in-flight /keys/query
+            # per user. Degrade gracefully if a future mautrix renames it.
+            lock = getattr(crypto, "_fetch_keys_lock", None)
+            if lock is not None:
+                async with lock:
+                    await crypto._fetch_keys(members, include_untracked=True)
+            else:
+                await crypto._fetch_keys(members, include_untracked=True)
+            self._device_refresh_ts[room_id] = now
+            logger.debug(
+                "Matrix: refreshed device lists for %d member(s) of %s before encrypted send",
+                len(members),
+                room_id,
+            )
+        except Exception as exc:
+            # Never let a device-list refresh failure block sending.
+            logger.debug("Matrix: device-list refresh for %s failed: %s", room_id, exc)
+
+    async def _send_room_event(
+        self, room_id: str, event_type: Any, content: Any
+    ) -> Any:
+        """Send a room event through the shared encrypted-send chokepoint.
+
+        Every outbound event that mautrix may encrypt (text, media, edits,
+        reactions, emotes/notices) is routed through here so stale peer
+        device lists are refreshed — throttled, best-effort — before the
+        megolm session is (re-)shared. Returns the event ID like
+        ``Client.send_message_event``.
+        """
+        await self._refresh_encrypted_room_devices(str(room_id))
+        return await self._client.send_message_event(
+            RoomID(room_id),
+            event_type,
+            content,
+        )
+
     async def send(
         self,
         chat_id: str,
@@ -1598,8 +1711,8 @@ class MatrixAdapter(BasePlatformAdapter):
 
             try:
                 event_id = await asyncio.wait_for(
-                    self._client.send_message_event(
-                        RoomID(chat_id),
+                    self._send_room_event(
+                        chat_id,
                         EventType.ROOM_MESSAGE,
                         msg_content,
                     ),
@@ -1613,8 +1726,8 @@ class MatrixAdapter(BasePlatformAdapter):
                     try:
                         await self._client.crypto.share_keys()
                         event_id = await asyncio.wait_for(
-                            self._client.send_message_event(
-                                RoomID(chat_id),
+                            self._send_room_event(
+                                chat_id,
                                 EventType.ROOM_MESSAGE,
                                 msg_content,
                             ),
@@ -1738,8 +1851,8 @@ class MatrixAdapter(BasePlatformAdapter):
         }
 
         try:
-            event_id = await self._client.send_message_event(
-                RoomID(chat_id),
+            event_id = await self._send_room_event(
+                chat_id,
                 EventType.ROOM_MESSAGE,
                 msg_content,
             )
@@ -2208,8 +2321,8 @@ class MatrixAdapter(BasePlatformAdapter):
         self._apply_relation_metadata(msg_content, reply_to=reply_to, metadata=metadata)
 
         try:
-            event_id = await self._client.send_message_event(
-                RoomID(room_id),
+            event_id = await self._send_room_event(
+                room_id,
                 EventType.ROOM_MESSAGE,
                 msg_content,
             )
@@ -3121,8 +3234,8 @@ class MatrixAdapter(BasePlatformAdapter):
             }
         }
         try:
-            resp_event_id = await self._client.send_message_event(
-                RoomID(room_id),
+            resp_event_id = await self._send_room_event(
+                room_id,
                 EventType.REACTION,
                 content,
             )
@@ -3722,8 +3835,8 @@ class MatrixAdapter(BasePlatformAdapter):
         msg_content = self._build_text_message_content(text, msgtype=msgtype)
 
         try:
-            event_id = await self._client.send_message_event(
-                RoomID(chat_id),
+            event_id = await self._send_room_event(
+                chat_id,
                 EventType.ROOM_MESSAGE,
                 msg_content,
             )
@@ -4562,6 +4675,8 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
         os.environ["MATRIX_AUTO_THREAD"] = str(matrix_cfg["auto_thread"]).lower()
     if "dm_mention_threads" in matrix_cfg and not os.getenv("MATRIX_DM_MENTION_THREADS"):
         os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
+    if "device_refresh_seconds" in matrix_cfg and not os.getenv("MATRIX_DEVICE_REFRESH_SECONDS"):
+        os.environ["MATRIX_DEVICE_REFRESH_SECONDS"] = str(matrix_cfg["device_refresh_seconds"])
     return None
 
 

--- a/tests/gateway/test_matrix_device_refresh.py
+++ b/tests/gateway/test_matrix_device_refresh.py
@@ -1,0 +1,261 @@
+"""Tests for the Matrix peer device-list refresh before encrypted sends.
+
+mautrix only re-fetches a peer's device list when the homeserver reports the
+peer in ``device_lists.changed`` during /sync (OlmMachine.handle_device_lists);
+there is no catch-up or invalidation path. If that signal is missed (gateway
+downtime during a peer's device rotation, crypto-store recreation, or a
+Conduit-family homeserver that fails to emit it), outbound megolm sessions are
+shared only to the peer's dead device forever and the peer can never decrypt.
+
+These tests cover ``MatrixAdapter._refresh_encrypted_room_devices()`` and the
+``_send_room_event()`` chokepoint that routes every encrypted send path
+(text, media, edits, reactions, emotes/notices) through the refresh.
+"""
+import asyncio
+import time
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import PlatformConfig
+
+
+ROOM = "!room:example.org"
+BOT = "@bot:example.org"
+PEER_TRACKED = "@alice:example.org"
+PEER_UNTRACKED = "@fresh-login:example.org"
+
+
+# ---------------------------------------------------------------------------
+# Adapter helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter(extra_overrides: dict | None = None):
+    """Create a MatrixAdapter wired to a fake encrypted-room client."""
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    extra = {
+        "homeserver": "https://matrix.example.org",
+        "user_id": BOT,
+    }
+    if extra_overrides:
+        extra.update(extra_overrides)
+    config = PlatformConfig(enabled=True, token="syt_test_token", extra=extra)
+    adapter = MatrixAdapter(config)
+
+    client = MagicMock()
+    client.send_message_event = AsyncMock(return_value="$sent:example.org")
+    client.upload_media = AsyncMock(return_value="mxc://example.org/media123")
+    client.state_store.is_encrypted = AsyncMock(return_value=True)
+    # One member mautrix already tracks and one it has never queried —
+    # include_untracked=True must requery BOTH (plus never our own user).
+    client.state_store.get_members = AsyncMock(
+        return_value=[BOT, PEER_TRACKED, PEER_UNTRACKED]
+    )
+    crypto = MagicMock()
+    crypto._fetch_keys = AsyncMock(return_value={})
+    crypto._fetch_keys_lock = asyncio.Lock()
+    crypto.share_keys = AsyncMock()
+    client.crypto = crypto
+
+    adapter._client = client
+    adapter._encryption = True
+    return adapter
+
+
+def _mark_interval_elapsed(adapter, room_id: str = ROOM):
+    """Pretend the last refresh for *room_id* happened over an interval ago.
+
+    ``time.monotonic()`` can be smaller than the default 300s interval on a
+    freshly booted machine, which would make the first-ever send look
+    throttled — pin the last-refresh timestamp instead of relying on uptime.
+    """
+    adapter._device_refresh_ts[room_id] = (
+        time.monotonic() - adapter._device_refresh_interval - 1
+    )
+
+
+# ---------------------------------------------------------------------------
+# Refresh before encrypted sends
+# ---------------------------------------------------------------------------
+
+class TestMatrixDeviceRefresh:
+    @pytest.mark.asyncio
+    async def test_refresh_called_before_encrypted_send_when_interval_elapsed(self):
+        adapter = _make_adapter()
+        _mark_interval_elapsed(adapter)
+
+        result = await adapter.send(ROOM, "hello")
+
+        assert result.success
+        adapter._client.crypto._fetch_keys.assert_awaited_once()
+        adapter._client.send_message_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_throttled_within_interval(self):
+        adapter = _make_adapter()
+        _mark_interval_elapsed(adapter)
+
+        await adapter.send(ROOM, "first")
+        await adapter.send(ROOM, "second")
+
+        # Second send is within the interval — no second /keys/query.
+        adapter._client.crypto._fetch_keys.assert_awaited_once()
+        assert adapter._client.send_message_event.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_refresh_disabled_when_config_zero(self):
+        adapter = _make_adapter({"device_refresh_seconds": 0})
+        _mark_interval_elapsed(adapter)
+
+        result = await adapter.send(ROOM, "hello")
+
+        assert result.success
+        adapter._client.crypto._fetch_keys.assert_not_awaited()
+        adapter._client.send_message_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fetch_keys_failure_does_not_break_send(self):
+        adapter = _make_adapter()
+        _mark_interval_elapsed(adapter)
+        adapter._client.crypto._fetch_keys = AsyncMock(
+            side_effect=RuntimeError("keys/query exploded")
+        )
+
+        result = await adapter.send(ROOM, "hello")
+
+        assert result.success
+        adapter._client.send_message_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_untracked_and_tracked_members_both_requeried(self):
+        adapter = _make_adapter()
+        _mark_interval_elapsed(adapter)
+
+        await adapter.send(ROOM, "hello")
+
+        args, kwargs = adapter._client.crypto._fetch_keys.await_args
+        queried = set(args[0])
+        # include_untracked=True is load-bearing: without it mautrix skips
+        # users it never tracked (fresh logins after crypto-store recreation).
+        assert kwargs.get("include_untracked") is True
+        assert queried == {PEER_TRACKED, PEER_UNTRACKED}
+        assert BOT not in queried
+
+    @pytest.mark.asyncio
+    async def test_unencrypted_room_skips_fetch(self):
+        adapter = _make_adapter()
+        _mark_interval_elapsed(adapter)
+        adapter._client.state_store.is_encrypted = AsyncMock(return_value=False)
+
+        result = await adapter.send(ROOM, "hello")
+
+        assert result.success
+        adapter._client.crypto._fetch_keys.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fetch_keys_lock_held_around_fetch(self):
+        adapter = _make_adapter()
+        _mark_interval_elapsed(adapter)
+        crypto = adapter._client.crypto
+        lock = crypto._fetch_keys_lock
+
+        async def _assert_locked(*args, **kwargs):
+            assert lock.locked(), "_fetch_keys must run under _fetch_keys_lock"
+            return {}
+
+        crypto._fetch_keys = AsyncMock(side_effect=_assert_locked)
+
+        await adapter.send(ROOM, "hello")
+
+        crypto._fetch_keys.assert_awaited_once()
+        assert not lock.locked()
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint coverage — every encrypted send path routes through the refresh
+# ---------------------------------------------------------------------------
+
+class TestMatrixSendChokepoint:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.refresh = AsyncMock()
+        self.adapter._refresh_encrypted_room_devices = self.refresh
+
+    @pytest.mark.asyncio
+    async def test_send_text_routes_through_refresh(self):
+        await self.adapter.send(ROOM, "hello")
+        self.refresh.assert_awaited_with(ROOM)
+
+    @pytest.mark.asyncio
+    async def test_edit_message_routes_through_refresh(self):
+        await self.adapter.edit_message(ROOM, "$orig:example.org", "edited")
+        self.refresh.assert_awaited_with(ROOM)
+
+    @pytest.mark.asyncio
+    async def test_media_upload_routes_through_refresh(self):
+        # Plaintext room here so the test doesn't depend on a real
+        # mautrix.crypto.attachments install; the routing through
+        # _send_room_event is identical either way.
+        self.adapter._client.state_store.is_encrypted = AsyncMock(return_value=False)
+        result = await self.adapter._upload_and_send(
+            ROOM, b"data", "photo.png", "image/png", "m.image"
+        )
+        assert result.success
+        self.refresh.assert_awaited_with(ROOM)
+
+    @pytest.mark.asyncio
+    async def test_reaction_routes_through_refresh(self):
+        await self.adapter._send_reaction(ROOM, "$msg:example.org", "👀")
+        self.refresh.assert_awaited_with(ROOM)
+
+    @pytest.mark.asyncio
+    async def test_simple_message_routes_through_refresh(self):
+        await self.adapter._send_simple_message(ROOM, "waves", "m.emote")
+        self.refresh.assert_awaited_with(ROOM)
+
+    @pytest.mark.asyncio
+    async def test_e2ee_retry_path_routes_through_refresh(self):
+        # First attempt fails, retry after share_keys() must also pass
+        # through the chokepoint.
+        self.adapter._client.send_message_event = AsyncMock(
+            side_effect=[Exception("no session"), "$retried:example.org"]
+        )
+        result = await self.adapter.send(ROOM, "hello")
+        assert result.success
+        assert self.refresh.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Config plumbing
+# ---------------------------------------------------------------------------
+
+class TestMatrixDeviceRefreshConfig:
+    def test_default_interval_is_300(self):
+        adapter = _make_adapter()
+        assert adapter._device_refresh_interval == 300.0
+
+    def test_extra_overrides_interval(self):
+        adapter = _make_adapter({"device_refresh_seconds": 60})
+        assert adapter._device_refresh_interval == 60.0
+
+    def test_env_bridge_used_when_extra_absent(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_DEVICE_REFRESH_SECONDS", "120")
+        adapter = _make_adapter()
+        assert adapter._device_refresh_interval == 120.0
+
+    def test_invalid_value_falls_back_to_default(self):
+        adapter = _make_adapter({"device_refresh_seconds": "not-a-number"})
+        assert adapter._device_refresh_interval == 300.0
+
+    def test_yaml_config_bridges_to_env(self, monkeypatch):
+        import os
+
+        from plugins.platforms.matrix.adapter import _apply_yaml_config
+
+        # setenv-to-empty records the prior state for teardown restore while
+        # still counting as "unset" for the env-precedence check in the bridge.
+        monkeypatch.setenv("MATRIX_DEVICE_REFRESH_SECONDS", "")
+        _apply_yaml_config({}, {"device_refresh_seconds": 45})
+
+        assert os.environ.get("MATRIX_DEVICE_REFRESH_SECONDS") == "45"

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -404,6 +404,7 @@ When E2EE is enabled, Hermes:
 - Uploads device keys on first connection
 - Decrypts incoming messages and encrypts outgoing messages automatically
 - Auto-joins encrypted rooms when invited
+- Re-queries room members' device lists before encrypted sends (at most once per room per `matrix.device_refresh_seconds` in `config.yaml`, default 300; set `0` to disable), so a peer that rotated its device while the gateway was offline, or on a homeserver that fails to announce the rotation, can still decrypt the bot's messages
 
 ### Matrix Tools and Controls
 


### PR DESCRIPTION
## What does this PR do?

Fixes a Matrix E2EE bug where a peer who rotates their device can permanently lose the ability to decrypt the bot's messages, because mautrix-python never re-fetches the peer's device list once the homeserver's one-shot notification is missed.

**Problem.** mautrix-python only invalidates its cached device list for another user when the homeserver reports that user in `device_lists.changed` in a `/sync` response (`OlmMachine.handle_device_lists` is the only code path). It has no catch-up (`/keys/changes` after a gap) and no manual invalidation path. If that single signal is missed, the cache is stale forever: outbound megolm sessions are shared only to the peer's dead device, and every message the bot sends is undecryptable for that peer. The peer's client shows the classic "unable to decrypt" and their key-share requests fail with "No one-time keys nor device keys got when trying to share keys".

The signal gets missed in realistic, recurring ways:

- The gateway crashes or is killed between consuming a `/sync` response (sync token advances) and fully applying its `device_lists` section. The entry is spent and is not replayed on the next sync.
- The homeserver fails to emit `device_lists.changed` for the rotation. This is a known long-standing bug class in the Conduit family: legacy Conduit (open since 2022, famedly/conduit#325), conduwuit (unmaintained), and Tuwunel before 1.6.1 (matrix-construct/tuwunel#377, fixed 2026-05). On those servers the tracked-but-stale state is reached on every peer rotation.
- Whatever the path into it, the failing state is the same and self-sustaining: a peer that is *tracked* in the crypto store with a stale device list is never re-queried, because `_share_group_session` only fetches keys for users whose cached device dict is absent entirely. Multiple users in #13891 are sitting in exactly this state today.

**Why own-device fixes don't cover this.** #14956 (and `_verify_device_keys_on_server` generally) handles the bot's OWN device keys being stale or missing on the server. This bug is the opposite direction: the bot's device is perfectly healthy; what is stale is the bot's cached view of the PEER's devices when encrypting TO them. That is why several users in #13891 still report the exact "No one-time keys nor device keys got when trying to share keys" symptom after #14956 landed.

**Precedent.** matrix-rust-sdk hit the same class and added an explicit invalidation API, `mark_all_tracked_users_as_dirty` (matrix-rust-sdk PR: https://github.com/matrix-org/matrix-rust-sdk/pull/3965). mautrix-python has no equivalent, so this fix performs a throttled proactive re-query at the send boundary instead.

**The fix.** All outbound events that mautrix may encrypt (text, media, edits, reactions, emotes/notices) already funnel through `Client.send_message_event`. This PR routes the adapter's six call sites through a single new chokepoint, `MatrixAdapter._send_room_event()`, which first runs `_refresh_encrypted_room_devices()`:

- Throttled: at most one refresh per room per `matrix.device_refresh_seconds` (config.yaml, default 300, `0` disables). Bridged to the internal `MATRIX_DEVICE_REFRESH_SECONDS` env var by `_apply_yaml_config`, same as the other matrix keys; docs point at config.yaml.
- Skips unencrypted rooms and the bot's own user; queries all other room members with `crypto._fetch_keys(members, include_untracked=True)`. `include_untracked=True` is load-bearing: it also repairs members mautrix never tracked (crypto-store recreation case).
- Holds the OlmMachine's `_fetch_keys_lock` around the query (hasattr-guarded, degrades gracefully if a future mautrix renames it) so the out-of-band `/keys/query` cannot race a sync-driven one.
- Best-effort and non-blocking: any failure is swallowed with debug-level logging and the send proceeds unchanged. No behavior change for rooms and servers where the sync signal works; the refresh finds no delta and mautrix keeps the existing group session.

When a rotation IS detected, mautrix's own `_process_fetched_keys` -> `on_devices_changed` drops the outbound group session, so the very next send re-shares keys to the peer's current device set. No new session churn otherwise.

## Related Issue

Fixes #13891

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py`
  - New `_refresh_encrypted_room_devices()` (throttled, locked, best-effort peer device-list re-query).
  - New `_send_room_event()` chokepoint; the six `send_message_event` call sites (`send()` incl. its E2EE retry, `edit_message()`, `_upload_and_send()`, `_send_reaction()`, `_send_simple_message()`) now route through it.
  - `__init__` reads `device_refresh_seconds` from `config.extra` with the established `MATRIX_DEVICE_REFRESH_SECONDS` env bridge fallback; `_apply_yaml_config` bridges the config.yaml key.
  - Module docstring documents the new setting alongside the existing aliases.
- `hermes_cli/config.py`: `matrix.device_refresh_seconds: 300` added to `DEFAULT_CONFIG` (additive key, no `_config_version` bump needed per AGENTS.md).
- `website/docs/user-guide/messaging/matrix.md`: one bullet in the E2EE section describing the refresh and the config knob.
- `tests/gateway/test_matrix_device_refresh.py`: 18 new tests (see below).

Out of scope on purpose: `_standalone_send()` (cron delivery) is a raw Client-Server API plaintext sender with no E2EE, so it is not part of this bug class.

## How to Test

Reproduce on current main. The deterministic variant simulates the tracked-but-stale state directly (it is reachable through any of the paths above; this makes it reproducible in minutes on any homeserver):

1. Set up two accounts on one homeserver: Hermes with `MATRIX_E2EE_MODE=required`, and a peer account (Element or a second Hermes instance) sharing an encrypted room. Exchange a few messages so the peer is tracked in the crypto store.
2. Stop the gateway. Rotate the peer's device (log the peer out and back in). Now poison one step deterministically: in the Hermes profile's `crypto.db`, the peer's cached device row still lists only the old (now dead) device — verify with `sqlite3 ... "SELECT device_id FROM crypto_device WHERE user_id='@peer:...'"`. (If your stop/rotate timing happened to deliver the `device_lists.changed`, delete the peer's new-device row to restore the stale state — this is exactly the state crash-loss or a Conduit-family server leaves behind.)
3. Start the gateway and send a message to the room. On main, the peer cannot decrypt it, and never will: mautrix encrypts to the dead device on every send, and the peer's key-share requests log "No one-time keys nor device keys got when trying to share keys". Nothing in main ever re-queries.
4. Conduit-family live variant (no poisoning): the same two accounts on legacy Conduit or Tuwunel < 1.6.1; rotate the peer while the gateway stays up — those servers fail to emit `device_lists.changed` for local users.
5. With this PR, the next encrypted send (at most `device_refresh_seconds` later) re-queries the peer's devices, mautrix drops the outbound session, and the message re-shares to the current device set. The peer decrypts normally.

Test suite: `pytest tests/gateway/test_matrix_device_refresh.py -q` (18 passed) covering: refresh before an encrypted send once the interval elapsed; throttling within the interval; `device_refresh_seconds: 0` disables; a `_fetch_keys` exception never breaks the send; tracked and untracked members both requeried with `include_untracked=True` and own user excluded; unencrypted rooms skipped; `_fetch_keys_lock` held around the query; every sibling send path (text, edit, media, reaction, emote/notice, E2EE retry) routed through the chokepoint; config precedence (extra > env bridge > default) and the `_apply_yaml_config` bridge. Existing matrix suites (`tests/gateway/test_matrix*.py`, `tests/hermes_cli/test_config.py`, `tests/hermes_cli/test_setup_matrix_e2ee.py`) pass unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (matrix + config areas run locally; see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (production gateways + test suite)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (matrix keys live in `DEFAULT_CONFIG` and the matrix docs page, matching the existing matrix settings; `cli-config.yaml.example` has no matrix block)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure asyncio + mautrix API calls, no OS-specific primitives)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Debug log line after a rotation is picked up:

```
Matrix: refreshed device lists for 1 member(s) of !room:example.org before encrypted send
```

Disclosure: this fix was developed and validated in production during an AI-assisted engineering session — a Hermes deployment doing agent-to-agent E2EE hit the tracked-but-stale state during a churn-heavy rollout (repeated device rotations while gateways restarted), and this refresh cured it immediately and durably. For honesty: we could not pin our incident on the homeserver — a controlled test on Tuwunel 1.8.0 showed it emits `device_lists.changed` correctly — which is precisely the point of fixing this client-side: the stale state arises from more than one path, and mautrix has no recovery from any of them. Ported to current main and adapted to the contribution rubric; a human reviewed everything before submission.
