### PR TITLE
fix(slack): read thread context from message attachments and blocks

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -207,6 +207,47 @@ def _extract_text_from_slack_blocks(blocks: list) -> str:
     return "\n".join(parts)
 
 
+def _extract_text_from_slack_attachments(attachments: list) -> str:
+    """Extract readable text from legacy Slack message ``attachments``.
+
+    Apps such as Alertmanager, Grafana, PagerDuty, and CI bots post messages
+    with an empty top-level ``text`` and the real content inside ``attachments``
+    (Slack's legacy secondary-content format) or nested Block Kit ``blocks``.
+    Without this, such messages are invisible when the agent reads thread
+    history — e.g. an alert that started the very thread the agent was asked to
+    investigate would come through blank.
+
+    Prefers structured fields (``pretext``/``title``/``text``/``fields``) and
+    only falls back to an attachment's ``fallback`` string when it carries
+    nothing else.
+    """
+    if not attachments:
+        return ""
+
+    lines: list[str] = []
+    for att in attachments:
+        if not isinstance(att, dict):
+            continue
+        got: list[str] = [
+            str(att[key]) for key in ("pretext", "title", "text") if att.get(key)
+        ]
+        for field in att.get("fields", []) or []:
+            if not isinstance(field, dict):
+                continue
+            got += [str(field[k]) for k in ("title", "value") if field.get(k)]
+        nested = att.get("blocks")
+        if nested:
+            block_text = _extract_text_from_slack_blocks(nested)
+            if block_text:
+                got.append(block_text)
+        # Only use the (often duplicative) fallback when nothing structured exists.
+        if not got and att.get("fallback"):
+            got.append(str(att["fallback"]))
+        lines += got
+
+    return "\n".join(line for line in lines if line).strip()
+
+
 def _serialize_slack_blocks_for_agent(blocks: list, max_chars: int = 6000) -> str:
     """Return a compact, redacted JSON view of the current message's Block Kit payload."""
     if not blocks:
@@ -3785,7 +3826,18 @@ class SlackAdapter(BasePlatformAdapter):
                 ):
                     continue
 
-                msg_text = msg.get("text", "").strip()
+                msg_text = (msg.get("text") or "").strip()
+                # Apps (Alertmanager, Grafana, CI bots) often post with an empty
+                # ``text`` and the content in blocks/attachments — fall back so
+                # messages that started or populate the thread aren't dropped.
+                if not msg_text:
+                    msg_text = _extract_text_from_slack_blocks(
+                        msg.get("blocks")
+                    ).strip()
+                if not msg_text:
+                    msg_text = _extract_text_from_slack_attachments(
+                        msg.get("attachments")
+                    ).strip()
                 if not msg_text:
                     continue
 
@@ -3889,6 +3941,14 @@ class SlackAdapter(BasePlatformAdapter):
                 return ""
             bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
             text = (parent.get("text") or "").strip()
+            # App-posted parents (e.g. an Alertmanager alert) carry their content
+            # in blocks/attachments with an empty ``text`` — fall back to those.
+            if not text:
+                text = _extract_text_from_slack_blocks(parent.get("blocks")).strip()
+            if not text:
+                text = _extract_text_from_slack_attachments(
+                    parent.get("attachments")
+                ).strip()
             if bot_uid:
                 text = text.replace(f"<@{bot_uid}>", "").strip()
             return text

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4187,3 +4187,114 @@ class TestThreadContextUnverifiedTagging:
         # Renders successfully without trust tag (exception → unknown trust).
         assert "U_X: hello" in content
         assert "[unverified]" not in content
