### PR TITLE
Preserve global providers in desktop model pickers

### DIFF
--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -7,8 +7,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { Switch } from '@/components/ui/switch'
 import type { HermesGateway } from '@/hermes'
-import { getGlobalModelOptions } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { requestModelOptions } from '@/lib/model-options'
 import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import { normalize } from '@/lib/text'
 import {
@@ -43,16 +43,7 @@ export function ModelVisibilityDialog({
 
   const modelOptions = useQuery({
     queryKey: ['model-options', sessionId || 'global'],
-    queryFn: (): Promise<ModelOptionsResponse> => {
-      if (gw && sessionId) {
-        return gw.request<ModelOptionsResponse>('model.options', {
-          session_id: sessionId,
-          explicit_only: true
-        })
-      }
-
-      return getGlobalModelOptions()
-    },
+    queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway: gw, sessionId }),
     enabled: open
   })
 

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -24,18 +24,46 @@ describe('requestModelOptions', () => {
 
     await expect(requestModelOptions({ gateway: gateway as never, sessionId: null })).resolves.toBe(gatewayPayload)
 
-    expect(gateway.request).toHaveBeenCalledWith('model.options', {})
+    expect(gateway.request).toHaveBeenCalledWith('model.options', { explicit_only: true })
     expect(getGlobalModelOptions).not.toHaveBeenCalled()
   })
 
-  it('passes the active session id and refresh flag through the gateway', async () => {
+  it('merges the global gateway catalog into session-scoped results', async () => {
+    const gatewayGlobal = {
+      model: 'gpt-5.4',
+      provider: 'openai-codex',
+      providers: [
+        { models: ['gpt-5.4'], name: 'OpenAI Codex', slug: 'openai-codex' },
+        { models: ['MiniMax M3'], name: 'MiniMax', slug: 'minimax' }
+      ]
+    }
+    const gatewayScoped = {
+      model: 'gpt-5.4',
+      provider: 'openai-codex',
+      providers: [{ models: ['MiniMax M3'], name: 'MiniMax', slug: 'minimax' }]
+    }
     const gateway = {
-      request: vi.fn(() => Promise.resolve(globalOptions))
+      request: vi
+        .fn()
+        .mockResolvedValueOnce(gatewayGlobal)
+        .mockResolvedValueOnce(gatewayScoped)
     }
 
-    await requestModelOptions({ gateway: gateway as never, refresh: true, sessionId: 'session-1' })
+    await expect(requestModelOptions({ gateway: gateway as never, refresh: true, sessionId: 'session-1' })).resolves
+      .toEqual({
+        ...gatewayScoped,
+        providers: [
+          { models: ['gpt-5.4'], name: 'OpenAI Codex', slug: 'openai-codex' },
+          { models: ['MiniMax M3'], name: 'MiniMax', slug: 'minimax' }
+        ]
+      })
 
-    expect(gateway.request).toHaveBeenCalledWith('model.options', {
+    expect(gateway.request).toHaveBeenNthCalledWith(1, 'model.options', {
+      explicit_only: true,
+      refresh: true
+    })
+    expect(gateway.request).toHaveBeenNthCalledWith(2, 'model.options', {
+      explicit_only: true,
       refresh: true,
       session_id: 'session-1'
     })
@@ -44,6 +72,6 @@ describe('requestModelOptions', () => {
   it('falls back to REST when no gateway is connected', async () => {
     await requestModelOptions({ refresh: true })
 
-    expect(getGlobalModelOptions).toHaveBeenCalledWith({ refresh: true })
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true, refresh: true })
   })
 })

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -10,7 +10,34 @@ interface ModelOptionsRequest {
   sessionId?: null | string
 }
 
-export function requestModelOptions({
+type ProviderCatalog = NonNullable<ModelOptionsResponse['providers']>
+
+function mergeProviderCatalog(globalProviders: ProviderCatalog = [], scopedProviders: ProviderCatalog = []): ProviderCatalog {
+  const scopedBySlug = new Map(scopedProviders.map(provider => [provider.slug, provider]))
+  const merged = globalProviders.map(provider => scopedBySlug.get(provider.slug) ?? provider)
+  const seen = new Set(globalProviders.map(provider => provider.slug))
+
+  for (const provider of scopedProviders) {
+    if (!seen.has(provider.slug)) {
+      merged.push(provider)
+    }
+  }
+
+  return merged
+}
+
+export function mergeModelOptions(
+  globalOptions: ModelOptionsResponse,
+  scopedOptions: ModelOptionsResponse
+): ModelOptionsResponse {
+  return {
+    ...globalOptions,
+    ...scopedOptions,
+    providers: mergeProviderCatalog(globalOptions.providers, scopedOptions.providers)
+  }
+}
+
+export async function requestModelOptions({
   explicitOnly = true,
   gateway,
   refresh = false,
@@ -18,10 +45,6 @@ export function requestModelOptions({
 }: ModelOptionsRequest): Promise<ModelOptionsResponse> {
   if (gateway) {
     const params: Record<string, unknown> = {}
-
-    if (sessionId) {
-      params.session_id = sessionId
-    }
 
     if (refresh) {
       params.refresh = true
@@ -31,7 +54,19 @@ export function requestModelOptions({
       params.explicit_only = true
     }
 
-    return gateway.request<ModelOptionsResponse>('model.options', params)
+    if (!sessionId) {
+      return gateway.request<ModelOptionsResponse>('model.options', params)
+    }
+
+    const [globalOptions, scopedOptions] = await Promise.all([
+      gateway.request<ModelOptionsResponse>('model.options', params),
+      gateway.request<ModelOptionsResponse>('model.options', {
+        ...params,
+        session_id: sessionId
+      })
+    ])
+
+    return mergeModelOptions(globalOptions, scopedOptions)
   }
 
   return getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) })


### PR DESCRIPTION
## Summary
- merge session-scoped `model.options` responses with the global gateway catalog instead of treating the scoped payload as authoritative
- preserve providers that disappear from scoped responses so configured providers such as `openai-codex` stay visible after the first message and after a model refresh
- route the model-visibility dialog through the shared helper so every desktop picker surface uses the same merged catalog behavior

## Root Cause
The desktop switches from the global catalog to a session-scoped `model.options` call after a session starts. When that scoped payload omits a configured provider, the picker drops it entirely even though it is still present in the global catalog.

## Validation
Validated locally before publishing this branch:
- `npm --workspace apps/desktop run test:ui -- src/lib/model-options.test.ts src/app/shell/model-menu-panel.test.tsx`
- `npm --workspace apps/desktop run typecheck`
