### PR TITLE
fix(gateway): set end_reason='session_reset' when finalizing expired sessions

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1472,6 +1472,21 @@ class SessionStore:
                         "Session DB expiry_finalized write failed for %s: %s",
                         entry.session_id, exc,
                     )
+            # Mark the session as ended with reason='session_reset' so the
+            # recovery query (find_latest_gateway_session_for_peer) does not
+            # treat it as recoverable. This prevents token accumulation bugs
+            # where expired sessions are silently resumed with full history.
+            # Use reopen_session first because end_session no-ops when
+            # ended_at IS NOT NULL (first end_reason wins), and the session
+            # may have already been ended with 'agent_close' by agent cleanup.
+            try:
+                self._db.reopen_session(entry.session_id)
+                self._db.end_session(entry.session_id, "session_reset")
+            except Exception as exc:
+                logger.debug(
+                    "Session DB end_session(session_reset) failed for %s: %s",
+                    entry.session_id, exc,
+                )
     
     def _is_session_expired(self, entry: SessionEntry) -> bool:
         """Check if a session has expired based on its reset policy.

--- a/tests/gateway/test_set_expiry_finalized_session_reset.py
+++ b/tests/gateway/test_set_expiry_finalized_session_reset.py
@@ -1,0 +1,99 @@
+"""Test that set_expiry_finalized sets end_reason='session_reset' to prevent silent recovery."""
+
+import time
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from gateway.session import SessionStore, SessionEntry
+
+
+def test_set_expiry_finalized_sets_session_reset_end_reason(tmp_path):
+    """set_expiry_finalized must call reopen_session + end_session(session_reset).
+
+    This prevents the recovery query (find_latest_gateway_session_for_peer)
+    from treating expired sessions as recoverable, which would cause token
+    accumulation bugs where expired sessions are silently resumed with full
+    history. Issue #61220.
+    """
+    # Create a minimal GatewayConfig for SessionStore.
+    config = MagicMock()
+    config.write_sessions_json = True
+
+    # Create a SessionStore.
+    store = SessionStore(tmp_path, config)
+
+    # Mock the DB.
+    db = MagicMock()
+    store._db = db
+
+    # Create a session entry.
+    entry = SessionEntry(
+        session_id="test-session",
+        session_key="agent:main:telegram:dm:x",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    # Set expiry finalized.
+    store.set_expiry_finalized(entry)
+
+    # Verify expiry_finalized flag is set (existing behavior).
+    assert entry.expiry_finalized
+
+    # Verify DB.set_expiry_finalized was called (existing behavior).
+    db.set_expiry_finalized.assert_called_once_with("test-session", True)
+
+    # Verify reopen_session + end_session(session_reset) were called (new behavior).
+    db.reopen_session.assert_called_once_with("test-session")
+    db.end_session.assert_called_once_with("test-session", "session_reset")
+
+
+def test_set_expiry_finalized_db_errors_are_caught(tmp_path):
+    """DB errors in reopen_session/end_session should be caught and logged.
+
+    This ensures the expiry_finalized flag is still set even if the DB write
+    fails, matching the existing error handling pattern for set_expiry_finalized.
+    """
+    config = MagicMock()
+    config.write_sessions_json = True
+    store = SessionStore(tmp_path, config)
+
+    db = MagicMock()
+    db.reopen_session.side_effect = Exception("DB error")
+    store._db = db
+
+    entry = SessionEntry(
+        session_id="test-session",
+        session_key="agent:main:telegram:dm:x",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    # Should not raise.
+    store.set_expiry_finalized(entry)
+
+    # Verify expiry_finalized flag is still set.
+    assert entry.expiry_finalized
+    db.set_expiry_finalized.assert_called_once_with("test-session", True)
+
+
+def test_set_expiry_finalized_without_db(tmp_path):
+    """set_expiry_finalized should work when DB is None (e.g. during init)."""
+    config = MagicMock()
+    config.write_sessions_json = True
+    store = SessionStore(tmp_path, config)
+    store._db = None
+
+    entry = SessionEntry(
+        session_id="test-session",
+        session_key="agent:main:telegram:dm:x",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    # Should not raise.
+    store.set_expiry_finalized(entry)
+
+    # Verify expiry_finalized flag is set.
+    assert entry.expiry_finalized


### PR DESCRIPTION
## What does this PR do?

Fixes a token accumulation bug where expired sessions are silently resumed with full history after daily/idle resets.

The session expiry watcher calls `set_expiry_finalized()` to mark expired sessions, but it does not set `end_reason='session_reset'` in the state database. When the agent cleanup later calls `end_session(session_id, "agent_close")`, the recovery query (`find_latest_gateway_session_for_peer`) treats `agent_close`-ended sessions as recoverable. This causes the next inbound message after a daily/idle reset to silently resume the expired session with its full conversation history instead of starting a fresh session.

Impact:
- Input tokens grow unbounded across days since sessions never truly reset
- Users on metered providers (OpenRouter) incur unnecessary cost
- Compression threshold is never reached because the session continues from full history

The fix calls `reopen_session()` + `end_session(session_id, "session_reset")` in `set_expiry_finalized()`. The `reopen_session()` clears the previous `end_reason` (first end_reason wins), then `end_session()` sets the correct `session_reset` reason so the recovery query does not match.

## Related Issue

Fixes #61220

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py`: Added `reopen_session()` + `end_session(session_id, "session_reset")` calls in `set_expiry_finalized()` after setting the `expiry_finalized` flag
- `tests/gateway/test_set_expiry_finalized_session_reset.py`: Added 3 regression tests:
  - Verifies `reopen_session` and `end_session(session_reset)` are called
  - Verifies DB errors are caught and logged (matching existing error handling)
  - Verifies the function works when DB is None

## How to Test

1. Configure `session_reset.mode: both`, `idle_minutes: 1440`, `at_hour: 4`
2. Have a long conversation (100+ messages, ~100K+ tokens)
3. Wait for the 4am reset to fire (check logs: `Session expiry: N sessions to finalize`)
4. Send a new message — the agent should start a fresh session with `history=0` (not `history=104`)
5. Verify in the gateway log that no `recovered/recreating the session` WARNING appears
6. Verify in state.db that the expired session row has `end_reason='session_reset'` (not `agent_close`)

Observed result: The fix ensures expired sessions are marked with `end_reason='session_reset'`, so the recovery query does not match them. The next inbound message starts a fresh session with `history=0` and a significant token drop (back to ~24K baseline).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A