### PR TITLE
feat(sync): support bidirectional platform command sync (Issue #4)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8847,6 +8847,49 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         self._console_print(f"[bold red]Quick command '{base_cmd}' has no target defined[/]")
                 else:
                     self._console_print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
+            # Check for commands.custom entries (new command store) with visible.cli
+            elif base_cmd.lstrip("/") in self.config.get("commands", {}).get("custom", {}):
+                cmd_name = base_cmd.lstrip("/")
+                cmds_custom = self.config.get("commands", {}).get("custom", {})
+                qcmd = cmds_custom[cmd_name]
+                if not qcmd.get("visible", {}).get("cli", True):
+                    pass  # not visible on CLI — fall through
+                else:
+                    if qcmd.get("type") == "exec":
+                        import subprocess
+                        exec_cmd = qcmd.get("command", "")
+                        if exec_cmd:
+                            try:
+                                from tools.environments.local import _sanitize_subprocess_env
+                                sanitized_env = _sanitize_subprocess_env(os.environ.copy())
+                                result = subprocess.run(
+                                    exec_cmd, shell=True, capture_output=True,
+                                    text=True, timeout=30, env=sanitized_env
+                                )
+                                output = result.stdout.strip() or result.stderr.strip()
+                                if output:
+                                    from agent.redact import redact_sensitive_text
+                                    output = redact_sensitive_text(output)
+                                    self._console_print(_rich_text_from_ansi(output))
+                                else:
+                                    self._console_print("[dim]Command returned no output[/]")
+                            except subprocess.TimeoutExpired:
+                                self._console_print("[bold red]Quick command timed out (30s)[/]")
+                            except Exception as e:
+                                self._console_print(f"[bold red]Quick command error: {e}[/]")
+                        else:
+                            self._console_print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
+                    elif qcmd.get("type") == "alias":
+                        target = qcmd.get("target", "").strip()
+                        if target:
+                            target = target if target.startswith("/") else f"/{target}"
+                            user_args = cmd_original[len(base_cmd):].strip()
+                            aliased_command = f"{target} {user_args}".strip()
+                            return self.process_command(aliased_command)
+                        else:
+                            self._console_print(f"[bold red]Quick command '{base_cmd}' has no target defined[/]")
+                    else:
+                        self._console_print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
             # Check for plugin-registered slash commands
             elif base_cmd.lstrip("/") in _get_plugin_cmd_handler_names():
                 from hermes_cli.plugins import (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8843,10 +8843,58 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _quick_key, _pending_confirm.get("confirm_id"), _confirm_choice,
                 )
                 return _resolved or ""
-            # Stale pending + unrelated command: drop the pending state so
-            # the confirm doesn't block normal usage indefinitely.  The user
-            # clearly moved on.
             _slash_confirm_mod.clear_if_stale(_quick_key)
+
+        # Early check if the slash command is disabled for this profile
+        command = event.get_command()
+        if command:
+            from hermes_cli.commands import (
+                resolve_command as _resolve_cmd_early,
+                is_gateway_known_command,
+            )
+            try:
+                _cmd_def_early = _resolve_cmd_early(command)
+                _canonical_early = _cmd_def_early.name if _cmd_def_early else command
+            except Exception:
+                _cmd_def_early = None
+                _canonical_early = command
+
+            # Resolve config for this source under the correct profile
+            profile_home = self._resolve_profile_home_for_source(source)
+            try:
+                with _profile_runtime_scope(profile_home):
+                    from hermes_cli.config import load_config_readonly as _load_cfg
+                    active_cfg = _load_cfg()
+            except Exception:
+                active_cfg = self.config
+
+            cmd_config = active_cfg.get("commands", {}) or {}
+            if not isinstance(cmd_config, dict):
+                cmd_config = {}
+
+            # Check built-in commands
+            if _canonical_early and is_gateway_known_command(_canonical_early):
+                builtin_cfg = cmd_config.get("builtin", {}) or {}
+                if isinstance(builtin_cfg, dict) and _canonical_early in builtin_cfg:
+                    b_cmd = builtin_cfg[_canonical_early]
+                    if isinstance(b_cmd, dict) and not b_cmd.get("enabled", True):
+                        return f"Command '/{command}' is disabled."
+            else:
+                # Check custom commands
+                custom_cfg = cmd_config.get("custom", {}) or {}
+                # Backward compat: also check quick_commands
+                quick_cfg = active_cfg.get("quick_commands", {}) or {}
+                if not isinstance(quick_cfg, dict):
+                    quick_cfg = {}
+
+                if isinstance(custom_cfg, dict) and command in custom_cfg:
+                    c_cmd = custom_cfg[command]
+                    if isinstance(c_cmd, dict) and not c_cmd.get("enabled", True):
+                        return f"Command '/{command}' is disabled."
+                elif command in quick_cfg:
+                    # quick_commands alias/exec - check if we can execute
+                    # quick_commands don't have disabled flags unless migrated, which is handled above
+                    pass
 
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
@@ -9668,15 +9716,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 
-        # User-defined quick commands (bypass agent loop, no LLM call)
+        # User-defined custom / quick commands (bypass agent loop, no LLM call)
         if command:
-            if isinstance(self.config, dict):
-                quick_commands = self.config.get("quick_commands", {}) or {}
-            else:
-                quick_commands = getattr(self.config, "quick_commands", {}) or {}
+            # Load active config scoped to this source's profile
+            profile_home = self._resolve_profile_home_for_source(source)
+            try:
+                with _profile_runtime_scope(profile_home):
+                    from hermes_cli.config import load_config_readonly as _load_cfg
+                    active_cfg = _load_cfg()
+            except Exception:
+                active_cfg = self.config
+
+            cmd_config = active_cfg.get("commands", {}) or {}
+            custom_cmds = cmd_config.get("custom", {}) if isinstance(cmd_config, dict) else {}
+            if not isinstance(custom_cmds, dict):
+                custom_cmds = {}
+            # Backward compat: also check quick_commands
+            quick_commands = active_cfg.get("quick_commands", {}) or {}
             if not isinstance(quick_commands, dict):
                 quick_commands = {}
-            if command in quick_commands:
+
+            if command in custom_cmds:
                 # Quick commands are slash capabilities too — and type:exec
                 # ones run a shell command in the gateway process. The early
                 # gate above only fires for registry-known commands, so quick
@@ -9687,7 +9747,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _denied = self._check_slash_access(source, command)
                 if _denied is not None:
                     return _denied
-                qcmd = quick_commands[command]
+                qcmd = custom_cmds[command]
+                if not isinstance(qcmd, dict) or not qcmd.get("enabled", True):
+                    return f"Command '/{command}' is disabled."
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
@@ -9709,7 +9771,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             if output:
                                 from agent.redact import redact_sensitive_text
                                 output = redact_sensitive_text(output)
-                            return output if output else "Command returned no output."
+                            if not output:
+                                return "" if qcmd.get("silent_empty") else "Command returned no output."
+                            return output
                         except asyncio.TimeoutError:
                             return "Quick command timed out (30s)."
                         except Exception as e:
@@ -9725,6 +9789,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         event.text = f"{target} {user_args}".strip()
                         command = target_command.split()[0] if target_command else target_command
                         # Fall through to normal command dispatch below
+                    else:
+                        return f"Quick command '/{command}' has no target defined."
+                else:
+                    return f"Quick command '/{command}' has unsupported type (supported: 'exec', 'alias')."
+
+            elif command in quick_commands:
+                _denied = self._check_slash_access(source, command)
+                if _denied is not None:
+                    return _denied
+                qcmd = quick_commands[command]
+                if qcmd.get("type") == "exec":
+                    exec_cmd = qcmd.get("command", "")
+                    if exec_cmd:
+                        try:
+                            from tools.environments.local import _sanitize_subprocess_env
+                            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
+                            proc = await asyncio.create_subprocess_shell(
+                                exec_cmd,
+                                stdout=asyncio.subprocess.PIPE,
+                                stderr=asyncio.subprocess.PIPE,
+                                env=sanitized_env,
+                            )
+                            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+                            output = (stdout or stderr).decode().strip()
+                            if output:
+                                from agent.redact import redact_sensitive_text
+                                output = redact_sensitive_text(output)
+                            return output if output else "Command returned no output."
+                        except asyncio.TimeoutError:
+                            return "Quick command timed out (30s)."
+                        except Exception as e:
+                            return f"Quick command error: {e}"
+                    else:
+                        return f"Quick command '/{command}' has no command defined."
+                elif qcmd.get("type") == "alias":
+                    target = qcmd.get("target", "").strip()
+                    if target:
+                        target = target if target.startswith("/") else f"/{target}"
+                        target_command = target.lstrip("/")
+                        user_args = event.get_command_args().strip()
+                        event.text = f"{target} {user_args}".strip()
+                        command = target_command.split()[0] if target_command else target_command
                     else:
                         return f"Quick command '/{command}' has no target defined."
                 else:
@@ -19872,6 +19978,19 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 logger.debug("spawn_async_diagnostic failed: %s", _e)
         asyncio.create_task(runner.stop())
 
+    async def _async_sync_all_commands():
+        for name, adapter in list(runner.adapters.items()):
+            try:
+                if name.value == "telegram" and hasattr(adapter, "_run_post_connect_housekeeping"):
+                    await adapter._run_post_connect_housekeeping()
+                elif name.value == "discord" and hasattr(adapter, "_safe_sync_slash_commands"):
+                    await adapter._safe_sync_slash_commands()
+            except Exception as e:
+                logger.error("Failed to sync commands for platform %s: %s", name, e)
+
+    def sync_signal_handler():
+        asyncio.create_task(_async_sync_all_commands())
+
     def restart_signal_handler():
         runner.request_restart(detached=False, via_service=True)
     
@@ -19900,6 +20019,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         if hasattr(signal, "SIGUSR1"):
             try:
                 loop.add_signal_handler(signal.SIGUSR1, restart_signal_handler)  # windows-footgun: ok — POSIX signal, guarded by hasattr above + try/except NotImplementedError
+            except NotImplementedError:
+                pass
+        if hasattr(signal, "SIGUSR2"):
+            try:
+                loop.add_signal_handler(signal.SIGUSR2, sync_signal_handler)
             except NotImplementedError:
                 pass
     else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9362,6 +9362,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         command = target_command.split()[0] if target_command else target_command
                         _cmd_def = _resolve_cmd(command) if command else None
                         canonical = _cmd_def.name if _cmd_def else command
+            # Also check commands.custom for alias expansion (new command store)
+            if _cmd_def is None and command:
+                if isinstance(self.config, dict):
+                    custom_cmds = self.config.get("commands", {}).get("custom", {}) or {}
+                else:
+                    custom_cmds = getattr(getattr(self.config, "commands", {}), "custom", {}) or {}
+                if isinstance(custom_cmds, dict) and command in custom_cmds:
+                    qcmd = custom_cmds[command]
+                    if isinstance(qcmd, dict) and qcmd.get("type") == "alias":
+                        target = qcmd.get("target", "").strip()
+                        if target:
+                            target = target if target.startswith("/") else f"/{target}"
+                            target_command = target.lstrip("/")
+                            user_args = event.get_command_args().strip()
+                            event.text = f"{target} {user_args}".strip()
+                            command = target_command.split()[0] if target_command else target_command
+                            _cmd_def = _resolve_cmd(command) if command else None
+                            canonical = _cmd_def.name if _cmd_def else command
 
         # Per-platform slash command access control. Only kicks in when the
         # operator has set ``allow_admin_from`` for the source's scope (DM

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -523,23 +523,61 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     Plugin-registered slash commands that require arguments are **excluded**
     because plugins may not provide a no-arg usage fallback.
     """
+    try:
+        from hermes_cli.config import load_config_readonly as _load_cfg
+        cfg = _load_cfg()
+    except Exception:
+        cfg = {}
+
+    cmd_config = cfg.get("commands", {}) or {}
+    if not isinstance(cmd_config, dict):
+        cmd_config = {}
+
+    builtin_cfg = cmd_config.get("builtin", {}) or {}
+    custom_cmds = cmd_config.get("custom", {}) or {}
+
     overrides = _resolve_config_gates()
     result: list[tuple[str, str]] = []
+
+    # 1. Built-in commands
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
+
+        # Check enabled & visible status
+        override = builtin_cfg.get(cmd.name, {}) or {}
+        if not override.get("enabled", True):
+            continue
+        if not override.get("visible", {}).get("telegram", True):
+            continue
+
         # Built-in arg-taking commands are included — their handlers show
         # usage text when invoked without arguments, and hiding them from
         # the menu hurts discoverability (issue #24312).
         tg_name = _sanitize_telegram_name(cmd.name)
         if tg_name:
             result.append((tg_name, cmd.description))
+
+    # 2. Plugin commands
     for name, description, args_hint in _iter_plugin_command_entries():
         if _requires_argument(args_hint):
             continue
         tg_name = _sanitize_telegram_name(name)
         if tg_name:
             result.append((tg_name, description))
+
+    # 3. Custom commands
+    for name, cmd in custom_cmds.items():
+        if not isinstance(cmd, dict):
+            continue
+        if not cmd.get("enabled", True):
+            continue
+        if not cmd.get("visible", {}).get("telegram", True):
+            continue
+        tg_name = _sanitize_telegram_name(name)
+        if tg_name:
+            result.append((tg_name, cmd.get("description", "") or f"Custom command /{name}"))
+
     return result
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -25,7 +25,7 @@ import sys
 import tempfile
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple, Set
 
@@ -2441,6 +2441,11 @@ DEFAULT_CONFIG = {
     "command_allowlist": [],
     # User-defined quick commands that bypass the agent loop (type: exec only)
     "quick_commands": {},
+    # Unified command management system
+    "commands": {
+        "builtin": {},  # overrides for built-in commands (enabled/visible per platform)
+        "custom": {},   # user-defined commands (replaces quick_commands)
+    },
 
     # Per-platform system-prompt hint overrides. Lets an admin append to or
     # replace Hermes' built-in platform hint for a single messaging platform
@@ -3128,7 +3133,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 33,
+    "_config_version": 34,
 }
 
 # =============================================================================
@@ -4989,7 +4994,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "moa", "custom_providers", "context", "memory", "gateway",
-    "sessions", "streaming", "updates", "mcp_servers",
+    "sessions", "streaming", "updates", "mcp_servers", "commands", "quick_commands",
 }
 
 # Valid fields inside a custom_providers list entry
@@ -5004,6 +5009,17 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
 
 # Fields that look like they should be inside custom_providers, not at root
 _CUSTOM_PROVIDER_LIKE_FIELDS = {"base_url", "api_key", "rate_limit_delay", "api_mode"}
+
+
+@dataclass
+class CommandConfig:
+    """Per-profile command configuration."""
+    description: str = ""
+    type: str = "exec"  # "exec" or future "builtin-override"
+    command: str = ""
+    enabled: bool = True
+    visible: Dict[str, bool] = field(default_factory=dict)  # platform -> bool
+    silent_empty: bool = False
 
 
 @dataclass
@@ -5822,6 +5838,65 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                     "delegation.max_concurrent_children now caps background "
                     "delegations too."
                 )
+
+    # ── Version 33 → 34: unify commands and quick_commands into commands.custom ──
+    if current_ver < 34:
+        config = read_raw_config()
+        touched = False
+        cmds = config.get("commands", {}) or {}
+        if not isinstance(cmds, dict) or "custom" not in cmds or "builtin" not in cmds:
+            # Let's rebuild cmds as dict
+            cmds = {"builtin": {}, "custom": {}}
+        else:
+            cmds = copy.deepcopy(cmds)
+        custom = cmds.setdefault("custom", {}) or {}
+
+        # Migrate quick_commands
+        quick = config.get("quick_commands")
+        if isinstance(quick, dict) and quick:
+            for name, cmd in quick.items():
+                if name not in custom:
+                    if isinstance(cmd, dict):
+                        custom[name] = copy.deepcopy(cmd)
+                    else:
+                        custom[name] = {
+                            "description": f"Quick command: {name}",
+                            "type": "exec",
+                            "command": str(cmd),
+                            "enabled": True,
+                            "visible": {"telegram": True, "discord": True, "cli": True},
+                            "silent_empty": True
+                        }
+            config.pop("quick_commands", None)
+            touched = True
+
+        # Migrate old flat commands if any
+        # Check original 'commands' section in raw config:
+        raw_cmds = config.get("commands")
+        if isinstance(raw_cmds, dict) and "custom" not in raw_cmds and "builtin" not in raw_cmds:
+            for name, cmd in raw_cmds.items():
+                if name not in custom:
+                    if isinstance(cmd, dict):
+                        custom[name] = copy.deepcopy(cmd)
+                    else:
+                        custom[name] = {
+                            "description": f"Custom command: {name}",
+                            "type": "exec",
+                            "command": str(cmd),
+                            "enabled": True,
+                            "visible": {"telegram": True, "discord": True, "cli": True},
+                            "silent_empty": True
+                        }
+            cmds["custom"] = custom
+            cmds["builtin"] = {}
+            touched = True
+
+        if touched:
+            config["commands"] = cmds
+            _persist_migration(config)
+            results["config_added"].append("commands.custom (migrated from quick_commands/commands)")
+            if not quiet:
+                print("  ✓ Migrated legacy quick_commands and commands into commands.custom")
 
     # ── Post-migration: disable exfiltration-shaped MCP stdio entries ──
     # Users can hand-edit mcp_servers, and older installs may already contain a
@@ -6646,6 +6721,53 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                         agent_user_config["max_turns"] = user_config["max_turns"]
                     user_config["agent"] = agent_user_config
                     user_config.pop("max_turns", None)
+
+                # Normalize legacy quick_commands and commands in user_config before deep merge
+                if isinstance(user_config, dict):
+                    # (1) Migrate quick_commands
+                    quick = user_config.get("quick_commands")
+                    if isinstance(quick, dict) and quick:
+                        user_cmds = user_config.setdefault("commands", {}) or {}
+                        if not isinstance(user_cmds, dict) or "custom" not in user_cmds or "builtin" not in user_cmds:
+                            user_cmds = {"builtin": {}, "custom": {}}
+                        else:
+                            user_cmds = copy.deepcopy(user_cmds)
+                        user_custom = user_cmds.setdefault("custom", {}) or {}
+                        for name, cmd in quick.items():
+                            if name not in user_custom:
+                                if isinstance(cmd, dict):
+                                    user_custom[name] = copy.deepcopy(cmd)
+                                else:
+                                    user_custom[name] = {
+                                        "description": f"Quick command: {name}",
+                                        "type": "exec",
+                                        "command": str(cmd),
+                                        "enabled": True,
+                                        "visible": {"telegram": True, "discord": True, "cli": True},
+                                        "silent_empty": True
+                                    }
+                        user_cmds["custom"] = user_custom
+                        user_config["commands"] = user_cmds
+
+                    # (2) Migrate legacy flat commands
+                    raw_cmds = user_config.get("commands")
+                    if isinstance(raw_cmds, dict) and "custom" not in raw_cmds and "builtin" not in raw_cmds:
+                        user_cmds = {"builtin": {}, "custom": {}}
+                        user_custom = {}
+                        for name, cmd in raw_cmds.items():
+                            if isinstance(cmd, dict):
+                                user_custom[name] = copy.deepcopy(cmd)
+                            else:
+                                user_custom[name] = {
+                                    "description": f"Custom command: {name}",
+                                    "type": "exec",
+                                    "command": str(cmd),
+                                    "enabled": True,
+                                    "visible": {"telegram": True, "discord": True, "cli": True},
+                                    "silent_empty": True
+                                }
+                        user_cmds["custom"] = user_custom
+                        user_config["commands"] = user_cmds
 
                 config = _deep_merge(config, user_config)
             except Exception as e:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9777,6 +9777,276 @@ async def remove_credential_pool_entry(provider: str, index: int):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Command management endpoints — list / add / delete / update / sync
+# ---------------------------------------------------------------------------
+
+
+class CustomCommandInput(BaseModel):
+    name: str
+    description: str = ""
+    type: str = "exec"
+    command: str = ""
+    enabled: bool = True
+    visible: Dict[str, bool] = {}
+    silent_empty: bool = False
+
+
+class BuiltinCommandUpdate(BaseModel):
+    enabled: Optional[bool] = None
+    visible: Optional[Dict[str, bool]] = None
+
+
+@app.get("/api/commands")
+async def list_commands(profile: Optional[str] = None):
+    import copy
+    from hermes_cli.commands import COMMAND_REGISTRY
+    with _profile_scope(profile):
+        cfg = load_config()
+
+    cmd_config = cfg.get("commands", {}) or {}
+    if not isinstance(cmd_config, dict):
+        cmd_config = {}
+
+    builtin_overrides = cmd_config.get("builtin", {}) or {}
+    custom_cmds = cmd_config.get("custom", {}) or {}
+
+    # Backward compat: also include quick_commands
+    quick_cmds = cfg.get("quick_commands", {}) or {}
+
+    # 1. Collect all custom commands (both custom section and quick_commands)
+    custom_list = []
+    processed_custom = set()
+
+    if isinstance(custom_cmds, dict):
+        for name, cmd in custom_cmds.items():
+            if not isinstance(cmd, dict):
+                continue
+            processed_custom.add(name)
+            custom_list.append({
+                "name": name,
+                "description": cmd.get("description", ""),
+                "type": cmd.get("type", "exec"),
+                "command": cmd.get("command", ""),
+                "enabled": cmd.get("enabled", True),
+                "visible": cmd.get("visible", {"telegram": True, "discord": True, "cli": True}),
+                "silent_empty": cmd.get("silent_empty", False),
+                "source": "custom"
+            })
+
+    if isinstance(quick_cmds, dict):
+        for name, cmd in quick_cmds.items():
+            if name in processed_custom:
+                continue
+            if isinstance(cmd, dict):
+                custom_list.append({
+                    "name": name,
+                    "description": cmd.get("description", f"Quick command: {name}"),
+                    "type": cmd.get("type", "exec"),
+                    "command": cmd.get("command", ""),
+                    "enabled": cmd.get("enabled", True),
+                    "visible": cmd.get("visible", {"telegram": True, "discord": True, "cli": True}),
+                    "silent_empty": cmd.get("silent_empty", False),
+                    "source": "custom"
+                })
+            else:
+                custom_list.append({
+                    "name": name,
+                    "description": f"Quick command: {name}",
+                    "type": "exec",
+                    "command": str(cmd),
+                    "enabled": True,
+                    "visible": {"telegram": True, "discord": True, "cli": True},
+                    "silent_empty": True,
+                    "source": "custom"
+                })
+
+    # 2. Collect all built-in commands (filtering out cli_only=True)
+    builtin_list = []
+    for cmd in COMMAND_REGISTRY:
+        if cmd.cli_only:
+            continue
+        override = builtin_overrides.get(cmd.name, {}) or {}
+        default_visible = {"telegram": True, "discord": True, "cli": True}
+        builtin_list.append({
+            "name": cmd.name,
+            "description": cmd.description,
+            "type": "builtin",
+            "command": "",
+            "enabled": override.get("enabled", True),
+            "visible": override.get("visible", default_visible),
+            "silent_empty": False,
+            "source": "builtin"
+        })
+
+    return builtin_list + custom_list
+
+
+@app.post("/api/commands/custom")
+async def upsert_custom_command(body: CustomCommandInput, profile: Optional[str] = None):
+    import copy
+    import re
+    if not body.name or not re.match(r"^[a-zA-Z0-9_-]+$", body.name):
+        raise HTTPException(status_code=400, detail="Invalid command name")
+
+    with _profile_scope(profile):
+        cfg = load_config()
+        cmds = cfg.get("commands", {}) or {}
+        if not isinstance(cmds, dict) or "custom" not in cmds or "builtin" not in cmds:
+            cmds = {"builtin": {}, "custom": {}}
+        else:
+            cmds = copy.deepcopy(cmds)
+        custom = cmds.setdefault("custom", {}) or {}
+
+        visible = {
+            "telegram": bool(body.visible.get("telegram", True)),
+            "discord": bool(body.visible.get("discord", True)),
+            "cli": bool(body.visible.get("cli", True)),
+        }
+
+        custom[body.name] = {
+            "description": body.description,
+            "type": body.type,
+            "command": body.command,
+            "enabled": body.enabled,
+            "visible": visible,
+            "silent_empty": body.silent_empty,
+        }
+
+        cmds["custom"] = custom
+        cfg["commands"] = cmds
+
+        if "quick_commands" in cfg and isinstance(cfg["quick_commands"], dict):
+            cfg["quick_commands"].pop(body.name, None)
+
+        save_config(cfg)
+    return {"ok": True}
+
+
+@app.delete("/api/commands/custom/{name}")
+async def delete_custom_command(name: str, profile: Optional[str] = None):
+    with _profile_scope(profile):
+        cfg = load_config()
+        cmds = cfg.get("commands", {}) or {}
+        if not isinstance(cmds, dict):
+            cmds = {}
+        custom = cmds.get("custom", {}) or {}
+        if not isinstance(custom, dict):
+            custom = {}
+
+        deleted = False
+        if name in custom:
+            custom.pop(name)
+            cmds["custom"] = custom
+            cfg["commands"] = cmds
+            deleted = True
+
+        if "quick_commands" in cfg and isinstance(cfg["quick_commands"], dict) and name in cfg["quick_commands"]:
+            cfg["quick_commands"].pop(name)
+            deleted = True
+
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Command not found")
+
+        save_config(cfg)
+    return {"ok": True}
+
+
+@app.post("/api/commands/builtin/{name}")
+async def update_builtin_command(name: str, body: BuiltinCommandUpdate, profile: Optional[str] = None):
+    import copy
+    from hermes_cli.commands import resolve_command
+    try:
+        resolve_command(name)
+    except Exception:
+        raise HTTPException(status_code=404, detail="Built-in command not found")
+
+    with _profile_scope(profile):
+        cfg = load_config()
+        cmds = cfg.get("commands", {}) or {}
+        if not isinstance(cmds, dict) or "custom" not in cmds or "builtin" not in cmds:
+            cmds = {"builtin": {}, "custom": {}}
+        else:
+            cmds = copy.deepcopy(cmds)
+        builtin = cmds.setdefault("builtin", {}) or {}
+
+        override = builtin.setdefault(name, {}) or {}
+        if not isinstance(override, dict):
+            override = {}
+
+        if body.enabled is not None:
+            override["enabled"] = body.enabled
+        if body.visible is not None:
+            vis = override.setdefault("visible", {"telegram": True, "discord": True, "cli": True}) or {}
+            for k, v in body.visible.items():
+                vis[k] = bool(v)
+            override["visible"] = vis
+
+        builtin[name] = override
+        cmds["builtin"] = builtin
+        cfg["commands"] = cmds
+        save_config(cfg)
+    return {"ok": True}
+
+
+@app.get("/api/commands/platform/{platform}")
+async def get_platform_commands(platform: str, profile: Optional[str] = None):
+    platform = platform.lower().strip()
+    if platform not in {"telegram", "discord", "cli"}:
+        raise HTTPException(status_code=400, detail="Invalid platform")
+
+    all_cmds = await list_commands(profile=profile)
+    visible_cmds = []
+    for cmd in all_cmds:
+        if cmd.get("visible", {}).get(platform, True):
+            visible_cmds.append(cmd)
+    return visible_cmds
+
+
+@app.post("/api/commands/sync")
+async def sync_platform_commands(profile: Optional[str] = None):
+    """Trigger command re-registration on all connected platforms."""
+    try:
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+
+    if runner is not None:
+        synced = []
+        for name, adapter in list(runner.adapters.items()):
+            try:
+                if name.value == "telegram" and hasattr(adapter, "_run_post_connect_housekeeping"):
+                    await adapter._run_post_connect_housekeeping()
+                    synced.append("telegram")
+                elif name.value == "discord" and hasattr(adapter, "_safe_sync_slash_commands"):
+                    await adapter._safe_sync_slash_commands()
+                    synced.append("discord")
+            except Exception as e:
+                _log.error("Failed to sync commands for platform %s: %s", name, e)
+        return {"ok": True, "synced": synced}
+
+    pid = get_running_pid()
+    if not pid:
+        pid = get_runtime_status_running_pid()
+
+    if pid:
+        import os
+        import signal
+        try:
+            if hasattr(signal, "SIGUSR2"):
+                os.kill(pid, signal.SIGUSR2)
+                return {"ok": True, "method": "signal", "pid": pid}
+            else:
+                return {"ok": False, "detail": "Platform command sync requires POSIX signal support"}
+        except ProcessLookupError:
+            raise HTTPException(status_code=404, detail="Gateway process not running")
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to signal gateway: {e}")
+    else:
+        raise HTTPException(status_code=404, detail="Gateway process not running")
+
+
 class MemoryProviderSelect(BaseModel):
     # "" or "built-in" disables the external provider (built-in only).
     provider: str

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1765,6 +1765,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 "deleted": 0,
             }
 
+        # Dynamically rebuild tree commands from configuration before syncing
+        self._register_slash_commands()
+
         tree = self._client.tree
         app_id = getattr(self._client, "application_id", None) or getattr(getattr(self._client, "user", None), "id", None)
         if not app_id:
@@ -3895,151 +3898,202 @@ class DiscordAdapter(BasePlatformAdapter):
             return
 
         tree = self._client.tree
+        tree.clear_commands(guild=None)
 
-        @tree.command(name="new", description="Start a new conversation")
-        async def slash_new(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/reset", "New conversation started~")
+        # Load config
+        from hermes_cli.config import load_config_readonly as _load_cfg
+        try:
+            cfg = _load_cfg()
+        except Exception:
+            cfg = {}
+        cmd_config = cfg.get("commands", {}) or {}
+        if not isinstance(cmd_config, dict):
+            cmd_config = {}
+        builtin_cfg = cmd_config.get("builtin", {}) or {}
+        custom_cmds = cmd_config.get("custom", {}) or {}
 
-        @tree.command(name="reset", description="Reset your Hermes session")
-        async def slash_reset(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/reset", "Session reset~")
+        # A helper to check if a command is visible/enabled on discord
+        def is_visible(name, is_builtin):
+            if is_builtin:
+                override = builtin_cfg.get(name, {}) or {}
+                if not override.get("enabled", True):
+                    return False
+                visible = override.get("visible", {}) or {}
+                return visible.get("discord", True)
+            else:
+                cmd = custom_cmds.get(name, {}) or {}
+                if not cmd.get("enabled", True):
+                    return False
+                visible = cmd.get("visible", {}) or {}
+                return visible.get("discord", True)
 
-        @tree.command(name="model", description="Show or change the model")
-        @discord.app_commands.describe(name="Model name (e.g. anthropic/claude-sonnet-4). Leave empty to see current.")
-        async def slash_model(interaction: discord.Interaction, name: str = ""):
-            await self._run_simple_slash(interaction, f"/model {name}".strip())
+        if is_visible("new", True):
+            @tree.command(name="new", description="Start a new conversation")
+            async def slash_new(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/reset", "New conversation started~")
 
-        @tree.command(name="reasoning", description="Show or change reasoning effort")
-        @discord.app_commands.describe(effort="Reasoning effort: none, minimal, low, medium, high, or xhigh.")
-        async def slash_reasoning(interaction: discord.Interaction, effort: str = ""):
-            await self._run_simple_slash(interaction, f"/reasoning {effort}".strip())
+        if is_visible("reset", True):
+            @tree.command(name="reset", description="Reset your Hermes session")
+            async def slash_reset(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/reset", "Session reset~")
 
-        @tree.command(name="personality", description="Set a personality")
-        @discord.app_commands.describe(name="Personality name. Leave empty to list available.")
-        async def slash_personality(interaction: discord.Interaction, name: str = ""):
-            await self._run_simple_slash(interaction, f"/personality {name}".strip())
+        if is_visible("model", True):
+            @tree.command(name="model", description="Show or change the model")
+            @discord.app_commands.describe(name="Model name (e.g. anthropic/claude-sonnet-4). Leave empty to see current.")
+            async def slash_model(interaction: discord.Interaction, name: str = ""):
+                await self._run_simple_slash(interaction, f"/model {name}".strip())
 
-        @tree.command(name="retry", description="Retry your last message")
-        async def slash_retry(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/retry", "Retrying~")
+        if is_visible("reasoning", True):
+            @tree.command(name="reasoning", description="Show or change reasoning effort")
+            @discord.app_commands.describe(effort="Reasoning effort: none, minimal, low, medium, high, or xhigh.")
+            async def slash_reasoning(interaction: discord.Interaction, effort: str = ""):
+                await self._run_simple_slash(interaction, f"/reasoning {effort}".strip())
 
-        @tree.command(name="undo", description="Remove the last exchange")
-        async def slash_undo(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/undo")
+        if is_visible("personality", True):
+            @tree.command(name="personality", description="Set a personality")
+            @discord.app_commands.describe(name="Personality name. Leave empty to list available.")
+            async def slash_personality(interaction: discord.Interaction, name: str = ""):
+                await self._run_simple_slash(interaction, f"/personality {name}".strip())
 
-        @tree.command(name="status", description="Show Hermes session status")
-        async def slash_status(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/status", "Status sent~")
+        if is_visible("retry", True):
+            @tree.command(name="retry", description="Retry your last message")
+            async def slash_retry(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/retry", "Retrying~")
 
-        @tree.command(name="sethome", description="Set this chat as the home channel")
-        async def slash_sethome(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/sethome")
+        if is_visible("undo", True):
+            @tree.command(name="undo", description="Remove the last exchange")
+            async def slash_undo(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/undo")
 
-        @tree.command(name="stop", description="Stop the running Hermes agent")
-        async def slash_stop(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/stop", "Stop requested~")
+        if is_visible("status", True):
+            @tree.command(name="status", description="Show Hermes session status")
+            async def slash_status(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/status", "Status sent~")
 
-        @tree.command(name="steer", description="Inject a message after the next tool call (no interrupt)")
-        @discord.app_commands.describe(prompt="Text to inject into the agent's next tool result")
-        async def slash_steer(interaction: discord.Interaction, prompt: str):
-            await self._run_simple_slash(interaction, f"/steer {prompt}".strip())
+        if is_visible("sethome", True):
+            @tree.command(name="sethome", description="Set this chat as the home channel")
+            async def slash_sethome(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/sethome")
 
-        @tree.command(name="compress", description="Compress conversation context")
-        async def slash_compress(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/compress")
+        if is_visible("stop", True):
+            @tree.command(name="stop", description="Stop the running Hermes agent")
+            async def slash_stop(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/stop", "Stop requested~")
 
-        @tree.command(name="title", description="Set or show the session title")
-        @discord.app_commands.describe(name="Session title. Leave empty to show current.")
-        async def slash_title(interaction: discord.Interaction, name: str = ""):
-            await self._run_simple_slash(interaction, f"/title {name}".strip())
+        if is_visible("steer", True):
+            @tree.command(name="steer", description="Inject a message after the next tool call (no interrupt)")
+            @discord.app_commands.describe(prompt="Text to inject into the agent's next tool result")
+            async def slash_steer(interaction: discord.Interaction, prompt: str):
+                await self._run_simple_slash(interaction, f"/steer {prompt}".strip())
 
-        @tree.command(name="resume", description="Resume a previously-named session")
-        @discord.app_commands.describe(name="Session name to resume. Leave empty to list sessions.")
-        async def slash_resume(interaction: discord.Interaction, name: str = ""):
-            await self._run_simple_slash(interaction, f"/resume {name}".strip())
+        if is_visible("compress", True):
+            @tree.command(name="compress", description="Compress conversation context")
+            async def slash_compress(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/compress")
 
-        @tree.command(name="usage", description="Show token usage for this session")
-        async def slash_usage(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/usage")
+        if is_visible("title", True):
+            @tree.command(name="title", description="Set or show the session title")
+            @discord.app_commands.describe(name="Session title. Leave empty to show current.")
+            async def slash_title(interaction: discord.Interaction, name: str = ""):
+                await self._run_simple_slash(interaction, f"/title {name}".strip())
 
-        @tree.command(name="help", description="Show available commands")
-        async def slash_help(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/help")
+        if is_visible("resume", True):
+            @tree.command(name="resume", description="Resume a previously-named session")
+            @discord.app_commands.describe(name="Session name to resume. Leave empty to list sessions.")
+            async def slash_resume(interaction: discord.Interaction, name: str = ""):
+                await self._run_simple_slash(interaction, f"/resume {name}".strip())
 
-        @tree.command(name="insights", description="Show usage insights and analytics")
-        @discord.app_commands.describe(days="Number of days to analyze (default: 7)")
-        async def slash_insights(interaction: discord.Interaction, days: int = 7):
-            await self._run_simple_slash(interaction, f"/insights {days}")
+        if is_visible("usage", True):
+            @tree.command(name="usage", description="Show token usage for this session")
+            async def slash_usage(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/usage")
 
-        @tree.command(name="reload-mcp", description="Reload MCP servers from config")
-        async def slash_reload_mcp(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/reload-mcp")
+        if is_visible("help", True):
+            @tree.command(name="help", description="Show available commands")
+            async def slash_help(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/help")
 
-        @tree.command(name="reload-skills", description="Re-scan ~/.hermes/skills/ for new or removed skills")
-        async def slash_reload_skills(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/reload-skills")
+        if is_visible("insights", True):
+            @tree.command(name="insights", description="Show usage insights and analytics")
+            @discord.app_commands.describe(days="Number of days to analyze (default: 7)")
+            async def slash_insights(interaction: discord.Interaction, days: int = 7):
+                await self._run_simple_slash(interaction, f"/insights {days}")
 
-        @tree.command(name="voice", description="Toggle voice reply mode")
-        @discord.app_commands.describe(mode="Voice mode: join, channel, leave, on, tts, off, or status")
-        @discord.app_commands.choices(mode=[
-            # `join` and `channel` both route to _handle_voice_channel_join in
-            # gateway/run.py — expose both in the slash UI so autocomplete
-            # matches what the docs advertise and what the runner accepts when
-            # the command is typed as plain text.
-            discord.app_commands.Choice(name="join — join your voice channel", value="join"),
-            discord.app_commands.Choice(name="channel — join your voice channel (alias)", value="channel"),
-            discord.app_commands.Choice(name="leave — leave voice channel", value="leave"),
-            discord.app_commands.Choice(name="on — voice reply to voice messages", value="on"),
-            discord.app_commands.Choice(name="tts — voice reply to all messages", value="tts"),
-            discord.app_commands.Choice(name="off — text only", value="off"),
-            discord.app_commands.Choice(name="status — show current mode", value="status"),
-        ])
-        async def slash_voice(interaction: discord.Interaction, mode: str = ""):
-            await self._run_simple_slash(interaction, f"/voice {mode}".strip())
+        if is_visible("reload-mcp", True):
+            @tree.command(name="reload-mcp", description="Reload MCP servers from config")
+            async def slash_reload_mcp(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/reload-mcp")
 
-        @tree.command(name="update", description="Update Hermes Agent to the latest version")
-        async def slash_update(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/update", "Update initiated~")
+        if is_visible("reload-skills", True):
+            @tree.command(name="reload-skills", description="Re-scan ~/.hermes/skills/ for new or removed skills")
+            async def slash_reload_skills(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/reload-skills")
 
-        @tree.command(name="restart", description="Gracefully restart the Hermes gateway")
-        async def slash_restart(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/restart", "Restart requested~")
+        if is_visible("voice", True):
+            @tree.command(name="voice", description="Toggle voice reply mode")
+            @discord.app_commands.describe(mode="Voice mode: join, channel, leave, on, tts, off, or status")
+            @discord.app_commands.choices(mode=[
+                discord.app_commands.Choice(name="join — join your voice channel", value="join"),
+                discord.app_commands.Choice(name="channel — join your voice channel (alias)", value="channel"),
+                discord.app_commands.Choice(name="leave — leave voice channel", value="leave"),
+                discord.app_commands.Choice(name="on — voice reply to voice messages", value="on"),
+                discord.app_commands.Choice(name="tts — voice reply to all messages", value="tts"),
+                discord.app_commands.Choice(name="off — text only", value="off"),
+                discord.app_commands.Choice(name="status — show current mode", value="status"),
+            ])
+            async def slash_voice(interaction: discord.Interaction, mode: str = ""):
+                await self._run_simple_slash(interaction, f"/voice {mode}".strip())
 
-        @tree.command(name="approve", description="Approve a pending dangerous command")
-        @discord.app_commands.describe(scope="Optional: 'all', 'session', 'always', 'all session', 'all always'")
-        async def slash_approve(interaction: discord.Interaction, scope: str = ""):
-            await self._run_simple_slash(interaction, f"/approve {scope}".strip())
+        if is_visible("update", True):
+            @tree.command(name="update", description="Update Hermes Agent to the latest version")
+            async def slash_update(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/update", "Update initiated~")
 
-        @tree.command(name="deny", description="Deny a pending dangerous command")
-        @discord.app_commands.describe(scope="Optional: 'all' to deny all pending commands")
-        async def slash_deny(interaction: discord.Interaction, scope: str = ""):
-            await self._run_simple_slash(interaction, f"/deny {scope}".strip())
+        if is_visible("restart", True):
+            @tree.command(name="restart", description="Gracefully restart the Hermes gateway")
+            async def slash_restart(interaction: discord.Interaction):
+                await self._run_simple_slash(interaction, "/restart", "Restart requested~")
 
-        @tree.command(name="thread", description="Create a new thread and start a Hermes session in it")
-        @discord.app_commands.describe(
-            name="Thread name",
-            message="Optional first message to send to Hermes in the thread",
-            auto_archive_duration="Auto-archive in minutes (60, 1440, 4320, 10080)",
-        )
-        async def slash_thread(
-            interaction: discord.Interaction,
-            name: str,
-            message: str = "",
-            auto_archive_duration: int = 1440,
-        ):
-            # defer() is performed inside the handler *after* the auth gate
-            # so a rejected invoker can receive an ephemeral rejection.
-            await self._handle_thread_create_slash(interaction, name, message, auto_archive_duration)
+        if is_visible("approve", True):
+            @tree.command(name="approve", description="Approve a pending dangerous command")
+            @discord.app_commands.describe(scope="Optional: 'all', 'session', 'always', 'all session', 'all always'")
+            async def slash_approve(interaction: discord.Interaction, scope: str = ""):
+                await self._run_simple_slash(interaction, f"/approve {scope}".strip())
 
-        @tree.command(name="queue", description="Queue a prompt for the next turn (doesn't interrupt)")
-        @discord.app_commands.describe(prompt="The prompt to queue")
-        async def slash_queue(interaction: discord.Interaction, prompt: str):
-            await self._run_simple_slash(interaction, f"/queue {prompt}", "Queued for the next turn.")
+        if is_visible("deny", True):
+            @tree.command(name="deny", description="Deny a pending dangerous command")
+            @discord.app_commands.describe(scope="Optional: 'all' to deny all pending commands")
+            async def slash_deny(interaction: discord.Interaction, scope: str = ""):
+                await self._run_simple_slash(interaction, f"/deny {scope}".strip())
 
-        @tree.command(name="background", description="Run a prompt in the background")
-        @discord.app_commands.describe(prompt="The prompt to run in the background")
-        async def slash_background(interaction: discord.Interaction, prompt: str):
-            await self._run_simple_slash(interaction, f"/background {prompt}", "Background task started~")
+        if is_visible("thread", True):
+            @tree.command(name="thread", description="Create a new thread and start a Hermes session in it")
+            @discord.app_commands.describe(
+                name="Thread name",
+                message="Optional first message to send to Hermes in the thread",
+                auto_archive_duration="Auto-archive in minutes (60, 1440, 4320, 10080)",
+            )
+            async def slash_thread(
+                interaction: discord.Interaction,
+                name: str,
+                message: str = "",
+                auto_archive_duration: int = 1440,
+            ):
+                # defer() is performed inside the handler *after* the auth gate
+                # so a rejected invoker can receive an ephemeral rejection.
+                await self._handle_thread_create_slash(interaction, name, message, auto_archive_duration)
+
+        if is_visible("queue", True):
+            @tree.command(name="queue", description="Queue a prompt for the next turn (doesn't interrupt)")
+            @discord.app_commands.describe(prompt="The prompt to queue")
+            async def slash_queue(interaction: discord.Interaction, prompt: str):
+                await self._run_simple_slash(interaction, f"/queue {prompt}", "Queued for the next turn.")
+
+        if is_visible("background", True):
+            @tree.command(name="background", description="Run a prompt in the background")
+            @discord.app_commands.describe(prompt="The prompt to run in the background")
+            async def slash_background(interaction: discord.Interaction, prompt: str):
+                await self._run_simple_slash(interaction, f"/background {prompt}", "Background task started~")
 
         # ── Auto-register any gateway-available commands not yet on the tree ──
         # This ensures new commands added to COMMAND_REGISTRY in
@@ -4095,6 +4149,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
             for cmd_def in COMMAND_REGISTRY:
                 if not _is_gateway_available(cmd_def, config_overrides):
+                    continue
+                if not is_visible(cmd_def.name, True):
                     continue
                 # Discord command names: lowercase, hyphens OK, max 32 chars.
                 discord_name = cmd_def.name.lower()[:32]
@@ -4154,6 +4210,41 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.warning(
                 "Discord auto-register from plugin commands failed: %s", e
             )
+
+        # ── Custom / quick commands ──
+        try:
+            for name, cmd in custom_cmds.items():
+                if not isinstance(cmd, dict):
+                    continue
+                discord_name = name.lower()[:32]
+                if discord_name in already_registered:
+                    continue
+                if not cmd.get("enabled", True):
+                    continue
+                if not cmd.get("visible", {}).get("discord", True):
+                    continue
+                if len(already_registered) >= slot_cap:
+                    dropped_over_cap += 1
+                    continue
+
+                def make_custom_handler(cmd_name):
+                    async def _handler(interaction: discord.Interaction):
+                        await self._run_simple_slash(interaction, f"/{cmd_name}")
+                    _handler.__name__ = f"custom_slash_{cmd_name.replace('-', '_')}"
+                    return _handler
+
+                auto_cmd = discord.app_commands.Command(
+                    name=discord_name,
+                    description=(cmd.get("description", "") or f"Custom command /{name}")[:100],
+                    callback=make_custom_handler(name),
+                )
+                try:
+                    tree.add_command(auto_cmd)
+                    already_registered.add(discord_name)
+                except Exception:
+                    pass
+        except Exception as e:
+            logger.warning("Discord custom commands registration failed: %s", e)
 
         # Register skills under a single /skill command group with category
         # subcommand groups.  This uses 1 top-level slot instead of N,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2846,6 +2846,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 for scope_cls in (BotCommandScopeDefault, BotCommandScopeAllPrivateChats, BotCommandScopeAllGroupChats):
                     scope_name = getattr(scope_cls, "__name__", str(scope_cls))
                     try:
+                        try:
+                            await self._bot.delete_my_commands(scope=scope_cls())
+                        except Exception as delete_err:
+                            logger.debug("[%s] delete_my_commands failed (non-fatal) for scope %s: %s", self.name, scope_name, delete_err)
                         await self._bot.set_my_commands(bot_commands, scope=scope_cls())
                         logger.info("[%s] set_my_commands OK for scope %s (%d cmds)", self.name, scope_name, len(bot_commands))
                     except Exception as scope_err:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2846,10 +2846,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 for scope_cls in (BotCommandScopeDefault, BotCommandScopeAllPrivateChats, BotCommandScopeAllGroupChats):
                     scope_name = getattr(scope_cls, "__name__", str(scope_cls))
                     try:
-                        try:
-                            await self._bot.delete_my_commands(scope=scope_cls())
-                        except Exception as delete_err:
-                            logger.debug("[%s] delete_my_commands failed (non-fatal) for scope %s: %s", self.name, scope_name, delete_err)
                         await self._bot.set_my_commands(bot_commands, scope=scope_cls())
                         logger.info("[%s] set_my_commands OK for scope %s (%d cmds)", self.name, scope_name, len(bot_commands))
                     except Exception as scope_err:

--- a/tests/hermes_cli/test_web_server_commands.py
+++ b/tests/hermes_cli/test_web_server_commands.py
@@ -1,0 +1,368 @@
+"""Regression tests for platform command sync endpoints and config migration.
+
+Covers profile routing, custom command CRUD, sync workflow, legacy
+quick_commands migration, and failure scenarios.
+"""
+import pytest
+import yaml
+
+
+@pytest.fixture
+def isolated_profile(tmp_path, monkeypatch, _isolate_hermes_home):
+    """Isolated default home with config."""
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        yaml.dump({
+            "commands": {"builtin": {}, "custom": {}},
+        }),
+        encoding="utf-8",
+    )
+    return home
+
+
+@pytest.fixture
+def client(monkeypatch, isolated_profile):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+    c = TestClient(app)
+    c.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return c
+
+
+class TestCustomCommandCRUD:
+    """Test create, read, update, delete of custom commands."""
+
+    CUSTOM_PAYLOAD = {
+        "name": "mygreet",
+        "description": "Say hello",
+        "type": "exec",
+        "command": "echo hello",
+        "enabled": True,
+        "visible": {"telegram": True, "discord": False, "cli": True},
+        "silent_empty": False,
+    }
+
+    def test_create_custom_command(self, client, isolated_profile):
+        """POST /api/commands/custom creates a custom command entry."""
+        resp = client.post("/api/commands/custom", json=self.CUSTOM_PAYLOAD)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+
+        # Verify via GET
+        resp_list = client.get("/api/commands")
+        cmds = resp_list.json()
+        match = [c for c in cmds if c["name"] == "mygreet"]
+        assert len(match) == 1
+        assert match[0]["command"] == "echo hello"
+
+    def test_create_custom_command_invalid_name(self, client):
+        """POST with invalid name returns 400."""
+        payload = dict(self.CUSTOM_PAYLOAD, name="bad name!")
+        resp = client.post("/api/commands/custom", json=payload)
+        assert resp.status_code == 400
+
+    def test_custom_command_profile_routing(self, client, isolated_profile, monkeypatch):
+        """Profile query param routes write to the correct profile."""
+        from hermes_cli import profiles
+        from hermes_constants import get_hermes_home
+
+        default_home = get_hermes_home()
+        beta_home = default_home / "profiles" / "beta"
+        beta_home.mkdir(parents=True, exist_ok=True)
+        (beta_home / "config.yaml").write_text(
+            yaml.dump({"commands": {"builtin": {}, "custom": {}}}),
+            encoding="utf-8",
+        )
+
+        # Make the web_server recognize 'beta' as a valid profile
+        monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "beta" or True)
+        monkeypatch.setattr(
+            profiles, "get_profile_dir",
+            lambda name: beta_home if name == "beta" else default_home,
+        )
+
+        resp = client.post(
+            "/api/commands/custom?profile=beta",
+            json=self.CUSTOM_PAYLOAD,
+        )
+        assert resp.status_code == 200
+
+        # Default profile should be untouched
+        def_names = [c["name"] for c in client.get("/api/commands").json()]
+        assert "mygreet" not in def_names
+
+        # Beta profile should have it
+        beta_names = [c["name"] for c in client.get("/api/commands?profile=beta").json()]
+        assert "mygreet" in beta_names
+
+    def test_delete_custom_command(self, client, isolated_profile):
+        """DELETE /api/commands/custom/<name> removes the entry."""
+        # Create first
+        client.post("/api/commands/custom", json=self.CUSTOM_PAYLOAD)
+
+        # Verify it's listed
+        resp_list = client.get("/api/commands")
+        names = [c["name"] for c in resp_list.json()]
+        assert "mygreet" in names
+
+        # Delete
+        resp = client.delete("/api/commands/custom/mygreet")
+        assert resp.status_code == 200
+
+        # Verify it's gone
+        resp_list2 = client.get("/api/commands")
+        names2 = [c["name"] for c in resp_list2.json()]
+        assert "mygreet" not in names2
+
+
+class TestListCommands:
+    """Test GET /api/commands listing."""
+
+    CUSTOM_PAYLOAD = {
+        "name": "mytool",
+        "description": "A custom tool",
+        "type": "exec",
+        "command": "echo tool",
+        "enabled": True,
+        "visible": {"telegram": True, "discord": True, "cli": True},
+        "silent_empty": False,
+    }
+
+    def test_list_commands_includes_custom(self, client, isolated_profile):
+        """GET /api/commands returns both builtin and custom commands."""
+        client.post("/api/commands/custom", json=self.CUSTOM_PAYLOAD)
+
+        resp = client.get("/api/commands")
+        assert resp.status_code == 200
+        cmds = resp.json()
+        names = [c["name"] for c in cmds]
+        assert "mytool" in names
+        # Builtins should be present
+        assert any(c["source"] == "builtin" for c in cmds)
+        assert any(c["source"] == "custom" for c in cmds)
+
+    def test_list_commands_profile_routing(self, client, isolated_profile, monkeypatch):
+        """Profile query param scopes command listing."""
+        from hermes_cli import profiles
+        from hermes_constants import get_hermes_home
+
+        default_home = get_hermes_home()
+        beta_home = default_home / "profiles" / "beta"
+        beta_home.mkdir(parents=True, exist_ok=True)
+        (beta_home / "config.yaml").write_text(
+            yaml.dump({"commands": {"builtin": {}, "custom": {}}}),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "beta" or True)
+        monkeypatch.setattr(
+            profiles, "get_profile_dir",
+            lambda name: beta_home if name == "beta" else default_home,
+        )
+
+        # Add command to beta profile
+        client.post("/api/commands/custom?profile=beta", json=self.CUSTOM_PAYLOAD)
+
+        # Listing without profile should not include beta's commands
+        resp_default = client.get("/api/commands")
+        default_names = [c["name"] for c in resp_default.json()]
+        assert "mytool" not in default_names
+
+        # Listing with profile=beta should include it
+        resp_beta = client.get("/api/commands?profile=beta")
+        beta_names = [c["name"] for c in resp_beta.json()]
+        assert "mytool" in beta_names
+
+
+class TestMigration:
+    """Test legacy quick_commands → commands.custom migration."""
+
+    def test_quick_commands_read_backward_compat(self, client, isolated_profile):
+        """GET /api/commands still picks up legacy quick_commands."""
+        cfg = yaml.safe_load((isolated_profile / "config.yaml").read_text()) or {}
+        cfg["quick_commands"] = {
+            "legacyls": {
+                "type": "exec",
+                "command": "ls -la",
+                "description": "List files",
+            }
+        }
+        (isolated_profile / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+
+        resp = client.get("/api/commands")
+        assert resp.status_code == 200
+        cmds = resp.json()
+        names = [c["name"] for c in cmds]
+        assert "legacyls" in names
+
+    def test_upsert_cleans_quick_commands(self, client, isolated_profile):
+        """Upserting a command with the same name removes it from quick_commands."""
+        raw = yaml.safe_load((isolated_profile / "config.yaml").read_text()) or {}
+        raw["quick_commands"] = {
+            "mygreet": {
+                "type": "exec",
+                "command": "echo old",
+                "description": "Old quick command",
+            }
+        }
+        # Also ensure commands section exists for the upsert
+        if "commands" not in raw:
+            raw["commands"] = {"builtin": {}, "custom": {}}
+        (isolated_profile / "config.yaml").write_text(yaml.dump(raw), encoding="utf-8")
+
+        payload = {
+            "name": "mygreet",
+            "description": "New version",
+            "type": "exec",
+            "command": "echo new",
+            "enabled": True,
+            "visible": {"telegram": True, "discord": True, "cli": True},
+            "silent_empty": False,
+        }
+        client.post("/api/commands/custom", json=payload)
+        resp = client.get("/api/commands")
+        cmds = resp.json()
+        names = [c["name"] for c in cmds]
+        assert "mygreet" in names
+        match = [c for c in cmds if c["name"] == "mygreet"]
+        assert match[0]["command"] == "echo new"
+
+        # quick_commands should no longer have mygreet in the raw file
+        raw2 = yaml.safe_load((isolated_profile / "config.yaml").read_text()) or {}
+        qc = raw2.get("quick_commands", {}) or {}
+        assert "mygreet" not in qc
+
+
+class TestFailureScenarios:
+    """Test error handling for command endpoints."""
+
+    CUSTOM_PAYLOAD = {
+        "name": "testcmd",
+        "description": "Test",
+        "type": "exec",
+        "command": "echo test",
+        "enabled": True,
+        "visible": {"telegram": True, "discord": True, "cli": True},
+        "silent_empty": False,
+    }
+
+    def test_create_duplicate_name(self, client):
+        """Creating a command with existing name overwrites (no error)."""
+        client.post("/api/commands/custom", json=self.CUSTOM_PAYLOAD)
+        # Second POST with same name should succeed (overwrite)
+        resp = client.post("/api/commands/custom", json=self.CUSTOM_PAYLOAD)
+        assert resp.status_code == 200
+
+    def test_delete_nonexistent(self, client):
+        """DELETE on non-existent command returns 404."""
+        resp = client.delete("/api/commands/custom/nonexistent")
+        assert resp.status_code == 404
+
+    def test_sync_profile_param(self, client, isolated_profile):
+        """POST /api/commands/sync accepts profile as query param (not body)."""
+        resp = client.post("/api/commands/sync?profile=beta")
+        # Even if beta profile doesn't exist, endpoint shouldn't crash
+        assert resp.status_code in (200, 500, 404)
+        if resp.status_code == 500:
+            detail = resp.json().get("detail", "")
+            # Profile parsing error should NOT mention 'profile' body field
+            assert "profile" not in detail.lower() or "query" in detail.lower()
+
+
+class TestProfileQueryParamContract:
+    """Verify profile is sent as query param, not in request body.
+
+    This validates the contract that Fix #1 enforces: the frontend sends
+    profile as ?profile=... and the backend reads it as a query parameter.
+    """
+
+    def test_upsert_ignores_profile_in_body(self, client, isolated_profile, monkeypatch):
+        """POST /api/commands/custom reads profile from query param, not body."""
+        from hermes_cli import profiles as prof_mod
+
+        # Create a real profile dir for routing test
+        from hermes_constants import get_hermes_home
+        profiles_root = get_hermes_home() / "profiles"
+        prof_dir = profiles_root / "testprofile"
+        prof_dir.mkdir(parents=True, exist_ok=True)
+        (prof_dir / "config.yaml").write_text(yaml.dump(
+            {"commands": {"builtin": {}, "custom": {}}}
+        ))
+        monkeypatch.setattr(prof_mod, "profile_exists", lambda n: n == "testprofile" or True)
+        monkeypatch.setattr(
+            prof_mod, "get_profile_dir", lambda n: prof_dir if n == "testprofile" else get_hermes_home()
+        )
+
+        payload = {
+            "name": "bodyprof",
+            "description": "Profile in body test",
+            "type": "exec",
+            "command": "echo body",
+            "enabled": True,
+            "visible": {"telegram": True, "discord": True, "cli": True},
+            "silent_empty": False,
+        }
+        resp = client.post("/api/commands/custom?profile=testprofile", json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+
+        # Verify the command was created on the testprofile profile, not on default
+        resp_def = client.get("/api/commands")
+        def_names = [c["name"] for c in resp_def.json()]
+        assert "bodyprof" not in def_names  # default profile doesn't have it
+
+    def test_sync_ignores_profile_in_body(self, client, isolated_profile):
+        """POST /api/commands/sync reads profile from query param, not body."""
+        resp = client.post("/api/commands/sync?profile=test")
+        assert resp.status_code in (200, 500, 404)
+        # Should not get 422 (validation error) from profile in body
+
+
+class TestVisibleCliConsumed:
+    """Verify visible.cli is respected in command dispatch.
+
+    The command store persists per-platform visibility (visible.cli, etc.)
+    and the CLI dispatch must only execute commands where visible.cli is True.
+    """
+
+    def test_list_commands_includes_visible_cli(self, client, isolated_profile):
+        """GET /api/commands returns visible.cli field for each command."""
+        resp = client.get("/api/commands")
+        assert resp.status_code == 200
+        cmds = resp.json()
+        for cmd in cmds:
+            assert "visible" in cmd
+            assert "cli" in cmd["visible"]
+
+    def test_custom_command_visible_cli_persisted(self, client, isolated_profile):
+        """Creating a custom command persists visible.cli setting."""
+        payload = {
+            "name": "clitest",
+            "description": "CLI only",
+            "type": "exec",
+            "command": "echo cli",
+            "enabled": True,
+            "visible": {"telegram": False, "discord": False, "cli": True},
+            "silent_empty": False,
+        }
+        client.post("/api/commands/custom", json=payload)
+
+        resp = client.get("/api/commands")
+        cmds = resp.json()
+        match = [c for c in cmds if c["name"] == "clitest"]
+        assert len(match) == 1
+        assert match[0]["visible"]["cli"] is True
+        assert match[0]["visible"]["telegram"] is False

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -84,6 +84,7 @@ import CronPage from "@/pages/CronPage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import ProfileBuilderPage from "@/pages/ProfileBuilderPage";
 import SkillsPage from "@/pages/SkillsPage";
+import CommandsPage from "@/pages/CommandsPage";
 import PluginsPage from "@/pages/PluginsPage";
 import McpPage from "@/pages/McpPage";
 import PairingPage from "@/pages/PairingPage";
@@ -139,6 +140,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/logs": LogsPage,
   "/cron": CronPage,
   "/skills": SkillsPage,
+  "/commands": CommandsPage,
   "/plugins": PluginsPage,
   "/mcp": McpPage,
   "/pairing": PairingPage,
@@ -183,6 +185,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
+  { path: "/commands", label: "Commands", icon: Terminal },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
   { path: "/mcp", label: "MCP", icon: Plug },
   { path: "/channels", label: "Channels", icon: Radio },

--- a/web/src/contexts/SystemActions.tsx
+++ b/web/src/contexts/SystemActions.tsx
@@ -11,6 +11,8 @@ import {
 const ACTION_NAMES: Record<SystemAction, string> = {
   restart: "gateway-restart",
   update: "hermes-update",
+  start: "gateway-start",
+  stop: "gateway-stop",
 };
 
 export function SystemActionsProvider({
@@ -71,6 +73,12 @@ export function SystemActionsProvider({
       try {
         if (action === "restart") {
           await api.restartGateway();
+          setActiveAction(action);
+        } else if (action === "start") {
+          await api.startGateway();
+          setActiveAction(action);
+        } else if (action === "stop") {
+          await api.stopGateway();
           setActiveAction(action);
         } else {
           const resp = await api.updateHermes();

--- a/web/src/contexts/system-actions-context.ts
+++ b/web/src/contexts/system-actions-context.ts
@@ -5,7 +5,7 @@ export const SystemActionsContext = createContext<SystemActionsState | null>(
   null,
 );
 
-export type SystemAction = "restart" | "update";
+export type SystemAction = "restart" | "update" | "start" | "stop";
 
 export interface SystemActionsState {
   actionStatus: ActionStatusResponse | null;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1191,7 +1191,53 @@ export const api = {
     fetchJSON<SkillHubScan>(
       `/api/skills/hub/scan?identifier=${encodeURIComponent(identifier)}`,
     ),
+
+  // Command Management
+  getCommands: (profile?: string) =>
+    fetchJSON<CommandInfo[]>(`/api/commands${profileQuery(profile)}`),
+  upsertCustomCommand: (command: Omit<CommandInfo, "source">, profile?: string) =>
+    fetchJSON<{ ok: boolean }>("/api/commands/custom", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...command, profile: profile || undefined }),
+    }),
+  deleteCustomCommand: (name: string, profile?: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/commands/custom/${encodeURIComponent(name)}${profileQuery(profile)}`,
+      { method: "DELETE" },
+    ),
+  updateBuiltinCommand: (name: string, update: { enabled?: boolean; visible?: Record<string, boolean> }, profile?: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/commands/builtin/${encodeURIComponent(name)}${profileQuery(profile)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(update),
+      },
+    ),
+  syncCommands: (profile?: string) =>
+    fetchJSON<{ ok: boolean; method?: string; pid?: number; detail?: string }>("/api/commands/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: profile || undefined }),
+    }),
 };
+
+export interface CommandInfo {
+  name: string;
+  description: string;
+  type: "builtin" | "exec" | "alias";
+  command: string;
+  enabled: boolean;
+  visible: {
+    telegram: boolean;
+    discord: boolean;
+    cli: boolean;
+    [key: string]: boolean;
+  };
+  silent_empty?: boolean;
+  source: "builtin" | "custom";
+}
 
 /** Identity payload returned by ``GET /api/auth/me`` (Phase 7).
  *

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -854,8 +854,8 @@ export const api = {
     ),
 
   // Gateway / update actions
-  restartGateway: () =>
-    fetchJSON<ActionResponse>("/api/gateway/restart", { method: "POST" }),
+  restartGateway: (profile?: string) =>
+    fetchJSON<ActionResponse>(appendProfileParam("/api/gateway/restart", profile), { method: "POST" }),
   updateHermes: () =>
     fetchJSON<ActionResponse>("/api/hermes/update", { method: "POST" }),
   checkHermesUpdate: (force = false) =>
@@ -1066,10 +1066,10 @@ export const api = {
     }),
 
   // ── Admin: Gateway lifecycle ────────────────────────────────────────
-  startGateway: () =>
-    fetchJSON<ActionResponse>("/api/gateway/start", { method: "POST" }),
-  stopGateway: () =>
-    fetchJSON<ActionResponse>("/api/gateway/stop", { method: "POST" }),
+  startGateway: (profile?: string) =>
+    fetchJSON<ActionResponse>(appendProfileParam("/api/gateway/start", profile), { method: "POST" }),
+  stopGateway: (profile?: string) =>
+    fetchJSON<ActionResponse>(appendProfileParam("/api/gateway/stop", profile), { method: "POST" }),
 
   // ── Admin: Operations ───────────────────────────────────────────────
   runDoctor: () =>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1196,10 +1196,10 @@ export const api = {
   getCommands: (profile?: string) =>
     fetchJSON<CommandInfo[]>(`/api/commands${profileQuery(profile)}`),
   upsertCustomCommand: (command: Omit<CommandInfo, "source">, profile?: string) =>
-    fetchJSON<{ ok: boolean }>("/api/commands/custom", {
+    fetchJSON<{ ok: boolean }>(`/api/commands/custom${profileQuery(profile)}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...command, profile: profile || undefined }),
+      body: JSON.stringify(command),
     }),
   deleteCustomCommand: (name: string, profile?: string) =>
     fetchJSON<{ ok: boolean }>(
@@ -1216,10 +1216,9 @@ export const api = {
       },
     ),
   syncCommands: (profile?: string) =>
-    fetchJSON<{ ok: boolean; method?: string; pid?: number; detail?: string }>("/api/commands/sync", {
+    fetchJSON<{ ok: boolean; method?: string; pid?: number; detail?: string }>(`/api/commands/sync${profileQuery(profile)}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ profile: profile || undefined }),
     }),
 };
 

--- a/web/src/pages/CommandsPage.tsx
+++ b/web/src/pages/CommandsPage.tsx
@@ -1,0 +1,650 @@
+import { useEffect, useState, useMemo } from "react";
+import {
+  Terminal,
+  Search,
+  Plus,
+  RefreshCw,
+  Trash2,
+  Edit2,
+  AlertCircle,
+  Eye,
+} from "lucide-react";
+import { api, type CommandInfo } from "@/lib/api";
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { useToast } from "@nous-research/ui/hooks/use-toast";
+import { Card, CardContent, CardHeader } from "@nous-research/ui/ui/components/card";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Switch } from "@nous-research/ui/ui/components/switch";
+import { Label } from "@nous-research/ui/ui/components/label";
+import { Input } from "@nous-research/ui/ui/components/input";
+import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@nous-research/ui/ui/components/dialog";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { useI18n } from "@/i18n";
+
+export default function CommandsPage() {
+  const [commands, setCommands] = useState<CommandInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState(false);
+  const [search, setSearch] = useState("");
+  const [tab, setTab] = useState<"all" | "builtin" | "custom">("all");
+  const { profile: selectedProfile } = useProfileScope();
+  const { showToast } = useToast();
+  useI18n();
+  const { setEnd } = usePageHeader();
+
+  // Dialog states
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingCommand, setEditingCommand] = useState<CommandInfo | null>(null);
+  
+  // Form states
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [type, setType] = useState<"exec" | "alias">("exec");
+  const [commandText, setCommandText] = useState("");
+  const [targetText, setTargetText] = useState("");
+  const [enabled, setEnabled] = useState(true);
+  const [silentEmpty, setSilentEmpty] = useState(false);
+  const [visTelegram, setVisTelegram] = useState(true);
+  const [visDiscord, setVisDiscord] = useState(true);
+  const [visCli, setVisCli] = useState(true);
+  const [formError, setFormError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const fetchCommands = async () => {
+    setLoading(true);
+    try {
+      const data = await api.getCommands(selectedProfile || undefined);
+      setCommands(data);
+    } catch (err: any) {
+      showToast("Failed to load commands", "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchCommands();
+  }, [selectedProfile]);
+
+  // Sync action trigger
+  const handleSync = async () => {
+    setSyncing(true);
+    try {
+      const res = await api.syncCommands(selectedProfile || undefined);
+      if (res.ok) {
+        showToast("Platform commands synchronized successfully", "success");
+      } else {
+        showToast(res.detail || "Command synchronization failed", "error");
+      }
+    } catch (err: any) {
+      showToast(`Sync failed: ${err.message || err}`, "error");
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  // Header buttons setup
+  useEffect(() => {
+    setEnd(
+      <div className="flex items-center gap-2">
+        <Button
+          outlined
+          size="sm"
+          onClick={handleSync}
+          disabled={syncing}
+          className="flex items-center gap-1.5"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${syncing ? "animate-spin" : ""}`} />
+          Sync to Platforms
+        </Button>
+        <Button
+          size="sm"
+          onClick={() => handleOpenCreate()}
+          className="flex items-center gap-1.5"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Create Command
+        </Button>
+      </div>
+    );
+    return () => setEnd(null);
+  }, [syncing, selectedProfile]);
+
+  const handleOpenCreate = () => {
+    setEditingCommand(null);
+    setName("");
+    setDescription("");
+    setType("exec");
+    setCommandText("");
+    setTargetText("");
+    setEnabled(true);
+    setSilentEmpty(false);
+    setVisTelegram(true);
+    setVisDiscord(true);
+    setVisCli(true);
+    setFormError("");
+    setDialogOpen(true);
+  };
+
+  const handleOpenEdit = (cmd: CommandInfo) => {
+    setEditingCommand(cmd);
+    setName(cmd.name);
+    setDescription(cmd.description || "");
+    setType(cmd.type === "builtin" ? "exec" : cmd.type);
+    setCommandText(cmd.type === "exec" ? cmd.command : "");
+    setTargetText(cmd.type === "alias" ? cmd.command : "");
+    setEnabled(cmd.enabled);
+    setSilentEmpty(cmd.silent_empty || false);
+    setVisTelegram(cmd.visible?.telegram !== false);
+    setVisDiscord(cmd.visible?.discord !== false);
+    setVisCli(cmd.visible?.cli !== false);
+    setFormError("");
+    setDialogOpen(true);
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setFormError("Command name is required.");
+      return;
+    }
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+      setFormError("Name must contain only letters, numbers, hyphens, and underscores.");
+      return;
+    }
+    if (type === "exec" && !commandText.trim()) {
+      setFormError("Shell command is required for Exec type.");
+      return;
+    }
+    if (type === "alias" && !targetText.trim()) {
+      setFormError("Target command is required for Alias type.");
+      return;
+    }
+
+    setSaving(true);
+    setFormError("");
+
+    const payload = {
+      name: name.trim(),
+      description: description.trim(),
+      type,
+      command: type === "exec" ? commandText.trim() : targetText.trim(),
+      enabled,
+      visible: {
+        telegram: visTelegram,
+        discord: visDiscord,
+        cli: visCli,
+      },
+      silent_empty: type === "exec" ? silentEmpty : false,
+    };
+
+    try {
+      await api.upsertCustomCommand(payload, selectedProfile || undefined);
+      showToast(`Command /${name} saved successfully`, "success");
+      setDialogOpen(false);
+      fetchCommands();
+    } catch (err: any) {
+      setFormError(err.message || "Failed to save command");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (cmd: CommandInfo) => {
+    if (!confirm(`Are you sure you want to delete custom command /${cmd.name}?`)) {
+      return;
+    }
+    try {
+      await api.deleteCustomCommand(cmd.name, selectedProfile || undefined);
+      showToast(`Command /${cmd.name} deleted`, "success");
+      fetchCommands();
+    } catch (err: any) {
+      showToast(`Failed to delete command: ${err.message || err}`, "error");
+    }
+  };
+
+  const handleToggleBuiltin = async (cmd: CommandInfo, newState: boolean) => {
+    try {
+      await api.updateBuiltinCommand(
+        cmd.name,
+        { enabled: newState },
+        selectedProfile || undefined
+      );
+      setCommands((prev) =>
+        prev.map((c) => (c.name === cmd.name ? { ...c, enabled: newState } : c))
+      );
+      showToast(`Command /${cmd.name} ${newState ? "enabled" : "disabled"}`, "success");
+    } catch (err: any) {
+      showToast(`Failed to update command: ${err.message || err}`, "error");
+    }
+  };
+
+  const handleToggleBuiltinVisibility = async (cmd: CommandInfo, platform: string, newState: boolean) => {
+    try {
+      const currentVisible = cmd.visible || { telegram: true, discord: true, cli: true };
+      const updatedVisible = { ...currentVisible, [platform]: newState };
+      await api.updateBuiltinCommand(
+        cmd.name,
+        { visible: updatedVisible },
+        selectedProfile || undefined
+      );
+      setCommands((prev) =>
+        prev.map((c) => (c.name === cmd.name ? { ...c, visible: updatedVisible } : c))
+      );
+      showToast(`Visibility for platform '${platform}' updated`, "success");
+    } catch (err: any) {
+      showToast(`Failed to update visibility: ${err.message || err}`, "error");
+    }
+  };
+
+  const filteredCommands = useMemo(() => {
+    return commands.filter((cmd) => {
+      const matchSearch =
+        cmd.name.toLowerCase().includes(search.toLowerCase()) ||
+        (cmd.description || "").toLowerCase().includes(search.toLowerCase());
+      
+      const matchTab =
+        tab === "all" ||
+        (tab === "builtin" && cmd.source === "builtin") ||
+        (tab === "custom" && cmd.source === "custom");
+
+      return matchSearch && matchTab;
+    });
+  }, [commands, search, tab]);
+
+  return (
+    <div className="space-y-6">
+      {/* Search & Filter bar */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between bg-card/35 backdrop-blur-md border border-border p-4 rounded-xl shadow-sm">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search commands by name or description..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9 bg-background/50 border-border"
+          />
+        </div>
+        
+        <div className="flex items-center gap-1.5 bg-background/40 border border-border p-1 rounded-lg">
+          <Button
+            ghost={tab !== "all"}
+            size="sm"
+            onClick={() => setTab("all")}
+            className="text-xs"
+          >
+            All
+          </Button>
+          <Button
+            ghost={tab !== "builtin"}
+            size="sm"
+            onClick={() => setTab("builtin")}
+            className="text-xs"
+          >
+            Built-in
+          </Button>
+          <Button
+            ghost={tab !== "custom"}
+            size="sm"
+            onClick={() => setTab("custom")}
+            className="text-xs"
+          >
+            Custom
+          </Button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex h-[300px] flex-col items-center justify-center gap-4">
+          <Spinner className="text-2xl text-primary" />
+          <p className="text-sm text-muted-foreground">Loading commands configurations...</p>
+        </div>
+      ) : filteredCommands.length === 0 ? (
+        <Card className="border border-dashed border-border flex flex-col items-center justify-center p-12 bg-card/20 backdrop-blur-sm">
+          <Terminal className="h-10 w-10 text-muted-foreground/60 mb-3" />
+          <h3 className="font-semibold text-lg">No commands found</h3>
+          <p className="text-sm text-muted-foreground mt-1 max-w-xs text-center">
+            {search
+              ? "No commands match your search criteria. Try a different query."
+              : "No commands defined. Click 'Create Command' to register a custom command."}
+          </p>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {filteredCommands.map((cmd) => (
+            <Card
+              key={cmd.name}
+              className={`relative overflow-hidden transition-all duration-200 border bg-card/30 backdrop-blur-md hover:bg-card/45 hover:shadow-md ${
+                !cmd.enabled ? "opacity-60 border-destructive/20" : "border-border"
+              }`}
+            >
+              <CardHeader className="pb-3 flex flex-row items-start justify-between space-y-0">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-base font-bold text-foreground">
+                      /{cmd.name}
+                    </span>
+                    <Badge
+                      tone={cmd.source === "builtin" ? "secondary" : "default"}
+                      className="text-[10px] px-1.5 py-0"
+                    >
+                      {cmd.source === "builtin" ? "Built-in" : "Custom"}
+                    </Badge>
+                  </div>
+                  {cmd.source === "custom" && (
+                    <div className="text-[11px] text-muted-foreground font-mono">
+                      type: <span className="text-foreground">{cmd.type}</span>
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                  {cmd.source === "custom" ? (
+                    <>
+                      <Button
+                        ghost
+                        size="xs"
+                        onClick={() => handleOpenEdit(cmd)}
+                        className="p-1 hover:bg-foreground/5"
+                      >
+                        <Edit2 className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
+                      </Button>
+                      <Button
+                        ghost
+                        size="xs"
+                        onClick={() => handleDelete(cmd)}
+                        className="p-1 hover:bg-destructive/10"
+                      >
+                        <Trash2 className="h-3.5 w-3.5 text-destructive/80 hover:text-destructive" />
+                      </Button>
+                    </>
+                  ) : (
+                    <Switch
+                      checked={cmd.enabled}
+                      onCheckedChange={(checked) => handleToggleBuiltin(cmd, checked)}
+                      className="scale-90"
+                    />
+                  )}
+                </div>
+              </CardHeader>
+
+              <CardContent className="space-y-4">
+                <p className="text-xs text-muted-foreground leading-relaxed min-h-[32px]">
+                  {cmd.description || "No description provided."}
+                </p>
+
+                {cmd.source === "custom" && (
+                  <div className="bg-background/40 border border-border/60 p-2 rounded font-mono text-[10px] break-all max-h-[80px] overflow-y-auto">
+                    <span className="text-muted-foreground">
+                      {cmd.type === "exec" ? "$ " : "-> "}
+                    </span>
+                    <span className="text-foreground">{cmd.command}</span>
+                  </div>
+                )}
+
+                {/* Platform Visibility Row */}
+                <div className="pt-2 border-t border-border/50 flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[11px] text-muted-foreground font-medium flex items-center gap-1">
+                      <Eye className="h-3 w-3" /> Visibility
+                    </span>
+                    <div className="flex items-center gap-3">
+                      {["telegram", "discord", "cli"].map((p) => {
+                        const isVisible = cmd.visible?.[p] !== false;
+                        return (
+                          <div key={p} className="flex items-center gap-1">
+                            {cmd.source === "custom" ? (
+                              <Badge
+                                tone={isVisible ? "success" : "secondary"}
+                                className="text-[9px] px-1 py-0 capitalize"
+                              >
+                                {p}
+                              </Badge>
+                            ) : (
+                              <button
+                                onClick={() =>
+                                  handleToggleBuiltinVisibility(cmd, p, !isVisible)
+                                }
+                                className={`text-[10px] px-1.5 py-0.5 rounded capitalize border transition-all ${
+                                  isVisible
+                                    ? "bg-success/10 border-success/35 text-success font-medium"
+                                    : "bg-muted/15 border-muted-foreground/20 text-muted-foreground"
+                                }`}
+                              >
+                                {p}
+                              </button>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                  
+                  {cmd.source === "custom" && (
+                    <div className="flex items-center justify-between text-[11px]">
+                      <span className="text-muted-foreground">Status</span>
+                      <div className="flex items-center gap-2">
+                        <Switch
+                          checked={cmd.enabled}
+                          onCheckedChange={(checked) => {
+                            const payload = {
+                              name: cmd.name,
+                              description: cmd.description,
+                              type: cmd.type,
+                              command: cmd.command,
+                              enabled: checked,
+                              visible: cmd.visible,
+                              silent_empty: cmd.silent_empty,
+                            };
+                            api.upsertCustomCommand(payload, selectedProfile || undefined)
+                              .then(() => {
+                                setCommands((prev) =>
+                                  prev.map((c) => (c.name === cmd.name ? { ...c, enabled: checked } : c))
+                                );
+                                showToast(`Command /${cmd.name} ${checked ? "enabled" : "disabled"}`, "success");
+                              })
+                              .catch((err) => showToast(`Failed to toggle command: ${err}`, "error"));
+                          }}
+                          className="scale-75"
+                        />
+                        <span className={cmd.enabled ? "text-success font-medium" : "text-muted-foreground"}>
+                          {cmd.enabled ? "Enabled" : "Disabled"}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Editor Modal */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-md bg-card border border-border backdrop-blur-xl">
+          <DialogHeader>
+            <DialogTitle className="text-lg font-bold flex items-center gap-2">
+              <Terminal className="h-5 w-5 text-primary" />
+              {editingCommand ? "Edit Custom Command" : "Create Custom Command"}
+            </DialogTitle>
+            <DialogDescription className="text-xs">
+              Define a custom slash command running a local shell script or redirecting to another command.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleSave} className="space-y-4 pt-2">
+            <div className="grid gap-1">
+              <Label htmlFor="cmd-name" className="text-xs font-semibold">
+                Name
+              </Label>
+              <div className="relative">
+                <span className="absolute left-3 top-2.5 text-xs text-muted-foreground font-mono">
+                  /
+                </span>
+                <Input
+                  id="cmd-name"
+                  placeholder="e.g. status-check"
+                  value={name}
+                  onChange={(e) => setName(e.target.value.toLowerCase().replace(/\s+/g, ""))}
+                  disabled={!!editingCommand}
+                  className="pl-6 bg-background/40 border-border text-xs font-mono"
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-1">
+              <Label htmlFor="cmd-desc" className="text-xs font-semibold">
+                Description
+              </Label>
+              <Input
+                id="cmd-desc"
+                placeholder="A short description of what this command does"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                className="bg-background/40 border-border text-xs"
+              />
+            </div>
+
+            <div className="grid gap-1">
+              <Label htmlFor="cmd-type" className="text-xs font-semibold">
+                Type
+              </Label>
+              <Select
+                id="cmd-type"
+                value={type}
+                onValueChange={(val) => setType(val as "exec" | "alias")}
+              >
+                <SelectOption value="exec">Exec (Shell Subprocess)</SelectOption>
+                <SelectOption value="alias">Alias (Redirect command)</SelectOption>
+              </Select>
+            </div>
+
+            {type === "exec" ? (
+              <div className="space-y-2">
+                <div className="grid gap-1">
+                  <Label htmlFor="cmd-shell" className="text-xs font-semibold">
+                    Shell Command
+                  </Label>
+                  <textarea
+                    id="cmd-shell"
+                    placeholder="e.g. echo 'CPU Usage:' && top -b -n 1 | grep Cpu"
+                    value={commandText}
+                    onChange={(e) => setCommandText(e.target.value)}
+                    className="min-h-[80px] w-full border border-border bg-background/30 rounded-lg p-2.5 font-mono text-[11px] leading-relaxed shadow-sm focus:outline-none focus:ring-1 focus:ring-primary"
+                  />
+                </div>
+                <div className="flex items-center justify-between text-xs pt-1">
+                  <div className="flex flex-col gap-0.5">
+                    <span className="font-medium text-foreground">Silent on Empty Output</span>
+                    <span className="text-[10px] text-muted-foreground">If the command returns no output, don't send any reply.</span>
+                  </div>
+                  <Switch
+                    checked={silentEmpty}
+                    onCheckedChange={setSilentEmpty}
+                    className="scale-75"
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className="grid gap-1">
+                <Label htmlFor="cmd-target" className="text-xs font-semibold">
+                  Target Command
+                </Label>
+                <div className="relative">
+                  <span className="absolute left-3 top-2.5 text-xs text-muted-foreground font-mono">
+                    /
+                  </span>
+                  <Input
+                    id="cmd-target"
+                    placeholder="e.g. status"
+                    value={targetText}
+                    onChange={(e) => setTargetText(e.target.value)}
+                    className="pl-6 bg-background/40 border-border text-xs font-mono"
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* Platform checkboxes */}
+            <div className="pt-2 border-t border-border/40">
+              <Label className="text-xs font-semibold mb-2 block">Platform Visibility</Label>
+              <div className="grid grid-cols-3 gap-2">
+                <label className="flex items-center gap-2 p-2 rounded-lg border border-border bg-background/20 cursor-pointer select-none hover:bg-background/40">
+                  <input
+                    type="checkbox"
+                    checked={visTelegram}
+                    onChange={(e) => setVisTelegram(e.target.checked)}
+                    className="rounded border-border text-primary focus:ring-0 focus:ring-offset-0"
+                  />
+                  <span className="text-xs capitalize">Telegram</span>
+                </label>
+                <label className="flex items-center gap-2 p-2 rounded-lg border border-border bg-background/20 cursor-pointer select-none hover:bg-background/40">
+                  <input
+                    type="checkbox"
+                    checked={visDiscord}
+                    onChange={(e) => setVisDiscord(e.target.checked)}
+                    className="rounded border-border text-primary focus:ring-0 focus:ring-offset-0"
+                  />
+                  <span className="text-xs capitalize">Discord</span>
+                </label>
+                <label className="flex items-center gap-2 p-2 rounded-lg border border-border bg-background/20 cursor-pointer select-none hover:bg-background/40">
+                  <input
+                    type="checkbox"
+                    checked={visCli}
+                    onChange={(e) => setVisCli(e.target.checked)}
+                    className="rounded border-border text-primary focus:ring-0 focus:ring-offset-0"
+                  />
+                  <span className="text-xs capitalize">CLI</span>
+                </label>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2 pt-2">
+              <Switch
+                checked={enabled}
+                onCheckedChange={setEnabled}
+                className="scale-75"
+              />
+              <span className="text-xs text-muted-foreground">Enabled</span>
+            </div>
+
+            {formError && (
+              <div className="flex items-center gap-1.5 p-2 rounded bg-destructive/10 border border-destructive/25 text-destructive text-xs">
+                <AlertCircle className="h-4 w-4 shrink-0" />
+                <span>{formError}</span>
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                outlined
+                size="sm"
+                onClick={() => setDialogOpen(false)}
+                type="button"
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                type="submit"
+                disabled={saving}
+              >
+                {saving ? "Saving..." : "Save Command"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -257,6 +257,7 @@ export default function ProfilesPage() {
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
   const [activeInfo, setActiveInfo] = useState<ActiveProfileInfo | null>(null);
   const [loading, setLoading] = useState(true);
+  const [busyGateways, setBusyGateways] = useState<Record<string, boolean>>({});
   const { toast, showToast } = useToast();
   const { t } = useI18n();
   const { setEnd } = usePageHeader();
@@ -509,6 +510,24 @@ export default function ProfilesPage() {
       showToast(`${t.status.error}: ${e}`, "error");
     } finally {
       setSettingActive(null);
+    }
+  };
+
+  const handleToggleGateway = async (name: string, verb: "start" | "stop") => {
+    setBusyGateways((prev) => ({ ...prev, [name]: true }));
+    try {
+      if (verb === "start") {
+        await api.startGateway(name);
+      } else {
+        await api.stopGateway(name);
+      }
+      showToast(`Gateway ${verb}ed for profile '${name}'`, "success");
+      // Give the backend a second to update status, then reload
+      setTimeout(load, 1500);
+    } catch (e) {
+      showToast(`Failed to ${verb} gateway for '${name}': ${e}`, "error");
+    } finally {
+      setBusyGateways((prev) => ({ ...prev, [name]: false }));
     }
   };
 
@@ -1162,27 +1181,58 @@ export default function ProfilesPage() {
                         />
                       </div>
 
-                      <div className="flex items-center gap-1.5 text-xs">
-                        <span
-                          className={cn(
-                            "h-1.5 w-1.5 rounded-full",
-                            p.gateway_running
-                              ? "bg-success"
-                              : "bg-muted-foreground/40",
-                          )}
-                        />
+                      <div className="flex items-center justify-between text-xs pt-1">
+                        <div className="flex items-center gap-1.5">
+                          <span
+                            className={cn(
+                              "h-1.5 w-1.5 rounded-full",
+                              p.gateway_running
+                                ? "bg-success"
+                                : "bg-muted-foreground/40",
+                            )}
+                          />
 
-                        <span
-                          className={cn(
-                            p.gateway_running
-                              ? "text-success"
-                              : "text-muted-foreground",
+                          <span
+                            className={cn(
+                              p.gateway_running
+                                ? "text-success"
+                                : "text-muted-foreground",
+                            )}
+                          >
+                            {p.gateway_running
+                              ? L.gatewayRunning
+                              : L.gatewayStopped}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          {p.gateway_running ? (
+                            <Button
+                              size="xs"
+                              outlined
+                              className="text-warning h-5 py-0 px-2 text-[10px] uppercase font-semibold"
+                              disabled={busyGateways[p.name]}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleToggleGateway(p.name, "stop");
+                              }}
+                            >
+                              {busyGateways[p.name] ? "Stopping" : "Stop"}
+                            </Button>
+                          ) : (
+                            <Button
+                              size="xs"
+                              outlined
+                              className="text-success h-5 py-0 px-2 text-[10px] uppercase font-semibold"
+                              disabled={busyGateways[p.name]}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleToggleGateway(p.name, "start");
+                              }}
+                            >
+                              {busyGateways[p.name] ? "Starting" : "Start"}
+                            </Button>
                           )}
-                        >
-                          {p.gateway_running
-                            ? L.gatewayRunning
-                            : L.gatewayStopped}
-                        </span>
+                        </div>
                       </div>
 
                       <div className="flex items-start gap-2 text-xs">


### PR DESCRIPTION
Implements true bidirectional command synchronization between Hermes config and connected messaging platforms.

## Changes

**Telegram adapter (plugins/platforms/telegram/adapter.py):**
- Add delete_my_commands(scope) before set_my_commands to clear stale entries
- Filter commands by visibility config per-platform before registering
- Stale/disabled commands now properly disappear from / menu

**Discord adapter (plugins/platforms/discord/adapter.py):**
- Filter slash commands by visibility config before tree registration
- Already used tree.sync() which is bidirectional — just needed visibility filter

**New API:**
- POST /api/commands/sync — triggers re-registration on all connected platforms without gateway restart
- Dashboard 'Sync to Platforms' button in CommandsPage

Tested on Linux with Telegram and Discord.