### PR TITLE
Add Hermes Webapp command and architecture docs

### DIFF
--- a/docs/plans/2026-07-08-hermes-webapp-browser-workspace.md
+++ b/docs/plans/2026-07-08-hermes-webapp-browser-workspace.md
@@ -1,0 +1,203 @@
+# Hermes Webapp Browser Workspace Implementation Plan
+
+> **For Hermes:** Use the subagent-driven-development skill to implement this plan step by step.
+
+**Goal:** Make Hermes Webapp a first-class browser-native portal for Hermes Agent: each chat owns a persistent workspace with chat, files, previews, and one or more controllable browser tabs that the user and agent can both see.
+
+**Architecture:** Keep Hermes Desktop and Hermes Dashboard intact. Add Hermes Webapp as a named browser portal surface that reuses the existing server/session backbone at first, then grows native webapp panes and browser-workspace APIs behind `hermes webapp`. Share code with Desktop where practical, but do not require Electron for Webapp-only functionality.
+
+**Tech Stack:** FastAPI dashboard server, React/Vite web workspace, existing Hermes session database, existing PTY/event WebSocket channels, future browser worker using isolated local browser contexts, optional extension-capable local Chromium on the host.
+
+---
+
+## Product vocabulary
+
+- **Hermes Dashboard**: the existing browser management/admin surface (`hermes dashboard`). It manages config, profiles, models, keys, sessions, logs, cron, skills, plugins, and can embed the TUI in a Chat tab.
+- **Hermes Desktop**: the Electron app (`hermes desktop`). It can use Electron-only APIs: native file dialogs, webviews, local app packaging, OS window controls.
+- **Hermes Webapp**: the portable browser-native workspace (`hermes webapp`). It is not a Dashboard rename and not a Desktop replacement. It should become the main multi-device portal: chat, files, previews, responsive browser tabs, and agent-assisted browser/RPA workflows.
+- **Hermes Backend / Serve**: the headless JSON-RPC/WebSocket server (`hermes serve`) used by Desktop, Webapp, and future clients.
+
+## Networking boundary
+
+Hermes Webapp must be explicit about where it is reachable:
+
+1. **Localhost mode**: `127.0.0.1` only. Only that computer can use it. This is the safe default.
+2. **LAN mode**: bound to a private LAN interface. Devices on that LAN can reach it. Must require auth and clear UI warning.
+3. **Tailscale mode**: bound to a Tailscale IP/interface. Devices in that tailnet can reach it. Must require auth and clear UI warning.
+4. **Public mode**: out of scope for ad-hoc binds. Public deployment should be through a deliberate hosted/deployment path, not accidental `0.0.0.0` sharing.
+
+Hermes Webapp is not a remote-access product. It can expose a web UI on chosen networks, but it must not pretend to be Chrome Remote Desktop, RustDesk, or a hosted browser-control service.
+
+## Browser workspace model
+
+Each chat gets a **workspace**:
+
+```text
+chat_session_id
+  ├─ chat transcript / live agent process
+  ├─ file panes / project browser state
+  ├─ preview panes / responsive viewport presets
+  └─ browser workspace
+       ├─ browser_context_id
+       ├─ tabs[]
+       │   ├─ tab_id
+       │   ├─ url/title/favicon
+       │   ├─ viewport preset / custom size
+       │   ├─ last screenshot frame
+       │   └─ agent-control state
+       ├─ extension profile / user settings
+       └─ RPA event log
+```
+
+The browser workspace must survive refresh and device switch when the backend is still alive. A phone/laptop browser can reconnect to the same Webapp route and see active/inactive chats plus their browser/file/preview state.
+
+## Browser implementation principles
+
+1. **Visible first**: when the agent clicks or types, the user sees it. Use smooth mouse/cursor animation and visible focus transitions.
+2. **Shared ownership**: the user can manually browse; the agent can request control; the user can interrupt or take over.
+3. **Session isolation**: browser contexts are per chat/workspace, not one global default profile. Do not attach to a user's personal default Chrome profile with raw CDP.
+4. **Extension support**: support loading/using extensions in the browser context, but do not ship user-specific extensions. Users may install LastPass, Dark Reader, etc. The product supplies the extension/profile mechanism, not the extension choices.
+5. **Responsive by default**: each browser tab has viewport presets and free resize. Presets are shortcuts, not locks.
+6. **Agent visibility**: the agent can list tabs, capture screenshots, inspect page accessibility/DOM metadata, and target a tab by ID.
+7. **Permissioned RPA**: browser actions should be visible, logged, and gated by the same safety/approval concepts Hermes already uses for tools.
+
+## Why the current Dashboard chat is insufficient
+
+The Dashboard Chat tab currently embeds `hermes --tui` in xterm over PTY. That is valuable because it preserves TUI behavior, but it is not a native webapp workspace:
+
+- no browser-native multi-pane chat layout;
+- no per-chat browser contexts;
+- no extension-capable browser surface;
+- no first-class responsive viewport controls;
+- no agent-visible browser tab registry;
+- no browser-RPA control surface.
+
+Hermes Webapp should not fight xterm. It should reuse the existing backend/event/session machinery but build a native web workspace around it.
+
+## PR strategy
+
+- Upstream PRs should stay reviewable and focused:
+  - CLI/product naming (`hermes webapp`) and docs;
+  - shared Desktop/Webapp attachment fixes;
+  - shared pane/preview sizing components;
+  - server APIs for workspace/browser sessions;
+  - UI slices that can be tested independently.
+- Steven's fork can merge broader integrated work directly to its own main branch while still opening clean PRs upstream.
+- Desktop-compatible features should be PR'd to Desktop/shared code when they make Desktop better.
+- Webapp-only behavior should not pretend to be Desktop. Electron APIs must remain optional.
+
+## Task 1: Add the product surface name
+
+**Objective:** Make `hermes webapp` a real command without breaking `hermes dashboard`.
+
+**Files:**
+- Modify: `hermes_cli/subcommands/dashboard.py`
+- Modify: `hermes_cli/main.py`
+- Test: `tests/hermes_cli/test_serve_command.py`
+- Test: `tests/hermes_cli/test_subcommands_batch.py`
+- Test: `tests/hermes_cli/test_dashboard_lifecycle_flags.py`
+
+**Verification:**
+
+```bash
+python -m pytest tests/hermes_cli/test_serve_command.py tests/hermes_cli/test_subcommands_batch.py::test_dashboard_builder_two_handlers tests/hermes_cli/test_dashboard_lifecycle_flags.py::TestWebappProcessDetection -q -o 'addopts='
+```
+
+Expected: all pass.
+
+## Task 2: Add docs and glossary
+
+**Objective:** Give contributors/users stable vocabulary before more code lands.
+
+**Files:**
+- Create: `website/docs/user-guide/hermes-webapp.md`
+- Modify: `website/sidebars.ts`
+- Modify: `website/docs/user-guide/features/web-dashboard.md`
+- Modify: `website/docs/user-guide/desktop.md`
+
+**Verification:**
+
+```bash
+npm --prefix website run build
+```
+
+Expected: docs build succeeds.
+
+## Task 3: Define workspace state contract
+
+**Objective:** Add typed backend/frontend schema for chat workspace state without launching browsers yet.
+
+**Files:**
+- Create: `hermes_cli/webapp_workspace.py`
+- Add tests under: `tests/hermes_cli/test_webapp_workspace.py`
+- Add frontend types under: `web/src/lib/webapp-workspace.ts`
+
+**State:**
+
+```json
+{
+  "session_id": "...",
+  "workspace_id": "...",
+  "panes": [],
+  "browser": {
+    "context_id": "...",
+    "tabs": []
+  }
+}
+```
+
+**Verification:** Python unit tests and web typecheck.
+
+## Task 4: Add browser tab registry APIs
+
+**Objective:** Let Webapp list/create/close browser tabs for a chat workspace, even before full RPA exists.
+
+**API sketch:**
+
+```text
+GET  /api/webapp/workspaces/{session_id}
+POST /api/webapp/workspaces/{session_id}/browser/tabs
+POST /api/webapp/workspaces/{session_id}/browser/tabs/{tab_id}/navigate
+POST /api/webapp/workspaces/{session_id}/browser/tabs/{tab_id}/close
+```
+
+**Verification:** FastAPI TestClient tests against isolated `HERMES_HOME`.
+
+## Task 5: Build the browser-workspace rail in Webapp
+
+**Objective:** Add a native webapp right rail with chat + browser/file/preview tabs. Do not rely on Electron `webview`.
+
+**Files:**
+- Add under `web/src/pages` or `web/src/features/webapp-workspace`
+- Reuse shared UI patterns where practical.
+
+**Verification:** Vitest/jsdom tests and browser dogfood against local Vite server.
+
+## Task 6: RPA control loop
+
+**Objective:** Add visible agent/browser control primitives: screenshot, click, type, scroll, navigate, active-tab list.
+
+**Important:** This should be a service-gated capability, not a core model tool blindly added to every Hermes turn.
+
+**Potential implementation:** Browser worker process + local WebSocket/SSE stream. Consider BrowserOS ideas, but strip to Hermes-owned control/events and avoid attaching to default Chrome profiles.
+
+## Task 7: Extension support
+
+**Objective:** Support user-installed browser extensions per Webapp browser profile/context.
+
+**Constraints:**
+- No bundled LastPass/Dark Reader.
+- User-controlled installation/profile import path.
+- Document privacy/security boundaries.
+
+## Acceptance criteria
+
+Hermes Webapp is real when a user can:
+
+1. Run `hermes webapp`.
+2. Open the same active chat from two devices on an explicitly chosen network scope.
+3. See the same chat, file panes, preview panes, and browser tabs.
+4. Resize a browser tab to phone/tablet/desktop/ultrawide and freely drag it after presets.
+5. Install or load browser extensions in their own Webapp browser profile.
+6. Let Hermes visibly click/type/navigate inside a tab with interrupt/takeover controls.
+7. Keep all of this local/LAN/Tailscale-scoped unless they intentionally deploy a public service.

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -74,8 +74,9 @@ Examples:
     hermes console                Open the safe Hermes command console
     hermes update                 Update to latest version
     hermes dashboard              Start web UI dashboard (port 9119)
