### PR TITLE
Serialize picker cache prewarm guard

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1382,11 +1382,30 @@ def switch_model(
 # ---------------------------------------------------------------------------
 
 # Process-level guard so the picker prewarm thread is spawned at most once per
-# process — mirrors run_agent's _openrouter_prewarm_done. Without a guard a
-# long-lived process (or repeated triggers) would leak one OS thread per call.
+# process. Without a guard a long-lived process (or repeated triggers) would
+# leak one OS thread per call.
 import threading as _threading  # noqa: E402
 
-_picker_prewarm_done = _threading.Event()
+_picker_prewarm_done = False
+_picker_prewarm_lock = _threading.Lock()
+
+
+def _claim_picker_prewarm() -> bool:
+    """Return True exactly once per process, even under concurrent callers."""
+    global _picker_prewarm_done
+    if _picker_prewarm_done:
+        return False
+    with _picker_prewarm_lock:
+        if _picker_prewarm_done:
+            return False
+        _picker_prewarm_done = True
+        return True
+
+
+def _reset_picker_prewarm_for_tests() -> None:
+    global _picker_prewarm_done
+    with _picker_prewarm_lock:
+        _picker_prewarm_done = False
 
 
 def _extra_headers_from_config(entry: Any) -> dict[str, str]:
@@ -1412,13 +1431,12 @@ def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:
     user types ``/model``, the picker hits the warm disk cache and renders in
     ~100ms.
 
-    Fire-and-forget. Process-level Event guard ensures it runs at most once.
+    Fire-and-forget. Process-level guard ensures it runs at most once.
     Fully exception-isolated — a slow or offline provider can never affect the
     session. Returns the spawned thread (for tests) or None if already warmed.
     """
-    if _picker_prewarm_done.is_set():
+    if not _claim_picker_prewarm():
         return None
-    _picker_prewarm_done.set()
 
     def _warm() -> None:
         try:

--- a/tests/hermes_cli/test_picker_prewarm.py
+++ b/tests/hermes_cli/test_picker_prewarm.py
@@ -9,13 +9,16 @@ and it delegates to ``list_authenticated_providers`` to do the warming.
 
 from __future__ import annotations
 
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
 
 import hermes_cli.model_switch as ms
 
 
 def _reset_guard():
-    ms._picker_prewarm_done.clear()
+    ms._reset_picker_prewarm_for_tests()
 
 
 def test_prewarm_runs_list_authenticated_providers_once():
@@ -42,6 +45,31 @@ def test_prewarm_guard_is_once_per_process():
         # Subsequent calls return None (guard set) — no new thread.
         assert ms.prewarm_picker_cache_async() is None
         assert ms.prewarm_picker_cache_async() is None
+    _reset_guard()
+
+
+def test_prewarm_guard_is_atomic_under_concurrent_calls():
+    """Concurrent session starts should still spawn only one prewarm thread."""
+    _reset_guard()
+    worker_count = 8
+    start = threading.Barrier(worker_count)
+
+    def invoke():
+        start.wait(timeout=10)
+        return ms.prewarm_picker_cache_async()
+
+    def slow_list(*_args, **_kwargs):
+        time.sleep(0.05)
+        return []
+
+    with patch.object(ms, "list_authenticated_providers", side_effect=slow_list) as mock_list:
+        with ThreadPoolExecutor(max_workers=worker_count) as pool:
+            threads = [thread for thread in pool.map(lambda _: invoke(), range(worker_count)) if thread is not None]
+        for thread in threads:
+            thread.join(timeout=10)
+
+    assert len(threads) == 1
+    mock_list.assert_called_once()
     _reset_guard()
 
 


### PR DESCRIPTION
## Problem
The `/model` picker prewarm guard used a non-atomic `Event.is_set()` / `.set()` pair. Concurrent session starts could pass the check before the event was set, spawning duplicate picker-cache prewarm threads.

## Solution
Replace the check/set sequence with a lock-backed `_claim_picker_prewarm()` helper that returns `True` exactly once per process, while keeping later calls as a cheap boolean fast path.

## Impact
The new regression test runs 8 concurrent callers and verifies exactly one prewarm thread is spawned and `list_authenticated_providers()` runs once, eliminating up to 87.5% duplicate prewarm work in that burst.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /Users/holim/code/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_picker_prewarm.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_picker_prewarm.py -q`
- `/Users/holim/code/hermes-agent/.venv/bin/ruff check hermes_cli/model_switch.py tests/hermes_cli/test_picker_prewarm.py`
- `git diff --check`
