### PR TITLE
Serialize Claude Code version detection

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -18,6 +18,7 @@ import platform
 import secrets
 import stat
 import subprocess
+import threading
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -344,6 +345,7 @@ _OAUTH_ONLY_BETAS = [
 # when the spoofed user-agent version is too far behind the actual release.
 _CLAUDE_CODE_VERSION_FALLBACK = "2.1.74"
 _claude_code_version_cache: Optional[str] = None
+_claude_code_version_lock = threading.Lock()
 
 
 def _detect_claude_code_version() -> str:
@@ -379,7 +381,9 @@ def _get_claude_code_version() -> str:
     """Lazily detect the installed Claude Code version when OAuth headers need it."""
     global _claude_code_version_cache
     if _claude_code_version_cache is None:
-        _claude_code_version_cache = _detect_claude_code_version()
+        with _claude_code_version_lock:
+            if _claude_code_version_cache is None:
+                _claude_code_version_cache = _detect_claude_code_version()
     return _claude_code_version_cache
 
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -2,7 +2,9 @@
 
 import json
 import sys
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
@@ -222,6 +224,36 @@ class TestBuildAnthropicClient:
             build_anthropic_bedrock_client("us-east-1")
             kwargs = mock_sdk.AnthropicBedrock.call_args[1]
             assert kwargs["max_retries"] == 0
+
+
+class TestClaudeCodeVersionCache:
+    def test_concurrent_get_claude_code_version_detects_once(self, monkeypatch):
+        import agent.anthropic_adapter as anthropic_adapter
+
+        worker_count = 8
+        start = threading.Barrier(worker_count)
+        detect_lock = threading.Lock()
+        detect_calls = 0
+
+        def fake_detect():
+            nonlocal detect_calls
+            with detect_lock:
+                detect_calls += 1
+            time.sleep(0.05)
+            return "9.9.9"
+
+        def get_version():
+            start.wait(timeout=10)
+            return anthropic_adapter._get_claude_code_version()
+
+        monkeypatch.setattr(anthropic_adapter, "_claude_code_version_cache", None)
+        monkeypatch.setattr(anthropic_adapter, "_detect_claude_code_version", fake_detect)
+
+        with ThreadPoolExecutor(max_workers=worker_count) as pool:
+            versions = list(pool.map(lambda _: get_version(), range(worker_count)))
+
+        assert versions == ["9.9.9"] * worker_count
+        assert detect_calls == 1
 
 
 class TestReadClaudeCodeCredentials:


### PR DESCRIPTION
## Problem
Fixes #24751. Concurrent OAuth header construction can call `_get_claude_code_version()` from multiple threads before the cached value is populated, which can spawn duplicate `claude --version` / `claude-code --version` probes.

## Solution
Serialize the first cache fill with a small lock and keep the existing fast path once `_claude_code_version` is populated.

## Impact
The regression test uses 8 concurrent callers and verifies version detection runs once instead of up to 8 times, reducing duplicate subprocess probes by up to 87.5% during the first OAuth burst.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /Users/holim/code/hermes-agent/.venv/bin/python -m pytest tests/agent/test_anthropic_adapter.py::TestClaudeCodeVersionCache -q`
- `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py -k TestClaudeCodeVersionCache -q`
- `/Users/holim/code/hermes-agent/.venv/bin/ruff check agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py`
- `git diff --check`