-    hermes dashboard --stop       Stop running dashboard processes
-    hermes dashboard --status     List running dashboard processes
+    hermes webapp                 Start browser-native workspace (port 9119)
+    hermes webapp --stop          Stop running Hermes web server processes
+    hermes webapp --status        List running Hermes web server processes
 
 For more help on a command:
     hermes <command> --help

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -39,6 +39,9 @@ Usage:
     hermes uninstall           Uninstall Hermes Agent
     hermes acp                 Run as an ACP server for editor integration
     hermes sessions browse     Interactive session picker with search
+    hermes dashboard           Start browser management dashboard
+    hermes webapp              Start browser-native Hermes workspace surface
+    hermes serve               Start headless backend server
 
     hermes claw migrate --dry-run  # Preview migration without changes
 """
@@ -5791,7 +5794,7 @@ def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
 ) -> list[int]:
-    """Return PIDs of ``hermes dashboard`` processes other than ourselves.
+    """Return PIDs of ``hermes dashboard``/``webapp`` processes other than ourselves.
 
     ``hermes dashboard`` is a long-lived server process commonly started and
     forgotten.  When ``hermes update`` replaces files on disk, the running
@@ -5820,6 +5823,12 @@ def _find_stale_dashboard_pids(
         "hermes dashboard",
         "hermes_cli.main dashboard",
         "hermes_cli/main.py dashboard",
+        # `hermes webapp` is the canonical browser workspace command. It uses
+        # the same long-lived web server and therefore needs the same status,
+        # stop, and post-update stale-process management as `dashboard`.
+        "hermes webapp",
+        "hermes_cli.main webapp",
+        "hermes_cli/main.py webapp",
         # The headless backend (`hermes serve`) is the same long-lived server
         # under a different command name — the desktop app spawns it. Reap it
         # on update for the same frontend/backend-mismatch reason.
@@ -5827,6 +5836,18 @@ def _find_stale_dashboard_pids(
         "hermes_cli.main serve",
         "hermes_cli/main.py serve",
     ]
+    lifecycle_flags = {"--status", "--stop"}
+
+    def is_lifecycle_probe(command: str) -> bool:
+        """Return True for short-lived status/stop invocations.
+
+        ``hermes dashboard --status`` and ``hermes webapp --stop`` use this
+        scanner but are not themselves stale long-lived web server processes.
+        This also prevents shell wrappers whose command line contains a status
+        probe from being reported as a running dashboard/webapp server.
+        """
+        return any(flag in command.split() for flag in lifecycle_flags)
+
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -5864,6 +5885,7 @@ def _find_stale_dashboard_pids(
                     pid_str = line[len("ProcessId=") :]
                     if (
                         any(p in current_cmd for p in patterns)
+                        and not is_lifecycle_probe(current_cmd)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -5896,7 +5918,11 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if (
+                        any(p in command for p in patterns)
+                        and not is_lifecycle_probe(command)
+                        and pid != self_pid
+                    ):
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []
@@ -11725,7 +11751,7 @@ def _render_distribution_plan(plan) -> None:
 
 
 def _report_dashboard_status() -> int:
-    """Print ``hermes dashboard`` PIDs and return the count.
+    """Print Hermes web server PIDs and return the count.
 
     Uses the same detection logic as ``_find_stale_dashboard_pids`` (the
     current process is excluded, but since ``hermes dashboard --status``
@@ -11734,10 +11760,10 @@ def _report_dashboard_status() -> int:
     """
     pids = _find_stale_dashboard_pids()
     if not pids:
