### PR TITLE
fix: keep password dashboard auth on login form

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,12 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Username/password providers do not implement the OAuth redirect flow.
+    # Let the /login page render the password form instead of auto-bouncing to
+    # /auth/login?provider=basic, which would call start_login() and 500.
+    if getattr(provider, "supports_password", False):
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -198,6 +198,12 @@ class TestProviderListFlag:
         prov = {p["name"]: p for p in resp.json()["providers"]}
         assert prov["testpw"]["supports_password"] is True
 
+    def test_single_password_provider_renders_login_instead_of_oauth_redirect(self, gated_app):
+        resp = gated_app.get("/sessions", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"].startswith("/login")
+        assert "/auth/login" not in resp.headers["location"]
+
     def test_oauth_provider_reports_false(self):
         clear_providers()
         register_provider(StubAuthProvider())


### PR DESCRIPTION
## Summary
- avoid auto-SSO OAuth redirect when the only dashboard auth provider supports password login
- keep password-only/basic auth on the /login form instead of hitting /auth/login and 500ing
- add regression coverage for the single password-provider path

## Test
- uv run --with pytest --with fastapi --with starlette --with httpx python -m pytest tests/hermes_cli/test_dashboard_auth_password_login.py -q