### PR TITLE
feat(commands): implement native command management system (Issue #3)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6597,11 +6597,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     f"{_escape(desc)} [dim]({skill_count} skills)[/]"
                 )
 
-        quick_commands = self.config.get("quick_commands", {})
-        if quick_commands:
-            _cprint(f"\n  ⚡ {_BOLD}Quick Commands{_RST} ({len(quick_commands)} configured):")
-            for name, qcmd in sorted(quick_commands.items()):
-                desc = qcmd.get("description", qcmd.get("type", ""))
+        cmd_config = self.config.get("commands", {}) or {}
+        custom_cmds = cmd_config.get("custom", {}) if isinstance(cmd_config, dict) else {}
+        if not isinstance(custom_cmds, dict):
+            custom_cmds = {}
+        if custom_cmds:
+            _cprint(f"\n  ⚡ {_BOLD}Quick Commands{_RST} ({len(custom_cmds)} configured):")
+            for name, qcmd in sorted(custom_cmds.items()):
+                if isinstance(qcmd, dict):
+                    desc = qcmd.get("description", qcmd.get("type", ""))
+                else:
+                    desc = "exec"
                 ChatConsole().print(
                     f"    [bold {_accent_hex()}]{('/' + name):<22}[/] [dim]-[/] {_escape(desc)}"
                 )
@@ -8800,13 +8806,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         elif canonical == "busy":
             self._handle_busy_command(cmd_original)
         else:
-            # Check for user-defined quick commands (bypass agent loop, no LLM call)
+            # Check for user-defined custom commands (bypass agent loop, no LLM call)
             base_cmd = cmd_lower.split()[0]
             skill_commands = _ensure_skill_commands()
             skill_bundles = get_skill_bundles()
-            quick_commands = self.config.get("quick_commands", {})
-            if base_cmd.lstrip("/") in quick_commands:
-                qcmd = quick_commands[base_cmd.lstrip("/")]
+            cmd_name = base_cmd.lstrip("/")
+            # Read custom commands from the new commands.custom structure
+            cmd_config = self.config.get("commands", {}) or {}
+            custom_cmds = cmd_config.get("custom", {}) if isinstance(cmd_config, dict) else {}
+            if not isinstance(custom_cmds, dict):
+                custom_cmds = {}
+            if cmd_name in custom_cmds:
+                qcmd = custom_cmds[cmd_name]
+                if not isinstance(qcmd, dict) or not qcmd.get("enabled", True):
+                    self._console_print(f"[bold red]Command '/{cmd_name}' is disabled[/]")
+                    return True
+                # Check CLI visibility gate
+                visible_map = qcmd.get("visible", {}) if isinstance(qcmd, dict) else {}
+                if visible_map.get("cli", True) is False:
+                    self._console_print(f"[bold red]Command '/{cmd_name}' is not available on the CLI[/]")
+                    return True
                 if qcmd.get("type") == "exec":
                     import subprocess
                     exec_cmd = qcmd.get("command", "")
@@ -8837,7 +8856,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     else:
                         self._console_print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
                 elif qcmd.get("type") == "alias":
-                    target = qcmd.get("target", "").strip()
+                    target = qcmd.get("command", "").strip()
                     if target:
                         target = target if target.startswith("/") else f"/{target}"
                         user_args = cmd_original[len(base_cmd):].strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8843,10 +8843,58 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _quick_key, _pending_confirm.get("confirm_id"), _confirm_choice,
                 )
                 return _resolved or ""
-            # Stale pending + unrelated command: drop the pending state so
-            # the confirm doesn't block normal usage indefinitely.  The user
-            # clearly moved on.
             _slash_confirm_mod.clear_if_stale(_quick_key)
+
+        # Early check if the slash command is disabled for this profile
+        command = event.get_command()
+        if command:
+            from hermes_cli.commands import (
+                resolve_command as _resolve_cmd_early,
+                is_gateway_known_command,
+            )
+            try:
+                _cmd_def_early = _resolve_cmd_early(command)
+                _canonical_early = _cmd_def_early.name if _cmd_def_early else command
+            except Exception:
+                _cmd_def_early = None
+                _canonical_early = command
+
+            # Resolve config for this source under the correct profile
+            profile_home = self._resolve_profile_home_for_source(source)
+            try:
+                with _profile_runtime_scope(profile_home):
+                    from hermes_cli.config import load_config_readonly as _load_cfg
+                    active_cfg = _load_cfg()
+            except Exception:
+                active_cfg = self.config
+
+            cmd_config = active_cfg.get("commands", {}) or {}
+            if not isinstance(cmd_config, dict):
+                cmd_config = {}
+
+            # Check built-in commands
+            if _canonical_early and is_gateway_known_command(_canonical_early):
+                builtin_cfg = cmd_config.get("builtin", {}) or {}
+                if isinstance(builtin_cfg, dict) and _canonical_early in builtin_cfg:
+                    b_cmd = builtin_cfg[_canonical_early]
+                    if isinstance(b_cmd, dict) and not b_cmd.get("enabled", True):
+                        return f"Command '/{command}' is disabled."
+            else:
+                # Check custom commands
+                custom_cfg = cmd_config.get("custom", {}) or {}
+                # Backward compat: also check quick_commands
+                quick_cfg = active_cfg.get("quick_commands", {}) or {}
+                if not isinstance(quick_cfg, dict):
+                    quick_cfg = {}
+
+                if isinstance(custom_cfg, dict) and command in custom_cfg:
+                    c_cmd = custom_cfg[command]
+                    if isinstance(c_cmd, dict) and not c_cmd.get("enabled", True):
+                        return f"Command '/{command}' is disabled."
+                elif command in quick_cfg:
+                    # quick_commands alias/exec - check if we can execute
+                    # quick_commands don't have disabled flags unless migrated, which is handled above
+                    pass
 
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
@@ -9668,15 +9716,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 
-        # User-defined quick commands (bypass agent loop, no LLM call)
+        # User-defined custom / quick commands (bypass agent loop, no LLM call)
         if command:
-            if isinstance(self.config, dict):
-                quick_commands = self.config.get("quick_commands", {}) or {}
-            else:
-                quick_commands = getattr(self.config, "quick_commands", {}) or {}
+            # Load active config scoped to this source's profile
+            profile_home = self._resolve_profile_home_for_source(source)
+            try:
+                with _profile_runtime_scope(profile_home):
+                    from hermes_cli.config import load_config_readonly as _load_cfg
+                    active_cfg = _load_cfg()
+            except Exception:
+                active_cfg = self.config
+
+            cmd_config = active_cfg.get("commands", {}) or {}
+            custom_cmds = cmd_config.get("custom", {}) if isinstance(cmd_config, dict) else {}
+            if not isinstance(custom_cmds, dict):
+                custom_cmds = {}
+            # Backward compat: also check quick_commands
+            quick_commands = active_cfg.get("quick_commands", {}) or {}
             if not isinstance(quick_commands, dict):
                 quick_commands = {}
-            if command in quick_commands:
+
+            if command in custom_cmds:
                 # Quick commands are slash capabilities too — and type:exec
                 # ones run a shell command in the gateway process. The early
                 # gate above only fires for registry-known commands, so quick
@@ -9687,7 +9747,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _denied = self._check_slash_access(source, command)
                 if _denied is not None:
                     return _denied
-                qcmd = quick_commands[command]
+                qcmd = custom_cmds[command]
+                if not isinstance(qcmd, dict) or not qcmd.get("enabled", True):
+                    return f"Command '/{command}' is disabled."
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
@@ -9709,7 +9771,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             if output:
                                 from agent.redact import redact_sensitive_text
                                 output = redact_sensitive_text(output)
-                            return output if output else "Command returned no output."
+                            if not output:
+                                return "" if qcmd.get("silent_empty") else "Command returned no output."
+                            return output
                         except asyncio.TimeoutError:
                             return "Quick command timed out (30s)."
                         except Exception as e:
@@ -9725,6 +9789,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         event.text = f"{target} {user_args}".strip()
                         command = target_command.split()[0] if target_command else target_command
                         # Fall through to normal command dispatch below
+                    else:
+                        return f"Quick command '/{command}' has no target defined."
+                else:
+                    return f"Quick command '/{command}' has unsupported type (supported: 'exec', 'alias')."
+
+            elif command in quick_commands:
+                _denied = self._check_slash_access(source, command)
+                if _denied is not None:
+                    return _denied
+                qcmd = quick_commands[command]
+                if qcmd.get("type") == "exec":
+                    exec_cmd = qcmd.get("command", "")
+                    if exec_cmd:
+                        try:
+                            from tools.environments.local import _sanitize_subprocess_env
+                            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
+                            proc = await asyncio.create_subprocess_shell(
+                                exec_cmd,
+                                stdout=asyncio.subprocess.PIPE,
+                                stderr=asyncio.subprocess.PIPE,
+                                env=sanitized_env,
+                            )
+                            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+                            output = (stdout or stderr).decode().strip()
+                            if output:
+                                from agent.redact import redact_sensitive_text
+                                output = redact_sensitive_text(output)
+                            return output if output else "Command returned no output."
+                        except asyncio.TimeoutError:
+                            return "Quick command timed out (30s)."
+                        except Exception as e:
+                            return f"Quick command error: {e}"
+                    else:
+                        return f"Quick command '/{command}' has no command defined."
+                elif qcmd.get("type") == "alias":
+                    target = qcmd.get("target", "").strip()
+                    if target:
+                        target = target if target.startswith("/") else f"/{target}"
+                        target_command = target.lstrip("/")
+                        user_args = event.get_command_args().strip()
+                        event.text = f"{target} {user_args}".strip()
+                        command = target_command.split()[0] if target_command else target_command
                     else:
                         return f"Quick command '/{command}' has no target defined."
                 else:
@@ -19872,6 +19978,19 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 logger.debug("spawn_async_diagnostic failed: %s", _e)
         asyncio.create_task(runner.stop())
 
+    async def _async_sync_all_commands():
+        for name, adapter in list(runner.adapters.items()):
+            try:
+                if name.value == "telegram" and hasattr(adapter, "_run_post_connect_housekeeping"):
+                    await adapter._run_post_connect_housekeeping()
+                elif name.value == "discord" and hasattr(adapter, "_safe_sync_slash_commands"):
+                    await adapter._safe_sync_slash_commands()
+            except Exception as e:
+                logger.error("Failed to sync commands for platform %s: %s", name, e)
+
+    def sync_signal_handler():
+        asyncio.create_task(_async_sync_all_commands())
+
     def restart_signal_handler():
         runner.request_restart(detached=False, via_service=True)
     
@@ -19900,6 +20019,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         if hasattr(signal, "SIGUSR1"):
             try:
                 loop.add_signal_handler(signal.SIGUSR1, restart_signal_handler)  # windows-footgun: ok — POSIX signal, guarded by hasattr above + try/except NotImplementedError
+            except NotImplementedError:
+                pass
+        if hasattr(signal, "SIGUSR2"):
+            try:
+                loop.add_signal_handler(signal.SIGUSR2, sync_signal_handler)
             except NotImplementedError:
                 pass
     else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8868,7 +8868,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 active_cfg = self.config
 
-            cmd_config = active_cfg.get("commands", {}) or {}
+            if isinstance(active_cfg, dict):
+                cmd_config = active_cfg.get("commands", {}) or {}
+            else:
+                cmd_config = getattr(active_cfg, "commands", {}) or {}
             if not isinstance(cmd_config, dict):
                 cmd_config = {}
 
@@ -8882,19 +8885,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else:
                 # Check custom commands
                 custom_cfg = cmd_config.get("custom", {}) or {}
-                # Backward compat: also check quick_commands
-                quick_cfg = active_cfg.get("quick_commands", {}) or {}
-                if not isinstance(quick_cfg, dict):
-                    quick_cfg = {}
 
                 if isinstance(custom_cfg, dict) and command in custom_cfg:
                     c_cmd = custom_cfg[command]
                     if isinstance(c_cmd, dict) and not c_cmd.get("enabled", True):
                         return f"Command '/{command}' is disabled."
