### PR TITLE
feat(desktop): add chat tool expansion preference

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1800,6 +1800,11 @@ DEFAULT_CONFIG = {
         "compact": False,
         "personality": "",
         "resume_display": "full",
+        # Persistent chat visibility preferences.
+        # Tool calls and reasoning remain collapsed by default, but users
+        # who want full inspection can enable these globally.
+        "tool_calls_default_expanded": False,
+        "reasoning_default_expanded": False,
         # Recap tuning for /resume and startup resume. The defaults match the
         # historical hardcoded values; expose them as config so power users can
         # widen or tighten the snapshot to taste.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -692,6 +692,14 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "How resumed sessions display history",
         "options": ["minimal", "full", "off"],
     },
+    "display.tool_calls_default_expanded": {
+        "type": "boolean",
+        "description": "Expand tool call details by default in chat",
+    },
+    "display.reasoning_default_expanded": {
+        "type": "boolean",
+        "description": "Expand reasoning sections by default when available",
+    },
     "display.busy_input_mode": {
         "type": "select",
         "description": "Input behavior while agent is running",


### PR DESCRIPTION
## Summary

Adds a persistent display preference for expanding chat tool call details by default.

## Changes

- Added `display.tool_calls_default_expanded` configuration option.
- Added schema metadata so the setting appears in Hermes configuration UI.
- Wired the preference through ChatSidebar.
- Updated ToolCall rendering to respect the default expansion preference.
- Preserved existing behavior:
  - error tool calls still auto-expand;
  - user interaction overrides the default.

## Validation

- Python syntax checks passed.
- Web TypeScript check passed:
  - `npm run typecheck`
- Production web build passed:
  - `npm run build`