### PR TITLE
fix(sessions): archive stale local endpoint resumes

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -377,7 +377,11 @@ class SessionManager:
         db = self._get_db()
         if db is not None:
             try:
-                rows = db.search_sessions(source="acp", limit=10000)
+                rows = db.search_sessions(
+                    source="acp",
+                    limit=10000,
+                    include_archived=True,
+                )
                 for row in rows:
                     sid = row["id"]
                     _clear_task_cwd(sid)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1161,6 +1161,12 @@ def _resolve_last_session(source: str = "cli") -> Optional[str]:
         from hermes_state import SessionDB
 
         db = SessionDB()
+        cleanup = getattr(db, "archive_stale_local_endpoint_sessions", None)
+        if callable(cleanup):
+            try:
+                cleanup(source=source)
+            except Exception:
+                pass
         sessions = db.search_sessions(source=source, limit=1)
         return sessions[0]["id"] if sessions else None
     except Exception:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -161,6 +161,16 @@ def _warm_gateway_module() -> None:
         pass
 
 
+def _archive_stale_local_endpoint_sessions_for_desktop_startup() -> int:
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        return db.archive_stale_local_endpoint_sessions()
+    finally:
+        db.close()
+
+
 def _resolve_restart_drain_timeout() -> float:
     try:
         from hermes_cli.gateway import _get_restart_drain_timeout
@@ -195,6 +205,18 @@ async def _lifespan(app: "FastAPI"):
     cron_stop: "threading.Event | None" = None
     cron_thread: "threading.Thread | None" = None
     if os.getenv("HERMES_DESKTOP") == "1":
