### PR TITLE
fix(state): dedup list_sessions_rich's recursive chain CTE (UNION not UNION ALL)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3171,7 +3171,16 @@ class SessionDB:
             query = f"""
                 WITH RECURSIVE chain(root_id, cur_id) AS (
                     SELECT s.id, s.id FROM sessions s {where_sql}
-                    UNION ALL
+                    -- UNION (not UNION ALL) dedups the working set so a
+                    -- corrupted parent_session_id chain that loops back on
+                    -- itself (a -> b -> a) terminates instead of recursing
+                    -- forever. Mirrors the _session_latest_descendant fix
+                    -- (#39140-adjacent) for the structurally identical
+                    -- parent-chain-walk hazard; a legitimate acyclic chain
+                    -- never produces a duplicate (root_id, cur_id) pair
+                    -- (parent_session_id is single-valued), so this is a
+                    -- no-op for correct data.
+                    UNION
                     SELECT c.root_id, child.id
                     FROM chain c
                     JOIN sessions parent ON parent.id = c.cur_id

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3994,6 +3994,48 @@ class TestExcludeSources:
         assert "s2" not in ids
         assert "s3" not in ids
 
+    def test_list_sessions_rich_survives_corrupted_compression_cycle(self, db):
+        """Regression: the recursive 'chain' CTE must dedup (UNION) so a
+        corrupted compression-continuation chain that loops (a -> b -> a)
+        terminates instead of recursing forever like UNION ALL would.
+
+        Mirrors test_latest_descendant_survives_parent_cycle
+        (tests/hermes_cli/test_web_server.py, #39140-adjacent) for the
+        structurally identical parent-chain-walk hazard in
+        list_sessions_rich's own recursive compression-chain CTE, which is
+        a separate query from _session_latest_descendant's and was not
+        covered by that fix.
+        """
+        db.create_session("cyc-a", "cli")
+        db.create_session("cyc-b", "cli", parent_session_id="cyc-a")
+        with db._lock:
+            db._conn.execute(
+                "UPDATE sessions SET end_reason='compression' WHERE id IN ('cyc-a', 'cyc-b')"
+            )
+            # Corrupt the chain into a 2-cycle: cyc-a now also claims cyc-b
+            # as its parent (cyc-a -> cyc-b -> cyc-a), mirroring the sibling
+            # test's corruption of a linear chain into a loop.
+            db._conn.execute(
+                "UPDATE sessions SET parent_session_id='cyc-b' WHERE id='cyc-a'"
+            )
+            db._conn.commit()
+
+        # The core regression property: the call returns at all (bounded
+        # time) instead of hanging forever walking the corrupted cycle.
+        # order_by_last_active=True is required to reach the recursive
+        # chain CTE at all -- it is only built in that code path.
+        # include_children=True is required for cyc-a/cyc-b (both have
+        # parent_session_id set) to even enter the CTE seed -- otherwise
+        # _LISTABLE_CHILD_SQL excludes them before recursion ever starts.
+        # The exact projection of a cyclic compression chain is undefined
+        # (there is no valid "latest tip" for data that can never occur
+        # from normal operation), so this only asserts termination and a
+        # well-formed result, not a specific row.
+        sessions = db.list_sessions_rich(
+            source="cli", limit=20, order_by_last_active=True, include_children=True
+        )
+        assert isinstance(sessions, list)
+
     def test_search_messages_excludes_tool_source(self, db):
         db.create_session("s1", "cli")
         db.append_message("s1", "user", "Python deployment question")


### PR DESCRIPTION
## Summary
`list_sessions_rich`'s `order_by_last_active=True` path builds a recursive `chain` CTE that walks compression-continuation edges forward via `child.parent_session_id = cur_id`, using `UNION ALL`. A corrupted parent chain that loops (`a -> b -> a`) never terminates: `UNION ALL` keeps re-deriving the same `(root_id, cur_id)` pairs forever since it doesn't dedup the working set.

This is the same class of bug just fixed in the sibling `_session_latest_descendant` query (1e2ad17af, "#39140 CTE ... recurses forever if a corrupted parent chain loops") — a separate, pre-existing recursive CTE in this file that fix didn't touch. `list_sessions_rich` is used far more broadly (dashboard, CLI, TUI, ACP adapter, ~20 call sites), so a corrupted/cyclic compression chain reaching this path would hang whichever caller invoked it, not just one endpoint.

## Fix
`UNION` instead of `UNION ALL`. A legitimate acyclic chain never produces a duplicate `(root_id, cur_id)` pair (`parent_session_id` is single-valued per row), so this is a no-op for correct data and only changes behavior for the corrupted-cycle case.

## Tests
`tests/test_hermes_state.py` — builds a 2-session cycle (`cyc-a <-> cyc-b`, both `end_reason='compression'`, mutually pointing at each other via `parent_session_id`) and asserts `list_sessions_rich(..., order_by_last_active=True, include_children=True)` returns instead of hanging.

## Test plan
- [x] Mutation-verified **empirically**, not just by code inspection: reverting the fix and running the new test with a bounded 8s timeout confirms it actually hangs (times out) against the pre-fix code; a raw-SQL reproduction against the exact cyclic fixture data independently confirmed the same `UNION ALL` query never returns. With the fix, the same test passes in under 0.1s.
- [x] Full `hermes_state.py` suite (340 tests) passes
- [x] Session-listing/filters/archiving suites (166 tests) pass
- [x] `hermes_cli/web_server.py` full suite (366 tests) passes
- [x] `ruff check` clean on both changed files