### PR TITLE
Serialize OpenRouter metadata prewarm claim

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -507,13 +507,14 @@ def init_agent(
     # Pre-warm OpenRouter model metadata cache in a background thread.
     # fetch_model_metadata() is cached for 1 hour; this avoids a blocking
     # HTTP request on the first API response when pricing is estimated.
-    # Use a process-level Event so this thread is only spawned once — a new
-    # AIAgent is created for every gateway request, so without the guard
+    # Use a process-level claim helper so this thread is only spawned once —
+    # a new AIAgent is created for every gateway request, so without the guard
     # each message leaks one OS thread and the process eventually exhausts
     # the system thread limit (RuntimeError: can't start new thread).
-    if (agent.provider == "openrouter" or agent._is_openrouter_url()) and \
-            not _ra()._openrouter_prewarm_done.is_set():
-        _ra()._openrouter_prewarm_done.set()
+    if (
+        (agent.provider == "openrouter" or agent._is_openrouter_url())
+        and _ra()._claim_openrouter_prewarm()
+    ):
         threading.Thread(
             target=fetch_model_metadata,
             daemon=True,

--- a/run_agent.py
+++ b/run_agent.py
@@ -264,7 +264,20 @@ _DB_PERSISTED_MARKER = "_db_persisted"
 # process, not once per AIAgent instantiation.  Without this, long-running
 # gateway processes leak one OS thread per incoming message and eventually
 # exhaust the system thread limit (RuntimeError: can't start new thread).
-_openrouter_prewarm_done = threading.Event()
+_openrouter_prewarm_done = False
+_openrouter_prewarm_lock = threading.Lock()
+
+
+def _claim_openrouter_prewarm() -> bool:
+    """Return True exactly once per process for OpenRouter metadata prewarm."""
+    global _openrouter_prewarm_done
+    if _openrouter_prewarm_done:
+        return False
+    with _openrouter_prewarm_lock:
+        if _openrouter_prewarm_done:
+            return False
+        _openrouter_prewarm_done = True
+        return True
 
 # =========================================================================
 # Large tool result handler — save oversized output to temp file

--- a/tests/run_agent/test_openrouter_prewarm_claim.py
+++ b/tests/run_agent/test_openrouter_prewarm_claim.py
@@ -1,0 +1,28 @@
+import sys
+import threading
+import types
+from concurrent.futures import ThreadPoolExecutor
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+
+
+def test_openrouter_prewarm_claim_is_process_singleton(monkeypatch):
+    worker_count = 16
+    start = threading.Barrier(worker_count)
+
+    monkeypatch.setattr(run_agent, "_openrouter_prewarm_done", False)
+    monkeypatch.setattr(run_agent, "_openrouter_prewarm_lock", threading.Lock())
+
+    def claim_once():
+        start.wait(timeout=2)
+        return run_agent._claim_openrouter_prewarm()
+
+    with ThreadPoolExecutor(max_workers=worker_count) as pool:
+        claims = list(pool.map(lambda _: claim_once(), range(worker_count)))
+
+    assert claims.count(True) == 1
+    assert claims.count(False) == worker_count - 1


### PR DESCRIPTION
## Problem
Fixes #24651. The OpenRouter metadata prewarm guard checks `Event.is_set()` and then calls `.set()` outside a shared critical section, so concurrent `AIAgent.__init__` calls can each start a prewarm thread before the flag is observed.

## Solution
Replace the non-atomic check/set sequence with `_claim_openrouter_prewarm()`, which uses a lock to make the one-time claim atomic while keeping later calls as a cheap boolean check.

## Impact
The concurrent regression test runs 16 callers and verifies exactly one prewarm claim succeeds, reducing duplicate prewarm thread starts from up to 16 to 1 in that burst.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /Users/holim/code/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_openrouter_prewarm_claim.py -q`
- `scripts/run_tests.sh tests/run_agent/test_openrouter_prewarm_claim.py -q`
- `/Users/holim/code/hermes-agent/.venv/bin/ruff check run_agent.py agent/agent_init.py tests/run_agent/test_openrouter_prewarm_claim.py`
- `git diff --check`
