### PR TITLE
feat(telemetry): export gateway health diagnostics

### DIFF
--- a/agent/telemetry/__init__.py
+++ b/agent/telemetry/__init__.py
@@ -14,7 +14,7 @@ constants and the aggregate upload gate (no uploader ships).
 
 from __future__ import annotations
 
-from . import emitter, events, metrics, policy, spans
+from . import emitter, events, gateway_health, gateway_health_export, metrics, policy, spans
 
 emit = emitter.emit
 get_emitter = emitter.get_emitter
@@ -22,6 +22,8 @@ get_emitter = emitter.get_emitter
 __all__ = [
     "emitter",
     "events",
+    "gateway_health",
+    "gateway_health_export",
     "metrics",
     "policy",
     "spans",

--- a/agent/telemetry/events.py
+++ b/agent/telemetry/events.py
@@ -102,10 +102,59 @@ class ErrorEvent:
         return {"event": "error", **asdict(self)}
 
 
+@dataclass(slots=True)
+class GatewayHealthEvent:
+    """Content-free gateway health snapshot or lifecycle event."""
+
+    name: str
+    gateway_state: Optional[str] = None
+    old_state: Optional[str] = None
+    new_state: Optional[str] = None
+    exit_reason: Optional[str] = None
+    restart_requested: Optional[bool] = None
+    active_agents: int = 0
+    gateway_busy: bool = False
+    gateway_drainable: bool = False
+    platform_count: int = 0
+    fatal_platform_count: int = 0
+    profile: Optional[str] = None
+    install_id: Optional[str] = None
+    version: Optional[str] = None
+    supervision_mode: Optional[str] = None
+    pid: Optional[int] = None
+    ts_ns: int = field(default_factory=_now_ns)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"event": "gateway_health", **asdict(self)}
+
+
+@dataclass(slots=True)
+class GatewayDiagnosticEvent:
+    """Redacted gateway diagnostic event for customer-owned operations."""
+
+    name: str
+    subsystem: str
+    error_class: str = "unknown"
+    error_code: Optional[str] = None
+    redacted_message: Optional[str] = None
+    platform: Optional[str] = None
+    old_state: Optional[str] = None
+    new_state: Optional[str] = None
+    profile: Optional[str] = None
+    version: Optional[str] = None
+    severity: str = "warning"
+    ts_ns: int = field(default_factory=_now_ns)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"event": "gateway_diagnostic", **asdict(self)}
+
+
 __all__ = [
     "RunEvent",
     "ModelCallEvent",
     "ToolCallEvent",
     "SpanEvent",
     "ErrorEvent",
+    "GatewayHealthEvent",
+    "GatewayDiagnosticEvent",
 ]

