### PR TITLE
Bound Discord attachment reads before URL fallback

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -47,6 +47,7 @@ _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.json"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+_DISCORD_ATTACHMENT_READ_TIMEOUT_SECONDS = 15.0
 # Discord enforces a hard cap of 100 global application (slash) commands per
 # app. Registering more makes the ENTIRE sync fail with error 30032
 # ("Maximum number of application commands reached"), which silently breaks
@@ -6035,7 +6036,17 @@ class DiscordAdapter(BasePlatformAdapter):
         if reader is None or not callable(reader):
             return None
         try:
-            raw_bytes = await reader()
+            raw_bytes = await asyncio.wait_for(
+                reader(),
+                timeout=_DISCORD_ATTACHMENT_READ_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[Discord] Authenticated attachment read timed out after %.1fs for %s",
+                _DISCORD_ATTACHMENT_READ_TIMEOUT_SECONDS,
+                getattr(att, "filename", None) or getattr(att, "url", "<unknown>"),
+            )
+            return None
         except Exception as e:
             logger.warning(
                 "[Discord] Authenticated attachment read failed for %s: %s",

--- a/tests/gateway/test_discord_attachment_download.py
+++ b/tests/gateway/test_discord_attachment_download.py
@@ -14,6 +14,7 @@ helpers. Verifies that:
   defense-in-depth. (issue #11345)
 """
 
+import asyncio
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -133,6 +134,33 @@ class TestReadAttachmentBytes:
 
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_returns_none_when_read_times_out(self, monkeypatch):
+        """Slow bot-session fetches should fall back before signed URLs expire."""
+        adapter = _make_adapter()
+        calls = 0
+
+        async def slow_read():
+            nonlocal calls
+            calls += 1
+            await asyncio.sleep(1)
+            return b"too late"
+
+        att = SimpleNamespace(
+            url="https://cdn.discordapp.com/attachments/fake/file.png",
+            filename="file.png",
+            read=slow_read,
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.discord.adapter._DISCORD_ATTACHMENT_READ_TIMEOUT_SECONDS",
+            0.01,
+        )
+
+        result = await adapter._read_attachment_bytes(att)
+
+        assert result is None
+        assert calls == 1
+
 
 # ---------------------------------------------------------------------------
 # _cache_discord_image
@@ -163,6 +191,39 @@ class TestCacheDiscordImage:
         """No .read() → URL path is used (existing SSRF-gated behavior)."""
         adapter = _make_adapter()
         att = _make_attachment_without_read()
+
+        with patch(
+            "plugins.platforms.discord.adapter.cache_image_from_bytes",
+        ) as mock_bytes, patch(
+            "plugins.platforms.discord.adapter.cache_image_from_url",
+            new_callable=AsyncMock,
+            return_value="/tmp/from_url.png",
+        ) as mock_url:
+            result = await adapter._cache_discord_image(att, ".png")
+
+        assert result == "/tmp/from_url.png"
+        mock_bytes.assert_not_called()
+        mock_url.assert_awaited_once_with(att.url, ext=".png")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_url_when_read_times_out(self, monkeypatch):
+        """Slow authenticated reads should still reach the signed URL fallback."""
+        adapter = _make_adapter()
+
+        async def slow_read():
+            await asyncio.sleep(1)
+            return _PNG_BYTES
+
+        att = SimpleNamespace(
+            url="https://cdn.discordapp.com/attachments/fake/file.png",
+            filename="file.png",
+            size=1024,
+            read=slow_read,
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.discord.adapter._DISCORD_ATTACHMENT_READ_TIMEOUT_SECONDS",
+            0.01,
+        )
 
         with patch(
             "plugins.platforms.discord.adapter.cache_image_from_bytes",


### PR DESCRIPTION
## Problem
Fixes #33400. Discord `Attachment.read()` can hang until OS-level network timeouts, which delays the existing signed-CDN URL fallback and can let short-lived URLs expire before Hermes tries them.

## Solution
Wrap authenticated attachment reads in a 15 second `asyncio.wait_for`. On timeout, log the bounded failure and return `None` so the existing URL fallback path runs. External task cancellation is still allowed to propagate.

## Impact
Bounds the authenticated read path to 15 seconds instead of waiting on OS/client network timeout behavior, while preserving the current fallback path for attachments that can still be fetched by URL.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /Users/holim/code/hermes-agent/.venv/bin/python -m pytest tests/gateway/test_discord_attachment_download.py -q`
- `scripts/run_tests.sh tests/gateway/test_discord_attachment_download.py -q`
- `/Users/holim/code/hermes-agent/.venv/bin/ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_attachment_download.py`
- `git diff --check`
