### PR TITLE
fix(agent): robust handling of context-window overflow on strict endpoints

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1025,6 +1025,12 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             anthropic_max_output=_ant_max,
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
+            context_length=(
+                getattr(getattr(agent, "context_compressor", None), "context_length", None)
+            ),
+            estimated_input_tokens=estimate_request_context_tokens(
+                {"messages": api_messages, "tools": tools_for_api}
+            ),
         )
 
     # ── Legacy flag path ────────────────────────────────────────────

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -49,6 +49,7 @@ from agent.message_sanitization import (
 )
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
+    OUTPUT_CAP_RETRY_SAFETY_MARGIN,
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
     get_context_length_from_provider_error,
@@ -626,7 +627,12 @@ def run_conversation(
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
-    output_cap_reductions = 0  # consecutive parseable output-cap 400s this turn (overflow-spiral guard)
+    # Consecutive parseable output-cap 400s in the CURRENT failing retry burst
+    # (overflow-spiral guard).  Burst-scoped, not turn-scoped: any successfully
+    # accepted response resets it (see the reset after the retry loop), so two
+    # unrelated output-cap errors many tool iterations apart are NOT mistaken
+    # for a non-converging burst that would force input compression.
+    output_cap_reductions = 0
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
     # Last composed answer intentionally held back by a verification gate. If
     # that continuation consumes the remaining budget, this is the best
@@ -3553,13 +3559,13 @@ def run_conversation(
                         )
                         local_available_out = old_ctx - request_input_estimate
                         if local_available_out > 0:
-                            safe_out = max(1, min(available_out, local_available_out) - 512)
+                            safe_out = max(1, min(available_out, local_available_out) - OUTPUT_CAP_RETRY_SAFETY_MARGIN)
                         else:
                             # The rough local estimate can overshoot the real
                             # request size.  Fall back to the provider-reported
                             # budget, which is authoritative for the failed
                             # request.
-                            safe_out = max(1, available_out - 512)
+                            safe_out = max(1, available_out - OUTPUT_CAP_RETRY_SAFETY_MARGIN)
                         agent._ephemeral_max_output_tokens = safe_out
                         agent._buffer_vprint(
                             f"⚠️  Output cap too large for current prompt — "
@@ -4312,6 +4318,20 @@ def run_conversation(
             agent.iteration_budget.refund()
             _retry.restart_with_rebuilt_messages = False
             continue
+
+        # A server-accepted response ends any output-cap 400 burst.  The
+        # overflow-spiral guard counts CONSECUTIVE parseable output-cap
+        # rejections of the request currently being retried; the failure
+        # restarts above `continue` before this line, so the count carries
+        # across their outer-loop round-trips.  Reaching here with a response
+        # means the provider accepted the request (including the
+        # length-continuation restart below, which follows a received
+        # response), so the next output-cap error — possibly many tool
+        # iterations later — starts a fresh burst and gets the cheap
+        # single-cap-reduction retry instead of being misclassified as a
+        # non-converging spiral that forces input compression.
+        if response is not None:
+            output_cap_reductions = 0
 
         if _retry.restart_with_length_continuation:
             # Progressively boost the output token budget on each retry.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -626,6 +626,7 @@ def run_conversation(
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
+    output_cap_reductions = 0  # consecutive parseable output-cap 400s this turn (overflow-spiral guard)
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
     # Last composed answer intentionally held back by a verification gate. If
     # that continuation consumes the remaining budget, this is the best
@@ -1043,7 +1044,7 @@ def run_conversation(
         if (
             agent.compression_enabled
             and len(messages) > 1
-            and compression_attempts < 3
+            and compression_attempts < 30
             and not _defer_preflight(request_pressure_tokens)
             and not _compression_cooldown
             and _compressor.should_compress(request_pressure_tokens)
@@ -1051,7 +1052,7 @@ def run_conversation(
             compression_attempts += 1
             logger.info(
                 "Pre-API compression: ~%s request tokens >= %s threshold "
-                "(context=%s, attempt=%s/3)",
+                "(context=%s, attempt=%s/30)",
                 f"{request_pressure_tokens:,}",
                 f"{int(getattr(_compressor, 'threshold_tokens', 0) or 0):,}",
                 f"{int(getattr(_compressor, 'context_length', 0) or 0):,}"
@@ -1125,7 +1126,7 @@ def run_conversation(
         retry_count = 0
         max_retries = agent._api_max_retries
         _retry = TurnRetryState()
-        max_compression_attempts = 3
+        max_compression_attempts = 30
 
         finish_reason = "stop"
         response = None  # Guard against UnboundLocalError if all retries fail
@@ -3519,26 +3520,46 @@ def run_conversation(
                     #       context_length = total window (input + output combined).
                     available_out = parse_available_output_tokens_from_error(error_msg)
                     if available_out is not None:
+                        output_cap_reductions += 1
+                    if available_out is not None and output_cap_reductions >= 2:
+                        # A reduction did NOT converge → the PROMPT itself overflows
+                        # the window. A strict endpoint (vLLM) reports the input as a
+                        # DERIVED bound (= context_length + 1 − max_tokens), so
+                        # ``available_out`` just tracks our shrinking cap and never
+                        # opens real headroom — the 8192→450 spiral that ends in an
+                        # auto-blocked task. Stop shrinking the OUTPUT; reduce the
+                        # INPUT via real compression instead (reset the spiralled cap
+                        # and fall through — do NOT break — past the output-cap
+                        # fail-fast into the compression block below).
+                        agent._ephemeral_max_output_tokens = None
+                        agent._buffer_vprint(
+                            "⚠️  Output-cap reduction did not converge — the prompt "
+                            "itself overflows the window; compressing the input instead."
+                        )
+                    elif available_out is not None:
                         # This is an output-cap error, not input overflow.
                         # The provider's available_tokens is the authoritative
                         # cap for the failed request, so keep it as an upper
                         # bound.  Also estimate the current API request shape
                         # (system prompt, injected context, tool schemas) because
                         # Hermes may add API-only content not present in persisted
-                        # messages.  Use the smaller budget and apply a small
-                        # safety margin.  Do not alter context_length.
+                        # messages.  Use the smaller budget and apply a safety
+                        # margin that absorbs input drift between retries (a
+                        # truncated-tool-call retry can GROW the prompt, so a tiny
+                        # margin fails once more before the spiral guard fires).
+                        # Do not alter context_length.
                         request_input_estimate = estimate_request_tokens_rough(
                             api_messages, tools=agent.tools or None,
                         )
                         local_available_out = old_ctx - request_input_estimate
                         if local_available_out > 0:
-                            safe_out = max(1, min(available_out, local_available_out) - 64)
+                            safe_out = max(1, min(available_out, local_available_out) - 512)
                         else:
                             # The rough local estimate can overshoot the real
                             # request size.  Fall back to the provider-reported
                             # budget, which is authoritative for the failed
                             # request.
-                            safe_out = max(1, available_out - 64)
+                            safe_out = max(1, available_out - 512)
                         agent._ephemeral_max_output_tokens = safe_out
                         agent._buffer_vprint(
                             f"⚠️  Output cap too large for current prompt — "
@@ -3577,8 +3598,11 @@ def run_conversation(
                     # on the oversized max_tokens.  Routing it into compression
                     # re-sends the same max_tokens, gets the identical 400, and
                     # death-loops until "cannot compress further" (#55546).
-                    # Fail fast with an actionable message instead of looping.
-                    if is_output_cap_error(error_msg):
+                    # Fail fast with an actionable message instead of looping —
+                    # UNLESS a prior reduction already failed to converge
+                    # (output_cap_reductions >= 2), meaning the prompt itself
+                    # overflows and we've already routed to compression above.
+                    if is_output_cap_error(error_msg) and output_cap_reductions < 2:
                         agent._flush_status_buffer()
                         agent._vprint(
                             f"{agent.log_prefix}❌ The provider rejected the request because "

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1248,6 +1248,15 @@ def get_context_length_from_provider_error(
     return None
 
 
+# Safety margin subtracted from a provider-reported available output budget
+# when retrying after an output-cap 400 (see the overflow handler in
+# agent/conversation_loop.py).  512, not the old 64: strict endpoints (vLLM)
+# count the fully-rendered prompt (chat template, special tokens, tool
+# scaffolding), so the input estimate can drift upward between retries; a
+# 64-token margin was regularly eaten by that drift and the retry 400'd again.
+OUTPUT_CAP_RETRY_SAFETY_MARGIN = 512
+
+
 def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     """Detect an "output cap too large" error and return how many output tokens are available.
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -566,6 +566,39 @@ class ChatCompletionsTransport(ProviderTransport):
         # they front several backends with different completion-token limits
         # (e.g. opencode-go: mimo-v2.5-pro = 131072).
         profile_max = profile.get_max_tokens(model)
+        if (
+            profile.name == "custom"
+            and profile_max
+            and user_max is None
+            and ephemeral is None
+        ):
+            # The custom profile's default exists to prevent Ollama's tiny
+            # server-side num_predict default, but a default equal to the whole
+            # context window is invalid for OpenAI-compatible servers like vLLM:
+            # it reserves the entire window for output and leaves no room for
+            # the prompt/tools. Adjust centrally from the actual request load;
+            # the local-first router must not carry arbitrary token caps.
+            try:
+                context_length = int(params.get("context_length") or 0)
+                estimated_input = int(params.get("estimated_input_tokens") or 0)
+            except (TypeError, ValueError):
+                context_length = 0
+                estimated_input = 0
+            if context_length > 0:
+                # Whenever the profile's output cap wouldn't fit alongside the
+                # prompt, clamp it so input+output stays inside the window on the
+                # FIRST try. ``estimated_input`` is a cheap chars/4 approximation;
+                # the server counts the fully-rendered prompt (chat template,
+                # special tokens, tool scaffolding) and has been observed ~2%
+                # higher, so reserve ~4% (floor 512) to absorb that undershoot. A
+                # strict endpoint (vLLM) otherwise 400s on the overflow and spirals
+                # through the retry+compression path. Covers BOTH the whole-window
+                # default (profile_max == ctx) and a moderate cap that still
+                # overflows a large prompt (e.g. 16384 output + 49153 input > ctx).
+                _reserve = max(512, estimated_input // 25)
+                available_output = context_length - estimated_input - _reserve
+                if profile_max >= available_output:
+                    profile_max = available_output if available_output > 0 else None
 
         if ephemeral is not None and max_tokens_fn:
             api_kwargs.update(max_tokens_fn(ephemeral))

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1164,3 +1164,73 @@ class TestChatCompletionsGeminiNativeExtraBodyStrip:
         )
         eb = kw.get("extra_body")
         assert eb and "tags" in eb
+
+
+class TestCustomProfileWindowClamp:
+    """The custom profile's default max_tokens is clamped to the request load.
+
+    The profile ships default_max_tokens=65536 to defeat Ollama's tiny
+    num_predict default, but a default equal to the whole context window
+    reserves no room for the prompt on strict OpenAI-compatible servers
+    (vLLM 400s when input + max_tokens > window).  The transport clamps the
+    DEFAULT (never an explicit user/ephemeral value) to
+    context_length - estimated_input - max(512, estimated_input // 25).
+    """
+
+    def _kwargs(self, transport, **extra):
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        assert profile is not None, "custom provider profile must be registered"
+        msgs = [{"role": "user", "content": "Hi"}]
+        return transport.build_kwargs(
+            model="qwen3", messages=msgs,
+            provider_profile=profile,
+            max_tokens_param_fn=lambda v: {"max_tokens": v},
+            **extra,
+        )
+
+    def test_default_clamped_so_input_plus_output_fit_window(self, transport):
+        est = 49_153
+        kw = self._kwargs(
+            transport, context_length=65_536, estimated_input_tokens=est,
+        )
+        reserve = max(512, est // 25)
+        assert kw["max_tokens"] == 65_536 - est - reserve
+        assert est + kw["max_tokens"] < 65_536
+
+    def test_whole_window_default_always_leaves_prompt_room(self, transport):
+        """Even a small prompt must shrink the whole-window default."""
+        kw = self._kwargs(
+            transport, context_length=65_536, estimated_input_tokens=1_000,
+        )
+        assert kw["max_tokens"] == 65_536 - 1_000 - 512  # floor reserve
+
+    def test_unknown_context_length_keeps_profile_default(self, transport):
+        """No window info → no clamp (Ollama num_predict guard preserved)."""
+        kw = self._kwargs(transport)
+        assert kw["max_tokens"] == 65_536
+
+    def test_user_max_tokens_never_clamped(self, transport):
+        """An explicit user cap is authoritative — the clamp only fixes the
+        profile DEFAULT."""
+        kw = self._kwargs(
+            transport, context_length=65_536, estimated_input_tokens=49_153,
+            max_tokens=60_000,
+        )
+        assert kw["max_tokens"] == 60_000
+
+    def test_ephemeral_cap_never_clamped(self, transport):
+        """The one-shot overflow-retry cap must pass through untouched."""
+        kw = self._kwargs(
+            transport, context_length=65_536, estimated_input_tokens=49_153,
+            ephemeral_max_output_tokens=5_024,
+        )
+        assert kw["max_tokens"] == 5_024
+
+    def test_prompt_filling_window_omits_max_tokens(self, transport):
+        """No positive output budget left → omit max_tokens entirely rather
+        than send a nonsensical value."""
+        kw = self._kwargs(
+            transport, context_length=65_536, estimated_input_tokens=65_536,
+        )
+        assert "max_tokens" not in kw

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -1048,3 +1048,149 @@ class TestOverflowWithCompactionDisabled:
         mock_compress.assert_called_once()
         assert result["completed"] is True
         assert result.get("compaction_disabled") is not True
+
+
+# ---------------------------------------------------------------------------
+# Output-cap retry burst scoping (strict-endpoint overflow fix)
+# ---------------------------------------------------------------------------
+
+
+def _make_output_cap_error(available_tokens=5_536, max_tokens=8_192,
+                           context_window=65_536):
+    """Strict-endpoint 400: input fits, input + max_tokens > window.
+
+    Canonical parseable wording (classified as context_overflow AND parsed by
+    parse_available_output_tokens_from_error).
+    """
+    input_tokens = context_window - max_tokens + (max_tokens - available_tokens)
+    err = Exception(
+        f"Error code: 400 - max_tokens: {max_tokens} > "
+        f"context_window: {context_window} - input_tokens: {input_tokens} "
+        f"= available_tokens: {available_tokens}"
+    )
+    err.status_code = 400
+    return err
+
+
+class TestOutputCapRetryBurstScoping:
+    """The overflow-spiral guard's counter is scoped to one failing retry
+    burst — a server-accepted response resets it — while consecutive failures
+    within a burst still escalate to input compression."""
+
+    def _prefill(self):
+        return [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+    def test_success_resets_burst_so_later_overflow_gets_cap_retry(self, agent):
+        """overflow → reduce → success → tool loop → unrelated overflow.
+
+        The second overflow must start a FRESH burst (single cap-reduction
+        retry, no forced input compression).  Before the reset fix, the
+        counter carried across the successful response and the second
+        overflow was misclassified as a non-converging burst (count=2),
+        forcing unnecessary compression.
+        """
+        from agent.model_metadata import OUTPUT_CAP_RETRY_SAFETY_MARGIN
+
+        tc = SimpleNamespace(
+            id="tc1", type="function",
+            function=SimpleNamespace(name="web_search", arguments='{"query":"q"}'),
+        )
+        tool_resp = _mock_response(content=None, finish_reason="stop", tool_calls=[tc])
+        ok_resp = _mock_response(content="All done", finish_reason="stop")
+
+        responses = [
+            _make_output_cap_error(),   # call 1: overflow (burst A, count=1)
+            tool_resp,                  # call 2: reduced-cap retry SUCCEEDS, tool call
+            _make_output_cap_error(),   # call 3: unrelated overflow (fresh burst B)
+            ok_resp,                    # call 4: reduced-cap retry succeeds
+        ]
+        sent_max_tokens = []
+
+        def _create(**kwargs):
+            sent_max_tokens.append(kwargs.get("max_tokens"))
+            item = responses.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        agent.client.chat.completions.create.side_effect = _create
+
+        with (
+            patch("run_agent.handle_function_call", return_value="tool output"),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "hello"}], "compressed",
+            )
+            result = agent.run_conversation("hello", conversation_history=self._prefill())
+
+        # Both overflows must be handled by the cheap cap-reduction retry;
+        # input compression must never be forced by burst misclassification.
+        mock_compress.assert_not_called()
+        assert result["completed"] is True
+        assert result["final_response"] == "All done"
+        assert len(sent_max_tokens) == 4
+
+        reduced = 5_536 - OUTPUT_CAP_RETRY_SAFETY_MARGIN
+        # Retries after each overflow carry the reduced one-shot cap...
+        assert sent_max_tokens[1] == reduced
+        assert sent_max_tokens[3] == reduced
+        # ...and the request AFTER the successful response returns to the
+        # normal cap (the reduction is consumed by its one retry, and the
+        # burst counter is reset — nothing carries into the tool loop).
+        assert sent_max_tokens[2] == sent_max_tokens[0]
+        assert sent_max_tokens[2] != reduced
+
+    def test_consecutive_overflows_still_escalate_to_compression(self, agent):
+        """Within ONE failing burst, a second parseable overflow means the
+        reduction did not converge: the prompt itself overflows.  The guard
+        must stop shrinking the output cap and route to input compression
+        (the 8192 → 450 → ... spiral fix), with the spiralled cap reset.
+        """
+        from agent.model_metadata import OUTPUT_CAP_RETRY_SAFETY_MARGIN
+
+        ok_resp = _mock_response(content="Recovered", finish_reason="stop")
+        responses = [
+            _make_output_cap_error(),   # count=1 → cap reduction retry
+            _make_output_cap_error(),   # count=2 → escalate to compression
+            ok_resp,                    # post-compression retry succeeds
+        ]
+        sent_max_tokens = []
+
+        def _create(**kwargs):
+            sent_max_tokens.append(kwargs.get("max_tokens"))
+            item = responses.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        agent.client.chat.completions.create.side_effect = _create
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": "hello"}], "compressed",
+            )
+            result = agent.run_conversation("hello", conversation_history=self._prefill())
+
+        # The non-converging burst routed into real input compression...
+        mock_compress.assert_called_once()
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered"
+        assert len(sent_max_tokens) == 3
+
+        reduced = 5_536 - OUTPUT_CAP_RETRY_SAFETY_MARGIN
+        # ...the first retry used the reduced cap, and the post-escalation
+        # retry dropped the spiralled ephemeral cap (back to the normal one).
+        assert sent_max_tokens[1] == reduced
+        assert sent_max_tokens[2] == sent_max_tokens[0]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5732,12 +5732,18 @@ class TestRunConversation:
         assert result["completed"] is True
 
         # Verify the local estimate is actually the lower bound.
-        from agent.model_metadata import estimate_request_tokens_rough
+        from agent.model_metadata import (
+            OUTPUT_CAP_RETRY_SAFETY_MARGIN,
+            estimate_request_tokens_rough,
+        )
         estimated_request = estimate_request_tokens_rough(
             first_call["messages"], tools=agent.tools or None,
         )
         local_available = 200_000 - estimated_request
-        expected_cap = max(1, min(50_000, local_available) - 64)
+        # Margin is the shared retry-safety constant (512, not 64): input can
+        # GROW between retries (~500 tokens observed on truncated-tool-call
+        # replays), so a tiny margin fails once more before converging.
+        expected_cap = max(1, min(50_000, local_available) - OUTPUT_CAP_RETRY_SAFETY_MARGIN)
         assert local_available < 50_000
         assert second_call["max_tokens"] == expected_cap
         assert agent.context_compressor.context_length == 200_000

--- a/tests/test_ctx_halving_fix.py
+++ b/tests/test_ctx_halving_fix.py
@@ -305,14 +305,18 @@ class TestContextNotHalvedOnOutputCapError:
     def test_output_cap_error_sets_ephemeral_not_context_length(self):
         """On 'max_tokens too large' error, _ephemeral_max_output_tokens is set
         and compressor.context_length is left unchanged."""
-        from agent.model_metadata import parse_available_output_tokens_from_error
+        from agent.model_metadata import (
+            OUTPUT_CAP_RETRY_SAFETY_MARGIN,
+            parse_available_output_tokens_from_error,
+        )
 
         error_msg = (
             "max_tokens: 128000 > context_window: 200000 "
             "- input_tokens: 180000 = available_tokens: 20000"
         )
 
-        # Simulate the handler logic from run_agent.py
+        # Simulate the handler logic from conversation_loop.py, using the
+        # production margin constant so this model cannot drift from the code.
         agent = self._make_agent_with_compressor(context_length=200_000)
         old_ctx = agent.context_compressor.context_length
 
@@ -320,11 +324,13 @@ class TestContextNotHalvedOnOutputCapError:
         assert available_out == 20_000, "parser must detect the error"
 
         # The fix: set ephemeral, skip context_length modification
-        agent._ephemeral_max_output_tokens = max(1, available_out - 64)
+        agent._ephemeral_max_output_tokens = max(
+            1, available_out - OUTPUT_CAP_RETRY_SAFETY_MARGIN
+        )
 
         # context_length must be untouched
         assert agent.context_compressor.context_length == old_ctx
-        assert agent._ephemeral_max_output_tokens == 19_936
+        assert agent._ephemeral_max_output_tokens == 20_000 - OUTPUT_CAP_RETRY_SAFETY_MARGIN
 
     def test_prompt_too_long_with_explicit_limit_uses_provider_limit(self):
         """Prompt-too-long errors only change context_length when they report a concrete limit."""
@@ -338,25 +344,39 @@ class TestContextNotHalvedOnOutputCapError:
         assert get_context_length_from_provider_error(error_msg, 1_000_000) == 200_000
 
     def test_output_cap_error_safety_margin(self):
-        """The ephemeral value includes a 64-token safety margin below available_out."""
-        from agent.model_metadata import parse_available_output_tokens_from_error
+        """The ephemeral value sits a safety margin below available_out.
+
+        The margin is the shared production constant (512 since the strict-
+        endpoint fix — a 64-token margin was regularly eaten by input-estimate
+        drift between retries); import it so this test validates the real
+        value instead of independently modeling a stale one.
+        """
+        from agent.model_metadata import (
+            OUTPUT_CAP_RETRY_SAFETY_MARGIN,
+            parse_available_output_tokens_from_error,
+        )
+
+        assert OUTPUT_CAP_RETRY_SAFETY_MARGIN == 512
 
         error_msg = (
             "max_tokens: 32768 > context_window: 200000 "
             "- input_tokens: 190000 = available_tokens: 10000"
         )
         available_out = parse_available_output_tokens_from_error(error_msg)
-        safe_out = max(1, available_out - 64)
-        assert safe_out == 9_936
+        safe_out = max(1, available_out - OUTPUT_CAP_RETRY_SAFETY_MARGIN)
+        assert safe_out == 10_000 - OUTPUT_CAP_RETRY_SAFETY_MARGIN
 
     def test_safety_margin_never_goes_below_one(self):
         """When available_out is very small, safe_out must be at least 1."""
-        from agent.model_metadata import parse_available_output_tokens_from_error
+        from agent.model_metadata import (
+            OUTPUT_CAP_RETRY_SAFETY_MARGIN,
+            parse_available_output_tokens_from_error,
+        )
 
         error_msg = (
             "max_tokens: 10 > context_window: 200000 "
             "- input_tokens: 199990 = available_tokens: 1"
         )
         available_out = parse_available_output_tokens_from_error(error_msg)
-        safe_out = max(1, available_out - 64)
+        safe_out = max(1, available_out - OUTPUT_CAP_RETRY_SAFETY_MARGIN)
         assert safe_out == 1


### PR DESCRIPTION
Strict OpenAI-compatible endpoints (e.g. vLLM) reject requests where
input + max_tokens exceeds the context window, and report a DERIVED
input bound (ctx+1 - max_tokens). Four related fixes:

1. Clamp a custom-profile max_tokens to ctx - est - max(512, est//25)
   when it cannot fit (plumb context_length + estimated_input_tokens
   into build_kwargs for that).
2. Overflow-spiral guard: after one non-converging output-cap
   reduction, route to real input compression instead of shrinking
   max_tokens forever (8192 -> 450 -> ...).
3. Raise the output-cap retry safety margin 64 -> 512 tokens.
4. Raise the compression-attempts cap 3 -> 30 (the no-progress early
   bail keeps it safe); context-heavy long-window tasks were being
   killed by "max compression attempts reached".

🤖 Generated with [Claude Code](https://claude.com/claude-code)