### PR TITLE
fix(gateway): classify OpenCode Zen model-not-found 401 as model error

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -293,6 +293,7 @@ _MODEL_NOT_FOUND_PATTERNS = [
     # and the error surfaces as a confusing "model not found" message
     # instead of automatically failing over.  See PR #58446.
     "no endpoints found that support tool use",
+    "model is not supported",
 ]
 
 # Request-validation patterns — the request is malformed and will fail
@@ -868,6 +869,28 @@ def _classify_by_status(
     """Classify based on HTTP status code with message-aware refinement."""
 
     if status_code == 401:
+        # OpenCode Zen misuses 401 for model-not-found errors: the body
+        # carries {"type": "error", "error": {"type": "ModelError", ...}}
+        # rather than an auth failure.  Check the body *before* falling
+        # through to the generic auth classification so the user sees
+        # "Model X is not supported" instead of "Provider authentication
+        # failed".
+        error_inner = body.get("error", {})
+        if isinstance(error_inner, dict):
+            inner_type = error_inner.get("type", "")
+            inner_msg = error_inner.get("message", error_msg)
+        else:
+            inner_type = ""
+            inner_msg = str(error_inner) if error_inner else error_msg
+        if (
+            inner_type == "ModelError"
+            or any(p in inner_msg for p in _MODEL_NOT_FOUND_PATTERNS)
+        ):
+            return result_fn(
+                FailoverReason.model_not_found,
+                retryable=False,
+                should_fallback=True,
+            )
         # Not retryable on its own — credential pool rotation and
         # provider-specific refresh (Codex, Anthropic, Nous) run before
         # the retryability check in run_agent.py.  If those succeed, the

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -878,10 +878,11 @@ def _classify_by_status(
         error_inner = body.get("error", {})
         if isinstance(error_inner, dict):
             inner_type = error_inner.get("type", "")
-            inner_msg = error_inner.get("message", error_msg)
+            inner_raw = error_inner.get("message")
+            inner_msg = str(inner_raw).lower() if isinstance(inner_raw, str) else error_msg
         else:
             inner_type = ""
-            inner_msg = str(error_inner) if error_inner else error_msg
+            inner_msg = str(error_inner).lower() if error_inner else error_msg
         if (
             inner_type == "ModelError"
             or any(p in inner_msg for p in _MODEL_NOT_FOUND_PATTERNS)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -81,6 +81,13 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     # Match authentication/authorization wording at a word boundary and the
     # 401/403 status codes as whole tokens, so "oauth", "4015" and similar do
     # not trip a misleading auth message.
+    # Model-not-found must be checked BEFORE the 401 auth catch-all — some
+    # providers (OpenCode Zen) misuse HTTP 401 for "model not supported".
+    if re.search(r"model\s+\S+\s+is\s+not\s+supported|is\s+not\s+a\s+supported\s+model", lower):
+        return (
+            f"⚠️ Cron '{job_name}' failed: model not supported by provider. "
+            "Full details saved in cron output."
+        )
     if re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text):
         return (
             f"⚠️ Cron '{job_name}' failed: provider authentication error. "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -355,6 +355,14 @@ def _redact_approval_command(cmd: "str | None") -> str:
 
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
+    # Model-not-found must be checked BEFORE the generic 401/403 auth
+    # catch-all — some providers (OpenCode Zen) misuse HTTP 401 for
+    # "model not supported" errors whose body carries "is not supported".
+    if re.search(r"(model\s+\S+\s+is\s+not\s+supported|is\s+not\s+a\s+supported\s+model)", text, re.IGNORECASE):
+        return (
+            "⚠️ This model is not supported by the provider. "
+            "Try a different free model from the provider's available list."
+        )
     if _GATEWAY_AUTH_ERROR_RE.search(text):
         return (
             "⚠️ Provider authentication failed. Check the configured credentials; "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -361,7 +361,7 @@ def _gateway_provider_error_reply(text: str) -> str:
     if re.search(r"(model\s+\S+\s+is\s+not\s+supported|is\s+not\s+a\s+supported\s+model)", text, re.IGNORECASE):
         return (
             "⚠️ This model is not supported by the provider. "
-            "Try a different free model from the provider's available list."
+            "Try a different model from the provider's available list."
         )
     if _GATEWAY_AUTH_ERROR_RE.search(text):
         return (

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -242,6 +242,78 @@ class TestClassifyApiError:
         assert result.retryable is False
         assert result.should_fallback is True
 
+    def test_401_opencode_zen_model_error_classifies_as_model_not_found(self):
+        """OpenCode Zen 401 with ModelError → model_not_found, NOT auth, NO credential rotation."""
+        e = MockAPIError(
+            "Unauthorized",
+            status_code=401,
+            body={
+                "type": "error",
+                "error": {
+                    "type": "ModelError",
+                    "message": "The model 'gpt-5' is not supported.",
+                },
+            },
+        )
+        result = classify_api_error(e, provider="opencode")
+        assert result.reason == FailoverReason.model_not_found
+        assert result.should_fallback is True
+        assert result.retryable is False
+        assert result.should_rotate_credential is False
+
+    def test_401_opencode_zen_mixed_case_message(self):
+        """Mixed-case inner message must still match lowercase model-not-found patterns."""
+        e = MockAPIError(
+            "Unauthorized",
+            status_code=401,
+            body={
+                "type": "error",
+                "error": {
+                    "type": "error",
+                    "message": "This Model Is Not Supported By This Provider",
+                },
+            },
+        )
+        result = classify_api_error(e, provider="opencode")
+        assert result.reason == FailoverReason.model_not_found
+        assert result.should_rotate_credential is False
+
+    def test_401_opencode_zen_null_inner_msg_falls_through_to_type_check(self):
+        """Null error.message with ModelError type → model_not_found via type check, not crash."""
+        e = MockAPIError(
+            "Unauthorized",
+            status_code=401,
+            body={
+                "type": "error",
+                "error": {
+                    "type": "ModelError",
+                    "message": None,
+                },
+            },
+        )
+        result = classify_api_error(e, provider="opencode")
+        # Falls through to type check: ModelError → model_not_found
+        assert result.reason == FailoverReason.model_not_found
+        assert result.should_rotate_credential is False
+
+    def test_401_dict_inner_msg_no_crash(self):
+        """Dict error.message must not crash; fall through to auth with rotation."""
+        e = MockAPIError(
+            "Unauthorized",
+            status_code=401,
+            body={
+                "type": "error",
+                "error": {
+                    "type": "error",
+                    "message": {"detail": [{"msg": "nested validation error"}]},
+                },
+            },
+        )
+        result = classify_api_error(e, provider="opencode")
+        # Dict doesn't match ModelError type or patterns → falls through to auth
+        assert result.reason == FailoverReason.auth
+        assert result.should_rotate_credential is True
+
     def test_403_classified_as_auth(self):
         e = MockAPIError("Forbidden", status_code=403)
         result = classify_api_error(e, provider="anthropic")


### PR DESCRIPTION
Properly classify OpenCode Zen model-not-found errors that use HTTP status 401. Detects ModelError/unsupported model in body/message to prevent auth rotation, and returns clear error messaging.