### PR TITLE
fix(kanban_db): route worker TMPDIR into the task workspace

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7742,6 +7742,13 @@ def _default_spawn(
     # here (leave the inherited value rather than write a meaningless one).
     if workspace and os.path.isabs(workspace) and os.path.isdir(workspace):
         env["TERMINAL_CWD"] = workspace
+    # Route the worker's temp writes into its own workspace. Python tempfile,
+    # the terminal wrapper's snapshot files (LocalEnvironment.get_temp_dir
+    # honors TMPDIR), Chrome scratch, and the gpu_sklearn handoff dirs all
+    # follow TMPDIR — so per-task scratch lives and dies with the workspace
+    # instead of accumulating in /tmp (a 24 GB tmpfs measured 100% full from
+    # exactly this: 82k gpu_sklearn_* dirs, browser profiles, shell snapshots).
+    env["TMPDIR"] = workspace
     if task.branch_name:
         env["HERMES_KANBAN_BRANCH"] = task.branch_name
     if task.current_run_id is not None:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7742,13 +7742,19 @@ def _default_spawn(
     # here (leave the inherited value rather than write a meaningless one).
     if workspace and os.path.isabs(workspace) and os.path.isdir(workspace):
         env["TERMINAL_CWD"] = workspace
-    # Route the worker's temp writes into its own workspace. Python tempfile,
-    # the terminal wrapper's snapshot files (LocalEnvironment.get_temp_dir
-    # honors TMPDIR), Chrome scratch, and the gpu_sklearn handoff dirs all
-    # follow TMPDIR — so per-task scratch lives and dies with the workspace
-    # instead of accumulating in /tmp (a 24 GB tmpfs measured 100% full from
-    # exactly this: 82k gpu_sklearn_* dirs, browser profiles, shell snapshots).
-    env["TMPDIR"] = workspace
+        # Route the worker's temp writes into its own workspace. Python
+        # tempfile, the terminal wrapper's snapshot files
+        # (LocalEnvironment.get_temp_dir honors TMPDIR), Chrome scratch, and
+        # the gpu_sklearn handoff dirs all follow TMPDIR — so per-task
+        # scratch lives and dies with the workspace instead of accumulating
+        # in /tmp (a 24 GB tmpfs measured 100% full from exactly this: 82k
+        # gpu_sklearn_* dirs, browser profiles, shell snapshots). Guarded by
+        # the same valid-workspace condition as TERMINAL_CWD above: Python
+        # consults TMPDIR first when choosing a temp directory
+        # (tempfile.gettempdir), so pointing it at a relative or missing
+        # path would break every temp write in the worker — when the
+        # workspace is invalid, leave the inherited TMPDIR untouched.
+        env["TMPDIR"] = workspace
     if task.branch_name:
         env["HERMES_KANBAN_BRANCH"] = task.branch_name
     if task.current_run_id is not None:

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -99,3 +99,43 @@ def test_terminal_cwd_not_pinned_for_nonexistent_workspace(monkeypatch, tmp_path
 
     # Inherited value is preserved (not overwritten with a bogus path).
     assert captured["env"]["TERMINAL_CWD"] == "/pre/existing/anchor"
+
+
+def test_tmpdir_routed_into_workspace_only_when_valid(monkeypatch, tmp_path):
+    """TMPDIR follows the same valid-workspace guard as TERMINAL_CWD.
+
+    Valid workspace: TMPDIR is routed into it so per-task scratch (tempfile,
+    terminal snapshot files, browser profiles) lives and dies with the task
+    instead of accumulating in /tmp.
+
+    Invalid workspace: the inherited process configuration must survive —
+    Python consults TMPDIR first when choosing a temp directory
+    (``tempfile.gettempdir``), so pointing it at a missing path would break
+    every temp write in the worker. Same guard, same rationale as the
+    TERMINAL_CWD safeguard above.
+    """
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "w").mkdir(parents=True)
+    (root / "profiles" / "w" / "config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    root.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    missing = tmp_path / "does-not-exist"
+
+    # Valid workspace → TMPDIR pinned to it (inherited value overridden).
+    monkeypatch.setenv("TMPDIR", "/pre/existing/tmp")
+    captured = _capture_spawn_env(kb, monkeypatch, str(workspace))
+    assert captured["env"]["TMPDIR"] == str(workspace)
+
+    # Invalid workspace → inherited TMPDIR preserved, not clobbered.
+    captured = _capture_spawn_env(kb, monkeypatch, str(missing))
+    assert captured["env"]["TMPDIR"] == "/pre/existing/tmp"
+
+    # Invalid workspace with no inherited TMPDIR → stays unset.
+    monkeypatch.delenv("TMPDIR", raising=False)
+    captured = _capture_spawn_env(kb, monkeypatch, str(missing))
+    assert "TMPDIR" not in captured["env"]


### PR DESCRIPTION
Long-running worker fleets accumulate per-task scratch (tempfile,
terminal snapshot files, browser profiles) in /tmp until it fills: a
24 GB tmpfs measured 100%% full from exactly this. Point TMPDIR at the
task workspace so scratch lives and dies with the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)