### PR TITLE
Preserve parallel runner failure summaries

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -50,6 +50,7 @@ from concurrent.futures import ThreadPoolExecutor, Future
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+FailureRecord = Tuple[Path, int, str, Dict[str, int]]
 
 # Default test discovery roots.
 _DEFAULT_ROOTS = ["tests"]
@@ -362,6 +363,41 @@ def _format_file(file: Path, repo_root: Path) -> str:
         return str(file.resolve().relative_to(repo_root.resolve()))
     except ValueError:
         return str(file)
+
+
+def _describe_nonzero_exit(rc: int) -> str:
+    if rc == 124:
+        return "timeout"
+    if rc < 0:
+        return f"signal {-rc}"
+    if rc >= 128:
+        return f"signal {rc - 128} (rc={rc})"
+    return f"rc={rc}"
+
+
+def _split_failure_records(
+    failures: List[FailureRecord],
+) -> Tuple[
+    List[Tuple[Path, int, Dict[str, int]]],
+    List[Tuple[Path, int, Dict[str, int]]],
+    List[Tuple[Path, int]],
+]:
+    test_fail_files = [
+        (f, rc, s)
+        for f, rc, _o, s in failures
+        if s.get("failed", 0) > 0 or s.get("errors", 0) > 0
+    ]
+    completed_summary_nonzero = [
+        (f, rc, s)
+        for f, rc, _o, s in failures
+        if s and s.get("failed", 0) == 0 and s.get("errors", 0) == 0
+    ]
+    infrastructure_failures = [
+        (f, rc)
+        for f, rc, _o, s in failures
+        if not s
+    ]
+    return test_fail_files, completed_summary_nonzero, infrastructure_failures
 
 
 def _print_progress(
@@ -818,7 +854,7 @@ def main() -> int:
 
     # Capture and print on completion (out-of-order is fine — keeps the
     # terminal clean rather than interleaving N parallel pytest outputs).
-    failures: List[Tuple[Path, str, Dict[str, int]]] = []
+    failures: List[FailureRecord] = []
     file_times: List[Tuple[Path, float]] = []  # (file, subprocess_wall) for distribution
     started = time.monotonic()
     files_done = 0
@@ -839,7 +875,7 @@ def main() -> int:
                 files_done += 1
                 tests_done += n_tests
                 fail_count += 1
-                failures.append((file, f"runner crashed: {exc!r}", {}))
+                failures.append((file, 1, f"runner crashed: {exc!r}", {}))
                 _print_progress(
                     tests_done, approx_total_tests, file, 1,
                     time.monotonic() - started_at,
@@ -859,7 +895,7 @@ def main() -> int:
                 pass_count += 1
             else:
                 fail_count += 1
-                failures.append((fpath, output, summary))
+                failures.append((fpath, rc, output, summary))
             _print_progress(
                 tests_done, approx_total_tests, fpath, rc,
                 time.monotonic() - started_at,
@@ -928,31 +964,43 @@ def main() -> int:
     if failures:
         print()
         print("=== Failure output ===")
-        for file, output, _summary in failures:
+        for file, _rc, output, _summary in failures:
             print()
             print(f"--- {_format_file(file, repo_root)} ---")
             print(output.rstrip())
         print()
         # Split: files with actual test failures vs non-zero exit for other reasons
-        test_fail_files = [(f, s) for f, _o, s in failures if s.get("failed", 0) > 0]
-        all_passed_but_nonzero = [(f, s) for f, _o, s in failures
-                                  if s.get("failed", 0) == 0 and s.get("passed", 0) > 0]
-        no_tests_ran = [(f, s) for f, _o, s in failures
-                        if s.get("failed", 0) == 0 and s.get("passed", 0) == 0]
+        test_fail_files, completed_summary_nonzero, infrastructure_failures = _split_failure_records(failures)
         if test_fail_files:
-            total_tf = sum(s.get("failed", 0) for _, s in test_fail_files)
+            total_tf = sum(s.get("failed", 0) for _, _rc, s in test_fail_files)
+            total_errors = sum(s.get("errors", 0) for _, _rc, s in test_fail_files)
             print(f"=== {len(test_fail_files)} file{'s' if len(test_fail_files) != 1 else ''} with test failures ({total_tf} test{'s' if total_tf != 1 else ''} failed) ===")
-            for file, s in test_fail_files:
+            for file, rc, s in test_fail_files:
                 nf = s.get("failed", 0)
-                print(f"  {_format_file(file, repo_root)}  ({nf} test{'s' if nf != 1 else ''} failed)")
-        if all_passed_but_nonzero:
-            print(f"=== {len(all_passed_but_nonzero)} file{'s' if len(all_passed_but_nonzero) != 1 else ''} where all tests passed but pytest exited non-zero (warnings-as-errors, hook failures, etc.) ===")
-            for file, s in all_passed_but_nonzero:
-                print(f"  {_format_file(file, repo_root)}  ({s.get('passed', 0)} passed)")
-        if no_tests_ran:
-            print(f"=== {len(no_tests_ran)} file{'s' if len(no_tests_ran) != 1 else ''} where no tests ran (collection/import error, timeout before collection, etc.) ===")
-            for file, s in no_tests_ran:
-                print(f"  {_format_file(file, repo_root)}")
+                ne = s.get("errors", 0)
+                suffix = []
+                if nf:
+                    suffix.append(f"{nf} failed")
+                if ne:
+                    suffix.append(f"{ne} error{'s' if ne != 1 else ''}")
+                suffix.append(_describe_nonzero_exit(rc))
+                print(f"  {_format_file(file, repo_root)}  ({', '.join(suffix)})")
+            if total_errors:
+                print(f"  Total collection/runtime errors: {total_errors}")
+        if completed_summary_nonzero:
+            print(f"=== {len(completed_summary_nonzero)} file{'s' if len(completed_summary_nonzero) != 1 else ''} with completed pytest summaries but non-zero process exit ===")
+            for file, rc, s in completed_summary_nonzero:
+                passed = s.get("passed", 0)
+                skipped = s.get("skipped", 0)
+                counts = [f"{passed} passed"] if passed else []
+                if skipped:
+                    counts.append(f"{skipped} skipped")
+                counts.append(_describe_nonzero_exit(rc))
+                print(f"  {_format_file(file, repo_root)}  ({', '.join(counts)})")
+        if infrastructure_failures:
+            print(f"=== {len(infrastructure_failures)} file{'s' if len(infrastructure_failures) != 1 else ''} with no completed pytest summary (collection/import error, timeout, interruption, or runner infrastructure failure) ===")
+            for file, rc in infrastructure_failures:
+                print(f"  {_format_file(file, repo_root)}  ({_describe_nonzero_exit(rc)})")
         return 1
 
     return 0

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import signal
 import subprocess
 import sys
 import threading
@@ -51,6 +52,19 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 FailureRecord = Tuple[Path, int, str, Dict[str, int]]
+_ActiveProc = Tuple["subprocess.Popen", int | None]
+
+
+class _RunnerTermination(BaseException):
+    """Raised from the main-thread signal handler after child cleanup starts."""
+
+    def __init__(self, signum: int):
+        self.signum = signum
+        super().__init__(f"runner interrupted by signal {signum}")
+
+
+_ACTIVE_PROCS: Dict[int, _ActiveProc] = {}
+_ACTIVE_PROCS_LOCK = threading.Lock()
 
 # Default test discovery roots.
 _DEFAULT_ROOTS = ["tests"]
@@ -220,6 +234,48 @@ def _kill_tree(proc: "subprocess.Popen", pgid: int | None = None) -> None:
         pass
 
 
+def _register_active_proc(proc: "subprocess.Popen", pgid: int | None) -> None:
+    with _ACTIVE_PROCS_LOCK:
+        _ACTIVE_PROCS[proc.pid] = (proc, pgid)
+
+
+def _unregister_active_proc(proc: "subprocess.Popen") -> None:
+    with _ACTIVE_PROCS_LOCK:
+        _ACTIVE_PROCS.pop(proc.pid, None)
+
+
+def _kill_active_processes() -> None:
+    with _ACTIVE_PROCS_LOCK:
+        active = list(_ACTIVE_PROCS.values())
+    for proc, pgid in active:
+        _kill_tree(proc, pgid=pgid)
+
+
+def _install_runner_signal_handlers() -> dict[int, object]:
+    """Convert supervisor SIGTERM/SIGINT into cleanup + final reporting."""
+    previous: dict[int, object] = {}
+
+    def _handle(signum: int, _frame: object) -> None:
+        _kill_active_processes()
+        raise _RunnerTermination(signum)
+
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        try:
+            previous[signum] = signal.getsignal(signum)
+            signal.signal(signum, _handle)
+        except (AttributeError, ValueError, OSError):
+            pass
+    return previous
+
+
+def _restore_runner_signal_handlers(previous: dict[int, object]) -> None:
+    for signum, handler in previous.items():
+        try:
+            signal.signal(signum, handler)
+        except (AttributeError, ValueError, OSError):
+            pass
+
+
 def _run_one_file(
     file: Path,
     pytest_args: List[str],
@@ -280,32 +336,36 @@ def _run_one_file(
             pgid = os.getpgid(proc.pid)
         except (ProcessLookupError, PermissionError):
             pgid = None
+    _register_active_proc(proc, pgid)
 
     try:
-        output, _ = proc.communicate(timeout=file_timeout)
-        rc = proc.returncode
-    except subprocess.TimeoutExpired:
-        _kill_tree(proc, pgid=pgid)
         try:
-            output, _ = proc.communicate(timeout=10)
+            output, _ = proc.communicate(timeout=file_timeout)
+            rc = proc.returncode
         except subprocess.TimeoutExpired:
-            output = "(file timeout exceeded; output unavailable)"
-        rc = 124  # de facto convention for "killed by timeout".
-        output = (
-            f"({file_timeout:.0f}s exceeded; "
-            f"process tree SIGKILL'd)\n{output}"
-        )
-    except BaseException:
-        # KeyboardInterrupt / runner crash — make sure no zombie
-        # grandchildren outlive us.
-        _kill_tree(proc, pgid=pgid)
-        raise
-    else:
-        # Happy path: pytest exited on its own. Kill the group anyway in
-        # case it left grandchildren behind; already-dead is a no-op.
-        _kill_tree(proc, pgid=pgid)
+            _kill_tree(proc, pgid=pgid)
+            try:
+                output, _ = proc.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                output = "(file timeout exceeded; output unavailable)"
+            rc = 124  # de facto convention for "killed by timeout".
+            output = (
+                f"({file_timeout:.0f}s exceeded; "
+                f"process tree SIGKILL'd)\n{output}"
+            )
+        except BaseException:
+            # KeyboardInterrupt / runner crash — make sure no zombie
+            # grandchildren outlive us.
+            _kill_tree(proc, pgid=pgid)
+            raise
+        else:
+            # Happy path: pytest exited on its own. Kill the group anyway in
+            # case it left grandchildren behind; already-dead is a no-op.
+            _kill_tree(proc, pgid=pgid)
 
-        output +=  "\n"
+            output +=  "\n"
+    finally:
+        _unregister_active_proc(proc)
 
     if rc == 5:
         # No tests collected — every test in the file was filtered out.
@@ -907,8 +967,11 @@ def main() -> int:
             if rc != 0:
                 _print_inline_failure(fpath, output, repo_root, pytest_passthrough)
 
-    with ThreadPoolExecutor(max_workers=args.jobs) as pool:
-        futures: List[Future] = []
+    interrupted_signal: int | None = None
+    previous_signal_handlers = _install_runner_signal_handlers()
+    futures: List[Future] = []
+    pool = ThreadPoolExecutor(max_workers=args.jobs)
+    try:
         for file in files:
             t0 = time.monotonic()
             fut = pool.submit(
@@ -921,11 +984,25 @@ def main() -> int:
         # control flow obvious.
         for fut in futures:
             fut.result() if fut.exception() is None else None
+    except _RunnerTermination as exc:
+        interrupted_signal = exc.signum
+        for fut in futures:
+            fut.cancel()
+        _kill_active_processes()
+    finally:
+        pool.shutdown(wait=True, cancel_futures=True)
+        _restore_runner_signal_handlers(previous_signal_handlers)
 
     elapsed = time.monotonic() - started
     print()
     pct = min(100, (tests_done / approx_total_tests * 100)) if approx_total_tests else 0
     print(f"=== Summary: {len(files)} files, {tests_passed} tests passed, {tests_failed} failed ({pct:.0f}% complete) in {elapsed:.1f}s ({args.jobs} workers) ===")
+    if interrupted_signal is not None:
+        print(
+            "=== Runner interrupted "
+            f"({_describe_nonzero_exit(128 + interrupted_signal)}); "
+            f"drained {files_done}/{len(files)} files before exit ==="
+        )
 
     # Save durations for future --slice runs. Each slice writes its own
     # partial test_durations.json; a CI merge step joins them later.
@@ -1001,7 +1078,12 @@ def main() -> int:
             print(f"=== {len(infrastructure_failures)} file{'s' if len(infrastructure_failures) != 1 else ''} with no completed pytest summary (collection/import error, timeout, interruption, or runner infrastructure failure) ===")
             for file, rc in infrastructure_failures:
                 print(f"  {_format_file(file, repo_root)}  ({_describe_nonzero_exit(rc)})")
+        if interrupted_signal is not None:
+            return 128 + interrupted_signal
         return 1
+
+    if interrupted_signal is not None:
+        return 128 + interrupted_signal
 
     return 0
 

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -21,6 +21,7 @@ POSIX-only: Windows has its own grandchild lifecycle (no shared session,
 from __future__ import annotations
 
 import json
+import importlib.util
 import os
 import subprocess
 import sys
@@ -36,6 +37,17 @@ import pytest
 # so concurrent invocations of the suite don't clobber each other.
 _HANDOFF_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "hermes-isolation-probe"
 _HANDOFF_DIR.mkdir(exist_ok=True)
+
+
+def _runner_module():
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+    spec = importlib.util.spec_from_file_location("run_tests_parallel_under_test", runner)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _handoff_path_for(nonce: str) -> Path:
@@ -223,6 +235,39 @@ def _run_runner(probe_dir: Path, *extra: str) -> subprocess.CompletedProcess:
         text=True,
         timeout=60,
     )
+
+
+def test_completed_full_suite_summary_counts_are_preserved() -> None:
+    runner = _runner_module()
+
+    summary = runner._parse_pytest_summary(
+        "9 failed, 8635 passed, 60 skipped, 260 warnings in 308.93s (0:05:08)"
+    )
+
+    assert summary["failed"] == 9
+    assert summary["passed"] == 8635
+    assert summary["skipped"] == 60
+
+
+def test_nonzero_exit_description_labels_signal_rc() -> None:
+    runner = _runner_module()
+
+    assert runner._describe_nonzero_exit(143) == "signal 15 (rc=143)"
+    assert runner._describe_nonzero_exit(124) == "timeout"
+
+
+def test_failure_buckets_keep_completed_summary_out_of_infrastructure() -> None:
+    runner = _runner_module()
+    file = Path("tests/gateway/test_full.py")
+    summary = {"failed": 9, "passed": 8635, "skipped": 60}
+
+    test_failures, completed_nonzero, infrastructure = runner._split_failure_records([
+        (file, 143, "summary output", summary)
+    ])
+
+    assert test_failures == [(file, 143, summary)]
+    assert completed_nonzero == []
+    assert infrastructure == []
 
 
 def test_bare_q_flag_passes_through(tmp_path: Path) -> None:

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import importlib.util
 import os
+import signal
 import subprocess
 import sys
 import textwrap
@@ -268,6 +269,70 @@ def test_failure_buckets_keep_completed_summary_out_of_infrastructure() -> None:
     assert test_failures == [(file, 143, summary)]
     assert completed_nonzero == []
     assert infrastructure == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal lifecycle probe")
+def test_runner_sigterm_drains_children_and_prints_summary(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+    probe_dir = tmp_path / "sigterm-probe"
+    probe_dir.mkdir()
+    started = tmp_path / "probe-started.txt"
+    probe = probe_dir / "test_sigterm_probe.py"
+    probe.write_text(textwrap.dedent(f"""
+        import os
+        import time
+        from pathlib import Path
+
+        STARTED = Path({str(started)!r})
+
+        def test_waits_for_runner_signal():
+            STARTED.write_text(str(os.getpid()))
+            time.sleep(600)
+    """).strip() + "\n")
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            str(runner),
+            "--paths",
+            str(probe_dir),
+            "-j",
+            "1",
+            "--file-timeout",
+            "300",
+        ],
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+
+    try:
+        deadline = time.monotonic() + 10.0
+        while not started.exists():
+            if proc.poll() is not None:
+                output = proc.stdout.read() if proc.stdout is not None else ""
+                pytest.fail(
+                    f"runner exited before probe started ({proc.returncode}):\n{output}"
+                )
+            if time.monotonic() > deadline:
+                output = proc.stdout.read() if proc.stdout is not None else ""
+                pytest.fail(f"probe did not start before timeout:\n{output}")
+            time.sleep(0.05)
+
+        os.kill(proc.pid, signal.SIGTERM)
+        output, _ = proc.communicate(timeout=20)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    assert proc.returncode == 143, output
+    assert "Runner interrupted (signal 15 (rc=143))" in output
+    assert "=== Summary:" in output
+    assert "Traceback" not in output
 
 
 def test_bare_q_flag_passes_through(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem
Fixes #60189. When the parallel runner sees a non-zero process exit such as rc=143, its final summary can blur together completed pytest summaries and infrastructure interruptions, making full-suite triage look worse than the actual pytest result.

## Solution
Keep the subprocess return code with each failure record, label signal-style exits explicitly, and split final reporting into test failures, completed pytest summaries with non-zero exits, and no-summary infrastructure failures.

## Impact
A completed pytest summary such as `9 failed, 8635 passed, 60 skipped ...` remains classified with its parsed counts instead of being treated as a no-summary harness artifact. This reduces rerun/triage waste without changing the runner's non-zero exit behavior.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /Users/holim/code/hermes-agent/.venv/bin/python -m pytest tests/test_run_tests_parallel.py -q`
- `scripts/run_tests.sh tests/test_run_tests_parallel.py -q`
- `/Users/holim/code/hermes-agent/.venv/bin/ruff check scripts/run_tests_parallel.py tests/test_run_tests_parallel.py`
- `git diff --check`