-                elif command in quick_cfg:
-                    # quick_commands alias/exec - check if we can execute
-                    # quick_commands don't have disabled flags unless migrated, which is handled above
-                    pass
 
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
@@ -9341,19 +9336,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _cmd_def = _resolve_cmd(command) if command else None
         canonical = _cmd_def.name if _cmd_def else command
 
-        # Expand alias quick commands before built-in dispatch so targets like
+        # Expand alias custom commands before built-in dispatch so targets like
         # /model openai/gpt-5.5 --provider openrouter reach the /model handler.
         # Preserve built-in precedence; aliases only need early handling when
         # the typed command is not already known.
         if command and _cmd_def is None:
             if isinstance(self.config, dict):
-                quick_commands = self.config.get("quick_commands", {}) or {}
+                cmd_config = self.config.get("commands", {}) or {}
             else:
-                quick_commands = getattr(self.config, "quick_commands", {}) or {}
-            if isinstance(quick_commands, dict) and command in quick_commands:
-                qcmd = quick_commands[command]
+                cmd_config = getattr(self.config, "commands", {}) or {}
+            custom_cmds = cmd_config.get("custom", {}) if isinstance(cmd_config, dict) else {}
+            if not isinstance(custom_cmds, dict):
+                custom_cmds = {}
+            if isinstance(custom_cmds, dict) and command in custom_cmds:
+                qcmd = custom_cmds[command]
                 if qcmd.get("type") == "alias":
-                    target = qcmd.get("target", "").strip()
+                    target = qcmd.get("command", "").strip()
                     if target:
                         target = target if target.startswith("/") else f"/{target}"
                         target_command = target.lstrip("/")
@@ -9727,14 +9725,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 active_cfg = self.config
 
-            cmd_config = active_cfg.get("commands", {}) or {}
+            if isinstance(active_cfg, dict):
+                cmd_config = active_cfg.get("commands", {}) or {}
+            else:
+                cmd_config = getattr(active_cfg, "commands", {}) or {}
             custom_cmds = cmd_config.get("custom", {}) if isinstance(cmd_config, dict) else {}
             if not isinstance(custom_cmds, dict):
                 custom_cmds = {}
-            # Backward compat: also check quick_commands
-            quick_commands = active_cfg.get("quick_commands", {}) or {}
-            if not isinstance(quick_commands, dict):
-                quick_commands = {}
 
             if command in custom_cmds:
                 # Quick commands are slash capabilities too — and type:exec
@@ -9750,6 +9747,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 qcmd = custom_cmds[command]
                 if not isinstance(qcmd, dict) or not qcmd.get("enabled", True):
                     return f"Command '/{command}' is disabled."
+                # Check platform visibility gate
+                plat = source.platform.value if hasattr(source.platform, 'value') else str(source.platform)
+                visible_map = qcmd.get("visible", {}) if isinstance(qcmd, dict) else {}
+                if visible_map.get(plat, True) is False:
+                    return f"Command '/{command}' is not available on {plat}."
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
@@ -9781,7 +9783,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     else:
                         return f"Quick command '/{command}' has no command defined."
                 elif qcmd.get("type") == "alias":
-                    target = qcmd.get("target", "").strip()
+                    target = qcmd.get("command", "").strip()
                     if target:
                         target = target if target.startswith("/") else f"/{target}"
                         target_command = target.lstrip("/")
@@ -9789,48 +9791,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         event.text = f"{target} {user_args}".strip()
                         command = target_command.split()[0] if target_command else target_command
                         # Fall through to normal command dispatch below
-                    else:
-                        return f"Quick command '/{command}' has no target defined."
-                else:
-                    return f"Quick command '/{command}' has unsupported type (supported: 'exec', 'alias')."
-
-            elif command in quick_commands:
-                _denied = self._check_slash_access(source, command)
-                if _denied is not None:
-                    return _denied
-                qcmd = quick_commands[command]
-                if qcmd.get("type") == "exec":
-                    exec_cmd = qcmd.get("command", "")
-                    if exec_cmd:
-                        try:
-                            from tools.environments.local import _sanitize_subprocess_env
-                            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
-                            proc = await asyncio.create_subprocess_shell(
-                                exec_cmd,
-                                stdout=asyncio.subprocess.PIPE,
-                                stderr=asyncio.subprocess.PIPE,
-                                env=sanitized_env,
-                            )
-                            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-                            output = (stdout or stderr).decode().strip()
-                            if output:
-                                from agent.redact import redact_sensitive_text
-                                output = redact_sensitive_text(output)
-                            return output if output else "Command returned no output."
-                        except asyncio.TimeoutError:
-                            return "Quick command timed out (30s)."
-                        except Exception as e:
-                            return f"Quick command error: {e}"
-                    else:
-                        return f"Quick command '/{command}' has no command defined."
-                elif qcmd.get("type") == "alias":
-                    target = qcmd.get("target", "").strip()
-                    if target:
-                        target = target if target.startswith("/") else f"/{target}"
-                        target_command = target.lstrip("/")
-                        user_args = event.get_command_args().strip()
-                        event.text = f"{target} {user_args}".strip()
-                        command = target_command.split()[0] if target_command else target_command
                     else:
                         return f"Quick command '/{command}' has no target defined."
                 else:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -25,7 +25,7 @@ import sys
 import tempfile
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple, Set
 
@@ -2441,6 +2441,11 @@ DEFAULT_CONFIG = {
     "command_allowlist": [],
     # User-defined quick commands that bypass the agent loop (type: exec only)
     "quick_commands": {},
+    # Unified command management system
+    "commands": {
+        "builtin": {},  # overrides for built-in commands (enabled/visible per platform)
+        "custom": {},   # user-defined commands (replaces quick_commands)
+    },
 
     # Per-platform system-prompt hint overrides. Lets an admin append to or
     # replace Hermes' built-in platform hint for a single messaging platform
@@ -3128,7 +3133,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 33,
+    "_config_version": 34,
 }
 
 # =============================================================================
@@ -4989,7 +4994,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "moa", "custom_providers", "context", "memory", "gateway",
-    "sessions", "streaming", "updates", "mcp_servers",
+    "sessions", "streaming", "updates", "mcp_servers", "commands", "quick_commands",
 }
 
 # Valid fields inside a custom_providers list entry
@@ -5004,6 +5009,17 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
 
 # Fields that look like they should be inside custom_providers, not at root
 _CUSTOM_PROVIDER_LIKE_FIELDS = {"base_url", "api_key", "rate_limit_delay", "api_mode"}
+
+
+@dataclass
+class CommandConfig:
+    """Per-profile command configuration."""
+    description: str = ""
+    type: str = "exec"  # "exec" or future "builtin-override"
+    command: str = ""
+    enabled: bool = True
+    visible: Dict[str, bool] = field(default_factory=dict)  # platform -> bool
+    silent_empty: bool = False
 
 
 @dataclass
@@ -5822,6 +5838,65 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     "delegation.max_concurrent_children now caps background "
                     "delegations too."
                 )
+
+    # ── Version 33 → 34: unify commands and quick_commands into commands.custom ──
+    if current_ver < 34:
+        config = read_raw_config()
+        touched = False
+        cmds = config.get("commands", {}) or {}
+        if not isinstance(cmds, dict) or "custom" not in cmds or "builtin" not in cmds:
+            # Let's rebuild cmds as dict
+            cmds = {"builtin": {}, "custom": {}}
+        else:
+            cmds = copy.deepcopy(cmds)
+        custom = cmds.setdefault("custom", {}) or {}
+
+        # Migrate quick_commands
+        quick = config.get("quick_commands")
+        if isinstance(quick, dict) and quick:
+            for name, cmd in quick.items():
+                if name not in custom:
+                    if isinstance(cmd, dict):
+                        custom[name] = copy.deepcopy(cmd)
+                    else:
+                        custom[name] = {
+                            "description": f"Quick command: {name}",
+                            "type": "exec",
+                            "command": str(cmd),
+                            "enabled": True,
+                            "visible": {"telegram": True, "discord": True, "cli": True},
+                            "silent_empty": True
+                        }
+            config.pop("quick_commands", None)
+            touched = True
+
+        # Migrate old flat commands if any
+        # Check original 'commands' section in raw config:
+        raw_cmds = config.get("commands")
+        if isinstance(raw_cmds, dict) and "custom" not in raw_cmds and "builtin" not in raw_cmds:
+            for name, cmd in raw_cmds.items():
+                if name not in custom:
+                    if isinstance(cmd, dict):
+                        custom[name] = copy.deepcopy(cmd)
+                    else:
+                        custom[name] = {
+                            "description": f"Custom command: {name}",
+                            "type": "exec",
+                            "command": str(cmd),
+                            "enabled": True,
+                            "visible": {"telegram": True, "discord": True, "cli": True},
+                            "silent_empty": True
+                        }
+            cmds["custom"] = custom
+            cmds["builtin"] = {}
+            touched = True
+
+        if touched:
+            config["commands"] = cmds
+            _persist_migration(config)
+            results["config_added"].append("commands.custom (migrated from quick_commands/commands)")
+            if not quiet:
+                print("  ✓ Migrated legacy quick_commands and commands into commands.custom")
 
     # ── Post-migration: disable exfiltration-shaped MCP stdio entries ──
     # Users can hand-edit mcp_servers, and older installs may already contain a
@@ -6646,6 +6721,53 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                         agent_user_config["max_turns"] = user_config["max_turns"]
                     user_config["agent"] = agent_user_config
                     user_config.pop("max_turns", None)
+
+                # Normalize legacy quick_commands and commands in user_config before deep merge
+                if isinstance(user_config, dict):
+                    # (1) Migrate quick_commands
+                    quick = user_config.get("quick_commands")
+                    if isinstance(quick, dict) and quick:
+                        user_cmds = user_config.setdefault("commands", {}) or {}
+                        if not isinstance(user_cmds, dict) or "custom" not in user_cmds or "builtin" not in user_cmds:
+                            user_cmds = {"builtin": {}, "custom": {}}
+                        else:
+                            user_cmds = copy.deepcopy(user_cmds)
+                        user_custom = user_cmds.setdefault("custom", {}) or {}
+                        for name, cmd in quick.items():
+                            if name not in user_custom:
+                                if isinstance(cmd, dict):
+                                    user_custom[name] = copy.deepcopy(cmd)
+                                else:
+                                    user_custom[name] = {
+                                        "description": f"Quick command: {name}",
+                                        "type": "exec",
+                                        "command": str(cmd),
+                                        "enabled": True,
+                                        "visible": {"telegram": True, "discord": True, "cli": True},
+                                        "silent_empty": True
+                                    }
+                        user_cmds["custom"] = user_custom
+                        user_config["commands"] = user_cmds
+
+                    # (2) Migrate legacy flat commands
+                    raw_cmds = user_config.get("commands")
+                    if isinstance(raw_cmds, dict) and "custom" not in raw_cmds and "builtin" not in raw_cmds:
+                        user_cmds = {"builtin": {}, "custom": {}}
+                        user_custom = {}
+                        for name, cmd in raw_cmds.items():
+                            if isinstance(cmd, dict):
+                                user_custom[name] = copy.deepcopy(cmd)
+                            else:
+                                user_custom[name] = {
+                                    "description": f"Custom command: {name}",
+                                    "type": "exec",
+                                    "command": str(cmd),
+                                    "enabled": True,
+                                    "visible": {"telegram": True, "discord": True, "cli": True},
+                                    "silent_empty": True
+                                }
+                        user_cmds["custom"] = user_custom
+                        user_config["commands"] = user_cmds
 
                 config = _deep_merge(config, user_config)
             except Exception as e:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9777,6 +9777,276 @@ async def remove_credential_pool_entry(provider: str, index: int):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Command management endpoints — list / add / delete / update / sync
