### PR TITLE
fix: add missing re import in SMS adapter markdown stripper

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -24,6 +24,7 @@ import hashlib
 import hmac
 import logging
 import os
+import re
 import urllib.parse
 from typing import Any, Dict, Optional
 


### PR DESCRIPTION
## Bug

`_strip_markdown_for_sms()` in `plugins/platforms/sms/adapter.py` calls `re.sub()` six times but the module never imports `re` at the top of the file. Every SMS send goes through this function to strip markdown before Twilio delivery, so **every SMS delivery attempt crashes** with:

```
NameError: name 're' is not defined
```

Traceback (from a cron job delivery attempt):

```
File "plugins/platforms/sms/adapter.py", line 971, in _send_to_platform
  result = await _registry_standalone_send("sms", pconfig, chat_id, chunk, thread_id)
File "plugins/platforms/sms/adapter.py", line 1276, in _registry_standalone_send
  return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id)
File "plugins/platforms/sms/adapter.py", line 413, in _strip_markdown_for_sms
  message = re.sub(r"\*\*(.+?)\*\*", r"\1", message, flags=re.DOTALL)
NameError: name 're' is not defined
```

This fails silently from the caller's perspective in most flows (e.g. `cron.scheduler._deliver_result` logs the error but the job itself still reports "ok"), so the underlying work completes but the SMS notification never goes out — easy to miss.

## Fix

Add `import re` to the top-level import block. One line, no behavior change beyond making the function actually work.

## Verification

```python
from plugins.platforms.sms.adapter import _strip_markdown_for_sms
_strip_markdown_for_sms("**bold** and `code` and [a link](http://x.com)")
# -> 'bold and code and a link'  (previously: NameError)
```

Confirmed via `errors.log` that this NameError fired on every scheduled cron job SMS delivery attempt for at least the last 3 days before this patch.