### PR TITLE
fix(mcp): launch managed studio MCP via node

### DIFF
--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 
 from tools.mcp_tool import MCPServerTask, _format_connect_error, _resolve_stdio_command, _MCP_AVAILABLE
+from tools.mcp_tool import _resolve_stdio_argv
 
 # Ensure the mcp module symbols exist for patching even when the SDK isn't installed
 if not _MCP_AVAILABLE:
@@ -64,6 +65,79 @@ def test_resolve_stdio_command_falls_back_to_usr_local_bin():
     # /usr/local/bin must be prepended so npx's shebang (`/usr/bin/env node`)
     # can find node in the same directory.
     assert env["PATH"].split(os.pathsep)[0] == os.path.dirname(target)
+
+
+def test_resolve_stdio_argv_launches_managed_studio_mcp_via_node(tmp_path, monkeypatch):
+    webui_bin = (
+        tmp_path
+        / ".hermes-web-ui"
+        / "webui"
+        / "0.6.20"
+        / "bin"
+    )
+    webui_bin.mkdir(parents=True)
+    studio_script = webui_bin / "hermes-studio-mcp.mjs"
+    studio_script.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+
+    node_bin = tmp_path / ".hermes" / "node" / "bin"
+    node_bin.mkdir(parents=True)
+    node_path = node_bin / "node"
+    node_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    node_path.chmod(0o755)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    command, args, env = _resolve_stdio_argv(
+        "hermes-studio-mcp",
+        ["api"],
+        {"PATH": "/usr/bin", "HERMES_WEB_UI_MANAGED_MCP": "1"},
+    )
+
+    assert command == str(node_path)
+    assert args == [str(studio_script), "api"]
+    path_parts = env["PATH"].split(os.pathsep)
+    assert path_parts[0] == str(webui_bin)
+    assert str(node_bin) in path_parts
+    assert str(webui_bin) in path_parts
+
+
+def test_resolve_stdio_argv_does_not_rewrite_unmarked_user_server(
+    tmp_path, monkeypatch
+):
+    webui_bin = tmp_path / ".hermes-web-ui" / "webui" / "0.6.20" / "bin"
+    webui_bin.mkdir(parents=True)
+    (webui_bin / "hermes-studio-mcp.mjs").write_text(
+        "#!/usr/bin/env node\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    command, args, env = _resolve_stdio_argv(
+        "hermes-studio-mcp",
+        ["user-mode"],
+        {"PATH": "/custom/bin"},
+    )
+
+    assert command == "hermes-studio-mcp"
+    assert args == ["user-mode"]
+    assert env["PATH"] == "/custom/bin"
+
+
+def test_resolve_stdio_argv_leaves_studio_mcp_alone_without_managed_script(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    command, args, env = _resolve_stdio_argv(
+        "hermes-studio-mcp",
+        ["api"],
+        {"PATH": "/usr/bin"},
+    )
+
+    assert command == "hermes-studio-mcp"
+    assert args == ["api"]
+    assert env["PATH"] == "/usr/bin"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -94,6 +94,7 @@ import contextvars
 import concurrent.futures
 import errno
 import fnmatch
+import glob
 import inspect
 import json
 import logging
@@ -697,6 +698,89 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
         resolved_env = _prepend_path(resolved_env, command_dir)
 
     return resolved_command, resolved_env
+
+
+def _is_bare_command(command: str) -> bool:
+    return not any(sep and sep in command for sep in (os.sep, os.altsep, "/", "\\") if sep)
+
+
+def _find_hermes_studio_mcp_script() -> Optional[str]:
+    """Return the newest Hermes Studio managed MCP script, if installed.
+
+    Hermes Web UI/Studio may generate managed MCP entries with a bare
+    ``command: hermes-studio-mcp`` even though the actual launcher on disk is
+    ``hermes-studio-mcp.mjs`` under the Web UI install tree.  Resolve it here
+    at spawn time so existing config files recover without requiring a config
+    rewrite.
+    """
+    script_name = "hermes-studio-mcp.mjs"
+    roots = []
+    for env_key in ("HERMES_WEB_UI_HOME", "HERMES_WEBUI_HOME"):
+        value = os.environ.get(env_key, "").strip()
+        if value:
+            roots.append(os.path.expanduser(value))
+    roots.append(os.path.join(os.path.expanduser("~"), ".hermes-web-ui"))
+
+    patterns = []
+    for root in roots:
+        patterns.extend([
+            os.path.join(root, "webui", "*", "bin", script_name),
+            os.path.join(root, "*", "bin", script_name),
+            os.path.join(root, "bin", script_name),
+        ])
+
+    candidates = {
+        os.path.abspath(path)
+        for pattern in patterns
+        for path in glob.glob(pattern)
+        if os.path.isfile(path)
+    }
+    if not candidates:
+        return None
+
+    def _mtime_key(path: str) -> tuple[float, str]:
+        try:
+            return (os.path.getmtime(path), path)
+        except OSError:
+            return (0.0, path)
+
+    return max(candidates, key=_mtime_key)
+
+
+def _resolve_node_for_stdio(env: dict) -> tuple[str, dict]:
+    """Resolve Node for Hermes-managed stdio launchers."""
+    try:
+        from hermes_constants import with_hermes_node_path
+
+        resolved_env = with_hermes_node_path(env)
+    except Exception:
+        resolved_env = dict(env or {})
+
+    node = shutil.which("node", path=resolved_env.get("PATH"))
+    if node:
+        return node, _prepend_path(resolved_env, os.path.dirname(node))
+    return "node", resolved_env
+
+
+def _resolve_stdio_argv(command: str, args: list, env: dict) -> tuple[str, list, dict]:
+    """Resolve stdio command, args, and env before passing them to the MCP SDK."""
+    original_command = str(command).strip()
+    resolved_args = list(args or [])
+    if (
+        _is_bare_command(original_command)
+        and original_command.lower() == "hermes-studio-mcp"
+        and str((env or {}).get("HERMES_WEB_UI_MANAGED_MCP", "")).strip() == "1"
+    ):
+        script = _find_hermes_studio_mcp_script()
+        if script:
+            resolved_command, resolved_env = _resolve_node_for_stdio(env)
+            resolved_env = _prepend_path(resolved_env, os.path.dirname(script))
+            if os.path.dirname(resolved_command):
+                resolved_env = _prepend_path(resolved_env, os.path.dirname(resolved_command))
+            return resolved_command, [script, *resolved_args], resolved_env
+
+    resolved_command, resolved_env = _resolve_stdio_command(command, env)
+    return resolved_command, resolved_args, resolved_env
 
 
 def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
@@ -2393,7 +2477,7 @@ class MCPServerTask:
             )
 
         safe_env = _build_safe_env(user_env)