+        try:
+            archived = await asyncio.to_thread(
+                _archive_stale_local_endpoint_sessions_for_desktop_startup
+            )
+            if archived:
+                _log.info(
+                    "Archived %d stale local-endpoint session(s) before desktop startup",
+                    archived,
+                )
+        except Exception as exc:
+            _log.debug("Desktop stale local-endpoint session cleanup skipped: %s", exc)
+
         cron_stop = threading.Event()
         cron_thread = threading.Thread(
             target=_start_desktop_cron_ticker,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -15,21 +15,149 @@ Key design decisions:
 """
 
 import asyncio
+import ipaddress
 import json
 import logging
 import random
 import re
 import sqlite3
+import socket
 import sys
 import threading
 import time
 from pathlib import Path
+from urllib.parse import urlparse
 
 from agent.memory_manager import sanitize_context
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
+
+_STALE_LOCAL_ENDPOINT_END_REASON = "archived_local_endpoint_stale"
+_LOCAL_ENDPOINT_SESSION_SOURCES = ("cli", "tui", "desktop")
+_LOCAL_ENDPOINT_URL_KEYS = (
+    "base_url",
+    "api_base",
+    "api_url",
+    "endpoint",
+    "inference_base_url",
+)
+_LOCAL_ENDPOINT_PROVIDER_HINTS = (
+    "ollama",
+    "lmstudio",
+    "lm-studio",
+    "vllm",
+    "llamacpp",
+    "llama.cpp",
+)
+_LOCAL_ENDPOINT_HOSTS = {
+    "localhost",
+    "127.0.0.1",
+    "::1",
+    "0.0.0.0",
+    "::",
+    "host.docker.internal",
+    "gateway.docker.internal",
+    "host.containers.internal",
+}
+_WILDCARD_LOCAL_HOSTS = {"0.0.0.0", "::"}
+_TAILSCALE_CGNAT = ipaddress.IPv4Network("100.64.0.0/10")
+
+
+def _normalize_endpoint_url(value: Any) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    return raw if "://" in raw else f"http://{raw}"
+
+
+def _endpoint_host(url: str) -> str:
+    try:
+        parsed = urlparse(_normalize_endpoint_url(url))
+    except Exception:
+        return ""
+    return (parsed.hostname or "").strip().lower()
+
+
+def _is_local_endpoint_url(url: str) -> bool:
+    host = _endpoint_host(url)
+    if not host:
+        return False
+    if host in _LOCAL_ENDPOINT_HOSTS:
+        return True
+    if host.endswith(".localhost") or host.endswith(".local"):
+        return True
+    if host and "." not in host:
+        return True
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if addr.is_private or addr.is_loopback or addr.is_link_local:
+        return True
+    return isinstance(addr, ipaddress.IPv4Address) and addr in _TAILSCALE_CGNAT
+
+
+def _local_endpoint_reachable(url: str, timeout: float = 0.25) -> bool:
+    try:
+        parsed = urlparse(_normalize_endpoint_url(url))
+        host = (parsed.hostname or "").strip()
+        if not host:
+            return False
+        if host in _WILDCARD_LOCAL_HOSTS:
+            host = "127.0.0.1"
+        port = parsed.port
+        if port is None:
+            port = 443 if parsed.scheme == "https" else 80
+        with socket.create_connection((host, port), timeout=max(timeout, 0.01)):
+            return True
+    except Exception:
+        return False
+
+
+def _loads_model_config(raw: Any) -> Dict[str, Any]:
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str):
+        return {}
+    try:
+        data = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _session_local_endpoint_urls(row: Dict[str, Any]) -> List[str]:
+    urls: List[str] = []
+    seen: set[str] = set()
+
+    def add(value: Any) -> None:
+        normalized = _normalize_endpoint_url(value)
+        if normalized and normalized not in seen and _is_local_endpoint_url(normalized):
+            seen.add(normalized)
+            urls.append(normalized)
+
+    add(row.get("billing_base_url"))
+    cfg = _loads_model_config(row.get("model_config"))
+    for key in _LOCAL_ENDPOINT_URL_KEYS:
+        add(cfg.get(key))
+    return urls
+
+
+def _session_has_local_endpoint_hint(row: Dict[str, Any]) -> bool:
+    cfg = _loads_model_config(row.get("model_config"))
+    parts = [
+        row.get("model"),
+        row.get("billing_provider"),
+        cfg.get("provider"),
+        cfg.get("provider_id"),
+        cfg.get("name"),
+    ]
+    haystack = " ".join(str(part or "").lower() for part in parts)
+    return any(hint in haystack for hint in _LOCAL_ENDPOINT_PROVIDER_HINTS)
 
 def _delegate_from_json(col: str = "model_config") -> str:
     return f"json_extract(COALESCE({col}, '{{}}'), '$._delegate_from')"
@@ -2036,6 +2164,117 @@ class SessionDB:
                 (session_id,),
             )
         self._execute_write(_do)
+
+    def archive_stale_local_endpoint_sessions(
+        self,
+        *,
+        source: Optional[str] = None,
+        sources: Optional[List[str]] = None,
+        stale_after_seconds: float = 300.0,
+        probe_timeout: float = 0.25,
+        max_candidates: int = 20,
+        endpoint_reachable: Optional[Callable[[str, float], bool]] = None,
+        now: Optional[float] = None,
+    ) -> int:
+        """Soft-archive abandoned local-endpoint sessions that can block resume.
+
+        A crashed TUI/CLI leaves its session row ``ended_at IS NULL``. If that
+        row points at a loopback/local OpenAI-compatible endpoint that is no
+        longer listening, auto-resume can hydrate the whole transcript and then
+        spend many seconds retrying the dead endpoint. This best-effort cleanup
+        marks only real, API-backed interactive sessions as ended + archived;
+        messages stay intact and explicit archived-history views can still show
+        them.
+
+        Sessions with a concrete local URL are archived only when a short TCP
+        connect probe says the endpoint is not listening. Provider-only local
+        hints are archived only after ``stale_after_seconds``.
+        """
+        now = time.time() if now is None else float(now)
+        cutoff = now - max(float(stale_after_seconds or 0), 0.0)
+        reachable = endpoint_reachable or _local_endpoint_reachable
+
+        if source:
+            source_values = [source]
+        elif sources is not None:
+            source_values = [s for s in sources if s]
+        else:
+            source_values = list(_LOCAL_ENDPOINT_SESSION_SOURCES)
+        if not source_values:
+            return 0
+        candidate_limit = max(1, int(max_candidates or 20))
+
+        placeholders = ",".join("?" for _ in source_values)
+        with self._lock:
+            rows = self._conn.execute(
+                f"""
+                SELECT
+                    s.id,
+                    s.source,
+                    s.model,
+                    s.model_config,
+                    s.started_at,
+                    s.message_count,
+                    s.api_call_count,
+                    s.billing_provider,
+                    s.billing_base_url,
+                    COALESCE(
+                        (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = s.id),
+                        s.started_at
+                    ) AS last_active
+                FROM sessions s
+                WHERE s.ended_at IS NULL
+                  AND COALESCE(s.archived, 0) = 0
+                  AND s.source IN ({placeholders})
+                  AND COALESCE(s.message_count, 0) > 0
+                  AND COALESCE(s.api_call_count, 0) > 0
+                ORDER BY last_active DESC, s.started_at DESC, s.id DESC
+                LIMIT ?
+                """,
+                [*source_values, candidate_limit],
+            ).fetchall()
+
+        archive_ids: List[str] = []
+
+        def is_reachable(url: str) -> bool:
+            try:
+                return bool(reachable(url, probe_timeout))
+            except Exception:
+                return False
+
+        for row in rows:
+            item = dict(row)
+            urls = _session_local_endpoint_urls(item)
+            if urls:
+                if any(is_reachable(url) for url in urls):
+                    continue
+                archive_ids.append(item["id"])
+                continue
+
+            last_active = float(item.get("last_active") or item.get("started_at") or 0)
+            if last_active <= cutoff and _session_has_local_endpoint_hint(item):
+                archive_ids.append(item["id"])
+
+        if not archive_ids:
+            return 0
+
+        def _do(conn):
+            id_placeholders = ",".join("?" for _ in archive_ids)
+            cursor = conn.execute(
+                f"""
+                UPDATE sessions
+                SET ended_at = ?,
+                    end_reason = ?,
+                    archived = 1
+                WHERE ended_at IS NULL
+                  AND COALESCE(archived, 0) = 0
+                  AND id IN ({id_placeholders})
+                """,
+                [now, _STALE_LOCAL_ENDPOINT_END_REASON, *archive_ids],
+            )
+            return cursor.rowcount
+
+        return self._execute_write(_do) or 0
 
     def update_session_cwd(
         self, session_id: str, cwd: str, git_branch: str = None, git_repo_root: str = None
@@ -4882,12 +5121,15 @@ class SessionDB:
         source: str = None,
         limit: int = 20,
         offset: int = 0,
+        include_archived: bool = False,
+        archived_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """List sessions, optionally filtered by source.
 
         Returns rows enriched with a computed ``last_active`` column (latest
         message timestamp for the session, falling back to ``started_at``),
-        ordered by most-recently-used first.
+        ordered by most-recently-used first. Soft-archived sessions are hidden
+        by default so archived rows are not automatically resumed.
         """
         select_with_last_active = (
             "SELECT s.*, COALESCE(m.last_active, s.started_at) AS last_active "
@@ -4897,20 +5139,25 @@ class SessionDB:
             "FROM messages GROUP BY session_id"
             ") m ON m.session_id = s.id "
         )
+        where_clauses: List[str] = []
+        params: List[Any] = []
+        if source:
+            where_clauses.append("s.source = ?")
+            params.append(source)
+        if archived_only:
+            where_clauses.append("COALESCE(s.archived, 0) = 1")
+        elif not include_archived:
+            where_clauses.append("COALESCE(s.archived, 0) = 0")
+        where_sql = f"WHERE {' AND '.join(where_clauses)} " if where_clauses else ""
+        params.extend([limit, offset])
+
         with self._lock:
-            if source:
-                cursor = self._conn.execute(
-                    f"{select_with_last_active}"
-                    "WHERE s.source = ? "
-                    "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
-                    (source, limit, offset),
-                )
-            else:
-                cursor = self._conn.execute(
-                    f"{select_with_last_active}"
-                    "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
-                    (limit, offset),
-                )
+            cursor = self._conn.execute(
+                f"{select_with_last_active}"
+                f"{where_sql}"
+                "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
+                params,
+            )
             return [dict(row) for row in cursor.fetchall()]
 
     # =========================================================================
@@ -5099,7 +5346,11 @@ class SessionDB:
         Export all sessions (with messages) as a list of dicts.
         Suitable for writing to a JSONL file for backup/analysis.
         """
-        sessions = self.search_sessions(source=source, limit=100000)
+        sessions = self.search_sessions(
+            source=source,
+            limit=100000,
+            include_archived=True,
+        )
         results = []
         for session in sessions:
             messages = self.get_messages(session["id"])

--- a/tests/hermes_cli/test_resolve_last_session.py
+++ b/tests/hermes_cli/test_resolve_last_session.py
@@ -155,3 +155,72 @@ def test_resolve_last_session_not_limited_to_newest_started_20(tmp_path, monkeyp
 
     monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
     assert _resolve_last_session("cli") == target
+
+
+def test_resolve_last_session_skips_unreachable_local_endpoint(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    import hermes_state
+
+    from pathlib import Path
+
+    state_db = Path(tmp_path / "state.db")
+    real_session_db = hermes_state.SessionDB
+    db = real_session_db(db_path=state_db)
+    try:
+        db.create_session(
+            "safe_remote",
+            source="tui",
+            model="openai/gpt-5.4",
+            model_config={"base_url": "https://api.openai.com/v1"},
+        )
+        db.append_message("safe_remote", role="user", content="remote session")
+        db.update_token_counts(
+            "safe_remote",
+            input_tokens=1,
+            output_tokens=1,
+            api_call_count=1,
+            billing_provider="openai",
+            billing_base_url="https://api.openai.com/v1",
+        )
+
+        db.create_session(
+            "dead_local",
+            source="tui",
+            model="local/test",
+            model_config={"base_url": "http://127.0.0.1:8082/v1"},
+        )
+        db.append_message("dead_local", role="user", content="latest local session")
+        db.update_token_counts(
+            "dead_local",
+            input_tokens=1,
+            output_tokens=1,
+            api_call_count=1,
+            billing_provider="ollama",
+            billing_base_url="http://127.0.0.1:8082/v1",
+        )
+        with db._lock:
+            db._conn.execute(
+                "UPDATE messages SET timestamp=? WHERE session_id=?",
+                (30_000.0, "dead_local"),
+            )
+            db._conn.execute(
+                "UPDATE messages SET timestamp=? WHERE session_id=?",
+                (20_000.0, "safe_remote"),
+            )
+            db._conn.commit()
+    finally:
+        db.close()
+
+    monkeypatch.setattr(hermes_state, "_local_endpoint_reachable", lambda _url, _timeout: False)
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
+
+    assert _resolve_last_session("tui") == "safe_remote"
+    check = real_session_db(db_path=state_db)
+    try:
+        dead = check.get_session("dead_local")
+        assert dead["end_reason"] == "archived_local_endpoint_stale"
+        assert dead["archived"] == 1
+    finally:
+        check.close()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -129,6 +129,32 @@ def _install_example_plugin(_isolate_hermes_home):
         web_server._dashboard_plugins_cache = None
 
 
+def test_desktop_startup_local_endpoint_cleanup_closes_session_db(monkeypatch):
+    from hermes_cli import web_server
+
+    instances = []
+
+    class FakeSessionDB:
+        def __init__(self):
+            self.closed = False
+            self.called = False
+            instances.append(self)
+
+        def archive_stale_local_endpoint_sessions(self):
+            self.called = True
+            return 2
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr("hermes_state.SessionDB", FakeSessionDB)
+
+    assert web_server._archive_stale_local_endpoint_sessions_for_desktop_startup() == 2
+    assert len(instances) == 1
+    assert instances[0].called is True
+    assert instances[0].closed is True
+
+
 # ---------------------------------------------------------------------------
 # reload_env tests
 # ---------------------------------------------------------------------------

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1825,6 +1825,21 @@ class TestSearchSessions:
         assert len(page2) == 2
         assert page1[0]["id"] != page2[0]["id"]
 
+    def test_archived_hidden_by_default(self, db):
+        db.create_session(session_id="live", source="cli")
+        db.create_session(session_id="archived", source="cli")
+        db.set_session_archived("archived", True)
+
+        assert [s["id"] for s in db.search_sessions(source="cli")] == ["live"]
+        assert {
+            s["id"]
+            for s in db.search_sessions(source="cli", include_archived=True)
+        } == {"live", "archived"}
+        assert [
+            s["id"]
+            for s in db.search_sessions(source="cli", archived_only=True)
+        ] == ["archived"]
+
 
 # =========================================================================
 # Counts
@@ -4920,6 +4935,106 @@ class TestSessionArchive:
         both = {s["id"] for s in db.list_sessions_rich(include_archived=True)}
         assert both == {"live", "hidden"}
         assert db.session_count(include_archived=True) == 2
+
+
+class TestStaleLocalEndpointSessionArchive:
+    def _seed_api_session(
+        self,
+        db,
+        sid,
+        *,
+        source="tui",
+        base_url="http://127.0.0.1:8082/v1",
+        provider="ollama",
+        api_call_count=1,
+    ):
+        model_config = {"provider": provider}
+        if base_url:
+            model_config["base_url"] = base_url
+        db.create_session(
+            session_id=sid,
+            source=source,
+            model="local/test-model",
+            model_config=model_config,
+        )
+        db.append_message(session_id=sid, role="user", content=f"hello from {sid}")
+        db.append_message(session_id=sid, role="assistant", content="hi")
+        if api_call_count:
+            db.update_token_counts(
+                sid,
+                input_tokens=1,
+                output_tokens=1,
+                api_call_count=api_call_count,
+                billing_provider=provider,
+                billing_base_url=base_url,
+            )
+
+    def test_archives_unreachable_local_endpoint_without_deleting_messages(self, db):
+        self._seed_api_session(db, "stale")
+
+        count = db.archive_stale_local_endpoint_sessions(
+            now=1234.5,
+            endpoint_reachable=lambda _url, _timeout: False,
+        )
+
+        assert count == 1
+        session = db.get_session("stale")
+        assert session["ended_at"] == 1234.5
+        assert session["end_reason"] == "archived_local_endpoint_stale"
+        assert session["archived"] == 1
+        assert [m["content"] for m in db.get_messages("stale")] == [
+            "hello from stale",
+            "hi",
+        ]
+        assert db.search_sessions(source="tui") == []
+        assert [
+            s["id"]
+            for s in db.search_sessions(source="tui", include_archived=True)
+        ] == ["stale"]
+
+    def test_keeps_reachable_local_endpoint_live(self, db):
+        self._seed_api_session(db, "live")
+
+        count = db.archive_stale_local_endpoint_sessions(
+            now=1234.5,
+            endpoint_reachable=lambda _url, _timeout: True,
+        )
+
+        assert count == 0
+        session = db.get_session("live")
+        assert session["ended_at"] is None
+        assert session["archived"] == 0
+
+    def test_ignores_remote_and_empty_local_sessions(self, db):
+        self._seed_api_session(
+            db,
+            "remote",
+            base_url="https://api.openai.com/v1",
+            provider="openai",
+        )
+        self._seed_api_session(db, "empty", api_call_count=0)
+
+        count = db.archive_stale_local_endpoint_sessions(
+            now=1234.5,
+            endpoint_reachable=lambda _url, _timeout: False,
+        )
+
+        assert count == 0
+        assert db.get_session("remote")["archived"] == 0
+        assert db.get_session("empty")["archived"] == 0
+
+    def test_provider_only_local_hint_must_age_out(self, db):
+        self._seed_api_session(db, "hint", base_url=None, provider="ollama")
+        now = time.time()
+
+        assert db.archive_stale_local_endpoint_sessions(
+            now=now,
+            stale_after_seconds=300,
+        ) == 0
+        assert db.archive_stale_local_endpoint_sessions(
+            now=now + 301,
+            stale_after_seconds=300,
+        ) == 1
 
 
 


### PR DESCRIPTION
## Summary
- Add a `SessionDB.archive_stale_local_endpoint_sessions()` cleanup that soft-archives abandoned CLI/TUI/Desktop sessions only when they have real messages/API calls and point at an unreachable local endpoint.
- Hide archived rows from `search_sessions()` by default so archived sessions are not picked by automatic resume, while keeping export/ACP cleanup callers explicitly inclusive.
- Run the cleanup before `_resolve_last_session()` and during desktop FastAPI startup so a dead localhost model endpoint cannot stall desktop readiness/status probes.

Fixes #58304.

## Duplicate / preflight
- Final preflight rerun: `preflight_issue.py 58304 --keyword local-endpoint --keyword archive_stale_local_endpoint_sessions --keyword archived_local_endpoint_stale --keyword _resolve_last_session --derive-title-keywords`
- Preflight still warns on broad keyword overlaps (`local-endpoint`, `_resolve_last_session`). I manually inspected the closest open PRs (#52538, #59520, #20686, #20885); they are adjacent local-endpoint/resume work but do not soft-archive stale local-endpoint session rows or make archived rows non-resumable by default.

## Tests
- `uv run --extra dev pytest tests/test_hermes_state.py -q` — 344 passed
- `uv run --extra dev pytest tests/hermes_cli/test_resolve_last_session.py tests/hermes_cli/test_session_browse.py tests/cli/test_cli_resume_command.py tests/hermes_cli/test_tui_resume_flow.py tests/hermes_cli/test_web_server_pty_reconnect.py -q` — 110 passed
- `uv run --extra dev pytest tests/hermes_state/test_session_archiving.py tests/hermes_state/test_resolve_resume_session_id.py -q` — 14 passed
- `uv run --extra dev pytest tests/hermes_cli/test_web_server.py::TestPtyWebSocket tests/hermes_cli/test_web_server.py::TestStatusRemoteGateway tests/hermes_cli/test_web_server.py::test_desktop_startup_local_endpoint_cleanup_closes_session_db -q` — 24 passed, 1 warning
- `uv run --extra dev ruff check hermes_state.py hermes_cli/main.py hermes_cli/web_server.py acp_adapter/session.py tests/test_hermes_state.py tests/hermes_cli/test_resolve_last_session.py tests/hermes_cli/test_web_server.py`
- `python -m py_compile hermes_state.py hermes_cli/main.py hermes_cli/web_server.py acp_adapter/session.py tests/test_hermes_state.py tests/hermes_cli/test_resolve_last_session.py tests/hermes_cli/test_web_server.py`
- `git diff --check`
- `git diff | gitleaks stdin --redact`
- `gitleaks git --log-opts='origin/main..HEAD' --redact .`