### PR TITLE
feat(cli): add silent_empty flag for quick commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8939,7 +8939,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                                 from agent.redact import redact_sensitive_text
                                 output = redact_sensitive_text(output)
                                 self._console_print(_rich_text_from_ansi(output))
-                            else:
+                            elif not qcmd.get("silent_empty"):
                                 self._console_print("[dim]Command returned no output[/]")
                         except subprocess.TimeoutExpired:
                             self._console_print("[bold red]Quick command timed out (30s)[/]")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10013,7 +10013,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             if output:
                                 from agent.redact import redact_sensitive_text
                                 output = redact_sensitive_text(output)
-                            return output if output else "Command returned no output."
+                            if output:
+                                return output
+                            if qcmd.get("silent_empty"):
+                                return ""
+                            return "Command returned no output."
                         except asyncio.TimeoutError:
                             return "Quick command timed out (30s)."
                         except Exception as e:

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -67,6 +67,18 @@ class TestCLIQuickCommands:
         args = cli.console.print.call_args[0][0]
         assert "no output" in args.lower()
 
+    def test_exec_command_silent_empty_suppresses_fallback(self):
+        cli = self._make_cli({"quiet": {"type": "exec", "command": "true", "silent_empty": True}})
+        cli.process_command("/quiet")
+        cli.console.print.assert_not_called()
+
+    def test_exec_command_silent_empty_false_still_shows_fallback(self):
+        cli = self._make_cli({"loud": {"type": "exec", "command": "true", "silent_empty": False}})
+        cli.process_command("/loud")
+        cli.console.print.assert_called_once()
+        args = cli.console.print.call_args[0][0]
+        assert "no output" in args.lower()
+
     def test_alias_command_routes_to_target(self):
         """Alias quick commands rewrite to the target command."""
         cli = self._make_cli({"shortcut": {"type": "alias", "target": "/help"}})
@@ -228,6 +240,32 @@ class TestGatewayQuickCommands:
             result = await runner._handle_message(event)
         assert result is not None
         assert "timed out" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_exec_command_no_output_returns_fallback(self):
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"silent": {"type": "exec", "command": "true"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("silent")
+        result = await runner._handle_message(event)
+        assert result == "Command returned no output."
+
+    @pytest.mark.asyncio
+    async def test_exec_command_silent_empty_returns_empty_string(self):
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"quiet": {"type": "exec", "command": "true", "silent_empty": True}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("quiet")
+        result = await runner._handle_message(event)
+        assert result == ""
 
     @pytest.mark.asyncio
     async def test_gateway_config_object_supports_quick_commands(self):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11836,7 +11836,14 @@ def _(rid, params: dict) -> dict:
                     4018,
                     output or f"quick command failed with exit code {r.returncode}",
                 )
-            return _ok(rid, {"type": "exec", "output": output})
+            return _ok(
+                rid,
+                {
+                    "type": "exec",
+                    "output": output,
+                    "silent_empty": qc.get("silent_empty", False),
+                },
+            )
         if qc.get("type") == "alias":
             return _ok(rid, {"type": "alias", "target": qc.get("target", "")})
 

