### PR TITLE
feat(tools): add guarded codex exec bridge

### DIFF
--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -20,6 +20,7 @@ Scope (what we expose):
   - image_generate                       — image generation
   - skill_view, skills_list              — Hermes' skill library
   - text_to_speech                       — TTS
+  - codex_exec                           — guarded Codex exec delegation
   - kanban_* (complete/block/comment/    — kanban worker + orchestrator
     heartbeat/show/list/create/            handoff (stateless: read env var,
     unblock/link)                          write ~/.hermes/kanban.db)
@@ -48,6 +49,7 @@ import json
 import logging
 import os
 import sys
+from inspect import Parameter, Signature
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -83,6 +85,7 @@ EXPOSED_TOOLS: tuple[str, ...] = (
     "skill_view",
     "skills_list",
     "text_to_speech",
+    "codex_exec",
     # Kanban worker handoff tools — gated on HERMES_KANBAN_TASK env var
     # (set by the kanban dispatcher when spawning a worker). Without these
     # in the callback, a worker spawned with openai_runtime=codex_app_server
@@ -103,6 +106,43 @@ EXPOSED_TOOLS: tuple[str, ...] = (
     "kanban_unblock",
     "kanban_link",
 )
+
+
+def _annotation_for_json_schema(prop: dict) -> Any:
+    schema_type = prop.get("type") if isinstance(prop, dict) else None
+    if isinstance(schema_type, list):
+        schema_type = next((item for item in schema_type if item != "null"), None)
+    return {
+        "string": str,
+        "integer": int,
+        "number": float,
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }.get(schema_type, Any)
+
+
+def _signature_from_parameters_schema(schema: dict) -> Signature:
+    if not isinstance(schema, dict):
+        return Signature()
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return Signature()
+    required = set(schema.get("required") or [])
+    parameters = []
+    for name, prop in properties.items():
+        if not isinstance(name, str) or not name.isidentifier():
+            continue
+        default = Parameter.empty if name in required else None
+        parameters.append(
+            Parameter(
+                name,
+                kind=Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=_annotation_for_json_schema(prop if isinstance(prop, dict) else {}),
+            )
+        )
+    return Signature(parameters)
 
 
 def _build_server() -> Any:
@@ -168,6 +208,7 @@ def _build_server() -> Any:
                     return json.dumps({"error": str(exc), "tool": tool_name})
             _dispatch.__name__ = tool_name
             _dispatch.__doc__ = description
+            _dispatch.__signature__ = _signature_from_parameters_schema(params_schema)
             return _dispatch
 
         try:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -49,10 +49,24 @@ def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
     return [item for item in normalized if item] or None
 
 
+def _discover_registry_toolsets() -> None:
+    """Import self-registering built-in tools so dynamic toolsets validate."""
+    try:
+        from tools.registry import discover_builtin_tools
+
+        discover_builtin_tools()
+    except Exception:
+        # Explicit --toolsets validation should still handle static toolsets,
+        # plugin discovery, and MCP names even if optional tool imports fail.
+        pass
+
+
 def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | None, str | None]:
     normalized = _normalize_toolsets(toolsets)
     if normalized is None:
         return None, None
