### PR TITLE
fix(skills): don't let an empty platform/namespace value match everything

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -170,6 +170,11 @@ def skill_matches_platform_list(platforms: Any) -> bool:
     running_in_termux = is_termux()
     for platform in platforms:
         normalized = str(platform).lower().strip()
+        if not normalized:
+            # An empty/whitespace tag must not match every OS — otherwise
+            # ``current.startswith("")`` short-circuits to True and the skill
+            # leaks onto all platforms. Mirrors skill_matches_environment.
+            continue
         mapped = PLATFORM_MAP.get(normalized, normalized)
         if current.startswith(mapped):
             return True
@@ -826,4 +831,6 @@ def is_valid_namespace(candidate: Optional[str]) -> bool:
     """Check whether *candidate* is a valid namespace (``[a-zA-Z0-9_-]+``)."""
     if not candidate:
         return False
-    return bool(_NAMESPACE_RE.match(candidate))
+    # ``fullmatch`` (not ``match``): with ``$``, ``re.match`` also accepts a
+    # single trailing newline (e.g. "foo\n"), which is not in the allowed set.
+    return bool(_NAMESPACE_RE.fullmatch(candidate))

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -9,6 +9,7 @@ from agent.skill_utils import (
     is_excluded_skill_path,
     is_external_skill_path,
     is_skill_support_path,
+    is_valid_namespace,
     iter_skill_index_files,
     resolve_skill_config_values,
     skill_matches_platform,
@@ -345,6 +346,25 @@ class TestSkillMatchesPlatformTermux:
             assert skill_matches_platform(fm) is True
             assert skill_matches_platform_list(fm["platforms"]) is True
 
+    def test_empty_platform_tag_does_not_leak_to_other_os(self):
+        # A stray empty/whitespace tag must not make a macOS-only skill match
+        # every OS: current.startswith("") would otherwise short-circuit True.
+        for tags in (["macos", ""], ["macos", "   "]):
+            fm = {"platforms": tags}
+            with patch("agent.skill_utils.sys.platform", "linux"), patch(
+                "agent.skill_utils.is_termux", return_value=False
+            ):
+                assert skill_matches_platform(fm) is False, tags
+                assert skill_matches_platform_list(tags) is False, tags
+
+    def test_only_empty_platform_tag_matches_nothing(self):
+        fm = {"platforms": [""]}
+        with patch("agent.skill_utils.sys.platform", "linux"), patch(
+            "agent.skill_utils.is_termux", return_value=False
+        ):
+            assert skill_matches_platform(fm) is False
+            assert skill_matches_platform_list([""]) is False
+
 
 class TestNormalizeSkillLookupName:
     def test_relative_path_unchanged(self, tmp_path, monkeypatch):
@@ -386,3 +406,23 @@ class TestNormalizeSkillLookupName:
         monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: tmp_path / "skills")
         outside = str(tmp_path / "outside" / "skill")
         assert normalize_skill_lookup_name(outside) == outside
+
+
+class TestIsValidNamespace:
+    def test_valid_names(self):
+        assert is_valid_namespace("plugin") is True
+        assert is_valid_namespace("my-plugin_1") is True
+
+    def test_rejects_empty_and_none(self):
+        assert is_valid_namespace("") is False
+        assert is_valid_namespace(None) is False
+
+    def test_rejects_trailing_newline(self):
+        # re.match("...$") also accepts a single trailing newline; fullmatch
+        # (or \Z) must reject it since \n is not in the allowed charset.
+        assert is_valid_namespace("plugin\n") is False
+        assert is_valid_namespace("plu\ngin") is False
+
+    def test_rejects_disallowed_chars(self):
+        assert is_valid_namespace("plugin:skill") is False
+        assert is_valid_namespace("has space") is False


### PR DESCRIPTION
## What does this PR do?

Fixes two related "empty value matches everything" input-validation bugs in
`agent/skill_utils.py`:

1. **`skill_matches_platform`** — an empty or whitespace `platforms` entry
   normalizes to `""`, and `current.startswith("")` is always `True`, so a
   skill declared for one OS leaks onto every OS:

   ```python
   # on Linux:
   skill_matches_platform({"platforms": ["macos", ""]})  # -> True (should be False)
   ```

   A stray empty tag (trailing comma in YAML, `["macos", ""]`, `["  "]`) makes
   a macOS-only skill load on Linux/Windows. The sibling
   `skill_matches_environment` already guards this with
   `if not normalized: continue`; this adds the same guard.

2. **`is_valid_namespace`** — `_NAMESPACE_RE.match(value)` with a `$` anchor
   also matches a single trailing newline (Python `$` matches just before a
   final `\n`), so `is_valid_namespace("plugin\n")` returned `True` even
   though `\n` isn't in the allowed `[a-zA-Z0-9_-]` set. Switched to
   `fullmatch`.

## Related Issue

No existing issue — found via a code audit (the sibling env function having
the guard made the platform gap obvious).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py` — guard empty/whitespace platform tags; use
  `fullmatch` for namespace validation.
- `tests/agent/test_skill_utils.py` — regression tests for empty/whitespace
  platform tags and newline/invalid namespaces.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_skill_utils.py -q` → all pass (26).
2. On Linux, `skill_matches_platform({"platforms": ["macos", ""]})` is now
   `False` (was `True`); `is_valid_namespace("plugin\n")` is now `False`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(skills):`)
- [x] I searched for existing PRs (none for these two bugs)
- [x] Only changes related to this fix
- [x] Affected test module passes — `tests/agent/test_skill_utils.py` (26). Full suite not run locally.
- [x] Added regression tests
- [x] Considered cross-platform impact (this *is* the platform-gating fix; verified linux/darwin/android/termux paths in tests)
- [x] Tested on: Ubuntu (WSL2)

### Documentation & Housekeeping

- [x] Behavior-only fix — N/A for docs / config / tool schemas
