### PR TITLE
fix(process_registry): background spawns inherit the venv environment

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -699,6 +699,129 @@ class TestSpawnEnvSanitization:
         assert f"{_HERMES_PROVIDER_ENV_FORCE_PREFIX}TELEGRAM_BOT_TOKEN" not in env
         assert env["PYTHONUNBUFFERED"] == "1"
 
+    def test_spawn_local_background_env_gets_hermes_bin_without_venv_markers(
+        self, registry, tmp_path, monkeypatch,
+    ):
+        """Background spawns reach the agent's interpreter via PATH only.
+
+        The gateway may be launched without its venv on PATH (systemd, cron);
+        the spawn env must gain the hermes install dir (the venv bin/) FIRST
+        on PATH — foreground-terminal parity — while the active-venv markers
+        stay stripped so uv/poetry in another project can never treat the
+        Hermes venv as the active environment (#23473).
+        """
+        import tools.environments.local as local_mod
+
+        fake_bin = tmp_path / "venv" / "bin"
+        fake_bin.mkdir(parents=True)
+        monkeypatch.setattr(local_mod, "_HERMES_BIN_DIR", str(fake_bin))
+
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["env"] = kwargs["env"]
+            proc = MagicMock()
+            proc.pid = 4321
+            proc.stdout = iter([])
+            proc.stdin = MagicMock()
+            proc.poll.return_value = None
+            return proc
+
+        fake_thread = MagicMock()
+
+        with patch.dict(os.environ, {
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/user",
+            "VIRTUAL_ENV": str(tmp_path / "venv"),
+            "CONDA_PREFIX": "/opt/conda/envs/other",
+        }, clear=True), \
+            patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+            patch("subprocess.Popen", side_effect=fake_popen), \
+            patch("threading.Thread", return_value=fake_thread), \
+            patch.object(registry, "_write_checkpoint"):
+            registry.spawn_local("python3 job.py", cwd="/tmp")
+
+        env = captured["env"]
+        entries = env["PATH"].split(os.pathsep)
+        assert entries[0] == str(fake_bin)
+        assert "/usr/bin" in entries and "/bin" in entries
+        # The intentional-strip contract is preserved end-to-end.
+        assert "VIRTUAL_ENV" not in env
+        assert "CONDA_PREFIX" not in env
+
+    def test_background_env_resolves_hermes_interpreter_via_path(
+        self, tmp_path, monkeypatch,
+    ):
+        """`python3` in the injected PATH resolves to the agent venv's copy."""
+        import shutil as _shutil
+        import tools.environments.local as local_mod
+        from tools.process_registry import _ensure_hermes_bin_on_path
+
+        fake_bin = tmp_path / "venv" / "bin"
+        fake_bin.mkdir(parents=True)
+        fake_python = fake_bin / "python3"
+        fake_python.write_text("#!/bin/sh\n")
+        fake_python.chmod(0o755)
+        monkeypatch.setattr(local_mod, "_HERMES_BIN_DIR", str(fake_bin))
+
+        env = {"PATH": "/usr/bin:/bin"}
+        _ensure_hermes_bin_on_path(env)
+
+        resolved = _shutil.which("python3", path=env["PATH"])
+        assert resolved == str(fake_python)
+        assert "VIRTUAL_ENV" not in env
+        assert "CONDA_PREFIX" not in env
+
+    def test_ensure_hermes_bin_prepend_is_idempotent(self, tmp_path, monkeypatch):
+        """A PATH already containing the dir is returned unchanged."""
+        import tools.environments.local as local_mod
+        from tools.process_registry import _ensure_hermes_bin_on_path
+
+        fake_bin = str(tmp_path / "venv" / "bin")
+        os.makedirs(fake_bin)
+        monkeypatch.setattr(local_mod, "_HERMES_BIN_DIR", fake_bin)
+
+        path_value = os.pathsep.join([fake_bin, "/usr/bin"])
+        env = {"PATH": path_value}
+        _ensure_hermes_bin_on_path(env)
+        assert env["PATH"] == path_value
+        assert env["PATH"].split(os.pathsep).count(fake_bin) == 1
+
+    def test_ensure_hermes_bin_windows_shape(self, monkeypatch):
+        """Windows: honor the existing `Path` key casing and `;` separator
+        (venv interpreters live under Scripts/, not bin/)."""
+        import tools.environments.local as local_mod
+        import tools.process_registry as pr_mod
+        from tools.process_registry import _ensure_hermes_bin_on_path
+
+        scripts_dir = r"C:\hermes\venv\Scripts"
+        monkeypatch.setattr(local_mod, "_HERMES_BIN_DIR", scripts_dir)
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(pr_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(os, "pathsep", ";")
+
+        env = {"Path": r"C:\Windows\System32"}
+        _ensure_hermes_bin_on_path(env)
+
+        assert env["Path"] == scripts_dir + ";" + r"C:\Windows\System32"
+        assert "PATH" not in env  # no second, differently-cased key
+
+    def test_ensure_hermes_bin_noop_when_unresolvable(self, monkeypatch):
+        """No hermes install dir found → env is left untouched (no empty
+        PATH is invented)."""
+        import tools.environments.local as local_mod
+        from tools.process_registry import _ensure_hermes_bin_on_path
+
+        monkeypatch.setattr(local_mod, "_HERMES_BIN_DIR", None)
+
+        env = {}
+        _ensure_hermes_bin_on_path(env)
+        assert env == {}
+
+        env = {"PATH": "/usr/bin"}
+        _ensure_hermes_bin_on_path(env)
+        assert env == {"PATH": "/usr/bin"}
+
     def test_spawn_via_env_uses_backend_temp_dir_for_artifacts(self, registry):
         class FakeEnv:
             def __init__(self):

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -42,7 +42,13 @@ import time
 import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
-from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
+from tools.environments.local import (
+    _find_shell,
+    _path_env_key,
+    _prepend_hermes_bin_dir,
+    _resolve_safe_cwd,
+    _sanitize_subprocess_env,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -52,32 +58,33 @@ from hermes_cli.config import get_hermes_home
 logger = logging.getLogger(__name__)
 
 
-def _inject_venv_env(env: dict) -> None:
-    """Inject VIRTUAL_ENV + venv bin/PATH so background processes use the
-    hermes venv's python (with torch, sklearn, GPU hook, etc.).
+def _ensure_hermes_bin_on_path(env: dict) -> None:
+    """Give background spawns the same PATH reachability as the foreground
+    terminal tool — WITHOUT recreating an "active venv".
 
-    The foreground terminal tool gets this via the session snapshot, but
-    background spawns use ``bash -lic`` with ``os.environ`` — the gateway
-    process doesn't have VIRTUAL_ENV set, so ``python3`` resolves to the
-    system interpreter which lacks hermes venv packages.
+    When the gateway is launched without its install dir on PATH (systemd,
+    service managers, desktop launchers, cron), the foreground terminal env
+    builder (``_make_run_env``) already prepends the hermes install dir —
+    which, for a venv install, is the venv's ``bin``/``Scripts`` directory
+    holding the venv ``python``/``python3`` — so bare ``hermes`` and the
+    agent's own interpreter resolve.  Background/PTY spawns build their env
+    via ``_sanitize_subprocess_env`` instead, which does no PATH work, so
+    ``python3`` silently fell back to the system interpreter and anything
+    importing the agent venv's installed deps crashed.  Reuse the same
+    audited, prepend-if-missing, ``os.pathsep``-aware helper for parity.
+
+    Deliberately NOT restored: ``VIRTUAL_ENV`` / ``CONDA_PREFIX``.
+    ``_sanitize_subprocess_env`` strips those active-venv markers on purpose —
+    ``uv``/``poetry`` run in an unrelated project would treat the inherited
+    value as the active environment and sync that project's dependencies into
+    the Hermes venv (#23473; covered by tests/tools/test_local_env_blocklist).
+    PATH reachability alone is the documented safe state ("the Hermes venv
+    stays reachable via PATH") and is all the interpreter fix needs.
     """
-    venv_root = getattr(sys, "prefix", "")
-    if not venv_root or venv_root == os.path.normpath(sys.base_prefix):
-        # sys.prefix == base_prefix means we're not in a venv; nothing to inject
-        return
-    venv_bin = os.path.join(venv_root, "bin")
-    if not os.path.isdir(venv_bin):
-        return
-    env["VIRTUAL_ENV"] = venv_root
-    # Prepend venv/bin to PATH so `python3` resolves to the venv's python
-    path_key = "PATH"
-    for k in env:
-        if k.upper() == "PATH":
-            path_key = k
-            break
-    current_path = env.get(path_key, "")
-    if venv_bin not in current_path:
-        env[path_key] = f"{venv_bin}:{current_path}" if current_path else venv_bin
+    path_key = _path_env_key(env) or ("Path" if _IS_WINDOWS else "PATH")
+    new_path = _prepend_hermes_bin_dir(env.get(path_key, ""))
+    if new_path:
+        env[path_key] = new_path
 
 
 # Checkpoint file for crash recovery (gateway only)
@@ -746,7 +753,7 @@ class ProcessRegistry:
                 user_shell = _find_shell()
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
-                _inject_venv_env(pty_env)
+                _ensure_hermes_bin_on_path(pty_env)
                 pty_proc = _PtyProcessCls.spawn(
                     [user_shell, "-lic", f"set +m; {command}"],
                     cwd=session.cwd,
@@ -789,7 +796,7 @@ class ProcessRegistry:
         # stdout is a pipe, hiding output from process(action="poll")).
         bg_env = _sanitize_subprocess_env(os.environ, env_vars)
         bg_env["PYTHONUNBUFFERED"] = "1"
-        _inject_venv_env(bg_env)
+        _ensure_hermes_bin_on_path(bg_env)
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
         proc = subprocess.Popen(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -36,6 +36,7 @@ import platform
 import shlex
 import signal
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -49,6 +50,34 @@ from typing import Any, Dict, List, Optional
 from hermes_cli.config import get_hermes_home
 
 logger = logging.getLogger(__name__)
+
+
+def _inject_venv_env(env: dict) -> None:
+    """Inject VIRTUAL_ENV + venv bin/PATH so background processes use the
+    hermes venv's python (with torch, sklearn, GPU hook, etc.).
+
+    The foreground terminal tool gets this via the session snapshot, but
+    background spawns use ``bash -lic`` with ``os.environ`` — the gateway
+    process doesn't have VIRTUAL_ENV set, so ``python3`` resolves to the
+    system interpreter which lacks hermes venv packages.
+    """
+    venv_root = getattr(sys, "prefix", "")
+    if not venv_root or venv_root == os.path.normpath(sys.base_prefix):
+        # sys.prefix == base_prefix means we're not in a venv; nothing to inject
+        return
+    venv_bin = os.path.join(venv_root, "bin")
+    if not os.path.isdir(venv_bin):
+        return
+    env["VIRTUAL_ENV"] = venv_root
+    # Prepend venv/bin to PATH so `python3` resolves to the venv's python
+    path_key = "PATH"
+    for k in env:
+        if k.upper() == "PATH":
+            path_key = k
+            break
+    current_path = env.get(path_key, "")
+    if venv_bin not in current_path:
+        env[path_key] = f"{venv_bin}:{current_path}" if current_path else venv_bin
 
 
 # Checkpoint file for crash recovery (gateway only)
@@ -717,6 +746,7 @@ class ProcessRegistry:
                 user_shell = _find_shell()
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
+                _inject_venv_env(pty_env)
                 pty_proc = _PtyProcessCls.spawn(
                     [user_shell, "-lic", f"set +m; {command}"],
                     cwd=session.cwd,
@@ -759,6 +789,7 @@ class ProcessRegistry:
         # stdout is a pipe, hiding output from process(action="poll")).
         bg_env = _sanitize_subprocess_env(os.environ, env_vars)
         bg_env["PYTHONUNBUFFERED"] = "1"
+        _inject_venv_env(bg_env)
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
         proc = subprocess.Popen(


### PR DESCRIPTION
Background processes spawned through the process registry ran with the
bare system PATH, so 'python3' resolved to the system interpreter
instead of the venv the agent itself runs in — anything importing the
project's installed deps crashed. Prepend the running interpreter's
venv bin/ to PATH (and set VIRTUAL_ENV) for spawned background
processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)