### PR TITLE
fix: Python 3.14 compatibility (daemon_pool worker signature, gateway liveness argv, dotenv reload race)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -332,6 +332,30 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
     return looks_like_gateway_runtime_command_line(cmdline)
 
 
+def _cmdline_is_bare_hermes_proctitle(command: str) -> bool:
+    """Return True when the live argv is exactly the stripped ``hermes`` proctitle.
+
+    ``main.py`` calls ``setproctitle("hermes")``, which replaces the whole
+    ``/proc/<pid>/cmdline`` with the single token ``hermes`` — erasing the
+    ``gateway run`` subcommand the liveness check normally looks for.  Only
+    that exact shape (one token whose basename is ``hermes``/``hermes.exe``)
+    qualifies; any other readable command line (``s6-supervise``, an unrelated
+    reused-PID process, a full ``hermes <subcommand>`` argv) must keep being
+    judged strictly on its own content.
+    """
+    if not command:
+        return False
+    try:
+        raw_tokens = shlex.split(command, posix=False)
+    except ValueError:
+        raw_tokens = command.split()
+    tokens = [t.strip("\"'") for t in raw_tokens if t.strip("\"'")]
+    if len(tokens) != 1:
+        return False
+    basename = tokens[0].replace("\\", "/").rsplit("/", 1)[-1].lower()
+    return basename in ("hermes", "hermes.exe")
+
+
 def _profile_name_for_home(profile_home: Path) -> Optional[str]:
     """Return the profile id a HERMES_HOME directory represents, or None.
 
@@ -403,10 +427,11 @@ def _record_matches_live_gateway_pid(
     persisted record so cross-platform behavior is preserved.
     """
     live_cmdline = _read_process_cmdline(pid)
