### PR TITLE
fix(cron): split job script field into executable + args

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -19,6 +19,7 @@ import re
 import shutil
 import subprocess
 import sys
+import shlex
 import threading
 import time
 
@@ -2046,7 +2047,11 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     scripts_dir.mkdir(parents=True, exist_ok=True)
     scripts_dir_resolved = scripts_dir.resolve()
 
-    raw = Path(script_path).expanduser()
+    # Split "script.py --arg1 val --arg2" into path + args so arguments
+    # aren't incorrectly treated as part of the filename.
+    parts = shlex.split(script_path)
+    raw = Path(parts[0]).expanduser()
+    extra_args = parts[1:]
     if raw.is_absolute():
         path = raw.resolve()
     else:
@@ -2089,9 +2094,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        argv = [_bash, str(path)]
+        argv = [_bash, str(path)] + extra_args
     else:
-        argv = [sys.executable, str(path)]
+        argv = [sys.executable, str(path)] + extra_args
 
     try:
         from tools.environments.local import _sanitize_subprocess_env

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -16,10 +16,10 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
-import shlex
 import threading
 import time
 
@@ -2012,6 +2012,35 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
+def _split_script_field(script_field: str, *, posix: bool | None = None) -> list[str]:
+    """Split a job's ``script`` field into executable + arguments, platform-aware.
+
+    POSIX ``shlex`` rules would mangle native Windows paths (backslashes are
+    escape characters: ``C:\\Users\\me\\collect.py`` becomes
+    ``C:Usersmecollect.py``), and this runner explicitly supports native
+    Windows.  Follow the repository idiom (``hermes_cli/mcp_security.py``):
+    ``posix=(os.name != "nt")`` with a whitespace-split fallback on unbalanced
+    quotes.  Non-POSIX mode keeps surrounding quotes on tokens, so strip them
+    afterwards (as ``gateway/status.py`` does when tokenizing cmdlines) —
+    otherwise the executable path never matches a real file and quoted
+    arguments reach the child with literal quote characters.
+
+    Args:
+        script_field: The raw ``script`` value, e.g. ``collect.py --flag "a b"``.
+        posix: Override the parsing mode (used by tests to exercise the
+            Windows branch on any host).  Defaults to the current platform.
+    """
+    if posix is None:
+        posix = os.name != "nt"
+    try:
+        parts = shlex.split(script_field, posix=posix)
+    except ValueError:
+        parts = script_field.split()
+    if not posix:
+        parts = [part.strip("\"'") for part in parts]
+    return parts
+
+
 def _run_job_script(script_path: str) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -2035,9 +2064,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     (SECURITY.md §2.3), matching terminal and MCP child processes.
 
     Args:
-        script_path: Path to the script.  Relative paths are resolved
-            against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
-            are also validated to ensure they stay within the scripts dir.
+        script_path: Path to the script, optionally followed by arguments
+            to forward (``collect.py --flag "a b"``); the field is split
+            platform-aware via ``_split_script_field``.  Relative paths are
+            resolved against HERMES_HOME/scripts/.  Absolute and ~-prefixed
+            paths are also validated to ensure they stay within the scripts
+            dir — containment applies to the parsed executable, arguments
+            never widen it.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -2048,8 +2081,11 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     scripts_dir_resolved = scripts_dir.resolve()
 
     # Split "script.py --arg1 val --arg2" into path + args so arguments
-    # aren't incorrectly treated as part of the filename.
-    parts = shlex.split(script_path)
+    # aren't incorrectly treated as part of the filename.  Parsing is
+    # platform-aware so Windows paths with backslashes/spaces survive.
+    parts = _split_script_field(script_path)
+    if not parts:
+        return False, f"Script field is empty: {script_path!r}"
     raw = Path(parts[0]).expanduser()
     extra_args = parts[1:]
     if raw.is_absolute():

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -212,6 +212,157 @@ class TestRunJobScript:
         assert parsed["new_prs"][0]["number"] == 42
 
 