--- a/agent/telemetry/gateway_health.py
+++ b/agent/telemetry/gateway_health.py
@@ -1,0 +1,388 @@
+"""Gateway health and diagnostics signal producer.
+
+This module keeps the plane narrow: service health monitoring plus
+redacted operational diagnostics. It reuses the existing gateway runtime-status
+contract and emits content-free metrics/events. No prompts, messages, tool args,
+session history, audit records, or product analytics belong here.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from agent.telemetry.events import GatewayDiagnosticEvent, GatewayHealthEvent
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayMetric:
+    name: str
+    value: int | float
+    attributes: Dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayHealthSnapshot:
+    metrics: List[GatewayMetric]
+    events: List[GatewayHealthEvent | GatewayDiagnosticEvent]
+
+
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+_BEARER_RE = re.compile(r"\bBearer\s+[A-Za-z0-9._~+\-/]+=*", re.IGNORECASE)
+_TOKEN_RE = re.compile(r"\b(xox[baprs]-[A-Za-z0-9-]+|sk-[A-Za-z0-9_-]{8,}|gh[pousr]_[A-Za-z0-9_]{8,})\b")
+_SECRET_LITERAL_RE = re.compile(r"\*{3,}")
+_PHONE_RE = re.compile(r"(?<!\w)(?:\+?\d{1,3}[\s.\-]?)?(?:\(\d{2,4}\)[\s.\-]?)?\d{3}[\s.\-]?\d{3,4}(?:[\s.\-]?\d{2,4})?(?!\w)")
+
+_RUNNING_PLATFORM_STATES = {"running", "connected", "ok", "ready"}
+_FATAL_PLATFORM_STATES = {"fatal", "degraded", "error", "failed"}
+
+
+def _allowed_logger(name: str) -> bool:
+    return name == "gateway" or name.startswith("gateway.")
+
+
+def redact_gateway_message(message: Any) -> str:
+    """Redact gateway diagnostic free text for customer-owned export."""
+    text = str(message or "")
+    try:
+        from agent.telemetry.redaction import redact_for_export
+        redacted = redact_for_export(text, content_mode="pii") or ""
+    except Exception:
+        redacted = "[redaction-unavailable]"
+    redacted = _BEARER_RE.sub("[redacted]", redacted)
+    redacted = _TOKEN_RE.sub("[redacted]", redacted)
+    redacted = _SECRET_LITERAL_RE.sub("[redacted]", redacted)
+    redacted = re.sub(r"\bBearer\s+\[[^\]]+\]", "[redacted]", redacted, flags=re.IGNORECASE)
+    redacted = _EMAIL_RE.sub("[email]", redacted)
+    redacted = _PHONE_RE.sub("[phone]", redacted)
+    return redacted[:500]
+
+
+def classify_gateway_error(raw: Any) -> str:
+    s = str(raw or "").lower()
+    if any(k in s for k in ("auth", "token", "unauthorized", "forbidden", "401", "403")):
+        return "auth_failed"
+    if "rate" in s and "limit" in s:
+        return "rate_limited"
+    if "timeout" in s or "timed out" in s:
+        return "timeout"
+    if any(k in s for k in ("network", "connection", "dns", "socket")):
+        return "network_error"
+    if any(k in s for k in ("config", "missing", "invalid")):
+        return "invalid_config"
+    if "startup" in s:
+        return "startup_failed"
+    if "fatal" in s:
+        return "platform_fatal"
+    return "unknown"
+
+
+def subsystem_for_logger(logger_name: str) -> str:
+    if logger_name.startswith("gateway.platforms."):
+        parts = logger_name.split(".")
+        if len(parts) >= 3 and parts[2]:
+            return f"platform.{parts[2]}"
+    if logger_name.startswith("gateway.platforms"):
+        return "platform"
+    if logger_name.startswith("gateway"):
+        return "gateway"
+    return "gateway"
+
+
+def platform_for_subsystem(subsystem: str) -> Optional[str]:
+    if subsystem.startswith("platform."):
+        return subsystem.split(".", 1)[1] or None
+    return None
+
+
+def _parse_active_agents(raw: Any) -> int:
+    try:
+        from gateway.status import parse_active_agents
+        return parse_active_agents(raw)
+    except Exception:
+        try:
+            return max(0, int(raw))
+        except (TypeError, ValueError):
+            return 0
+
+
+def _derive_busy(gateway_running: bool, gateway_state: Any, active_agents: Any) -> bool:
+    try:
+        from gateway.status import derive_gateway_busy
+        return derive_gateway_busy(
+            gateway_running=gateway_running,
+            gateway_state=gateway_state,
+            active_agents=active_agents,
+        )
+    except Exception:
+        return bool(gateway_running and gateway_state == "running" and _parse_active_agents(active_agents) > 0)
+
+
+def _derive_drainable(gateway_running: bool, gateway_state: Any) -> bool:
+    try:
+        from gateway.status import derive_gateway_drainable
+        return derive_gateway_drainable(gateway_running=gateway_running, gateway_state=gateway_state)
+    except Exception:
+        return bool(gateway_running and gateway_state == "running")
+
+
+def _base_attrs(*, profile: str, install_id: str, version: str, supervision_mode: str) -> Dict[str, str]:
+    return {
+        "hermes.profile": str(profile),
+        "service.instance.id": str(install_id),
+        "service.version": str(version),
+        "hermes.supervision_mode": str(supervision_mode),
+    }
+
+
+def _metric(name: str, value: int | float, attrs: Dict[str, str], **extra: str) -> GatewayMetric:
+    out = dict(attrs)
+    for key, val in extra.items():
+        if val is not None:
+            out[key] = str(val)
+    return GatewayMetric(name=name, value=value, attributes=out)
+
+
+def build_gateway_health_snapshot(
+    runtime: Optional[dict[str, Any]],
+    *,
+    gateway_running: bool,
+    profile: str,
+    install_id: str,
+    version: str,
+    supervision_mode: str = "unknown",
+) -> GatewayHealthSnapshot:
+    """Convert gateway_state.json-compatible runtime state into P0 signals."""
+    runtime = runtime or {}
+    gateway_state = runtime.get("gateway_state")
+    active_agents = _parse_active_agents(runtime.get("active_agents", 0))
+    busy = _derive_busy(gateway_running, gateway_state, active_agents)
+    drainable = _derive_drainable(gateway_running, gateway_state)
+    platforms = runtime.get("platforms") if isinstance(runtime.get("platforms"), dict) else {}
+    base = _base_attrs(profile=profile, install_id=install_id, version=version, supervision_mode=supervision_mode)
+
+    metrics: list[GatewayMetric] = [
+        _metric("hermes.gateway.up", 1 if gateway_running else 0, base),
+        _metric("hermes.gateway.active_agents", active_agents, base),
+        _metric("hermes.gateway.busy", 1 if busy else 0, base),
+        _metric("hermes.gateway.drainable", 1 if drainable else 0, base),
+        _metric("hermes.gateway.restart_requested", 1 if runtime.get("restart_requested") else 0, base),
+    ]
+    if gateway_state:
+        metrics.append(_metric("hermes.gateway.state", 1, base, **{"hermes.gateway.state": str(gateway_state)}))
+
+    fatal_count = 0
+    events: list[GatewayHealthEvent | GatewayDiagnosticEvent] = []
+    for platform, pdata in platforms.items():
+        pdata = pdata if isinstance(pdata, dict) else {}
+        state = str(pdata.get("state") or "unknown").lower()
+        raw_error = pdata.get("error_code") or pdata.get("error_message")
+        error_code = classify_gateway_error(raw_error)
+        is_up = state in _RUNNING_PLATFORM_STATES
+        is_degraded = state in _FATAL_PLATFORM_STATES
+        if is_degraded:
+            fatal_count += 1
+        metrics.append(_metric(
+            "hermes.platform.up",
+            1 if is_up else 0,
+            base,
+            **{"hermes.platform": str(platform), "hermes.platform.state": state},
+        ))
+        metrics.append(_metric(
+            "hermes.platform.degraded",
+            1 if is_degraded else 0,
+            base,
+            **{"hermes.platform": str(platform), "hermes.platform.state": state, "hermes.error_code": error_code},
+        ))
+        if is_degraded:
+            events.append(GatewayDiagnosticEvent(
+                name="platform.fatal",
+                subsystem=f"platform.{platform}",
+                platform=str(platform),
+                error_code=error_code,
+                error_class=classify_gateway_error(error_code or pdata.get("error_message")),
+                redacted_message=redact_gateway_message(pdata.get("error_message")),
+                profile=profile,
+                version=version,
+                severity="error" if state == "fatal" else "warning",
+            ))
+
+    events.insert(0, GatewayHealthEvent(
+        name="gateway.health_snapshot",
+        gateway_state=str(gateway_state) if gateway_state is not None else None,
+        active_agents=active_agents,
+        gateway_busy=busy,
+        gateway_drainable=drainable,
+        platform_count=len(platforms),
+        fatal_platform_count=fatal_count,
+        profile=profile,
+        install_id=install_id,
+        version=version,
+        supervision_mode=supervision_mode,
+        pid=_coerce_pid(runtime.get("pid")),
+    ))
+    return GatewayHealthSnapshot(metrics=metrics, events=events)
+
+
+def _safe_profile() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        return str(get_active_profile_name() or "default")
+    except Exception:
+        return "default"
+
+
+def _safe_version() -> str:
+    try:
+        from hermes_cli import __version__
+        return str(__version__)
+    except Exception:
+        return "unknown"
+
+
+def emit_runtime_status_transition(previous: Optional[dict[str, Any]], current: dict[str, Any]) -> None:
+    """Emit immediate content-free gateway events for runtime status changes.
+
+    Called by gateway.status.write_runtime_status after persisting the new status.
+    Fully fail-open: failures never affect gateway status writes.
+    """
+    try:
+        from agent.telemetry import emitter
+        out: list[GatewayHealthEvent | GatewayDiagnosticEvent] = []
+        profile = _safe_profile()
+        version = _safe_version()
+        old_gateway_state = str((previous or {}).get("gateway_state")) if (previous or {}).get("gateway_state") is not None else None
+        new_gateway_state = str(current.get("gateway_state")) if current.get("gateway_state") is not None else None
+        if old_gateway_state != new_gateway_state and new_gateway_state:
+            out.append(GatewayHealthEvent(
+                name="gateway.lifecycle",
+                gateway_state=new_gateway_state,
+                old_state=old_gateway_state,
+                new_state=new_gateway_state,
+                exit_reason=current.get("exit_reason"),
+                restart_requested=bool(current.get("restart_requested")),
+                active_agents=_parse_active_agents(current.get("active_agents", 0)),
+                profile=profile,
+                version=version,
+                pid=_coerce_pid(current.get("pid")),
+            ))
+            if new_gateway_state == "startup_failed":
+                out.append(GatewayDiagnosticEvent(
+                    name="gateway.startup_failed",
+                    subsystem="gateway",
+                    error_class=classify_gateway_error(current.get("exit_reason") or "startup_failed"),
+                    error_code=classify_gateway_error(current.get("exit_reason") or "startup_failed"),
+                    redacted_message=redact_gateway_message(current.get("exit_reason") or "startup failed"),
+                    profile=profile,
+                    version=version,
+                    severity="error",
+                ))
+            if new_gateway_state == "stopped":
+                out.append(GatewayHealthEvent(
+                    name="gateway.exit",
+                    gateway_state=new_gateway_state,
+                    old_state=old_gateway_state,
+                    new_state=new_gateway_state,
+                    exit_reason=current.get("exit_reason"),
+                    restart_requested=bool(current.get("restart_requested")),
+                    active_agents=_parse_active_agents(current.get("active_agents", 0)),
+                    profile=profile,
+                    version=version,
+                    pid=_coerce_pid(current.get("pid")),
+                ))
+
+        old_platforms_raw = (previous or {}).get("platforms")
+        new_platforms_raw = current.get("platforms")
+        old_platforms = old_platforms_raw if isinstance(old_platforms_raw, dict) else {}
+        new_platforms = new_platforms_raw if isinstance(new_platforms_raw, dict) else {}
+        for platform, pdata in new_platforms.items():
+            pdata = pdata if isinstance(pdata, dict) else {}
+            prev_raw = old_platforms.get(platform, {})
+            prev = prev_raw if isinstance(prev_raw, dict) else {}
+            old_state = str(prev.get("state")) if prev.get("state") is not None else None
+            new_state = str(pdata.get("state")) if pdata.get("state") is not None else None
+            if old_state == new_state or not new_state:
+                continue
+            error_code = classify_gateway_error(pdata.get("error_code") or pdata.get("error_message"))
+            severity = "error" if new_state.lower() in {"fatal", "failed", "error"} else "warning"
+            out.append(GatewayDiagnosticEvent(
+                name="platform.state_change",
+                subsystem=f"platform.{platform}",
+                platform=str(platform),
+                old_state=old_state,
+                new_state=new_state,
+                error_code=error_code,
+                error_class=error_code,
+                redacted_message=redact_gateway_message(pdata.get("error_message")),
+                profile=profile,
+                version=version,
+                severity=severity,
+            ))
+            if new_state.lower() in _FATAL_PLATFORM_STATES:
+                out.append(GatewayDiagnosticEvent(
+                    name="platform.fatal",
+                    subsystem=f"platform.{platform}",
+                    platform=str(platform),
+                    error_code=error_code,
+                    error_class=error_code,
+                    redacted_message=redact_gateway_message(pdata.get("error_message")),
+                    profile=profile,
+                    version=version,
+                    severity=severity,
+                ))
+        for ev in out:
+            emitter.emit(ev)
+    except Exception:
+        logging.getLogger(__name__).debug("gateway runtime status transition emit failed", exc_info=True)
+
+
+def _coerce_pid(raw: Any) -> Optional[int]:
+    try:
+        pid = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
+
+class GatewayDiagnosticLogHandler(logging.Handler):
+    """Allowlisted warning/error bridge for gateway-owned diagnostics."""
+
+    def __init__(self, *, profile: str = "default", version: str = "unknown") -> None:
+        super().__init__(level=logging.WARNING)
+        self.profile = profile
+        self.version = version
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            if record.levelno < logging.WARNING:
+                return
+            if not _allowed_logger(record.name):
+                return
+            subsystem = subsystem_for_logger(record.name)
+            message = record.getMessage()
+            event = GatewayDiagnosticEvent(
+                name=f"gateway.log.{record.levelname.lower()}",
+                subsystem=subsystem,
+                platform=platform_for_subsystem(subsystem),
+                error_class=classify_gateway_error(message),
+                redacted_message=redact_gateway_message(message),
+                profile=self.profile,
+                version=self.version,
+                severity=record.levelname.lower(),
+            )
+            from agent.telemetry import emitter
+            emitter.get_emitter().emit(event)
+        except Exception:
+            logging.getLogger(__name__).debug("gateway diagnostic emit failed", exc_info=True)
+
+
+__all__ = [
+    "GatewayMetric",
+    "GatewayHealthSnapshot",
+    "GatewayDiagnosticLogHandler",
+    "build_gateway_health_snapshot",
+    "classify_gateway_error",
+    "redact_gateway_message",
+]

--- a/agent/telemetry/gateway_health_export.py
+++ b/agent/telemetry/gateway_health_export.py
@@ -1,0 +1,405 @@
+"""Gateway Health & Diagnostics OTLP export runtime.
+
+This exporter emits operator-owned gateway service-health metrics plus
+narrow redacted diagnostic events. It is deliberately in-process and fail-open so
+it works under systemd, launchd, s6, containers, tmux, nohup, or a simple shell
+without a sidecar/watchdog dependency.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class GatewayHealthExportRuntime:
+    enabled: bool
+    reason: str = "disabled"
+    streamer: Any = None
+    metric_provider: Any = None
+    log_handler: Any = None
+    log_streamer: Any = None
+    thread: Optional[threading.Thread] = None
+    stop_event: Optional[threading.Event] = None
+
+    def shutdown(self) -> None:
+        if self.stop_event is not None:
+            self.stop_event.set()
+        if self.thread is not None:
+            self.thread.join(timeout=2.0)
+        if self.log_handler is not None:
+            try:
+                logging.getLogger().removeHandler(self.log_handler)
+            except Exception:
+                pass
+        if self.streamer is not None:
+            try:
+                self.streamer.shutdown()
+            except Exception:
+                pass
+        if self.log_streamer is not None:
+            try:
+                self.log_streamer.shutdown()
+            except Exception:
+                pass
+        if self.metric_provider is not None:
+            try:
+                self.metric_provider.shutdown()
+            except Exception:
+                pass
+
+
+def _gateway_health_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    tel = (config or {}).get("telemetry") or {}
+    return tel.get("gateway_health_export") or {}
+
+
+def _otlp_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    tel = (config or {}).get("telemetry") or {}
+    export = tel.get("export") or {}
+    return export.get("otlp") or {}
+
+
+def _enabled(config: Dict[str, Any]) -> bool:
+    gh = _gateway_health_config(config)
+    otlp = _otlp_config(config)
+    return bool(gh.get("enabled") and otlp.get("enabled") and otlp.get("endpoint"))
+
+
+def _require_metrics_sdk(*, auto_install: bool = True, prompt: bool = False) -> Dict[str, Any]:
+    if auto_install:
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            _lazy_ensure("export.otlp", prompt=prompt)
+        except Exception:
+            pass
+    try:
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+        from opentelemetry.metrics import Observation
+        from opentelemetry.trace import INVALID_SPAN_ID, INVALID_TRACE_ID, TraceFlags
+        from opentelemetry._logs import LogRecord
+        from opentelemetry._logs.severity import SeverityNumber
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+        return {
+            "OTLPLogExporter": OTLPLogExporter,
+            "OTLPMetricExporter": OTLPMetricExporter,
+            "Observation": Observation,
+            "LogRecord": LogRecord,
+            "LoggerProvider": LoggerProvider,
+            "INVALID_SPAN_ID": INVALID_SPAN_ID,
+            "INVALID_TRACE_ID": INVALID_TRACE_ID,
+            "TraceFlags": TraceFlags,
+            "SeverityNumber": SeverityNumber,
+            "BatchLogRecordProcessor": BatchLogRecordProcessor,
+            "MeterProvider": MeterProvider,
+            "PeriodicExportingMetricReader": PeriodicExportingMetricReader,
+            "Resource": Resource,
+        }
+    except Exception as exc:
+        raise RuntimeError(f"OTLP metrics SDK unavailable: {exc}") from exc
+
+
+def _resolve_headers(headers_env: Optional[Dict[str, str]]) -> Dict[str, str]:
+    resolved: Dict[str, str] = {}
+    for header_name, env_name in (headers_env or {}).items():
+        val = os.environ.get(str(env_name))
+        if val:
+            resolved[str(header_name)] = val
+    return resolved
+
+
+def _metric_endpoint(endpoint: str) -> str:
+    if endpoint.endswith("/v1/traces"):
+        return endpoint[: -len("/v1/traces")] + "/v1/metrics"
+    return endpoint
+
+
+def _logs_endpoint(endpoint: str) -> str:
+    if endpoint.endswith("/v1/traces"):
+        return endpoint[: -len("/v1/traces")] + "/v1/logs"
+    if endpoint.endswith("/v1/metrics"):
+        return endpoint[: -len("/v1/metrics")] + "/v1/logs"
+    return endpoint
+
+
+def _version() -> str:
+    try:
+        from hermes_cli import __version__
+        return str(__version__)
+    except Exception:
+        return "unknown"
+
+
+def _profile() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        return str(get_active_profile_name() or "default")
+    except Exception:
+        return "default"
+
+
+def _install_id(config: Dict[str, Any]) -> str:
+    try:
+        from agent.telemetry.policy import ensure_install_id
+        return str(ensure_install_id(config))
+    except Exception:
+        return "unknown"
+
+
+def _supervision_mode() -> str:
+    if os.environ.get("INVOCATION_ID"):
+        return "systemd"
+    if os.environ.get("S6_CMD_ARG0") or os.environ.get("S6_VERSION"):
+        return "s6"
+    if os.environ.get("container") or os.path.exists("/.dockerenv"):
+        return "container"
+    if os.environ.get("LAUNCHD_SOCKET"):
+        return "launchd"
+    return "manual"
+
+
+def _read_runtime_snapshot(config: Dict[str, Any]):
+    from agent.telemetry.gateway_health import build_gateway_health_snapshot
+    try:
+        from gateway.status import read_runtime_status
+        runtime = read_runtime_status() or {}
+    except Exception:
+        runtime = {}
+    return build_gateway_health_snapshot(
+        runtime,
+        gateway_running=True,
+        profile=_profile(),
+        install_id=_install_id(config),
+        version=_version(),
+        supervision_mode=_supervision_mode(),
+    )
+
+
+def _emit_snapshot_events(config: Dict[str, Any]) -> None:
+    gh = _gateway_health_config(config)
+    if not gh.get("diagnostic_events_enabled", True):
+        return
+    try:
+        from agent.telemetry import emitter
+        snapshot = _read_runtime_snapshot(config)
+        for event in snapshot.events:
+            emitter.emit(event)
+    except Exception:
+        logger.debug("gateway health snapshot emit failed", exc_info=True)
+
+
+def _start_metric_provider(config: Dict[str, Any], sdk: Dict[str, Any]) -> Any:
+    gh = _gateway_health_config(config)
+    if not gh.get("metrics_enabled", True):
+        return None
+    otlp = _otlp_config(config)
+    endpoint = _metric_endpoint(str(otlp.get("endpoint")))
+    headers = _resolve_headers(otlp.get("headers_env"))
+    exporter = sdk["OTLPMetricExporter"](endpoint=endpoint, headers=headers or None)
+    interval_ms = max(5, int(gh.get("export_interval_seconds", 60))) * 1000
+    reader = sdk["PeriodicExportingMetricReader"](exporter, export_interval_millis=interval_ms)
+    resource_attrs = dict((gh.get("resource_attributes") or {}))
+    resource_attrs.setdefault("service.name", "hermes-gateway")
+    resource_attrs.setdefault("telemetry.scope", "gateway_health")
+    provider = sdk["MeterProvider"](
+        metric_readers=[reader],
+        resource=sdk["Resource"].create(resource_attrs),
+    )
+    meter = provider.get_meter("hermes.gateway.health")
+    Observation = sdk["Observation"]
+
+    metric_names = [
+        "hermes.gateway.up",
+        "hermes.gateway.state",
+        "hermes.gateway.active_agents",
+        "hermes.gateway.busy",
+        "hermes.gateway.drainable",
+        "hermes.gateway.restart_requested",
+        "hermes.platform.up",
+        "hermes.platform.degraded",
+    ]
+
+    def callback(name: str):
+        def _cb(_options=None):
+            try:
+                snapshot = _read_runtime_snapshot(config)
+                return [Observation(m.value, m.attributes) for m in snapshot.metrics if m.name == name]
+            except Exception:
+                logger.debug("gateway metric callback failed", exc_info=True)
+                return []
+        return _cb
+
+    for metric_name in metric_names:
+        meter.create_observable_gauge(metric_name, callbacks=[callback(metric_name)])
+    return provider
+
+
+def _severity_number(sdk: Dict[str, Any], severity: Any) -> Any:
+    SeverityNumber = sdk["SeverityNumber"]
+    sev = str(severity or "warning").lower()
+    if sev in {"critical", "fatal"}:
+        return SeverityNumber.FATAL
+    if sev == "error":
+        return SeverityNumber.ERROR
+    if sev in {"info", "information"}:
+        return SeverityNumber.INFO
+    if sev == "debug":
+        return SeverityNumber.DEBUG
+    return SeverityNumber.WARN
+
+
+class GatewayDiagnosticLogStreamer:
+    """Emitter subscriber that sends gateway diagnostic events as OTLP logs."""
+
+    def __init__(self, config: Dict[str, Any], sdk: Dict[str, Any]):
+        otlp = _otlp_config(config)
+        gh = _gateway_health_config(config)
+        headers = _resolve_headers(otlp.get("headers_env"))
+        endpoint = _logs_endpoint(str(otlp.get("endpoint")))
+        resource_attrs = dict((gh.get("resource_attributes") or {}))
+        resource_attrs.setdefault("service.name", "hermes-gateway")
+        resource_attrs.setdefault("telemetry.scope", "gateway_diagnostics")
+        self._provider = sdk["LoggerProvider"](resource=sdk["Resource"].create(resource_attrs))
+        self._processor = sdk["BatchLogRecordProcessor"](
+            sdk["OTLPLogExporter"](endpoint=endpoint, headers=headers or None)
+        )
+        self._provider.add_log_record_processor(self._processor)
+        self._logger = self._provider.get_logger("hermes.gateway.diagnostics")
+        self._LogRecord = sdk["LogRecord"]
+        self._sdk = sdk
+        self.exported = 0
+
+    def __call__(self, batch: list[Dict[str, Any]]) -> None:
+        for ev in batch:
+            if ev.get("event") != "gateway_diagnostic":
+                continue
+            attrs = {
+                f"hermes.{key}": val
+                for key, val in ev.items()
+                if key not in {"event", "redacted_message", "ts_ns"} and val is not None
+            }
+            body = ev.get("redacted_message") or ev.get("name") or "gateway diagnostic"
+            record = self._LogRecord(
+                timestamp=ev.get("ts_ns"),
+                trace_id=self._sdk["INVALID_TRACE_ID"],
+                span_id=self._sdk["INVALID_SPAN_ID"],
+                trace_flags=self._sdk["TraceFlags"].DEFAULT,
+                severity_text=str(ev.get("severity") or "warning").upper(),
+                severity_number=_severity_number(self._sdk, ev.get("severity")),
+                body=str(body),
+                attributes=attrs,
+            )
+            self._logger.emit(record)
+            self.exported += 1
+
+    def shutdown(self) -> None:
+        try:
+            from agent.telemetry.emitter import get_emitter
+            get_emitter().unsubscribe(self)
+        except Exception:
+            pass
+        try:
+            self._processor.force_flush()
+            self._provider.shutdown()
+        except Exception:
+            pass
+
+
+def _start_diagnostic_log_streamer(config: Dict[str, Any], sdk: Dict[str, Any]) -> GatewayDiagnosticLogStreamer:
+    from agent.telemetry.emitter import get_emitter
+    streamer = GatewayDiagnosticLogStreamer(config, sdk)
+    get_emitter().subscribe(streamer)
+    return streamer
+
+
+def _start_snapshot_thread(config: Dict[str, Any], stop_event: threading.Event) -> threading.Thread:
+    interval = max(5, int(_gateway_health_config(config).get("logs_export_interval_seconds", 5)))
+
+    def _run() -> None:
+        while not stop_event.wait(interval):
+            _emit_snapshot_events(config)
+
+    thread = threading.Thread(target=_run, name="hermes-gateway-health-export", daemon=True)
+    thread.start()
+    return thread
+
+
+def _attach_log_handler(config: Dict[str, Any]) -> Any:
+    gh = _gateway_health_config(config)
+    if not gh.get("warning_error_events_enabled", True):
+        return None
+    from agent.telemetry.gateway_health import GatewayDiagnosticLogHandler
+    handler = GatewayDiagnosticLogHandler(profile=_profile(), version=_version())
+    root = logging.getLogger()
+    if handler not in root.handlers:
+        root.addHandler(handler)
+    return handler
+
+
+def _gateway_health_event(ev: Dict[str, Any]) -> bool:
+    return ev.get("event") == "gateway_health"
+
+
+def start_gateway_health_export(config: Dict[str, Any]) -> GatewayHealthExportRuntime:
+    """Start P0 gateway health export if configured. Never raises."""
+    if not _enabled(config):
+        return GatewayHealthExportRuntime(enabled=False, reason="disabled")
+    gh = _gateway_health_config(config)
+    runtime = GatewayHealthExportRuntime(enabled=True, reason="enabled")
+    sdk: Optional[Dict[str, Any]] = None
+
+    if gh.get("metrics_enabled", True) or gh.get("diagnostic_events_enabled", True):
+        try:
+            sdk = _require_metrics_sdk(prompt=False)
+        except Exception:
+            logger.warning(
+                "telemetry.gateway_health_export.enabled but OTLP SDK is unavailable; "
+                "install 'hermes-agent[otlp]'",
+                exc_info=True,
+            )
+            return GatewayHealthExportRuntime(enabled=False, reason="otlp_unavailable")
+
+    if gh.get("metrics_enabled", True) and sdk is not None:
+        try:
+            runtime.metric_provider = _start_metric_provider(config, sdk)
+        except Exception:
+            logger.warning("gateway health OTLP metrics failed to start", exc_info=True)
+            runtime.shutdown()
+            return GatewayHealthExportRuntime(enabled=False, reason="metrics_start_failed")
+
+    if gh.get("diagnostic_events_enabled", True) and sdk is not None:
+        try:
+            from agent.telemetry import otlp_exporter
+            runtime.streamer = otlp_exporter.start_streaming(config, event_filter=_gateway_health_event)
+            runtime.log_streamer = _start_diagnostic_log_streamer(config, sdk)
+        except Exception:
+            logger.debug("gateway diagnostic OTLP export failed to start", exc_info=True)
+
+    try:
+        runtime.log_handler = _attach_log_handler(config)
+    except Exception:
+        logger.debug("gateway diagnostic log handler failed to attach", exc_info=True)
+    try:
+        _emit_snapshot_events(config)
+        runtime.stop_event = threading.Event()
+        runtime.thread = _start_snapshot_thread(config, runtime.stop_event)
+    except Exception:
+        logger.debug("gateway health snapshot thread failed to start", exc_info=True)
+    return runtime
+
+
+__all__ = [
+    "GatewayHealthExportRuntime",
+    "start_gateway_health_export",
+]