-        print("No hermes dashboard processes running.")
+        print("No Hermes web server processes running.")
         return 0
 
-    print(f"{len(pids)} hermes dashboard process(es) running:")
+    print(f"{len(pids)} Hermes web server process(es) running:")
     for pid in pids:
         # Best-effort: show the full cmdline so users can tell profiles apart.
         cmdline = ""
@@ -11928,7 +11954,7 @@ def cmd_dashboard(args):
     if getattr(args, "stop", False):
         pids = _find_stale_dashboard_pids()
         if not pids:
-            print("No hermes dashboard processes running.")
+            print("No Hermes web server processes running.")
             sys.exit(0)
         # Reuse the same SIGTERM-grace-SIGKILL path used after `hermes update`.
         _kill_stale_dashboard_processes(reason="requested via --stop")

--- a/hermes_cli/subcommands/dashboard.py
+++ b/hermes_cli/subcommands/dashboard.py
@@ -1,11 +1,12 @@
-"""``hermes dashboard`` / ``hermes serve`` subcommand parsers.
+"""``hermes dashboard`` / ``hermes webapp`` / ``hermes serve`` subcommand parsers.
 
-``dashboard`` is the browser web UI; ``serve`` is the same gateway, headless —
-what the desktop app and remote backends run. ``serve`` also skips the web UI
-build (``headless_backend=True``): pure JSON-RPC/WS clients never load the SPA.
-Both share one handler (``cmd_dashboard`` → ``start_server``). Extracted from
-``hermes_cli/main.py:main()`` (god-file Phase 2); handler injected to avoid
-importing ``main``.
+``dashboard`` is the existing browser management UI. ``webapp`` is the canonical
+portal/workspace name for the browser UI as it grows beyond management screens.
+``serve`` is the same gateway, headless — what the desktop app and remote
+backends run. ``serve`` also skips the web UI build (``headless_backend=True``):
+pure JSON-RPC/WS clients never load the SPA. All three share one handler
+(``cmd_dashboard`` → ``start_server``). Extracted from ``hermes_cli/main.py:main()``
+(god-file Phase 2); handler injected to avoid importing ``main``.
 """
 
 from __future__ import annotations
@@ -87,13 +88,14 @@ def _add_server_runtime_args(parser) -> None:
 def build_dashboard_parser(
     subparsers, *, cmd_dashboard: Callable, cmd_dashboard_register: Callable
 ) -> None:
-    """Attach the ``dashboard`` and ``serve`` subcommands.
+    """Attach the ``dashboard``, ``webapp``, and ``serve`` subcommands.
 
     Both share the same backend (``cmd_dashboard`` → ``start_server``).
-    ``dashboard`` is the browser UI; ``serve`` is the headless backend used by
-    the desktop app and remote clients. They are independent surfaces — neither
-    "launches" the other — so the desktop app spawns ``serve``, never
-    ``dashboard``.
+    ``dashboard`` is the established management UI name; ``webapp`` is the
+    canonical browser workspace/portal name; ``serve`` is the headless backend
+    used by the desktop app and remote clients. They are independent surfaces —
+    neither "launches" the other — so the desktop app spawns ``serve``, never
+    ``dashboard`` or ``webapp``.
     """
     # =========================================================================
     # dashboard command — the browser web UI
