### PR TITLE
Memoize desktop thread message grouping

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildGroups } from './list'
+
+describe('buildGroups', () => {
+  it('groups each user message with following assistant turns', () => {
+    const groups = buildGroups(
+      [
+        '0:u1:user:1',
+        '1:a1:assistant:2',
+        '2:t1:tool:3',
+        '3:u2:user:1',
+        '4:a2:assistant:4'
+      ].join('\n')
+    )
+
+    expect(groups).toEqual([
+      { id: 'u1', indices: [0, 1, 2], kind: 'turn', weight: 6 },
+      { id: 'u2', indices: [3, 4], kind: 'turn', weight: 5 }
+    ])
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState
 } from 'react'
@@ -53,7 +54,7 @@ interface ThreadMessageListProps {
 // Group each user message with the assistant turn(s) that follow it so the
 // human bubble can `position: sticky` against the scroller across its whole
 // turn (see StickyHumanMessageContainer in thread.tsx).
-function buildGroups(signature: string): MessageGroup[] {
+export function buildGroups(signature: string): MessageGroup[] {
   if (!signature) {
     return []
   }
@@ -103,7 +104,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   )
 
   const { t } = useI18n()
-  const groups = buildGroups(messageSignature)
+  const groups = useMemo(() => buildGroups(messageSignature), [messageSignature])
   const renderEmpty = groups.length === 0 && Boolean(emptyPlaceholder)
 
   // use-stick-to-bottom owns scrollTop (single writer): follow while locked,


### PR DESCRIPTION
## Problem
The desktop thread list rebuilds grouped turn metadata from `messageSignature` on every render. In long sessions, unrelated local state changes can repeatedly re-split and regroup the same signature.

## Solution
Memoize `buildGroups(messageSignature)` with `useMemo` and add a focused test for the grouping helper contract.

## Impact
Unchanged message signatures now reuse the previous grouping array across local re-renders, avoiding repeated O(message count) grouping work during thread UI updates.

## Validation
- `npm run test:ui --workspace apps/desktop -- src/components/assistant-ui/thread/list.test.ts`
- `npm run typecheck --workspace apps/desktop`
- `git diff --check`

Note: running unrelated existing `streaming.test.tsx` / `block-direction.test.tsx` in this fresh worktree hit pre-existing jsdom environment issues around `CSS.escape`/canvas; the new focused test and typecheck passed.