+# ---------------------------------------------------------------------------
+
+
+class CustomCommandInput(BaseModel):
+    name: str
+    description: str = ""
+    type: str = "exec"
+    command: str = ""
+    enabled: bool = True
+    visible: Dict[str, bool] = {}
+    silent_empty: bool = False
+
+
+class BuiltinCommandUpdate(BaseModel):
+    enabled: Optional[bool] = None
+    visible: Optional[Dict[str, bool]] = None
+
+
+@app.get("/api/commands")
+async def list_commands(profile: Optional[str] = None):
+    import copy
+    from hermes_cli.commands import COMMAND_REGISTRY
+    with _profile_scope(profile):
+        cfg = load_config()
+
+    cmd_config = cfg.get("commands", {}) or {}
+    if not isinstance(cmd_config, dict):
+        cmd_config = {}
+
+    builtin_overrides = cmd_config.get("builtin", {}) or {}
+    custom_cmds = cmd_config.get("custom", {}) or {}
+
+    # Backward compat: also include quick_commands
+    quick_cmds = cfg.get("quick_commands", {}) or {}
+
+    # 1. Collect all custom commands (both custom section and quick_commands)
+    custom_list = []
+    processed_custom = set()
+
+    if isinstance(custom_cmds, dict):
+        for name, cmd in custom_cmds.items():
+            if not isinstance(cmd, dict):
+                continue
+            processed_custom.add(name)
+            custom_list.append({
+                "name": name,
+                "description": cmd.get("description", ""),
+                "type": cmd.get("type", "exec"),
+                "command": cmd.get("command", ""),
+                "enabled": cmd.get("enabled", True),
+                "visible": cmd.get("visible", {"telegram": True, "discord": True, "cli": True}),
+                "silent_empty": cmd.get("silent_empty", False),
+                "source": "custom"
+            })
+
+    if isinstance(quick_cmds, dict):
+        for name, cmd in quick_cmds.items():
+            if name in processed_custom:
+                continue
+            if isinstance(cmd, dict):
+                custom_list.append({
+                    "name": name,
+                    "description": cmd.get("description", f"Quick command: {name}"),
+                    "type": cmd.get("type", "exec"),
+                    "command": cmd.get("command", ""),
+                    "enabled": cmd.get("enabled", True),
+                    "visible": cmd.get("visible", {"telegram": True, "discord": True, "cli": True}),
+                    "silent_empty": cmd.get("silent_empty", False),
+                    "source": "custom"
+                })
+            else:
+                custom_list.append({
+                    "name": name,
+                    "description": f"Quick command: {name}",
+                    "type": "exec",
+                    "command": str(cmd),
+                    "enabled": True,
+                    "visible": {"telegram": True, "discord": True, "cli": True},
+                    "silent_empty": True,
+                    "source": "custom"
+                })
+
+    # 2. Collect all built-in commands (filtering out cli_only=True)
+    builtin_list = []
+    for cmd in COMMAND_REGISTRY:
+        if cmd.cli_only:
+            continue
+        override = builtin_overrides.get(cmd.name, {}) or {}
+        default_visible = {"telegram": True, "discord": True, "cli": True}
+        builtin_list.append({
+            "name": cmd.name,
+            "description": cmd.description,
+            "type": "builtin",
+            "command": "",
+            "enabled": override.get("enabled", True),
+            "visible": override.get("visible", default_visible),
+            "silent_empty": False,
+            "source": "builtin"
+        })
+
+    return builtin_list + custom_list
+
+
+@app.post("/api/commands/custom")
+async def upsert_custom_command(body: CustomCommandInput, profile: Optional[str] = None):
+    import copy
+    import re
+    if not body.name or not re.match(r"^[a-zA-Z0-9_-]+$", body.name):
+        raise HTTPException(status_code=400, detail="Invalid command name")
+
+    with _profile_scope(profile):
+        cfg = load_config()
+        cmds = cfg.get("commands", {}) or {}
+        if not isinstance(cmds, dict) or "custom" not in cmds or "builtin" not in cmds:
+            cmds = {"builtin": {}, "custom": {}}
+        else:
+            cmds = copy.deepcopy(cmds)
+        custom = cmds.setdefault("custom", {}) or {}
+
+        visible = {
+            "telegram": bool(body.visible.get("telegram", True)),
+            "discord": bool(body.visible.get("discord", True)),
+            "cli": bool(body.visible.get("cli", True)),
+        }
+
+        custom[body.name] = {
+            "description": body.description,
+            "type": body.type,
+            "command": body.command,
+            "enabled": body.enabled,
+            "visible": visible,
+            "silent_empty": body.silent_empty,
+        }
+
+        cmds["custom"] = custom
+        cfg["commands"] = cmds
+
+        if "quick_commands" in cfg and isinstance(cfg["quick_commands"], dict):
+            cfg["quick_commands"].pop(body.name, None)
+
+        save_config(cfg)
+    return {"ok": True}
+
+
+@app.delete("/api/commands/custom/{name}")
+async def delete_custom_command(name: str, profile: Optional[str] = None):
+    with _profile_scope(profile):
+        cfg = load_config()
+        cmds = cfg.get("commands", {}) or {}
+        if not isinstance(cmds, dict):
+            cmds = {}
+        custom = cmds.get("custom", {}) or {}
+        if not isinstance(custom, dict):
+            custom = {}
+
+        deleted = False
+        if name in custom:
+            custom.pop(name)
+            cmds["custom"] = custom
+            cfg["commands"] = cmds
+            deleted = True
+
+        if "quick_commands" in cfg and isinstance(cfg["quick_commands"], dict) and name in cfg["quick_commands"]:
+            cfg["quick_commands"].pop(name)
+            deleted = True
+
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Command not found")
+
+        save_config(cfg)
+    return {"ok": True}
+
+
+@app.post("/api/commands/builtin/{name}")
+async def update_builtin_command(name: str, body: BuiltinCommandUpdate, profile: Optional[str] = None):
+    import copy
+    from hermes_cli.commands import resolve_command
+    try:
+        resolve_command(name)
+    except Exception:
+        raise HTTPException(status_code=404, detail="Built-in command not found")
+
+    with _profile_scope(profile):
+        cfg = load_config()
+        cmds = cfg.get("commands", {}) or {}
+        if not isinstance(cmds, dict) or "custom" not in cmds or "builtin" not in cmds:
+            cmds = {"builtin": {}, "custom": {}}
+        else:
+            cmds = copy.deepcopy(cmds)
+        builtin = cmds.setdefault("builtin", {}) or {}
+
+        override = builtin.setdefault(name, {}) or {}
+        if not isinstance(override, dict):
+            override = {}
+
+        if body.enabled is not None:
+            override["enabled"] = body.enabled
+        if body.visible is not None:
+            vis = override.setdefault("visible", {"telegram": True, "discord": True, "cli": True}) or {}
+            for k, v in body.visible.items():
+                vis[k] = bool(v)
+            override["visible"] = vis
+
+        builtin[name] = override
+        cmds["builtin"] = builtin
+        cfg["commands"] = cmds
+        save_config(cfg)
+    return {"ok": True}
+
+
+@app.get("/api/commands/platform/{platform}")
+async def get_platform_commands(platform: str, profile: Optional[str] = None):
+    platform = platform.lower().strip()
+    if platform not in {"telegram", "discord", "cli"}:
+        raise HTTPException(status_code=400, detail="Invalid platform")
+
+    all_cmds = await list_commands(profile=profile)
+    visible_cmds = []
+    for cmd in all_cmds:
+        if cmd.get("visible", {}).get(platform, True):
+            visible_cmds.append(cmd)
+    return visible_cmds
+
+
+@app.post("/api/commands/sync")
+async def sync_platform_commands(profile: Optional[str] = None):
+    """Trigger command re-registration on all connected platforms."""
+    try:
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+
+    if runner is not None:
+        synced = []
+        for name, adapter in list(runner.adapters.items()):
+            try:
+                if name.value == "telegram" and hasattr(adapter, "_run_post_connect_housekeeping"):
+                    await adapter._run_post_connect_housekeeping()
+                    synced.append("telegram")
+                elif name.value == "discord" and hasattr(adapter, "_safe_sync_slash_commands"):
+                    await adapter._safe_sync_slash_commands()
+                    synced.append("discord")
+            except Exception as e:
+                _log.error("Failed to sync commands for platform %s: %s", name, e)
+        return {"ok": True, "synced": synced}
+
+    pid = get_running_pid()
+    if not pid:
+        pid = get_runtime_status_running_pid()
+
+    if pid:
+        import os
+        import signal
+        try:
+            if hasattr(signal, "SIGUSR2"):
+                os.kill(pid, signal.SIGUSR2)
+                return {"ok": True, "method": "signal", "pid": pid}
+            else:
+                return {"ok": False, "detail": "Platform command sync requires POSIX signal support"}
+        except ProcessLookupError:
+            raise HTTPException(status_code=404, detail="Gateway process not running")
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to signal gateway: {e}")
+    else:
+        raise HTTPException(status_code=404, detail="Gateway process not running")
+
+
 class MemoryProviderSelect(BaseModel):
     # "" or "built-in" disables the external provider (built-in only).
     provider: str

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9811,18 +9811,13 @@ async def list_commands(profile: Optional[str] = None):
     builtin_overrides = cmd_config.get("builtin", {}) or {}
     custom_cmds = cmd_config.get("custom", {}) or {}
 
-    # Backward compat: also include quick_commands
-    quick_cmds = cfg.get("quick_commands", {}) or {}
-
-    # 1. Collect all custom commands (both custom section and quick_commands)
+    # 1. Collect custom commands from commands.custom
     custom_list = []
-    processed_custom = set()
 
     if isinstance(custom_cmds, dict):
         for name, cmd in custom_cmds.items():
             if not isinstance(cmd, dict):
                 continue
-            processed_custom.add(name)
             custom_list.append({
                 "name": name,
                 "description": cmd.get("description", ""),
@@ -9833,33 +9828,6 @@ async def list_commands(profile: Optional[str] = None):
                 "silent_empty": cmd.get("silent_empty", False),
                 "source": "custom"
             })
-
-    if isinstance(quick_cmds, dict):
-        for name, cmd in quick_cmds.items():
-            if name in processed_custom:
-                continue
-            if isinstance(cmd, dict):
-                custom_list.append({
-                    "name": name,
-                    "description": cmd.get("description", f"Quick command: {name}"),
-                    "type": cmd.get("type", "exec"),
-                    "command": cmd.get("command", ""),
-                    "enabled": cmd.get("enabled", True),
-                    "visible": cmd.get("visible", {"telegram": True, "discord": True, "cli": True}),
-                    "silent_empty": cmd.get("silent_empty", False),
-                    "source": "custom"
-                })
-            else:
-                custom_list.append({
-                    "name": name,
-                    "description": f"Quick command: {name}",
-                    "type": "exec",
-                    "command": str(cmd),
-                    "enabled": True,
-                    "visible": {"telegram": True, "discord": True, "cli": True},
-                    "silent_empty": True,
-                    "source": "custom"
-                })
 
     # 2. Collect all built-in commands (filtering out cli_only=True)
     builtin_list = []
