### PR TITLE
fix(feishu): add return_exceptions to asyncio.gather in comment handler

### DIFF
--- a/plugins/platforms/feishu/feishu_comment.py
+++ b/plugins/platforms/feishu/feishu_comment.py
@@ -1202,7 +1202,15 @@ async def handle_drive_comment_event(
     comment_task = asyncio.ensure_future(
         batch_query_comment(client, file_token, file_type, comment_id)
     )
-    doc_meta, comment_detail = await asyncio.gather(meta_task, comment_task)
+    doc_results = await asyncio.gather(
+        meta_task, comment_task, return_exceptions=True,
+    )
+    doc_meta = {} if isinstance(doc_results[0], BaseException) else doc_results[0]
+    comment_detail = {} if isinstance(doc_results[1], BaseException) else doc_results[1]
+    if isinstance(doc_results[0], BaseException):
+        logger.warning("[Feishu-Comment] Failed to fetch doc meta: %s", doc_results[0])
+    if isinstance(doc_results[1], BaseException):
+        logger.warning("[Feishu-Comment] Failed to fetch comment detail: %s", doc_results[1])
 
     doc_title = doc_meta.get("title", "Untitled")
     doc_url = doc_meta.get("url", "")


### PR DESCRIPTION
## Summary

Add `return_exceptions=True` to `asyncio.gather()` in `handle_drive_comment_event` to prevent unhandled exceptions from crashing the Feishu comment event handler.

## Problem

In `plugins/platforms/feishu/feishu_comment.py`, `handle_drive_comment_event` calls `asyncio.gather(meta_task, comment_task)` without `return_exceptions=True`. If either `query_document_meta` or `batch_query_comment` raises an unhandled exception (e.g., network error, SSL error from `client.request`), the entire event handler crashes instead of gracefully degrading.

This can happen because `_exec_request` calls `await asyncio.to_thread(client.request, request)` which may raise if the underlying HTTP client encounters a connection error, timeout, or SSL issue.

## Fix

- Added `return_exceptions=True` to the `asyncio.gather()` call
- Handle exception results by defaulting to `{}` (empty dict) for failed fetches, consistent with the existing error-handling behavior of the individual functions
- Log warnings when fetch operations fail, so failures are observable

## Testing
- Syntax check passed (py_compile)
- Behavior verified