### PR TITLE
Add external Kanban provider projections

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -206,6 +206,7 @@
   // can inspect any board without shifting the CLI's active board out
   // from under a terminal they left open.
   const LS_BOARD_KEY = "hermes.kanban.selectedBoard";
+  const LS_PROVIDER_KEY = "hermes.kanban.selectedProvider";
 
   function readSelectedBoard() {
     try {
@@ -232,6 +233,20 @@
     } catch (_e) { /* ignore quota / private mode */ }
   }
 
+  function readSelectedProvider() {
+    try {
+      const v = window.localStorage.getItem(LS_PROVIDER_KEY);
+      return (v || "").trim() || "native";
+    } catch (_e) { return "native"; }
+  }
+
+  function writeSelectedProvider(provider) {
+    try {
+      const value = (provider || "native").trim() || "native";
+      window.localStorage.setItem(LS_PROVIDER_KEY, value);
+    } catch (_e) { /* ignore quota / private mode */ }
+  }
+
   function withBoard(url, board) {
     // Always append ?board=<slug> when we have one picked — including
     // "default". Omitting the param would fall through to the backend's
@@ -242,6 +257,17 @@
     if (!board) return url;
     const sep = url.indexOf("?") >= 0 ? "&" : "?";
     return `${url}${sep}board=${encodeURIComponent(board)}`;
+  }
+
+  function withProvider(url, provider) {
+    const name = (provider || "native").trim() || "native";
+    if (name === "native") return url;
+    const sep = url.indexOf("?") >= 0 ? "&" : "?";
+    return `${url}${sep}provider=${encodeURIComponent(name)}`;
+  }
+
+  function withBoardProvider(url, board, provider) {
+    return withProvider(withBoard(url, board), provider);
   }
 
   // The SDK's Select component fires ``onValueChange(value)`` directly
