### PR TITLE
fix(cron): refresh env before no-agent runs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2480,6 +2480,27 @@ def _guard_job_credential_exfil(job: dict) -> None:
         raise RuntimeError(f"Cron job '{job_id}' blocked for safety: {err}")
 
 
+def _refresh_cron_runtime_env() -> None:
+    """Reload Hermes secrets/config env for a cron run.
+
+    Scheduler processes can live across config and .env updates. Refresh before
+    both script-only and agent-backed jobs so delivery and provider resolution
+    see the same current runtime state.
+
+    Route through load_hermes_dotenv rather than bare load_dotenv and reset the
+    secret-source cache first: startup may already have recorded this
+    HERMES_HOME in _APPLIED_HOMES, so a naive reload would re-apply only a .env
+    placeholder and skip external secret sources (#33465).
+    """
+    from hermes_cli.env_loader import (
+        load_hermes_dotenv,
+        reset_secret_source_cache,
+    )
+
+    reset_secret_source_cache()
+    load_hermes_dotenv(hermes_home=_get_hermes_home())
+
+
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None
 ) -> tuple[bool, str, str, Optional[str]]:
@@ -2501,6 +2522,11 @@ def run_job(
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    # Re-read .env and config.yaml fresh every run so provider/key changes
+    # (Telegram token, email creds, API keys, ...) take effect without a
+    # gateway restart. This must run before the no_agent short-circuit because
+    # script-only jobs return before the agent path's delivery setup.
+    _refresh_cron_runtime_env()
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -2770,25 +2796,6 @@ def run_job(
         if _job_workdir:
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
-
-        # Re-read .env and config.yaml fresh every run so provider/key
-        # changes take effect without a gateway restart. Route through
-        # load_hermes_dotenv (not a bare load_dotenv) and reset the secret-
-        # source cache first: startup already applied external secrets and
-        # recorded this HERMES_HOME in _APPLIED_HOMES, so a naive reload would
-        # re-apply only the .env placeholder and never re-resolve a Bitwarden/
-        # BSM-backed secret — leaving cron jobs 401'ing on the placeholder
-        # (#33465). Clearing the cache forces the re-pull; the resolved secret
-        # overrides the placeholder only when secrets.bitwarden.override_existing
-        # is set (mirrors startup), and the Bitwarden value-cache keeps the
-        # forced re-pull off the network. load_hermes_dotenv also handles the
-        # utf-8/latin-1 encoding fallback internally.
-        from hermes_cli.env_loader import (
-            load_hermes_dotenv,
-            reset_secret_source_cache,
-        )
-        reset_secret_source_cache()
-        load_hermes_dotenv(hermes_home=_get_hermes_home())
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import patch
 
 import pytest
@@ -208,6 +209,34 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert error is None
     assert "RAM 92% on host" in final_response
     assert "RAM 92% on host" in doc
+
+
+def test_run_job_no_agent_refreshes_env_before_returning(hermes_env, monkeypatch):
+    """Script-only jobs must refresh process env for post-run delivery."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "env.sh"
+    script_path.write_text("#!/bin/bash\nprintf ready\n")
+    job = create_job(
+        prompt=None, schedule="every 5m", script="env.sh", no_agent=True, deliver="local"
+    )
+    monkeypatch.delenv("EMAIL_ADDRESS", raising=False)
+
+    def _load_current_env(*_args, **_kwargs):
+        os.environ["EMAIL_ADDRESS"] = "fresh@example.com"
+        return []
+
+    with patch("hermes_cli.env_loader.reset_secret_source_cache") as reset_cache, \
+         patch("hermes_cli.env_loader.load_hermes_dotenv", side_effect=_load_current_env) as load_env:
+        success, _doc, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert final_response == "ready"
+    assert os.environ["EMAIL_ADDRESS"] == "fresh@example.com"
+    reset_cache.assert_called_once()
+    load_env.assert_called_once()
 
 
 def test_run_job_no_agent_empty_output_is_silent(hermes_env):


### PR DESCRIPTION
## Problem

`no_agent` cron jobs return from `run_job()` before the existing `.env` / external-secret refresh runs. Long-lived scheduler or tool-serving processes can therefore deliver script-only job output with stale platform credentials even after `.env` is updated.

Fixes #59030.

## Root cause

The runtime env refresh lived inside the agent-backed path after the `no_agent` short-circuit. Script-only jobs execute the script and return immediately, so the process environment used by post-run delivery never gets reloaded for that tick.

## Fix

Extract the existing refresh into `_refresh_cron_runtime_env()` and call it at the start of every `run_job()` before deciding whether the job is script-only or agent-backed. This preserves the secret-source cache reset behavior from the existing path and makes both job modes share the same runtime state.

## Tests

- `scripts/run_tests.sh tests/cron/test_cron_no_agent.py -q`
- `scripts/run_tests.sh tests/cron/test_scheduler.py -k 'resets_secret_source_cache_before_reload or RunJobSessionPersistence' -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check cron/scheduler.py tests/cron/test_cron_no_agent.py`
- `git diff --check`