### PR TITLE
fix(gateway): honor session_reset.mode none in resume_pending freshness gate

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10805,6 +10805,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
             elif reset_reason == "daily":
                 context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
+            elif reset_reason == "resume_pending_expired":
+                context_note = "[System note: The user's previous session expired after a gateway restart timeout. This is a fresh conversation with no prior context.]"
             else:
                 context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
             context_prompt = context_note + "\n\n" + context_prompt
@@ -10834,6 +10836,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             reason_text = "previous session was stopped or interrupted"
                         elif reset_reason == "daily":
                             reason_text = f"daily schedule at {policy.at_hour}:00"
+                        elif reset_reason == "resume_pending_expired":
+                            reason_text = "previous session expired after gateway resume timeout"
                         else:
                             hours = policy.idle_minutes // 60
                             mins = policy.idle_minutes % 60

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1786,11 +1786,20 @@ class SessionStore:
                         # session as a zombie and fall through to auto-reset.
                         reset_reason = self._should_reset(entry, source)
                         if not reset_reason:
-                            _fw = auto_continue_freshness_window()
-                            _ref_time = entry.last_resume_marked_at or entry.updated_at
-                            if _fw > 0 and (now - _ref_time).total_seconds() > _fw:
-                                reset_reason = "resume_pending_expired"
-                            else:
+                            # Freshness gate (#46934) — only fire when resets
+                            # are actually enabled. When session_reset.mode is
+                            # "none", _should_reset returns None and the user
+                            # explicitly opted out of ALL auto-resets.
+                            _policy = self.config.get_reset_policy(
+                                platform=source.platform,
+                                session_type=source.chat_type,
+                            )
+                            if _policy.mode != "none":
+                                _fw = auto_continue_freshness_window()
+                                _ref_time = entry.last_resume_marked_at or entry.updated_at
+                                if _fw > 0 and (now - _ref_time).total_seconds() > _fw:
+                                    reset_reason = "resume_pending_expired"
+                            if not reset_reason:
                                 entry.updated_at = now
                                 self._save()
                                 return entry

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -278,3 +278,47 @@ class TestSessionEntryAutoResetRoundtrip:
         assert reloaded.was_auto_reset is False
         assert reloaded.auto_reset_reason is None
         assert reloaded.reset_had_activity is False
+
+
+# ---------------------------------------------------------------------------
+# resume_pending_expired respects session_reset.mode: none
+# ---------------------------------------------------------------------------
+
+class TestResumePendingExpiredModeNone:
+    """resume_pending_expired freshness gate must honor session_reset.mode."""
+
+    def test_mode_none_prevents_freshness_gate(self, tmp_path):
+        """session_reset.mode: none → resume_pending must NOT be freshness-reset."""
+        store = _make_store(
+            SessionResetPolicy(mode="none"),
+            tmp_path,
+        )
+        source = _make_source()
+
+        entry = store.get_or_create_session(source)
+        entry.resume_pending = True
+        entry.last_resume_marked_at = datetime.now() - timedelta(hours=48)
+        store._save()
+
+        entry2 = store.get_or_create_session(source)
+        assert not entry2.was_auto_reset
+        assert entry2.auto_reset_reason is None
+        assert entry2.session_id == entry.session_id
+
+    def test_mode_idle_still_fires_freshness_gate(self, tmp_path):
+        """session_reset.mode: idle → resume_pending freshness gate still works."""
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=9999),
+            tmp_path,
+        )
+        source = _make_source()
+
+        entry = store.get_or_create_session(source)
+        entry.resume_pending = True
+        entry.last_resume_marked_at = datetime.now() - timedelta(hours=48)
+        store._save()
+
+        entry2 = store.get_or_create_session(source)
+        assert entry2.was_auto_reset
+        assert entry2.auto_reset_reason == "resume_pending_expired"
+        assert entry2.session_id != entry.session_id


### PR DESCRIPTION
Fixes #61052

## Problem

Two bugs in the `resume_pending_expired` freshness gate (introduced in v0.18.1, commit `a1f62f4777`):

1. **Policy violation**: the freshness gate could auto-reset a `resume_pending` session even when `session_reset.mode: none`, ignoring the user's opt-out of all auto-resets.

2. **Misleading notification**: `resume_pending_expired` fell into the `else` branch that formats the message using `policy.idle_minutes`, showing "inactive for 24h" when the real trigger was the freshness window.

## Changes

- `gateway/session.py` — check `policy.mode != "none"` before applying the freshness gate, so `mode: none` prevents this reset path (not just idle/daily resets from `_should_reset`).
- `gateway/run.py` — add dedicated `resume_pending_expired` case in:
  - The user-facing notification (`reason_text`)
  - The system context note injected into the agent's prompt
- `tests/gateway/test_session_reset_notify.py` — regression tests verifying:
  - `mode: none` prevents freshness gate from resetting
  - `mode: idle` still allows freshness gate to fire

## Testing

```
pytest tests/gateway/test_session_reset_notify.py tests/gateway/test_restart_resume_pending.py -q
# 99 passed (98 existing + 2 new)
```