--- a/agent/telemetry/otlp_exporter.py
+++ b/agent/telemetry/otlp_exporter.py
@@ -31,7 +31,7 @@ import logging
 import os
 import sqlite3
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +148,14 @@ def _span_attrs(ev: Dict[str, Any]) -> Dict[str, Any]:
                        "cache_write_tokens", "reasoning_tokens", "latency_ms"),
         "tool_call": ("tool_name", "duration_ms", "result_class"),
         "error": ("error_class", "subsystem", "recovery"),
+        "gateway_health": ("name", "gateway_state", "old_state", "new_state",
+                           "exit_reason", "restart_requested", "active_agents",
+                           "gateway_busy", "gateway_drainable", "platform_count",
+                           "fatal_platform_count", "profile", "install_id", "version",
+                           "supervision_mode", "pid"),
+        "gateway_diagnostic": ("name", "subsystem", "error_class", "error_code",
+                               "redacted_message", "platform", "old_state", "new_state",
+                               "profile", "version", "severity"),
     }
     for col in keep_by_kind.get(kind, ()):  # type: ignore[arg-type]
         v = ev.get(col)
@@ -225,14 +233,29 @@ class OTLPStreamer:
     Register with ``emitter.subscribe(streamer)``. Fail-isolated by the emitter.
     """
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        *,
+        event_filter: Optional[Callable[[Dict[str, Any]], bool]] = None,
+    ):
         self._provider, self._processor = _make_provider(config)
+        self._event_filter = event_filter
         self.exported = 0
 
     def __call__(self, batch: List[Dict[str, Any]]) -> None:
+        if self._event_filter is not None:
+            batch = [ev for ev in batch if self._event_filter(ev)]
+        if not batch:
+            return
         self.exported += export_batch(self._provider, batch)
 
     def shutdown(self) -> None:
+        try:
+            from agent.telemetry.emitter import get_emitter
+            get_emitter().unsubscribe(self)
+        except Exception:
+            pass
         try:
             self._processor.force_flush()
             self._provider.shutdown()
@@ -255,8 +278,15 @@ def is_enabled(config: Dict[str, Any]) -> bool:
     return bool(otlp.get("enabled") and otlp.get("endpoint"))
 
 
-def start_streaming(config: Dict[str, Any]) -> Optional[OTLPStreamer]:
+def start_streaming(
+    config: Dict[str, Any],
+    *,
+    event_filter: Optional[Callable[[Dict[str, Any]], bool]] = None,
+) -> Optional[OTLPStreamer]:
     """If OTLP is enabled, attach a streamer to the singleton emitter.