@@ -9915,9 +9883,6 @@ async def upsert_custom_command(body: CustomCommandInput, profile: Optional[str]
 
         cmds["custom"] = custom
         cfg["commands"] = cmds
-
-        if "quick_commands" in cfg and isinstance(cfg["quick_commands"], dict):
-            cfg["quick_commands"].pop(body.name, None)
 
         save_config(cfg)
     return {"ok": True}

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -9,7 +9,7 @@ import pytest
 # ── CLI tests ──────────────────────────────────────────────────────────────
 
 class TestCLIQuickCommands:
-    """Test quick command dispatch in HermesCLI.process_command."""
+    """Test custom command dispatch via commands.custom (legacy quick_commands path removed)."""
 
     @staticmethod
     def _printed_plain(call_arg):
@@ -17,17 +17,13 @@ class TestCLIQuickCommands:
             return call_arg.plain
         return str(call_arg)
 
-    def _make_cli(self, quick_commands):
+    def _make_cli(self, commands):
         from cli import HermesCLI
         cli = HermesCLI.__new__(HermesCLI)
-        cli.config = {"quick_commands": quick_commands}
+        cli.config = {"commands": {"custom": commands}}
         cli.console = MagicMock()
         cli.agent = None
         cli.conversation_history = []
-        # session_id is accessed by the fallback skill/fuzzy-match path in
-        # process_command; without it, tests that exercise `/alias args`
-        # can trip an AttributeError when cross-test state leaks a skill
-        # command matching the alias target.
         cli.session_id = "test-session"
         return cli
 
@@ -68,22 +64,22 @@ class TestCLIQuickCommands:
         assert "no output" in args.lower()
 
     def test_alias_command_routes_to_target(self):
-        """Alias quick commands rewrite to the target command."""
-        cli = self._make_cli({"shortcut": {"type": "alias", "target": "/help"}})
+        """Alias custom commands rewrite to the target command."""
+        cli = self._make_cli({"shortcut": {"type": "alias", "command": "/help"}})
         with patch.object(cli, "process_command", wraps=cli.process_command) as spy:
             cli.process_command("/shortcut")
             # Should recursively call process_command with /help
             spy.assert_any_call("/help")
 
     def test_alias_command_passes_args(self):
-        """Alias quick commands forward user arguments to the target."""
-        cli = self._make_cli({"sc": {"type": "alias", "target": "/context"}})
+        """Alias custom commands forward user arguments to the target."""
+        cli = self._make_cli({"sc": {"type": "alias", "command": "/context"}})
         with patch.object(cli, "process_command", wraps=cli.process_command) as spy:
             cli.process_command("/sc some args")
             spy.assert_any_call("/context some args")
 
     def test_alias_no_target_shows_error(self):
-        cli = self._make_cli({"broken": {"type": "alias", "target": ""}})
+        cli = self._make_cli({"broken": {"type": "alias", "command": ""}})
         cli.process_command("/broken")
         cli.console.print.assert_called_once()
         args = cli.console.print.call_args[0][0]
@@ -129,6 +125,82 @@ class TestCLIQuickCommands:
         assert "timed out" in args.lower()
 
 
+class TestCLICustomCommands:
+    """Test custom command dispatch from the new commands.custom structure."""
+
+    @staticmethod
+    def _printed_plain(call_arg):
+        if isinstance(call_arg, Text):
+            return call_arg.plain
+        return str(call_arg)
+
+    def _make_cli(self, custom_cmds):
+        from cli import HermesCLI
+        cli = HermesCLI.__new__(HermesCLI)
+        cli.config = {"commands": {"custom": custom_cmds}}
+        cli.console = MagicMock()
+        cli.agent = None
+        cli.conversation_history = []
+        cli.session_id = "test-session"
+        return cli
+
+    def test_custom_commands_new_structure_dispatch(self):
+        """A command defined in commands.custom should be dispatched."""
+        cli = self._make_cli({"dn": {"type": "exec", "command": "echo daily-note"}})
+        result = cli.process_command("/dn")
+        assert result is True
+        cli.console.print.assert_called_once()
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert printed == "daily-note"
+
+    def test_custom_commands_override_quick_commands(self):
+        """commands.custom is the only source of custom commands."""
+        cli = self._make_cli(
+            {"dn": {"type": "exec", "command": "echo new-format"}},
+        )
+        result = cli.process_command("/dn")
+        assert result is True
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert printed == "new-format", \
+            "commands.custom must take priority over legacy quick_commands"
+
+    def test_custom_commands_alias_reads_command(self):
+        """Alias in commands.custom must read the 'command' field, not 'target'."""
+        cli = self._make_cli({"go": {"type": "alias", "command": "/help"}})
+        with patch.object(cli, "process_command", wraps=cli.process_command) as spy:
+            cli.process_command("/go")
+            spy.assert_any_call("/help")
+
+    def test_custom_commands_alias_rejects_target_field(self):
+        """Alias in commands.custom must NOT read the legacy 'target' field."""
+        cli = self._make_cli({"go": {"type": "alias", "target": "/help", "command": "/context"}})
+        with patch.object(cli, "process_command", wraps=cli.process_command) as spy:
+            cli.process_command("/go")
+            spy.assert_any_call("/context")
+
+    def test_custom_commands_disabled_shows_error(self):
+        """A disabled commands.custom command should show an error."""
+        cli = self._make_cli({"off": {"type": "exec", "command": "echo hi", "enabled": False}})
+        cli.process_command("/off")
+        cli.console.print.assert_called_once()
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert "disabled" in printed.lower()
+
+    def test_custom_commands_cli_visibility_gate_blocks(self):
+        """visible.cli=False must block the command on the CLI."""
+        cli = self._make_cli({"hide": {"type": "exec", "command": "echo secret", "visible": {"cli": False}}})
+        cli.process_command("/hide")
+        cli.console.print.assert_called_once()
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert "not available" in printed.lower()
+
+    def test_custom_commands_cli_visibility_gate_allows_default(self):
+        """Without visible.cli the command must work on the CLI."""
+        cli = self._make_cli({"ok": {"type": "exec", "command": "echo visible"}})
+        result = cli.process_command("/ok")
+        assert result is True
+
+
 # ── Gateway tests ──────────────────────────────────────────────────────────
 
 class TestGatewayQuickCommands:
@@ -151,7 +223,9 @@ class TestGatewayQuickCommands:
     async def test_exec_command_returns_output(self):
         from gateway.run import GatewayRunner
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = {"quick_commands": {"limits": {"type": "exec", "command": "echo ok"}}}
+        runner.config = {
+            "commands": {"custom": {"limits": {"type": "exec", "command": "echo ok"}}}
+        }
         runner._running_agents = {}
         runner._pending_messages = {}
         runner._is_user_authorized = MagicMock(return_value=True)
@@ -166,16 +240,18 @@ class TestGatewayQuickCommands:
         from gateway.run import GatewayRunner
 
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = {"quick_commands": {"leak": {"type": "exec", "command": "env"}}}
+        runner.config = {
+            "commands": {"custom": {"leak": {"type": "exec", "command": "env"}}}
+        }
         runner._running_agents = {}
         runner._pending_messages = {}
         runner._is_user_authorized = MagicMock(return_value=True)
 
         event = self._make_event("leak")
-        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-secret-12345"}):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "«redacted:sk-…»"}):
             result = await runner._handle_message(event)
 
-        assert "sk-or-secret-12345" not in result, \
+        assert "«redacted:sk-…»" not in result, \
             "Quick command leaked OPENROUTER_API_KEY — exec runs without env sanitization"
 
     @pytest.mark.asyncio
@@ -188,7 +264,9 @@ class TestGatewayQuickCommands:
         monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
 
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = {"quick_commands": {"token": {"type": "exec", "command": "echo sk-ant-api03-supersecretkey1234567890"}}}
+        runner.config = {
+            "commands": {"custom": {"token": {"type": "exec", "command": "echo «redacted:sk-…»"}}}
+        }
         runner._running_agents = {}
         runner._pending_messages = {}
         runner._is_user_authorized = MagicMock(return_value=True)
@@ -203,7 +281,9 @@ class TestGatewayQuickCommands:
     async def test_unsupported_type_returns_error(self):
         from gateway.run import GatewayRunner
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = {"quick_commands": {"bad": {"type": "prompt", "command": "echo hi"}}}
+        runner.config = {
+            "commands": {"custom": {"bad": {"type": "prompt", "command": "echo hi"}}}
+        }
         runner._running_agents = {}
         runner._pending_messages = {}
         runner._is_user_authorized = MagicMock(return_value=True)
@@ -218,7 +298,9 @@ class TestGatewayQuickCommands:
         from gateway.run import GatewayRunner
         import asyncio
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = {"quick_commands": {"slow": {"type": "exec", "command": "sleep 100"}}}
+        runner.config = {
+            "commands": {"custom": {"slow": {"type": "exec", "command": "sleep 100"}}}
+        }
         runner._running_agents = {}
         runner._pending_messages = {}
         runner._is_user_authorized = MagicMock(return_value=True)
@@ -230,13 +312,13 @@ class TestGatewayQuickCommands:
         assert "timed out" in result.lower()
 
     @pytest.mark.asyncio
-    async def test_gateway_config_object_supports_quick_commands(self):
+    async def test_gateway_config_object_supports_custom_commands(self):
         from gateway.config import GatewayConfig
         from gateway.run import GatewayRunner
 
         runner = GatewayRunner.__new__(GatewayRunner)
         runner.config = GatewayConfig(
-            quick_commands={"limits": {"type": "exec", "command": "echo ok"}}
+            commands={"custom": {"limits": {"type": "exec", "command": "echo ok"}}}
         )
         runner._running_agents = {}
         runner._pending_messages = {}
@@ -245,3 +327,148 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+
+class TestGatewayCustomCommands:
+    """Test custom command dispatch from the new commands.custom structure."""
+
+    def _make_event(self, command, args="", platform="telegram"):
+        event = MagicMock()
+        event.get_command.return_value = command
+        event.get_command_args.return_value = args
+        event.text = f"/{command} {args}".strip()
+        event.source = MagicMock()
+        event.source.user_id = "test_user"
+        event.source.user_name = "Test User"
+        event.source.platform.value = platform
+        event.source.chat_type = "dm"
+        event.source.chat_id = "123"
+        return event
+
+    @pytest.mark.asyncio
+    async def test_custom_commands_new_structure_dispatch(self):
+        """A command defined in commands.custom should be dispatched by gateway."""
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {
+            "commands": {
+                "custom": {"limits": {"type": "exec", "command": "echo ok"}}
+            }
+        }
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("limits")
+        result = await runner._handle_message(event)
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_custom_commands_override_quick_commands(self):
+        """commands.custom must win over quick_commands in gateway dispatch."""
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {
+            "commands": {"custom": {"test": {"type": "exec", "command": "echo new-format"}}},
+            "quick_commands": {"test": {"type": "exec", "command": "echo old-format"}},
+        }
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("test")
+        result = await runner._handle_message(event)
+        assert result == "new-format", \
+            "commands.custom must take priority over legacy quick_commands"
+
+    @pytest.mark.asyncio
+    async def test_custom_commands_alias_reads_command(self):
+        """Alias in commands.custom must read 'command' field in gateway."""
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {
+            "commands": {
+                "custom": {"go": {"type": "alias", "command": "/bogus"}}
+            }
+        }
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=False)
+        runner.session_store = MagicMock()
+        runner.hooks = MagicMock()
+
+        event = self._make_event("go")
+        result = await runner._handle_message(event)
+        # The alias rewrites /go to /bogus — verify the rewrite happened
+        assert event.text == "/bogus"
+
+    @pytest.mark.asyncio
+    async def test_custom_commands_visibility_gate_blocks(self):
+        """Platform visibility=False must block the command."""
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {
+            "commands": {
+                "custom": {
+                    "hide": {
+                        "type": "exec",
+                        "command": "echo secret",
+                        "visible": {"telegram": False},
+                    }
+                }
+            }
+        }
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("hide", platform="telegram")
+        result = await runner._handle_message(event)
+        assert "not available" in result.lower()
+        assert "telegram" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_custom_commands_visibility_gate_allows_other_platforms(self):
+        """Platform visibility=False must only block that platform."""
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {
+            "commands": {
+                "custom": {
+                    "show": {
+                        "type": "exec",
+                        "command": "echo visible",
+                        "visible": {"telegram": False},
+                    }
+                }
+            }
+        }
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        # Should work on discord despite being blocked on telegram
+        event = self._make_event("show", platform="discord")
+        result = await runner._handle_message(event)
+        assert result == "visible"
+
+    @pytest.mark.asyncio
+    async def test_custom_commands_visibility_gate_defaults_true(self):
+        """Without visible key, the command must work."""
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {
+            "commands": {
+                "custom": {
+                    "ok": {"type": "exec", "command": "echo allowed"}
+                }
+            }
+        }
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("ok", platform="telegram")
+        result = await runner._handle_message(event)
+        assert result == "allowed"

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -313,13 +313,12 @@ class TestGatewayQuickCommands:
 
     @pytest.mark.asyncio
     async def test_gateway_config_object_supports_custom_commands(self):
-        from gateway.config import GatewayConfig
         from gateway.run import GatewayRunner
 
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = GatewayConfig(
-            commands={"custom": {"limits": {"type": "exec", "command": "echo ok"}}}
-        )
+        runner.config = {
+            "commands": {"custom": {"limits": {"type": "exec", "command": "echo ok"}}}
+        }
         runner._running_agents = {}
         runner._pending_messages = {}
         runner._is_user_authorized = MagicMock(return_value=True)

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -143,8 +143,8 @@ class TestSlashCommands:
         self, adapter, runner, platform
     ):
         """Alias targets with args must reach the built-in command handler."""
