### PR TITLE
Pass Firecrawl scrape timeout to SDK

### DIFF
--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -56,6 +56,9 @@ from tools.website_policy import check_website_access
 
 logger = logging.getLogger(__name__)
 
+_FIRECRAWL_SCRAPE_TIMEOUT_SECONDS = 60
+_FIRECRAWL_SCRAPE_TIMEOUT_MS = _FIRECRAWL_SCRAPE_TIMEOUT_SECONDS * 1000
+
 
 # ---------------------------------------------------------------------------
 # Lazy Firecrawl SDK proxy
@@ -491,8 +494,9 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                             _get_firecrawl_client().scrape,
                             url=url,
                             formats=formats,
+                            timeout=_FIRECRAWL_SCRAPE_TIMEOUT_MS,
                         ),
-                        timeout=60,
+                        timeout=_FIRECRAWL_SCRAPE_TIMEOUT_SECONDS,
                     )
                 except asyncio.TimeoutError:
                     logger.warning("Firecrawl scrape timed out for %s", url)
@@ -502,8 +506,10 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                             "title": "",
                             "content": "",
                             "error": (
-                                "Scrape timed out after 60s — page may be too large "
-                                "or unresponsive. Try browser_navigate instead."
+                                "Scrape timed out after "
+                                f"{_FIRECRAWL_SCRAPE_TIMEOUT_SECONDS}s — page may "
+                                "be too large or unresponsive. Try "
+                                "browser_navigate instead."
                             ),
                         }
                     )

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -428,7 +428,7 @@ class TestWebToolPolicy:
             pytest.fail(f"unexpected URL checked: {url}")
 
         class FakeFirecrawlClient:
-            def scrape(self, url, formats):
+            def scrape(self, *, url, formats, timeout=None):
                 return {
                     "markdown": "secret content",
                     "metadata": {
@@ -449,6 +449,36 @@ class TestWebToolPolicy:
         assert result["results"][0]["url"] == "https://blocked.test/final"
         assert result["results"][0]["content"] == ""
         assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"
+
+    @pytest.mark.asyncio
+    async def test_web_extract_passes_firecrawl_scrape_timeout(self, monkeypatch):
+        from tools import web_tools
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        async def _allow_ssrf(_url: str) -> bool:
+            return True
+
+        seen = {}
+
+        class FakeFirecrawlClient:
+            def scrape(self, *, url, formats, timeout=None):
+                seen["timeout"] = timeout
+                return {
+                    "markdown": "content",
+                    "metadata": {"title": "Allowed", "sourceURL": url},
+                }
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_ssrf)
+        monkeypatch.setattr(firecrawl_provider, "is_safe_url", lambda url: True)
+        monkeypatch.setattr(firecrawl_provider, "check_website_access", lambda url: None)
+        monkeypatch.setattr(firecrawl_provider, "_get_firecrawl_client", lambda: FakeFirecrawlClient())
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fake-key")
+
+        result = json.loads(await web_tools.web_extract_tool(["https://allowed.test"]))
+
+        assert result["results"][0]["content"] == "content"
+        assert seen["timeout"] == 60000
 
     @pytest.mark.asyncio
     async def test_web_extract_blocks_firecrawl_unsafe_final_url(self, monkeypatch):
@@ -474,7 +504,7 @@ class TestWebToolPolicy:
             pytest.fail(f"unexpected website policy check for unsafe URL: {url}")
 
         class FakeFirecrawlClient:
-            def scrape(self, url, formats):
+            def scrape(self, *, url, formats, timeout=None):
                 return {
                     "markdown": "metadata credentials",
                     "metadata": {


### PR DESCRIPTION
## Problem
Fixes #43272. The Firecrawl wrapper waits up to 60 seconds, but the SDK scrape call does not receive the matching server-side timeout, so Firecrawl can still abort around its default timeout first.

## Solution
Pass a 60000 ms timeout into the Firecrawl `scrape` call while keeping the existing 60 second Python-side `asyncio.wait_for` guard.

## Impact
Aligns the Firecrawl server timeout with Hermes' existing 60 second wrapper budget. Slow pages now get the full configured scrape budget instead of being cut short by the SDK/server default.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /Users/holim/code/hermes-agent/.venv/bin/python -m pytest tests/tools/test_website_policy.py -q`
- `scripts/run_tests.sh tests/tools/test_website_policy.py -q`
- `/Users/holim/code/hermes-agent/.venv/bin/ruff check plugins/web/firecrawl/provider.py tests/tools/test_website_policy.py`
- `git diff --check`
