### PR TITLE
fix(kanban_db): serialize first DB init with a blocking cross-process byte lock

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1285,14 +1285,6 @@ _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
 DEFAULT_BUSY_TIMEOUT_MS = 120_000
 
-# Bounded acquire for the cross-process init lock (#36644). The original bare
-# blocking flock had no timeout, so a wedged holder blocked the dispatcher's
-# next-tick connect forever. We retry a non-blocking acquire up to this
-# deadline, polling at this interval, then proceed without the cross-process
-# lock (the in-process _INIT_LOCK + idempotent init remain the backstop).
-_INIT_LOCK_TIMEOUT_SECONDS = 10.0
-_INIT_LOCK_POLL_SECONDS = 0.05
-
 
 def _resolve_busy_timeout_ms() -> int:
     """Return the SQLite busy timeout for Kanban connections.
@@ -1337,76 +1329,41 @@ def _cross_process_init_lock(path: Path):
     lock keeps header validation, integrity probing, WAL activation, and
     additive migrations single-file/single-writer across the whole host while
     leaving normal post-init DB usage concurrent under SQLite WAL.
-
-    The acquire is **bounded** (issue #36644): the original bare blocking
-    ``flock(LOCK_EX)`` had no timeout, so a single process stalled inside the
-    critical section (or a stale lock held by a wedged worker) blocked every
-    other ``connect()`` — including the long-lived gateway dispatcher's
-    next-tick connect — forever, with no traceback and no recovery short of a
-    restart. We now retry a non-blocking acquire up to a deadline; on timeout
-    we log a WARNING and proceed WITHOUT the cross-process lock. That is safe:
-    the in-process ``_INIT_LOCK`` still serializes same-process threads, and
-    the init work itself is idempotent (``CREATE TABLE IF NOT EXISTS`` +
-    additive migrations), so the worst case of two processes racing first-init
-    is redundant work, not corruption. A bounded "proceed anyway" beats an
-    unbounded hang that silently stops the board.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_name(path.name + ".init.lock")
     handle = lock_path.open("a+b")
-    acquired = False
     try:
-        deadline = time.monotonic() + _INIT_LOCK_TIMEOUT_SECONDS
         if _IS_WINDOWS:
             import msvcrt
 
+            # Lock a single byte in the sidecar file. ``msvcrt.locking`` starts
+            # at the current file position, so seek explicitly before both
+            # lock and unlock.  The file is opened in append/read binary mode so
+            # it always exists but the byte-range lock is the synchronization
+            # primitive; no payload needs to be written.
+            handle.seek(0)
             locking = getattr(msvcrt, "locking")
-            nb_lock = getattr(msvcrt, "LK_NBLCK")
-            while True:
-                try:
-                    handle.seek(0)
-                    locking(handle.fileno(), nb_lock, 1)
-                    acquired = True
-                    break
-                except OSError:
-                    if time.monotonic() >= deadline:
-                        break
-                    time.sleep(_INIT_LOCK_POLL_SECONDS)
+            lock_mode = getattr(msvcrt, "LK_LOCK")
+            locking(handle.fileno(), lock_mode, 1)
         else:
             import fcntl
 
-            while True:
-                try:
-                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                    acquired = True
-                    break
-                except (BlockingIOError, OSError):
-                    if time.monotonic() >= deadline:
-                        break
-                    time.sleep(_INIT_LOCK_POLL_SECONDS)
-        if not acquired:
-            _log.warning(
-                "kanban init lock for %s not acquired within %.0fs — proceeding "
-                "without the cross-process lock (in-process lock + idempotent "
-                "init are the correctness backstop). A stuck holder is no longer "
-                "able to block this connect indefinitely (#36644).",
-                lock_path, _INIT_LOCK_TIMEOUT_SECONDS,
-            )
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         yield
     finally:
         try:
-            if acquired:
-                if _IS_WINDOWS:
-                    import msvcrt
+            if _IS_WINDOWS:
+                import msvcrt
 
-                    handle.seek(0)
-                    locking = getattr(msvcrt, "locking")
-                    unlock_mode = getattr(msvcrt, "LK_UNLCK")
-                    locking(handle.fileno(), unlock_mode, 1)
-                else:
-                    import fcntl
+                handle.seek(0)
+                locking = getattr(msvcrt, "locking")
+                unlock_mode = getattr(msvcrt, "LK_UNLCK")
+                locking(handle.fileno(), unlock_mode, 1)
+            else:
+                import fcntl
 
-                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         finally:
             handle.close()
 
@@ -1706,35 +1663,6 @@ def connect(
     else:
         path = kanban_db_path(board=board)
     path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Fast path: once THIS process has initialized this path, the expensive
-    # first-open work (header validation, integrity probe, schema + additive
-    # migrations) is already done and cached in _INITIALIZED_PATHS. Acquiring
-    # the cross-process init lock on every connect is what let a single stalled
-    # holder (e.g. an external `hermes kanban list` mid-integrity-probe) block
-    # the long-lived gateway dispatcher's next-tick connect() forever — an
-    # unbounded flock with no timeout, no LOCK_NB, no recovery (#36644). On the
-    # steady-state path there is nothing for the cross-process lock to protect
-    # (no schema/migration writes run), so skip it entirely and just open the
-    # connection with WAL/pragmas under the cheap in-process _INIT_LOCK.
-    resolved = str(path.resolve())
-    if resolved in _INITIALIZED_PATHS:
-        conn = _sqlite_connect(path)
-        try:
-            conn.row_factory = sqlite3.Row
-            with _INIT_LOCK:
-                from hermes_state import apply_wal_with_fallback
-                apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-                conn.execute("PRAGMA synchronous=FULL")
-                conn.execute("PRAGMA wal_autocheckpoint=100")
-                conn.execute("PRAGMA foreign_keys=ON")
-                conn.execute("PRAGMA secure_delete=ON")
-                conn.execute("PRAGMA cell_size_check=ON")
-        except Exception:
-            conn.close()
-            raise
-        return conn
-
     with _cross_process_init_lock(path):
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
         # and other invalid-header cases without opening a sqlite connection.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1329,6 +1329,20 @@ def _cross_process_init_lock(path: Path):
     lock keeps header validation, integrity probing, WAL activation, and
     additive migrations single-file/single-writer across the whole host while
     leaving normal post-init DB usage concurrent under SQLite WAL.
+
+    First-init only: :func:`connect` reaches this lock exclusively on the
+    first-init path — paths already initialized by this process skip it via
+    the ``_INITIALIZED_PATHS`` fast path, which is what keeps a stalled or
+    slow holder from ever blocking a steady-state connect such as the gateway
+    dispatcher's next tick (#36644, ``84ba83b09``).
+
+    On that first-init path the acquire deliberately **blocks**. The previous
+    bounded acquire (non-blocking retries up to a deadline, then "proceed
+    anyway") timed out spuriously under fresh-board bursts of ~20 processes,
+    and the losers fell through the lock against a half-initialized database.
+    Losers of the first-init race must wait for the owner to finish, however
+    long that takes; correctness here beats latency because this cost is paid
+    once per process per path.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_name(path.name + ".init.lock")
@@ -1663,6 +1677,38 @@ def connect(
     else:
         path = kanban_db_path(board=board)
     path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Fast path: once THIS process has initialized this path, the expensive
+    # first-open work (header validation, integrity probe, schema + additive
+    # migrations) is already done and cached in _INITIALIZED_PATHS. The
+    # cross-process init lock below is deliberately BLOCKING (losers of a
+    # fresh-board race must wait for the owner rather than proceed against a
+    # half-initialized database), so acquiring it on every connect would let
+    # a single stalled holder (e.g. an external `hermes kanban list`
+    # mid-integrity-probe) block the long-lived gateway dispatcher's
+    # next-tick connect() forever — the #36644 dispatcher stall, fixed by
+    # 84ba83b09. On the steady-state path there is nothing for the
+    # cross-process lock to protect (no schema/migration writes run), so skip
+    # it entirely and just open the connection with WAL/pragmas under the
+    # cheap in-process _INIT_LOCK.
+    resolved = str(path.resolve())
+    if resolved in _INITIALIZED_PATHS:
+        conn = _sqlite_connect(path)
+        try:
+            conn.row_factory = sqlite3.Row
+            with _INIT_LOCK:
+                from hermes_state import apply_wal_with_fallback
+                apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+                conn.execute("PRAGMA synchronous=FULL")
+                conn.execute("PRAGMA wal_autocheckpoint=100")
+                conn.execute("PRAGMA foreign_keys=ON")
+                conn.execute("PRAGMA secure_delete=ON")
+                conn.execute("PRAGMA cell_size_check=ON")
+        except Exception:
+            conn.close()
+            raise
+        return conn
+
     with _cross_process_init_lock(path):
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
         # and other invalid-header cases without opening a sqlite connection.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -79,15 +79,18 @@ def test_connect_honors_kanban_busy_timeout_env(kanban_home, monkeypatch):
 
 
 def test_cross_process_init_lock_uses_windows_byte_range_lock(tmp_path, monkeypatch):
-    """Windows must use a real (non-blocking) process lock, not a no-op open.
+    """Windows must use a real (blocking) process lock, not a no-op open.
 
-    The init lock acquires with LK_NBLCK in a bounded retry loop (#36644) so a
-    wedged holder can never block connect() forever; a clean acquire takes the
-    lock once and releases it once.
+    The init lock acquires with LK_LOCK — a blocking byte-range lock — so a
+    loser of a fresh-board first-init race waits for the owner instead of
+    proceeding against a half-initialized database. Steady-state connects
+    never reach this lock (the _INITIALIZED_PATHS fast path skips it), which
+    is what keeps a wedged holder from stalling the dispatcher (#36644). A
+    clean acquire takes the lock once and releases it once.
     """
     calls: list[tuple[int, int, int]] = []
     fake_msvcrt = types.SimpleNamespace(
-        LK_NBLCK=3,
+        LK_LOCK=1,
         LK_UNLCK=2,
         locking=lambda fd, mode, nbytes: calls.append((fd, mode, nbytes)),
     )