+
+    ``event_filter`` is used by plane-specific exporters, e.g. gateway-health
+    export, so enabling one plane does not silently export unrelated telemetry.
 
     Non-interactive context (startup): attempts a lazy install with prompt=False
     so a configured-but-missing SDK is installed once (gated by
@@ -272,7 +302,7 @@ def start_streaming(config: Dict[str, Any]) -> Optional[OTLPStreamer]:
                        "be installed/imported; install 'hermes-agent[otlp]'")
         return None
     from agent.telemetry.emitter import get_emitter
-    streamer = OTLPStreamer(config)
+    streamer = OTLPStreamer(config, event_filter=event_filter)
     get_emitter().subscribe(streamer)
     return streamer
 

--- a/docs/observability/telemetry.md
+++ b/docs/observability/telemetry.md
@@ -150,7 +150,7 @@ telemetry:
       enabled: true
       endpoint: "https://collector.your-corp.internal:4318/v1/traces"
       headers_env:                 # secrets by reference — env var NAMES, not values
-        Authorization: MY_OTLP_TOKEN_ENVVAR
+        Authorization: HERMES_OTLP_AUTH_HEADER
 ```
 
 Set the referenced environment variable, then run the export:
@@ -167,6 +167,125 @@ Each telemetry event is exported as an OTel span carrying its recorded attribute
 (provider, model, tokens, duration, etc.). The `tel_spans` timing/parent linkage is not
 yet reconstructed into connected OTel `SpanContext`s, so spans currently arrive as
 independent records rather than a connected trace tree; that projection is planned.
+
+### Gateway Health & Diagnostics Export
+
+Gateway Health & Diagnostics Export is the enterprise monitoring plane for a long-running Hermes gateway. It is separate from product usage analytics, governance/audit logs, quality reporting, trajectories, and session content.
+
+Enable it when a customer wants their Hermes gateway to report service health to their own OpenTelemetry Collector or DataDog pipeline:
+
+```yaml
+telemetry:
+  gateway_health_export:
+    enabled: true
+    metrics_enabled: true
+    diagnostic_events_enabled: true
+    warning_error_events_enabled: true
+    export_interval_seconds: 60
+    logs_export_interval_seconds: 5
+  export:
+    otlp:
+      enabled: true
+      endpoint: "http://otel-collector:4318/v1/traces"
+      headers_env: {}
+```
+
+This exports only the P0 gateway monitoring signals:
+
+- gateway lifecycle/state: `hermes.gateway.up`, `hermes.gateway.state`, restart requested
+- service/process health derived from the in-process gateway runtime status
+- platform connector health: `hermes.platform.up`, `hermes.platform.degraded`
+- active agents, busy, and drainable gauges
+- narrow redacted warning/error diagnostic events from gateway-owned loggers
+
+It does not export prompts, messages, tool arguments/results, session history, audit records, product usage analytics, quality reports, or trajectories.
+
+The exporter is in-process and fail-open. It works under systemd, launchd, s6, containers, tmux/nohup, or a simple shell process. Service-manager data is best-effort enrichment only; correctness does not depend on a sidecar, watchdog, `systemctl`, host agent, or `/proc` behavior.
+
+#### DataDog collector recipe
+
+Use an OpenTelemetry Collector close to the gateway and send from Hermes to the collector:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch: {}
+
+exporters:
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+      site: datadoghq.com
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]
+```
+
+Then point Hermes at the collector:
+
+```bash
+hermes config set telemetry.export.otlp.enabled true
+hermes config set telemetry.export.otlp.endpoint http://otel-collector:4318/v1/traces
+hermes config set telemetry.gateway_health_export.enabled true
+hermes gateway restart
+```
+
+For direct hosted collectors that require auth, keep the secret in the environment and reference only the variable name in config:
+
+```yaml
+telemetry:
+  export:
+    otlp:
+      headers_env:
+        Authorization: HERMES_OTLP_AUTHORIZATION
+```
+
+#### Local no-Docker smoke test
+
+For development environments without Docker, use the checked-in OTLP capture receiver. It accepts OTLP/HTTP protobuf on `/v1/traces`, `/v1/metrics`, and `/v1/logs` and records request metadata as JSONL.
+
+```bash
+# Terminal/tmux pane 1
+python scripts/observability/otel_capture_collector.py \
+  --host 127.0.0.1 \
+  --port 4318 \
+  --log /tmp/hermes_otel_capture.jsonl
+
+# Terminal/tmux pane 2
+python scripts/observability/gateway_health_export_probe.py \
+  --endpoint http://127.0.0.1:4318/v1/traces \
+  --log /tmp/hermes_otel_capture.jsonl \
+  --wait 7
+```
+
+A passing run reports all three OTLP paths:
+
+```json
+{
+  "paths": ["/v1/logs", "/v1/metrics", "/v1/traces"]
+}
+```
+
+Gateway health/lifecycle events are projected to OTLP traces, gateway metrics go to OTLP metrics, and redacted gateway diagnostics go to OTLP logs. The collector is a local test receiver only; production deployments should use the customer's OpenTelemetry Collector or equivalent managed receiver.
 
 ## Redaction
 
