### PR TITLE
fix(gateway): don't resolve a blank channel target to the only channel

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -71,7 +71,10 @@ def _apply_channel_aliases(platforms: Dict[str, Any]) -> None:
 
 
 def _normalize_channel_query(value: str) -> str:
-    return value.lstrip("#").strip().lower()
+    # Strip surrounding whitespace *before* removing the leading ``#`` sigil,
+    # otherwise a leading space (common in copy-pasted targets like
+    # " #general") shields the ``#`` and it survives normalization.
+    return value.strip().lstrip("#").strip().lower()
 
 
 def _channel_target_name(platform_name: str, channel: Dict[str, Any]) -> str:
@@ -353,6 +356,13 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
             return ch["id"]
 
     query = _normalize_channel_query(name)
+
+    # An empty/whitespace/``#``-only query must not resolve to a channel: the
+    # prefix step below uses ``startswith(query)``, and every string starts
+    # with "", so a blank query would silently resolve to the only channel and
+    # misdeliver the message.
+    if not query:
+        return None
 
     # 1. Exact name match, including the display labels shown by send_message(action="list")
     for ch in channels:

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -144,6 +144,29 @@ class TestResolveChannelName:
         with self._setup(tmp_path, {}):
             assert resolve_channel_name("telegram", "someone") is None
 
+    def test_empty_query_does_not_resolve_to_only_channel(self, tmp_path):
+        # A blank/whitespace/#-only target must not prefix-match the only
+        # channel (startswith("") is always True) and misdeliver the message.
+        platforms = {
+            "telegram": [{"id": "123", "name": "Alice", "type": "dm"}]
+        }
+        with self._setup(tmp_path, platforms):
+            assert resolve_channel_name("telegram", "") is None
+            assert resolve_channel_name("telegram", "   ") is None
+            assert resolve_channel_name("telegram", "#") is None
+            # A real prefix still resolves.
+            assert resolve_channel_name("telegram", "Ali") == "123"
+
+    def test_leading_space_hash_sigil_is_stripped(self, tmp_path):
+        # " #general" (copy-pasted with a leading space) must normalize the
+        # same as "#general"; the sigil must not survive the leading space.
+        platforms = {
+            "slack": [{"id": "C01", "name": "general", "type": "channel"}]
+        }
+        with self._setup(tmp_path, platforms):
+            assert resolve_channel_name("slack", " #general") == "C01"
+            assert resolve_channel_name("slack", "#general") == "C01"
+
     def test_no_match_returns_none(self, tmp_path):
         platforms = {
             "telegram": [{"id": "123", "name": "John", "type": "dm"}]


### PR DESCRIPTION
## What does this PR do?

Fixes two channel-resolution bugs in `gateway/channel_directory.py`, one of
which can **misdeliver a message to an unintended chat**.

1. **Blank target resolves to the only channel.** `resolve_channel_name`'s
   final step prefix-matches with `startswith(query)`. Every string starts
   with `""`, so an empty / whitespace / `"#"`-only target prefix-matches
   *every* channel; when the platform has exactly one channel,
   `len(matches) == 1` and that channel id is returned:

   ```python
   # directory: {"telegram": [{"id": "123", "name": "Alice", "type": "dm"}]}
   resolve_channel_name("telegram", "")     # -> "123"  (should be None)
   resolve_channel_name("telegram", "   ")  # -> "123"
   resolve_channel_name("telegram", "#")    # -> "123"
   ```

   A blank/garbage target silently resolves to "the only channel" and the
   message goes to an unintended chat. Guard: return `None` for an empty
   normalized query.

2. **Leading space defeats the `#` sigil strip.** `_normalize_channel_query`
   ran `lstrip("#")` *before* `strip()`, so leading whitespace shielded the
   `#`: `" #general"` normalized to `"#general"` (not `"general"`) and failed
   to match the `general` channel. Copy-pasted targets with a leading space
   are the realistic trigger. Fix: `strip()` first, then remove the sigil.

## Related Issue

No existing issue — found via a code audit of channel-name resolution.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/channel_directory.py` — return `None` for an empty normalized
  query; strip whitespace before removing the `#` sigil.
- `tests/gateway/test_channel_directory.py` — regression tests for
  blank/whitespace/`#`-only targets and a leading-space `#` sigil.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_channel_directory.py -q` → all pass (41).
2. With a single-channel directory, `resolve_channel_name(platform, "")` is
   now `None` (was the channel id); `resolve_channel_name("slack", " #general")`
   now resolves like `"#general"`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs (none for these two bugs)
- [x] Only changes related to this fix
- [x] Affected test module passes — `tests/gateway/test_channel_directory.py` (41). Full suite not run locally.
- [x] Added regression tests
- [x] Tested on: Ubuntu (WSL2)

### Documentation & Housekeeping

- [x] Behavior-only fix — N/A for docs / config / tool schemas
