### PR TITLE
fix(web): don't crash on a null web/backend config value

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -568,6 +568,22 @@ class TestCheckWebApiKey:
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
 
+    def test_null_backend_value_does_not_crash(self):
+        # config.yaml with ``web:\n  backend:`` yields backend=None. The gate
+        # must not raise AttributeError on None.lower() — mirrors _get_backend.
+        with patch("tools.web_tools._load_web_config", return_value={"backend": None}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
+
+    def test_null_web_section_does_not_crash(self):
+        # config.yaml with a present-but-null ``web:`` section makes the raw
+        # ``.get("web", {})`` return None; _load_web_config must still yield a
+        # dict so no caller does None.get(...).
+        with patch("hermes_cli.config.load_config", return_value={"web": None}):
+            from tools.web_tools import _load_web_config, check_web_api_key
+            assert _load_web_config() == {}
+            assert check_web_api_key() is False
+
     def test_firecrawl_key_only(self):
         with patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
             from tools.web_tools import check_web_api_key

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -132,7 +132,11 @@ def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
     try:
         from hermes_cli.config import load_config
-        return load_config().get("web", {})
+        # ``or {}``: a present-but-null ``web:`` section (YAML ``web:`` with no
+        # body) makes ``.get("web", {})`` return None, which would break every
+        # caller that does ``_load_web_config().get(...)``. Honor the ``-> dict``
+        # contract so callers never see None.
+        return load_config().get("web") or {}
     except (ImportError, Exception):
         return {}
 
@@ -1004,7 +1008,9 @@ def check_web_api_key() -> bool:
     :func:`_is_backend_available`, which delegates non-legacy names to the
     registry.
     """
-    configured = _load_web_config().get("backend", "").lower().strip()
+    # ``or ""``: a null ``web.backend`` value yields None from ``.get``, and
+    # ``None.lower()`` would raise. Mirrors ``_get_backend``.
+    configured = (_load_web_config().get("backend") or "").lower().strip()
     if configured and _is_backend_available(configured):
         return True
     # Any built-in backend with credentials present. This is a boolean OR, so


### PR DESCRIPTION
## What does this PR do?

Fixes an `AttributeError` crash when the `web:` config section — or the
`web.backend` value — is present but null.

`_load_web_config()` is typed `-> dict` but returns
`load_config().get("web", {})`. When the config has a present-but-null `web:`
section (YAML `web:` with no body), `.get("web", {})` returns **None** (the
default only applies when the key is *absent*), so every caller that does
`_load_web_config().get(...)` raises:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

This affects `_get_backend`, `check_web_api_key`, and the extract-char-limit
reader.

Separately, `check_web_api_key()` read the backend as
`.get("backend", "").lower()`. A null `web.backend` value yields `None`, so
`None.lower()` raised. Since `check_web_api_key` is the `check_fn` gate for the
`web_search` / `web_extract` tools, this surfaced as an exception during
tool-availability checking rather than a clean bool.

## Fix

- `_load_web_config()` — honor the `-> dict` contract with `... or {}`, fixing
  the null-`web:`-section crash at **every** call site (root cause).
- `check_web_api_key()` — guard the backend value with `or ""`, mirroring the
  existing guard in the sibling `_get_backend()`.

## Related Issue

No existing issue — found via a code audit. (Open PR #57808 also touches
`check_web_api_key`, but only its registered-provider walk — not the
null-guard line — so this is orthogonal.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/web_tools.py` — `_load_web_config` returns `load_config().get("web")
  or {}`; `check_web_api_key` reads `(... .get("backend") or "").lower()`.
- `tests/tools/test_web_tools_config.py` — regression tests for a null
  `web.backend` value and a null `web:` section.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_web_tools_config.py -q` → all pass (65).
2. With `_load_web_config` returning `{"backend": None}`, or `load_config`
   returning `{"web": None}`, `check_web_api_key()` returns `False` instead of
   raising.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(web):`)
- [x] I searched for existing PRs (none fix this null-config crash)
- [x] Only changes related to this fix
- [x] Affected test module passes — `tests/tools/test_web_tools_config.py` (65). Full suite not run locally.
- [x] Added regression tests
- [x] Tested on: Ubuntu (WSL2), against current `main`

### Documentation & Housekeeping

- [x] Behavior-only fix — N/A for docs / config / tool schemas