@@ -194,6 +313,20 @@ telemetry:
   content_redaction: none     # none | pii
   trajectories:
     enabled: false            # unlocks full-content export to your destination
+  gateway_health_export:
+    enabled: false            # customer-owned gateway health metrics and diagnostics
+    metrics_enabled: true
+    diagnostic_events_enabled: true
+    warning_error_events_enabled: true
+    export_interval_seconds: 60
+    logs_export_interval_seconds: 5
+    resource_attributes:
+      service.name: hermes-gateway
+      deployment.environment: production
+    redaction:
+      enabled: true
+      include_stack_summary: true
+      include_raw_stack: false
   export:
     otlp:
       enabled: false

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5953,6 +5953,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             write_runtime_status(gateway_state="starting", exit_reason=None)
         except Exception:
             pass
+        try:
+            from hermes_cli.config import load_config
+            from agent.telemetry.gateway_health_export import start_gateway_health_export
+            self._gateway_health_export_runtime = start_gateway_health_export(load_config())
+            if getattr(self._gateway_health_export_runtime, "enabled", False):
+                logger.info("Gateway health OTLP export: enabled")
+        except Exception:
+            logger.debug("gateway health OTLP export startup failed", exc_info=True)
 
         # Log any active supply-chain security advisories. Operators see this
         # in gateway.log and `hermes status` surfaces it; we do NOT block
