### PR TITLE
fix(tools): strip required: null from tool schemas to prevent HTTP 400

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -189,6 +189,21 @@ def test_required_all_missing_is_dropped():
     assert "required" not in out[0]["function"]["parameters"]
 
 
+def test_required_null_is_dropped():
+    """``required: null`` is invalid JSON Schema and causes HTTP 400 on
+    strict OpenAI-compatible backends (issue #60752)."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"msg": {"type": "string"}},
+        "required": None,
+    })]
+    out = sanitize_tool_schemas(tools)
+    params = out[0]["function"]["parameters"]
+    assert "required" not in params
+    # Properties must survive.
+    assert "msg" in params["properties"]
+
+
 def test_well_formed_schema_unchanged():
     schema = {
         "type": "object",

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -351,6 +351,12 @@ def _sanitize_node(node: Any, path: str) -> Any:
         elif len(valid) != len(out["required"]):
             out["required"] = valid
 
+    # ``required: null`` is invalid JSON Schema (must be an array or absent)
+    # and causes HTTP 400 on strict OpenAI-compatible backends (#60752).
+    # Normalise to absent — an omitted ``required`` is universally accepted.
+    if out.get("required") is None:
+        out.pop("required", None)
+
     return out
 
 


### PR DESCRIPTION
## Summary

The schema sanitizer in `tools/schema_sanitizer.py` passes through `required: null` unchanged, which is invalid JSON Schema. Strict OpenAI-compatible backends (e.g. arityflow.top) reject it with HTTP 400.

**Root cause**: The post-loop guard at line 346 only handles `required` when it is a `list` — `None` falls through untouched.

**Fix**: Add a final guard that removes `required` when its value is `None`, normalising to an omitted key (universally accepted).

## Changes

- `tools/schema_sanitizer.py`: Add `required: null` → remove guard
- `tests/tools/test_schema_sanitizer.py`: Add `test_required_null_is_dropped` test

## Test Plan

- [x] All 48 schema sanitizer tests pass (`pytest tests/tools/test_schema_sanitizer.py`)
- [x] New test `test_required_null_is_dropped` verifies the fix

Closes #60752