-    if live_cmdline and _gateway_command_subcommand(live_cmdline) is not None:
-        # The live argv still carries an explicit gateway subcommand (e.g.
-        # "gateway run") — trust it strictly so a reused PID now running some
-        # other command cannot masquerade as the gateway.
+    if live_cmdline and not _cmdline_is_bare_hermes_proctitle(live_cmdline):
+        # The live argv is readable and is NOT the stripped "hermes"
+        # proctitle — trust it strictly, so a reused PID now running some
+        # other command (s6-supervise, an unrelated daemon) cannot
+        # masquerade as the gateway no matter what the stale record says.
         if not looks_like_gateway_runtime_command_line(live_cmdline):
             return False
         if expected_home is not None and not _command_line_belongs_to_profile(
@@ -414,13 +439,14 @@ def _record_matches_live_gateway_pid(
         ):
             return False
         return True
-    # Otherwise the argv is unreadable, or it has been replaced by the bare
-    # "hermes" proctitle that main.py installs via setproctitle("hermes"), which
-    # erases the "gateway run" subcommand. The caller has already confirmed the
-    # PID exists and its start_time matches this record, so the process genuinely
-    # is the one that wrote it — defer to the persisted gateway identity rather
-    # than failing on the stripped argv (otherwise a systemd-run gateway whose
-    # proctitle is just "hermes" is misreported as offline in the dashboard).
+    # Otherwise the argv is unreadable (Windows/permission), or it has been
+    # replaced by the bare "hermes" proctitle that main.py installs via
+    # setproctitle("hermes"), which erases the "gateway run" subcommand. The
+    # callers have already confirmed the PID exists and its start_time matches
+    # this record, so the process genuinely is the one that wrote it — defer
+    # to the persisted gateway identity rather than failing on the stripped
+    # argv (otherwise a systemd-run gateway whose proctitle is just "hermes"
+    # is misreported as offline in the dashboard).
     return _record_looks_like_gateway(record)
 
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -403,7 +403,10 @@ def _record_matches_live_gateway_pid(
     persisted record so cross-platform behavior is preserved.
     """
     live_cmdline = _read_process_cmdline(pid)
-    if live_cmdline:
+    if live_cmdline and _gateway_command_subcommand(live_cmdline) is not None:
+        # The live argv still carries an explicit gateway subcommand (e.g.
+        # "gateway run") — trust it strictly so a reused PID now running some
+        # other command cannot masquerade as the gateway.
         if not looks_like_gateway_runtime_command_line(live_cmdline):
             return False
         if expected_home is not None and not _command_line_belongs_to_profile(
@@ -411,6 +414,13 @@ def _record_matches_live_gateway_pid(
         ):
             return False
         return True
+    # Otherwise the argv is unreadable, or it has been replaced by the bare
+    # "hermes" proctitle that main.py installs via setproctitle("hermes"), which
+    # erases the "gateway run" subcommand. The caller has already confirmed the
+    # PID exists and its start_time matches this record, so the process genuinely
+    # is the one that wrote it — defer to the persisted gateway identity rather
+    # than failing on the stripped argv (otherwise a systemd-run gateway whose
+    # proctitle is just "hermes" is misreported as offline in the dashboard).
     return _record_looks_like_gateway(record)
 
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -152,6 +152,14 @@ def _sanitize_loaded_credentials() -> None:
 
 
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
+    def _load_with_encoding_fallback() -> None:
+        # UTF-8 first; on undecodable bytes (Windows-1252 exports, copy-paste
+        # artifacts) reread permissively as latin-1, which accepts any byte.
+        try:
+            load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
+        except UnicodeDecodeError:
+            load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+
     # Retry on a transient KeyError. python-dotenv's resolve_variables does
     # ``env.update(os.environ)``, which iterates os.environ; in the multi-threaded
     # gateway another thread mutates os.environ concurrently (the kanban
@@ -160,12 +168,11 @@ def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
     # vanished between keys() and __getitem__ (crashed cron jobs, #external-probe).
     # The window is microseconds and the failing load applied nothing (the error
     # is in .dict() before set_as_environment_variables), so retrying is safe.
+    # BOTH encoding paths run inside the retry loop — the latin-1 fallback
+    # races os.environ exactly like the utf-8 path does.
     for _attempt in range(3):
         try:
-            load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
-            break
-        except UnicodeDecodeError:
-            load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+            _load_with_encoding_fallback()
             break
         except KeyError:
             if _attempt == 2:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -152,10 +152,24 @@ def _sanitize_loaded_credentials() -> None:
 
 
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
-    try:
-        load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
-    except UnicodeDecodeError:
-        load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+    # Retry on a transient KeyError. python-dotenv's resolve_variables does
+    # ``env.update(os.environ)``, which iterates os.environ; in the multi-threaded
+    # gateway another thread mutates os.environ concurrently (the kanban
+    # auto-decomposer pins/unpins HERMES_KANBAN_BOARD per board —
+    # gateway/kanban_watchers.py), so dict.update can KeyError on a key that
+    # vanished between keys() and __getitem__ (crashed cron jobs, #external-probe).
+    # The window is microseconds and the failing load applied nothing (the error
+    # is in .dict() before set_as_environment_variables), so retrying is safe.
+    for _attempt in range(3):
+        try:
+            load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
+            break
+        except UnicodeDecodeError:
+            load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+            break
+        except KeyError:
+            if _attempt == 2:
+                raise
     # Strip non-ASCII characters from credential env vars that were just
     # loaded.  API keys must be pure ASCII since they're sent as HTTP
     # header values (httpx encodes headers as ASCII).  Non-ASCII chars

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -622,6 +622,63 @@ class TestGatewayRuntimeStatus:
             == 139
         )
 
+    def test_runtime_status_running_pid_accepts_setproctitle_stripped_argv(self, monkeypatch):
+        """main.py installs setproctitle("hermes"), erasing the gateway
+        subcommand from the live argv.  With the PID and start_time already
+        matched against the record, the bare proctitle must defer to the
+        persisted gateway identity — otherwise a healthy systemd-run gateway
+        is misreported as offline in the dashboard."""
+        payload = {
+            "pid": 132,
+            "start_time": 123,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["/opt/hermes/.venv/bin/hermes", "gateway", "run", "--replace"],
+        }
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "hermes")
+
+        assert status.get_runtime_status_running_pid(payload) == 132
+
+    def test_runtime_status_running_pid_stripped_argv_still_validates_record(self, monkeypatch):
+        """The stripped-proctitle fallback still judges the RECORD: a bare
+        "hermes" cmdline whose persisted argv is not a gateway runtime must
+        not be reported running."""
+        payload = {
+            "pid": 132,
+            "start_time": 123,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "kanban", "watch"],
+        }
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "hermes")
+
+        assert status.get_runtime_status_running_pid(payload) is None
+
+    def test_runtime_status_running_pid_other_readable_cmdlines_stay_strict(self, monkeypatch):
+        """Only the exact stripped proctitle defers to the record — any other
+        readable non-gateway command line (a reused PID) keeps being rejected
+        even when the stale record argv looks like a gateway."""
+        payload = {
+            "pid": 132,
+            "start_time": 123,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["/opt/hermes/.venv/bin/hermes", "gateway", "run", "--replace"],
+        }
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+
+        for cmdline in ("sshd: worker [net]", "hermes kanban watch", "python3 tail.py"):
+            monkeypatch.setattr(status, "_read_process_cmdline", lambda pid, c=cmdline: c)
+            assert status.get_runtime_status_running_pid(payload) is None, cmdline
+
     def test_write_runtime_status_records_platform_failure(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
@@ -668,6 +725,32 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["discord"]["state"] == "connected"
         assert payload["platforms"]["discord"]["error_code"] is None
         assert payload["platforms"]["discord"]["error_message"] is None
+
+
+class TestBareHermesProctitle:
+    """_cmdline_is_bare_hermes_proctitle() accepts exactly the stripped
+    setproctitle("hermes") shape and nothing else."""
+
+    def test_accepts_stripped_proctitle_shapes(self):
+        for cmdline in (
+            "hermes",
+            "/usr/local/bin/hermes",
+            "hermes.exe",
+            r'"C:\Program Files\Hermes\hermes.exe"',
+        ):
+            assert status._cmdline_is_bare_hermes_proctitle(cmdline) is True, cmdline
+
+    def test_rejects_everything_else(self):
+        for cmdline in (
+            "",
+            "hermes gateway run",
+            "hermes kanban watch",
+            "s6-supervise gateway-coder",
+            "hermes-gateway",  # dedicated entrypoint keeps its own strict path
+            "python -m hermes_cli.main gateway run",
+            "sshd: worker [net]",
+        ):
+            assert status._cmdline_is_bare_hermes_proctitle(cmdline) is False, cmdline
 
 
 class TestGetProcessStartTime:

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -2,6 +2,8 @@ import importlib
 import os
 import sys
 
+import pytest
+
 from hermes_cli.env_loader import load_hermes_dotenv
 
 
@@ -103,3 +105,83 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_non_utf8_env_file_loads_via_latin1_fallback(tmp_path, monkeypatch):
+    """Undecodable UTF-8 bytes reread permissively as latin-1 (real dotenv path)."""
+    from hermes_cli import env_loader
+
+    env_file = tmp_path / ".env"
+    env_file.write_bytes(b"LATIN_VAR=caf\xe9\n")  # 0xE9 = é in latin-1
+
+    monkeypatch.delenv("LATIN_VAR", raising=False)
+
+    env_loader._load_dotenv_with_fallback(env_file, override=True)
+
+    assert os.getenv("LATIN_VAR") == "caf\xe9"
+
+
+class TestDotenvTransientKeyErrorRetry:
+    """The dotenv reload retries a transient KeyError from another thread
+    mutating os.environ mid-``env.update`` — on BOTH encoding paths.
+
+    Regression for the review finding that the latin-1 fallback originally
+    ran outside the retry handler, so a KeyError raised there escaped
+    instead of retrying.
+    """
+
+    def test_keyerror_on_utf8_path_retries(self, tmp_path, monkeypatch):
+        from hermes_cli import env_loader
+
+        calls = []
+
+        def fake_load_dotenv(*, dotenv_path, override, encoding):
+            calls.append(encoding)
+            if len(calls) == 1:
+                raise KeyError("VAR_VANISHED_MID_UPDATE")
+            return True
+
+        monkeypatch.setattr(env_loader, "load_dotenv", fake_load_dotenv)
+
+        env_loader._load_dotenv_with_fallback(tmp_path / ".env", override=True)
+
+        assert calls == ["utf-8", "utf-8"]
+
+    def test_keyerror_on_latin1_fallback_retries(self, tmp_path, monkeypatch):
+        from hermes_cli import env_loader
+
+        calls = []
+
+        def fake_load_dotenv(*, dotenv_path, override, encoding):
+            calls.append(encoding)
+            if encoding == "utf-8":
+                raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+            if calls.count("latin-1") == 1:
+                raise KeyError("VAR_VANISHED_MID_UPDATE")
+            return True
+
+        monkeypatch.setattr(env_loader, "load_dotenv", fake_load_dotenv)
+
+        env_loader._load_dotenv_with_fallback(tmp_path / ".env", override=True)
+
+        # Attempt 1: utf-8 → UnicodeDecodeError → latin-1 → KeyError (transient).
+        # Attempt 2: utf-8 → UnicodeDecodeError → latin-1 → success.
+        assert calls == ["utf-8", "latin-1", "utf-8", "latin-1"]
+
+    def test_persistent_keyerror_reraises_after_three_attempts(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import env_loader
+
+        calls = []
+
+        def fake_load_dotenv(*, dotenv_path, override, encoding):
+            calls.append(encoding)
+            raise KeyError("ALWAYS_MISSING")
+
+        monkeypatch.setattr(env_loader, "load_dotenv", fake_load_dotenv)
+
+        with pytest.raises(KeyError):
+            env_loader._load_dotenv_with_fallback(tmp_path / ".env", override=True)
+
+        assert calls == ["utf-8", "utf-8", "utf-8"]

--- a/tests/tools/test_daemon_pool.py
+++ b/tests/tools/test_daemon_pool.py
@@ -87,3 +87,93 @@ def _repo_root():
     import pathlib
 
     return pathlib.Path(__file__).resolve().parents[2]
+
+
+# ── Python 3.14 _worker signature compatibility ─────────────────────────────
+#
+# CPython 3.14 changed ThreadPoolExecutor._worker from
+# (executor_ref, work_queue, initializer, initargs) to
+# (executor_ref, ctx, work_queue), folding initializer/initargs into a
+# worker-context object built by _create_worker_context(). The subclass
+# feature-detects that method; both branches are pinned here directly so the
+# suite covers them regardless of which interpreter it runs on.
+
+
+def test_worker_context_probe_matches_interpreter():
+    """The 3.14 branch keys off _create_worker_context — pin that the probe
+    tracks the running interpreter, so a future stdlib reshape shows up here
+    instead of as silently-dying worker threads.
+
+    On 3.14 it is an INSTANCE attribute (unpacked in __init__ from
+    prepare_context()), so probe a constructed executor, exactly like the
+    hasattr(self, ...) guard in _worker_args does.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    expected = sys.version_info >= (3, 14)
+    pool = ThreadPoolExecutor(max_workers=1)
+    try:
+        assert hasattr(pool, "_create_worker_context") is expected
+    finally:
+        pool.shutdown(wait=False)
+
+
+class _OldShapeExecutor:
+    """Stand-in with the pre-3.14 attribute surface (no _create_worker_context)."""
+
+    def __init__(self):
+        self._work_queue = object()
+        self._initializer = lambda: None
+        self._initargs = ("tag",)
+
+
+class _NewShapeExecutor:
+    """Stand-in with the 3.14+ attribute surface."""
+
+    _ctx = object()
+
+    def __init__(self):
+        self._work_queue = object()
+
+    def _create_worker_context(self):
+        return self._ctx
+
+
+def test_worker_args_pre_314_shape():
+    """Without _create_worker_context the historical 4-tuple is built."""
+    fake = _OldShapeExecutor()
+
+    args = DaemonThreadPoolExecutor._worker_args(fake, lambda *_: None)
+
+    assert len(args) == 4
+    executor_ref, work_queue, initializer, initargs = args
+    assert executor_ref() is fake
+    assert work_queue is fake._work_queue
+    assert initializer is fake._initializer
+    assert initargs == ("tag",)
+
+
+def test_worker_args_314_shape():
+    """With _create_worker_context the 3.14 3-tuple (ref, ctx, queue) is built."""
+    fake = _NewShapeExecutor()
+
+    args = DaemonThreadPoolExecutor._worker_args(fake, lambda *_: None)
+
+    assert len(args) == 3
+    executor_ref, ctx, work_queue = args
+    assert executor_ref() is fake
+    assert ctx is _NewShapeExecutor._ctx
+    assert work_queue is fake._work_queue
+
+
+def test_live_pool_spawns_working_threads_on_this_interpreter():
+    """End-to-end guard for whichever branch is live: on 3.14 the pre-fix
+    4-tuple made every worker thread die at spawn (TypeError in _worker), so
+    submitted futures never completed."""
+    pool = DaemonThreadPoolExecutor(max_workers=1)
+    try:
+        assert pool.submit(lambda: "alive").result(timeout=10) == "alive"
+        assert len(pool._threads) == 1
+        assert all(t.is_alive() for t in pool._threads)
+    finally:
+        pool.shutdown(wait=True)

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -37,8 +37,34 @@ __all__ = ["DaemonThreadPoolExecutor"]
 class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
+    def _worker_args(self, weakref_cb) -> tuple:
+        """Build the ``_worker`` target args for the running interpreter.
+
+        CPython 3.14 changed ``ThreadPoolExecutor._worker`` from
+        ``(executor_ref, work_queue, initializer, initargs)`` to
+        ``(executor_ref, ctx, work_queue)``, folding initializer/initargs
+        into a worker-context object built by ``_create_worker_context()``.
+        Feature-detect on that method — the probe is a no-op on 3.8–3.13,
+        where the attribute does not exist and the historical four-tuple is
+        used unchanged.
+        """
+        if hasattr(self, "_create_worker_context"):
+            # Python 3.14+: (executor_ref, ctx, work_queue).
+            return (
+                weakref.ref(self, weakref_cb),
+                self._create_worker_context(),
+                self._work_queue,
+            )
+        # Python 3.8–3.13: (executor_ref, work_queue, initializer, initargs).
+        return (
+            weakref.ref(self, weakref_cb),
+            self._work_queue,
+            self._initializer,
+            self._initargs,
+        )
+
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
+        # Mirrors CPython's implementation with two changes:
         # daemon=True and no _threads_queues registration.
         if self._idle_semaphore.acquire(timeout=0):
             return
@@ -49,26 +75,10 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            if hasattr(self, "_create_worker_context"):
-                # Python 3.14+: _worker signature is (executor_ref, ctx, work_queue);
-                # the initializer/initargs are folded into a worker context object.
-                _args = (
-                    weakref.ref(self, weakref_cb),
-                    self._create_worker_context(),
-                    self._work_queue,
-                )
-            else:
-                # Python 3.8-3.13: _worker signature is (executor_ref, work_queue, initializer, initargs).
-                _args = (
-                    weakref.ref(self, weakref_cb),
-                    self._work_queue,
-                    self._initializer,
-                    self._initargs,
-                )
             t = threading.Thread(
                 name=thread_name,
                 target=_worker,
-                args=_args,
+                args=self._worker_args(weakref_cb),
                 daemon=True,
             )
             t.start()

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -49,15 +49,26 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
+            if hasattr(self, "_create_worker_context"):
+                # Python 3.14+: _worker signature is (executor_ref, ctx, work_queue);
+                # the initializer/initargs are folded into a worker context object.
+                _args = (
+                    weakref.ref(self, weakref_cb),
+                    self._create_worker_context(),
+                    self._work_queue,
+                )
+            else:
+                # Python 3.8-3.13: _worker signature is (executor_ref, work_queue, initializer, initargs).
+                _args = (
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,
                     self._initargs,
-                ),
+                )
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=_args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
Three small fixes that together make the agent run correctly on Python 3.14. Each is its own commit:

---

### fix(daemon_pool): Python 3.14 ThreadPoolExecutor._worker signature compat

Python 3.14 changed ThreadPoolExecutor._worker to (executor_ref, ctx,
work_queue), folding initializer/initargs into a worker context object.
The subclass still passed the old 4-tuple, so every pool thread died at
spawn: on 3.14 the kanban dispatcher spawned zero workers. Branch on the
presence of _create_worker_context so 3.8-3.13 keep the old path.


### fix(gateway): status liveness check tolerates setproctitle-stripped argv

main.py calls setproctitle("hermes"), erasing the gateway subcommand
from /proc cmdline. The liveness check then failed its "looks like a
gateway" test and reported a healthy systemd gateway as OFFLINE. When
argv carries no gateway subcommand but PID + start_time match the
persisted record, defer to the recorded gateway identity.


### fix(env_loader): retry dotenv reload on transient KeyError

python-dotenv's env.update(os.environ) can race another thread mutating
os.environ (the in-gateway kanban decomposer pins/unpins env vars per
board), raising a transient KeyError that crashed in-gateway cron jobs.
Retry once on that specific failure.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)