### PR TITLE
fix(delegation): prevent credential pool from overriding explicit delegation.base_url

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1355,9 +1355,15 @@ def _build_child_agent(
 
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
-    child_pool = _resolve_child_credential_pool(
-        effective_provider, parent_agent, effective_base_url
-    )
+    # When override_base_url is set (from delegation config), skip the credential
+    # pool entirely to prevent _swap_credential from overwriting the delegation-
+    # configured endpoint with a different pool entry's base_url (#61195).
+    if override_base_url:
+        child_pool = None
+    else:
+        child_pool = _resolve_child_credential_pool(
+            effective_provider, parent_agent, effective_base_url
+        )
     if child_pool is not None:
         child._credential_pool = child_pool
 


### PR DESCRIPTION
## Description

Fixes #61195

When `delegation.base_url` is explicitly configured (e.g. `https://api.anthropic.com`) while the primary model uses a different provider (e.g. `openrouter`), the subagent's `agent.base_url`, `agent.provider`, and `agent.api_mode` are correctly resolved to the delegation values throughout `init_agent()`. However, the credential pool leasing in `_run_single_child()` could later call `_swap_credential()`, which overwrites `self.base_url` (and `self._client_kwargs['base_url']`) with values from the pool entry — potentially restoring the parent agent's OpenRouter endpoint and causing 401 authentication failures.

## Fix

Skip credential pool assignment in `_build_child_agent()` when `override_base_url` is set from the delegation config (`delegation.base_url`). This ensures the explicitly configured endpoint is always honored and never overwritten by a stale pool entry.

## Rationale

When the user explicitly configures `delegation.base_url`, they are directing subagents to a specific endpoint. A credential pool that was loaded for the same provider name (e.g. `anthropic`) may contain entries with a different `runtime_base_url` than the one configured in `delegation.base_url`, because the pool was set up for a different use case (e.g. rate-limiting rotation on the parent's provider).

The credential pool is still available for subagents that inherit the parent's provider (where `override_base_url` is not set), preserving the rate-limit rotation feature for the default case.

## Test Plan

- [ ] `pytest tests/tools/test_delegate.py -v`
- [ ] `pytest tests/tools/test_async_delegation.py -v`
- [ ] Manual: configure delegation.base_url to a different provider than the primary model, trigger delegate_task, verify the subagent's API calls go to the configured endpoint