### PR TITLE
fix(kanban_db): decompose children inherit the root task's priority

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5074,7 +5074,7 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, tenant, workspace_kind, workspace_path, priority "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -5083,6 +5083,11 @@ def decompose_triage_task(
         if root_row["status"] != "triage":
             return None
         tenant = root_row["tenant"]
+        # Children inherit the root's dispatch priority. Without this they were
+        # created at the column default (p0) and starved forever under perpetual
+        # p1-p4 refill — the whole family (children in todo, root waiting on
+        # them) parked permanently, invisible except as "stuck in todo".
+        root_priority = root_row["priority"] if root_row["priority"] is not None else 0
         # Children inherit the root's workspace by default so a fan-out
         # of a code-gen task lands in the parent's project dir/worktree
         # rather than throwaway scratch tmp dirs. A child dict can still
@@ -5113,14 +5118,15 @@ def decompose_triage_task(
                 child_ws_path = None
             conn.execute(
                 "INSERT INTO tasks "
-                "(id, title, body, assignee, status, workspace_kind, "
+                "(id, title, body, assignee, status, priority, workspace_kind, "
                 " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
                     body if isinstance(body, str) else None,
                     assignee,
+                    root_priority,
                     child_ws_kind,
                     child_ws_path,
                     tenant,

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -206,6 +206,51 @@ def test_decompose_children_stay_scratch_when_root_scratch(kanban_home):
     assert t.workspace_path is None
 
 
+def test_decompose_children_inherit_root_priority(kanban_home):
+    """Children of a nonzero-priority root inherit its dispatch priority.
+
+    Regression: children used to be INSERTed without a priority column and
+    defaulted to 0, so every auto-decomposed family starved forever on
+    boards saturated with priority>=1 work (dispatch claims priority DESC).
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="urgent root", assignee="worker",
+            priority=3, triage=True,
+        )
+        child_ids = kb.decompose_triage_task(
+            conn, tid, root_assignee="orchestrator",
+            children=[
+                {"title": "first"},
+                {"title": "second", "parents": [0]},
+            ],
+            author="decomposer",
+        )
+    assert child_ids and len(child_ids) == 2
+    with kb.connect() as conn:
+        c0 = kb.get_task(conn, child_ids[0])
+        c1 = kb.get_task(conn, child_ids[1])
+    # Unblocked child is ready at the root's priority.
+    assert (c0.status, c0.priority) == ("ready", 3)
+    # The sibling-gated child parked in todo carries it too, so it
+    # dispatches at the right rank once its parent completes.
+    assert (c1.status, c1.priority) == ("todo", 3)
+
+
+def test_decompose_default_priority_root_keeps_default(kanban_home):
+    """No regression: a default-priority root still yields priority-0 children."""
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        child_ids = kb.decompose_triage_task(
+            conn, tid, root_assignee="orch",
+            children=[{"title": "only child"}], author="me",
+        )
+    assert child_ids and len(child_ids) == 1
+    with kb.connect() as conn:
+        child = kb.get_task(conn, child_ids[0])
+    assert child.priority == 0
+
+
 def test_decompose_per_child_workspace_override(kanban_home):
     """An explicit per-child workspace beats inheritance."""
     proj = "/home/teknium/myproject"


### PR DESCRIPTION
decompose_triage_task created children with no priority, so they
defaulted to 0 and never dispatched on boards that stay saturated with
priority>=1 work: every auto-decomposed family (children plus the root
waiting in todo) parked forever. Children now inherit the ROOT task's
priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)