### PR TITLE
fix(gateway): offload sync SQLite queries in build_channel_directory to thread

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -6,6 +6,7 @@ Built on gateway startup, refreshed periodically (every 5 min), and saved to
 action="list" and for resolving human-friendly channel names to numeric IDs.
 """
 
+import asyncio
 import json
 import logging
 from datetime import datetime
@@ -121,7 +122,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     for platform, adapter in adapters.items():
         try:
             if platform == Platform.DISCORD:
-                platforms["discord"] = _build_discord(adapter)
+                platforms["discord"] = await asyncio.to_thread(_build_discord, adapter)
             elif platform == Platform.SLACK:
                 platforms["slack"] = await _build_slack(adapter)
         except Exception as e:
@@ -142,7 +143,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
             or plat_name not in adapter_platform_names
         ):
             continue
-        platforms[plat_name] = _build_from_sessions(plat_name)
+        platforms[plat_name] = await asyncio.to_thread(_build_from_sessions, plat_name)
 
     # Include plugin-registered platforms (dynamic enum members aren't in
     # Platform.__members__, so the loop above misses them). Same
@@ -156,7 +157,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
                 and entry.name not in platforms
                 and entry.name in adapter_platform_names
             ):
-                platforms[entry.name] = _build_from_sessions(entry.name)
+                platforms[entry.name] = await asyncio.to_thread(_build_from_sessions, entry.name)
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary

`build_channel_directory()` is an `async def` invoked on gateway startup and every 5 minutes. It calls `_build_discord()` and `_build_from_sessions()` **synchronously** on the event loop thread, blocking it for 10-40s on large `state.db`. This starves discord.py's heartbeat task, causing `Shard ID None heartbeat blocked for more than 10 seconds` warnings and gateway disconnects.

## Fix

Wrap the three synchronous call sites with `asyncio.to_thread()`:

1. `_build_discord(adapter)` → `await asyncio.to_thread(_build_discord, adapter)`
2. `_build_from_sessions(plat_name)` → `await asyncio.to_thread(_build_from_sessions, plat_name)` (2 call sites)

## Files Changed

- `gateway/channel_directory.py`: Add `import asyncio`, wrap 3 sync calls with `asyncio.to_thread()`

## Test Plan

- [x] All 315 gateway tests pass (`pytest tests/test_tui_gateway_server.py`)
- [x] Module imports successfully

Closes #60794