+
+    _discover_registry_toolsets()
 
     try:
         from toolsets import validate_toolset

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -63,6 +63,7 @@ CONFIGURABLE_TOOLSETS = [
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
     ("file",            "📁 File Operations",           "read, write, patch, search"),
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
+    ("codex_exec",      "🧑‍💻 Codex Programming Engine", "delegate repo coding/debugging to codex exec"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("video",           "🎬 Video Analysis",            "video_analyze (requires video-capable model)"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),

--- a/tests/agent/transports/test_hermes_tools_mcp_server.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_server.py
@@ -46,8 +46,20 @@ class TestModuleSurface:
             "vision_analyze",
             "image_generate",
             "skill_view",
+            "codex_exec",
         ):
             assert required in EXPOSED_TOOLS, f"missing {required!r}"
+
+    def test_codex_exec_publishes_real_mcp_schema(self):
+        import agent.transports.hermes_tools_mcp_server as m
+
+        server = m._build_server()
+        tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
+
+        schema = tools["codex_exec"].parameters
+        assert "kwargs" not in schema.get("properties", {})
+        assert {"task", "cwd", "sandbox"} <= set(schema.get("properties", {}))
+        assert schema.get("required") == ["task"]
 
     def test_agent_loop_tools_not_exposed(self):
         """delegate_task / memory / session_search / todo require the

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -729,6 +729,33 @@ def test_oneshot_filters_invalid_toolsets_before_redirect(monkeypatch, capsys):
     assert "nope" in capsys.readouterr().err
 
 
+def test_oneshot_accepts_registry_toolset_after_discovery(monkeypatch):
+    _stub_plugin_discovery(monkeypatch)
+    import hermes_cli.oneshot as oneshot_mod
+    from tools.registry import registry
+
+    def register_dynamic_toolset():
+        registry.register(
+            name="oneshot_dynamic_demo",
+            toolset="oneshot_dynamic",
+            schema={
+                "name": "oneshot_dynamic_demo",
+                "description": "demo dynamic tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda _args: "{}",
+        )
+
+    monkeypatch.setattr(oneshot_mod, "_discover_registry_toolsets", register_dynamic_toolset)
+    try:
+        valid, error = oneshot_mod._validate_explicit_toolsets("oneshot_dynamic")
+    finally:
+        registry.deregister("oneshot_dynamic_demo")
+
+    assert valid == ["oneshot_dynamic"]
+    assert error is None
+
+
 def test_oneshot_all_toolsets_means_all_not_configured_cli():
     from hermes_cli.oneshot import _validate_explicit_toolsets
 

--- a/tests/tools/test_codex_exec_tool.py
+++ b/tests/tools/test_codex_exec_tool.py
@@ -1,0 +1,172 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tools import codex_exec_tool as tool
+
+
+def _fake_completed(stdout="", stderr="", returncode=0):
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def test_resolve_cwd_requires_allowed_root(tmp_path):
+    allowed = tmp_path / "allowed"
+    blocked = tmp_path / "blocked"
+    allowed.mkdir()
+    blocked.mkdir()
+
+    assert tool._resolve_cwd(str(allowed), [allowed]) == allowed.resolve()
+
+    try:
+        tool._resolve_cwd(str(blocked), [allowed])
+    except PermissionError as exc:
+        assert "outside codex_exec.allowed_roots" in str(exc)
+    else:
+        raise AssertionError("expected PermissionError")
+
+
+def test_scrub_env_drops_secret_like_values():
+    clean = tool._scrub_env(
+        {
+            "PATH": "/bin",
+            "HOME": "/tmp/home",
+            "OPENAI_API_KEY": "sk-secret",
+            "RANDOM_TOKEN": "secret",
+            "CODEX_HOME": "/tmp/codex",
+            "GIT_CONFIG_GLOBAL": "/tmp/gitconfig",
+        }
+    )
+
+    assert clean["PATH"] == "/bin"
+    assert clean["CODEX_HOME"] == "/tmp/codex"
+    assert clean["GIT_CONFIG_GLOBAL"] == "/tmp/gitconfig"
+    assert "OPENAI_API_KEY" not in clean
+    assert "RANDOM_TOKEN" not in clean
+
+
+def test_codex_exec_blocks_danger_without_opt_in(tmp_path, monkeypatch):
+    monkeypatch.setattr(tool.shutil, "which", lambda name: "/usr/bin/codex")
+    monkeypatch.setattr(tool, "_codex_auth_available", lambda env=None: True)
+    monkeypatch.setattr(tool, "_configured_allowed_roots", lambda config=None: [tmp_path])
+
+    result = json.loads(
+        tool.codex_exec_tool(
+            task="diagnose",
+            cwd=str(tmp_path),
+            sandbox="danger-full-access",
+        )
+    )
+
+    assert "error" in result
+    assert "allow_danger" in result["error"]
+
+
+def test_codex_exec_writes_artifacts_and_summary(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    token = set_hermes_home_override(hermes_home)
+    calls = []
+
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "thread.started", "thread_id": "thread-1"}),
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "command_execution", "command": "ls"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "done"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "turn.completed",
+                    "usage": {"input_tokens": 10, "output_tokens": 2},
+                }
+            ),
+        ]
+    )
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[:2] == ["git", "-C"]:
+            return _fake_completed(stdout="")
+        return _fake_completed(stdout=stdout, stderr="progress", returncode=0)
+
+    try:
+        monkeypatch.setattr(tool.shutil, "which", lambda name: "/usr/bin/codex")
+        monkeypatch.setattr(tool, "_codex_auth_available", lambda env=None: True)
+        monkeypatch.setattr(tool, "_configured_allowed_roots", lambda config=None: [repo])
+        monkeypatch.setattr(tool.subprocess, "run", fake_run)
+
+        result = json.loads(
+            tool.codex_exec_tool(
+                task="summarize",
+                cwd=str(repo),
+                sandbox="read-only",
+                timeout_seconds=30,
+            )
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    assert result["success"] is True
+    assert result["thread_id"] == "thread-1"
+    assert result["usage"] == {"input_tokens": 10, "output_tokens": 2}
+    assert result["command_count"] == 1
+    assert result["final_message"] == "done"
+
+    artifact_dir = Path(result["artifact_dir"])
+    assert (artifact_dir / "stdout.jsonl").read_text() == stdout
+    assert (artifact_dir / "stderr.txt").read_text() == "progress"
+    metadata = json.loads((artifact_dir / "metadata.json").read_text())
+    assert metadata["cwd"] == str(repo.resolve())
+    assert metadata["sandbox"] == "read-only"
+
+    codex_cmd = [call for call, _kw in calls if call and call[0] == "codex"][0]
+    codex_kwargs = [_kw for call, _kw in calls if call and call[0] == "codex"][0]
+    assert "--json" in codex_cmd
+    assert "--ephemeral" in codex_cmd
+    assert codex_kwargs["stdin"] is tool.subprocess.DEVNULL
+    sandbox_idx = codex_cmd.index("--sandbox")
+    assert codex_cmd[sandbox_idx:sandbox_idx + 2] == ["--sandbox", "read-only"]
+
+
+def test_codex_exec_requires_output_schema_inside_cwd(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    other = tmp_path / "other"
+    repo.mkdir()
+    other.mkdir()
+    schema = other / "schema.json"
+    schema.write_text("{}")
+
+    monkeypatch.setattr(tool.shutil, "which", lambda name: "/usr/bin/codex")
+    monkeypatch.setattr(tool, "_codex_auth_available", lambda env=None: True)
+    monkeypatch.setattr(tool, "_configured_allowed_roots", lambda config=None: [repo])
+
+    result = json.loads(
+        tool.codex_exec_tool(
+            task="summarize",
+            cwd=str(repo),
+            output_schema=str(schema),
+        )
+    )
+
+    assert "error" in result
+    assert "output_schema must resolve inside cwd" in result["error"]
+
+
+def test_codex_exec_fails_closed_without_codex_auth(tmp_path, monkeypatch):
+    monkeypatch.setattr(tool.shutil, "which", lambda name: "/usr/bin/codex")
+    monkeypatch.setattr(tool, "_codex_auth_available", lambda env=None: False)
+
+    result = json.loads(tool.codex_exec_tool(task="diagnose", cwd=str(tmp_path)))
+
+    assert "error" in result
+    assert "does not fall back" in result["error"]

--- a/tools/codex_exec_tool.py
+++ b/tools/codex_exec_tool.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Codex execution bridge for Hermes.
+
+This tool intentionally treats Codex as a separate programming runtime instead
+of another Hermes model provider. Hermes decides when to delegate; Codex keeps
+its own auth, sandboxing, repo instructions, session traces, and JSONL events.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry, tool_error, tool_result
+
+
+_MAX_TASK_CHARS = 32_000
+_DEFAULT_TIMEOUT_SECONDS = 20 * 60
+_MAX_TIMEOUT_SECONDS = 60 * 60
+_SAFE_SANDBOXES = {"read-only", "workspace-write"}
+_ALL_SANDBOXES = _SAFE_SANDBOXES | {"danger-full-access"}
+_SECRET_ENV_RE = re.compile(r"(API[_-]?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|PRIVATE[_-]?KEY)", re.I)
+_ALWAYS_KEEP_ENV = {
+    "CODEX_HOME",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LOGNAME",
+    "PATH",
+    "SHELL",
+    "SSH_AUTH_SOCK",
+    "TERM",
+    "TMPDIR",
+    "USER",
+}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _load_codex_exec_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+        section = cfg.get("codex_exec") or {}
+        return section if isinstance(section, dict) else {}
+    except Exception:
+        return {}
+
+
+def _as_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value if str(item).strip()]
+    return []
+
+
+def _configured_allowed_roots(config: Optional[Dict[str, Any]] = None) -> List[Path]:
+    cfg = config if config is not None else _load_codex_exec_config()
+    roots: List[str] = []
+    roots.extend(_as_list(cfg.get("allowed_roots")))
+    roots.extend(_as_list(cfg.get("allowed_root")))
+    env_roots = os.getenv("HERMES_CODEX_EXEC_ALLOWED_ROOTS", "")
+    if env_roots.strip():
+        roots.extend(part for part in env_roots.split(os.pathsep) if part.strip())
+
+    if not roots:
+        roots = [str(_repo_root())]
+
+    resolved: List[Path] = []
+    for root in roots:
+        try:
+            path = Path(root).expanduser().resolve()
+        except Exception:
+            continue
+        if path.exists() and path.is_dir() and path not in resolved:
+            resolved.append(path)
+    return resolved
+
+
+def _configured_default_sandbox(config: Optional[Dict[str, Any]] = None) -> str:
+    cfg = config if config is not None else _load_codex_exec_config()
+    value = str(cfg.get("default_sandbox") or "read-only").strip()
+    return value if value in _SAFE_SANDBOXES else "read-only"
+
+
+def _configured_max_timeout(config: Optional[Dict[str, Any]] = None) -> int:
+    cfg = config if config is not None else _load_codex_exec_config()
+    try:
+        value = int(cfg.get("max_timeout_seconds") or _MAX_TIMEOUT_SECONDS)
+    except (TypeError, ValueError):
+        value = _MAX_TIMEOUT_SECONDS
+    return max(10, min(value, _MAX_TIMEOUT_SECONDS))
+
+
+def _resolve_cwd(cwd: Optional[str], allowed_roots: Optional[Iterable[Path]] = None) -> Path:
+    raw = (cwd or str(_repo_root())).strip()
+    if not raw:
+        raw = str(_repo_root())
+    path = Path(raw).expanduser().resolve()
+    if not path.exists() or not path.is_dir():
+        raise ValueError(f"cwd must be an existing directory: {raw}")
+
+    roots = list(allowed_roots) if allowed_roots is not None else _configured_allowed_roots()
+    for root in roots:
+        try:
+            path.relative_to(root)
+            return path
+        except ValueError:
+            continue
+    allowed = ", ".join(str(root) for root in roots) or "(none)"
+    raise PermissionError(f"cwd is outside codex_exec.allowed_roots. cwd={path}; allowed={allowed}")
+
+
+def _artifact_root() -> Path:
+    return Path(get_hermes_home()) / "codex-runs"
+
+
+def _make_artifact_dir() -> Path:
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    path = _artifact_root() / f"{stamp}-{uuid.uuid4().hex[:8]}"
+    path.mkdir(parents=True, exist_ok=False)
+    return path
+
+
+def _scrub_env(env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    source = dict(env or os.environ)
+    clean: Dict[str, str] = {}
+    for key, value in source.items():
+        if key in _ALWAYS_KEEP_ENV:
+            clean[key] = value
+            continue
+        if _SECRET_ENV_RE.search(key):
+            continue
+        if key.startswith(("CODEX_", "GIT_", "HERMES_CODEX_EXEC_")):
+            clean[key] = value
+    return clean
+
+
+def _codex_home(env: Optional[Dict[str, str]] = None) -> Path:
+    source = env or os.environ
+    raw = str(source.get("CODEX_HOME") or "").strip()
+    return Path(raw).expanduser() if raw else Path.home() / ".codex"
+
+
+def _codex_auth_available(env: Optional[Dict[str, str]] = None) -> bool:
+    return (_codex_home(env) / "auth.json").is_file()
+
+
+def _git_status(cwd: Path) -> Optional[str]:
+    if not (cwd / ".git").exists():
+        try:
+            subprocess.run(
+                ["git", "-C", str(cwd), "rev-parse", "--is-inside-work-tree"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+            )
+        except Exception:
+            return None
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(cwd), "status", "--short"],
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        return proc.stdout
+    except Exception:
+        return None
+
+
+def _parse_jsonl(stdout: str) -> Dict[str, Any]:
+    final_messages: List[str] = []
+    command_count = 0
+    tool_call_count = 0
+    thread_id = None
+    usage = None
+    errors: List[Any] = []
+
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        event_type = event.get("type")
+        if event_type == "thread.started":
+            thread_id = event.get("thread_id") or thread_id
+        elif event_type == "turn.completed":
+            usage = event.get("usage") or usage
+        elif event_type == "error":
+            errors.append(event)
+
+        item = event.get("item") if isinstance(event.get("item"), dict) else {}
+        item_type = item.get("type")
+        if item_type == "agent_message":
+            text = item.get("text")
+            if isinstance(text, str):
+                final_messages.append(text)
+        elif item_type == "command_execution":
+            command_count += 1
+        elif item_type == "mcp_tool_call":
+            tool_call_count += 1
+
+    final_message = final_messages[-1] if final_messages else ""
+    return {
+        "thread_id": thread_id,
+        "usage": usage,
+        "command_count": command_count,
+        "tool_call_count": tool_call_count,
+        "final_message": final_message,
+        "errors": errors,
+    }
+
+
+def _build_prompt(task: str) -> str:
+    return (
+        "You are Codex being invoked by Hermes through the codex_exec tool.\n"
+        "Respect the target repository instructions, keep changes scoped, avoid "
+        "printing secrets, and finish with a concise summary of what you did and "
+        "how you verified it.\n\n"
+        f"Task:\n{task}"
+    )
+
+
+def check_codex_exec_requirements() -> bool:
+    return shutil.which("codex") is not None and _codex_auth_available()
+
+
+def codex_exec_tool(
+    task: str,
+    cwd: Optional[str] = None,
+    sandbox: Optional[str] = None,
+    timeout_seconds: Optional[int] = None,
+    model: Optional[str] = None,
+    profile: Optional[str] = None,
+    output_schema: Optional[str] = None,
+    allow_danger: bool = False,
+    ephemeral: bool = True,
+    skip_git_repo_check: bool = False,
+) -> str:
+    """Run Codex non-interactively and return a compact audited summary."""
+    if not shutil.which("codex"):
+        return tool_error("codex CLI is not installed or not on PATH.")
+    if not _codex_auth_available():
+        return tool_error("Codex auth is unavailable. Run `codex login` and retry; codex_exec does not fall back.")
+
+    if not isinstance(task, str) or not task.strip():
+        return tool_error("task is required.")
+    task = task.strip()
+    if len(task) > _MAX_TASK_CHARS:
+        return tool_error(f"task is too large ({len(task)} chars; max {_MAX_TASK_CHARS}).")
+
+    cfg = _load_codex_exec_config()
+    sandbox = (sandbox or _configured_default_sandbox(cfg)).strip()
+    if sandbox not in _ALL_SANDBOXES:
+        return tool_error(f"invalid sandbox '{sandbox}'. Use read-only, workspace-write, or danger-full-access.")
+    if sandbox == "danger-full-access" and not allow_danger:
+        return tool_error("danger-full-access requires allow_danger=true.")
+
+    try:
+        resolved_cwd = _resolve_cwd(cwd)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+    try:
+        timeout = int(timeout_seconds or _DEFAULT_TIMEOUT_SECONDS)
+    except (TypeError, ValueError):
+        return tool_error("timeout_seconds must be an integer.")
+    timeout = max(10, min(timeout, _configured_max_timeout(cfg)))
+
+    schema_path = None
+    if output_schema:
+        try:
+            schema_path = Path(output_schema).expanduser().resolve()
+            schema_path.relative_to(resolved_cwd)
+        except Exception:
+            return tool_error("output_schema must resolve inside cwd.")
+        if not schema_path.exists() or not schema_path.is_file():
+            return tool_error(f"output_schema does not exist: {schema_path}")
+
+    artifact_dir = _make_artifact_dir()
+    before_status = _git_status(resolved_cwd)
+
+    cmd = ["codex", "exec", "--json", "--sandbox", sandbox, "--cd", str(resolved_cwd)]
+    if ephemeral:
+        cmd.append("--ephemeral")
+    if skip_git_repo_check:
+        cmd.append("--skip-git-repo-check")
+    if model:
+        cmd.extend(["--model", str(model)])
+    if profile:
+        cmd.extend(["--profile", str(profile)])
+    if schema_path:
+        cmd.extend(["--output-schema", str(schema_path)])
+    cmd.append(_build_prompt(task))
+
+    started = time.monotonic()
+    timed_out = False
+    try:
+        proc = subprocess.run(
+            cmd,
+            text=True,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            cwd=str(resolved_cwd),
+            env=_scrub_env(),
+            timeout=timeout,
+        )
+        stdout = proc.stdout or ""
+        stderr = proc.stderr or ""
+        returncode = proc.returncode
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        stdout = exc.stdout if isinstance(exc.stdout, str) else (exc.stdout or b"").decode("utf-8", "replace")
+        stderr = exc.stderr if isinstance(exc.stderr, str) else (exc.stderr or b"").decode("utf-8", "replace")
+        returncode = 124
+
+    duration = round(time.monotonic() - started, 2)
+    parsed = _parse_jsonl(stdout)
+    after_status = _git_status(resolved_cwd)
+
+    (artifact_dir / "stdout.jsonl").write_text(stdout, encoding="utf-8")
+    (artifact_dir / "stderr.txt").write_text(stderr, encoding="utf-8")
+    if parsed.get("final_message"):
+        (artifact_dir / "final_message.md").write_text(parsed["final_message"], encoding="utf-8")
+    metadata = {
+        "cmd": [part if part != cmd[-1] else "<prompt>" for part in cmd],
+        "cwd": str(resolved_cwd),
+        "sandbox": sandbox,
+        "timeout_seconds": timeout,
+        "duration_seconds": duration,
+        "returncode": returncode,
+        "timed_out": timed_out,
+        "thread_id": parsed.get("thread_id"),
+        "usage": parsed.get("usage"),
+        "before_git_status": before_status,
+        "after_git_status": after_status,
+    }
+    (artifact_dir / "metadata.json").write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    return tool_result(
+        success=(returncode == 0 and not timed_out),
+        returncode=returncode,
+        timed_out=timed_out,
+        duration_seconds=duration,
+        cwd=str(resolved_cwd),
+        sandbox=sandbox,
+        artifact_dir=str(artifact_dir),
+        thread_id=parsed.get("thread_id"),
+        usage=parsed.get("usage"),
+        command_count=parsed.get("command_count"),
+        tool_call_count=parsed.get("tool_call_count"),
+        before_git_status=before_status,
+        after_git_status=after_status,
+        final_message=parsed.get("final_message", "")[-6000:],
+        stderr_tail=stderr[-4000:],
+        errors=parsed.get("errors", [])[-5:],
+    )
+
+
+CODEX_EXEC_SCHEMA = {
+    "name": "codex_exec",
+    "description": (
+        "Delegate coding, repository analysis, debugging, or test-fix loops to "
+        "OpenAI Codex CLI using Codex auth. Hermes remains the orchestrator; "
+        "Codex runs as a separate audited programming engine with JSONL traces "
+        "saved under ~/.hermes/codex-runs. Use read-only for diagnosis and "
+        "workspace-write for scoped implementation. Do not use for sending "
+        "messages, deploys, DB migrations, or secret handling without explicit "
+        "human approval."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task": {
+                "type": "string",
+                "description": "The coding/repo task for Codex. Include expected tests or constraints.",
+            },
+            "cwd": {
+                "type": "string",
+                "description": "Target repository/workspace directory. Must be inside codex_exec.allowed_roots.",
+            },
+            "sandbox": {
+                "type": "string",
+                "enum": ["read-only", "workspace-write", "danger-full-access"],
+                "default": "read-only",
+                "description": "Codex sandbox. Use read-only for audits, workspace-write for edits.",
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "minimum": 10,
+                "maximum": _MAX_TIMEOUT_SECONDS,
+                "default": _DEFAULT_TIMEOUT_SECONDS,
+            },
+            "model": {"type": "string", "description": "Optional Codex model override."},
+            "profile": {"type": "string", "description": "Optional Codex config profile."},
+            "output_schema": {
+                "type": "string",
+                "description": "Optional JSON schema path inside cwd for Codex final response.",
+            },
+            "allow_danger": {
+                "type": "boolean",
+                "default": False,
+                "description": "Required true to permit danger-full-access.",
+            },
+            "ephemeral": {
+                "type": "boolean",
+                "default": True,
+                "description": "Use codex --ephemeral; Hermes still stores artifacts.",
+            },
+            "skip_git_repo_check": {
+                "type": "boolean",
+                "default": False,
+                "description": "Pass --skip-git-repo-check for controlled non-git workspaces.",
+            },
+        },
+        "required": ["task"],
+    },
+}
+
+
+registry.register(
+    name="codex_exec",
+    toolset="codex_exec",
+    schema=CODEX_EXEC_SCHEMA,
+    handler=lambda args, **kw: codex_exec_tool(
+        task=args.get("task", ""),
+        cwd=args.get("cwd"),
+        sandbox=args.get("sandbox", "read-only"),
+        timeout_seconds=args.get("timeout_seconds"),
+        model=args.get("model"),
+        profile=args.get("profile"),
+        output_schema=args.get("output_schema"),
+        allow_danger=bool(args.get("allow_danger", False)),
+        ephemeral=bool(args.get("ephemeral", True)),
+        skip_git_repo_check=bool(args.get("skip_git_repo_check", False)),
+    ),
+    check_fn=check_codex_exec_requirements,
+    emoji="🧑‍💻",
+    max_result_size_chars=20_000,
+)


### PR DESCRIPTION
## Summary
- add a guarded `codex_exec` tool that delegates repo work to the Codex CLI while preserving Codex auth, sandboxing, and artifacts
- expose `codex_exec` through the Hermes tools MCP server with a real JSON-schema-derived FastMCP signature
- allow registry-backed toolsets such as `codex_exec` to validate in oneshot/TUI flows after tool discovery

## Safety
- restricts cwd to configured allowed roots
- defaults to read-only sandbox and requires explicit opt-in for danger-full-access
- strips secret-like environment variables before launching Codex
- writes stdout/stderr/metadata artifacts under Hermes home for auditability

## Tests
```bash
uv run --with pytest --with mcp pytest \
  tests/tools/test_codex_exec_tool.py \
  tests/agent/transports/test_hermes_tools_mcp_server.py \
  tests/hermes_cli/test_tui_resume_flow.py \
  -q -o 'addopts='\n```\n\nResult: `65 passed`.\n