### PR TITLE
Move TTS audio encoding off the event loop

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3663,6 +3663,19 @@ def _voice_list_error_logged_once(signature: Optional[str]) -> bool:
     return True
 
 
+def _read_unlink_and_encode_audio(file_path: str) -> str:
+    """Read a generated audio file, base64-encode it, then remove it."""
+    try:
+        with open(file_path, "rb") as fh:
+            audio_bytes = fh.read()
+    finally:
+        try:
+            os.unlink(file_path)
+        except OSError:
+            pass
+    return base64.b64encode(audio_bytes).decode("ascii")
+
+
 @app.get("/api/audio/elevenlabs/voices")
 async def get_elevenlabs_voices():
     """Return ElevenLabs voices when an API key is configured.
@@ -3777,17 +3790,15 @@ async def speak_text(payload: TTSSpeakRequest):
     }.get(ext, "audio/mpeg")
 
     try:
-        with open(file_path, "rb") as fh:
-            audio_bytes = fh.read()
+        loop = asyncio.get_running_loop()
+        encoded = await loop.run_in_executor(
+            None,
+            _read_unlink_and_encode_audio,
+            file_path,
+        )
     except OSError as exc:
         raise HTTPException(status_code=500, detail=f"Could not read audio: {exc}")
-    finally:
-        try:
-            os.unlink(file_path)
-        except OSError:
-            pass
 
-    encoded = base64.b64encode(audio_bytes).decode("ascii")
     return {
         "ok": True,
         "data_url": f"data:{mime_type};base64,{encoded}",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1561,6 +1561,18 @@ class TestWebServerEndpoints:
         # The handler streams the bytes back and removes the temp file.
         assert not audio_file.exists()
 
+    def test_read_unlink_and_encode_audio_removes_temp_file(self, tmp_path):
+        import base64
+        import hermes_cli.web_server as web_server
+
+        audio_file = tmp_path / "speech.mp3"
+        audio_file.write_bytes(b"ID3fake-audio-bytes")
+
+        encoded = web_server._read_unlink_and_encode_audio(str(audio_file))
+
+        assert encoded == base64.b64encode(b"ID3fake-audio-bytes").decode("ascii")
+        assert not audio_file.exists()
+
     def test_speak_text_requires_nonempty_text(self):
         resp = self.client.post("/api/audio/speak", json={"text": "   "})
         assert resp.status_code == 400


### PR DESCRIPTION
## Problem
The desktop `/api/audio/speak` endpoint already runs TTS synthesis in an executor, but then reads the generated audio file and base64-encodes it inline on the event loop before responding.

## Solution
Move the file read, base64 encoding, and temp-file cleanup into a small synchronous helper and run that helper through the existing executor path.

## Impact
The event loop no longer performs synchronous disk reads or base64 encoding for generated TTS audio. For larger voice replies, that removes a response-size-proportional blocking section from the web server loop.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /Users/holim/code/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -k 'desktop_audio_routes_registered or elevenlabs_voices_unavailable_without_key or speak_text' -q`
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k 'desktop_audio_routes_registered or elevenlabs_voices_unavailable_without_key or speak_text' -q`
- `/Users/holim/code/hermes-agent/.venv/bin/ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`
