### PR TITLE
fix(desktop): re-apply UI zoom after minimize/restore on Windows

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4744,7 +4744,13 @@ function installPreviewShortcut(window) {
 // survives reloads/restarts) rather than a main-process JSON file. The main
 // process owns setZoomLevel, so we mirror each change into localStorage and
 // read it back on did-finish-load to re-apply after reloads or crash recovery.
-import { clampZoomLevel, percentToZoomLevel, ZOOM_STORAGE_KEY, zoomLevelToPercent } from './zoom'
+import {
+  clampZoomLevel,
+  installZoomReassertOnWindowEvents,
+  percentToZoomLevel,
+  ZOOM_STORAGE_KEY,
+  zoomLevelToPercent
+} from './zoom'
 
 function setAndPersistZoomLevel(window, zoomLevel) {
   if (!window || window.isDestroyed()) {
@@ -6512,6 +6518,8 @@ function wireCommonWindowHandlers(win) {
   installPreviewShortcut(win)
   installDevToolsShortcut(win)
   installZoomShortcuts(win)
+  installZoomReassertOnWindowEvents(win, () => restorePersistedZoomLevel(win))
+  win.webContents.once('did-finish-load', () => restorePersistedZoomLevel(win))
   installContextMenu(win)
   win.webContents.setWindowOpenHandler(details => {
     openExternalUrl(details.url)
@@ -6894,7 +6902,6 @@ function createWindow() {
   }
 
   mainWindow.webContents.once('did-finish-load', () => {
-    restorePersistedZoomLevel(mainWindow)
     broadcastBootProgress()
     sendWindowStateChanged()
     startHermes().catch(error => rememberLog(error.stack || error.message))

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -7,7 +7,14 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { clampZoomLevel, percentToZoomLevel, ZOOM_STORAGE_KEY, zoomLevelToPercent } from './zoom'
+import {
+  clampZoomLevel,
+  installZoomReassertOnWindowEvents,
+  percentToZoomLevel,
+  ZOOM_REASSERT_WINDOW_EVENTS,
+  ZOOM_STORAGE_KEY,
+  zoomLevelToPercent
+} from './zoom'
 
 test('storage key stays stable so persisted zoom survives upgrades', () => {
   assert.equal(ZOOM_STORAGE_KEY, 'hermes:desktop:zoomLevel')
@@ -52,4 +59,41 @@ test('conversion is monotonic across the preset range', () => {
 test('extreme percentages clamp to the level bounds', () => {
   assert.equal(percentToZoomLevel(1), -9)
   assert.equal(percentToZoomLevel(1_000_000), 9)
+})
+
+test('installZoomReassertOnWindowEvents wires show and restore', () => {
+  const handlers = new Map()
+  const win = {
+    isDestroyed: () => false,
+    on(event, listener) {
+      handlers.set(event, listener)
+    }
+  }
+  let calls = 0
+  installZoomReassertOnWindowEvents(win, () => {
+    calls += 1
+  })
+
+  assert.deepEqual([...handlers.keys()], [...ZOOM_REASSERT_WINDOW_EVENTS])
+  handlers.get('show')()
+  handlers.get('restore')()
+  assert.equal(calls, 2)
+})
+
+test('installZoomReassertOnWindowEvents skips destroyed windows', () => {
+  const handlers = new Map()
+  let destroyed = false
+  const win = {
+    isDestroyed: () => destroyed,
+    on(event, listener) {
+      handlers.set(event, listener)
+    }
+  }
+  let calls = 0
+  installZoomReassertOnWindowEvents(win, () => {
+    calls += 1
+  })
+  destroyed = true
+  handlers.get('show')()
+  assert.equal(calls, 0)
 })

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -31,3 +31,22 @@ export function percentToZoomLevel(percent) {
 
   return clampZoomLevel(Math.log(percent / 100) / Math.log(ZOOM_FACTOR_BASE))
 }
+
+// Chromium on Windows can drop webContents zoom when a BrowserWindow is minimized
+// and restored. Re-apply the persisted level on these lifecycle transitions.
+export const ZOOM_REASSERT_WINDOW_EVENTS = ['show', 'restore']
+
+export function installZoomReassertOnWindowEvents(win, reassert) {
+  if (!win?.on) {
+    return
+  }
+
+  for (const event of ZOOM_REASSERT_WINDOW_EVENTS) {
+    win.on(event, () => {
+      if (win.isDestroyed?.()) {
+        return
+      }
+      reassert()
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- Re-apply the persisted UI zoom level when a desktop window is shown or restored, fixing Windows minimize/restore snapping back to 100% while Settings still shows 125%/150%.
- Wire zoom restore through `wireCommonWindowHandlers` so secondary session windows get the same lifecycle coverage as the main window.

Fixes #61081

## Test plan
- [x] `npx tsx --test apps/desktop/electron/zoom.test.ts`
- [ ] Windows: set UI Scale to 125%, minimize, restore — scale should stay at 125%