### PR TITLE
feat(desktop): group tool calls across text-less assistant messages

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -19,7 +19,13 @@ import { ErrorState } from '@/components/ui/error-state'
 import { getGlobalModelOptions, type HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
-import { quickModelOptions, sessionTitle, toRuntimeMessage } from '@/lib/chat-runtime'
+import {
+  coalesceToolOnlyAssistants,
+  createToolMergeCache,
+  quickModelOptions,
+  sessionTitle,
+  toRuntimeMessage
+} from '@/lib/chat-runtime'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
 import { cn } from '@/lib/utils'
 import type { ComposerAttachment } from '@/store/composer'
@@ -201,6 +207,7 @@ function ChatRuntimeBoundary({
   const storeMessages = useStore($messages)
   const messages = suppressMessages ? NO_MESSAGES : storeMessages
   const runtimeMessageCacheRef = useRef(new WeakMap<ChatMessage, ThreadMessage>())
+  const toolMergeCacheRef = useRef(createToolMergeCache())
 
   const runtimeMessageRepository = useMemo(() => {
     const items: { message: ThreadMessage; parentId: string | null }[] = []
@@ -208,7 +215,7 @@ function ChatRuntimeBoundary({
     let visibleParentId: string | null = null
     let headId: string | null = null
 
-    for (const message of messages) {
+    for (const message of coalesceToolOnlyAssistants(messages, toolMergeCacheRef.current)) {
       let parentId = visibleParentId
 
       if (message.role === 'assistant' && message.branchGroupId) {

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -383,3 +383,61 @@ export function toRuntimeMessage(message: ChatMessage): ThreadMessage {
     }
   } as ThreadMessage
 }
+
+export type ToolMergeCache = WeakMap<
+  ChatMessage,
+  { merged: ChatMessage; parts: ChatMessagePart[]; prev: ChatMessage; prevParts: ChatMessagePart[] }
+>
+
+export function createToolMergeCache(): ToolMergeCache {
+  return new WeakMap()
+}
+
+// A settled assistant message with only tool calls — no prose, no reasoning.
+// The model routinely emits a follow-up batch of calls as its own text-less
+// message; on screen it looks like one continuous run, but assistant-ui can't
+// group tool calls across a message boundary.
+function isToolOnlyAssistant(message: ChatMessage): boolean {
+  return (
+    message.role === 'assistant' &&
+    !message.pending &&
+    !message.error &&
+    !message.hidden &&
+    message.parts.length > 0 &&
+    message.parts.every(part => part.type === 'tool-call')
+  )
+}
+
+/**
+ * Fold each settled tool-only assistant message into the preceding assistant
+ * message so its calls join that message's tool group (and can collapse into
+ * the auto-scrolling window). Render-only — never mutates the `$messages` store
+ * — and settle-only: pending messages are left alone, so a live turn is never
+ * merged/un-merged mid-stream. `cache` keys merged results by source identity,
+ * so a stable turn yields stable merged objects (no re-render churn).
+ */
+export function coalesceToolOnlyAssistants(messages: ChatMessage[], cache: ToolMergeCache): ChatMessage[] {
+  const out: ChatMessage[] = []
+
+  for (const message of messages) {
+    const prev = out.at(-1)
+
+    if (prev && prev.role === 'assistant' && !prev.pending && !prev.hidden && isToolOnlyAssistant(message)) {
+      const cached = cache.get(message)
+
+      const merged =
+        cached && cached.prev === prev && cached.prevParts === prev.parts && cached.parts === message.parts
+          ? cached.merged
+          : { ...prev, parts: [...prev.parts, ...message.parts] }
+
+      cache.set(message, { merged, parts: message.parts, prev, prevParts: prev.parts })
+      out[out.length - 1] = merged
+
+      continue
+    }
+
+    out.push(message)
+  }
+
+  return out
+}


### PR DESCRIPTION
## Summary

Follow-up to the auto-scrolling tool window (#57913). That window only ever grouped tool calls **within a single assistant message**, because assistant-ui's `ToolGroup` can't span message boundaries. But the model routinely emits a follow-up batch of tool calls as its **own assistant message with no prose or reasoning** — on screen those rows look like one continuous run, so the window silently failed to trigger.

Concrete repro (session `20260708_012709_8e8889`): one turn ran 4 back-to-back `search_files`, but as two assistant messages — `[intro text + 2 calls]` then `[(empty) + 2 calls]`. The threshold-of-3 window saw `2` and `2` and never fired, even though the UI showed 4 seamless rows.

This coalesces each **settled, text-less, reasoning-less** tool-only assistant message into the preceding assistant message so its calls join that message's tool group and the window can collapse the full run.

## Why it's safe

- **Render-only.** Merging happens in the `runtimeMessageRepository` build (`ChatRuntimeBoundary`), never in the `$messages` store — search, export, copy, and persistence are untouched.
- **Settle-only.** Pending messages are skipped, so a live streaming turn is never merged/un-merged mid-stream (avoids identity churn, remount, and animation replay). The collapse appears at turn settle — the same reflow profile the tool ranges already have today.
- **No re-render churn.** Merged results are cached by source identity (`prev`/`prev.parts`/`message.parts`), so a stable turn yields stable merged objects → stable `ThreadMessage` identity via the existing per-message cache.
- **Graceful degradation.** Worst case a run stays uncollapsed; never a crash or cache break.

Only fires for messages whose parts are *entirely* `tool-call` (no text, no reasoning) — narrated/thought-between batches stay separate by design.

## Files

- `apps/desktop/src/lib/chat-runtime.ts` — `coalesceToolOnlyAssistants` + `ToolMergeCache`/`createToolMergeCache` + `isToolOnlyAssistant`.
- `apps/desktop/src/app/chat/index.tsx` — run the coalescing pass over `messages` in the repository `useMemo`, with a `useRef` cache.

## Test plan

- [ ] Prompt the model into two back-to-back tool batches where the second batch is its own text-less message (e.g. searches → read results → more searches). The full run now collapses into the auto-scrolling window.
- [ ] A batch that *is* narrated between (text/thinking between batches) stays as separate groups.
- [ ] Streaming: rows render flat as they stream; the run collapses only once the turn settles — no mid-stream jump/remount.
- [ ] Scroll/expand behavior of the window unchanged; enter animation plays once per row.
- [ ] `npm run typecheck` and `eslint` clean.