### PR TITLE
fix(models): route bare-provider /model switch through the cost-safe default

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1921,7 +1921,18 @@ def detect_static_provider_for_model(
             and default_models
             and resolved_provider not in current_keys
         ):
-            return (resolved_provider, default_models[0])
+            # Route through the cost-safe default rather than picking
+            # ``default_models[0]`` directly. For metered aggregators whose
+            # curated list is ordered most-capable-first (e.g. Nous Portal),
+            # entry [0] is the priciest flagship, and typing ``/model nous``
+            # would silently escalate to it — the exact billing footgun
+            # ``_PROVIDER_SILENT_DEFAULT_OVERRIDES`` exists to prevent. For
+            # providers without an override this is unchanged (it returns
+            # ``models[0]``).
+            return (
+                resolved_provider,
+                get_default_model_for_provider(resolved_provider) or default_models[0],
+            )
 
     # Aggregators list other providers' models — never auto-switch TO them
     # If the model belongs to the current provider's catalog, don't suggest switching

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -71,6 +71,46 @@ class TestGetDefaultModelForProvider:
             assert result == models_mod._PROVIDER_MODELS["openai-codex"][0]
 
 
+class TestDetectStaticProviderCostSafeDefault:
+    """detect_static_provider_for_model must apply the same cost-safe default
+    as get_default_model_for_provider when a bare provider name is typed as a
+    model (e.g. ``/model nous``)."""
+
+    def test_bare_nous_does_not_escalate_to_flagship(self):
+        from hermes_cli.models import (
+            _PROVIDER_MODELS,
+            get_default_model_for_provider,
+            detect_static_provider_for_model,
+        )
+
+        result = detect_static_provider_for_model("nous", "openrouter")
+        assert result is not None
+        provider, model = result
+        assert provider == "nous"
+        # Must match the cost-safe silent default, NOT the priciest catalog
+        # entry [0]. Regression: this path returned _PROVIDER_MODELS["nous"][0]
+        # directly, re-introducing the billing footgun on the interactive
+        # ``/model nous`` path.
+        assert model == get_default_model_for_provider("nous")
+        assert "opus" not in model.lower()
+        assert model != _PROVIDER_MODELS["nous"][0]
+
+    def test_provider_without_override_still_uses_first_model(self):
+        """Providers with no silent-default override are unchanged."""
+        from hermes_cli.models import (
+            _PROVIDER_MODELS,
+            _PROVIDER_SILENT_DEFAULT_OVERRIDES,
+            detect_static_provider_for_model,
+        )
+
+        for provider in ("anthropic", "xai"):
+            if provider in _PROVIDER_SILENT_DEFAULT_OVERRIDES:
+                continue
+            result = detect_static_provider_for_model(provider, "openrouter")
+            assert result is not None
+            assert result[1] == _PROVIDER_MODELS[provider][0]
+
+
 class TestGatewayEmptyModelFallback:
     """Test that _resolve_session_agent_runtime fills in empty model from provider catalog."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes a **billing footgun**: typing `/model nous` (or any bare provider name)
silently switched to that provider's **priciest flagship** instead of its
cost-safe default.

`detect_static_provider_for_model` resolves a bare provider name typed as a
model by returning `_PROVIDER_MODELS[provider][0]` — the first curated entry.
For metered aggregators whose curated list is ordered *most-capable-first*
(Nous Portal), entry [0] is the most expensive model:

```python
detect_static_provider_for_model("nous", "openrouter")
# before: ('nous', 'anthropic/claude-fable-5')      # priciest flagship
# after:  ('nous', 'deepseek/deepseek-v4-flash')     # cost-safe default
get_default_model_for_provider("nous")               # 'deepseek/deepseek-v4-flash'
```

This is exactly the footgun `_PROVIDER_SILENT_DEFAULT_OVERRIDES` /
`get_default_model_for_provider` were built to prevent — their docstring notes
a missing model "escalated to Opus and billed 863 requests before the user
noticed." The **non-interactive** fallback already routes through that helper;
the **interactive** `/model <provider>` path did not.

## Fix

Route the bare-provider branch through `get_default_model_for_provider`, which
honors the cost-safe override. Providers **without** an override are unchanged
(the helper returns `models[0]`), so only overridden providers (currently
`nous`) change behavior — from the flagship to the low-cost default.

## Related Issue

No existing issue — found via a code audit; the asymmetry between the two
resolution paths (one cost-guarded, one not) made it clear.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py` — `detect_static_provider_for_model` returns
  `get_default_model_for_provider(resolved_provider) or default_models[0]`
  for the bare-provider-name case.
- `tests/test_empty_model_fallback.py` — regression tests: `/model nous`
  resolves to the cost-safe default (not the flagship); non-overridden
  providers still resolve to their first catalog model.

## How to Test

1. `scripts/run_tests.sh tests/test_empty_model_fallback.py -q` → all pass (16).
2. `detect_static_provider_for_model("nous", "openrouter")` now returns the
   `_PROVIDER_SILENT_DEFAULT_OVERRIDES["nous"]` model instead of
   `_PROVIDER_MODELS["nous"][0]`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(models):`)
- [x] I searched for existing PRs (none touch this function's default selection)
- [x] Only changes related to this fix
- [x] Affected test module passes — `tests/test_empty_model_fallback.py` (16). Full suite not run locally.
- [x] Added regression tests
- [x] Tested on: Ubuntu (WSL2), against current `main`

### Documentation & Housekeeping

- [x] Behavior-only fix — N/A for docs / config / tool schemas