--- a/ui-tui/src/__tests__/asCommandDispatch.test.ts
+++ b/ui-tui/src/__tests__/asCommandDispatch.test.ts
@@ -5,6 +5,11 @@ import { asCommandDispatch } from '../lib/rpc.js'
 describe('asCommandDispatch', () => {
   it('parses exec, alias, skill, and send', () => {
     expect(asCommandDispatch({ type: 'exec', output: 'hi' })).toEqual({ type: 'exec', output: 'hi' })
+    expect(asCommandDispatch({ type: 'exec', output: '', silent_empty: true })).toEqual({
+      type: 'exec',
+      output: '',
+      silent_empty: true
+    })
     expect(asCommandDispatch({ type: 'alias', target: 'help' })).toEqual({ type: 'alias', target: 'help' })
     expect(asCommandDispatch({ type: 'skill', name: 'x', message: 'do' })).toEqual({
       type: 'skill',

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -792,6 +792,60 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.gw.request).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
   })
 
+  it('suppresses (no output) when silent_empty is true on command.dispatch exec', async () => {
+    patchUiState({ sid: 'sid-abc' })
+
+    const ctx = buildCtx({
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          request: vi.fn((method: string) => {
+            if (method === 'slash.exec') {
+              return Promise.resolve({ output: '', silent_empty: true, type: 'exec' })
+            }
+            return Promise.resolve({})
+          })
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    const h = createSlashHandler(ctx)
+    expect(h('/silent-cmd')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.gateway.gw.request).toHaveBeenCalledWith('slash.exec', expect.objectContaining({ command: 'silent-cmd' }))
+    })
+    await new Promise(r => setTimeout(r, 50))
+    expect(ctx.transcript.sys).not.toHaveBeenCalledWith(expect.stringContaining('no output'))
+  })
+
+  it('still shows (no output) when silent_empty is false on command.dispatch exec', async () => {
+    patchUiState({ sid: 'sid-abc' })
+
+    const ctx = buildCtx({
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          request: vi.fn((method: string) => {
+            if (method === 'slash.exec') {
+              return Promise.resolve({ output: '', silent_empty: false, type: 'exec' })
+            }
+            return Promise.resolve({})
+          })
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    const h = createSlashHandler(ctx)
+    expect(h('/noisy-cmd')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('(no output)')
+    })
+  })
+
   it('/history pages the current TUI transcript (user + assistant)', () => {
     const ctx = buildCtx({
       local: {

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -82,7 +82,13 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
       }
 
       if (d.type === 'exec' || d.type === 'plugin') {
-        return sys(d.output || '(no output)')
+        if (d.output) {
+          return sys(d.output)
+        }
+        if (!d.silent_empty) {
+          return sys('(no output)')
+        }
+        return
       }
 
       if (d.type === 'alias') {

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -143,7 +143,7 @@ export interface BillingMutationResponse {
 }
 
 export type CommandDispatchResponse =
-  | { output?: string; type: 'exec' | 'plugin' }
+  | { output?: string; silent_empty?: boolean; type: 'exec' | 'plugin' }
   | { target: string; type: 'alias' }
   | { message?: string; name: string; type: 'skill' }
   | { message: string; notice?: string; type: 'send' }

--- a/ui-tui/src/lib/rpc.ts
+++ b/ui-tui/src/lib/rpc.ts
@@ -15,7 +15,11 @@ export const asCommandDispatch = (value: unknown): CommandDispatchResponse | nul
   const t = o.type
 
   if (t === 'exec' || t === 'plugin') {
-    return { type: t, output: typeof o.output === 'string' ? o.output : undefined }
+    return {
+      type: t,
+      output: typeof o.output === 'string' ? o.output : undefined,
+      silent_empty: typeof o.silent_empty === 'boolean' ? o.silent_empty : undefined
+    }
   }
 
   if (t === 'alias' && typeof o.target === 'string') {

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1696,6 +1696,22 @@ quick_commands:
 
 Usage: type `/status`, `/disk`, `/update`, `/gpu`, or `/restart` in the CLI or any messaging platform. `exec` commands run locally on the host and return the output directly — no LLM call, no tokens consumed. `alias` commands rewrite to the configured slash command target.
 
+```yaml
+# Suppress "(no output)" / "Command returned no output." fallback for
+# quick commands that succeed with no output (e.g., a silent health
+# check or a background file sync).
+quick_commands:
+  sync-logs:
+    type: exec
+    command: rsync -a /var/log/hermes/ /mnt/backup/logs/
+    silent_empty: true
+```
+
+When `silent_empty` is `true` (default `false`), the CLI, gateway, and TUI will
+not render a placeholder message if the command exits with code 0 but produces
+no output. This keeps the interface quiet for commands where silence is the
+expected success signal.
+
 - **30-second timeout** — long-running commands are killed with an error message
 - **Priority** — quick commands are checked before skill commands, so you can override skill names
 - **Autocomplete** — quick commands are resolved at dispatch time and are not shown in the built-in slash-command autocomplete tables


### PR DESCRIPTION
Add support for a silent_empty flag in quick commands. When enabled, suppresses the fallback 'Command returned no output' message when the command runs silently without any stdout or stderr.