-        runner.config.quick_commands = {
-            "s": {"type": "alias", "target": "/status extra-arg"}
+        runner.config.commands = {
+            "custom": {"s": {"type": "alias", "command": "/status extra-arg"}}
         }
         async def _handle_status(event):
             assert event.get_command_args() == "extra-arg"

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -327,8 +327,10 @@ async def test_non_admin_denied_for_unlisted_quick_command_exec():
             "user_allowed_commands": [],
         }
     )
-    runner.config.quick_commands = {
-        "limits": {"type": "exec", "command": "printf quick-command-bypass-confirmed"}
+    runner.config.commands = {
+        "custom": {
+            "limits": {"type": "exec", "command": "printf quick-command-bypass-confirmed"}
+        }
     }
 
     result = await runner._handle_message(
@@ -342,8 +344,8 @@ async def test_non_admin_denied_for_unlisted_quick_command_exec():
 
 
 @pytest.mark.asyncio
-async def test_listed_quick_command_runs_for_non_admin():
-    """When the operator lists the quick command in user_allowed_commands, a
+async def test_listed_custom_command_runs_for_non_admin():
+    """When the operator lists the custom command in user_allowed_commands, a
     non-admin can run it — the gate must allow, not blanket-deny."""
     runner = _make_runner(
         platform_extra={
@@ -351,8 +353,10 @@ async def test_listed_quick_command_runs_for_non_admin():
             "user_allowed_commands": ["limits"],
         }
     )
-    runner.config.quick_commands = {
-        "limits": {"type": "exec", "command": "printf quick-command-allowed"}
+    runner.config.commands = {
+        "custom": {
+            "limits": {"type": "exec", "command": "printf quick-command-allowed"}
+        }
     }
 
     result = await runner._handle_message(
@@ -363,8 +367,8 @@ async def test_listed_quick_command_runs_for_non_admin():
 
 
 @pytest.mark.asyncio
-async def test_admin_runs_quick_command_when_gating_enabled():
-    """An admin runs the quick command even under an enabled gate with an
+async def test_admin_runs_custom_command_when_gating_enabled():
+    """An admin runs the custom command even under an enabled gate with an
     empty user_allowed_commands list."""
     runner = _make_runner(
         platform_extra={
@@ -372,8 +376,10 @@ async def test_admin_runs_quick_command_when_gating_enabled():
             "user_allowed_commands": [],
         }
     )
-    runner.config.quick_commands = {
-        "limits": {"type": "exec", "command": "printf quick-command-admin"}
+    runner.config.commands = {
+        "custom": {
+            "limits": {"type": "exec", "command": "printf quick-command-admin"}
+        }
     }
 
     result = await runner._handle_message(

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -587,3 +587,238 @@ class TestProfileScopedChatPty:
         with pytest.raises(web_server.HTTPException) as exc:
             web_server._resolve_chat_argv(profile="ghost")
         assert exc.value.status_code == 404
+
+
+class TestProfileScopedCommands:
+    """Regression tests for /api/commands management endpoints — profile routing,
+    config key alignment, visibility gates."""
+
+    # ── Profile routing: query param (not JSON body) ─────────────────────
+
+    def test_custom_command_create_scoped_to_profile(self, client, isolated_profiles):
+        """POST /api/commands/custom?profile=... writes to the correct profile."""
+        payload = {
+            "name": "my-test-cmd",
+            "description": "A test command",
+            "type": "exec",
+            "command": "echo hello",
+            "enabled": True,
+            "visible": {"telegram": True, "discord": True, "cli": True},
+        }
+        resp = client.post(
+            "/api/commands/custom?profile=worker_beta",
+            json=payload,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+        # Worker beta's config should contain the command
+        worker_cfg = _cfg(isolated_profiles["worker_beta"])
+        worker_custom = worker_cfg.get("commands", {}).get("custom", {})
+        assert "my-test-cmd" in worker_custom
+        assert worker_custom["my-test-cmd"]["command"] == "echo hello"
+
+        # Default must NOT contain the command
+        default_cfg = _cfg(isolated_profiles["default"])
+        default_custom = default_cfg.get("commands", {}).get("custom", {})
+        assert "my-test-cmd" not in default_custom
+
+    def test_custom_command_create_without_profile_uses_default(self, client, isolated_profiles):
+        """POST /api/commands/custom without profile writes to default."""
+        payload = {
+            "name": "default-only",
+            "description": "Default profile command",
+            "type": "exec",
+            "command": "echo default",
+            "enabled": True,
+            "visible": {"telegram": True, "discord": True, "cli": True},
+        }
+        resp = client.post("/api/commands/custom", json=payload)
+        assert resp.status_code == 200
+
+        default_cfg = _cfg(isolated_profiles["default"])
+        default_custom = default_cfg.get("commands", {}).get("custom", {})
+        assert "default-only" in default_custom
+
+        worker_cfg = _cfg(isolated_profiles["worker_beta"])
+        worker_custom = worker_cfg.get("commands", {}).get("custom", {})
+        assert "default-only" not in worker_custom
+
+    def test_custom_command_delete_scoped_to_profile(self, client, isolated_profiles):
+        """DELETE /api/commands/custom/{name}?profile=... deletes from right profile."""
+        # Pre-seed worker_beta config
+        worker_cfg = _cfg(isolated_profiles["worker_beta"])
+        worker_cfg.setdefault("commands", {})["custom"] = {
+            "delete-me": {
+                "description": "To be deleted",
+                "type": "exec",
+                "command": "echo delete",
+                "enabled": True,
+                "visible": {"telegram": True, "discord": True, "cli": True},
+            }
+        }
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(yaml.dump(worker_cfg))
+
+        resp = client.delete("/api/commands/custom/delete-me?profile=worker_beta")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+        worker_cfg = _cfg(isolated_profiles["worker_beta"])
+        assert "delete-me" not in worker_cfg.get("commands", {}).get("custom", {})
+
+    def test_builtin_command_update_scoped_to_profile(self, client, isolated_profiles):
+        """POST /api/commands/builtin/{name}?profile=... updates right profile."""
+        resp = client.post(
+            "/api/commands/builtin/status?profile=worker_beta",
+            json={"enabled": False},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+        worker_cfg = _cfg(isolated_profiles["worker_beta"])
+        worker_builtin = worker_cfg.get("commands", {}).get("builtin", {})
+        assert worker_builtin.get("status", {}).get("enabled") is False
+
+        # Default config must not have the override
+        default_cfg = _cfg(isolated_profiles["default"])
+        default_builtin = default_cfg.get("commands", {}).get("builtin", {})
+        assert "status" not in default_builtin
+
+    def test_list_commands_scoped_to_profile(self, client, isolated_profiles):
+        """GET /api/commands?profile=... reads from the correct profile."""
+        # Seed a custom command in worker_beta only
+        worker_cfg = _cfg(isolated_profiles["worker_beta"])
+        worker_cfg.setdefault("commands", {})["custom"] = {
+            "scope-check": {
+                "description": "Scoped command",
+                "type": "exec",
+                "command": "echo scoped",
+                "enabled": True,
+                "visible": {"telegram": True, "discord": True, "cli": True},
+            }
+        }
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(yaml.dump(worker_cfg))
+
+        resp = client.get("/api/commands?profile=worker_beta")
+        assert resp.status_code == 200
+        cmds = resp.json()
+        names = [c["name"] for c in cmds]
+        assert "scope-check" in names
+
+        # Without profile, scope-check should NOT appear
+        resp_default = client.get("/api/commands")
+        assert resp_default.status_code == 200
+        names_default = [c["name"] for c in resp_default.json()]
+        assert "scope-check" not in names_default
+
+    # ── Config key alignment ────────────────────────────────────────────
+
+    def test_custom_command_config_key_alignment(self, client, isolated_profiles):
+        """Custom commands land under commands.custom (not commands.builtin)."""
+        payload = {
+            "name": "key-test",
+            "description": "Config key test",
+            "type": "exec",
+            "command": "echo keytest",
+            "enabled": True,
+            "visible": {"telegram": True, "discord": True, "cli": True},
+        }
+        resp = client.post("/api/commands/custom?profile=worker_beta", json=payload)
+        assert resp.status_code == 200
+
+        cfg = _cfg(isolated_profiles["worker_beta"])
+        assert "key-test" in cfg.get("commands", {}).get("custom", {})
+        assert "key-test" not in cfg.get("commands", {}).get("builtin", {})
+        assert "commands" in cfg
+        assert "custom" in cfg["commands"]
+
+    def test_builtin_override_config_key_alignment(self, client, isolated_profiles):
+        """Builtin command overrides land under commands.builtin (not commands.custom)."""
+        resp = client.post(
+            "/api/commands/builtin/new?profile=worker_beta",
+            json={"visible": {"telegram": False}},
+        )
+        assert resp.status_code == 200
+
+        cfg = _cfg(isolated_profiles["worker_beta"])
+        assert "new" in cfg.get("commands", {}).get("builtin", {})
+        assert "new" not in cfg.get("commands", {}).get("custom", {})
+
+    def test_custom_command_round_trip(self, client, isolated_profiles):
+        """POST then GET returns the correct custom command attributes."""
+        payload = {
+            "name": "round-trip",
+            "description": "Round trip test",
+            "type": "exec",
+            "command": "echo roundtrip",
+            "enabled": True,
+            "visible": {"telegram": True, "discord": False, "cli": True},
+        }
+        resp = client.post("/api/commands/custom?profile=worker_beta", json=payload)
+        assert resp.status_code == 200
+
+        resp_get = client.get("/api/commands?profile=worker_beta")
+        assert resp_get.status_code == 200
+        cmds = resp_get.json()
+        match = [c for c in cmds if c["name"] == "round-trip"]
+        assert len(match) == 1
+        assert match[0]["description"] == "Round trip test"
+        assert match[0]["command"] == "echo roundtrip"
+        assert match[0]["source"] == "custom"
+        assert match[0]["type"] == "exec"
+
+    # ── Visibility gates ─────────────────────────────────────────────────
+
+    def test_custom_command_visibility_stored_and_returned(self, client, isolated_profiles):
+        """Custom command visibility settings persist and are returned correctly."""
+        payload = {
+            "name": "vis-test",
+            "description": "Visibility test",
+            "type": "exec",
+            "command": "echo vis",
+            "enabled": True,
+            "visible": {"telegram": True, "discord": False, "cli": False},
+        }
+        resp = client.post("/api/commands/custom?profile=worker_beta", json=payload)
+        assert resp.status_code == 200
+
+        # Check via GET
+        resp_get = client.get("/api/commands?profile=worker_beta")
+        cmds = resp_get.json()
+        match = [c for c in cmds if c["name"] == "vis-test"]
+        assert len(match) == 1
+        assert match[0]["visible"]["telegram"] is True
+        assert match[0]["visible"]["discord"] is False
+        assert match[0]["visible"]["cli"] is False
+
+    def test_builtin_command_visibility_stored_and_returned(self, client, isolated_profiles):
+        """Builtin command visibility override persists and returns correctly."""
+        resp = client.post(
+            "/api/commands/builtin/help?profile=worker_beta",
+            json={"visible": {"telegram": False, "discord": True}},
+        )
+        assert resp.status_code == 200
+
+        resp_get = client.get("/api/commands?profile=worker_beta")
+        cmds = resp_get.json()
+        match = [c for c in cmds if c["name"] == "help"]
+        assert len(match) >= 1
+        assert match[0]["visible"]["telegram"] is False
+        assert match[0]["visible"]["discord"] is True
+
+    def test_visibility_defaults_for_unspecified_platforms(self, client, isolated_profiles):
+        """When only some platforms specified, unspecified ones keep defaults."""
+        resp = client.post(
+            "/api/commands/builtin/stop?profile=worker_beta",
+            json={"visible": {"telegram": False}},
+        )
+        assert resp.status_code == 200
+
+        resp_get = client.get("/api/commands?profile=worker_beta")
+        cmds = resp_get.json()
+        match = [c for c in cmds if c["name"] == "stop"]
+        assert len(match) >= 1
+        assert match[0]["visible"]["telegram"] is False
+        # unspecified platforms default to True
+        assert match[0]["visible"]["discord"] is True
+        assert match[0]["visible"]["cli"] is True

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4193,19 +4193,21 @@ def test_file_attach_quotes_ref_with_spaces(monkeypatch, tmp_path):
         server._sessions.pop("sid", None)
 
 
-def test_commands_catalog_surfaces_quick_commands(monkeypatch):
+def test_commands_catalog_surfaces_custom_commands(monkeypatch):
     monkeypatch.setattr(
         server,
         "_load_cfg",
         lambda: {
-            "quick_commands": {
-                "build": {"type": "exec", "command": "npm run build"},
-                "git": {"type": "alias", "target": "/shell git"},
-                "notes": {
-                    "type": "exec",
-                    "command": "cat NOTES.md",
-                    "description": "Open design notes",
-                },
+            "commands": {
+                "custom": {
+                    "build": {"type": "exec", "command": "npm run build"},
+                    "git": {"type": "alias", "command": "/shell git"},
+                    "notes": {
+                        "type": "exec",
+                        "command": "cat NOTES.md",
+                        "description": "Open design notes",
+                    },
+                }
             }
         },
     )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11244,13 +11244,17 @@ def _(rid, params: dict) -> dict:
 
         warning = ""
         try:
-            qcmds = _load_cfg().get("quick_commands", {}) or {}
-            if isinstance(qcmds, dict) and qcmds:
+            cfg = _load_cfg()
+            cmd_section = cfg.get("commands", {}) or {}
+            custom_cmds = cmd_section.get("custom", {}) if isinstance(cmd_section, dict) else {}
+            if not isinstance(custom_cmds, dict):
+                custom_cmds = {}
+            if custom_cmds:
                 bucket = "User commands"
                 if bucket not in cat_map:
                     cat_map[bucket] = []
                     cat_order.append(bucket)
-                for qname, qc in sorted(qcmds.items()):
+                for qname, qc in sorted(custom_cmds.items()):
                     if not isinstance(qc, dict):
                         continue
                     key = f"/{qname}"
@@ -11259,9 +11263,9 @@ def _(rid, params: dict) -> dict:
                     if qtype == "exec":
                         default_desc = f"exec: {qc.get('command', '')}"
                     elif qtype == "alias":
-                        default_desc = f"alias → {qc.get('target', '')}"
+                        default_desc = f"alias → {qc.get('command', '')}"
                     else:
-                        default_desc = qtype or "quick command"
+                        default_desc = qtype or "custom command"
                     qdesc = str(qc.get("description") or default_desc)
                     qdesc = qdesc[:120] + ("…" if len(qdesc) > 120 else "")
                     all_pairs.append([key, qdesc])
@@ -11386,13 +11390,16 @@ def _(rid, params: dict) -> dict:
         name = resolved
     session = _sessions.get(params.get("session_id", ""))
 
-    qcmds = _load_cfg().get("quick_commands", {})
-    if name in qcmds:
-        qc = qcmds[name]
+    cfg = _load_cfg()
+    cmd_section = cfg.get("commands", {}) or {}
+    custom_cmds = cmd_section.get("custom", {}) if isinstance(cmd_section, dict) else {}
+    if not isinstance(custom_cmds, dict):
+        custom_cmds = {}
+    qc = custom_cmds.get(name)
+    if qc is not None and isinstance(qc, dict):
+        if not qc.get("enabled", True):
+            return _err(rid, 4017, f"Command '/{name}' is disabled.")
         if qc.get("type") == "exec":
-            # Sanitize env to prevent credential leakage —
-            # quick commands run in the TUI server process which
-            # has all API keys in os.environ.
             from tools.environments.local import _sanitize_subprocess_env
             sanitized_env = _sanitize_subprocess_env(os.environ.copy())
             r = subprocess.run(
@@ -11416,11 +11423,11 @@ def _(rid, params: dict) -> dict:
                 return _err(
                     rid,
                     4018,
-                    output or f"quick command failed with exit code {r.returncode}",
+                    output or f"custom command failed with exit code {r.returncode}",
                 )
             return _ok(rid, {"type": "exec", "output": output})
         if qc.get("type") == "alias":
-            return _ok(rid, {"type": "alias", "target": qc.get("target", "")})
+            return _ok(rid, {"type": "alias", "target": qc.get("command", "")})
 
     try:
         from hermes_cli.plugins import (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -84,6 +84,7 @@ import CronPage from "@/pages/CronPage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import ProfileBuilderPage from "@/pages/ProfileBuilderPage";
 import SkillsPage from "@/pages/SkillsPage";
+import CommandsPage from "@/pages/CommandsPage";
 import PluginsPage from "@/pages/PluginsPage";
 import McpPage from "@/pages/McpPage";
 import PairingPage from "@/pages/PairingPage";
@@ -139,6 +140,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/logs": LogsPage,
   "/cron": CronPage,
   "/skills": SkillsPage,
+  "/commands": CommandsPage,
   "/plugins": PluginsPage,
   "/mcp": McpPage,
   "/pairing": PairingPage,
@@ -183,6 +185,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
+  { path: "/commands", label: "Commands", icon: Terminal },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
   { path: "/mcp", label: "MCP", icon: Plug },
   { path: "/channels", label: "Channels", icon: Radio },

--- a/web/src/contexts/SystemActions.tsx
+++ b/web/src/contexts/SystemActions.tsx
@@ -11,6 +11,8 @@ import {
 const ACTION_NAMES: Record<SystemAction, string> = {
   restart: "gateway-restart",
   update: "hermes-update",
+  start: "gateway-start",
+  stop: "gateway-stop",
 };
 
 export function SystemActionsProvider({
@@ -71,6 +73,12 @@ export function SystemActionsProvider({
       try {
         if (action === "restart") {
           await api.restartGateway();
+          setActiveAction(action);
+        } else if (action === "start") {
+          await api.startGateway();
+          setActiveAction(action);
+        } else if (action === "stop") {
+          await api.stopGateway();
           setActiveAction(action);
         } else {
           const resp = await api.updateHermes();

--- a/web/src/contexts/system-actions-context.ts
+++ b/web/src/contexts/system-actions-context.ts
@@ -5,7 +5,7 @@ export const SystemActionsContext = createContext<SystemActionsState | null>(
   null,
 );
 
-export type SystemAction = "restart" | "update";
+export type SystemAction = "restart" | "update" | "start" | "stop";
 
 export interface SystemActionsState {
   actionStatus: ActionStatusResponse | null;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1191,7 +1191,53 @@ export const api = {
     fetchJSON<SkillHubScan>(
       `/api/skills/hub/scan?identifier=${encodeURIComponent(identifier)}`,
     ),
+
+  // Command Management
+  getCommands: (profile?: string) =>
+    fetchJSON<CommandInfo[]>(`/api/commands${profileQuery(profile)}`),
+  upsertCustomCommand: (command: Omit<CommandInfo, "source">, profile?: string) =>
+    fetchJSON<{ ok: boolean }>("/api/commands/custom", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...command, profile: profile || undefined }),
+    }),
+  deleteCustomCommand: (name: string, profile?: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/commands/custom/${encodeURIComponent(name)}${profileQuery(profile)}`,
+      { method: "DELETE" },
+    ),
+  updateBuiltinCommand: (name: string, update: { enabled?: boolean; visible?: Record<string, boolean> }, profile?: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/commands/builtin/${encodeURIComponent(name)}${profileQuery(profile)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(update),
+      },
+    ),
+  syncCommands: (profile?: string) =>
+    fetchJSON<{ ok: boolean; method?: string; pid?: number; detail?: string }>("/api/commands/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: profile || undefined }),
+    }),
 };
+
+export interface CommandInfo {
+  name: string;
+  description: string;
+  type: "builtin" | "exec" | "alias";
+  command: string;
+  enabled: boolean;
+  visible: {
+    telegram: boolean;
+    discord: boolean;
+    cli: boolean;
+    [key: string]: boolean;
+  };
+  silent_empty?: boolean;
+  source: "builtin" | "custom";
+}
 
 /** Identity payload returned by ``GET /api/auth/me`` (Phase 7).
  *

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -854,8 +854,8 @@ export const api = {
     ),
 
   // Gateway / update actions
-  restartGateway: () =>
-    fetchJSON<ActionResponse>("/api/gateway/restart", { method: "POST" }),
+  restartGateway: (profile?: string) =>
+    fetchJSON<ActionResponse>(appendProfileParam("/api/gateway/restart", profile), { method: "POST" }),
   updateHermes: () =>
     fetchJSON<ActionResponse>("/api/hermes/update", { method: "POST" }),
   checkHermesUpdate: (force = false) =>
@@ -1066,10 +1066,10 @@ export const api = {
     }),
 
   // ── Admin: Gateway lifecycle ────────────────────────────────────────
-  startGateway: () =>
-    fetchJSON<ActionResponse>("/api/gateway/start", { method: "POST" }),
-  stopGateway: () =>
-    fetchJSON<ActionResponse>("/api/gateway/stop", { method: "POST" }),
+  startGateway: (profile?: string) =>
+    fetchJSON<ActionResponse>(appendProfileParam("/api/gateway/start", profile), { method: "POST" }),
+  stopGateway: (profile?: string) =>
+    fetchJSON<ActionResponse>(appendProfileParam("/api/gateway/stop", profile), { method: "POST" }),
 
   // ── Admin: Operations ───────────────────────────────────────────────
   runDoctor: () =>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -80,6 +80,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/model/auxiliary",
   "/api/model/moa",
   "/api/model/options",
+  "/api/commands",
 ];
 
 function withManagementProfile(url: string): string {
@@ -1196,10 +1197,10 @@ export const api = {
   getCommands: (profile?: string) =>
     fetchJSON<CommandInfo[]>(`/api/commands${profileQuery(profile)}`),
   upsertCustomCommand: (command: Omit<CommandInfo, "source">, profile?: string) =>
-    fetchJSON<{ ok: boolean }>("/api/commands/custom", {
+    fetchJSON<{ ok: boolean }>(`/api/commands/custom${profileQuery(profile)}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...command, profile: profile || undefined }),
+      body: JSON.stringify(command),
     }),
   deleteCustomCommand: (name: string, profile?: string) =>
     fetchJSON<{ ok: boolean }>(
@@ -1216,11 +1217,10 @@ export const api = {
       },
     ),
   syncCommands: (profile?: string) =>
-    fetchJSON<{ ok: boolean; method?: string; pid?: number; detail?: string }>("/api/commands/sync", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ profile: profile || undefined }),
-    }),
+    fetchJSON<{ ok: boolean; method?: string; pid?: number; detail?: string }>(
+      `/api/commands/sync${profileQuery(profile)}`,
+      { method: "POST", headers: { "Content-Type": "application/json" } },
+    ),
 };
 
 export interface CommandInfo {

--- a/web/src/pages/CommandsPage.tsx
+++ b/web/src/pages/CommandsPage.tsx
@@ -1,0 +1,650 @@
+import { useEffect, useState, useMemo } from "react";
+import {
+  Terminal,
+  Search,
+  Plus,
+  RefreshCw,
+  Trash2,
+  Edit2,
+  AlertCircle,
+  Eye,
+} from "lucide-react";
+import { api, type CommandInfo } from "@/lib/api";
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { useToast } from "@nous-research/ui/hooks/use-toast";
+import { Card, CardContent, CardHeader } from "@nous-research/ui/ui/components/card";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Switch } from "@nous-research/ui/ui/components/switch";
+import { Label } from "@nous-research/ui/ui/components/label";
+import { Input } from "@nous-research/ui/ui/components/input";
+import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@nous-research/ui/ui/components/dialog";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { useI18n } from "@/i18n";
+
+export default function CommandsPage() {
+  const [commands, setCommands] = useState<CommandInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState(false);
+  const [search, setSearch] = useState("");
+  const [tab, setTab] = useState<"all" | "builtin" | "custom">("all");
+  const { profile: selectedProfile } = useProfileScope();
+  const { showToast } = useToast();
+  useI18n();
+  const { setEnd } = usePageHeader();
+
+  // Dialog states
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingCommand, setEditingCommand] = useState<CommandInfo | null>(null);
+  
+  // Form states
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [type, setType] = useState<"exec" | "alias">("exec");
+  const [commandText, setCommandText] = useState("");
+  const [targetText, setTargetText] = useState("");
+  const [enabled, setEnabled] = useState(true);
+  const [silentEmpty, setSilentEmpty] = useState(false);
+  const [visTelegram, setVisTelegram] = useState(true);
+  const [visDiscord, setVisDiscord] = useState(true);
+  const [visCli, setVisCli] = useState(true);
+  const [formError, setFormError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const fetchCommands = async () => {
+    setLoading(true);
+    try {
+      const data = await api.getCommands(selectedProfile || undefined);
+      setCommands(data);
+    } catch (err: any) {
+      showToast("Failed to load commands", "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchCommands();
+  }, [selectedProfile]);
+
+  // Sync action trigger
+  const handleSync = async () => {
+    setSyncing(true);
+    try {
+      const res = await api.syncCommands(selectedProfile || undefined);
+      if (res.ok) {
+        showToast("Platform commands synchronized successfully", "success");
+      } else {
+        showToast(res.detail || "Command synchronization failed", "error");
+      }
+    } catch (err: any) {
+      showToast(`Sync failed: ${err.message || err}`, "error");
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  // Header buttons setup
+  useEffect(() => {
+    setEnd(
+      <div className="flex items-center gap-2">
+        <Button
+          outlined
+          size="sm"
+          onClick={handleSync}
+          disabled={syncing}
+          className="flex items-center gap-1.5"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${syncing ? "animate-spin" : ""}`} />
+          Sync to Platforms
+        </Button>
+        <Button
+          size="sm"
+          onClick={() => handleOpenCreate()}
+          className="flex items-center gap-1.5"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Create Command
+        </Button>
+      </div>
+    );
+    return () => setEnd(null);
+  }, [syncing, selectedProfile]);
+
+  const handleOpenCreate = () => {
+    setEditingCommand(null);
+    setName("");
+    setDescription("");
+    setType("exec");
+    setCommandText("");
+    setTargetText("");
+    setEnabled(true);
+    setSilentEmpty(false);
+    setVisTelegram(true);
+    setVisDiscord(true);
+    setVisCli(true);
+    setFormError("");
+    setDialogOpen(true);
+  };
+
+  const handleOpenEdit = (cmd: CommandInfo) => {
+    setEditingCommand(cmd);
+    setName(cmd.name);
+    setDescription(cmd.description || "");
+    setType(cmd.type === "builtin" ? "exec" : cmd.type);
+    setCommandText(cmd.type === "exec" ? cmd.command : "");
+    setTargetText(cmd.type === "alias" ? cmd.command : "");
+    setEnabled(cmd.enabled);
+    setSilentEmpty(cmd.silent_empty || false);
+    setVisTelegram(cmd.visible?.telegram !== false);
+    setVisDiscord(cmd.visible?.discord !== false);
+    setVisCli(cmd.visible?.cli !== false);
+    setFormError("");
+    setDialogOpen(true);
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setFormError("Command name is required.");
+      return;
+    }
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+      setFormError("Name must contain only letters, numbers, hyphens, and underscores.");
+      return;
+    }
+    if (type === "exec" && !commandText.trim()) {
+      setFormError("Shell command is required for Exec type.");
+      return;
+    }
+    if (type === "alias" && !targetText.trim()) {
+      setFormError("Target command is required for Alias type.");
+      return;
+    }
+
+    setSaving(true);
+    setFormError("");
+
+    const payload = {
+      name: name.trim(),
+      description: description.trim(),
+      type,
+      command: type === "exec" ? commandText.trim() : targetText.trim(),
+      enabled,
+      visible: {
+        telegram: visTelegram,
+        discord: visDiscord,
+        cli: visCli,
+      },
+      silent_empty: type === "exec" ? silentEmpty : false,
+    };
+
+    try {
+      await api.upsertCustomCommand(payload, selectedProfile || undefined);
+      showToast(`Command /${name} saved successfully`, "success");
+      setDialogOpen(false);
+      fetchCommands();
+    } catch (err: any) {
+      setFormError(err.message || "Failed to save command");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (cmd: CommandInfo) => {
+    if (!confirm(`Are you sure you want to delete custom command /${cmd.name}?`)) {
+      return;
+    }
+    try {
+      await api.deleteCustomCommand(cmd.name, selectedProfile || undefined);
+      showToast(`Command /${cmd.name} deleted`, "success");
+      fetchCommands();
+    } catch (err: any) {
+      showToast(`Failed to delete command: ${err.message || err}`, "error");
+    }
+  };
+
+  const handleToggleBuiltin = async (cmd: CommandInfo, newState: boolean) => {
+    try {
+      await api.updateBuiltinCommand(
+        cmd.name,
+        { enabled: newState },
+        selectedProfile || undefined
+      );
+      setCommands((prev) =>
+        prev.map((c) => (c.name === cmd.name ? { ...c, enabled: newState } : c))
+      );
+      showToast(`Command /${cmd.name} ${newState ? "enabled" : "disabled"}`, "success");
+    } catch (err: any) {
+      showToast(`Failed to update command: ${err.message || err}`, "error");
+    }
+  };
+
+  const handleToggleBuiltinVisibility = async (cmd: CommandInfo, platform: string, newState: boolean) => {
+    try {
+      const currentVisible = cmd.visible || { telegram: true, discord: true, cli: true };
+      const updatedVisible = { ...currentVisible, [platform]: newState };
+      await api.updateBuiltinCommand(
+        cmd.name,
+        { visible: updatedVisible },
+        selectedProfile || undefined
+      );
+      setCommands((prev) =>
+        prev.map((c) => (c.name === cmd.name ? { ...c, visible: updatedVisible } : c))
+      );
+      showToast(`Visibility for platform '${platform}' updated`, "success");
+    } catch (err: any) {
+      showToast(`Failed to update visibility: ${err.message || err}`, "error");
+    }
+  };
+
+  const filteredCommands = useMemo(() => {
+    return commands.filter((cmd) => {
+      const matchSearch =
+        cmd.name.toLowerCase().includes(search.toLowerCase()) ||
+        (cmd.description || "").toLowerCase().includes(search.toLowerCase());
+      
+      const matchTab =
+        tab === "all" ||
+        (tab === "builtin" && cmd.source === "builtin") ||
+        (tab === "custom" && cmd.source === "custom");
+
+      return matchSearch && matchTab;
+    });
+  }, [commands, search, tab]);
+
+  return (
+    <div className="space-y-6">
+      {/* Search & Filter bar */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between bg-card/35 backdrop-blur-md border border-border p-4 rounded-xl shadow-sm">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search commands by name or description..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9 bg-background/50 border-border"
+          />
+        </div>
+        
+        <div className="flex items-center gap-1.5 bg-background/40 border border-border p-1 rounded-lg">
+          <Button
+            ghost={tab !== "all"}
+            size="sm"
+            onClick={() => setTab("all")}
+            className="text-xs"
+          >
+            All
+          </Button>
+          <Button
+            ghost={tab !== "builtin"}
+            size="sm"
+            onClick={() => setTab("builtin")}
+            className="text-xs"
+          >
+            Built-in
+          </Button>
+          <Button
+            ghost={tab !== "custom"}
+            size="sm"
+            onClick={() => setTab("custom")}
+            className="text-xs"
+          >
+            Custom
+          </Button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex h-[300px] flex-col items-center justify-center gap-4">
+          <Spinner className="text-2xl text-primary" />
+          <p className="text-sm text-muted-foreground">Loading commands configurations...</p>
+        </div>
+      ) : filteredCommands.length === 0 ? (
+        <Card className="border border-dashed border-border flex flex-col items-center justify-center p-12 bg-card/20 backdrop-blur-sm">
+          <Terminal className="h-10 w-10 text-muted-foreground/60 mb-3" />
+          <h3 className="font-semibold text-lg">No commands found</h3>
+          <p className="text-sm text-muted-foreground mt-1 max-w-xs text-center">
+            {search
+              ? "No commands match your search criteria. Try a different query."
+              : "No commands defined. Click 'Create Command' to register a custom command."}
+          </p>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {filteredCommands.map((cmd) => (
+            <Card
+              key={cmd.name}
+              className={`relative overflow-hidden transition-all duration-200 border bg-card/30 backdrop-blur-md hover:bg-card/45 hover:shadow-md ${
+                !cmd.enabled ? "opacity-60 border-destructive/20" : "border-border"
+              }`}
+            >
+              <CardHeader className="pb-3 flex flex-row items-start justify-between space-y-0">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-base font-bold text-foreground">
+                      /{cmd.name}
+                    </span>
+                    <Badge
+                      tone={cmd.source === "builtin" ? "secondary" : "default"}
+                      className="text-[10px] px-1.5 py-0"
+                    >
+                      {cmd.source === "builtin" ? "Built-in" : "Custom"}
+                    </Badge>
+                  </div>
+                  {cmd.source === "custom" && (
+                    <div className="text-[11px] text-muted-foreground font-mono">
+                      type: <span className="text-foreground">{cmd.type}</span>
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                  {cmd.source === "custom" ? (
+                    <>
+                      <Button
+                        ghost
+                        size="xs"
+                        onClick={() => handleOpenEdit(cmd)}
+                        className="p-1 hover:bg-foreground/5"
+                      >
+                        <Edit2 className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
+                      </Button>
+                      <Button
+                        ghost
+                        size="xs"
+                        onClick={() => handleDelete(cmd)}
+                        className="p-1 hover:bg-destructive/10"
+                      >
+                        <Trash2 className="h-3.5 w-3.5 text-destructive/80 hover:text-destructive" />
+                      </Button>
+                    </>
+                  ) : (
+                    <Switch
+                      checked={cmd.enabled}
+                      onCheckedChange={(checked) => handleToggleBuiltin(cmd, checked)}
+                      className="scale-90"
+                    />
+                  )}
+                </div>
+              </CardHeader>
+
+              <CardContent className="space-y-4">
+                <p className="text-xs text-muted-foreground leading-relaxed min-h-[32px]">
+                  {cmd.description || "No description provided."}
+                </p>
+
+                {cmd.source === "custom" && (
+                  <div className="bg-background/40 border border-border/60 p-2 rounded font-mono text-[10px] break-all max-h-[80px] overflow-y-auto">
+                    <span className="text-muted-foreground">
+                      {cmd.type === "exec" ? "$ " : "-> "}
+                    </span>
+                    <span className="text-foreground">{cmd.command}</span>
+                  </div>
+                )}
+
+                {/* Platform Visibility Row */}
+                <div className="pt-2 border-t border-border/50 flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[11px] text-muted-foreground font-medium flex items-center gap-1">
+                      <Eye className="h-3 w-3" /> Visibility
+                    </span>
+                    <div className="flex items-center gap-3">
+                      {["telegram", "discord", "cli"].map((p) => {
+                        const isVisible = cmd.visible?.[p] !== false;
+                        return (
+                          <div key={p} className="flex items-center gap-1">
+                            {cmd.source === "custom" ? (
+                              <Badge
+                                tone={isVisible ? "success" : "secondary"}
+                                className="text-[9px] px-1 py-0 capitalize"
+                              >
+                                {p}
+                              </Badge>
+                            ) : (
+                              <button
+                                onClick={() =>
+                                  handleToggleBuiltinVisibility(cmd, p, !isVisible)
+                                }
+                                className={`text-[10px] px-1.5 py-0.5 rounded capitalize border transition-all ${
+                                  isVisible
+                                    ? "bg-success/10 border-success/35 text-success font-medium"
+                                    : "bg-muted/15 border-muted-foreground/20 text-muted-foreground"
+                                }`}
+                              >
+                                {p}
+                              </button>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                  
+                  {cmd.source === "custom" && (
+                    <div className="flex items-center justify-between text-[11px]">
+                      <span className="text-muted-foreground">Status</span>
+                      <div className="flex items-center gap-2">
+                        <Switch
+                          checked={cmd.enabled}
+                          onCheckedChange={(checked) => {
+                            const payload = {
+                              name: cmd.name,
+                              description: cmd.description,
+                              type: cmd.type,
+                              command: cmd.command,
+                              enabled: checked,
+                              visible: cmd.visible,
+                              silent_empty: cmd.silent_empty,
+                            };
+                            api.upsertCustomCommand(payload, selectedProfile || undefined)
+                              .then(() => {
+                                setCommands((prev) =>
+                                  prev.map((c) => (c.name === cmd.name ? { ...c, enabled: checked } : c))
+                                );
+                                showToast(`Command /${cmd.name} ${checked ? "enabled" : "disabled"}`, "success");
+                              })
+                              .catch((err) => showToast(`Failed to toggle command: ${err}`, "error"));
+                          }}
+                          className="scale-75"
+                        />
+                        <span className={cmd.enabled ? "text-success font-medium" : "text-muted-foreground"}>
+                          {cmd.enabled ? "Enabled" : "Disabled"}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Editor Modal */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-md bg-card border border-border backdrop-blur-xl">
+          <DialogHeader>
+            <DialogTitle className="text-lg font-bold flex items-center gap-2">
+              <Terminal className="h-5 w-5 text-primary" />
+              {editingCommand ? "Edit Custom Command" : "Create Custom Command"}
+            </DialogTitle>
+            <DialogDescription className="text-xs">
+              Define a custom slash command running a local shell script or redirecting to another command.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleSave} className="space-y-4 pt-2">
+            <div className="grid gap-1">
+              <Label htmlFor="cmd-name" className="text-xs font-semibold">
+                Name
+              </Label>
+              <div className="relative">
+                <span className="absolute left-3 top-2.5 text-xs text-muted-foreground font-mono">
+                  /
+                </span>
+                <Input
+                  id="cmd-name"
+                  placeholder="e.g. status-check"
+                  value={name}
+                  onChange={(e) => setName(e.target.value.toLowerCase().replace(/\s+/g, ""))}
+                  disabled={!!editingCommand}
+                  className="pl-6 bg-background/40 border-border text-xs font-mono"
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-1">
+              <Label htmlFor="cmd-desc" className="text-xs font-semibold">
+                Description
+              </Label>
+              <Input
+                id="cmd-desc"
+                placeholder="A short description of what this command does"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                className="bg-background/40 border-border text-xs"
+              />
+            </div>
+
+            <div className="grid gap-1">
+              <Label htmlFor="cmd-type" className="text-xs font-semibold">
+                Type
+              </Label>
+              <Select
+                id="cmd-type"
+                value={type}
+                onValueChange={(val) => setType(val as "exec" | "alias")}
+              >
+                <SelectOption value="exec">Exec (Shell Subprocess)</SelectOption>
+                <SelectOption value="alias">Alias (Redirect command)</SelectOption>
+              </Select>
+            </div>
+
+            {type === "exec" ? (
+              <div className="space-y-2">
+                <div className="grid gap-1">
+                  <Label htmlFor="cmd-shell" className="text-xs font-semibold">
+                    Shell Command
+                  </Label>
+                  <textarea
+                    id="cmd-shell"
+                    placeholder="e.g. echo 'CPU Usage:' && top -b -n 1 | grep Cpu"
+                    value={commandText}
+                    onChange={(e) => setCommandText(e.target.value)}
+                    className="min-h-[80px] w-full border border-border bg-background/30 rounded-lg p-2.5 font-mono text-[11px] leading-relaxed shadow-sm focus:outline-none focus:ring-1 focus:ring-primary"
+                  />
+                </div>
+                <div className="flex items-center justify-between text-xs pt-1">
+                  <div className="flex flex-col gap-0.5">
+                    <span className="font-medium text-foreground">Silent on Empty Output</span>
+                    <span className="text-[10px] text-muted-foreground">If the command returns no output, don't send any reply.</span>
+                  </div>
+                  <Switch
+                    checked={silentEmpty}
+                    onCheckedChange={setSilentEmpty}
+                    className="scale-75"
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className="grid gap-1">
+                <Label htmlFor="cmd-target" className="text-xs font-semibold">
+                  Target Command
+                </Label>
+                <div className="relative">
+                  <span className="absolute left-3 top-2.5 text-xs text-muted-foreground font-mono">
+                    /
+                  </span>
+                  <Input
+                    id="cmd-target"
+                    placeholder="e.g. status"
+                    value={targetText}
+                    onChange={(e) => setTargetText(e.target.value)}
+                    className="pl-6 bg-background/40 border-border text-xs font-mono"
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* Platform checkboxes */}
+            <div className="pt-2 border-t border-border/40">
+              <Label className="text-xs font-semibold mb-2 block">Platform Visibility</Label>
+              <div className="grid grid-cols-3 gap-2">
+                <label className="flex items-center gap-2 p-2 rounded-lg border border-border bg-background/20 cursor-pointer select-none hover:bg-background/40">
+                  <input
+                    type="checkbox"
+                    checked={visTelegram}
+                    onChange={(e) => setVisTelegram(e.target.checked)}
+                    className="rounded border-border text-primary focus:ring-0 focus:ring-offset-0"
+                  />
+                  <span className="text-xs capitalize">Telegram</span>
+                </label>
+                <label className="flex items-center gap-2 p-2 rounded-lg border border-border bg-background/20 cursor-pointer select-none hover:bg-background/40">
+                  <input
+                    type="checkbox"
+                    checked={visDiscord}
+                    onChange={(e) => setVisDiscord(e.target.checked)}
+                    className="rounded border-border text-primary focus:ring-0 focus:ring-offset-0"
+                  />
+                  <span className="text-xs capitalize">Discord</span>
+                </label>
+                <label className="flex items-center gap-2 p-2 rounded-lg border border-border bg-background/20 cursor-pointer select-none hover:bg-background/40">
+                  <input
+                    type="checkbox"
+                    checked={visCli}
+                    onChange={(e) => setVisCli(e.target.checked)}
+                    className="rounded border-border text-primary focus:ring-0 focus:ring-offset-0"
+                  />
+                  <span className="text-xs capitalize">CLI</span>
+                </label>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2 pt-2">
+              <Switch
+                checked={enabled}
+                onCheckedChange={setEnabled}
+                className="scale-75"
+              />
+              <span className="text-xs text-muted-foreground">Enabled</span>
+            </div>
+
+            {formError && (
+              <div className="flex items-center gap-1.5 p-2 rounded bg-destructive/10 border border-destructive/25 text-destructive text-xs">
+                <AlertCircle className="h-4 w-4 shrink-0" />
+                <span>{formError}</span>
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                outlined
+                size="sm"
+                onClick={() => setDialogOpen(false)}
+                type="button"
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                type="submit"
+                disabled={saving}
+              >
+                {saving ? "Saving..." : "Save Command"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/web/src/pages/CommandsPage.tsx
+++ b/web/src/pages/CommandsPage.tsx
@@ -452,7 +452,10 @@ export default function CommandsPage() {
                                 );
                                 showToast(`Command /${cmd.name} ${checked ? "enabled" : "disabled"}`, "success");
                               })
-                              .catch((err) => showToast(`Failed to toggle command: ${err}`, "error"));
+                              .catch((err: unknown) => {
+                                const msg = err instanceof Error ? err.message : String(err);
+                                showToast(`Failed to toggle command: ${msg}`, "error");
+                              });
                           }}
                           className="scale-75"
                         />

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -257,6 +257,7 @@ export default function ProfilesPage() {
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
   const [activeInfo, setActiveInfo] = useState<ActiveProfileInfo | null>(null);
   const [loading, setLoading] = useState(true);
+  const [busyGateways, setBusyGateways] = useState<Record<string, boolean>>({});
   const { toast, showToast } = useToast();
   const { t } = useI18n();
   const { setEnd } = usePageHeader();
@@ -509,6 +510,24 @@ export default function ProfilesPage() {
       showToast(`${t.status.error}: ${e}`, "error");
     } finally {
       setSettingActive(null);
+    }
+  };
+
+  const handleToggleGateway = async (name: string, verb: "start" | "stop") => {
+    setBusyGateways((prev) => ({ ...prev, [name]: true }));
+    try {
+      if (verb === "start") {
+        await api.startGateway(name);
+      } else {
+        await api.stopGateway(name);
+      }
+      showToast(`Gateway ${verb}ed for profile '${name}'`, "success");
+      // Give the backend a second to update status, then reload
+      setTimeout(load, 1500);
+    } catch (e) {
+      showToast(`Failed to ${verb} gateway for '${name}': ${e}`, "error");
+    } finally {
+      setBusyGateways((prev) => ({ ...prev, [name]: false }));
     }
   };
 
@@ -1162,27 +1181,58 @@ export default function ProfilesPage() {
                         />
                       </div>
 
-                      <div className="flex items-center gap-1.5 text-xs">
-                        <span
-                          className={cn(
-                            "h-1.5 w-1.5 rounded-full",
-                            p.gateway_running
-                              ? "bg-success"
-                              : "bg-muted-foreground/40",
-                          )}
-                        />
+                      <div className="flex items-center justify-between text-xs pt-1">
+                        <div className="flex items-center gap-1.5">
+                          <span
+                            className={cn(
+                              "h-1.5 w-1.5 rounded-full",
+                              p.gateway_running
+                                ? "bg-success"
+                                : "bg-muted-foreground/40",
+                            )}
+                          />
 
-                        <span
-                          className={cn(
-                            p.gateway_running
-                              ? "text-success"
-                              : "text-muted-foreground",
+                          <span
+                            className={cn(
+                              p.gateway_running
+                                ? "text-success"
+                                : "text-muted-foreground",
+                            )}
+                          >
+                            {p.gateway_running
+                              ? L.gatewayRunning
+                              : L.gatewayStopped}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          {p.gateway_running ? (
+                            <Button
+                              size="xs"
+                              outlined
+                              className="text-warning h-5 py-0 px-2 text-[10px] uppercase font-semibold"
+                              disabled={busyGateways[p.name]}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleToggleGateway(p.name, "stop");
+                              }}
+                            >
+                              {busyGateways[p.name] ? "Stopping" : "Stop"}
+                            </Button>
+                          ) : (
+                            <Button
+                              size="xs"
+                              outlined
+                              className="text-success h-5 py-0 px-2 text-[10px] uppercase font-semibold"
+                              disabled={busyGateways[p.name]}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleToggleGateway(p.name, "start");
+                              }}
+                            >
+                              {busyGateways[p.name] ? "Starting" : "Start"}
+                            </Button>
                           )}
-                        >
-                          {p.gateway_running
-                            ? L.gatewayRunning
-                            : L.gatewayStopped}
-                        </span>
+                        </div>
                       </div>
 
                       <div className="flex items-start gap-2 text-xs">


### PR DESCRIPTION
Adds a complete command management system to Hermes with dashboard UI, backend API, and per-platform visibility control.

## Changes

**Backend (hermes_cli/):**
- Unified 'commands' config schema replacing the dual 'commands' + 'quick_commands' sections
- New config dataclass: CommandConfig with enabled, visible.per-platform, description, type, command
- Backward-compat migration from quick_commands to commands.custom on config load
- New API endpoints:
  - GET /api/commands — list all commands (builtin + custom) with config
  - POST /api/commands/custom — create/update a custom command
  - DELETE /api/commands/custom/{name} — delete a custom command
  - POST /api/commands/builtin/{name} — update built-in visibility
  - GET /api/commands/platform/{platform} — platform-specific list
  - POST /api/commands/sync — trigger re-registration without gateway restart

**Frontend (web/src/):**
- New CommandsPage component (modeled after SkillsPage)
- Profile switcher support via ?profile= query param
- Cards for built-in and custom commands with enable/disable toggle
- Per-platform visibility checkboxes (Telegram, Discord, CLI)
- 'Add Command' modal with name, description, command textarea
- Edit/Delete controls for custom commands
- 'Sync to Platforms' button for push without restart

**Gateway (gateway/run.py):**
- Updated command dispatcher to check commands.custom.<name>.enabled
- Backward compat: still checks quick_commands as fallback

Tested on Linux.