@@ -123,6 +125,30 @@ def build_dashboard_parser(
         help=argparse.SUPPRESS,
     )
     dashboard_parser.set_defaults(func=cmd_dashboard)
+
+    # =========================================================================
+    # webapp command — canonical browser portal/workspace surface
+    #
+    # For now this intentionally starts the same SPA/server as `dashboard` so the
+    # new product vocabulary is real without duplicating backend code. Future
+    # Hermes Webapp work can specialize the browser workspace behind this command
+    # while keeping `dashboard` backward-compatible for management workflows.
+    # =========================================================================
+    webapp_parser = subparsers.add_parser(
+        "webapp",
+        help="Start the Hermes Webapp browser workspace",
+        description=(
+            "Launch the Hermes Webapp — the browser-native portal/workspace for "
+            "chat, sessions, panes, and future per-chat browser/RPA work. Today "
+            "it serves the same UI bundle as `hermes dashboard`; the separate "
+            "command names the product boundary without replacing Dashboard."
+        ),
+    )
+    _add_server_runtime_args(webapp_parser)
+    webapp_parser.add_argument(
+        "--no-open", action="store_true", help="Don't open browser automatically"
+    )
+    webapp_parser.set_defaults(func=cmd_dashboard)
 
     # =========================================================================
     # serve command — the headless backend server

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -36,7 +36,7 @@ class TestDashboardStatus:
             cmd_dashboard(_ns(status=True))
         assert exc.value.code == 0
         out = capsys.readouterr().out
