### PR TITLE
fix(caching): include Kimi/Moonshot in OpenRouter prompt cache policy (#26014 salvage)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1569,8 +1569,12 @@ def anthropic_prompt_cache_policy(
     # moonshotai/kimi-k2.6 falls through to (False, False), serving ~1%
     # cache hits on 64K-token prompts and re-billing the full prompt on
     # every turn.  Observed within-turn progression with cache enabled:
-    # 1% → 67% → 84% → 97% (#25970).
-    is_kimi = "kimi" in model_lower or "moonshot" in model_lower
+    # 1% → 67% → 84% → 97% (#25970).  Reuses the canonical family matcher
+    # (covers bare k1./k2./k25 release slugs the substring check missed).
+    from agent.anthropic_adapter import _model_name_is_kimi_family
+    is_kimi = (
+        _model_name_is_kimi_family(eff_model) or "moonshot" in model_lower
+    )
     is_openrouter = base_url_host_matches(eff_base_url, "openrouter.ai")
     # Nous Portal proxies to OpenRouter behind the scenes — identical
     # OpenAI-wire envelope cache_control semantics. Treat it as an

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1564,6 +1564,13 @@ def anthropic_prompt_cache_policy(
     model_lower = eff_model.lower()
     provider_lower = eff_provider.lower()
     is_claude = "claude" in model_lower
+    # Kimi / Moonshot family via OpenRouter: same cache_control wire format
+    # as Claude on OpenRouter (envelope layout).  Without this branch
+    # moonshotai/kimi-k2.6 falls through to (False, False), serving ~1%
+    # cache hits on 64K-token prompts and re-billing the full prompt on
+    # every turn.  Observed within-turn progression with cache enabled:
+    # 1% → 67% → 84% → 97% (#25970).
+    is_kimi = "kimi" in model_lower or "moonshot" in model_lower
     is_openrouter = base_url_host_matches(eff_base_url, "openrouter.ai")
     # Nous Portal proxies to OpenRouter behind the scenes — identical
     # OpenAI-wire envelope cache_control semantics. Treat it as an
@@ -1577,7 +1584,7 @@ def anthropic_prompt_cache_policy(
 
     if is_native_anthropic:
         return True, True
-    if (is_openrouter or is_nous_portal) and is_claude:
+    if (is_openrouter or is_nous_portal) and (is_claude or is_kimi):
         return True, False
     # Nous Portal Qwen (e.g. qwen3.6-plus) takes the same envelope-layout
     # cache_control path as Portal Claude. Portal proxies to OpenRouter

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -75,6 +75,46 @@ class TestOpenRouter:
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
 
+class TestKimiMoonshotOnOpenRouter:
+    """Kimi/Moonshot on OpenRouter honour envelope-layout cache_control (#25970)."""
+
+    def test_kimi_k26_on_openrouter_caches_with_envelope_layout(self):
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="moonshotai/kimi-k2.6",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_moonshot_v1_on_openrouter_caches_with_envelope_layout(self):
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="moonshotai/moonshot-v1-8k",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_kimi_on_nous_portal_caches_with_envelope_layout(self):
+        agent = _make_agent(
+            provider="nous",
+            base_url="https://api.nousresearch.com/v1",
+            api_mode="chat_completions",
+            model="moonshotai/kimi-k2.6",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_kimi_on_non_openrouter_host_does_not_cache(self):
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://api.moonshot.cn/v1",
+            api_mode="chat_completions",
+            model="moonshotai/kimi-k2.6",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+
 class TestThirdPartyAnthropicGateway:
     """Third-party gateways speaking the Anthropic protocol (MiniMax, Zhipu GLM, LiteLLM)."""
 

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -105,6 +105,17 @@ class TestKimiMoonshotOnOpenRouter:
         )
         assert agent._anthropic_prompt_cache_policy() == (True, False)
 
+    def test_kimi_bare_release_slug_on_openrouter_caches(self):
+        """Bare release slugs (k2-thinking) lack the 'kimi'/'moonshot' substring;
+        the canonical family matcher must still catch them."""
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="k2-thinking",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
     def test_kimi_on_non_openrouter_host_does_not_cache(self):
         agent = _make_agent(
             provider="custom",


### PR DESCRIPTION
## Summary
Kimi/Moonshot models on OpenRouter now get prompt caching: `anthropic_prompt_cache_policy()` previously fell through to `(False, False)` for them, serving ~1% cache hits on 64K-token prompts and re-billing the full prompt every turn. With the envelope-layout markers enabled, observed within-turn cache-hit progression is 1% -> 67% -> 84% -> 97% (#25970).

Extraction salvage of #26014 by @zccyman: the PR's single live hunk (+8/-1 in `agent/agent_runtime_helpers.py`) cherry-picked with authorship preserved; the branch's unrelated `.dev-workflow` artifacts (786 lines) are not included.

## Changes
- `agent/agent_runtime_helpers.py`: `is_kimi` branch joins `is_claude` in the OpenRouter/Nous-Portal envelope-layout path; uses the canonical `_model_name_is_kimi_family` matcher (covers bare release slugs like `k2-thinking` that a substring check misses)
- `tests/run_agent/test_anthropic_prompt_cache_policy.py`: 5 tests in the canonical seam — kimi-k2.6/moonshot-v1 on OpenRouter, kimi via Nous Portal, bare-slug `k2-thinking`, and the non-OpenRouter negative case

## Validation
| Check | Result |
|---|---|
| `tests/run_agent/test_anthropic_prompt_cache_policy.py` | 29 passed |
| Mutation check (source hunk reverted) | 4 new tests fail, as intended |
| ruff / ty (net-new vs main) | clean / 0 |

Supersedes #26014 — can be closed in favor of this PR (authorship preserved via cherry-pick; contributor email already in AUTHOR_MAP).

Fixes #25970.