@@ -507,6 +533,7 @@
   function KanbanPage() {
     const { t } = useI18n();
     const [board, setBoard] = useState(() => readSelectedBoard() || null);
+    const [provider, setProvider] = useState(() => readSelectedProvider());
     const [boardList, setBoardList] = useState([]);      // [{slug, name, counts, ...}]
     const [showNewBoard, setShowNewBoard] = useState(false);
 
@@ -570,7 +597,7 @@
       if (tenantFilter) qs.set("tenant", tenantFilter);
       if (includeArchived) qs.set("include_archived", "true");
       const url = qs.toString() ? `${API}/board?${qs}` : `${API}/board`;
-      return SDK.fetchJSON(withBoard(url, board))
+      return SDK.fetchJSON(withBoardProvider(url, board, provider))
         .then(function (data) {
           setBoardData(data);
           cursorRef.current = data.latest_event_id || 0;
@@ -580,7 +607,7 @@
           setError(String(err && err.message ? err.message : err));
         })
         .finally(function () { setLoading(false); });
-    }, [tenantFilter, includeArchived, board]);
+    }, [tenantFilter, includeArchived, board, provider]);
 
     // --- load list of boards for the switcher ------------------------------
     const loadBoardList = useCallback(function () {
@@ -626,7 +653,7 @@
 
     // --- WebSocket ---------------------------------------------------------
     useEffect(function () {
-      if (!boardData) return undefined;
+      if (!boardData || provider !== "native") return undefined;
       wsClosedRef.current = false;
       function openWs() {
         if (wsClosedRef.current) return;
@@ -692,7 +719,13 @@
         wsClosedRef.current = true;
         try { wsRef.current && wsRef.current.close(); } catch (_e) { /* noop */ }
       };
-    }, [!!boardData, board, scheduleReload]);
+    }, [!!boardData, board, provider, scheduleReload]);
+
+    useEffect(function () {
+      if (provider === "native") return undefined;
+      const id = setInterval(function () { loadBoard(); }, 10000);
+      return function () { clearInterval(id); };
+    }, [provider, loadBoard]);
 
     // --- filtering ----------------------------------------------------------
     const filteredBoard = useMemo(function () {
@@ -716,6 +749,10 @@
 
     // --- actions ------------------------------------------------------------
     const moveTask = useCallback(function (taskId, newStatus) {
+      if (boardData && boardData.readonly) {
+        setError("This Kanban provider is read-only.");
+        return;
+      }
       const confirmMsg = getDestructiveConfirm(t, newStatus);
       if (confirmMsg && !window.confirm(confirmMsg)) return;
       const patch = withCompletionSummary({ status: newStatus }, 1, t);
@@ -736,7 +773,7 @@
         }
         return Object.assign({}, b, { columns });
       });
-      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(taskId)}`, board), {
+      SDK.fetchJSON(withBoardProvider(`${API}/tasks/${encodeURIComponent(taskId)}`, board, provider), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(patch),
@@ -744,7 +781,7 @@
         setError(tx(t, "moveFailed", "Move failed: ") + parseApiErrorMessage(err));
         loadBoard();
       });
-    }, [loadBoard, board, t]);
+    }, [loadBoard, board, provider, t, boardData]);
 
     const clearSelected = useCallback(function () {
       setSelectedIds(new Set());
@@ -752,6 +789,10 @@
       setFailedIds(new Set());
     }, []);
     const moveSelected = useCallback(function (newStatus) {
+      if (boardData && boardData.readonly) {
+        setError("This Kanban provider is read-only.");
+        return;
+      }
       const confirmMsg = DESTRUCTIVE_TRANSITIONS[newStatus];
       if (confirmMsg && !window.confirm(confirmMsg)) return;
       if (selectedIds.size === 0) return;
@@ -774,7 +815,7 @@
         if (dest) dest.tasks = moved.concat(dest.tasks);
         return Object.assign({}, b, { columns });
       });
-      SDK.fetchJSON(withBoard(`${API}/tasks/bulk`, board), {
+      SDK.fetchJSON(withBoardProvider(`${API}/tasks/bulk`, board, provider), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(Object.assign({ ids }, patch)),
@@ -794,10 +835,14 @@
         setFailedIds(new Set(selectedIds));
         loadBoard();
       });
-    }, [selectedIds, loadBoard, board]);
+    }, [selectedIds, loadBoard, board, provider, boardData]);
 
     const createTask = useCallback(function (body) {
-      return SDK.fetchJSON(withBoard(`${API}/tasks`, board), {
+      if (boardData && boardData.readonly) {
+        setError("This Kanban provider is read-only.");
+        return Promise.resolve();
+      }
+      return SDK.fetchJSON(withBoardProvider(`${API}/tasks`, board, provider), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -813,7 +858,7 @@
         loadBoardList();  // refresh counts in the switcher
         return res;
       });
-    }, [loadBoard, loadBoardList, board, t]);
+    }, [loadBoard, loadBoardList, board, provider, t, boardData]);
 
     const toggleSelected = useCallback(function (id, additive) {
       setSelectedIds(function (prev) {
@@ -891,6 +936,10 @@
 
     const applyBulk = useCallback(function (patch, confirmMsg) {
       if (selectedIds.size === 0) return;
+      if (boardData && boardData.readonly) {
+        setError("This Kanban provider is read-only.");
+        return;
+      }
       if (confirmMsg && !window.confirm(confirmMsg)) return;
       const finalPatch = withCompletionSummary(patch, selectedIds.size, t);
       if (!finalPatch) return;
@@ -913,7 +962,7 @@
           return Object.assign({}, b, { columns });
         });
       }
-      SDK.fetchJSON(withBoard(`${API}/tasks/bulk`, board), {
+      SDK.fetchJSON(withBoardProvider(`${API}/tasks/bulk`, board, provider), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -937,7 +986,18 @@
           setFailedIds(new Set(selectedIds));
           loadBoard();
         });
-    }, [selectedIds, loadBoard, board, t]);
+    }, [selectedIds, loadBoard, board, provider, t, boardData]);
+
+    const switchProvider = useCallback(function (nextProvider) {
+      const value = (nextProvider || "native").trim() || "native";
+      if (value === provider) return;
+      setBoardData(null);
+      cursorRef.current = 0;
+      setLoading(true);
+      setProvider(value);
+      writeSelectedProvider(value);
+      clearSelected();
+    }, [provider, clearSelected]);
 
     // --- board switching ----------------------------------------------------
     const switchBoard = useCallback(function (nextSlug) {
@@ -982,8 +1042,12 @@
     }, [board, loadBoardList, switchBoard]);
 
    const deleteTask = useCallback(function (taskId) {
+     if (boardData && boardData.readonly) {
+       setError("This Kanban provider is read-only.");
+       return Promise.resolve();
+     }
      if (!window.confirm(tx(t, "trash.confirm", FALLBACK_TRASH.confirm))) return Promise.resolve();
-     return SDK.fetchJSON(`${API}/tasks/${encodeURIComponent(taskId)}`, {
+     return SDK.fetchJSON(withBoardProvider(`${API}/tasks/${encodeURIComponent(taskId)}`, board, provider), {
        method: "DELETE",
      }).then(function () {
        loadBoard();
@@ -993,19 +1057,23 @@
          return next;
        });
      }).catch(function (e) { setError(String(e.message || e)); });
-   }, [board, loadBoard, t]);
+   }, [board, provider, loadBoard, t, boardData]);
 
     const deleteSelected = useCallback(function (count) {
       if (selectedIds.size === 0) return Promise.resolve();
+      if (boardData && boardData.readonly) {
+        setError("This Kanban provider is read-only.");
+        return Promise.resolve();
+      }
       if (!window.confirm(tx(t, "trash.confirmMany", "Permanently delete {n} selected tasks? This cannot be undone.", { n: count }))) return Promise.resolve();
       const ids = Array.from(selectedIds);
       setSelectedIds(new Set());
       return Promise.all(ids.map(function (id) {
-        return SDK.fetchJSON(`${API}/tasks/${encodeURIComponent(id)}`, { method: "DELETE" });
+        return SDK.fetchJSON(withBoardProvider(`${API}/tasks/${encodeURIComponent(id)}`, board, provider), { method: "DELETE" });
       })).then(function () {
         loadBoard();
       }).catch(function (e) { setError(String(e.message || e)); });
-    }, [selectedIds, board, loadBoard, t]);
+    }, [selectedIds, board, provider, loadBoard, t, boardData]);
 
     // --- render -------------------------------------------------------------
     if (loading && !boardData) {
@@ -1049,13 +1117,20 @@
         }),
         h(BoardToolbar, {
           board: boardData,
+          provider,
+          setProvider: switchProvider,
+          readonly: !!(boardData && boardData.readonly),
           tenantFilter, setTenantFilter,
           assigneeFilter, setAssigneeFilter,
           includeArchived, setIncludeArchived,
           laneByProfile, setLaneByProfile,
           search, setSearch,
           onNudgeDispatch: function () {
-            SDK.fetchJSON(withBoard(`${API}/dispatch?max=8`, board), { method: "POST" })
+            if (boardData && boardData.readonly) {
+              setError("This Kanban provider is read-only.");
+              return;
+            }
+            SDK.fetchJSON(withBoardProvider(`${API}/dispatch?max=8`, board, provider), { method: "POST" })
               .then(loadBoard)
               .catch(function (e) { setError(String(e.message || e)); });
           },
@@ -1086,11 +1161,14 @@
           onDelete: deleteTask,
           onOpen: setSelectedTaskId,
           onCreate: createTask,
+          readonly: !!(boardData && boardData.readonly),
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
         }),
         selectedTaskId ? h(TaskDrawer, {
           taskId: selectedTaskId,
           boardSlug: board,
+          provider,
+          readonly: !!(boardData && boardData.readonly),
           onClose: function () { setSelectedTaskId(null); },
           onRefresh: loadBoard,
           renderMarkdown: renderMd,
@@ -2013,6 +2091,17 @@
     const assignees = (props.board && props.board.assignees) || [];
     return h("div", { className: "flex flex-wrap items-end gap-3" },
       h("div", { className: "flex flex-col gap-1",
+                 title: "Choose the task provider rendered by this Kanban board. External providers are read-only projections." },
+        h(Label, { className: "text-xs text-muted-foreground" }, "Provider"),
+        h(Select, Object.assign({
+          value: props.provider || "native",
+          className: "h-8",
+        }, selectChangeHandler(props.setProvider)),
+          h(SelectOption, { value: "native" }, "Native Hermes"),
+          h(SelectOption, { value: "gloops" }, "GLoops projection"),
+        ),
+      ),
+      h("div", { className: "flex flex-col gap-1",
                  title: "Fuzzy-match tasks by id, title, or description. Matches across all columns." },
         h(Label, { className: "text-xs text-muted-foreground" }, tx(t, "search", "Search")),
         h(Input, {
@@ -2068,6 +2157,7 @@
       h(Button, {
         onClick: props.onNudgeDispatch,
         size: "sm",
+        disabled: props.readonly,
         title: "Wake the dispatcher to claim ready tasks now instead of waiting for the next tick. Use this after adding tasks if you want them picked up immediately.",
       }, tx(t, "nudgeDispatcher", "Nudge dispatcher")),
       h(Button, {
@@ -2395,6 +2485,7 @@
           onMoveSelected: props.onMoveSelected,
           onOpen: props.onOpen,
           onCreate: props.onCreate,
+          readonly: props.readonly,
           allTasks: props.allTasks,
         });
       }),
@@ -2417,6 +2508,7 @@
       if (!colRef.current) return undefined;
       const el = colRef.current;
       function onTouchDrop(e) {
+        if (props.readonly) return;
         if (e.detail && e.detail.status === props.column.name) {
           const taskId = e.detail.taskId;
           if (props.selectedIds && props.selectedIds.has(taskId) && props.selectedIds.size > 1 && props.onMoveSelected) {
@@ -2431,6 +2523,7 @@
     }, [props.column.name, props.onMove, props.selectedIds, props.onMoveSelected]);
 
     const handleDragOver = function (e) {
+      if (props.readonly) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
       if (!dragOver) setDragOver(true);
@@ -2439,6 +2532,7 @@
     const handleDrop = function (e) {
       e.preventDefault();
       setDragOver(false);
+      if (props.readonly) return;
       const taskId = e.dataTransfer.getData(MIME_TASK);
       if (!taskId) return;
       if (props.selectedIds && props.selectedIds.has(taskId) && props.selectedIds.size > 1) {
@@ -2496,12 +2590,13 @@
           type: "button",
           className: "hermes-kanban-column-add",
           title: tx(t, "createTask", "Create task in this column"),
+          disabled: props.readonly,
           onClick: function () { setShowCreate(function (v) { return !v; }); },
-        }, showCreate ? "×" : "+"),
+        }, props.readonly ? "·" : (showCreate ? "×" : "+")),
       ),
       h("div", { className: "hermes-kanban-column-sub" },
         colHelp || ""),
-      showCreate ? h(InlineCreate, {
+      showCreate && !props.readonly ? h(InlineCreate, {
         columnName: props.column.name,
         allTasks: props.allTasks,
         onSubmit: function (body) {
@@ -2529,6 +2624,7 @@
                       toggleSelected: props.toggleSelected,
                       toggleRange: props.toggleRange,
                       onOpen: props.onOpen,
+                      readonly: props.readonly,
                     });
                   }),
                 );
@@ -2543,6 +2639,7 @@
                   toggleSelected: props.toggleSelected,
                   toggleRange: props.toggleRange,
                   onOpen: props.onOpen,
+                  readonly: props.readonly,
                 });
               }),
       ),
@@ -2580,10 +2677,15 @@
     const cardRef = useRef(null);
 
     useEffect(function () {
+      if (props.readonly || t.readonly) return undefined;
       return attachTouchDrag(cardRef.current, t.id);
-    }, [t.id]);
+    }, [t.id, props.readonly, t.readonly]);
 
     const handleDragStart = function (e) {
+      if (props.readonly || t.readonly) {
+        e.preventDefault();
+        return;
+      }
       e.dataTransfer.setData(MIME_TASK, t.id);
       e.dataTransfer.effectAllowed = "move";
       const selectedCards = document.querySelectorAll(".hermes-kanban-card--selected");
@@ -2606,6 +2708,7 @@
         return;
       }
       if (e.ctrlKey || e.metaKey) {
+        if (props.readonly || t.readonly) return;
         e.preventDefault();
         e.stopPropagation();
         props.toggleSelected(t.id, true);
@@ -2623,6 +2726,7 @@
       }
     };
     const handleCheckedChange = function () {
+      if (props.readonly || t.readonly) return;
       props.toggleSelected(t.id, true);
     };
 
@@ -2639,7 +2743,7 @@
         props.draggingSource ? "hermes-kanban-card--dragging-source" : "",
         stalenessClass(t),
       ),
-      draggable: true,
+      draggable: !(props.readonly || t.readonly),
       tabIndex: 0,
       role: "button",
       "aria-label": `${t.title || "untitled"} — ${t.id} — ${t.status}`,
@@ -2658,6 +2762,7 @@
               h(Checkbox, {
                 className: "hermes-kanban-card-check",
                 checked: props.selected,
+                disabled: props.readonly || t.readonly,
                 onCheckedChange: handleCheckedChange,
                 onClick: function (e) { e.stopPropagation(); },
                 "aria-label": `Select task ${t.id}`,
@@ -2704,7 +2809,22 @@
                   title: tx(i18n, "needsAssigneeHint", "Dependencies are satisfied, but the dispatcher skips this task until you assign a profile."),
                 }, tx(i18n, "needsAssignee", "Needs assignee"))
               : null,
+            t.readonly || t.external_provider
+              ? h(Badge, { variant: "outline", className: "hermes-kanban-tag",
+                           title: "Read-only external projection." }, t.external_provider || "read-only")
+              : null,
           ),
+          t.badges && t.badges.length
+            ? h("div", { className: "hermes-kanban-card-row hermes-kanban-card-badges" },
+                t.badges.slice(0, 4).map(function (badge, idx) {
+                  return h(Badge, {
+                    key: `${badge.kind || "badge"}-${idx}`,
+                    variant: "outline",
+                    className: cn("hermes-kanban-external-badge", "hermes-kanban-external-badge--" + (badge.severity || "info")),
+                    title: badge.kind || "",
+                  }, badge.label || badge.kind || "badge");
+                }))
+            : null,
           h("div", { className: "hermes-kanban-card-title" },
             t.title || tx(i18n, "untitled", "(untitled)")),
           h("div", { className: "hermes-kanban-card-row hermes-kanban-card-meta" },
@@ -2939,21 +3059,27 @@
     const [homeChannels, setHomeChannels] = useState([]);
     const [homeBusy, setHomeBusy] = useState({});
     const boardSlug = props.boardSlug;
+    const provider = props.provider || "native";
+    const readonly = !!props.readonly || !!(data && data.readonly) || !!(data && data.task && data.task.readonly);
 
     const load = useCallback(function () {
-      return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug))
+      return SDK.fetchJSON(withBoardProvider(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug, provider))
         .then(function (d) { setData(d); setErr(null); setPatchErr(null); })
         .catch(function (e) { setErr(String(e.message || e)); })
         .finally(function () { setLoading(false); });
-    }, [props.taskId, boardSlug]);
+    }, [props.taskId, boardSlug, provider]);
 
     const loadHomeChannels = useCallback(function () {
+      if (provider !== "native") {
+        setHomeChannels([]);
+        return Promise.resolve();
+      }
       const qs = new URLSearchParams({ task_id: props.taskId });
       const url = withBoard(`${API}/home-channels?${qs}`, boardSlug);
       return SDK.fetchJSON(url)
         .then(function (d) { setHomeChannels(d.home_channels || []); })
         .catch(function () { /* silent — endpoint optional on older gateways */ });
-    }, [props.taskId, boardSlug]);
+    }, [props.taskId, boardSlug, provider]);
 
     // Reload when the WS stream reports new events for this task id
     // (completion, block, crash, etc. — anything that'd make the drawer
@@ -2969,7 +3095,11 @@
     const handleComment = function () {
       const body = newComment.trim();
       if (!body) return;
-      SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/comments`, boardSlug), {
+      if (readonly) {
+        setErr("This Kanban provider is read-only.");
+        return;
+      }
+      SDK.fetchJSON(withBoardProvider(`${API}/tasks/${encodeURIComponent(props.taskId)}/comments`, boardSlug, provider), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ body }),
@@ -2986,9 +3116,13 @@
     const handleUpload = function (fileList) {
       const files = Array.prototype.slice.call(fileList || []);
       if (!files.length) return;
+      if (readonly) {
+        setUploadErr("This Kanban provider is read-only.");
+        return;
+      }
       setUploadBusy(true);
       setUploadErr(null);
-      const url = withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/attachments`, boardSlug);
+      const url = withBoardProvider(`${API}/tasks/${encodeURIComponent(props.taskId)}/attachments`, boardSlug, provider);
       // Upload sequentially so a partial failure leaves a clear state.
       let chain = Promise.resolve();
       files.forEach(function (f) {
@@ -3020,7 +3154,11 @@
     };
 
     const handleDeleteAttachment = function (attachmentId) {
-      return SDK.fetchJSON(withBoard(`${API}/attachments/${attachmentId}`, boardSlug), { method: "DELETE" })
+      if (readonly) {
+        setUploadErr("This Kanban provider is read-only.");
+        return Promise.resolve();
+      }
+      return SDK.fetchJSON(withBoardProvider(`${API}/attachments/${attachmentId}`, boardSlug, provider), { method: "DELETE" })
         .then(function () { load(); props.onRefresh(); })
         .catch(function (e) { setUploadErr(String(e.message || e)); });
     };
@@ -3031,8 +3169,12 @@
       }
       const finalPatch = withCompletionSummary(patch, 1);
       if (!finalPatch) return Promise.resolve();
+      if (readonly) {
+        setPatchErr("This Kanban provider is read-only.");
+        return Promise.resolve();
+      }
       setPatchErr(null);
-      return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug), {
+      return SDK.fetchJSON(withBoardProvider(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug, provider), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(finalPatch),
@@ -3167,6 +3309,7 @@
         err ? h("div", { className: "p-4 text-sm text-destructive" }, err) :
         data ? h(TaskDetail, {
           data, editing, setEditing,
+          readonly,
           renderMarkdown: props.renderMarkdown,
           allTasks: props.allTasks,
           assignees: props.assignees || [],
@@ -3187,7 +3330,7 @@
           uploadBusy: uploadBusy,
           uploadErr: uploadErr,
         }) : null,
-        data ? h("div", { className: "hermes-kanban-drawer-comment-row" },
+        data && !readonly ? h("div", { className: "hermes-kanban-drawer-comment-row" },
           h(Input, {
             value: newComment,
             onChange: function (e) { setNewComment(e.target.value); },
@@ -3322,11 +3465,12 @@
     const events = props.data.events || [];
     const attachments = props.data.attachments || [];
     const links = props.data.links || { parents: [], children: [] };
+    const readonly = !!props.readonly || !!t.readonly;
 
     return h("div", { className: "hermes-kanban-drawer-body" },
       h("div", { className: "hermes-kanban-drawer-title" },
         h("span", { className: cn("hermes-kanban-dot", COLUMN_DOT[t.status]) }),
-        props.editing
+        props.editing && !readonly
           ? h(TitleEditor, {
               initial: t.title || "",
               onSave: function (newTitle) {
@@ -3337,13 +3481,13 @@
           : h("span", {
               className: "hermes-kanban-drawer-title-text",
               title: tx(i18n, "clickToEdit", "Click to edit"),
-              onClick: function () { props.setEditing(true); },
+              onClick: function () { if (!readonly) props.setEditing(true); },
             }, t.title || tx(i18n, "untitled", "(untitled)")),
       ),
       h("div", { className: "hermes-kanban-drawer-meta" },
         h(MetaRow, { label: tx(i18n, "status", "Status"), value: t.status }),
-        h(AssigneeEditor, { task: t, onPatch: props.onPatch }),
-        h(PriorityEditor, { task: t, onPatch: props.onPatch }),
+        readonly ? h(MetaRow, { label: tx(i18n, "assignee", "Assignee"), value: t.assignee || "unassigned" }) : h(AssigneeEditor, { task: t, onPatch: props.onPatch }),
+        readonly ? h(MetaRow, { label: tx(i18n, "priority", "Priority"), value: String(t.priority || 0) }) : h(PriorityEditor, { task: t, onPatch: props.onPatch }),
         t.tenant ? h(MetaRow, { label: tx(i18n, "tenant", "Tenant"), value: t.tenant }) : null,
         h(MetaRow, {
           label: tx(i18n, "workspace", "Workspace"),
@@ -3360,8 +3504,27 @@
             : "on",
         }) : null,
         t.created_by ? h(MetaRow, { label: tx(i18n, "createdBy", "Created by"), value: t.created_by }) : null,
+        t.external_provider ? h(MetaRow, { label: "Provider", value: t.external_provider }) : null,
       ),
-      h(StatusActions, {
+      t.external_url ? h("div", { className: "hermes-kanban-section" },
+        h("a", {
+          href: t.external_url,
+          target: "_blank",
+          rel: "noreferrer",
+          className: "hermes-kanban-external-link",
+        }, "Open in source system"),
+      ) : null,
+      t.badges && t.badges.length ? h("div", { className: "hermes-kanban-card-row hermes-kanban-card-badges" },
+        t.badges.map(function (badge, idx) {
+          return h(Badge, {
+            key: `${badge.kind || "badge"}-${idx}`,
+            variant: "outline",
+            className: cn("hermes-kanban-external-badge", "hermes-kanban-external-badge--" + (badge.severity || "info")),
+            title: badge.kind || "",
+          }, badge.label || badge.kind || "badge");
+        })
+      ) : null,
+      readonly ? null : h(StatusActions, {
         task: t,
         onPatch: props.onPatch,
         onSpecify: props.onSpecify,
@@ -3374,17 +3537,20 @@
         diagnostics: t.diagnostics || [],
         onRefresh: props.onRefresh,
       }),
-      h(HomeSubsSection, {
+      readonly ? null : h(HomeSubsSection, {
         homeChannels: props.homeChannels || [],
         homeBusy: props.homeBusy || {},
         onToggle: props.onToggleHomeSub,
       }),
-      h(BodyEditor, {
+      readonly ? (t.body ? h("div", { className: "hermes-kanban-section" },
+        h("div", { className: "hermes-kanban-section-head" }, tx(i18n, "description", "Description")),
+        h(MarkdownBlock, { source: t.body, enabled: props.renderMarkdown }),
+      ) : null) : h(BodyEditor, {
         task: t,
         renderMarkdown: props.renderMarkdown,
         onPatch: props.onPatch,
       }),
-      h(DependencyEditor, {
+      readonly ? null : h(DependencyEditor, {
         task: t,
         links, allTasks: props.allTasks,
         onAddParent: props.onAddParent,
@@ -3396,7 +3562,7 @@
         h("div", { className: "hermes-kanban-section-head" }, tx(i18n, "result", "Result")),
         h(MarkdownBlock, { source: t.result, enabled: props.renderMarkdown }),
       ) : null,
-      h(AttachmentsSection, {
+      readonly ? null : h(AttachmentsSection, {
         attachments: attachments,
         boardSlug: props.boardSlug,
         onUpload: props.onUpload,

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -1590,3 +1590,40 @@
 .hermes-kanban-trash-label {
   font-weight: 500;
 }
+
+/* ---- External provider projections ----------------------------------- */
+.hermes-kanban-card-badges {
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.hermes-kanban-external-badge {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hermes-kanban-external-badge--warning {
+  border-color: color-mix(in srgb, #d97706 55%, var(--color-border));
+}
+
+.hermes-kanban-external-badge--error {
+  border-color: color-mix(in srgb, var(--color-destructive, #d14a4a) 65%, var(--color-border));
+  color: var(--color-destructive, #d14a4a);
+}
+
+.hermes-kanban-external-link {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 2rem;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-foreground);
+  text-decoration: none;
+}
+
+.hermes-kanban-external-link:hover {
+  background: var(--color-muted);
+}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -50,6 +50,7 @@ from pydantic import BaseModel, Field
 
 from hermes_cli import kanban_db
 from hermes_cli import kanban_diagnostics as kd
+from plugins.kanban.dashboard.providers import ExternalHttpTaskProvider, resolve_provider
 
 log = logging.getLogger(__name__)
 
@@ -133,6 +134,16 @@ def _conn(board: Optional[str] = None):
     except Exception as exc:
         log.warning("kanban init_db failed: %s", exc)
     return kanban_db.connect(board=board)
+
+
+def _ensure_native_provider(provider: Optional[str]) -> None:
+    """Reject mutations against read-only external projection providers."""
+    selected = resolve_provider(provider)
+    if not selected.is_native:
+        raise HTTPException(
+            status_code=403,
+            detail=f"kanban provider {selected.name!r} is read-only",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +391,7 @@ def get_board(
     tenant: Optional[str] = Query(None, description="Filter to a single tenant"),
     include_archived: bool = Query(False),
     board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+    provider: Optional[str] = Query(None, description="Kanban task provider (omit for native)"),
     workflow_template_id: Optional[str] = Query(
         None, description="Restrict to tasks using this workflow template id",
     ),
@@ -396,6 +408,16 @@ def get_board(
     through to the active board (``HERMES_KANBAN_BOARD`` env → on-disk
     ``current`` pointer → ``default``).
     """
+    selected_provider = resolve_provider(provider)
+    if not selected_provider.is_native:
+        return ExternalHttpTaskProvider(selected_provider).get_board({
+            "tenant": tenant,
+            "include_archived": "true" if include_archived else None,
+            "board": board,
+            "workflow_template_id": workflow_template_id,
+            "current_step_key": current_step_key,
+        })
+
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -505,6 +527,8 @@ def get_board(
             "assignees": assignees,
             "latest_event_id": int(latest_event_id),
             "now": int(time.time()),
+            "provider": "native",
+            "readonly": False,
         }
     finally:
         conn.close()
@@ -518,6 +542,7 @@ def get_board(
 def get_task(
     task_id: str,
     board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
     run_state_type: Optional[str] = Query(
         None, description="With run_state_name: filter runs by column 'status' or 'outcome'",
     ),
@@ -525,6 +550,14 @@ def get_task(
         None, description="With run_state_type: exact value for that run column",
     ),
 ):
+    selected_provider = resolve_provider(provider)
+    if not selected_provider.is_native:
+        return ExternalHttpTaskProvider(selected_provider).get_task(task_id, {
+            "board": board,
+            "run_state_type": run_state_type,
+            "run_state_name": run_state_name,
+        })
+
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -595,7 +628,12 @@ class CreateTaskBody(BaseModel):
 
 
 @router.post("/tasks")
-def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
+def create_task(
+    payload: CreateTaskBody,
+    board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
+):
+    _ensure_native_provider(provider)
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -669,7 +707,12 @@ def _safe_attachment_name(raw: str) -> str:
 
 
 @router.get("/tasks/{task_id}/attachments")
-def list_task_attachments(task_id: str, board: Optional[str] = Query(None)):
+def list_task_attachments(
+    task_id: str,
+    board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
+):
+    _ensure_native_provider(provider)
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -689,6 +732,7 @@ async def upload_task_attachment(
     task_id: str,
     file: UploadFile = File(...),
     board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
     uploaded_by: Optional[str] = Form(None),
 ):
     """Store an uploaded file for a task and record its metadata.
@@ -697,6 +741,7 @@ async def upload_task_attachment(
     sanitised, collision-resolved name. The worker reads it via the
     absolute path surfaced in ``build_worker_context``.
     """
+    _ensure_native_provider(provider)
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -760,7 +805,12 @@ async def upload_task_attachment(
 
 
 @router.get("/attachments/{attachment_id}")
-def download_attachment(attachment_id: int, board: Optional[str] = Query(None)):
+def download_attachment(
+    attachment_id: int,
+    board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
+):
+    _ensure_native_provider(provider)
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -787,7 +837,12 @@ def download_attachment(attachment_id: int, board: Optional[str] = Query(None)):
 
 
 @router.delete("/attachments/{attachment_id}")
-def remove_attachment(attachment_id: int, board: Optional[str] = Query(None)):
+def remove_attachment(
+    attachment_id: int,
+    board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
+):
+    _ensure_native_provider(provider)
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -819,7 +874,13 @@ class UpdateTaskBody(BaseModel):
 
 
 @router.patch("/tasks/{task_id}")
-def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Query(None)):
+def update_task(
+    task_id: str,
+    payload: UpdateTaskBody,
+    board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
+):
+    _ensure_native_provider(provider)
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -942,7 +1003,12 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
 # ---------------------------------------------------------------------------
 
 @router.delete("/tasks/{task_id}")
-def delete_task(task_id: str, board: Optional[str] = Query(None)):
+def delete_task(
+    task_id: str,
+    board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
+):
+    _ensure_native_provider(provider)
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -1089,7 +1155,13 @@ class CommentBody(BaseModel):
 
 
 @router.post("/tasks/{task_id}/comments")
-def add_comment(task_id: str, payload: CommentBody, board: Optional[str] = Query(None)):
+def add_comment(
+    task_id: str,
+    payload: CommentBody,
+    board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
+):
+    _ensure_native_provider(provider)
     if not payload.body.strip():
         raise HTTPException(status_code=400, detail="body is required")
     board = _resolve_board(board)
@@ -1115,7 +1187,12 @@ class LinkBody(BaseModel):
 
 
 @router.post("/links")
-def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
+def add_link(
+    payload: LinkBody,
+    board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
+):
+    _ensure_native_provider(provider)
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -1132,7 +1209,9 @@ def delete_link(
     parent_id: str = Query(...),
     child_id: str = Query(...),
     board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
 ):
+    _ensure_native_provider(provider)
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -1159,7 +1238,11 @@ class BulkTaskBody(BaseModel):
 
 
 @router.post("/tasks/bulk")
-def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
+def bulk_update(
+    payload: BulkTaskBody,
+    board: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None),
+):
     """Apply the same patch to every id in ``payload.ids``.
 
     This is an *independent* iteration — per-task failures don't abort
@@ -1168,6 +1251,7 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
     ids = [i for i in (payload.ids or []) if i]
     if not ids:
         raise HTTPException(status_code=400, detail="ids is required")
+    _ensure_native_provider(provider)
     results: list[dict] = []
     board = _resolve_board(board)
     conn = _conn(board=board)

--- a/plugins/kanban/dashboard/providers.py
+++ b/plugins/kanban/dashboard/providers.py
@@ -1,0 +1,207 @@
+"""Provider helpers for the Kanban dashboard.
+
+The native Kanban board is still backed by ``hermes_cli.kanban_db``.  This
+module adds a small external read-provider seam so the dashboard can render
+task-shaped projections owned by another system without copying those rows
+into Hermes' execution database.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, quote
+from urllib.request import Request, urlopen
+
+from fastapi import HTTPException
+
+from hermes_cli.config import load_config
+
+
+BOARD_COLUMNS: list[str] = [
+    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
+]
+
+_VALID_COLUMNS = set(BOARD_COLUMNS + ["archived"])
+
+
+@dataclass(frozen=True)
+class ProviderSelection:
+    name: str
+    kind: str
+    config: dict[str, Any]
+
+    @property
+    def is_native(self) -> bool:
+        return self.kind == "native"
+
+
+def resolve_provider(provider: Optional[str]) -> ProviderSelection:
+    """Resolve a dashboard provider name from config.
+
+    ``native`` is always available and remains the default. External providers
+    are configured under ``dashboard.kanban.providers``:
+
+    dashboard:
+      kanban:
+        providers:
+          gloops:
+            type: external_http
+            base_url: http://localhost:3000/api/hermes-kanban
+            token_env: GLOOPS_HERMES_KANBAN_TOKEN
+    """
+    name = (provider or "native").strip() or "native"
+    if name == "native":
+        return ProviderSelection(name="native", kind="native", config={})
+
+    cfg = load_config()
+    dash_cfg = cfg.get("dashboard") or {}
+    kanban_cfg = dash_cfg.get("kanban") if isinstance(dash_cfg, dict) else {}
+    providers = (
+        kanban_cfg.get("providers")
+        if isinstance(kanban_cfg, dict)
+        else None
+    )
+    if not isinstance(providers, dict) or name not in providers:
+        raise HTTPException(status_code=404, detail=f"kanban provider {name!r} not configured")
+
+    raw = providers.get(name)
+    if not isinstance(raw, dict):
+        raise HTTPException(status_code=400, detail=f"kanban provider {name!r} config must be an object")
+    kind = str(raw.get("type") or raw.get("kind") or "external_http").strip()
+    if kind != "external_http":
+        raise HTTPException(status_code=400, detail=f"unsupported kanban provider type {kind!r}")
+    if not str(raw.get("base_url") or "").strip():
+        raise HTTPException(status_code=400, detail=f"kanban provider {name!r} missing base_url")
+    return ProviderSelection(name=name, kind=kind, config=dict(raw))
+
+
+class ExternalHttpTaskProvider:
+    """Read-only provider backed by an external HTTP projection API."""
+
+    def __init__(self, selection: ProviderSelection):
+        self.selection = selection
+        base = str(selection.config.get("base_url") or "").strip()
+        self.base_url = base.rstrip("/")
+        self.timeout = float(selection.config.get("timeout_seconds") or 5.0)
+        self.token_env = str(selection.config.get("token_env") or "").strip() or None
+
+    def get_board(self, params: dict[str, Any]) -> dict[str, Any]:
+        payload = self._get_json("/board", params=params)
+        return self._normalize_board(payload)
+
+    def get_task(self, task_id: str, params: dict[str, Any]) -> dict[str, Any]:
+        payload = self._get_json(f"/tasks/{quote(task_id, safe='')}", params=params)
+        return self._normalize_task_detail(payload)
+
+    def _get_json(self, path: str, *, params: Optional[dict[str, Any]] = None) -> Any:
+        cleaned = {
+            k: v
+            for k, v in (params or {}).items()
+            if v is not None and v != ""
+        }
+        query = f"?{urlencode(cleaned, doseq=True)}" if cleaned else ""
+        url = f"{self.base_url}{path}{query}"
+        headers = {"Accept": "application/json"}
+        if self.token_env:
+            token = os.environ.get(self.token_env, "").strip()
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+        req = Request(url, headers=headers, method="GET")
+        try:
+            with urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read(10 * 1024 * 1024)
+        except HTTPError as exc:
+            detail = exc.read(1024).decode("utf-8", errors="replace") if exc.fp else str(exc)
+            raise HTTPException(status_code=502, detail=f"external kanban provider returned {exc.code}: {detail}")
+        except URLError as exc:
+            raise HTTPException(status_code=502, detail=f"external kanban provider unavailable: {exc.reason}")
+        except TimeoutError:
+            raise HTTPException(status_code=504, detail="external kanban provider timed out")
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail=f"external kanban provider returned invalid JSON: {exc}")
+
+    def _normalize_board(self, payload: Any) -> dict[str, Any]:
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=502, detail="external kanban board payload must be an object")
+        raw_columns = payload.get("columns")
+        if not isinstance(raw_columns, list):
+            raise HTTPException(status_code=502, detail="external kanban board payload missing columns")
+
+        grouped: dict[str, list[dict[str, Any]]] = {name: [] for name in BOARD_COLUMNS}
+        if bool(payload.get("include_archived")) or any(
+            isinstance(c, dict) and c.get("name") == "archived" for c in raw_columns
+        ):
+            grouped["archived"] = []
+
+        for column in raw_columns:
+            if not isinstance(column, dict):
+                continue
+            name = str(column.get("name") or "todo")
+            if name not in _VALID_COLUMNS:
+                name = "todo"
+            if name == "archived" and name not in grouped:
+                grouped[name] = []
+            raw_tasks = column.get("tasks") or []
+            if not isinstance(raw_tasks, list):
+                raw_tasks = []
+            for task in raw_tasks:
+                if not isinstance(task, dict):
+                    continue
+                normalized = self._normalize_task(task, default_status=name)
+                grouped.setdefault(normalized["status"], []).append(normalized)
+
+        return {
+            "columns": [{"name": name, "tasks": grouped.get(name, [])} for name in grouped.keys()],
+            "tenants": _string_list(payload.get("tenants")),
+            "assignees": _string_list(payload.get("assignees")),
+            "latest_event_id": int(payload.get("latest_event_id") or 0),
+            "now": int(payload.get("now") or time.time()),
+            "provider": self.selection.name,
+            "readonly": True,
+        }
+
+    def _normalize_task_detail(self, payload: Any) -> dict[str, Any]:
+        if not isinstance(payload, dict) or not isinstance(payload.get("task"), dict):
+            raise HTTPException(status_code=502, detail="external kanban task payload missing task")
+        task = self._normalize_task(payload["task"])
+        return {
+            "task": task,
+            "comments": _list(payload.get("comments")),
+            "events": _list(payload.get("events")),
+            "attachments": _list(payload.get("attachments")),
+            "links": payload.get("links") if isinstance(payload.get("links"), dict) else {"parents": [], "children": []},
+            "runs": _list(payload.get("runs")),
+            "provider": self.selection.name,
+            "readonly": True,
+        }
+
+    def _normalize_task(self, task: dict[str, Any], *, default_status: str = "todo") -> dict[str, Any]:
+        task_id = str(task.get("id") or "").strip()
+        if not task_id:
+            raise HTTPException(status_code=502, detail="external kanban task missing id")
+        status = str(task.get("status") or default_status)
+        if status not in _VALID_COLUMNS:
+            status = "todo"
+        out = dict(task)
+        out["id"] = task_id
+        out["status"] = status
+        out["readonly"] = True
+        out["external_provider"] = out.get("external_provider") or self.selection.name
+        return out
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(v) for v in value if v is not None]
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -25,19 +25,29 @@ from hermes_cli import kanban_db as kb
 # ---------------------------------------------------------------------------
 
 
-def _load_plugin_router():
-    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+def _load_plugin_module():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return it."""
     repo_root = Path(__file__).resolve().parents[2]
     plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
     assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
 
+    mod_name = "hermes_dashboard_plugin_kanban_test"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+
     spec = importlib.util.spec_from_file_location(
-        "hermes_dashboard_plugin_kanban_test", plugin_file,
+        mod_name, plugin_file,
     )
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_plugin_router():
+    """Dynamically load plugins/kanban/dashboard/plugin_api.py and return its router."""
+    mod = _load_plugin_module()
     return mod.router
 
 
@@ -59,6 +69,11 @@ def client(kanban_home):
     return TestClient(app)
 
 
+@pytest.fixture
+def plugin_module(kanban_home):
+    return _load_plugin_module()
+
+
 # ---------------------------------------------------------------------------
 # GET /board on an empty DB
 # ---------------------------------------------------------------------------
@@ -77,6 +92,128 @@ def test_board_empty(client):
     assert data["tenants"] == []
     assert data["assignees"] == []
     assert data["latest_event_id"] == 0
+    assert data["provider"] == "native"
+    assert data["readonly"] is False
+
+
+def test_provider_native_query_matches_default(client):
+    client.post("/api/plugins/kanban/tasks", json={"title": "native-default"})
+
+    default = client.get("/api/plugins/kanban/board").json()
+    explicit = client.get("/api/plugins/kanban/board?provider=native").json()
+
+    assert explicit["columns"] == default["columns"]
+    assert explicit["provider"] == "native"
+    assert explicit["readonly"] is False
+
+
+def test_external_provider_board_routes_to_provider(plugin_module, monkeypatch):
+    class Selection:
+        name = "gloops"
+        is_native = False
+
+    class FakeExternalProvider:
+        def __init__(self, selection):
+            self.selection = selection
+
+        def get_board(self, params):
+            assert self.selection.name == "gloops"
+            assert params["tenant"] == "acme"
+            return {
+                "columns": [
+                    {
+                        "name": "ready",
+                        "tasks": [
+                            {
+                                "id": "external:gloops:execution_request:exec-1",
+                                "title": "Projected work",
+                                "status": "ready",
+                                "readonly": True,
+                            }
+                        ],
+                    }
+                ],
+                "tenants": ["acme"],
+                "assignees": [],
+                "latest_event_id": 0,
+                "now": 1,
+                "provider": "gloops",
+                "readonly": True,
+            }
+
+    monkeypatch.setattr(plugin_module, "resolve_provider", lambda provider: Selection())
+    monkeypatch.setattr(plugin_module, "ExternalHttpTaskProvider", FakeExternalProvider)
+    app = FastAPI()
+    app.include_router(plugin_module.router, prefix="/api/plugins/kanban")
+    local_client = TestClient(app)
+
+    r = local_client.get("/api/plugins/kanban/board?provider=gloops&tenant=acme")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["provider"] == "gloops"
+    assert body["readonly"] is True
+    assert body["columns"][0]["tasks"][0]["readonly"] is True
+
+
+def test_external_provider_task_routes_to_provider(plugin_module, monkeypatch):
+    class Selection:
+        name = "gloops"
+        is_native = False
+
+    class FakeExternalProvider:
+        def __init__(self, selection):
+            self.selection = selection
+
+        def get_task(self, task_id, params):
+            assert task_id == "external:gloops:execution_request:exec-1"
+            return {
+                "task": {
+                    "id": task_id,
+                    "title": "Projected work",
+                    "status": "ready",
+                    "readonly": True,
+                },
+                "comments": [],
+                "events": [],
+                "attachments": [],
+                "links": {"parents": [], "children": []},
+                "runs": [],
+                "provider": "gloops",
+                "readonly": True,
+            }
+
+    monkeypatch.setattr(plugin_module, "resolve_provider", lambda provider: Selection())
+    monkeypatch.setattr(plugin_module, "ExternalHttpTaskProvider", FakeExternalProvider)
+    app = FastAPI()
+    app.include_router(plugin_module.router, prefix="/api/plugins/kanban")
+    local_client = TestClient(app)
+
+    r = local_client.get(
+        "/api/plugins/kanban/tasks/external%3Agloops%3Aexecution_request%3Aexec-1?provider=gloops"
+    )
+
+    assert r.status_code == 200
+    assert r.json()["task"]["readonly"] is True
+
+
+def test_external_provider_mutation_is_read_only(plugin_module, monkeypatch):
+    class Selection:
+        name = "gloops"
+        is_native = False
+
+    monkeypatch.setattr(plugin_module, "resolve_provider", lambda provider: Selection())
+    app = FastAPI()
+    app.include_router(plugin_module.router, prefix="/api/plugins/kanban")
+    local_client = TestClient(app)
+
+    r = local_client.patch(
+        "/api/plugins/kanban/tasks/external%3Agloops%3Aexecution_request%3Aexec-1?provider=gloops",
+        json={"status": "done"},
+    )
+
+    assert r.status_code == 403
+    assert "read-only" in r.json()["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +363,36 @@ def test_dashboard_client_side_filtering_includes_tenant_filter():
 
     assert "if (tenantFilter && t.tenant !== tenantFilter) return false;" in js
     assert "[boardData, tenantFilter, assigneeFilter, search]" in js
+
+
+def test_dashboard_provider_selection_is_persisted_and_sent_to_api():
+    """The dashboard can switch from native tasks to a configured read provider."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert 'const LS_PROVIDER_KEY = "hermes.kanban.selectedProvider";' in js
+    assert "function readSelectedProvider()" in js
+    assert "function writeSelectedProvider(provider)" in js
+    assert "function withBoardProvider(url, board, provider)" in js
+    assert 'h(SelectOption, { value: "gloops" }, "GLoops projection")' in js
+    assert "SDK.fetchJSON(withBoardProvider(url, board, provider))" in js
+
+
+def test_dashboard_external_projection_cards_are_readonly():
+    """Read-only provider cards must not advertise native mutation affordances."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert 'setError("This Kanban provider is read-only.");' in js
+    assert "draggable: !(props.readonly || t.readonly)" in js
+    assert "disabled: props.readonly || t.readonly" in js
+    assert "readonly ? null : h(StatusActions" in js
+    assert "Open in source system" in js
+    assert "hermes-kanban-external-badge" in js
 
 
 def test_dashboard_initial_board_uses_backend_current_when_unpinned():


### PR DESCRIPTION
## Summary
- Add a generic read-only external HTTP provider for the Kanban dashboard
- Keep native Hermes Kanban behavior as the default provider
- Add provider-aware UI controls, read-only external cards, badges, and source links
- Guard native mutation endpoints so external projection IDs cannot write to kanban.db

## Tests
- pytest tests/plugins/test_kanban_dashboard_plugin.py
- pytest tests/plugins/test_kanban_worker_runs.py
- pytest tests/tools/test_kanban_tools.py
- pytest tests/hermes_cli/test_kanban_db.py