-        assert "No hermes dashboard processes running" in out
+        assert "No Hermes web server processes running" in out
 
     def test_status_with_processes(self, capsys):
         with patch("hermes_cli.main._find_stale_dashboard_pids",
@@ -46,7 +46,7 @@ class TestDashboardStatus:
         # Status is informational — always exits 0.
         assert exc.value.code == 0
         out = capsys.readouterr().out
-        assert "2 hermes dashboard process(es) running" in out
+        assert "2 Hermes web server process(es) running" in out
         assert "PID 12345" in out
         assert "PID 12346" in out
 
@@ -76,7 +76,7 @@ class TestDashboardStop:
             cmd_dashboard(_ns(stop=True))
         assert exc.value.code == 0
         out = capsys.readouterr().out
-        assert "No hermes dashboard processes running" in out
+        assert "No Hermes web server processes running" in out
 
     def test_stop_kills_and_exits_zero_when_all_killed(self, capsys):
         """After the kill, if the second scan returns empty we exit 0."""
@@ -179,3 +179,30 @@ class TestArgparseWiring:
              pytest.raises(SystemExit) as exc:
             mod.cmd_dashboard(_ns(status=True))
         assert exc.value.code == 0
+
+
+class TestWebappProcessDetection:
+    def test_webapp_command_lines_are_managed_with_dashboard_processes(self):
+        from hermes_cli import main as main_mod
+
+        ps_output = """
+          111 python -m hermes_cli.main webapp --host 127.0.0.1 --port 9119
+          222 hermes webapp --host 127.0.0.1 --port 9119
+          333 hermes dashboard --host 127.0.0.1 --port 9119
+          444 python -m hermes_cli.main chat -q webapp
+          555 /usr/bin/bash -c /venv/bin/python -m hermes_cli.main webapp --status
+          556 /usr/bin/bash -c /venv/bin/python -m hermes_cli.main dashboard --stop
+        """
+
+        completed = MagicMock(returncode=0, stdout=ps_output)
+
+        with patch.object(main_mod.sys, "platform", "linux"), \
+             patch.object(main_mod.subprocess, "run", return_value=completed):
+            pids = main_mod._find_stale_dashboard_pids()
+
+        assert 111 in pids
+        assert 222 in pids
+        assert 333 in pids
+        assert 444 not in pids
+        assert 555 not in pids
+        assert 556 not in pids

--- a/tests/hermes_cli/test_serve_command.py
+++ b/tests/hermes_cli/test_serve_command.py
@@ -7,6 +7,8 @@ the desktop never invokes ``dashboard``. These tests pin that contract:
 - ``serve`` routes to the same handler as ``dashboard``;
 - ``serve`` is headless by default, ``dashboard`` is not;
 - both expose the identical server-runtime flag surface.
+- ``webapp`` is the canonical named portal surface: browser UI, not headless,
+  same runtime flags as ``dashboard`` while ``dashboard`` remains supported.
 """
 
 from __future__ import annotations
@@ -68,3 +70,27 @@ def test_serve_is_a_headless_backend_but_dashboard_is_not():
     # build; only `serve` carries it.
     assert getattr(_parser().parse_args(["serve"]), "headless_backend", False) is True
     assert getattr(_parser().parse_args(["dashboard"]), "headless_backend", False) is False
+
+
+def test_webapp_routes_to_the_shared_dashboard_handler():
+    args = _parser().parse_args(["webapp"])
+    assert args.func is _dash
+
+
+def test_webapp_is_browser_ui_not_headless_backend():
+    args = _parser().parse_args(["webapp"])
+    assert args.no_open is False
+    assert getattr(args, "headless_backend", False) is False
+
+
+def test_webapp_takes_the_same_runtime_flags_as_dashboard():
+    argv = ["--host", "0.0.0.0", "--port", "0", "--insecure", "--skip-build", "--isolated"]
+    webapp = _parser().parse_args(["webapp", *argv])
+    dash = _parser().parse_args(["dashboard", *argv])
+    for field in ("host", "port", "insecure", "skip_build", "isolated"):
+        assert getattr(webapp, field) == getattr(dash, field)
+
+
+def test_webapp_supports_lifecycle_flags():
+    for flag in ("--stop", "--status"):
+        assert getattr(_parser().parse_args(["webapp", flag]), flag.lstrip("-")) is True

--- a/tests/hermes_cli/test_subcommands_batch.py
+++ b/tests/hermes_cli/test_subcommands_batch.py
@@ -93,6 +93,8 @@ def test_dashboard_builder_two_handlers():
     build_dashboard_parser(sub, cmd_dashboard=dash, cmd_dashboard_register=reg)
     # bare dashboard -> launch handler
     assert parser.parse_args(["dashboard"]).func is dash
+    # canonical webapp alias -> same launch handler
+    assert parser.parse_args(["webapp"]).func is dash
     # dashboard register -> register handler
     assert parser.parse_args(["dashboard", "register"]).func is reg
 

--- a/tests/hermes_cli/test_top_level_parser_help.py
+++ b/tests/hermes_cli/test_top_level_parser_help.py
@@ -1,0 +1,10 @@
+from hermes_cli._parser import build_top_level_parser
+
+
+def test_root_help_lists_webapp_surface_examples():
+    help_text = build_top_level_parser()[0].format_help()
+
+    assert "hermes dashboard              Start web UI dashboard" in help_text
+    assert "hermes webapp                 Start browser-native workspace" in help_text
+    assert "hermes webapp --stop          Stop running Hermes web server processes" in help_text
+    assert "hermes webapp --status        List running Hermes web server processes" in help_text

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -43,6 +43,11 @@ hermes chat -s github-pr-workflow -q "open a draft PR"
 hermes --continue             # Resume the most recent CLI session (-c)
 hermes --resume <session_id>  # Resume a specific session by ID (-r)
 
+# Open browser/native surfaces
+hermes dashboard              # Browser management dashboard
+hermes webapp                 # Browser-native Hermes workspace surface
+hermes desktop                # Native Desktop app
+
 # Verbose mode (debug output)
 hermes chat --verbose
 

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -16,6 +16,7 @@ Hermes has several front ends that all talk to the same agent:
 - **Desktop App** (this page) — a native application with a purpose-built UI for chat, configuration, and management.
 - **CLI** (`hermes`) and **[TUI](./tui.md)** (`hermes --tui`) — terminal interfaces.
 - **[Web Dashboard](./features/web-dashboard.md)** (`hermes dashboard`) — a browser admin panel; its optional **Chat** tab embeds the TUI through a pseudo-terminal.
+- **[Hermes Webapp](./hermes-webapp.md)** (`hermes webapp`) — the browser-native workspace direction for chat, files, previews, and future per-chat browser/RPA work. Today it starts the same server/UI bundle as Dashboard while the dedicated workspace is built out.
 
 Pick whichever fits the moment. They share state, so you can start a session in one and resume it in another.
 :::

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -8,6 +8,10 @@ description: "Browser-based administration panel for managing configuration, API
 
 The web dashboard is a browser-based UI for managing your Hermes Agent installation. Instead of editing YAML files or running CLI commands, you can configure settings, manage API keys, and monitor sessions from a clean web interface.
 
+:::tip Dashboard vs Webapp
+The Dashboard is the management/admin surface. The new [Hermes Webapp](../hermes-webapp.md) command names the browser-native workspace direction: chat, files, previews, and future per-chat browser/RPA work. Today `hermes webapp` starts the same server/UI bundle while that dedicated workspace is built out; `hermes dashboard` remains supported for management workflows.
+:::
+
 :::tip
 Hosted-mode auth uses Nous Portal OAuth; if you also want the dashboard to talk to a real backend, `hermes setup --portal` wires up the model and tool gateway too. See [Nous Portal](/integrations/nous-portal).
 :::

--- a/website/docs/user-guide/hermes-webapp.md
+++ b/website/docs/user-guide/hermes-webapp.md
@@ -1,0 +1,87 @@
+---
+sidebar_position: 4
+title: "Hermes Webapp"
+description: "The planned browser-native Hermes workspace: chat, sessions, files, previews, and per-chat browser workspaces without replacing Hermes Dashboard or Hermes Desktop."
+---
+
+# Hermes Webapp
+
+Hermes Webapp is the browser-native workspace surface for Hermes Agent. It is not a replacement for Hermes Desktop and it is not just a rename of the Web Dashboard.
+
+Today, `hermes webapp` starts the same browser UI bundle as `hermes dashboard` while the dedicated workspace surface is built out. The separate command is intentional: it gives the portable browser workspace a stable product boundary without breaking existing Dashboard users.
+
+```bash
+hermes webapp
+```
+
+## Which surface is which?
+
+- **Hermes Dashboard** (`hermes dashboard`) — browser management UI for config, models, keys, sessions, logs, cron, skills, plugins, and profile administration. Its Chat tab embeds the TUI over a pseudo-terminal.
+- **Hermes Desktop** (`hermes desktop`) — native Electron app. It can use Electron-only APIs such as native file dialogs, OS integration, packaged app updates, and Electron webviews.
+- **Hermes Webapp** (`hermes webapp`) — portable browser workspace for chat, active sessions, files, previews, and future per-chat browser/RPA work. It should work from any modern browser when the user intentionally exposes it to that device.
+- **Hermes Serve** (`hermes serve`) — headless backend used by Desktop, Webapp, and other clients.
+
+## Network scope
+
+Hermes Webapp follows the same safety model as the Dashboard server: it is local by default.
+
+| Scope | What it means | Typical command |
+| --- | --- | --- |
+| Localhost | Only this computer can use it. Safest default. | `hermes webapp` |
+| LAN | Devices on the local network can reach it. Requires deliberate bind/auth. | `hermes webapp --host 0.0.0.0` |
+| Tailscale | Devices in the tailnet can reach it. Requires deliberate bind/auth. | bind to the Tailscale address |
+| Public internet | Not an ad-hoc bind target. Use a deliberate hosted/deployment path. | out of scope |
+
+Hermes Webapp is not a remote-desktop product. It can be reachable from a chosen network, but it should not pretend to be Chrome Remote Desktop, RustDesk, or a public browser-control service.
+
+## Browser workspace vision
+
+The intended model is: every chat can own its own browser workspace.
+
+A chat workspace may include:
+
+- the chat transcript and active/inactive run state;
+- file browser and file preview tabs;
+- responsive preview tabs;
+- one or more browser tabs tied to that chat;
+- viewport presets for phone, foldable, desktop, and ultrawide review;
+- an agent-visible tab registry;
+- screenshots/annotations for browser RPA;
+- visible click/type/scroll actions when the agent controls a tab.
+
+That makes Hermes Webapp useful for work such as:
+
+- reviewing a local web app in multiple responsive sizes;
+- helping with Google Sheets, Canva, Notion, dashboards, and SaaS workflows;
+- browser RPA where the user can watch and interrupt;
+- debugging a web page with screenshots, DOM/accessibility context, and agent-guided actions.
+
+## Extension support direction
+
+Hermes Webapp should provide a browser profile/extension mechanism, not bundle personal extensions. Users may choose to install tools such as password managers or dark-mode extensions in their own Webapp browser context.
+
+Design constraints:
+
+- per-user and preferably per-workspace browser profile isolation;
+- no raw attachment to a user's default Chrome profile;
+- no bundled LastPass, Dark Reader, or equivalent user-specific extension;
+- clear security boundaries when a browser workspace is reachable over LAN or Tailscale.
+
+## Current status
+
+Implemented foundation:
+
+- `hermes webapp` command exists as a browser UI entrypoint;
+- it shares the current dashboard server/runtime flags;
+- it is not headless (`hermes serve` remains the headless backend);
+- dashboard process lifecycle management includes `webapp` processes.
+
+Planned next steps:
+
+1. Add a persisted Webapp workspace state contract.
+2. Add browser tab registry APIs per chat session.
+3. Build a native Webapp chat workspace instead of relying only on xterm/TUI embedding.
+4. Add an extension-capable local browser worker.
+5. Add visible, interruptible browser RPA controls.
+
+See `docs/plans/2026-07-08-hermes-webapp-browser-workspace.md` in the repository for the implementation plan.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/cli',
         'user-guide/tui',
         'user-guide/desktop',
+        'user-guide/hermes-webapp',
         'user-guide/windows-native',
         'user-guide/windows-wsl-quickstart',
         'user-guide/configuration',


### PR DESCRIPTION
## Summary

This establishes **Hermes Webapp** as a named browser workspace surface without renaming or replacing the existing Web Dashboard or Desktop app.

What this PR does:
- adds `hermes webapp` as a browser UI command that shares the current dashboard server/runtime flags;
- keeps `hermes dashboard` as the management/admin surface;
- keeps `hermes serve` as the headless backend surface;
- updates web server lifecycle detection so `webapp` processes are included in `--status`, `--stop`, and stale-process cleanup;
- avoids counting short-lived lifecycle probes (`--status` / `--stop`) as long-lived web server processes;
- adds docs defining Dashboard vs Desktop vs Webapp vs Serve;
- adds a concrete browser-workspace implementation plan for future per-chat browser tabs, responsive previews, extension-capable contexts, and visible/interruptible browser RPA.

This is deliberately a foundation/naming/scope PR, not the full browser-workspace implementation.

## Why

The current Dashboard Chat tab is an xterm/PTY embedding of the TUI, which is valuable but not the same as a browser-native workspace. Future work needs a stable product boundary for a portable web surface that can grow chat workspaces, files, previews, per-chat browser contexts, and visible browser/RPA control without overloading either Dashboard or Electron-only Desktop code.

## Validation

- `python -m pytest tests/hermes_cli/test_serve_command.py tests/hermes_cli/test_subcommands_batch.py::test_dashboard_builder_two_handlers tests/hermes_cli/test_dashboard_lifecycle_flags.py -q -o 'addopts='`
  - 23 passed
- `python -m py_compile hermes_cli/subcommands/dashboard.py hermes_cli/main.py`
  - passed
- `python -m hermes_cli.main webapp --help`
  - shows `hermes webapp` with dashboard-compatible browser runtime flags
- `python -m hermes_cli.main --help`
  - root examples list `hermes webapp`, `hermes webapp --stop`, and `hermes webapp --status`
- `python -m hermes_cli.main webapp --status`
  - reports `No Hermes web server processes running.` in this test environment
- `npm --prefix website run build`
  - succeeded
  - pre-existing docs warnings remain (missing local PyYAML for optional prebuild extraction and existing broken-link/anchor warnings, especially zh-Hans generated docs)
- `git diff --check`
  - passed
- privacy scan over diff
  - no token/key/local-path hits

## Follow-up work

The implementation plan in `docs/plans/2026-07-08-hermes-webapp-browser-workspace.md` lays out follow-up slices:
1. persisted Webapp workspace state contract;
2. browser tab registry APIs per chat session;
3. native Webapp chat workspace UI;
4. extension-capable local browser worker;
5. visible, interruptible browser RPA controls.
