### PR TITLE
feat(telegram): add command menu auto-registration toggle

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -634,6 +634,7 @@ def _telegram_command_menu_config() -> dict[str, Any]:
         "max_commands": max_commands,
         "priority_mode": priority_mode,
         "priority": priority,
+        "enabled": menu_cfg.get("enabled"),  # None if not set, False to disable
     }
 
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2931,6 +2931,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 max_commands = telegram_menu_max_commands()
                 menu_commands, hidden_count = telegram_menu_commands(max_commands=max_commands)
                 bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
+                # Allow users to disable auto-registration via config:
+                #   platforms.telegram.extra.command_menu.enabled: false
+                # When disabled, skip set_my_commands so manual BotFather edits survive.
+                try:
+                    from hermes_cli.commands import _telegram_command_menu_config
+                    menu_cfg = _telegram_command_menu_config()
+                    if menu_cfg.get("enabled") is False:
+                        logger.info("[%s] Telegram command menu auto-registration disabled by config", self.name)
+                        bot_commands = []
+                except Exception:
+                    pass
                 # Register for all scopes independently — Telegram picks the
                 # narrowest matching scope per chat type (forum topics fall
                 # through to AllGroupChats or Default).

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2934,24 +2934,26 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Allow users to disable auto-registration via config:
                 #   platforms.telegram.extra.command_menu.enabled: false
                 # When disabled, skip set_my_commands so manual BotFather edits survive.
+                _menu_disabled = False
                 try:
                     from hermes_cli.commands import _telegram_command_menu_config
                     menu_cfg = _telegram_command_menu_config()
                     if menu_cfg.get("enabled") is False:
                         logger.info("[%s] Telegram command menu auto-registration disabled by config", self.name)
-                        bot_commands = []
+                        _menu_disabled = True
                 except Exception:
                     pass
                 # Register for all scopes independently — Telegram picks the
                 # narrowest matching scope per chat type (forum topics fall
                 # through to AllGroupChats or Default).
-                for scope_cls in (BotCommandScopeDefault, BotCommandScopeAllPrivateChats, BotCommandScopeAllGroupChats):
-                    scope_name = getattr(scope_cls, "__name__", str(scope_cls))
-                    try:
-                        await self._bot.set_my_commands(bot_commands, scope=scope_cls())
-                        logger.info("[%s] set_my_commands OK for scope %s (%d cmds)", self.name, scope_name, len(bot_commands))
-                    except Exception as scope_err:
-                        logger.warning("[%s] set_my_commands FAILED for scope %s: %s", self.name, scope_name, scope_err)
+                if not _menu_disabled:
+                    for scope_cls in (BotCommandScopeDefault, BotCommandScopeAllPrivateChats, BotCommandScopeAllGroupChats):
+                        scope_name = getattr(scope_cls, "__name__", str(scope_cls))
+                        try:
+                            await self._bot.set_my_commands(bot_commands, scope=scope_cls())
+                            logger.info("[%s] set_my_commands OK for scope %s (%d cmds)", self.name, scope_name, len(bot_commands))
+                        except Exception as scope_err:
+                            logger.warning("[%s] set_my_commands FAILED for scope %s: %s", self.name, scope_name, scope_err)
                 # Forum topics don't inherit AllGroupChats — Telegram resolves
                 # commands via BotCommandScopeChat(chat_id) for forum groups.
                 # Lazy registration happens in _ensure_forum_commands on first
@@ -7466,6 +7468,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 chat_id = int(chat.id)
                 if chat_id in self._forum_command_registered:
                     return
+                # Respect the global command_menu.enabled config:
+                # if auto-registration is disabled, skip lazy registration too.
+                try:
+                    from hermes_cli.commands import _telegram_command_menu_config
+                    if _telegram_command_menu_config().get("enabled") is False:
+                        return
+                except Exception:
+                    pass
                 from telegram import BotCommand, BotCommandScopeChat
                 from hermes_cli.commands import telegram_menu_commands, telegram_menu_max_commands
                 menu_commands, _ = telegram_menu_commands(max_commands=telegram_menu_max_commands())

