### PR TITLE
fix(dashboard): prevent SSO auto-redirect crash on password-only providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -178,6 +178,11 @@ def _auto_sso_response(request: Request) -> Response | None:
     # list_session_providers() already filters on supports_session=True, so
     # token-only credentials (drain/service providers) are never candidates.
     providers = list_session_providers()
+    # Filter out password-only providers — they don't support the OAuth
+    # redirect flow that /auth/login initiates.  Without this filter a
+    # single basic-auth provider would be auto-redirected to an endpoint
+    # that immediately 500s (NotImplementedError).
+    providers = [p for p in providers if not getattr(p, "supports_password", False)]
     if len(providers) != 1:
         # Zero → nothing to redirect to. Two+ → user must choose at /login.
         return None


### PR DESCRIPTION
Prevent SSO auto-redirect flow from triggering on password-only authentication providers, which causes 500 errors. Filters out these providers in the SSO middleware check.