### PR TITLE
feat(api_server): stream model reasoning as reasoning.delta on /v1/runs/events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1237,6 +1237,7 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
+        reasoning_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
@@ -1354,6 +1355,7 @@ class APIServerAdapter(BasePlatformAdapter):
             platform="api_server",
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
+            reasoning_callback=reasoning_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
             session_db=self._ensure_session_db(),
@@ -4274,6 +4276,22 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
+        # Wire reasoning_callback so the model's real reasoning (e.g. DeepSeek
+        # reasoning_content) streams as reasoning.delta events, ahead of the
+        # message.delta answer stream. Mirrors tui_gateway/server.py.
+        def _reasoning_cb(text: Optional[str]) -> None:
+            if not text:
+                return
+            try:
+                loop.call_soon_threadsafe(q.put_nowait, {
+                    "event": "reasoning.delta",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                    "delta": text,
+                })
+            except Exception:
+                pass
+
         self._set_run_status(
             run_id,
             "queued",
@@ -4293,6 +4311,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_id=session_id,
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
+                    reasoning_callback=_reasoning_cb,
                     gateway_session_key=gateway_session_key,
                     route=route,
                 )

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -305,7 +305,48 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_events_stream_emits_reasoning_delta(self, adapter):
+        """reasoning_callback should surface model reasoning as reasoning.delta SSE events.
 
+        Verifies the wiring added so DES can stream real reasoning (e.g. DeepSeek
+        reasoning_content) ahead of the message.delta answer on /v1/runs/events.
+        """
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            captured = {}
+
+            def _fake_create_agent(**kwargs):
+                # _run_and_close must pass reasoning_callback=_reasoning_cb through.
+                captured["reasoning_callback"] = kwargs.get("reasoning_callback")
+                mock_agent = MagicMock()
+
+                def _run(user_message=None, conversation_history=None, task_id=None):
+                    cb = kwargs.get("reasoning_callback")
+                    if cb:
+                        cb("thinking about the answer")
+                    return {"final_response": "the answer"}
+
+                mock_agent.run_conversation.side_effect = _run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                return mock_agent
+
+            with patch.object(adapter, "_create_agent", side_effect=_fake_create_agent):
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+
+        # _run_and_close wired reasoning_callback into _create_agent.
+        assert captured.get("reasoning_callback") is not None
+        # That callback pushes reasoning.delta onto the SSE stream.
+        assert "reasoning.delta" in body
+        assert "thinking about the answer" in body
 
     @pytest.mark.asyncio
     async def test_approval_response_without_pending_returns_409(self, adapter):


### PR DESCRIPTION
## What does this PR do?

The HTTP API Server (`/v1/runs`) never wired `reasoning_callback`, so the model's real reasoning — DeepSeek `reasoning_content`, codex `response.reasoning.*.delta`, Bedrock thinking, inline `<think>` — was captured internally (`on_reasoning_delta` → `_fire_reasoning_delta`) but **dropped on the API Server codepath**. As a result `/v1/runs/{id}/events` only ever streamed the answer (`message.delta`), and the one-shot `reasoning.available` event carried an answer-derived snippet (first 500 chars of `assistant_message.content`), **not** real reasoning.

The CLI/TUI already display real reasoning (they set `reasoning_callback`). This PR brings the API Server to parity: wire `reasoning_callback` through `_create_agent` and emit a `reasoning.delta` SSE event from the `/v1/runs` handler (mirrors the existing pattern in `tui_gateway/server.py`). Clients now receive the real reasoning stream ahead of the answer:

```
reasoning.delta × N     ← real reasoning, token stream (NEW)
message.delta × N       ← answer
reasoning.available     ← unchanged (answer-derived snippet; clients may ignore)
run.completed
```

Backward compatible: `reasoning.available` is unchanged; clients that don't handle `reasoning.delta` are unaffected. Only `/v1/runs` is changed — `/v1/chat/completions` and `/v1/responses` are untouched.

## Related Issue

N/A (no existing issue; happy to open one if preferred).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/api_server.py` — `_create_agent` now accepts and forwards `reasoning_callback`; the `/v1/runs` handler (`_run_and_close`) wires a `_reasoning_cb` that pushes a `reasoning.delta` SSE event (payload field `delta`, same shape as `message.delta`).
- `tests/gateway/test_api_server_runs.py` — added `TestRunEvents::test_events_stream_emits_reasoning_delta`: asserts `reasoning_callback` is wired through `_create_agent` and that its output reaches the SSE stream as `reasoning.delta`.

Additive only: +60 lines across 2 files, no change to existing events.

## How to Test

1. Unit: `uv run --extra dev pytest tests/gateway/test_api_server_runs.py -q` → all pass, including the new `test_events_stream_emits_reasoning_delta`.
2. Live: run the API server with a reasoning model (e.g. DeepSeek reasoner, `reasoning_effort != none`), `POST /v1/runs`, then `GET /v1/runs/{id}/events` → confirm `reasoning.delta` events arrive **ahead of** `message.delta` and contain real reasoning (distinct from the final answer).

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — `feat(api_server): stream model reasoning as reasoning.delta on /v1/runs/events`
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected file `tests/gateway/test_api_server_runs.py` (24 passed); the full `tests/` suite was not run on this base
- [x] I've added tests for my changes — `test_events_stream_emits_reasoning_delta`
- [x] I've tested on my platform: Windows 11 — unit tests pass; live SSE verified end-to-end against a DeepSeek reasoning model via an API Server client

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (no docs surface changed; the new `reasoning.delta` event mirrors `tui_gateway`'s existing one)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas — or N/A

## Screenshots / Logs

`/v1/runs/{id}/events` with a reasoning model — before this PR only `message.delta` + `reasoning.available` were emitted; after, `reasoning.delta` streams first:

```
event: reasoning_delta
data: {"event":"reasoning.delta","run_id":"...","delta":"<real reasoning chunk>"}
... (more reasoning.delta) ...
event: message_delta
data: {"event":"message.delta","run_id":"...","delta":"<answer chunk>"}
...
event: run_completed
```
