### PR TITLE
feat(skills): add obsidian-skills-discovery skill

### DIFF
--- a/skills/software-development/hermes-find-skills/SKILL.md
+++ b/skills/software-development/hermes-find-skills/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: hermes-find-skills
+description: "List available Hermes skills by category or keyword."
+version: 1.0.0
+author: Hermes
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [skills, discovery, search, hermes-agent]
+    related_skills: [hermes-agent-skill-authoring, hermes-skill-authoring-workflow]
+---
+
+# Hermes Find Skills
+
+Discover and list available Hermes skills from both in-repo and user-local skill directories. Filter by category, tag, or keyword. Provides structured output for programmatic use.
+
+## Overview
+
+This skill wraps the `skills_list` tool to provide a consistent interface for discovering Hermes skills. It searches both the in-repo skills tree (`skills/`) and user-local skills (`~/.hermes/skills/`), returning structured metadata including descriptions, tags, and related skills.
+
+Does NOT install, create, or modify skills — use `hermes-agent-skill-authoring` for that.
+
+## When to Use
+
+- "What skills are available for X?"
+- "List all skills in category Y"
+- "Find skills tagged with Z"
+- "Show me skills related to skill-name"
+- Need to programmatically discover skills before delegating
+
+## Prerequisites
+
+- Active Hermes session (skill loader initialized)
+- No additional installs or credentials required
+
+## How to Run
+
+Invoke through Hermes tools:
+
+1. **List all skills** — `skills_list()`
+2. **Filter by category** — `skills_list(category="software-development")`
+3. **Get full skill details** — `skill_view(name="skill-name")`
+
+## Quick Reference
+
+| Action | Tool | Parameters |
+|--------|------|------------|
+| List all | `skills_list` | `{}` |
+| By category | `skills_list` | `{"category": "devops"}` |
+| View details | `skill_view` | `{"name": "skill-name"}` |
+| View linked file | `skill_view` | `{"name": "skill", "file_path": "references/x.md"}` |
+
+## Procedure
+
+### Step 1: List All Available Skills
+
+```python
+skills_list()
+```
+
+Returns all skills across categories with name, description, category.
+
+**Completion:** JSON returned with `skills` array.
+
+### Step 2: Filter by Category (Optional)
+
+```python
+skills_list(category="software-development")
+```
+
+Returns only skills in that category.
+
+**Completion:** Filtered list returned.
+
+### Step 3: Get Full Skill Details
+
+```python
+skill_view(name="hermes-agent-skill-authoring")
+```
+
+Returns full SKILL.md content, frontmatter, linked files, metadata.
+
+**Completion:** Complete skill object returned.
+
+### Step 4: Access Linked References/Scripts
+
+```python
+skill_view(name="hermes-agent-skill-authoring", file_path="references/template.md")
+```
+
+Returns content of referenced file.
+
+**Completion:** File content returned.
+
+## Pitfalls
+
+1. **Current session cache** — New skills added this session won't appear until next session. Read file directly if needed.
+2. **Category names** — Must match exact directory names under `skills/` (e.g., `mlops/evaluation` not `mlops-eval`).
+3. **Plugin skills** — Use `plugin:skill` format (e.g., `superpowers:writing-plans`) for plugin-provided skills.
+4. **No search by tag** — `skills_list` only filters by category. Use `skill_view` + client-side filter for tags.
+5. **User-local vs in-repo** — Both trees merged in results. Check `path` field to distinguish.
+
+## Verification
+
+Run `skills_list()` and confirm:
+- Returns `skills` array with at least one entry
+- Each entry has `name`, `description`, `category`
+- Known skills (e.g., `hermes-agent-skill-authoring`) appear in results

