### PR TITLE
fix(kanban): close kanban SQLite FDs on context-manager exit (_ConnContext)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1312,11 +1312,23 @@ def _resolve_busy_timeout_ms() -> int:
     return DEFAULT_BUSY_TIMEOUT_MS
 
 
-def _sqlite_connect(path: Path) -> sqlite3.Connection:
-    """Open a Kanban SQLite connection with consistent lock waiting."""
+def _sqlite_connect(
+    path: Path,
+    factory: type = sqlite3.Connection,
+) -> sqlite3.Connection:
+    """Open a Kanban SQLite connection with consistent lock waiting.
+
+    Args:
+        path: Path to the SQLite database file.
+        factory: Connection class to instantiate (default: ``sqlite3.Connection``).
+            Pass ``_ConnContext`` to get a connection whose context manager
+            ``__exit__`` closes the file descriptor in addition to the
+            normal commit/rollback.
+    """
     busy_timeout_ms = _resolve_busy_timeout_ms()
     conn = sqlite3.connect(
         str(path),
+        factory=factory,
         isolation_level=None,
         timeout=busy_timeout_ms / 1000.0,
     )
@@ -1678,11 +1690,51 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
     raise KanbanDbCorruptError(resolved, backup, reason)
 
 
+class _ConnContext(sqlite3.Connection):
+    """``sqlite3.Connection`` subclass that closes the FD on context-manager exit.
+
+    ``sqlite3.Connection.__exit__`` only commits or rolls back the active
+    transaction; it does **not** close the underlying file descriptor (see
+    CPython ``Modules/_sqlite/connection.c``).  Every
+    ``with kb.connect() as conn:`` call site therefore leaks an open FD to
+    ``kanban.db`` and its WAL sidecar file.  In long-lived processes (gateway
+    dispatcher, dashboard server) that route every kanban operation through
+    ``connect()``, these accumulate until the process hits the kernel FD
+    limit and crashes with ``[Errno 24] Too many open files``.
+    Production incident: #33159.
+
+    This subclass overrides ``__exit__`` to call ``self.close()`` after the
+    base commit/rollback, making ``with kb.connect() as conn:`` safe without
+    requiring any call-site changes.  ``connect_closing()`` is kept for
+    backwards compatibility but is now redundant.
+    """
+
+    def __exit__(
+        self,
+        exc_type: object,
+        exc_val: object,
+        exc_tb: object,
+    ) -> bool:
+        # Let the base class handle commit/rollback first.
+        try:
+            super().__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            # Always release the file descriptor regardless of transaction
+            # outcome. Swallow any error from close() itself so as not to
+            # mask the original exception.
+            try:
+                self.close()
+            except Exception:  # pragma: no cover
+                pass
+        # Return False — do not suppress the caller's exception.
+        return False
+
+
 def connect(
     db_path: Optional[Path] = None,
     *,
     board: Optional[str] = None,
-) -> sqlite3.Connection:
+) -> "_ConnContext":
     """Open (and initialize if needed) the kanban DB.
 
     WAL mode is enabled on every connection; it's a no-op after the first
@@ -1719,7 +1771,7 @@ def connect(
     # connection with WAL/pragmas under the cheap in-process _INIT_LOCK.
     resolved = str(path.resolve())
     if resolved in _INITIALIZED_PATHS:
-        conn = _sqlite_connect(path)
+        conn = _sqlite_connect(path, factory=_ConnContext)
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
@@ -1744,7 +1796,7 @@ def connect(
         # via _INITIALIZED_PATHS so it only runs once per process per path.
         _guard_existing_db_is_healthy(path)
         resolved = str(path.resolve())
-        conn = _sqlite_connect(path)
+        conn = _sqlite_connect(path, factory=_ConnContext)
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
@@ -1805,9 +1857,9 @@ def connect_closing(
 
     See #33159 for the production incident.
 
-    The ``connect()`` function itself remains unchanged so callers that
-    intentionally manage the connection lifetime (tests, long-lived
-    callers) continue to work.
+    The ``connect()`` function now returns a ``_ConnContext`` whose context
+    manager automatically closes the connection, making this wrapper
+    redundant, but it is kept for backwards compatibility.
     """
     conn = connect(db_path=db_path, board=board)
     try:
