### PR TITLE
Cache composer input history derivation

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -473,8 +473,8 @@ export function ChatBar({
     }
 
     // ArrowUp/ArrowDown navigate, in priority order: the queue (edit entries in
-    // place) then sent-message history. The history ring is derived from live
-    // session messages each press — single source of truth, no mirror.
+    // place) then sent-message history. The history ring is derived from cached
+    // live-message snapshots — single source of truth, no mirror.
     if (event.key === 'ArrowUp') {
       const currentDraft = draftRef.current
 

--- a/apps/desktop/src/store/composer-input-history.test.ts
+++ b/apps/desktop/src/store/composer-input-history.test.ts
@@ -27,6 +27,28 @@ describe('deriveUserHistory', () => {
 
     expect(deriveUserHistory(messages, m => m.text)).toEqual(['second', 'first'])
   })
+
+  it('reuses the derived ring for the same messages snapshot', () => {
+    const messages = [MSG('user', 'first'), MSG('assistant', 'hi'), MSG('user', 'second')]
+    let calls = 0
+    const getText = (m: (typeof messages)[number]) => {
+      calls += 1
+      return m.text
+    }
+
+    const first = deriveUserHistory(messages, getText)
+    const second = deriveUserHistory(messages, getText)
+
+    expect(second).toBe(first)
+    expect(calls).toBe(2)
+  })
+
+  it('recomputes when the caller provides a new messages snapshot', () => {
+    const getText = (m: ReturnType<typeof MSG>) => m.text
+
+    expect(deriveUserHistory([MSG('user', 'first')], getText)).toEqual(['first'])
+    expect(deriveUserHistory([MSG('user', 'first'), MSG('user', 'second')], getText)).toEqual(['second', 'first'])
+  })
 })
 
 describe('browseBackward', () => {

--- a/apps/desktop/src/store/composer-input-history.ts
+++ b/apps/desktop/src/store/composer-input-history.ts
@@ -3,10 +3,9 @@ import { atom } from 'nanostores'
 /**
  * Per-session input history browse state.
  *
- * The user-text ring is **derived from the live session messages** on each
- * keypress — it is not mirrored anywhere. This keeps a single source of truth
- * and avoids the entire class of seeding/dedup bugs that come from trying to
- * keep a parallel ring in sync with submit/queue/voice paths.
+ * The user-text ring is **derived from the live session messages** and cached
+ * per immutable messages snapshot. This keeps a single source of truth while
+ * avoiding repeated O(n) scans during ArrowUp/ArrowDown history browsing.
  *
  * We only persist the cursor and the saved draft:
  *   - `cursor` — index into the derived user-text ring (0 = newest, larger = older).
@@ -20,6 +19,10 @@ export interface SessionBrowseState {
 }
 
 const $perSessionBrowse = atom<Record<string, SessionBrowseState>>({})
+const userHistoryCache = new WeakMap<
+  readonly { role: string }[],
+  { getText: unknown; history: string[] }
+>()
 
 function ensure(sessionId: string): SessionBrowseState {
   const all = { ...$perSessionBrowse.get() }
@@ -50,6 +53,12 @@ export function deriveUserHistory<T extends { role: string }>(
   messages: readonly T[],
   getText: (m: T) => string
 ): string[] {
+  const cached = userHistoryCache.get(messages)
+
+  if (cached?.getText === getText) {
+    return cached.history
+  }
+
   const out: string[] = []
 
   for (let i = messages.length - 1; i >= 0; i--) {
@@ -65,6 +74,8 @@ export function deriveUserHistory<T extends { role: string }>(
       out.push(t)
     }
   }
+
+  userHistoryCache.set(messages, { getText, history: out })
 
   return out
 }


### PR DESCRIPTION
## Problem
Composer ArrowUp/ArrowDown history browsing derives the user-message ring by scanning live session messages on each keypress. In long sessions, repeated history navigation pays the same O(message count) scan repeatedly for the same messages snapshot.

## Solution
Cache derived user-history rings in a `WeakMap` keyed by the immutable messages snapshot and text extractor. Session cursor/draft state remains unchanged, and the live messages remain the single source of truth.

## Impact
Repeated history navigation over the same messages snapshot reuses the derived ring instead of rescanning messages. The regression test confirms the same snapshot calls the text extractor once per user message across repeated derivations.

## Validation
- `npm run test:ui --workspace apps/desktop -- src/store/composer-input-history.test.ts src/app/chat/composer/enter-submit-dom-race.test.tsx`
- `npm run typecheck --workspace apps/desktop`
- `git diff --check`