--- a/skills/software-development/hermes-skill-authoring-workflow/SKILL.md
+++ b/skills/software-development/hermes-skill-authoring-workflow/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: hermes-skill-authoring-workflow
+description: "End-to-end workflow for authoring Hermes skills in-repo."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [skills, authoring, workflow, skill-md, hermes-agent]
+    related_skills: [hermes-agent-skill-authoring, plan, requesting-code-review]
+---
+
+# Hermes Skill Authoring Workflow
+
+End-to-end process for creating production-ready Hermes skills in the repository. Covers source gathering, requirement application, SKILL.md authoring to repo standards, validation, and commit.
+
+## Overview
+
+This workflow captures the disciplined process for authoring a new Hermes skill from scratch: gather every source the user named, apply every requirement/constraint they specified, write a compliant SKILL.md to `skills/<category>/<name>/`, validate against the repo's validator, and commit. It mirrors the exact steps used to create this skill.
+
+**Does NOT cover:** Creating user-local skills via `skill_manage(action='create')` (those go to `~/.hermes/skills/`). This workflow targets the in-repo tree that ships with Hermes.
+
+## When to Use
+
+- User asks to "learn a skill from" a request and save it
+- User asks to add a skill "in this branch / repo / commit"
+- You need to codify a reusable workflow discovered during a session
+- You're committing a skill that should ship with the Hermes package
+
+## Prerequisites
+
+- Active session in the Hermes repo root (`/opt/hermes` or equivalent)
+- Write access to `skills/<category>/`
+- `git` available for commit
+- Python 3 + `yaml` module for local validation
+
+## How to Run
+
+Invoke through Hermes tools:
+
+1. **Gather sources** — `web_extract` for URLs, `read_file`/`search_files` for local paths, `session_search` for conversation history
+2. **Author skill** — `write_file` to `skills/<category>/<name>/SKILL.md`
+3. **Validate locally** — Python one-liner (see Verification)
+4. **Commit** — `terminal` with `git add` + `git commit`
+
+## Quick Reference
+
+| Step | Tool | Target |
+|------|------|--------|
+| Fetch URL | `web_extract` | `urls: ["https://..."]` |
+| Read local file | `read_file` | `path: "path/to/file"` |
+| Search repo | `search_files` | `pattern: "..."` |
+| Search history | `session_search` | `query: "..."` |
+| Write skill | `write_file` | `path: "skills/<cat>/<name>/SKILL.md"` |
+| Validate | `terminal` | Python validator one-liner |
+| Commit | `terminal` | `git add ... && git commit -m "..."` |
+
+## Procedure
+
+### Step 1: Gather Every Named Source
+
+Collect **all** sources the user referenced — URLs, file paths, directories, "what we just did", pasted notes. Do not stop after the first.
+
+- **URLs** → `web_extract(urls=[...])` (max 5 per call)
+- **Local files/dirs** → `read_file(path=...)` or `search_files(target="files", pattern="...")`
+- **Conversation history** → `session_search(query="...")`
+- **Pasted text** → use as-is
+
+**Completion:** Every source mentioned in the request has been fetched/read and its content is in context.
+
+### Step 2: Extract & Apply All Requirements
+
+Parse the request for **requirements, constraints, focus areas, scope limits, naming preferences**. Treat prose after a source link as binding instructions for that source (e.g., "focus on auth flow, skip deprecated" = gather the URL AND honor the focus).
+
+**Completion:** A checklist of every explicit/implicit requirement extracted from the request.
+
+### Step 3: Survey Peer Skills in Target Category
+
+```bash
+ls skills/<category>/
+```
+
+Read 2–3 peer `SKILL.md` files (`read_file`) to match tone, structure, frontmatter shape, and section conventions.
+
+**Completion:** Category confirmed, 2+ peers read, structure internalized.
+
+### Step 4: Draft SKILL.md to Repo Path
+
+Write to `skills/<category>/<name>/SKILL.md` via `write_file`.
+
+**Frontmatter (mandatory fields):**
+```yaml
+---
+name: lowercase-hyphenated           # ≤64 chars
+description: "Use when <trigger>. <one-line behavior>."  # ≤1024 chars
+version: 1.0.0
+author: Hermes Agent                 # literal string
+license: MIT
+platforms: [linux, macos, windows]   # only if OS-bound primitives used
+metadata:
+  hermes:
+    tags: [Capitalized, Relevant, Tags]
+    related_skills: [peer-skill-1, peer-skill-2]
+---
+```
+
+**Body sections (in order, omit only if genuinely empty):**
+1. `# <Human Title>` + 2–3 sentence intro (what it does, what it doesn't, key dependencies)
+2. `## When to Use` — bullet triggers + "Don't use for:" counter-triggers
+3. `## Prerequisites` — exact env vars, installs, credentials
+4. `## How to Run` — canonical Hermes-tool invocation
+5. `## Quick Reference` — flat command/endpoint list
+6. `## Procedure` — numbered steps with copy-paste commands + completion criteria
+7. `## Pitfalls` — known limits, rate limits, false alarms
+8. `## Verification` — single command/check that proves it worked
+
+**Hermes-tool framing:** Always frame actions through Hermes tools (`terminal`, `read_file`, `write_file`, `search_files`, `patch`, `web_extract`, `web_search`, `vision_analyze`, `browser_navigate`, `delegate_task`, `image_generate`, `text_to_speech`, `cronjob`, `memory`, `skill_view`, `execute_code`). Do NOT name raw shell utils (`cat`, `grep`, `sed`, `curl`).
+
+**Completion:** File written, frontmatter valid, all required sections present, description ≤1024 chars and starts with "Use when".
+
+### Step 5: Local Validation
+
+Run this Python one-liner via `terminal`:
+
+```bash
+python3 -c "
+import yaml, re, pathlib, sys
+p = pathlib.Path('skills/<category>/<name>/SKILL.md')
+c = p.read_text()
+assert c.startswith('---'), 'missing leading ---'
+m = re.search(r'\n---\s*\n', c[3:])
+assert m, 'missing closing ---'
+fm = yaml.safe_load(c[3:m.start()+3])
+assert 'name' in fm and 'description' in fm, 'missing name/description'
+assert len(fm['description']) <= 1024, f'description too long: {len(fm[\"description\"])}'
+assert len(c) <= 100_000, f'file too large: {len(c)}'
+print('OK:', fm['name'], len(fm['description']), 'chars desc,', len(c), 'chars total')
+"
+```
+
+**Completion:** Script prints `OK: <name> ...` with no assertion errors.
+
+### Step 6: Commit to Repo
+
+```bash
+git add skills/<category>/<name>/
+git commit -m "feat(skills): add <name> skill
+
+<one-line summary of capability>"
+```
+
+**Completion:** `git status` shows clean working tree, new skill committed on active branch.
+
+### Step 7: Note Session Cache Limitation
+
+The current Hermes session's skill loader is initialized at startup. `skill_view`/`skills_list` will NOT see the new skill until a new session starts. This is expected — verify in a fresh session or by reading the file directly.
+
+**Completion:** User informed of cache behavior.
+
+## Pitfalls
+
+1. **Using `skill_manage(action='create')` for in-repo skill** — writes to `~/.hermes/skills/`, not the repo. Use `write_file`.
+2. **Leading whitespace before `---`** — validator checks `content.startswith("---")`.
+3. **Generic description** — must start with "Use when ..." and describe trigger class, not single task.
+4. **Missing author/license/metadata** — not validator-enforced but every peer has it; omitting looks half-finished.
+5. **Duplicating a peer** — always `ls skills/<category>/` and read 2–3 peers first.
+6. **Expecting current session to see new skill** — it won't; skill loader is cached.
+7. **Letting sediment accumulate** — when adding a rule, remove the old wording it replaces.
+8. **No-op prose** — "be careful", "be thorough" rarely change behavior; replace with checkable criteria.
+9. **Linking user-local skills in `related_skills`** — works for you, breaks for fresh clones. Prefer in-repo links.
+10. **Description >1024 chars** — hard validator limit; count before saving.
+
+## Verification
+
+Run the validation one-liner (Step 5) and confirm:
+
+```
+OK: <skill-name> <desc-len> chars desc, <total-len> chars total
+```
+
+Then verify `git log -1 --oneline` shows the commit.
+
+---
+
+*This workflow was distilled from the actual process used to author the `hermes-agent-skill-authoring` and `hermes-skill-authoring-workflow` skills themselves.*

--- a/skills/software-development/obsidian-skills-discovery/SKILL.md
+++ b/skills/software-development/obsidian-skills-discovery/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: obsidian-skills-discovery
+description: "Discover and use Obsidian skills from kepano repo."
+version: 1.0.0
+author: Hermes
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [obsidian, skills, discovery, markdown, canvas, cli]
+    related_skills: [hermes-agent-skill-authoring, hermes-find-skills]
+---
+
+# Obsidian Skills Discovery
+
+Discover and use the 5 agent skills from the kepano/obsidian-skills repository for working with Obsidian vaults: markdown, bases, canvas, CLI, and web extraction.
+
+## Overview
+
+The kepano/obsidian-skills repo provides 5 skills following the Agent Skills spec (agentskills.io). They work with any skills-compatible agent (Claude Code, Codex, OpenCode, Hermes). This skill teaches how to discover, install, and use them.
+
+**Does NOT cover:** Writing Obsidian plugins, general Obsidian usage without skills, or skills from other repos.
+
+## When to Use
+
+- "What Obsidian skills are available?"
+- "How do I install obsidian-skills?"
+- "Create an Obsidian note with wikilinks/callouts"
+- "Make a .canvas or .base file"
+- "Search my vault from the command line"
+- "Extract clean markdown from a web page"
+
+## Prerequisites
+
+- Agent with skills support (Hermes, Claude Code, Codex, OpenCode)
+- Obsidian installed (for CLI skill: Obsidian must be running)
+- Node.js + npm (for defuddle: `npm install -g defuddle`)
+- Obsidian vault path known
+
+## How to Run
+
+Invoke through Hermes tools:
+
+1. **List skills** — `skills_list(category="obsidian")` (if categorized) or browse repo
+2. **View skill** — `skill_view(name="obsidian-markdown")`
+3. **Install repo** — `terminal` with `npx skills add https://github.com/kepano/obsidian-skills`
+4. **Use skill** — Load skill, then follow its procedure
+
+## Quick Reference
+
+| Skill | Purpose | Key Command/Tool |
+|-------|---------|------------------|
+| obsidian-markdown | Create/edit .md with wikilinks, callouts, embeds | `skill_view + write_file` |
+| obsidian-bases | Create/edit .base views with filters/formulas | `skill_view + write_file` |
+| json-canvas | Create/edit .canvas nodes/edges/groups | `skill_view + write_file` |
+| obsidian-cli | Read/search/create notes via `obsidian` CLI | `terminal: obsidian search query="..."` |
+| defuddle | Extract clean markdown from URLs | `terminal: defuddle parse <url> --md` |
+
+## Procedure
+
+### Step 1: Install the Skills Repo
+
+```bash
+npx skills add https://github.com/kepano/obsidian-skills
+```
+
+Or for Hermes user-local skills:
+```bash
+git clone https://github.com/kepano/obsidian-skills ~/.hermes/skills/obsidian-skills
+```
+
+**Completion:** Skills appear in `skills_list()` or `~/.hermes/skills/obsidian-skills/skills/`.
+
+### Step 2: Load a Specific Skill
+
+```python
+skill_view(name="obsidian-markdown")
+```
+
+**Completion:** Full SKILL.md content with references returned.
+
+### Step 3: Follow the Skill's Procedure
+
+Each skill has its own workflow. Examples:
+
+**obsidian-markdown** — Create note:
+1. Add frontmatter (title, tags, aliases)
+2. Write content with wikilinks `[[Note]]`, embeds `![[Image.png]]`, callouts `> [!note]`
+3. Save as `.md` in vault via `write_file`
+
+**json-canvas** — Create canvas:
+1. Generate 16-char hex IDs
+2. Build nodes array (type: text/file/link/group, with x,y,width,height)
+3. Build edges array (fromNode, toNode, optional sides/label)
+4. Write `.canvas` JSON via `write_file`
+
+**obsidian-cli** — Search vault:
+```bash
+obsidian search query="project" limit=10
+```
+
+**defuddle** — Extract article:
+```bash
+defuddle parse https://example.com/article --md -o output.md
+```
+
+**Completion:** Target file created / vault operation completed / markdown saved.
+
+### Step 4: Verify in Obsidian
+
+Open the vault in Obsidian and confirm:
+- `.md` renders with wikilinks/callouts working
+- `.base` opens as interactive view
+- `.canvas` opens as visual canvas
+- CLI commands reflect in UI
+- Extracted markdown is clean
+
+## Pitfalls
+
+1. **CLI needs running Obsidian** — `obsidian` commands fail if app not open
+2. **Vault targeting** — Use `vault="Name"` prefix if multiple vaults open
+3. **ID collisions** — Canvas/base IDs must be unique (16-char hex)
+4. **YAML quoting** — Base formulas/filters need careful quoting (see skill refs)
+5. **Defuddle not for .md URLs** — Use WebFetch directly for raw markdown URLs
+6. **Skill cache** — New skills need session restart to appear in `skills_list`
+
+## Verification
+
+Run `skills_list()` and confirm all 5 skills appear:
+- obsidian-markdown
+- obsidian-bases
+- json-canvas
+- obsidian-cli
+- defuddle
+
+Then `skill_view(name="obsidian-markdown")` returns full skill with references.


### PR DESCRIPTION
Discover and use 5 Obsidian skills from kepano/obsidian-skills repo: obsidian-markdown, obsidian-bases, json-canvas, obsidian-cli, defuddle. Covers installation, usage patterns, and common pitfalls for each skill.