### PR TITLE
fix(langfuse): use update_trace so turn Input/Output columns fill

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -658,10 +658,12 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         )
         root_span = root_ctx.__enter__()
 
+    # SDK v3 uses update_trace() (not set_trace_io). Failures must never block
+    # the rest of the turn — the observation still carries input from start.
     try:
-        root_span.set_trace_io(input=trace_input)
-    except Exception:
-        pass
+        root_span.update_trace(input=trace_input)
+    except Exception as exc:
+        _debug(f"update_trace(input) failed: {exc}")
 
     _debug(f"started trace {trace_id} for {task_key}")
     return TraceState(trace_id=trace_id, root_ctx=root_ctx, root_span=root_span)
@@ -754,11 +756,29 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
                 _end_observation(observation)
         final_output = _merge_trace_output(output, state)
         if final_output is not None:
-            state.root_span.set_trace_io(output=final_output)
-            state.root_span.update(output=final_output)
-        state.root_span.end()
+            # update_trace sets TRACE-level Input/Output columns in the UI.
+            # Root observation I/O is set via update(); never let either call
+            # prevent end() — otherwise generations/tools export without a
+            # CHAIN root and the list view looks half-empty.
+            try:
+                state.root_span.update_trace(output=final_output)
+            except Exception as exc:
+                _debug(f"update_trace(output) failed: {exc}")
+            try:
+                state.root_span.update(output=final_output)
+            except Exception as exc:
+                _debug(f"root update(output) failed: {exc}")
+        try:
+            state.root_span.end()
+        except Exception as exc:
+            _debug(f"root end() failed: {exc}")
     except Exception as exc:  # pragma: no cover - fail-open
         _debug(f"finish trace failed: {exc}")