@@ -96,12 +99,12 @@ def test_cross_process_init_lock_uses_windows_byte_range_lock(tmp_path, monkeypa
 
     db_path = tmp_path / "kanban.db"
     with kb._cross_process_init_lock(db_path):
-        # Acquired exactly once via the non-blocking byte-range lock.
-        assert [call[1:] for call in calls] == [(fake_msvcrt.LK_NBLCK, 1)]
+        # Acquired exactly once via the blocking byte-range lock.
+        assert [call[1:] for call in calls] == [(fake_msvcrt.LK_LOCK, 1)]
 
     # Released once on exit.
     assert [call[1:] for call in calls] == [
-        (fake_msvcrt.LK_NBLCK, 1),
+        (fake_msvcrt.LK_LOCK, 1),
         (fake_msvcrt.LK_UNLCK, 1),
     ]
 

--- a/tests/hermes_cli/test_kanban_init_lock_bounded.py
+++ b/tests/hermes_cli/test_kanban_init_lock_bounded.py
@@ -1,21 +1,26 @@
-"""Tests for the bounded kanban init lock (issue #36644).
+"""Tests for the kanban cross-process init lock.
 
-`connect()` wrapped its entire body in an unbounded blocking `flock(LOCK_EX)`
-on every call. A single process stalled inside the critical section blocked the
-long-lived gateway dispatcher's next-tick `connect()` forever — no timeout, no
-recovery, board silently stops being worked.
+Two guarantees, both covered here:
 
-Two fixes, both covered here:
-1. Fast path: once a path is initialized in this process, `connect()` skips the
-   cross-process init lock entirely (nothing left to serialize), so a held lock
-   cannot block a steady-state connect.
-2. Bounded acquire: even on first-init, `_cross_process_init_lock` retries a
-   non-blocking acquire up to a deadline, then proceeds (with a WARNING) rather
-   than hanging.
+1. Fast path (#36644, ``84ba83b09``): once a path is initialized in this
+   process, `connect()` skips the cross-process init lock entirely (nothing
+   left to serialize), so a held lock cannot block a steady-state connect —
+   in particular the long-lived gateway dispatcher's next-tick `connect()`.
+2. Blocking first-init: on the first-init path the acquire deliberately
+   blocks. The previous bounded acquire ("retry until a deadline, then
+   proceed without the lock") timed out spuriously under fresh-board bursts
+   of ~20 processes and the losers proceeded against a half-initialized
+   database. Losers must wait for the owner, then see a fully initialized
+   schema.
 """
 
 from __future__ import annotations
 
+import os
+import sqlite3
+import subprocess
+import sys
+import textwrap
 import threading
 import time
 from pathlib import Path
@@ -45,7 +50,7 @@ def _hold_init_lock(db_path: Path):
     def _holder():
         with kb._cross_process_init_lock(db_path):
             holding.set()
-            release.wait(timeout=10)
+            release.wait(timeout=30)
 
     t = threading.Thread(target=_holder, daemon=True)
     t.start()
@@ -72,21 +77,169 @@ def test_initialized_path_connect_skips_init_lock(kanban_home):
         t.join(timeout=5)
 
 
-def test_first_init_connect_is_bounded_when_lock_held(kanban_home, monkeypatch):
-    """First-init connect must time out the cross-process lock and proceed,
-    not hang forever, when another holder owns it."""
-    monkeypatch.setattr(kb, "_INIT_LOCK_TIMEOUT_SECONDS", 0.6)
-    db_path = kb.kanban_db_path(board="default")
+def test_first_init_connect_blocks_until_lock_released(kanban_home):
+    """First-init connect must WAIT for the lock holder, not fall through.
 
-    release, t = _hold_init_lock(db_path)
+    The old bounded acquire proceeded WITHOUT the cross-process lock after a
+    timeout, so a loser of a fresh-board race could read a half-initialized
+    database. With the blocking acquire, a first-init connect must still be
+    waiting while the lock is held, and must complete once it is released.
+    """
+    db_path = kb.kanban_db_path(board="default")
+    release, holder = _hold_init_lock(db_path)
+
+    result: dict = {}
+
+    def _first_init_connect():
+        try:
+            conn = kb.connect()  # path NOT yet initialized — takes the lock path
+            conn.close()
+            result["ok"] = True
+        except Exception as exc:  # pragma: no cover - failure detail for assert
+            result["error"] = exc
+
+    connector = threading.Thread(target=_first_init_connect, daemon=True)
     try:
-        start = time.monotonic()
-        conn = kb.connect()  # path NOT yet initialized — must take the bounded path
-        conn.close()
-        elapsed = time.monotonic() - start
-        # Proceeded within roughly the timeout window (not unbounded).
-        assert 0.4 <= elapsed < 3.0, f"expected bounded ~0.6s acquire, got {elapsed:.2f}s"
+        connector.start()
+        # While the lock is held, the first-init connect must NOT complete.
+        connector.join(timeout=1.2)
+        assert connector.is_alive(), (
+            "first-init connect() returned while the init lock was held — "
+            "the blocking acquire fell through"
+        )
+        assert str(db_path.resolve()) not in kb._INITIALIZED_PATHS
+
+        # Release the holder: the blocked connect must now finish initialization.
+        release.set()
+        connector.join(timeout=15)
+        assert not connector.is_alive(), "first-init connect never completed after release"
+        assert result.get("ok"), f"first-init connect failed: {result.get('error')!r}"
         assert str(db_path.resolve()) in kb._INITIALIZED_PATHS
     finally:
         release.set()
-        t.join(timeout=5)
+        holder.join(timeout=5)
+        connector.join(timeout=15)
+
+
+_FIRST_INIT_WORKER = textwrap.dedent(
+    """
+    import sys, time
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+
+    db_path = Path(sys.argv[1])
+    ready_file = Path(sys.argv[2])
+    go_file = Path(sys.argv[3])
+
+    # Imports done — report ready, then spin until the parent fires the gun so
+    # every worker hits the fresh board's first init as simultaneously as
+    # possible.
+    ready_file.touch()
+    deadline = time.monotonic() + 60
+    while not go_file.exists():
+        if time.monotonic() >= deadline:
+            sys.exit(3)
+        time.sleep(0.002)
+
+    conn = kb.connect(db_path)
+    try:
+        # The schema must be fully present: a loser that fell through the lock
+        # mid-init would fail here (missing tables) or in the integrity probe
+        # inside connect() itself.
+        conn.execute("SELECT COUNT(*) FROM tasks").fetchone()
+        row = conn.execute("PRAGMA integrity_check").fetchone()
+        if (row[0] or "").lower() != "ok":
+            sys.exit(4)
+    finally:
+        conn.close()
+    sys.exit(0)
+    """
+)
+
+
+def test_concurrent_fresh_board_first_init_subprocesses(tmp_path):
+    """Simultaneous fresh-board first-inits serialize behind the byte lock.
+
+    Regression test for the fresh-board race: ~20 processes connecting to a
+    brand-new board made the old bounded lock wait time out, and the losers
+    fell through against a half-initialized database (integrity failures,
+    quarantine-backup storms). Every process must succeed, see the complete
+    schema, and produce no quarantine backup.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    db_path = tmp_path / "board" / "kanban.db"
+    go_file = tmp_path / "go"
+    repo_root = Path(kb.__file__).resolve().parent.parent
+    n_procs = 8
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(home)
+    env["HERMES_KANBAN_HOME"] = str(home)
+    env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
+
+    procs = []
+    ready_files = []
+    for i in range(n_procs):
+        ready = tmp_path / f"ready-{i}"
+        ready_files.append(ready)
+        procs.append(
+            subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    _FIRST_INIT_WORKER,
+                    str(db_path),
+                    str(ready),
+                    str(go_file),
+                ],
+                env=env,
+                cwd=str(tmp_path),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        )
+
+    try:
+        # Wait until every worker has finished importing and is spinning on the
+        # go file, then start them all at once.
+        deadline = time.monotonic() + 60
+        while not all(f.exists() for f in ready_files):
+            assert time.monotonic() < deadline, "workers never became ready"
+            for p in procs:
+                if p.poll() is not None and p.returncode != 0:
+                    raise AssertionError(
+                        f"worker died before start (rc={p.returncode}): "
+                        f"{p.communicate()[1]}"
+                    )
+            time.sleep(0.01)
+        go_file.touch()
+
+        failures = []
+        for p in procs:
+            out, err = p.communicate(timeout=120)
+            if p.returncode != 0:
+                failures.append((p.returncode, err.strip().splitlines()[-5:]))
+        assert not failures, f"concurrent first-init workers failed: {failures}"
+    finally:
+        for p in procs:
+            if p.poll() is None:
+                p.kill()
+                p.communicate()
+
+    # No loser may have quarantined the database mid-init.
+    corrupt_backups = list(db_path.parent.glob("*.corrupt.*"))
+    assert not corrupt_backups, f"quarantine backups created: {corrupt_backups}"
+
+    # The board is fully initialized and healthy after the burst.
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='tasks'"
+        ).fetchone(), "schema incomplete after concurrent first-init"
+        row = conn.execute("PRAGMA integrity_check").fetchone()
+        assert (row[0] or "").lower() == "ok"
+    finally:
+        conn.close()


### PR DESCRIPTION
Under ~20 processes connecting to a fresh board concurrently, the
bounded init-lock wait times out spuriously and losers proceed against
a half-initialized database. Serialize first init behind a blocking
byte-range lock on a sidecar lock file; the already-initialized path
detects the schema marker and skips locking entirely, so steady-state
connects stay lock-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)