### PR TITLE
fix(irc): replace Libera.Chat default examples with neutral IRC server guidance

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4296,7 +4296,7 @@ OPTIONAL_ENV_VARS = {
         "category": "messaging",
     },
     "IRC_SERVER": {
-        "description": "IRC server hostname (e.g. irc.libera.chat)",
+        "description": "IRC server hostname (e.g. irc.example.net; see docs about public network policies)",
         "prompt": "IRC server",
         "url": None,
         "password": False,

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -12,7 +12,7 @@ Configuration in config.yaml::
         irc:
           enabled: true
           extra:
-            server: irc.libera.chat
+            server: irc.example.net
             port: 6697
             nickname: hermes-bot
             channel: "#hermes"
@@ -21,6 +21,10 @@ Configuration in config.yaml::
             nickserv_password: ""     # optional NickServ identification
             allowed_users: []         # empty = allow all, or list of nicks
             max_message_length: 450   # IRC line limit (safe default)
+
+    ⚠ Note: Many public IRC networks (e.g. Libera.Chat) prohibit
+      LLM-driven autonomous clients. For production use, run a local
+      IRCd such as Ergo (https://github.com/ergochat/ergo).
 
 Or via environment variables (overrides config.yaml):
     IRC_SERVER, IRC_PORT, IRC_NICKNAME, IRC_CHANNEL, IRC_USE_TLS,
@@ -560,10 +564,10 @@ def interactive_setup() -> None:
             return
 
     print_info("Connect Hermes to an IRC network. Uses Python stdlib — no extra packages needed.")
-    print_info("   Works with Libera.Chat, OFTC, your own ZNC/InspIRCd, etc.")
+    print_info("   ⚠ Many public IRC networks (e.g. Libera.Chat) prohibit LLM-driven autonomous clients.")
     print()
 
-    server = prompt("IRC server hostname (e.g. irc.libera.chat)", default=existing_server or "")
+    server = prompt("IRC server hostname (e.g. irc.example.net; prefer a local IRCd for production)", default=existing_server or "")
     if not server:
         print_warning("Server is required — skipping IRC setup")
         return

--- a/plugins/platforms/irc/plugin.yaml
+++ b/plugins/platforms/irc/plugin.yaml
@@ -12,7 +12,7 @@ author: Nous Research
 # platform-plugin env var injector in ``hermes_cli/config.py``.
 requires_env:
   - name: IRC_SERVER
-    description: "IRC server hostname (e.g. irc.libera.chat)"
+    description: "IRC server hostname (e.g. irc.example.net; see docs about public network policies)"
     prompt: "IRC server"
     password: false
   - name: IRC_CHANNEL

--- a/tests/gateway/test_irc_adapter.py
+++ b/tests/gateway/test_irc_adapter.py
@@ -82,7 +82,7 @@ class TestIRCAdapterInit:
         cfg = PlatformConfig(
             enabled=True,
             extra={
-                "server": "irc.libera.chat",
+                "server": "irc.example.net",
                 "port": 6697,
                 "nickname": "hermes",
                 "channel": "#hermes-dev",
@@ -91,7 +91,7 @@ class TestIRCAdapterInit:
         )
         adapter = IRCAdapter(cfg)
 
-        assert adapter.server == "irc.libera.chat"
+        assert adapter.server == "irc.example.net"
         assert adapter.port == 6697
         assert adapter.nickname == "hermes"
         assert adapter.channel == "#hermes-dev"

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -211,7 +211,7 @@ class TestGatewayConfigPluginPlatform:
         data = {
             "platforms": {
                 "telegram": {"enabled": True, "token": "test-token"},
-                "irc": {"enabled": True, "extra": {"server": "irc.libera.chat"}},
+                "irc": {"enabled": True, "extra": {"server": "irc.example.net"}},
             }
         }
         cfg = GatewayConfig.from_dict(data)

--- a/tests/hermes_cli/test_setup_irc.py
+++ b/tests/hermes_cli/test_setup_irc.py
@@ -98,7 +98,7 @@ class TestIRCFreshInstallDiscovery:
 
         plat = _register_irc_platform()
         try:
-            monkeypatch.setenv("IRC_SERVER", "irc.libera.chat")
+            monkeypatch.setenv("IRC_SERVER", "irc.example.net")
             monkeypatch.setenv("IRC_CHANNEL", "#hermes")
             monkeypatch.setenv("IRC_NICKNAME", "hermes-bot")
 
@@ -115,7 +115,7 @@ class TestIRCFreshInstallDiscovery:
         try:
             monkeypatch.delenv("IRC_CHANNEL", raising=False)
             monkeypatch.delenv("IRC_NICKNAME", raising=False)
-            monkeypatch.setenv("IRC_SERVER", "irc.libera.chat")
+            monkeypatch.setenv("IRC_SERVER", "irc.example.net")
 
             status = gateway_mod._platform_status(plat)
             assert status == "not configured"
@@ -225,7 +225,7 @@ class TestIRCGatewaySetupFreshInstall:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         _register_irc_platform()
         try:
-            monkeypatch.setenv("IRC_SERVER", "irc.libera.chat")
+            monkeypatch.setenv("IRC_SERVER", "irc.example.net")
             monkeypatch.setenv("IRC_CHANNEL", "#hermes")
             monkeypatch.setenv("IRC_NICKNAME", "hermes-bot")
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -591,7 +591,7 @@ Connect Hermes to an IRC server. No external dependencies. See [the IRC messagin
 
 | Variable | Description |
 |----------|-------------|
-| `IRC_SERVER` | IRC server hostname (e.g. `irc.libera.chat`). Required. |
+| `IRC_SERVER` | IRC server hostname (e.g. `irc.example.net`; prefer a local IRCd for production). Required. |
 | `IRC_CHANNEL` | Channel(s) to join (e.g. `#hermes`); comma-separate for multiple. Required. |
 | `IRC_NICKNAME` | Bot nickname (default: `hermes-bot`). Required. |
 | `IRC_PORT` | Server port (default: `6697` with TLS, `6667` without). |

--- a/website/docs/user-guide/messaging/irc.md
+++ b/website/docs/user-guide/messaging/irc.md
@@ -1,6 +1,8 @@
 # IRC
 
-The IRC adapter connects Hermes to any IRC server and relays messages between an IRC channel (or direct messages) and the agent. It speaks the IRC protocol over Python's stdlib `asyncio` — **no external dependencies, no SDK, no daemon**. It works with public networks like [Libera.Chat](https://libera.chat/) and any self-hosted ircd.
+The IRC adapter connects Hermes to any IRC server and relays messages between an IRC channel (or direct messages) and the agent. It speaks the IRC protocol over Python's stdlib `asyncio` — **no external dependencies, no SDK, no daemon**.
+
+> ⚠ **Warning:** Many public IRC networks (including [Libera.Chat](https://libera.chat/news/bot-policy-update)) prohibit LLM-driven autonomous clients. For production use, [run a local IRCd](https://github.com/ergochat/ergo) or use a network that explicitly allows agentic connections.
 
 IRC is plain text: there is no voice, image, file, thread, reaction, typing, or streaming support — replies are sent as `PRIVMSG` lines, with long messages split to fit the IRC line limit.
 
@@ -8,7 +10,7 @@ IRC is plain text: there is no voice, image, file, thread, reaction, typing, or 
 
 ## Prerequisites
 
-- An IRC server to connect to (e.g. `irc.libera.chat`)
+- An IRC server to connect to (e.g. `irc.example.net`; prefer a local IRCd for production)
 - A channel to join (e.g. `#hermes`) — comma-separate to join several
 - A nickname for the bot (default: `hermes-bot`)
 - Optional: a registered nick + NickServ password if your network requires identification
@@ -25,7 +27,7 @@ gateway:
     irc:
       enabled: true
       extra:
-        server: irc.libera.chat
+        server: irc.example.net
         port: 6697
         nickname: hermes-bot
         channel: "#hermes"
@@ -40,7 +42,7 @@ gateway:
 
 | Variable | Required | Description |
 |----------|:--------:|-------------|
-| `IRC_SERVER` | ✅ | IRC server hostname (e.g. `irc.libera.chat`) |
+| `IRC_SERVER` | ✅ | IRC server hostname (e.g. `irc.example.net`; prefer a local IRCd for production) |
 | `IRC_CHANNEL` | ✅ | Channel(s) to join — comma-separate for multiple |
 | `IRC_NICKNAME` | ✅ | Bot nickname (default: `hermes-bot`) |
 | `IRC_PORT` | — | Server port (default: `6697` with TLS, `6667` without) |


### PR DESCRIPTION
## Description

Fixes #61181.

Libera.Chat has a [policy](https://libera.chat/news/bot-policy-update) prohibiting LLM-driven autonomous clients. The IRC plugin's documentation, config examples, and interactive setup flow all recommended `irc.libera.chat` as the default server, causing users to inadvertently violate network policies.

## Changes

- **plugin.yaml** — changed example from `irc.libera.chat` to `irc.example.net` with a note to check docs about public network policies
- **adapter.py** — updated docstring example, setup prompt, and added a warning banner during interactive setup (`hermes gateway setup`)
- **config.py** — updated IRC_SERVER env var description
- **website docs** — updated both the reference (env vars) and user guide (IRC messaging) pages with warnings and neutral examples
- **tests** — updated test fixtures to use `irc.example.net` instead of `irc.libera.chat`

## Testing

All changes are to documentation strings, example strings, and test fixtures — no runtime logic was modified. The IRC plugin continues to function identically regardless of what server the user configures.