### PR TITLE
fix(cron): honor per-job max tokens

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2806,6 +2806,7 @@ def run_job(
         # ``cronjob action=update model=...`` after a failed run takes effect
         # on the next tick — there is no in-memory cache.
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+        job_max_tokens = job.get("max_tokens")
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
@@ -3050,6 +3051,7 @@ def run_job(
             acp_command=runtime.get("command"),
             acp_args=runtime.get("args"),
             max_iterations=max_iterations,
+            max_tokens=job_max_tokens,
             reasoning_config=reasoning_config,
             prefill_messages=prefill_messages,
             fallback_model=fallback_model,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -962,6 +962,7 @@ class TestRunJobSessionPersistence:
             "id": "test-job",
             "name": "test",
             "prompt": "hello",
+            "max_tokens": 4096,
         }
         fake_db = MagicMock()
 
@@ -992,6 +993,7 @@ class TestRunJobSessionPersistence:
         assert "ok" in output
 
         kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["max_tokens"] == 4096
         assert kwargs["session_db"] is fake_db
         assert kwargs["platform"] == "cron"
         assert kwargs["session_id"].startswith("cron_test-job_")


### PR DESCRIPTION
## Problem

Cron job entries can store `max_tokens`, but `cron/scheduler.py::run_job()` never read that field when constructing `AIAgent`. The per-job output cap was therefore inert: cron runs always used the global/default model cap.

Fixes #58423.

## Root cause

The cron scheduler already forwards other per-job runtime settings into `AIAgent`, but omitted `job.get("max_tokens")`. The downstream agent/runtime plumbing already supports `max_tokens`; the value was just never passed from the job record.

## Fix

Read `job["max_tokens"]` during per-run job resolution and pass it as `max_tokens=` to `AIAgent`. The regression test now asserts the scheduler forwards the stored value through the real `run_job()` constructor path.

## Tests

- `scripts/run_tests.sh tests/cron/test_scheduler.py -k 'test_run_job_passes_session_db_and_cron_platform' -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check cron/scheduler.py tests/cron/test_scheduler.py`
- `git diff --check`