### PR TITLE
feat(cli): add runtime change advisories

### DIFF
--- a/hermes_cli/change_impact.py
+++ b/hermes_cli/change_impact.py
@@ -1,0 +1,190 @@
+"""Runtime impact advisories for configuration and tool changes.
+
+This module is intentionally small and side-effect-free: callers that mutate
+config/env/tool state can ask what kind of refresh is needed and print the
+same concise reminder everywhere instead of each surface guessing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class ImpactScope(str, Enum):
+    """How far a change reaches before it becomes visible."""
+
+    IMMEDIATE = "immediate"
+    NEW_SESSION = "new_session"
+    GATEWAY_RESTART = "gateway_restart"
+    PROCESS_RESTART = "process_restart"
+
+
+@dataclass(frozen=True)
+class ChangeAdvisory:
+    """User-facing refresh guidance for a just-applied change."""
+
+    scope: ImpactScope
+    action: str
+    reason: str
+    title: str = "Runtime note"
+
+
+_GATEWAY_ENV_PREFIXES = (
+    "DISCORD_",
+    "TELEGRAM_",
+    "SLACK_",
+    "SIGNAL_",
+    "SMS_",
+    "MATRIX_",
+    "MATTERMOST_",
+    "DINGTALK_",
+    "FEISHU_",
+    "WECOM_",
+    "WEIXIN_",
+    "YUANBAO_",
+    "WHATSAPP_",
+    "IMESSAGE_",
+    "PHOTON_",
+    "LINE_",
+    "SIMPLEX_",
+    "NTFY_",
+    "GOOGLE_CHAT_",
+    "TEAMS_",
+)
+
+_PROCESS_RESTART_KEYS = {
+    "security.redact_secrets": ChangeAdvisory(
+        scope=ImpactScope.PROCESS_RESTART,
+        action="restart Hermes",
+        reason="Secret redaction is snapshotted by the running process; restart before expecting this setting to change live behavior.",
+    ),
+}
+
+_NEW_SESSION_KEYS = {
+    "model",
+    "toolsets",
+    "mcp_servers",
+    "custom_providers",
+}
+
+_NEW_SESSION_PREFIXES = (
+    "model.",
+    "fallback_model",
+    "auxiliary.",
+    "agent.",
+    "delegation.",
+    "terminal.",
+    "display.",
+    "compression.",
+    "memory.",
+    "toolsets",
+    "tools.",
+    "mcp_servers",
+    "custom_providers",
+)
+
+_GATEWAY_RESTART_PREFIXES = (
+    "gateway.",
+    "platforms.",
+    "stt.",
+    "tts.",
+    "cron.",
+    "kanban.",
+)
+
+
+def _normalize_key(key: str) -> str:
+    return str(key or "").strip()
+
+
+def advisory_for_config_key(key: str) -> Optional[ChangeAdvisory]:
+    """Return refresh guidance for a config/env key, if one is useful.
+
+    The mapping deliberately favors concrete, actionable reminders over broad
+    noise. Unknown keys return ``None`` so callers do not nag users for every
+    harmless save.
+    """
+
+    raw_key = _normalize_key(key)
+    if not raw_key:
+        return None
+
+    lower = raw_key.lower()
+    upper = raw_key.upper()
+
+    if lower in _PROCESS_RESTART_KEYS:
+        return _PROCESS_RESTART_KEYS[lower]
+
+    if upper.startswith(_GATEWAY_ENV_PREFIXES):
+        return ChangeAdvisory(
+            scope=ImpactScope.GATEWAY_RESTART,
+            action="hermes gateway restart",
+            reason="Gateway credentials/channel settings are read by the running gateway process; restart it before expecting messaging behavior to change.",
+        )
+
+    if upper.startswith("TERMINAL_SSH"):
+        return ChangeAdvisory(
+            scope=ImpactScope.NEW_SESSION,
+            action="/new",
+            reason="Terminal backend credentials/settings are resolved by new sessions; current terminal environments may keep using the old value.",
+        )
+
+    if lower.startswith("platform_toolsets"):
+        parts = lower.split(".")
+        platform = parts[1] if len(parts) > 1 else ""
+        if platform and platform != "cli":
+            return ChangeAdvisory(
+                scope=ImpactScope.GATEWAY_RESTART,
+                action="hermes gateway restart",
+                reason="Gateway platform tool schemas are built from platform toolsets when sessions start; restart the gateway to rebuild them cleanly.",
+            )
+        return ChangeAdvisory(
+            scope=ImpactScope.NEW_SESSION,
+            action="/new",
+            reason="Tool schema changes are snapshotted at current session start; start a new session before expecting these tools to appear or disappear.",
+        )
+
+    if lower.startswith(_GATEWAY_RESTART_PREFIXES):
+        return ChangeAdvisory(
+            scope=ImpactScope.GATEWAY_RESTART,
+            action="hermes gateway restart",
+            reason="Gateway runtime settings are loaded by the running gateway process; restart it before expecting this change to affect messaging sessions.",
+        )
+
+    if lower in _NEW_SESSION_KEYS or lower.startswith(_NEW_SESSION_PREFIXES):
+        return ChangeAdvisory(
+            scope=ImpactScope.NEW_SESSION,
+            action="/new",
+            reason="This setting is resolved when new sessions start; current sessions may keep using the old value.",
+        )
+
+    return None
+
+
+def toolset_change_advisory(platform: str = "cli") -> ChangeAdvisory:
+    """Return the advisory for a toolset mutation on ``platform``."""
+
+    return advisory_for_config_key(f"platform_toolsets.{platform}") or ChangeAdvisory(
+        scope=ImpactScope.NEW_SESSION,
+        action="/new",
+        reason="Tool schema changes are snapshotted at current session start; start a new session before expecting these tools to appear or disappear.",
+    )
+
+
+def format_advisory(advisory: ChangeAdvisory) -> str:
+    """Format a compact, grep/test-friendly advisory line."""
+
+    return f"{advisory.title}: {advisory.reason} Next action: {advisory.action}."
+
+
+def print_advisory(advisory: Optional[ChangeAdvisory]) -> None:
+    """Print ``advisory`` if present.
+
+    Kept as a tiny wrapper so call sites stay consistent and tests can assert a
+    stable prefix.
+    """
+
+    if advisory is not None:
+        print(format_advisory(advisory))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8065,6 +8065,8 @@ def set_config_value(key: str, value: str):
     if key.upper() in api_keys or key.upper().endswith(('_API_KEY', '_TOKEN')) or key.upper().startswith('TERMINAL_SSH'):
         save_env_value(key.upper(), value)
         print(f"✓ Set {key} in {get_env_path()}")
+        from hermes_cli.change_impact import advisory_for_config_key, print_advisory
+        print_advisory(advisory_for_config_key(key.upper()))
         return
     
     # Otherwise it goes to config.yaml
@@ -8127,6 +8129,8 @@ def set_config_value(key: str, value: str):
     else:
         _display_value = value
     print(f"✓ Set {key} = {_display_value} in {config_path}")
+    from hermes_cli.change_impact import advisory_for_config_key, print_advisory
+    print_advisory(advisory_for_config_key(key))
 
 
 # =============================================================================

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -4503,3 +4503,5 @@ def tools_disable_enable_command(args):
     if successful:
         verb = "Disabled" if action == "disable" else "Enabled"
         _print_success(f"{verb}: {', '.join(successful)}")
+        from hermes_cli.change_impact import print_advisory, toolset_change_advisory
+        print_advisory(toolset_change_advisory(platform))

--- a/tests/hermes_cli/test_change_impact_advisor.py
+++ b/tests/hermes_cli/test_change_impact_advisor.py
@@ -1,0 +1,61 @@
+"""Tests for runtime refresh/restart advisories after config/tool changes."""
+
+from argparse import Namespace
+from unittest.mock import patch
+
+from hermes_cli.change_impact import ImpactScope, advisory_for_config_key, format_advisory
+from hermes_cli.tools_config import tools_disable_enable_command
+from hermes_cli.config import set_config_value
+
+
+def test_toolset_config_requires_new_session_advisory():
+    advisory = advisory_for_config_key("platform_toolsets.cli")
+
+    assert advisory is not None
+    assert advisory.scope is ImpactScope.NEW_SESSION
+    assert advisory.action == "/new"
+    assert "tool schema" in advisory.reason.lower()
+    assert "current session" in format_advisory(advisory).lower()
+
+
+def test_gateway_platform_config_requires_gateway_restart_advisory():
+    advisory = advisory_for_config_key("gateway.platforms.discord.enabled")
+
+    assert advisory is not None
+    assert advisory.scope is ImpactScope.GATEWAY_RESTART
+    assert advisory.action == "hermes gateway restart"
+    assert "gateway" in advisory.reason.lower()
+
+
+def test_model_config_is_next_session_or_process_advisory():
+    advisory = advisory_for_config_key("model.default")
+
+    assert advisory is not None
+    assert advisory.scope is ImpactScope.NEW_SESSION
+    assert advisory.action == "/new"
+    assert "new sessions" in advisory.reason.lower()
+
+
+def test_env_secret_config_requires_gateway_restart_advisory(capsys, tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").touch()
+
+    set_config_value("DISCORD_BOT_TOKEN", "test-token")
+
+    out = capsys.readouterr().out
+    assert "Runtime note" in out
+    assert "gateway restart" in out.lower()
+
+
+def test_tools_disable_enable_prints_new_session_advisory(capsys):
+    config = {"platform_toolsets": {"cli": ["web", "memory"]}}
+    with patch("hermes_cli.tools_config.load_config", return_value=config), \
+         patch("hermes_cli.tools_config.save_config"):
+        tools_disable_enable_command(
+            Namespace(tools_action="disable", names=["web"], platform="cli")
+        )
+
+    out = capsys.readouterr().out
+    assert "Runtime note" in out
+    assert "/new" in out
+    assert "tool schema" in out.lower()


### PR DESCRIPTION
## Summary
- Add a side-effect-free `hermes_cli.change_impact` helper for runtime refresh/restart advisories.
- Print consistent runtime notes after config/env mutations that require `/new`, gateway restart, or process restart.
- Print a new-session advisory after CLI toolset enable/disable changes.

## Test plan
- `python -m pytest tests/hermes_cli/test_change_impact_advisor.py -q --tb=short -n 0` → 5 passed
- `env -u HERMES_HOME python -m pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_change_impact_advisor.py -q --tb=short -n 0` → 263 passed, 1 skipped, 1 existing environment-sensitive failure in `TestGetHermesHome.test_default_path` because this desktop install resolves Hermes home to `C:/Users/Jamie/AppData/Local/hermes` instead of `Path.home() / ".hermes"`.
- `git diff --check origin/main...HEAD` → passed

## Notes
- Secret scan only found expected non-secret test strings (`test-token`) and config key names.