### PR TITLE
fix(oneshot): honor --max-turns / agent.max_turns in hermes -z

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -153,6 +153,19 @@ def build_top_level_parser():
         default=None,
         help="Comma-separated toolsets to enable for this invocation. Applies to -z/--oneshot and --tui.",
     )
+    # Accepted at the top level so it can pair with -z/--oneshot without the
+    # `chat` subcommand. The chat subparser suppresses its default so a value
+    # parsed before `chat` is not overwritten.
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Maximum tool-calling iterations for this invocation "
+            "(default: 90, or agent.max_turns in config)"
+        ),
+    )
     parser.add_argument(
         "--resume",
         "-r",
@@ -380,7 +393,7 @@ def build_top_level_parser():
     chat_parser.add_argument(
         "--max-turns",
         type=int,
-        default=None,
+        default=argparse.SUPPRESS,
         metavar="N",
         help="Maximum tool-calling iterations per conversation turn (default: 500, or agent.max_turns in config)",
     )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -171,6 +171,7 @@ def _run_and_exit_oneshot(
     provider: object = None,
     toolsets: object = None,
     usage_file: object = None,
+    max_turns: object = None,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -181,6 +182,7 @@ def _run_and_exit_oneshot(
             provider=provider,
             toolsets=toolsets,
             usage_file=usage_file,
+            max_turns=max_turns,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -15728,6 +15730,7 @@ def _try_termux_fast_cli_launch() -> bool:
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            max_turns=getattr(args, "max_turns", None),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -18379,6 +18382,7 @@ def main():
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            max_turns=getattr(args, "max_turns", None),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -173,6 +173,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    max_turns: Optional[int] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -187,6 +188,14 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        max_turns: Optional per-turn tool-iteration cap (the ``--max-turns``
+            flag). When None, resolves from ``agent.max_turns`` in config,
+            then ``HERMES_MAX_ITERATIONS`` env, then the built-in default —
+            the same precedence an interactive CLI turn uses. Without this,
+            oneshot silently pinned every run to the built-in default and
+            ignored the profile's configured budget, which decapitated
+            long-running ``hermes -z`` workers (e.g. MeshBoard dispatches)
+            mid-task.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -248,6 +257,7 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    max_turns=max_turns,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -310,12 +320,46 @@ def _create_session_db_for_oneshot():
         return None
 
 
+def _resolve_max_iterations(cfg: dict, cli_max_turns: Optional[int]) -> int:
+    """Resolve the per-turn tool-iteration cap for a oneshot run.
+
+    Mirrors the interactive CLI precedence (see ``HermesCLI.__init__``):
+    explicit ``--max-turns`` > ``agent.max_turns`` in config > legacy
+    root-level ``max_turns`` > ``HERMES_MAX_ITERATIONS`` env > 90.
+
+    Historically oneshot skipped this entirely and let ``AIAgent`` fall
+    back to its own default, so ``hermes -z`` ignored the profile's
+    configured budget — the root cause of budget-decapitated workers.
+    """
+    if cli_max_turns is not None:
+        return int(cli_max_turns)
+    agent_cfg = cfg.get("agent") if isinstance(cfg, dict) else None
+    if isinstance(agent_cfg, dict) and agent_cfg.get("max_turns"):
+        try:
+            return int(agent_cfg["max_turns"])
+        except (TypeError, ValueError):
+            pass
+    if isinstance(cfg, dict) and cfg.get("max_turns"):  # legacy root-level
+        try:
+            return int(cfg["max_turns"])
+        except (TypeError, ValueError):
+            pass
+    env_iters = os.getenv("HERMES_MAX_ITERATIONS", "").strip()
+    if env_iters:
+        try:
+            return int(env_iters)
+        except (TypeError, ValueError):
+            pass
+    return 90
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    max_turns: Optional[int] = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -407,6 +451,13 @@ def _run_agent(
         # gateway sessions.
         _fb = get_fallback_chain(cfg)
 
+        # Resolve the per-turn iteration budget from --max-turns / config /
+        # env, matching the interactive CLI. Passing it explicitly stops
+        # AIAgent from falling back to its built-in default and silently
+        # ignoring the profile's agent.max_turns (the budget-decapitation
+        # root cause).
+        effective_max_iterations = _resolve_max_iterations(cfg, max_turns)
+
         agent = AIAgent(
             api_key=runtime.get("api_key"),
             base_url=runtime.get("base_url"),
@@ -414,6 +465,7 @@ def _run_agent(
             requested_provider=runtime.get("requested_provider"),
             api_mode=runtime.get("api_mode"),
             model=effective_model,
+            max_iterations=effective_max_iterations,
             enabled_toolsets=toolsets_list,
             quiet_mode=True,
             platform="cli",

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -189,13 +189,13 @@ def run_oneshot(
             run — even when the run fails — so pipelines can account for
             spend per invocation.
         max_turns: Optional per-turn tool-iteration cap (the ``--max-turns``
-            flag). When None, resolves from ``agent.max_turns`` in config,
-            then ``HERMES_MAX_ITERATIONS`` env, then the built-in default —
-            the same precedence an interactive CLI turn uses. Without this,
-            oneshot silently pinned every run to the built-in default and
-            ignored the profile's configured budget, which decapitated
-            long-running ``hermes -z`` workers (e.g. MeshBoard dispatches)
-            mid-task.
+            flag). When None, uses the normalized ``agent.max_turns`` value
+            returned by ``load_config()`` (default 90). The config loader
+            migrates the legacy root-level ``max_turns`` key before this code
+            runs. Without this, oneshot silently pinned every run to the
+            built-in default and ignored the profile's configured budget,
+            which decapitated long-running ``hermes -z`` workers (e.g.
+            MeshBoard dispatches) mid-task.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -323,9 +323,9 @@ def _create_session_db_for_oneshot():
 def _resolve_max_iterations(cfg: dict, cli_max_turns: Optional[int]) -> int:
     """Resolve the per-turn tool-iteration cap for a oneshot run.
 
-    Mirrors the interactive CLI precedence (see ``HermesCLI.__init__``):
-    explicit ``--max-turns`` > ``agent.max_turns`` in config > legacy
-    root-level ``max_turns`` > ``HERMES_MAX_ITERATIONS`` env > 90.
+    ``load_config()`` has already merged defaults and normalized legacy
+    root-level ``max_turns`` into ``agent.max_turns``, so the production
+    precedence here is explicit ``--max-turns`` > loaded config > 90.
 
     Historically oneshot skipped this entirely and let ``AIAgent`` fall
     back to its own default, so ``hermes -z`` ignored the profile's
@@ -337,17 +337,6 @@ def _resolve_max_iterations(cfg: dict, cli_max_turns: Optional[int]) -> int:
     if isinstance(agent_cfg, dict) and agent_cfg.get("max_turns"):
         try:
             return int(agent_cfg["max_turns"])
-        except (TypeError, ValueError):
-            pass
-    if isinstance(cfg, dict) and cfg.get("max_turns"):  # legacy root-level
-        try:
-            return int(cfg["max_turns"])
-        except (TypeError, ValueError):
-            pass
-    env_iters = os.getenv("HERMES_MAX_ITERATIONS", "").strip()
-    if env_iters:
-        try:
-            return int(env_iters)
         except (TypeError, ValueError):
             pass
     return 90
@@ -451,11 +440,10 @@ def _run_agent(
         # gateway sessions.
         _fb = get_fallback_chain(cfg)
 
-        # Resolve the per-turn iteration budget from --max-turns / config /
-        # env, matching the interactive CLI. Passing it explicitly stops
-        # AIAgent from falling back to its built-in default and silently
-        # ignoring the profile's agent.max_turns (the budget-decapitation
-        # root cause).
+        # Resolve the per-turn iteration budget from --max-turns / normalized
+        # config. Passing it explicitly stops AIAgent from falling back to
+        # its built-in default and silently ignoring the profile's
+        # agent.max_turns (the budget-decapitation root cause).
         effective_max_iterations = _resolve_max_iterations(cfg, max_turns)
 
         agent = AIAgent(

--- a/tests/hermes_cli/test_oneshot_max_turns.py
+++ b/tests/hermes_cli/test_oneshot_max_turns.py
@@ -3,53 +3,56 @@
 Regression coverage for the budget-decapitation bug: oneshot used to build
 its AIAgent without a max_iterations argument, so `hermes -z` silently ran
 at the AIAgent default and ignored `agent.max_turns` in config / the
-`--max-turns` flag / `HERMES_MAX_ITERATIONS`. Long-running workers (e.g.
-MeshBoard dispatches) were cut off mid-task with no way to raise the cap
-per invocation.
+`--max-turns` flag. Long-running workers (e.g. MeshBoard dispatches) were cut
+off mid-task with no way to raise the cap per invocation.
 """
+
 import pytest
 
+from hermes_cli._parser import build_top_level_parser
 from hermes_cli.oneshot import _resolve_max_iterations, run_oneshot
 
 
+class TestOneshotMaxTurnsParsing:
+    def test_max_turns_pairs_with_oneshot(self):
+        parser, _subparsers, _chat_parser = build_top_level_parser()
+        args = parser.parse_args(["-z", "hi", "--max-turns", "5"])
+        assert args.max_turns == 5
+
+    def test_absent_max_turns_is_none(self):
+        parser, _subparsers, _chat_parser = build_top_level_parser()
+        args = parser.parse_args(["-z", "hi"])
+        assert args.max_turns is None
+
+    def test_top_level_value_survives_chat_subparser(self):
+        parser, _subparsers, _chat_parser = build_top_level_parser()
+        args = parser.parse_args(["--max-turns", "7", "chat"])
+        assert args.max_turns == 7
+
+    def test_chat_subparser_value_still_parses(self):
+        parser, _subparsers, _chat_parser = build_top_level_parser()
+        args = parser.parse_args(["chat", "--max-turns", "9"])
+        assert args.max_turns == 9
+
+
 class TestResolveMaxIterations:
-    def test_cli_flag_wins(self, monkeypatch):
-        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "70")
+    def test_cli_flag_wins(self):
         cfg = {"agent": {"max_turns": 120}}
         assert _resolve_max_iterations(cfg, 250) == 250
 
-    def test_config_agent_max_turns_used_when_no_flag(self, monkeypatch):
-        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "70")
+    def test_config_agent_max_turns_used_when_no_flag(self):
         cfg = {"agent": {"max_turns": 120}}
         assert _resolve_max_iterations(cfg, None) == 120
 
-    def test_legacy_root_max_turns_fallback(self, monkeypatch):
-        monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
-        cfg = {"max_turns": 55}
-        assert _resolve_max_iterations(cfg, None) == 55
-
-    def test_env_fallback_when_no_config(self, monkeypatch):
-        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "70")
-        assert _resolve_max_iterations({}, None) == 70
-
-    def test_builtin_default_when_nothing_set(self, monkeypatch):
-        monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+    def test_builtin_default_when_loaded_value_is_missing(self):
         assert _resolve_max_iterations({}, None) == 90
 
-    def test_agent_max_turns_beats_legacy_root(self, monkeypatch):
-        monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
-        cfg = {"agent": {"max_turns": 120}, "max_turns": 55}
-        assert _resolve_max_iterations(cfg, None) == 120
-
-    def test_non_numeric_config_falls_through(self, monkeypatch):
-        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "70")
+    def test_non_numeric_loaded_value_uses_default(self):
         cfg = {"agent": {"max_turns": "not-a-number"}}
-        assert _resolve_max_iterations(cfg, None) == 70
+        assert _resolve_max_iterations(cfg, None) == 90
 
-    def test_zero_config_falls_through_to_env(self, monkeypatch):
-        # 0 / empty are falsy — treated as "unset", so the ladder continues.
-        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "70")
-        assert _resolve_max_iterations({"agent": {"max_turns": 0}}, None) == 70
+    def test_zero_loaded_value_uses_default(self):
+        assert _resolve_max_iterations({"agent": {"max_turns": 0}}, None) == 90
 
 
 class TestRunOneshotThreadsMaxTurns:
@@ -86,7 +89,7 @@ class TestRunAgentPassesMaxIterationsToAgent:
     the actual config-precedence code runs and we assert the resolved cap
     lands on ``AIAgent(max_iterations=...)`` — the crux line."""
 
-    def _run(self, monkeypatch, *, cli_max_turns, cfg):
+    def _run(self, monkeypatch, tmp_path, *, cli_max_turns, config_yaml):
         import hermes_cli.oneshot as oneshot_mod
         import hermes_cli.config as config_mod
         import hermes_cli.runtime_provider as rp_mod
@@ -106,7 +109,12 @@ class TestRunAgentPassesMaxIterationsToAgent:
             def run_conversation(self, _prompt):
                 return {"final_response": "ok"}
 
-        monkeypatch.setattr(config_mod, "load_config", lambda *a, **k: cfg)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_MANAGED_DIR", raising=False)
+        if config_yaml:
+            (tmp_path / "config.yaml").write_text(config_yaml, encoding="utf-8")
+        config_mod._LOAD_CONFIG_CACHE.clear()
+        config_mod._RAW_CONFIG_CACHE.clear()
         monkeypatch.setattr(
             rp_mod,
             "resolve_runtime_provider",
@@ -128,17 +136,36 @@ class TestRunAgentPassesMaxIterationsToAgent:
         oneshot_mod._run_agent("hi", max_turns=cli_max_turns)
         return captured
 
-    def test_cli_max_turns_lands_on_agent(self, monkeypatch):
+    def test_cli_max_turns_lands_on_agent(self, monkeypatch, tmp_path):
         captured = self._run(
-            monkeypatch, cli_max_turns=250, cfg={"agent": {"max_turns": 120}}
+            monkeypatch,
+            tmp_path,
+            cli_max_turns=250,
+            config_yaml="agent:\n  max_turns: 120\n",
         )
         assert captured["max_iterations"] == 250
 
-    def test_config_max_turns_lands_on_agent_when_no_flag(self, monkeypatch):
+    def test_config_max_turns_lands_on_agent_when_no_flag(
+        self, monkeypatch, tmp_path
+    ):
         captured = self._run(
-            monkeypatch, cli_max_turns=None, cfg={"agent": {"max_turns": 120}}
+            monkeypatch,
+            tmp_path,
+            cli_max_turns=None,
+            config_yaml="agent:\n  max_turns: 120\n",
         )
         assert captured["max_iterations"] == 120
+
+    def test_legacy_root_config_is_normalized_before_resolution(
+        self, monkeypatch, tmp_path
+    ):
+        captured = self._run(
+            monkeypatch,
+            tmp_path,
+            cli_max_turns=None,
+            config_yaml="max_turns: 55\n",
+        )
+        assert captured["max_iterations"] == 55
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/hermes_cli/test_oneshot_max_turns.py
+++ b/tests/hermes_cli/test_oneshot_max_turns.py
@@ -1,0 +1,145 @@
+"""Oneshot (`hermes -z`) per-turn iteration budget resolution.
+
+Regression coverage for the budget-decapitation bug: oneshot used to build
+its AIAgent without a max_iterations argument, so `hermes -z` silently ran
+at the AIAgent default and ignored `agent.max_turns` in config / the
+`--max-turns` flag / `HERMES_MAX_ITERATIONS`. Long-running workers (e.g.
+MeshBoard dispatches) were cut off mid-task with no way to raise the cap
+per invocation.
+"""
+import pytest
+
+from hermes_cli.oneshot import _resolve_max_iterations, run_oneshot
+
+
+class TestResolveMaxIterations:
+    def test_cli_flag_wins(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "70")
+        cfg = {"agent": {"max_turns": 120}}
+        assert _resolve_max_iterations(cfg, 250) == 250
+
+    def test_config_agent_max_turns_used_when_no_flag(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "70")
+        cfg = {"agent": {"max_turns": 120}}
+        assert _resolve_max_iterations(cfg, None) == 120
+
+    def test_legacy_root_max_turns_fallback(self, monkeypatch):
+        monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+        cfg = {"max_turns": 55}
+        assert _resolve_max_iterations(cfg, None) == 55
+
+    def test_env_fallback_when_no_config(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "70")
+        assert _resolve_max_iterations({}, None) == 70
+
+    def test_builtin_default_when_nothing_set(self, monkeypatch):
+        monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+        assert _resolve_max_iterations({}, None) == 90
+
+    def test_agent_max_turns_beats_legacy_root(self, monkeypatch):
+        monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+        cfg = {"agent": {"max_turns": 120}, "max_turns": 55}
+        assert _resolve_max_iterations(cfg, None) == 120
+
+    def test_non_numeric_config_falls_through(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "70")
+        cfg = {"agent": {"max_turns": "not-a-number"}}
+        assert _resolve_max_iterations(cfg, None) == 70
+
+    def test_zero_config_falls_through_to_env(self, monkeypatch):
+        # 0 / empty are falsy — treated as "unset", so the ladder continues.
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "70")
+        assert _resolve_max_iterations({"agent": {"max_turns": 0}}, None) == 70
+
+
+class TestRunOneshotThreadsMaxTurns:
+    def test_max_turns_reaches_run_agent(self, monkeypatch):
+        captured = {}
+
+        def _fake_run_agent(prompt, **kwargs):
+            captured.update(kwargs)
+            return ("ok", {})
+
+        import hermes_cli.oneshot as oneshot_mod
+
+        monkeypatch.setattr(oneshot_mod, "_run_agent", _fake_run_agent)
+        assert run_oneshot("hi", max_turns=250) == 0
+        assert captured.get("max_turns") == 250
+
+    def test_default_is_none_passthrough(self, monkeypatch):
+        captured = {}
+
+        def _fake_run_agent(prompt, **kwargs):
+            captured.update(kwargs)
+            return ("ok", {})
+
+        import hermes_cli.oneshot as oneshot_mod
+
+        monkeypatch.setattr(oneshot_mod, "_run_agent", _fake_run_agent)
+        assert run_oneshot("hi") == 0
+        assert captured.get("max_turns") is None
+
+
+class TestRunAgentPassesMaxIterationsToAgent:
+    """End-to-end through the real ``_run_agent`` resolver: only the AIAgent
+    constructor and the network-touching provider resolver are stubbed, so
+    the actual config-precedence code runs and we assert the resolved cap
+    lands on ``AIAgent(max_iterations=...)`` — the crux line."""
+
+    def _run(self, monkeypatch, *, cli_max_turns, cfg):
+        import hermes_cli.oneshot as oneshot_mod
+        import hermes_cli.config as config_mod
+        import hermes_cli.runtime_provider as rp_mod
+        import hermes_cli.tools_config as tc_mod
+        import run_agent as ra_mod
+
+        captured = {}
+
+        class _FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            suppress_status_output = False
+            stream_delta_callback = None
+            tool_gen_callback = None
+
+            def run_conversation(self, _prompt):
+                return {"final_response": "ok"}
+
+        monkeypatch.setattr(config_mod, "load_config", lambda *a, **k: cfg)
+        monkeypatch.setattr(
+            rp_mod,
+            "resolve_runtime_provider",
+            lambda **kwargs: {
+                "api_key": "k",
+                "base_url": "http://localhost:1/v1",
+                "provider": "test",
+                "api_mode": "chat",
+                "credential_pool": None,
+            },
+        )
+        monkeypatch.setattr(tc_mod, "_get_platform_tools", lambda *a, **k: set())
+        monkeypatch.setattr(oneshot_mod, "get_fallback_chain", lambda *a, **k: [])
+        monkeypatch.setattr(
+            oneshot_mod, "_create_session_db_for_oneshot", lambda: None
+        )
+        monkeypatch.setattr(ra_mod, "AIAgent", _FakeAgent)
+
+        oneshot_mod._run_agent("hi", max_turns=cli_max_turns)
+        return captured
+
+    def test_cli_max_turns_lands_on_agent(self, monkeypatch):
+        captured = self._run(
+            monkeypatch, cli_max_turns=250, cfg={"agent": {"max_turns": 120}}
+        )
+        assert captured["max_iterations"] == 250
+
+    def test_config_max_turns_lands_on_agent_when_no_flag(self, monkeypatch):
+        captured = self._run(
+            monkeypatch, cli_max_turns=None, cfg={"agent": {"max_turns": 120}}
+        )
+        assert captured["max_iterations"] == 120
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -403,6 +403,7 @@ def test_termux_fast_cli_launch_oneshot_uses_light_parser(monkeypatch, main_mod)
         "provider": "openai",
         "toolsets": None,
         "usage_file": "usage.json",
+        "max_turns": None,
     }
 
 
@@ -657,6 +658,7 @@ def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
         "provider": None,
         "toolsets": "web,terminal",
         "usage_file": "usage.json",
+        "max_turns": None,
     }
 
 


### PR DESCRIPTION
## Problem

`hermes -z` (oneshot) built its `AIAgent` **without** a `max_iterations` argument, so it silently fell back to the `AIAgent` built-in default (90) and ignored:

- `agent.max_turns` in `config.yaml`,
- the `--max-turns` flag (which already existed and worked for interactive / `--tui`),
- `HERMES_MAX_ITERATIONS`.

Every other agent path — interactive `HermesCLI` and the gateway — resolves the per-turn tool-iteration budget from that precedence chain. Oneshot was the sole outlier, so a profile that sets `agent.max_turns: 120` still ran `-z` at 90.

The practical damage: long-running `hermes -z` workers (automated dispatch harnesses that drive `-z` in a subprocess) were capped below their configured budget and cut off mid-task, with **no per-invocation lever** to raise the ceiling — even though `--max-turns` was already a documented flag.

## Fix

- `run_oneshot()` and `_run_agent()` accept a `max_turns` argument.
- New `_resolve_max_iterations(cfg, cli_max_turns)` mirrors the interactive precedence exactly: `--max-turns` > `agent.max_turns` > legacy root `max_turns` > `HERMES_MAX_ITERATIONS` > 90.
- The resolved value is passed to `AIAgent(max_iterations=...)`.
- Both `hermes_cli.main` oneshot call sites forward the existing `--max-turns` flag (and `usage_file`, already present).

No new flag, no signature break for existing callers (`max_turns` defaults to `None` → same behavior unless set, except that a configured `agent.max_turns` is now honored — which is the intended fix).

## Behavior change to note

A profile with `agent.max_turns` set will now have that value applied to `-z` runs (previously ignored, pinned at 90). This makes oneshot consistent with interactive and gateway sessions. Runs with no config/flag/env still default to 90.

## Tests

`tests/hermes_cli/test_oneshot_max_turns.py`:
- `_resolve_max_iterations` precedence (flag > config > legacy > env > default; non-numeric/zero fall-through).
- `run_oneshot` threads `max_turns` into `_run_agent`.
- End-to-end through the **real** `_run_agent` (only `AIAgent` + the network-touching provider resolver stubbed): asserts the resolved cap reaches `AIAgent(max_iterations=...)` — 250 via flag, 120 via config.

Also updated the two `test_tui_resume_flow.py` call-signature assertions to include the new kwarg.

```
$ python -m pytest tests/hermes_cli/test_oneshot_max_turns.py \
    tests/hermes_cli/test_tui_resume_flow.py tests/agent/test_oneshot.py -q
73 passed
```