-        command, safe_env = _resolve_stdio_command(command, safe_env)
+        command, args, safe_env = _resolve_stdio_argv(command, args, safe_env)
 
         # Check package against OSV malware database before spawning.
         # Run off the event loop (the urllib HTTPS call is blocking) and bound


### PR DESCRIPTION
## Summary
- resolve managed `hermes-studio-mcp` stdio entries to the installed `hermes-studio-mcp.mjs` script at spawn time
- launch that `.mjs` script through a resolved Node executable so Windows does not ask `CreateProcess` to execute an extensionless/mjs command directly
- keep the resolver fail-open: if the managed Studio script is not installed, ordinary MCP command resolution is unchanged

Fixes #54141

## Why
On Windows, the Studio/Web UI managed MCP entries can be generated as:

```yaml
command: hermes-studio-mcp
args: [api]
```

but the real launcher lives under the Web UI install tree as `hermes-studio-mcp.mjs`. The agent subprocess PATH may not include that bin directory, and Windows cannot directly execute the `.mjs` file through `CreateProcess`. This patch resolves the managed launcher before the MCP SDK receives `StdioServerParameters`, producing the equivalent of:

```text
node <webui>/<version>/bin/hermes-studio-mcp.mjs api
```

## Duplicate Check
- Final preflight for #54141: no exact open PR; warnings only for broad `WinError` / `hermes-studio` keyword overlap.
- Inspected overlaps: the closest PRs cover WinError 32/5 cleanup, Windows socketpair tests, codex `.CMD` PATHEXT, cron Studio child session source, dashboard autoscroll, and launchd runtime preservation. None resolve the managed `hermes-studio-mcp.mjs` stdio spawn path from #54141.

## Validation
- `scripts/run_tests.sh tests/tools/test_mcp_tool_issue_948.py` -> 10 passed
- `scripts/run_tests.sh tests/tools/test_mcp_tool.py` -> 214 passed
- `.venv/bin/ruff check .` -> passed
- `.venv/bin/python scripts/check-windows-footguns.py --all` -> 790 files scanned, no findings
- `.venv/bin/python -m py_compile tools/mcp_tool.py tests/tools/test_mcp_tool_issue_948.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- publish gate gitleaks scan of `origin/main..HEAD` -> no leaks found

## Notes
- I did not run a native Windows live Studio smoke test on this macOS host. The regression tests mock the managed Web UI install layout and verify the resolved argv/env contract before `StdioServerParameters` is built.
- Fresh CI on the rebased head hit the known host-uptime-dependent MCP breaker test flake. The focused, CI-green upstream correction is #68896; this PR intentionally does not duplicate that unrelated test-only fix.