+        # Last-chance end so an earlier unexpected error still exports the root.
+        try:
+            state.root_span.end()
+        except Exception:
+            pass
     finally:
         try:
             client.flush()

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -271,14 +271,20 @@ class TestTurnTraceIsolation:
         """
 
         class _Span:
+            def __init__(self):
+                self.ended = False
+                self.updates = []
+                self.trace_updates = []
+
             def update(self, **kw):
-                pass
+                self.updates.append(kw)
 
             def end(self, **kw):
-                pass
+                self.ended = True
 
-            def set_trace_io(self, **kw):
-                pass
+            def update_trace(self, **kw):
+                # Real SDK method on LangfuseChain/Span (NOT set_trace_io).
+                self.trace_updates.append(kw)
 
             def start_observation(self, **kw):
                 return _Span()
@@ -1021,3 +1027,167 @@ class TestUsageFromSanitizedResponse:
 
         assert seen["resp"] is resp
         assert captured["usage_details"] == {"input": 7, "output": 3}
+
+
+class TestFinishTraceUsesUpdateTrace:
+    """Regression: SDK v3 has update_trace, not set_trace_io.
+
+    Calling the non-existent set_trace_io raised AttributeError inside
+    _finish_trace's try block and skipped root_span.end(). Generations/tools
+    still exported, so the Langfuse list showed Observation Levels + Latency
+    but blank Input/Output columns (no CHAIN root).
+    """
+
+    def test_finish_ends_root_and_calls_update_trace(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        roots: list = []
+
+        class _Span:
+            def __init__(self):
+                self.ended = False
+                self.updates = []
+                self.trace_updates = []
+
+            def update(self, **kw):
+                self.updates.append(kw)
+
+            def end(self, **kw):
+                self.ended = True
+
+            def update_trace(self, **kw):
+                self.trace_updates.append(kw)
+
+            def start_observation(self, **kw):
+                return _Span()
+
+            # Deliberately NO set_trace_io — mirrors real LangfuseChain.
+
+        class _RootCM:
+            def __init__(self):
+                self.span = _Span()
+                roots.append(self.span)
+
+            def __enter__(self):
+                return self.span
+
+            def __exit__(self, *exc):
+                return False
+
+        class _Client:
+            def create_trace_id(self, seed=None):
+                return f"trace::{seed}"
+
+            def start_as_current_observation(self, **kw):
+                return _RootCM()
+
+            def flush(self):
+                pass
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _Client())
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        mod.on_pre_llm_request(
+            task_id="t1",
+            session_id="s1",
+            model="m",
+            provider="p",
+            api_mode="chat",
+            api_call_count=1,
+            request_messages=[{"role": "user", "content": "hi"}],
+            turn_id="turn-1",
+        )
+        mod.on_post_llm_call(
+            task_id="t1",
+            session_id="s1",
+            model="m",
+            provider="p",
+            api_mode="chat",
+            api_call_count=1,
+            assistant_content_chars=12,
+            assistant_tool_call_count=0,
+            assistant_response="hello world!",
+            turn_id="turn-1",
+        )
+
+        assert len(roots) == 1
+        root = roots[0]
+        assert root.ended is True
+        assert any("output" in u for u in root.trace_updates)
+        assert any("output" in u for u in root.updates)
+        assert mod._TRACE_STATE == {}
+
+    def test_finish_still_ends_when_update_trace_raises(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        roots: list = []
+
+        class _Span:
+            def __init__(self):
+                self.ended = False
+
+            def update(self, **kw):
+                pass
+
+            def end(self, **kw):
+                self.ended = True
+
+            def update_trace(self, **kw):
+                raise RuntimeError("simulated update_trace failure")
+
+            def start_observation(self, **kw):
+                return _Span()
+
+        class _RootCM:
+            def __init__(self):
+                self.span = _Span()
+                roots.append(self.span)
+
+            def __enter__(self):
+                return self.span
+
+            def __exit__(self, *exc):
+                return False
+
+        class _Client:
+            def create_trace_id(self, seed=None):
+                return f"trace::{seed}"
+
+            def start_as_current_observation(self, **kw):
+                return _RootCM()
+
+            def flush(self):
+                pass
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: _Client())
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        mod.on_pre_llm_request(
+            task_id="t1",
+            session_id="s1",
+            model="m",
+            provider="p",
+            api_mode="chat",
+            api_call_count=1,
+            request_messages=[{"role": "user", "content": "hi"}],
+            turn_id="turn-1",
+        )
+        mod.on_post_llm_call(
+            task_id="t1",
+            session_id="s1",
+            model="m",
+            provider="p",
+            api_mode="chat",
+            api_call_count=1,
+            assistant_content_chars=5,
+            assistant_tool_call_count=0,
+            assistant_response="done",
+            turn_id="turn-1",
+        )
+
+        assert roots[0].ended is True
+        assert mod._TRACE_STATE == {}


### PR DESCRIPTION
## Bug Description

Self-hosted Langfuse list view shows many `Hermes turn` rows with **blank Input/Output** while Observation Levels and Latency are still populated. Drilling in shows GENERATION/TOOL observations but **no CHAIN root**.

## Root Cause

Langfuse Python SDK **v3** exposes `span.update_trace()`, not `set_trace_io()`.

`_finish_trace` called the missing method inside a broad `try`:

```python
state.root_span.set_trace_io(output=final_output)  # AttributeError
state.root_span.update(output=final_output)       # never reached
state.root_span.end()                             # never reached
```

The exception was swallowed by fail-open logging. Child generations/tools had already called `end()`, so they still exported — producing the half-empty list UI.

## Fix

- Use `update_trace()` for TRACE-level Input/Output
- Isolate `update_trace` / `update` failures so `end()` always runs
- Last-chance `end()` if the outer try still fails
- Tests mock the real SDK method; add regression coverage

## How to Verify

1. With `langfuse==3.15.0` and the plugin enabled, run any multi-step turn.
2. Langfuse list row should show Input + Output text, not empty cells.
3. Trace detail should include a `CHAIN` observation named `Hermes turn`.

## Test Plan

- [x] `pytest tests/plugins/test_langfuse_plugin.py` — 50 passed
- [x] Live repro: AttributeError on `set_trace_io`; `update_trace` works
- [x] Manual diagnostic traces against self-hosted Langfuse confirm CHAIN+I/O when root ends

## Risk Assessment

**Low** — observability plugin only; fail-open behavior preserved; `end()` is more defensive than before.