### PR TITLE
fix(wecom): decode percent-encoded filenames to prevent Windows MAX_PATH overflow

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -833,9 +833,9 @@ class WeComAdapter(BasePlatformAdapter):
         if content_disposition:
             match = re.search(r'filename="?([^";]+)"?', content_disposition)
             if match:
-                return match.group(1)
+                return unquote(match.group(1))
 
-        name = Path(urlparse(url).path).name or "document"
+        name = unquote(Path(urlparse(url).path).name or "document")
         if "." not in name:
             ext = mimetypes.guess_extension(content_type) or ".bin"
             name = f"{name}{ext}"


### PR DESCRIPTION
## Description

Fixes #61211

When a WeCom user sends a file with a non-ASCII filename (e.g. Chinese characters), WeCom returns the filename percent-encoded in the Content-Disposition header. The `_guess_filename()` method in the WeCom adapter returned this raw percent-encoded string without decoding it.

On Windows, the encoded filename can balloon to ~210 chars (each Chinese character becomes 9 chars like `%E3%80%90`), and combined with the cache directory prefix (`C:\Users\...\.hermes\cache\documents\doc_xxx_`), the total path exceeds Windows MAX_PATH (260), causing a `FileNotFoundError`.

## Fix

- Apply `unquote()` to the filename extracted from Content-Disposition
- Also apply `unquote()` to the URL path fallback for consistency

`unquote` was already imported at the top of the file.

## Test Plan

- [ ] Existing tests pass: `pytest tests/gateway/test_wecom.py`
- [ ] Manual: Send a file with Chinese filename via WeCom on Windows, confirm the file is cached and delivered to the agent