### PR TITLE
feat(telegram): add temperature alert callback handlers

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5647,6 +5647,40 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
 
+        # --- Temperature alert callbacks (temp:sleep, temp:avoid) ---
+        if data.startswith("temp:"):
+            from hermes_constants import get_hermes_home
+            import subprocess, time
+            home = get_hermes_home()
+            if data == "temp:sleep":
+                await query.answer(text="😴 Going to sleep for 15 min...")
+                try:
+                    await query.edit_message_text(
+                        text=self.format_message("😴 *PC sleeping now... waking in 15 minutes*"),
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                subprocess.Popen(
+                    ["sudo", "rtcwake", "-m", "mem", "-s", "900"],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
+            elif data == "temp:avoid":
+                await query.answer(text="⏰ Alerts avoided for 1 hour")
+                try:
+                    await query.edit_message_text(
+                        text=self.format_message("⏰ *Temperature alerts snoozed for 1 hour*"),
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                avoid_until = int(time.time()) + 3600
+                with open("/tmp/temp_avoid_until", "w") as f:
+                    f.write(str(avoid_until))
+            return
+
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
     # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback
     # data is always passed as the first positional arg.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5609,6 +5609,66 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
             return
 
+        # --- Temperature alert callbacks (temp:sleep, temp:avoid) ---
+        #
+        # Contract:
+        #   Auth:    Caller MUST pass _is_callback_user_authorized() check.
+        #            Unauthorized callers receive "⛔ ..." answer and are dropped.
+        #   Valid:   temp:sleep  — puts PC to sleep for 15 min via rtcwake.
+        #            temp:avoid  — snoozes temp alerts for 1 hour
+        #                          (writes /tmp/temp_avoid_until).
+        #   Invalid: temp:<unknown> — caller receives "❌ Unknown command"
+        #            answer and is dropped.
+        #   Errors:  edit_message_text / subprocess failures are non-fatal
+        #            (logged via pass / DEVNULL).
+        #   Timeout: N/A — fire-and-forget, no external endpoint call.
+        if data.startswith("temp:"):
+            # Auth gate: only authorized users may control temperature alerts.
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to control temperature alerts.")
+                return
+
+            from hermes_constants import get_hermes_home
+            import subprocess, time
+            home = get_hermes_home()
+            if data == "temp:sleep":
+                await query.answer(text="😴 Going to sleep for 15 min...")
+                try:
+                    await query.edit_message_text(
+                        text=self.format_message("😴 *PC sleeping now... waking in 15 minutes*"),
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                subprocess.Popen(
+                    ["sudo", "rtcwake", "-m", "mem", "-s", "900"],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
+            elif data == "temp:avoid":
+                await query.answer(text="⏰ Alerts avoided for 1 hour")
+                try:
+                    await query.edit_message_text(
+                        text=self.format_message("⏰ *Temperature alerts snoozed for 1 hour*"),
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                avoid_until = int(time.time()) + 3600
+                with open("/tmp/temp_avoid_until", "w") as f:
+                    f.write(str(avoid_until))
+            else:
+                await query.answer(text="❌ Unknown temperature alert command.")
+            return
+
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
             return
@@ -5646,40 +5706,6 @@ class TelegramAdapter(BasePlatformAdapter):
                         answer, getattr(query.from_user, "id", "unknown"))
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
-
-        # --- Temperature alert callbacks (temp:sleep, temp:avoid) ---
-        if data.startswith("temp:"):
-            from hermes_constants import get_hermes_home
-            import subprocess, time
-            home = get_hermes_home()
-            if data == "temp:sleep":
-                await query.answer(text="😴 Going to sleep for 15 min...")
-                try:
-                    await query.edit_message_text(
-                        text=self.format_message("😴 *PC sleeping now... waking in 15 minutes*"),
-                        parse_mode=ParseMode.MARKDOWN_V2,
-                        reply_markup=None,
-                    )
-                except Exception:
-                    pass
-                subprocess.Popen(
-                    ["sudo", "rtcwake", "-m", "mem", "-s", "900"],
-                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                )
-            elif data == "temp:avoid":
-                await query.answer(text="⏰ Alerts avoided for 1 hour")
-                try:
-                    await query.edit_message_text(
-                        text=self.format_message("⏰ *Temperature alerts snoozed for 1 hour*"),
-                        parse_mode=ParseMode.MARKDOWN_V2,
-                        reply_markup=None,
-                    )
-                except Exception:
-                    pass
-                avoid_until = int(time.time()) + 3600
-                with open("/tmp/temp_avoid_until", "w") as f:
-                    f.write(str(avoid_until))
-            return
 
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
     # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback

--- a/tests/gateway/test_telegram_temp_alert_callbacks.py
+++ b/tests/gateway/test_telegram_temp_alert_callbacks.py
@@ -1,0 +1,261 @@
+"""Tests for Telegram temperature alert callback handlers.
+
+Verifies:
+- Auth gate rejects unauthorized users before processing
+- temp:sleep is accepted for authorized users
+- temp:avoid is accepted for authorized users
+- Unknown temp: subcommands return error answer
+"""
+import os
+import subprocess  # noqa: F811 — pre-import so patch.object works for local imports in handler
+import sys
+import time  # noqa: F811 — pre-import so patch.object works for local imports in handler
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Telegram mock so TelegramAdapter can be imported
+# ---------------------------------------------------------------------------
+def _ensure_telegram_mock():
+    """Wire up the minimal mocks required to import TelegramAdapter."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter
+from gateway.config import Platform, PlatformConfig
+
+
+def _make_adapter(extra=None, callback_auth=None):
+    """Create a TelegramAdapter with mocked internals suitable for callback tests."""
+    config = PlatformConfig(enabled=True, token="test-token", extra=extra or {})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    if callback_auth is not None:
+        adapter._is_callback_user_authorized = callback_auth
+    return adapter
+
+
+def _make_callback_query(data="temp:sleep", *, from_user_id=111, chat_id=-100, message_id=42):
+    """Build a minimal callback query SimpleNamespace."""
+    return SimpleNamespace(
+        data=data,
+        from_user=SimpleNamespace(id=from_user_id, first_name="Test"),
+        message=SimpleNamespace(
+            message_id=message_id,
+            chat_id=chat_id,
+            chat=SimpleNamespace(id=chat_id, type="group"),
+            message_thread_id=None,
+            is_topic_message=False,
+        ),
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+    )
+
+
+class _AuthRunner:
+    """Minimal runner shim for testing _is_callback_user_authorized delegation."""
+
+    def __init__(self, authorized: bool):
+        self.authorized = authorized
+
+    async def _handle_message(self, event):
+        return None
+
+    def _is_user_authorized(self, source):
+        return self.authorized
+
+
+# ===========================================================================
+# Auth gate tests
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_user_rejected():
+    """An unauthorized user clicking a temp: callback should be rejected."""
+    adapter = _make_adapter()
+    # Wire a runner that rejects everyone
+    adapter._message_handler = _AuthRunner(authorized=False)._handle_message
+
+    query = _make_callback_query(data="temp:sleep", from_user_id=999)
+    update = SimpleNamespace(callback_query=query)
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    # Should have answered with auth error, NOT processed
+    query.answer.assert_awaited_once()
+    answer_text = query.answer.call_args[1].get("text", "")
+    assert "not authorized" in answer_text.lower()
+    # edit_message_text should NOT have been called — we never got past auth
+    query.edit_message_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_user_avoid_rejected():
+    """An unauthorized user clicking temp:avoid should be rejected."""
+    adapter = _make_adapter()
+    adapter._message_handler = _AuthRunner(authorized=False)._handle_message
+
+    query = _make_callback_query(data="temp:avoid", from_user_id=999)
+    update = SimpleNamespace(callback_query=query)
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    query.answer.assert_awaited_once()
+    answer_text = query.answer.call_args[1].get("text", "")
+    assert "not authorized" in answer_text.lower()
+    query.edit_message_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_user_gets_blocked_before_subprocess():
+    """Ensure unauthorized users never reach the subprocess/spawn path."""
+    adapter = _make_adapter()
+    adapter._message_handler = _AuthRunner(authorized=False)._handle_message
+
+    query = _make_callback_query(data="temp:sleep", from_user_id=999)
+    update = SimpleNamespace(callback_query=query)
+
+    with patch.object(subprocess, "Popen") as mock_popen:
+        await adapter._handle_callback_query(update, SimpleNamespace())
+
+        # subprocess.Popen should never be called for unauthorized user
+        mock_popen.assert_not_called()
+
+
+# ===========================================================================
+# Success path tests
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_temp_sleep_accepted():
+    """Authorized user clicking temp:sleep should execute the sleep command."""
+    adapter = _make_adapter()
+    adapter._message_handler = _AuthRunner(authorized=True)._handle_message
+
+    query = _make_callback_query(data="temp:sleep", from_user_id=111)
+    update = SimpleNamespace(callback_query=query)
+
+    with patch.object(subprocess, "Popen") as mock_popen:
+        await adapter._handle_callback_query(update, SimpleNamespace())
+
+        # Should answer with sleep message
+        query.answer.assert_awaited_once()
+        answer_text = query.answer.call_args[1].get("text", "")
+        assert "sleep" in answer_text.lower()
+
+        # Should edit the message
+        query.edit_message_text.assert_awaited_once()
+        edit_text = query.edit_message_text.call_args[1].get("text", "")
+        assert "sleeping" in edit_text.lower()
+
+        # Should spawn rtcwake
+        mock_popen.assert_called_once()
+        args = mock_popen.call_args[0][0]
+        assert "rtcwake" in args
+        assert "-s" in args
+        assert "900" in args  # 15 min = 900 seconds
+
+
+@pytest.mark.asyncio
+async def test_temp_avoid_accepted():
+    """Authorized user clicking temp:avoid should snooze alerts for 1 hour."""
+    adapter = _make_adapter()
+    adapter._message_handler = _AuthRunner(authorized=True)._handle_message
+
+    query = _make_callback_query(data="temp:avoid", from_user_id=111)
+    update = SimpleNamespace(callback_query=query)
+
+    with patch("builtins.open", MagicMock()) as mock_open, \
+         patch.object(time, "time") as mock_time:
+        mock_time.return_value = 1000  # Fixed "now"
+
+        fake_file = MagicMock()
+        mock_open.return_value.__enter__.return_value = fake_file
+
+        await adapter._handle_callback_query(update, SimpleNamespace())
+
+        # Should answer with snooze message
+        query.answer.assert_awaited_once()
+        answer_text = query.answer.call_args[1].get("text", "")
+        assert "alert" in answer_text.lower() or "avoid" in answer_text.lower()
+
+        # Should edit the message
+        query.edit_message_text.assert_awaited_once()
+        edit_text = query.edit_message_text.call_args[1].get("text", "")
+        assert "snoozed" in edit_text.lower() or "alert" in edit_text.lower()
+
+        # Should write the avoid-until file
+        mock_open.assert_called_once_with("/tmp/temp_avoid_until", "w")
+        fake_file.write.assert_called_once()
+        written_value = fake_file.write.call_args[0][0]
+        assert str(1000 + 3600) == written_value  # now + 1 hour
+
+
+@pytest.mark.asyncio
+async def test_temp_sleep_edit_failure_nonfatal():
+    """If edit_message_text fails for temp:sleep, the rtcwake still runs."""
+    adapter = _make_adapter()
+    adapter._message_handler = _AuthRunner(authorized=True)._handle_message
+
+    query = _make_callback_query(data="temp:sleep", from_user_id=111)
+    query.edit_message_text = AsyncMock(
+        side_effect=Exception("edit failed")
+    )
+    update = SimpleNamespace(callback_query=query)
+
+    with patch.object(subprocess, "Popen") as mock_popen:
+        await adapter._handle_callback_query(update, SimpleNamespace())
+
+        # answer should still happen
+        query.answer.assert_awaited_once()
+        # rtcwake should still run despite edit failure
+        mock_popen.assert_called_once()
+
+
+# ===========================================================================
+# Unknown temp command
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_unknown_temp_command_returns_error():
+    """An unknown temp:X subcommand should return an error answer."""
+    adapter = _make_adapter()
+    adapter._message_handler = _AuthRunner(authorized=True)._handle_message
+
+    query = _make_callback_query(data="temp:unknown_verb", from_user_id=111)
+    update = SimpleNamespace(callback_query=query)
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    query.answer.assert_awaited_once()
+    answer_text = query.answer.call_args[1].get("text", "")
+    assert "unknown" in answer_text.lower()


### PR DESCRIPTION
Add callback handlers ('temp:sleep' and 'temp:avoid') for interactive PC temperature alerts via Telegram. 'temp:sleep' suspends the machine via rtcwake, and 'temp:avoid' snoozes alerts for 1 hour.