@@ -7523,6 +7531,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._update_runtime_status("running", self._exit_reason)
             else:
                 self._update_runtime_status("stopped", self._exit_reason)
+            try:
+                _gh_runtime = getattr(self, "_gateway_health_export_runtime", None)
+                if _gh_runtime is not None:
+                    _gh_runtime.shutdown()
+            except Exception:
+                logger.debug("gateway health OTLP export shutdown failed", exc_info=True)
             logger.info("Gateway stopped (total teardown %.2fs)", _phase_elapsed())
 
         self._stop_task = asyncio.create_task(_stop_impl())

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -11,6 +11,7 @@ that will be useful when we add named profiles (multiple agents running
 concurrently under distinct configurations).
 """
 
+import copy
 import hashlib
 import json
 import os
@@ -757,6 +758,7 @@ def write_runtime_status(
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
+    previous_payload = copy.deepcopy(payload)
     current_record = _build_pid_record()
     payload.setdefault("platforms", {})
     payload["kind"] = current_record["kind"]
@@ -791,6 +793,11 @@ def write_runtime_status(
         payload["platforms"][platform] = platform_payload
 
     _write_json_file(path, payload)
+    try:
+        from agent.telemetry.gateway_health import emit_runtime_status_transition
+        emit_runtime_status_transition(previous_payload, payload)
+    except Exception:
+        pass
 
 
 def read_runtime_status(path: Optional[Path] = None) -> Optional[dict[str, Any]]:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1950,6 +1950,26 @@ DEFAULT_CONFIG = {
         "trajectories": {
             "enabled": False,
         },
+        # Gateway Health & Diagnostics Export. Customer-owned service health and
+        # narrow gateway diagnostics only: no prompts, messages, tool args/results,
+        # product analytics, audit logs, quality reports, or trajectories.
+        "gateway_health_export": {
+            "enabled": False,
+            "metrics_enabled": True,
+            "diagnostic_events_enabled": True,
+            "warning_error_events_enabled": True,
+            "export_interval_seconds": 60,
+            "logs_export_interval_seconds": 5,
+            "resource_attributes": {
+                "service.name": "hermes-gateway",
+                "deployment.environment": "production",
+            },
+            "redaction": {
+                "enabled": True,
+                "include_stack_summary": True,
+                "include_raw_stack": False,
+            },
+        },
         # Exporters. The OTLP exporter sends to a configured Collector endpoint;
         # endpoint headers reference environment variable names rather than inline
         # secrets.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12418,6 +12418,12 @@ def cmd_telemetry(args):
                       "telemetry only")
             print("    Secret redaction: on (always)")
             print(f"    PII redaction:    {redaction.content_mode_for(config)}")
+            tel_cfg = tel if isinstance(tel, dict) else {}
+            gh = tel_cfg.get("gateway_health_export") if isinstance(tel_cfg.get("gateway_health_export"), dict) else {}
+            if gh.get("enabled"):
+                print("    Gateway health: enabled (metrics + redacted diagnostics to customer OTLP)")
+            else:
+                print("    Gateway health: disabled (telemetry.gateway_health_export.enabled)")
             print("    Bulk export:    hermes telemetry export --out FILE [--otlp]")
         except Exception:
             pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ hindsight = ["hindsight-client==0.6.1"]
 # OTLP telemetry export (optional). Provides the OpenTelemetry SDK + OTLP/HTTP
 # exporter so `hermes telemetry export --otlp` can send spans to a Collector.
 # Lazy-imported by agent/telemetry/otlp_exporter.py; never a core dependency.
-otlp = ["opentelemetry-sdk==1.30.0", "opentelemetry-exporter-otlp-proto-http==1.30.0"]
+otlp = ["opentelemetry-sdk==1.39.1", "opentelemetry-exporter-otlp-proto-http==1.39.1"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.4", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/scripts/observability/gateway_health_export_probe.py
+++ b/scripts/observability/gateway_health_export_probe.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Exercise Gateway Health & Diagnostics Export against a local OTLP capture collector."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", default="http://127.0.0.1:4318/v1/traces")
+    parser.add_argument("--log", required=True, help="JSONL file written by otel_capture_collector.py")
+    parser.add_argument("--wait", type=float, default=7.0)
+    args = parser.parse_args()
+
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-otel-smoke-"))
+    os.environ["HERMES_HOME"] = str(hermes_home)
+
+    from gateway.status import write_runtime_status
+    from agent.telemetry.gateway_health_export import start_gateway_health_export
+    from agent.telemetry import emitter
+
+    config = {
+        "telemetry": {
+            "local": True,
+            "gateway_health_export": {
+                "enabled": True,
+                "metrics_enabled": True,
+                "diagnostic_events_enabled": True,
+                "warning_error_events_enabled": True,
+                "export_interval_seconds": 5,
+                "logs_export_interval_seconds": 5,
+                "resource_attributes": {
+                    "service.name": "hermes-gateway-smoke",
+                    "deployment.environment": "local-smoke",
+                },
+                "redaction": {"enabled": True, "include_raw_stack": False},
+            },
+            "export": {
+                "otlp": {
+                    "enabled": True,
+                    "endpoint": args.endpoint,
+                    "headers_env": {},
+                }
+            },
+        }
+    }
+
+    runtime = start_gateway_health_export(config)
+    if not runtime.enabled:
+        raise SystemExit(f"gateway health exporter did not enable: {runtime.reason}")
+
+    write_runtime_status(gateway_state="starting", active_agents=0)
+    write_runtime_status(gateway_state="running", active_agents=2)
+    write_runtime_status(platform="slack", platform_state="running")
+    write_runtime_status(
+        platform="slack",
+        platform_state="fatal",
+        error_code="auth_failed",
+        error_message="Bearer *** rejected for smoke@example.com",
+    )
+    logging.getLogger("gateway.platforms.slack").warning("Slack token *** rejected for smoke@example.com")
+    emitter.get_emitter().flush(timeout=2.0)
+    time.sleep(args.wait)
+    runtime.shutdown()
+    emitter.get_emitter().flush(timeout=2.0)
+
+    log_path = Path(args.log)
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    paths = {row["path"] for row in rows}
+    print(json.dumps({"hermes_home": str(hermes_home), "requests": len(rows), "paths": sorted(paths)}, indent=2))
+    if "/v1/traces" not in paths:
+        raise SystemExit("missing /v1/traces request")
+    if "/v1/logs" not in paths:
+        raise SystemExit("missing /v1/logs request")
+    if "/v1/metrics" not in paths:
+        raise SystemExit("missing /v1/metrics request")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/observability/otel_capture_collector.py
+++ b/scripts/observability/otel_capture_collector.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Tiny local OTLP/HTTP capture collector for Hermes gateway health smoke tests.
+
+This is not a production collector. It accepts OTLP protobuf POSTs on /v1/traces
+and /v1/metrics, records request metadata as JSONL, and returns 200 so local
+exporters can be exercised without Docker or a vendor backend.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+class CaptureHandler(BaseHTTPRequestHandler):
+    log_path: Path
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        length = int(self.headers.get("content-length") or 0)
+        body = self.rfile.read(length) if length else b""
+        record = {
+            "ts": time.time(),
+            "path": self.path,
+            "content_type": self.headers.get("content-type"),
+            "content_length": length,
+            "body_prefix_hex": body[:24].hex(),
+        }
+        with self.log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True) + "\n")
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    def log_message(self, format: str, *args) -> None:
+        # Keep tmux panes clean; JSONL file is the assertion surface.
+        return
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=4318)
+    parser.add_argument("--log", required=True)
+    args = parser.parse_args()
+
+    log_path = Path(args.log).expanduser().resolve()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("", encoding="utf-8")
+    CaptureHandler.log_path = log_path
+    server = ThreadingHTTPServer((args.host, args.port), CaptureHandler)
+    print(f"OTLP capture collector listening on http://{args.host}:{args.port}; log={log_path}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/telemetry/test_gateway_health_export.py
+++ b/tests/telemetry/test_gateway_health_export.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import logging
+
+
+def test_default_config_keeps_gateway_health_export_disabled():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    cfg = DEFAULT_CONFIG["telemetry"]["gateway_health_export"]
+
+    assert cfg["enabled"] is False
+    assert cfg["metrics_enabled"] is True
+    assert cfg["diagnostic_events_enabled"] is True
+    assert cfg["warning_error_events_enabled"] is True
+    assert cfg["export_interval_seconds"] == 60
+    assert cfg["logs_export_interval_seconds"] == 5
+    assert cfg["redaction"]["enabled"] is True
+    assert cfg["redaction"]["include_raw_stack"] is False
+
+
+def test_gateway_health_snapshot_maps_runtime_status_to_low_cardinality_metrics():
+    from agent.telemetry.gateway_health import build_gateway_health_snapshot
+
+    runtime = {
+        "gateway_state": "running",
+        "pid": 1234,
+        "active_agents": "2",
+        "restart_requested": False,
+        "platforms": {
+            "slack": {"state": "running"},
+            "telegram": {
+                "state": "fatal",
+                "error_code": "auth_failed",
+                "error_message": "token xoxb-secret rejected for user 123",
+            },
+        },
+    }
+
+    snapshot = build_gateway_health_snapshot(
+        runtime,
+        gateway_running=True,
+        profile="default",
+        install_id="install-1",
+        version="2026.7.test",
+        supervision_mode="manual",
+    )
+
+    metric_names = {m.name for m in snapshot.metrics}
+    assert {
+        "hermes.gateway.up",
+        "hermes.gateway.active_agents",
+        "hermes.gateway.busy",
+        "hermes.gateway.drainable",
+        "hermes.gateway.restart_requested",
+        "hermes.platform.up",
+        "hermes.platform.degraded",
+    } <= metric_names
+
+    active = next(m for m in snapshot.metrics if m.name == "hermes.gateway.active_agents")
+    assert active.value == 2
+    assert active.attributes == {
+        "hermes.profile": "default",
+        "service.instance.id": "install-1",
+        "service.version": "2026.7.test",
+        "hermes.supervision_mode": "manual",
+    }
+
+    busy = next(m for m in snapshot.metrics if m.name == "hermes.gateway.busy")
+    drainable = next(m for m in snapshot.metrics if m.name == "hermes.gateway.drainable")
+    assert busy.value == 1
+    assert drainable.value == 1
+
+    degraded = next(
+        m for m in snapshot.metrics
+        if m.name == "hermes.platform.degraded" and m.attributes["hermes.platform"] == "telegram"
+    )
+    assert degraded.value == 1
+    assert degraded.attributes["hermes.error_code"] == "auth_failed"
+    assert all("secret" not in str(v).lower() for v in degraded.attributes.values())
+
+
+def test_gateway_health_snapshot_emits_content_free_diagnostic_event():
+    from agent.telemetry.gateway_health import build_gateway_health_snapshot
+
+    snapshot = build_gateway_health_snapshot(
+        {
+            "gateway_state": "running",
+            "active_agents": 1,
+            "platforms": {
+                "slack": {"state": "fatal", "error_code": "auth_failed", "error_message": "Bearer sk-live-secret"},
+            },
+        },
+        gateway_running=True,
+        profile="default",
+        install_id="install-1",
+        version="v-test",
+        supervision_mode="container",
+    )
+
+    events = [event.to_dict() for event in snapshot.events]
+    health = next(e for e in events if e["event"] == "gateway_health")
+    platform = next(e for e in events if e["event"] == "gateway_diagnostic" and e["name"] == "platform.fatal")
+
+    assert health["gateway_state"] == "running"
+    assert health["active_agents"] == 1
+    assert health["gateway_busy"] is True
+    assert health["gateway_drainable"] is True
+    assert health["fatal_platform_count"] == 1
+    assert platform["platform"] == "slack"
+    assert platform["error_code"] == "auth_failed"
+    assert "secret" not in platform["redacted_message"].lower()
+    assert "Bearer" not in platform["redacted_message"]
+
+
+def test_gateway_diagnostic_log_handler_redacts_and_filters(caplog):
+    from agent.telemetry import emitter
+    from agent.telemetry.gateway_health import GatewayDiagnosticLogHandler
+
+    captured = []
+
+    class DummyEmitter:
+        def emit(self, event):
+            captured.append(event.to_dict())
+
+    old = emitter.get_emitter
+    emitter.get_emitter = lambda: DummyEmitter()  # type: ignore[assignment]
+    try:
+        handler = GatewayDiagnosticLogHandler(profile="default", version="v-test")
+        logger = logging.getLogger("gateway.platforms.slack")
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+        try:
+            logger.info("ignore info token sk-live-secret")
+            logger.warning("Slack token sk-live-secret failed for user@example.com")
+        finally:
+            logger.removeHandler(handler)
+    finally:
+        emitter.get_emitter = old  # type: ignore[assignment]
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event["event"] == "gateway_diagnostic"
+    assert event["name"] == "gateway.log.warning"
+    assert event["subsystem"] == "platform.slack"
+    assert event["error_class"] == "auth_failed"
+    assert "***" not in event["redacted_message"]
+    assert "user@example.com" not in event["redacted_message"]
+
+
+def test_runtime_status_transition_emits_lifecycle_and_platform_events(monkeypatch):
+    from agent.telemetry import emitter
+    from agent.telemetry.gateway_health import emit_runtime_status_transition
+
+    captured = []
+
+    class DummyEmitter:
+        def emit(self, event):
+            captured.append(event.to_dict())
+
+    old = emitter.emit
+    monkeypatch.setattr(emitter, "emit", lambda event: captured.append(event.to_dict()))
+
+    previous = {"gateway_state": "starting", "platforms": {"slack": {"state": "running"}}}
+    current = {
+        "gateway_state": "running",
+        "pid": 123,
+        "active_agents": 1,
+        "platforms": {
+            "slack": {
+                "state": "fatal",
+                "error_code": "auth_failed",
+                "error_message": "Bearer *** failed",
+            }
+        },
+    }
+
+    emit_runtime_status_transition(previous, current)
+
+    names = [e["name"] for e in captured]
+    assert "gateway.lifecycle" in names
+    assert "platform.state_change" in names
+    assert "platform.fatal" in names
+    lifecycle = next(e for e in captured if e["name"] == "gateway.lifecycle")
+    assert lifecycle["old_state"] == "starting"
+    assert lifecycle["new_state"] == "running"
+    platform = next(e for e in captured if e["name"] == "platform.state_change")
+    assert platform["old_state"] == "running"
+    assert platform["new_state"] == "fatal"
+    assert platform["error_code"] == "auth_failed"
+    assert "Bearer" not in platform["redacted_message"]
+
+
+def test_runtime_status_transition_emits_startup_failed_and_exit():
+    from agent.telemetry.gateway_health import emit_runtime_status_transition
+    from agent.telemetry import emitter
+
+    captured = []
+    old = emitter.emit
+    emitter.emit = lambda event: captured.append(event.to_dict())  # type: ignore[assignment]
+    try:
+        emit_runtime_status_transition({"gateway_state": "starting"}, {"gateway_state": "startup_failed", "exit_reason": "startup token ***"})
+        emit_runtime_status_transition({"gateway_state": "running"}, {"gateway_state": "stopped", "exit_reason": "shutdown", "restart_requested": True})
+    finally:
+        emitter.emit = old  # type: ignore[assignment]
+
+    names = [e["name"] for e in captured]
+    assert "gateway.startup_failed" in names
+    assert "gateway.exit" in names
+    failed = next(e for e in captured if e["name"] == "gateway.startup_failed")
+    assert "***" not in failed["redacted_message"]
+    exit_event = next(e for e in captured if e["name"] == "gateway.exit")
+    assert exit_event["restart_requested"] is True
+
+
+def test_otlp_attrs_include_gateway_transition_fields():
+    from agent.telemetry.otlp_exporter import _span_attrs
+
+    attrs = _span_attrs({
+        "event": "gateway_health",
+        "name": "gateway.lifecycle",
+        "old_state": "starting",
+        "new_state": "running",
+        "exit_reason": "restart",
+        "restart_requested": True,
+    })
+
+    assert attrs["hermes.old_state"] == "starting"
+    assert attrs["hermes.new_state"] == "running"
+    assert attrs["hermes.exit_reason"] == "restart"
+    assert attrs["hermes.restart_requested"] is True
+
+
+def test_gateway_health_export_start_is_fail_open_when_otlp_missing(monkeypatch):
+    from agent.telemetry import gateway_health_export
+    from agent.telemetry.gateway_health_export import GatewayHealthExportRuntime
+
+    monkeypatch.setattr(gateway_health_export, "_require_metrics_sdk", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("missing sdk")))
+
+    runtime = gateway_health_export.start_gateway_health_export({
+        "telemetry": {
+            "gateway_health_export": {"enabled": True},
+            "export": {"otlp": {"enabled": True, "endpoint": "http://collector:4317"}},
+        }
+    })
+
+    assert isinstance(runtime, GatewayHealthExportRuntime)
+    assert runtime.enabled is False
+    assert runtime.reason == "otlp_unavailable"
+
+
+def test_gateway_health_export_streams_only_gateway_events(monkeypatch):
+    from agent.telemetry import gateway_health_export
+
+    captured = {}
+
+    def fake_start_streaming(config, *, event_filter=None):
+        captured["filter"] = event_filter
+        return object()
+
+    monkeypatch.setattr(gateway_health_export, "_start_metric_provider", lambda *a, **k: None)
+    monkeypatch.setattr(gateway_health_export, "_require_metrics_sdk", lambda *a, **k: {})
+    monkeypatch.setattr(gateway_health_export, "_attach_log_handler", lambda *a, **k: None)
+    monkeypatch.setattr(gateway_health_export, "_emit_snapshot_events", lambda *a, **k: None)
+    monkeypatch.setattr(gateway_health_export, "_start_snapshot_thread", lambda *a, **k: None)
+    from agent.telemetry import otlp_exporter
+    monkeypatch.setattr(otlp_exporter, "start_streaming", fake_start_streaming)
+
+    runtime = gateway_health_export.start_gateway_health_export({
+        "telemetry": {
+            "gateway_health_export": {"enabled": True, "metrics_enabled": False},
+            "export": {"otlp": {"enabled": True, "endpoint": "http://collector:4318/v1/traces"}},
+        }
+    })
+
+    assert runtime.enabled is True
+    event_filter = captured["filter"]
+    assert event_filter({"event": "gateway_health"}) is True
+    assert event_filter({"event": "gateway_diagnostic"}) is False
+    assert event_filter({"event": "run"}) is False
+    assert event_filter({"event": "model_call"}) is False
+    assert event_filter({"event": "tool_call"}) is False
+
+
+def test_gateway_health_export_metric_failure_does_not_start_streamer(monkeypatch):
+    from agent.telemetry import gateway_health_export, otlp_exporter
+
+    started = []
+    monkeypatch.setattr(gateway_health_export, "_require_metrics_sdk", lambda *a, **k: {})
+    monkeypatch.setattr(gateway_health_export, "_start_metric_provider", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(otlp_exporter, "start_streaming", lambda *a, **k: started.append(True))
+
+    runtime = gateway_health_export.start_gateway_health_export({
+        "telemetry": {
+            "gateway_health_export": {"enabled": True},
+            "export": {"otlp": {"enabled": True, "endpoint": "http://collector:4318/v1/traces"}},
+        }
+    })
+
+    assert runtime.enabled is False
+    assert runtime.reason == "metrics_start_failed"
+    assert started == []
+
+
+def test_otlp_streamer_shutdown_unsubscribes(monkeypatch):
+    from agent.telemetry import emitter
+    from agent.telemetry.otlp_exporter import OTLPStreamer
+
+    class Dummy:
+        def force_flush(self):
+            pass
+        def shutdown(self):
+            pass
+
+    e = emitter.get_emitter()
+    streamer = OTLPStreamer.__new__(OTLPStreamer)
+    streamer._processor = Dummy()
+    streamer._provider = Dummy()
+    streamer._event_filter = None
+    streamer.exported = 0
+    e.subscribe(streamer)
+    assert streamer in e._subscribers
+
+    streamer.shutdown()
+
+    assert streamer not in e._subscribers
+
+
+def test_gateway_diagnostic_log_handler_never_raises_on_malformed_record():
+    from agent.telemetry.gateway_health import GatewayDiagnosticLogHandler
+
+    handler = GatewayDiagnosticLogHandler(profile="default", version="v-test")
+    record = logging.LogRecord(
+        "gateway.platforms.slack",
+        logging.WARNING,
+        __file__,
+        1,
+        "broken %s %s",
+        ("one",),
+        None,
+    )
+
+    handler.emit(record)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -139,8 +139,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # `hermes telemetry export --otlp`. Tracks the `otlp` extra in
     # pyproject.toml — bump both together.
     "export.otlp": (
-        "opentelemetry-sdk==1.30.0",
-        "opentelemetry-exporter-otlp-proto-http==1.30.0",
+        "opentelemetry-sdk==1.39.1",
+        "opentelemetry-exporter-otlp-proto-http==1.39.1",
     ),
 
     # ─── Memory providers ──────────────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -1568,6 +1568,10 @@ modal = [
 nemo-relay = [
     { name = "nemo-relay" },
 ]
+otlp = [
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+]
 parallel-web = [
     { name = "parallel-web" },
 ]
@@ -1700,6 +1704,8 @@ requires-dist = [
     { name = "nemo-relay", marker = "extra == 'nemo-relay'", specifier = "==0.3" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
     { name = "openai", specifier = "==2.24.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otlp'", specifier = "==1.39.1" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otlp'", specifier = "==1.39.1" },
     { name = "packaging", specifier = "==26.0" },
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "pathspec", specifier = "==1.1.1" },
@@ -1745,7 +1751,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "otlp", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"


### PR DESCRIPTION
## Summary
- adds a Gateway Health and Diagnostics Export on top of PR #51714's telemetry spine
- emits content-free gateway health metrics plus redacted gateway diagnostic events to an operator-configured OTLP endpoint
- wires fail-open startup/shutdown into the gateway without sidecar/watchdog scope
- documents DataDog/OpenTelemetry Collector setup and config knobs
- includes a no-Docker local OTLP capture collector and probe for tmux smoke testing

## Taxonomy alignment
This is Service Health Monitoring plus Operational Diagnostics only. It does not export prompts, messages, tool args/results, session history, product usage analytics, governance/audit logs, quality reports, or trajectories.

## Scope additions
- immediate gateway lifecycle events from `write_runtime_status()` transitions
- startup-failed and gateway-exit events
- platform state-change and platform-fatal events
- OTLP metrics for gateway/platform health
- OTLP traces/events for gateway health/lifecycle events
- OTLP logs for redacted gateway diagnostics on `/v1/logs`
- gateway-only OTLP filters so generic run/model/tool telemetry is not exported by this plane
- local tmux smoke scripts under `scripts/observability/`

## Review fixes
Addressed independent review blockers:
- gateway export now passes an event filter into the OTLP streamer so this plane does not stream run/model/tool telemetry
- metric startup failure does not start the diagnostic streamer and cleans up partial runtime state
- `OTLPStreamer.shutdown()` unsubscribes itself from the emitter
- diagnostic log handler is fully fail-open for malformed log records
- metric error codes are bounded through the classifier; gateway logger allowlist uses `gateway` / `gateway.*` only

## Verification
- `python -m pytest tests/telemetry/test_gateway_health_export.py -q -o 'addopts='` -> 12 passed
- `python -m pytest tests/telemetry -q -o 'addopts='` -> 88 passed
- `python -m pytest tests/gateway/test_status.py tests/gateway/test_status_command.py tests/gateway/test_version_command.py tests/cli/test_version_command.py -q -o 'addopts='` -> 112 passed
- `python -m py_compile agent/telemetry/gateway_health.py agent/telemetry/gateway_health_export.py agent/telemetry/events.py agent/telemetry/otlp_exporter.py gateway/status.py gateway/run.py hermes_cli/config.py hermes_cli/main.py scripts/observability/otel_capture_collector.py scripts/observability/gateway_health_export_probe.py`
- `git diff --check`
- docs code-fence sanity check passed
- security grep scan clean
- tmux local OTLP smoke passed: `/v1/logs`, `/v1/metrics`, and `/v1/traces` captured

Stacked on #51714; should merge after or into that telemetry PR.


## CI triage note
Compared #61252 with base PR #51714. The broad failing test/build jobs were inherited from #51714: `hermes-agent[otlp]` pinned OpenTelemetry `1.30.0`, while `mistralai==2.4.8` requires `opentelemetry-api>=1.33.1`. This branch now bumps the OTLP extra and `tools.lazy_deps` to OpenTelemetry `1.39.1`, matching the existing `uv.lock` package set, and reran `uv lock`.

The only #61252-specific failure found was ruff `unspecified-encoding` in the local OTLP probe script. Fixed by adding explicit UTF-8 decoding.