+class TestSplitScriptField:
+    """Platform-aware parsing of the script field into executable + args.
+
+    The Windows branch (``posix=False``) is exercised directly so these
+    regressions run on every host: POSIX shlex rules treat backslashes as
+    escape characters and would mangle native Windows paths.
+    """
+
+    def test_posix_quoting_round_trip(self):
+        import shlex
+
+        from cron.scheduler import _split_script_field
+
+        argv = ["monitors/collect.py", "--msg", "hello world", "--path", "a b/c.txt"]
+        assert _split_script_field(shlex.join(argv), posix=True) == argv
+
+    def test_windows_backslash_path_preserved(self):
+        from cron.scheduler import _split_script_field
+
+        parts = _split_script_field(r"C:\Users\me\collect.py --flag value", posix=False)
+        assert parts == [r"C:\Users\me\collect.py", "--flag", "value"]
+
+    def test_windows_quoted_path_with_spaces(self):
+        """Quoted Windows paths with spaces parse into unquoted usable tokens."""
+        from cron.scheduler import _split_script_field
+
+        field = r'"C:\My Scripts\collect.py" --in "C:\Data Files\a.csv"'
+        parts = _split_script_field(field, posix=False)
+        assert parts == [r"C:\My Scripts\collect.py", "--in", r"C:\Data Files\a.csv"]
+
+    def test_default_mode_follows_platform(self, monkeypatch):
+        """Without an explicit mode the parser keys off os.name (nt = non-POSIX)."""
+        import os as os_mod
+
+        from cron.scheduler import _split_script_field
+
+        field = r"C:\Users\me\collect.py --flag"
+        monkeypatch.setattr(os_mod, "name", "nt")
+        assert _split_script_field(field)[0] == r"C:\Users\me\collect.py"
+        monkeypatch.setattr(os_mod, "name", "posix")
+        # POSIX rules eat the backslashes — exactly why the nt branch exists.
+        assert _split_script_field(field)[0] == "C:Usersmecollect.py"
+
+    def test_unbalanced_quote_falls_back_to_whitespace_split(self):
+        from cron.scheduler import _split_script_field
+
+        parts = _split_script_field('collect.py "unclosed', posix=True)
+        assert parts == ["collect.py", '"unclosed']
+
+
+class TestRunJobScriptArguments:
+    """Argument forwarding: the script field is executable + argv, not a bare path."""
+
+    @pytest.fixture
+    def argecho(self, cron_env):
+        script = cron_env / "scripts" / "argecho.py"
+        script.write_text("import json, sys\nprint(json.dumps(sys.argv[1:]))\n")
+        return script
+
+    def test_python_script_args_forwarded(self, cron_env, argecho):
+        from cron.scheduler import _run_job_script
+
+        success, output = _run_job_script("argecho.py --flag value")
+        assert success is True
+        assert json.loads(output) == ["--flag", "value"]
+
+    def test_python_script_quoted_args_round_trip(self, cron_env, argecho):
+        """A quoted argument containing spaces arrives as ONE argv element."""
+        import shlex
+
+        from cron.scheduler import _run_job_script
+
+        field = shlex.join(["argecho.py", "--msg", "hello world", "plain"])
+        success, output = _run_job_script(field)
+        assert success is True
+        assert json.loads(output) == ["--msg", "hello world", "plain"]
+
+    def test_python_script_quoted_executable_with_spaces(self, cron_env):
+        """A quoted script path containing spaces still resolves and runs."""
+        import shlex
+
+        from cron.scheduler import _run_job_script
+
+        subdir = cron_env / "scripts" / "space dir"
+        subdir.mkdir()
+        script = subdir / "arg echo.py"
+        script.write_text("import json, sys\nprint(json.dumps(sys.argv[1:]))\n")
+
+        field = shlex.join(["space dir/arg echo.py", "--tag", "a b"])
+        success, output = _run_job_script(field)
+        assert success is True
+        assert json.loads(output) == ["--tag", "a b"]
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Shell scripts require bash (Git Bash may be absent on CI)",
+    )
+    def test_shell_script_args_forwarded(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "args.sh"
+        script.write_text('printf "%s\\n" "$@"\n')
+
+        success, output = _run_job_script("args.sh one 'two words'")
+        assert success is True
+        assert output.splitlines() == ["one", "two words"]
+
+    def test_no_args_behaviour_unchanged(self, cron_env, argecho):
+        from cron.scheduler import _run_job_script
+
+        success, output = _run_job_script("argecho.py")
+        assert success is True
+        assert json.loads(output) == []
+
+    def test_traversal_with_args_still_blocked(self, cron_env):
+        """Containment applies to the parsed executable when args are present."""
+        from cron.scheduler import _run_job_script
+
+        success, output = _run_job_script("../../etc/passwd --flag value")
+        assert success is False
+        assert "blocked" in output.lower() or "outside" in output.lower()
+
+    def test_absolute_outside_with_args_blocked(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        outside = cron_env / "outside.py"
+        outside.write_text('print("should not run")\n')
+
+        success, output = _run_job_script(f"{outside} --flag")
+        assert success is False
+        assert "blocked" in output.lower() or "outside" in output.lower()
+
+    def test_empty_field_fails_cleanly(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        success, output = _run_job_script("   ")
+        assert success is False
+        assert "empty" in output.lower()
+
+    def test_unbalanced_quotes_do_not_crash(self, cron_env, argecho):
+        """Unbalanced quotes degrade to whitespace splitting, not an exception."""
+        from cron.scheduler import _run_job_script
+
+        success, output = _run_job_script('argecho.py "unclosed')
+        assert success is True
+        args = json.loads(output)
+        # POSIX forwards the literal '"unclosed'; the Windows branch strips
+        # the stray quote — accept both so the test is platform-portable.
+        assert len(args) == 1 and "unclosed" in args[0]
+
+
 class TestBuildJobPromptWithScript:
     """Test that script output is injected into the prompt."""
 


### PR DESCRIPTION
A cron job whose script field is "script.py --flag value" was treated
as one filename, so any args-bearing script job failed to dispatch.
shlex-split the field into path + argv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)