@@ -1817,6 +1869,7 @@ def connect_closing(
             conn.close()
         except Exception:
             pass
+
 
 
 def init_db(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -921,14 +921,19 @@ class SessionDB:
                 # must already exist + be initialised (callers guard on
                 # db_path.exists()); a SELECT against an empty file raises and
                 # the caller degrades per-profile.
-                self._conn = sqlite3.connect(
+                _ro_conn = sqlite3.connect(
                     f"file:{self.db_path}?mode=ro",
                     uri=True,
                     check_same_thread=False,
                     timeout=1.0,
                     isolation_level=None,
                 )
-                self._conn.row_factory = sqlite3.Row
+                try:
+                    _ro_conn.row_factory = sqlite3.Row
+                except Exception:
+                    _ro_conn.close()
+                    raise
+                self._conn = _ro_conn
                 return
 
             self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3065,13 +3065,15 @@ def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch,
 
     real_connect = _sqlite3.connect
 
-    class _WalBlockingConnection(_sqlite3.Connection):
-        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
-            if "journal_mode=wal" in sql.lower().replace(" ", ""):
-                raise _sqlite3.OperationalError("locking protocol")
-            return super().execute(sql, *args, **kwargs)
-
     def wal_blocking_connect(*args, **kwargs):
+        requested_factory = kwargs.pop("factory", _sqlite3.Connection)
+
+        class _WalBlockingConnection(requested_factory):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                if "journal_mode=wal" in sql.lower().replace(" ", ""):
+                    raise _sqlite3.OperationalError("locking protocol")
+                return super().execute(sql, *args, **kwargs)
+
         return real_connect(
             *args, factory=_WalBlockingConnection, **kwargs
         )
@@ -4752,17 +4754,83 @@ def test_connect_closing_yields_usable_connection(tmp_path):
         assert task.title == "closing-cm test"
 
 
-def test_bare_connect_does_not_close_on_context_exit(tmp_path):
-    """Document the leak that connect_closing exists to prevent.
+def test_connect_closes_fd_on_context_manager_exit(tmp_path):
+    """Regression: with kb.connect() as conn: must close the FD on exit.
 
-    sqlite3.Connection's __exit__ commits/rollbacks but doesn't close.
-    This is the upstream behaviour we cannot change; the regression
-    guard is to make sure connect_closing() does the right thing.
+    Before the ``_ConnContext`` fix, ``sqlite3.Connection.__exit__`` only
+    committed/rolled back the transaction; it did NOT close the file
+    descriptor.  Every ``with connect()`` call therefore leaked an open FD
+    to kanban.db + kanban.db-wal.  In long-lived gateway / dashboard
+    processes these accumulated until the kernel FD limit was hit:
+    ``[Errno 24] Too many open files``.  Production incident: #33159.
     """
+    import gc
+
     db_path = tmp_path / "kanban.db"
     kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    try:
+        fd_before = set(int(f) for f in os.listdir(f"/proc/{os.getpid()}/fd"))
+    except OSError:
+        pytest.skip("Cannot enumerate /proc FDs on this platform")
+
     with kb.connect(db_path=db_path) as conn:
-        pass
-    # Still usable after with-block exit (the leak).
-    conn.execute("SELECT 1").fetchone()
-    conn.close()  # explicit close to avoid leaking THIS test
+        _ = kb.list_tasks(conn)
+
+    gc.collect()
+
+    fd_after = set(int(f) for f in os.listdir(f"/proc/{os.getpid()}/fd"))
+    new_fds = fd_after - fd_before
+    assert len(new_fds) <= 2, (
+        f"FD leak: {len(new_fds)} new file descriptors remain open after "
+        f"'with kb.connect() as conn:' block exited. "
+        f"_ConnContext.__exit__ must close the connection. New FDs: {new_fds}"
+    )
+
+
+def test_connect_closes_fd_on_exception_inside_with_block(tmp_path):
+    """FD must be released even when an exception is raised inside the with block."""
+    import gc
+
+    db_path = tmp_path / "kanban.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    try:
+        fd_before = set(int(f) for f in os.listdir(f"/proc/{os.getpid()}/fd"))
+    except OSError:
+        pytest.skip("Cannot enumerate /proc FDs on this platform")
+
+    with pytest.raises(RuntimeError, match="intentional"):
+        with kb.connect(db_path=db_path) as conn:
+            _ = kb.list_tasks(conn)
+            raise RuntimeError("intentional error inside with block")
+
+    gc.collect()
+
+    fd_after = set(int(f) for f in os.listdir(f"/proc/{os.getpid()}/fd"))
+    new_fds = fd_after - fd_before
+    assert len(new_fds) <= 2, (
+        f"FD leak on exception: {len(new_fds)} new FDs remain after exception "
+        f"in 'with kb.connect()' block. _ConnContext.__exit__ must close on error."
+    )
+
+
+def test_connect_returns_conn_context_type(tmp_path):
+    """connect() must return a _ConnContext instance, not a bare sqlite3.Connection.
+
+    This is an isinstance guard: if someone ever removes the _ConnContext wrapper
+    from connect(), this test will catch the regression immediately.
+    """
+    from hermes_cli.kanban_db import _ConnContext
+
+    db_path = tmp_path / "kanban.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    conn = kb.connect(db_path=db_path)
+    try:
+        assert isinstance(conn, _ConnContext), (
+            f"connect() returned {type(conn).__qualname__}, expected _ConnContext. "
+            "The FD-leak fix (_ConnContext wrapper) is not active."
+        )
+    finally:
+        conn.close()
+


### PR DESCRIPTION
Fixes #33159

## What changed and why

Under heavy concurrency or in long-lived dispatcher processes (such as the gateway run-slash command handlers or dashboard web server), the Kanban dispatcher eventually crashes with `[Errno 24] Too many open files` due to a file descriptor leak on `kanban.db` and its WAL sidecar.

This stems from a two-stage root cause:
- Stage 1 (Surface Symptom): `kanban_db.connect()` returns a standard `sqlite3.Connection` which gets wrapped in `with kb.connect() as conn:` blocks.
- Stage 2 (Deeper Mechanism): The native `sqlite3.Connection.__exit__` context manager implementation only handles transaction commit or rollback on exit; it does NOT automatically close the connection or release the underlying file descriptor. Since caller functions rely on the `with` block's context manager to clean up resources, the file descriptors are leaked on every connection request until the kernel limit is hit.

## Fix

### `hermes_cli/kanban_db.py`
- Introduced the `_ConnContext(sqlite3.Connection)` subclass that overrides `__exit__` to guarantee `self.close()` is called after transaction commit/rollback.
- Updated `_sqlite_connect()` to accept a `factory` parameter, passing it down to `sqlite3.connect`.
- Updated all `_sqlite_connect` calls inside `connect()` to pass `factory=_ConnContext`, ensuring returned connections are safe context managers without requiring any changes to the hundreds of caller sites.
- Updated the return type annotation of `connect()` to `"_ConnContext"`.

### `hermes_state.py`
- Fixed a minor exception-path leak in `SessionDB.__init__` read-only mode by adding a try-except block to close the connection if `row_factory` assignment raises.

### `tests/hermes_cli/test_kanban_db.py`
- Added three regression tests (`test_connect_closes_fd_on_context_manager_exit`, `test_connect_closes_fd_on_exception_inside_with_block`, `test_connect_returns_conn_context_type`) to verify that the file descriptor counts in `/proc` are correctly released and that the wrapper type is returned.
- Updated the existing mock helper `wal_blocking_connect` to dynamically subclass the passed connection factory to avoid multiple value assignment conflicts in mocks.

## What this does NOT change

- No change to the `connect_closing()` helper (retained for backward compatibility).
- No changes to external API/TUI calls or schema definitions.

## How to test

Run the Kanban connection test suite:
```bash
.venv/bin/pytest tests/hermes_cli/test_kanban_db.py -k "connect" -o addopts=""
```

All 17 connection tests pass successfully.

## Platforms tested

Linux. Pure Python logic.