+
+
+# ---------------------------------------------------------------------------
+# TestThreadContextAppMessages
+# ---------------------------------------------------------------------------
+
+
+class TestThreadContextAppMessages:
+    """App-posted messages (Alertmanager, Grafana, CI bots) frequently carry
+    their content in ``attachments``/``blocks`` with an empty top-level
+    ``text``. Thread-context must fall back to those so, e.g., an alert that
+    started the thread the bot was asked to investigate is not dropped."""
+
+    @staticmethod
+    def _make_replies(messages):
+        return AsyncMock(return_value={"messages": messages})
+
+    @pytest.mark.asyncio
+    async def test_attachment_only_parent_is_included(self, adapter):
+        """Alertmanager-style parent: empty text, content in a legacy attachment."""
+        adapter._thread_context_cache.clear()
+        messages = [
+            {  # parent posted by the Alertmanager app: text="" , content in attachment
+                "ts": "100.0",
+                "bot_id": "B_ALERTMGR",
+                "subtype": "bot_message",
+                "username": "Alertmanager",
+                "text": "",
+                "attachments": [
+                    {
+                        "fallback": "[FIRING:1] KubeJobFailed cluster-01 "
+                        "batch-job-123456",
+                        "color": "danger",
+                    }
+                ],
+            },
+            {"ts": "101.0", "user": "U_BOB", "text": "<@U_BOT> investigate"},
+        ]
+        adapter._app.client.conversations_replies = self._make_replies(messages)
+
+        with patch.object(
+            adapter, "_resolve_user_name",
+            new=AsyncMock(side_effect=lambda uid, **_: uid),
+        ):
+            content = await adapter._fetch_thread_context(
+                channel_id="C1", thread_ts="100.0", current_ts="999.0",
+            )
+
+        # The alert text (previously dropped) is now present in the context.
+        assert "KubeJobFailed" in content
+        assert "batch-job-123456" in content
+        assert "[thread parent]" in content
+
+    @pytest.mark.asyncio
+    async def test_blocks_only_message_is_included(self, adapter):
+        """Block Kit message with empty text falls back to block text."""
+        adapter._thread_context_cache.clear()
+        messages = [
+            {"ts": "100.0", "user": "U_BOB", "text": "kickoff"},
+            {
+                "ts": "101.0",
+                "bot_id": "B_CI",
+                "subtype": "bot_message",
+                "username": "CI",
+                "text": "",
+                "blocks": [
+                    {
+                        "type": "rich_text",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [
+                                    {"type": "text", "text": "deploy #42 succeeded"}
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        ]
+        adapter._app.client.conversations_replies = self._make_replies(messages)
+
+        with patch.object(
+            adapter, "_resolve_user_name",
+            new=AsyncMock(side_effect=lambda uid, **_: uid),
+        ):
+            content = await adapter._fetch_thread_context(
+                channel_id="C1", thread_ts="100.0", current_ts="999.0",
+            )
+
+        assert "deploy #42 succeeded" in content
+
+    @pytest.mark.asyncio
+    async def test_message_without_any_text_is_skipped(self, adapter):
+        """A message with no text/blocks/attachments is still skipped (no crash)."""
+        adapter._thread_context_cache.clear()
+        messages = [
+            {"ts": "100.0", "user": "U_BOB", "text": "hello"},
+            {"ts": "101.0", "bot_id": "B_X", "subtype": "bot_message", "text": ""},
+        ]
+        adapter._app.client.conversations_replies = self._make_replies(messages)
+
+        with patch.object(
+            adapter, "_resolve_user_name",
+            new=AsyncMock(side_effect=lambda uid, **_: uid),
+        ):
+            content = await adapter._fetch_thread_context(
+                channel_id="C1", thread_ts="100.0", current_ts="999.0",
+            )
+
+        assert "hello" in content  # the real message survives; empty bot msg dropped


### PR DESCRIPTION
## Problem

When the bot is @mentioned mid-thread for the first time, `_fetch_thread_context`
fetches prior thread messages (`conversations.replies`) and prepends them as context —
but it reads only each message's plain `text` field:

```python
msg_text = msg.get("text", "").strip()
if not msg_text:
    continue
```

Apps like **Alertmanager, Grafana, PagerDuty, and CI bots** post with an **empty `text`**
and the real content in legacy **`attachments`** or Block Kit **`blocks`**. Those messages
are dropped — so when such a message *starts* the thread (e.g. a firing alert), an agent
asked to investigate sees an empty thread and can only reply *"What should I investigate?"*.

Observed on a real Alertmanager thread (details genericized):

| sender | `text` | content |
|---|---|---|
| Alertmanager (bot) | `""` | `attachments[0]` → `[FIRING:1] KubeJobFailed cluster-01 batch-job-123456` |
| user | `@bot investigate` | — |
| bot | *"What should I investigate? …"* | — |

`_fetch_thread_parent_text` has the same gap.

## Fix

When `text` is empty, fall back to:
1. `_extract_text_from_slack_blocks(msg["blocks"])` — already used for live incoming messages;
2. a new `_extract_text_from_slack_attachments(msg["attachments"])` helper that pulls
   `pretext`/`title`/`text`/`fields` (plus nested blocks), using the `fallback` string only
   when an attachment has nothing structured.

Applied in both `_fetch_thread_context` and `_fetch_thread_parent_text`. No behavior change
for messages that already have `text`.

## Tests

New `TestThreadContextAppMessages` covers attachment-only (Alertmanager-style), blocks-only,
and truly-empty messages. `tests/gateway/test_slack.py` passes (incl. existing thread-context
tests) and `ruff check` is clean.
