### PR TITLE
fix(desktop,gateway): respect profile terminal backend in Desktop app (#61115)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4802,6 +4802,24 @@ function readActiveDesktopProfile() {
   return null
 }
 
+// Returns the CLI's sticky active profile from ~/.hermes/active_profile, or
+// null when unset / invalid.  Used as a fallback when readActiveDesktopProfile()
+// returns null (no desktop-specific preference), so the Desktop honours the
+// same profile the user selected via `hermes profile use <name>` in the CLI.
+function readCliActiveProfile() {
+  try {
+    const activePath = path.join(HERMES_HOME, 'active_profile')
+    if (!fs.existsSync(activePath)) return null
+    const name = fs.readFileSync(activePath, 'utf8').trim()
+    if (name && name !== 'default' && PROFILE_NAME_RE.test(name)) {
+      return name
+    }
+  } catch {
+    // Missing, unreadable, or invalid → no fallback.
+  }
+  return null
+}
+
 function writeActiveDesktopProfile(name) {
   const value = typeof name === 'string' ? name.trim() : ''
 
@@ -5252,7 +5270,17 @@ async function waitForBackendExit(child, timeoutMs = 5000) {
 // returns the desktop's stored preference, or null when unset (legacy launch
 // that defers to active_profile / default).
 function primaryProfileKey() {
-  return readActiveDesktopProfile() || 'default'
+  // 1. Desktop-specific preference (active-profile.json in userData).
+  const desktopProfile = readActiveDesktopProfile()
+  if (desktopProfile) return desktopProfile
+  // 2. Fall back to the CLI's sticky active_profile so the Desktop
+  //    automatically uses the profile the user selected via
+  //    `hermes profile use <name>` without requiring a separate
+  //    Desktop-side configuration step.
+  const cliProfile = readCliActiveProfile()
+  if (cliProfile) return cliProfile
+  // 3. No preference → legacy behaviour (default HERMES_HOME).
+  return 'default'
 }
 
 // Resolve a backend connection for the given profile. Routes the primary
@@ -5572,9 +5600,10 @@ async function startHermes() {
     // Pin the desktop's chosen profile via the global --profile flag. This is
     // deterministic (it wins over the sticky ~/.hermes/active_profile file) and
     // resolves HERMES_HOME the same way `hermes -p <name>` does on the CLI. An
-    // unset preference keeps the legacy launch so existing installs are
-    // unaffected.
-    const activeProfile = readActiveDesktopProfile()
+    // unset preference falls back to the CLI's active_profile so the Desktop
+    // automatically honours `hermes profile use <name>` without a separate
+    // Desktop-side configuration step.
+    const activeProfile = readActiveDesktopProfile() || readCliActiveProfile()
     if (activeProfile) {
       backendArgs.unshift('--profile', activeProfile)
     }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1477,6 +1477,13 @@ if _config_path.exists():
         # config.yaml overrides .env for these since it's the documented config path.
         _terminal_cfg = _cfg.get("terminal", {})
         if _terminal_cfg and isinstance(_terminal_cfg, dict):
+            # Normalize legacy env_type key to backend for gateway-mode parity
+            # with cli.py's config bridge, which maps env_type → TERMINAL_ENV.
+            # The documented key is "backend"; accept `env_type` as a fallback
+            # so existing profiles written with the legacy key work the same
+            # when served by the gateway (serve / dashboard / desktop app).
+            if "backend" not in _terminal_cfg and "env_type" in _terminal_cfg:
+                _terminal_cfg["backend"] = _terminal_cfg["env_type"]
             _terminal_backend = str(
                 _terminal_cfg.get("backend") or os.environ.get("TERMINAL_ENV") or ""
             ).strip().lower()


### PR DESCRIPTION
## Summary

Fixes #61115 — Hermes Desktop does not use the same profile terminal backend / sandbox as the CLI profile command.

## Problem

When a user creates a profile (e.g. `code-review`) with a Docker sandbox terminal backend, the CLI (`code-review chat`) correctly runs commands inside the sandbox (`/workspace/project`, read-only, no network). However, the Hermes Desktop app spawns commands locally on the host, ignoring the profile's terminal backend configuration.

## Root Causes

Two issues were identified:

### 1. Gateway config bridge ignores legacy `env_type` key

`gateway/run.py` only bridges the documented `backend` key to `TERMINAL_ENV`, while `cli.py` additionally normalizes `backend` → `env_type`. Profiles using the legacy `terminal.env_type` key would have their terminal backend correctly applied in CLI mode but silently ignored in gateway mode (serve / dashboard / desktop app).

### 2. Desktop doesn't check CLI's sticky active_profile

The Desktop's `startHermes()` only consulted its own desktop-specific profile preference (`active-profile.json` in userData). When unset, no `--profile` flag was passed to the backend, and the backend fell back to the default config — losing any profile the user selected via `hermes profile use <name>`.

## Changes

### `gateway/run.py`
- Add `env_type` → `backend` normalization in the config bridge so legacy configs work identically in gateway mode.

### `apps/desktop/electron/main.cjs`
- Add `readCliActiveProfile()` that reads `~/.hermes/active_profile` (the CLI's sticky active profile).
- Update `primaryProfileKey()` to fall back to the CLI's active profile when no desktop-specific preference is stored.
- Update `startHermes()` to pass `--profile <name>` based on desktop preference OR CLI active profile, so the spawned backend uses the correct profile's terminal config deterministically.

## Testing

- [ ] Gateway config bridge: existing tests in `tests/gateway/test_config_cwd_bridge.py` cover the bridge semantics. The `env_type` normalization is additive and backward-compatible.
- [ ] Desktop profile fallback: no automated tests exist for the Electron main process; manual verification of profile resolution is needed.