--- a/tests/gateway/test_telegram_command_menu_disabled.py
+++ b/tests/gateway/test_telegram_command_menu_disabled.py
@@ -1,0 +1,86 @@
+"""Tests for the Telegram command_menu.enabled: false toggle.
+
+Verifies that when auto-registration is disabled, neither the startup
+housekeeping path nor the lazy forum-registration path call set_my_commands.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_adapter():
+    """Build a TelegramAdapter without running __init__."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+    from gateway.config import Platform, PlatformConfig
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***", extra={})
+    # ``name`` is a property derived from platform.value.title()
+    adapter._bot = MagicMock()
+    adapter._bot.set_my_commands = AsyncMock()
+    adapter._forum_command_registered = set()
+    adapter._post_connect_task = None
+    # Shut up subsequent non-fatal housekeeping steps that touch self.name
+    # but aren't relevant to the command-menu test: status indicator and
+    # DM topics.  Their guard methods return early when the relevant
+    # config flags are falsy — we just need them not to fail.
+    adapter._status_indicator_enabled = False
+    adapter._dm_topic_setup_done = True
+    adapter._dm_topics_config = []
+    adapter._dm_topics = {}
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_startup_registration_skipped_when_disabled():
+    """When command_menu.enabled is False, _run_post_connect_housekeeping
+    must NOT call set_my_commands for any scope."""
+    adapter = _make_adapter()
+
+    with patch("hermes_cli.commands._telegram_command_menu_config") as mock_cfg:
+        mock_cfg.return_value = {"enabled": False}
+        with patch("hermes_cli.commands.telegram_menu_commands") as mock_menu:
+            mock_menu.return_value = ([("start", "Start")], 0)
+            with patch("telegram.BotCommand"):
+                with patch(
+                    "telegram.BotCommandScopeDefault",
+                ), patch(
+                    "telegram.BotCommandScopeAllPrivateChats",
+                ), patch(
+                    "telegram.BotCommandScopeAllGroupChats",
+                ):
+                    await adapter._run_post_connect_housekeeping()
+
+    # Must NOT have called set_my_commands at all
+    adapter._bot.set_my_commands.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_registration_proceeds_when_enabled():
+    """When command_menu.enabled is not set (default), registration must proceed
+    normally and call set_my_commands for each scope."""
+    adapter = _make_adapter()
+
+    with patch("hermes_cli.commands._telegram_command_menu_config") as mock_cfg:
+        # enabled=None is the default (not configured)
+        mock_cfg.return_value = {
+            "enabled": None,
+            "max_commands": 60,
+            "priority_mode": "prepend",
+            "priority": [],
+        }
+        with patch("hermes_cli.commands.telegram_menu_commands") as mock_menu:
+            mock_menu.return_value = ([("start", "Start")], 0)
+            with patch("telegram.BotCommand"):
+                with patch(
+                    "telegram.BotCommandScopeDefault",
+                ), patch(
+                    "telegram.BotCommandScopeAllPrivateChats",
+                ), patch(
+                    "telegram.BotCommandScopeAllGroupChats",
+                ):
+                    await adapter._run_post_connect_housekeeping()
+
+    # Must have called set_my_commands (once per scope = 3 calls)
+    assert adapter._bot.set_my_commands.await_count == 3

--- a/tests/gateway/test_telegram_forum_commands.py
+++ b/tests/gateway/test_telegram_forum_commands.py
@@ -101,6 +101,27 @@ async def test_ensure_forum_commands_handles_set_failure():
 
 
 @pytest.mark.asyncio
+async def test_ensure_forum_commands_skips_when_menus_disabled():
+    """When command_menu.enabled is False, _ensure_forum_commands must NOT
+    call set_my_commands -- respect the global disable toggle."""
+    adapter = _make_test_adapter()
+    msg = _forum_message(chat_id=-999, is_forum=True)
+
+    with patch("hermes_cli.commands._telegram_command_menu_config") as mock_cfg:
+        mock_cfg.return_value = {"enabled": False}
+        with patch("hermes_cli.commands.telegram_menu_commands") as mock_menu:
+            mock_menu.return_value = ([("new", "Start new session")], 0)
+            with patch("telegram.BotCommand"):
+                with patch("telegram.BotCommandScopeChat"):
+                    await adapter._ensure_forum_commands(msg)
+
+    # set_my_commands must NOT have been called
+    adapter._bot.set_my_commands.assert_not_called()
+    # The chat must NOT be added to the registered set either
+    assert -999 not in adapter._forum_command_registered
+
+
+@pytest.mark.asyncio
 async def test_ensure_forum_commands_race_safety():
     """Two concurrent coroutines must not double-register the same chat."""
     adapter = _make_test_adapter()

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -90,11 +90,14 @@ platforms:
   telegram:
     extra:
       command_menu:
+        enabled: true          # true (default) or false to skip auto-registration
         max_commands: 60
         priority_mode: prepend  # prepend | append | replace
         priority:
           - my_plugin_command
 ```
+
+Set `enabled: false` to skip auto-registration entirely. This is useful when you have custom bot commands configured via BotFather and want Hermes to leave them intact. When disabled, neither the initial startup registration nor the lazy forum-topic registration will call `set_my_commands`.
 
 `priority_mode` controls how your list combines with Hermes' built-in priority list:
 


### PR DESCRIPTION
Adds an 'enabled' field to the command menu configuration. If set to false, skips auto-registering bot commands with the Telegram API during startup, allowing manual BotFather configurations to survive.