### PR TITLE
fix(cron): register whatsapp_cloud delivery target

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -205,7 +205,7 @@ _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "telegram", "discord", "slack", "whatsapp", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
     "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
-    "qqbot", "yuanbao",
+    "qqbot", "yuanbao", "whatsapp_cloud",
 })
 
 # Platforms that support a configured cron/notification home target, mapped to

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -165,6 +165,7 @@ class TestResolveDeliveryTarget:
             ("wecom", "WECOM_HOME_CHANNEL", "wecom-home"),
             ("weixin", "WEIXIN_HOME_CHANNEL", "wxid_home"),
             ("qqbot", "QQ_HOME_CHANNEL", "group-openid-home"),
+            ("whatsapp_cloud", "WHATSAPP_CLOUD_HOME_CHANNEL", "15551234567"),
         ],
     )
     def test_origin_delivery_without_origin_falls_back_to_supported_home_channels(
@@ -186,6 +187,7 @@ class TestResolveDeliveryTarget:
             "WECOM_HOME_CHANNEL",
             "WEIXIN_HOME_CHANNEL",
             "QQ_HOME_CHANNEL",
+            "WHATSAPP_CLOUD_HOME_CHANNEL",
         ):
             monkeypatch.delenv(fallback_env, raising=False)
         monkeypatch.setenv(env_var, chat_id)
@@ -4091,10 +4093,11 @@ class TestHomeTargetEnvVarRegistry:
         """``deliver=whatsapp_cloud`` routes through
         WHATSAPP_CLOUD_HOME_CHANNEL — added alongside the existing
         ``whatsapp`` Baileys entry."""
-        from cron.scheduler import _HOME_TARGET_ENV_VARS
+        from cron.scheduler import _HOME_TARGET_ENV_VARS, _is_known_delivery_platform
 
         assert "whatsapp_cloud" in _HOME_TARGET_ENV_VARS
         assert _HOME_TARGET_ENV_VARS["whatsapp_cloud"] == "WHATSAPP_CLOUD_HOME_CHANNEL"
+        assert _is_known_delivery_platform("whatsapp_cloud") is True
 
     def test_baileys_whatsapp_still_registered(self):
         """Sanity guard: the Cloud addition didn't disturb Baileys


### PR DESCRIPTION
## Problem

`whatsapp_cloud` is a built-in gateway platform with `WHATSAPP_CLOUD_HOME_CHANNEL`, but cron delivery validation did not include it in `_KNOWN_DELIVERY_PLATFORMS`. A bare `deliver=whatsapp_cloud` job therefore failed target resolution before reading the configured home channel.

Fixes #59988.

## Root cause

`cron/scheduler.py` had two platform registries: `_HOME_TARGET_ENV_VARS` already listed `whatsapp_cloud`, while `_KNOWN_DELIVERY_PLATFORMS` did not. `_resolve_delivery_target()` checks `_is_known_delivery_platform()` before `_get_home_target_chat_id()`, so the home-channel mapping was unreachable.

## Fix

Add `whatsapp_cloud` to `_KNOWN_DELIVERY_PLATFORMS` and extend cron tests so both direct delivery resolution and the registry guard cover it.

## Tests

- `scripts/run_tests.sh tests/cron/test_scheduler.py -k 'HomeTargetEnvVarRegistry or origin_delivery_without_origin_falls_back_to_supported_home_channels' -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check cron/scheduler.py tests/cron/test_scheduler.py`
- `git diff --check`