### PR TITLE
feat(memory): bump hindsight-client to 0.8.5

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -144,4 +144,4 @@ Available in `hybrid` and `tools` memory modes:
 
 ## Client Version
 
-Requires `hindsight-client >= 0.6.1`. The plugin auto-upgrades on session start if an older version is detected.
+Requires `hindsight-client >= 0.8.4`. The plugin auto-upgrades on session start if an older version is detected.

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -144,4 +144,4 @@ Available in `hybrid` and `tools` memory modes:
 
 ## Client Version
 
-Requires `hindsight-client >= 0.8.4`. The plugin auto-upgrades on session start if an older version is detected.
+Requires `hindsight-client==0.8.5`. The plugin re-pins the client to that reviewed version on session start if a different version is installed. Local embedded setup installs `hindsight-all` alongside the same exact client constraint.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
-_MIN_CLIENT_VERSION = "0.6.1"
+_MIN_CLIENT_VERSION = "0.8.4"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -52,8 +52,12 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
-# Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
-_MIN_CLIENT_VERSION = "0.8.4"
+# Keep in sync with the [hindsight] extra in pyproject.toml, tools/lazy_deps.py
+# ("memory.hindsight"), and plugin.yaml. tests/test_packaging_metadata.py
+# enforces the four-way lockstep without importing this provider.
+_PINNED_CLIENT_VERSION = "0.8.5"
+# Single source of truth for every provider-managed install/repair path.
+_CLIENT_REQUIREMENT = f"hindsight-client=={_PINNED_CLIENT_VERSION}"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
@@ -169,6 +173,21 @@ def _meets_minimum_version(actual: str | None, required: str) -> bool:
     try:
         from packaging.version import Version
         return Version(actual) >= Version(required)
+    except Exception:
+        return False
+
+
+def _client_version_supported(actual: str | None) -> bool:
+    """True only when the installed client matches the reviewed exact pin.
+
+    A missing, malformed, older, or newer version is unsupported so the caller
+    converges every provider-managed environment on the same known-good client.
+    """
+    if not actual:
+        return False
+    try:
+        from packaging.version import Version
+        return Version(actual) == Version(_PINNED_CLIENT_VERSION)
     except Exception:
         return False
 
@@ -791,10 +810,12 @@ class HindsightMemoryProvider(MemoryProvider):
         env_writes: dict = {}
 
         # Step 2: Install/upgrade deps for selected mode
-        cloud_dep = f"hindsight-client>={_MIN_CLIENT_VERSION}"
+        cloud_dep = _CLIENT_REQUIREMENT
         local_dep = "hindsight-all"
         if mode == "local_embedded":
-            deps_to_install = [local_dep]
+            # The current hindsight-all release only requires
+            # hindsight-client>=0.0.7, so constrain it in the same solve.
+            deps_to_install = [local_dep, cloud_dep]
         elif mode == "local_external":
             deps_to_install = [cloud_dep]
         else:
@@ -1199,6 +1220,45 @@ class HindsightMemoryProvider(MemoryProvider):
             return self._session_id, "append"
         return fallback_document_id, None
 
+    def _ensure_supported_client(self) -> None:
+        """Re-pin hindsight-client when it differs from the reviewed version.
+
+        Packaging metadata governs fresh resolver installs, but an existing
+        environment may carry an older or newer client from another install.
+        Converge any such drift on ``_CLIENT_REQUIREMENT`` via uv. Best-effort:
+        failures are logged and initialization proceeds so a transient install
+        hiccup cannot wedge the session.
+        """
+        try:
+            from importlib.metadata import version as pkg_version
+            installed = pkg_version("hindsight-client")
+        except Exception:
+            return  # metadata unavailable — let any real import error surface later
+        if _client_version_supported(installed):
+            return
+        logger.warning(
+            "hindsight-client %s does not match the pinned version (need %s), "
+            "attempting to reinstall...", installed, _CLIENT_REQUIREMENT,
+        )
+        import shutil
+        import subprocess
+        import sys
+        uv_path = shutil.which("uv")
+        if not uv_path:
+            logger.warning("uv not found. Run: pip install '%s'", _CLIENT_REQUIREMENT)
+            return
+        try:
+            subprocess.run(
+                [uv_path, "pip", "install", "--python", sys.executable,
+                 "--quiet", "--upgrade", _CLIENT_REQUIREMENT],
+                check=True, timeout=120, capture_output=True,
+                stdin=subprocess.DEVNULL,
+            )
+            logger.info("hindsight-client re-pinned to %s", _CLIENT_REQUIREMENT)
+        except Exception as e:
+            logger.warning("Auto-reinstall failed: %s. Run: uv pip install '%s'",
+                           e, _CLIENT_REQUIREMENT)
+
     def initialize(self, session_id: str, **kwargs) -> None:
         self._session_id = str(session_id or "").strip()
         self._parent_session_id = str(kwargs.get("parent_session_id", "") or "").strip()
@@ -1211,34 +1271,8 @@ class HindsightMemoryProvider(MemoryProvider):
         start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         self._document_id = f"{self._session_id}-{start_ts}"
 
-        # Check client version and auto-upgrade if needed
-        try:
-            from importlib.metadata import version as pkg_version
-            from packaging.version import Version
-            installed = pkg_version("hindsight-client")
-            if Version(installed) < Version(_MIN_CLIENT_VERSION):
-                logger.warning("hindsight-client %s is outdated (need >=%s), attempting upgrade...",
-                               installed, _MIN_CLIENT_VERSION)
-                import shutil
-                import subprocess
-                import sys
-                uv_path = shutil.which("uv")
-                if uv_path:
-                    try:
-                        subprocess.run(
-                            [uv_path, "pip", "install", "--python", sys.executable,
-                             "--quiet", "--upgrade", f"hindsight-client>={_MIN_CLIENT_VERSION}"],
-                            check=True, timeout=120, capture_output=True,
-                            stdin=subprocess.DEVNULL,
-                        )
-                        logger.info("hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION)
-                    except Exception as e:
-                        logger.warning("Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
-                                       e, _MIN_CLIENT_VERSION)
-                else:
-                    logger.warning("uv not found. Run: pip install 'hindsight-client>=%s'", _MIN_CLIENT_VERSION)
-        except Exception:
-            pass  # packaging not available or other issue — proceed anyway
+        # Keep the installed client within the supported bounded range.
+        self._ensure_supported_client()
 
         self._config = _load_config()
         self._platform = str(kwargs.get("platform") or "").strip()

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.8.4,<0.9"
+  - "hindsight-client==0.8.5"
 requires_env: []
 hooks:
   - on_session_end

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.6.1"
+  - "hindsight-client>=0.8.4,<0.9"
 requires_env: []
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ fal = ["fal-client==0.13.1"]
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client>=0.8.4,<0.9"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.1", "brotlicffi==1.2.0.1", "slack-bolt==1.29.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.1: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ fal = ["fal-client==0.13.1"]
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
-hindsight = ["hindsight-client>=0.8.4,<0.9"]
+hindsight = ["hindsight-client==0.8.5"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.1", "brotlicffi==1.2.0.1", "slack-bolt==1.29.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.1: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -21,6 +21,9 @@ from plugins.memory.hindsight import (
     RECALL_SCHEMA,
     REFLECT_SCHEMA,
     RETAIN_SCHEMA,
+    _CLIENT_REQUIREMENT,
+    _PINNED_CLIENT_VERSION,
+    _client_version_supported,
     _load_config,
     _build_embedded_profile_env,
     _normalize_observation_scopes,
@@ -500,7 +503,9 @@ class TestPostSetup:
         assert not (hermes_home / "hindsight" / "config.json").exists()
         assert not (user_home / ".hindsight" / "profiles" / "hermes.env").exists()
 
-    def test_local_embedded_setup_materializes_profile_env(self, tmp_path, monkeypatch):
+    def test_local_embedded_setup_materializes_profile_env(
+        self, tmp_path, monkeypatch, capsys
+    ):
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"
         user_home.mkdir()
@@ -518,6 +523,8 @@ class TestPostSetup:
         provider = HindsightMemoryProvider()
         provider.post_setup(str(hermes_home), {"memory": {}})
 
+        output = capsys.readouterr().out
+        assert f"hindsight-all {_CLIENT_REQUIREMENT}" in output
         assert saved_configs[-1]["memory"]["provider"] == "hindsight"
         env_text = (hermes_home / ".env").read_text()
         assert "HINDSIGHT_LLM_API_KEY=sk-local-test\n" in env_text
@@ -1819,3 +1826,70 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+class TestClientVersionGate:
+    """Provider-managed installs must converge on the reviewed exact client.
+
+    Packaging metadata governs fresh installs, while the runtime gate repairs
+    any older or newer client already present in the environment.
+    """
+
+    def test_client_requirement_is_exact_pin(self):
+        # Guards the single source of truth the install paths interpolate.
+        assert _CLIENT_REQUIREMENT == (
+            f"hindsight-client=={_PINNED_CLIENT_VERSION}"
+        )
+
+    @pytest.mark.parametrize(
+        "installed,supported",
+        [
+            ("0.6.1", False),        # the old repository pin
+            ("0.8.4", False),        # previous PR target
+            ("0.8.5", True),         # the reviewed exact pin
+            ("0.8.6", False),        # nearest future patch drift
+            ("0.9.0", False),        # previous exclusive cap
+            ("1.2.0", False),        # future major drift
+            (None, False),            # metadata missing
+            ("not-a-version", False),  # malformed
+        ],
+    )
+    def test_version_pin_membership(self, installed, supported):
+        assert _client_version_supported(installed) is supported
+
+    def _run_gate(self, monkeypatch, installed):
+        """Drive _ensure_supported_client with a faked installed version and a
+        captured subprocess.run, returning the mock for assertions."""
+        monkeypatch.setattr("importlib.metadata.version", lambda dist: installed)
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv")
+        run = MagicMock()
+        monkeypatch.setattr("subprocess.run", run)
+        HindsightMemoryProvider()._ensure_supported_client()
+        return run
+
+    def test_below_pin_reinstalls_exact_spec(self, monkeypatch):
+        run = self._run_gate(monkeypatch, "0.6.1")
+        run.assert_called_once()
+        cmd = run.call_args.args[0]
+        # The exact reviewed requirement is what gets installed.
+        assert cmd[-1] == _CLIENT_REQUIREMENT
+        assert "--upgrade" in cmd
+
+    def test_above_pin_reinstalls_exact_spec(self, monkeypatch):
+        # Preserve the original >=0.9 regression case from the bounded gate.
+        run = self._run_gate(monkeypatch, "0.9.1")
+        run.assert_called_once()
+        assert run.call_args.args[0][-1] == _CLIENT_REQUIREMENT
+
+    def test_pinned_version_is_left_untouched(self, monkeypatch):
+        run = self._run_gate(monkeypatch, "0.8.5")
+        run.assert_not_called()
+
+    def test_missing_uv_does_not_crash(self, monkeypatch):
+        monkeypatch.setattr("importlib.metadata.version", lambda dist: "0.6.1")
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        run = MagicMock()
+        monkeypatch.setattr("subprocess.run", run)
+        # No uv on PATH: log a hint, never attempt an install, never raise.
+        HindsightMemoryProvider()._ensure_supported_client()
+        run.assert_not_called()

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -342,3 +342,92 @@ def test_security_pins_present_in_mirrored_lazy_features():
         "pyproject extras — the lazy install path would not enforce the "
         "CVE-patched floor:\n  " + "\n  ".join(problems)
     )
+
+
+# ---------------------------------------------------------------------------
+# Mirrored dependency: hindsight-client
+#
+# The exact-pin lockstep tests above compare pyproject with tools/lazy_deps.py,
+# but plugin.yaml and the provider-managed requirement are separate hand-kept
+# sources. A bump that misses either one makes the installed version depend on
+# the setup path. Compare the complete requirement across all four sources.
+# ---------------------------------------------------------------------------
+
+_HINDSIGHT_DIST = "hindsight-client"
+
+
+def _specifier_of(specs, dist):
+    """Return the version specifier for *dist* as an order-insensitive set.
+
+    Clauses are split on commas, whitespace-stripped, and collected into a
+    frozenset. Returns None when *dist* is absent from *specs*.
+    """
+    canon = _canonical(dist)
+    for spec in specs:
+        name = _distribution_name(spec)  # already lowercased, PEP 508 aware
+        if _canonical(name) != canon:
+            continue
+        no_marker = spec.split(";", 1)[0]  # drop environment markers
+        # Strip the leading name and optional [extra] prefix, leaving clauses.
+        version_part = re.sub(
+            r"^\s*[A-Za-z0-9][A-Za-z0-9._-]*(?:\[[^\]]*\])?\s*", "", no_marker
+        )
+        clauses = [c.replace(" ", "") for c in version_part.split(",") if c.strip()]
+        return frozenset(clauses)
+    return None
+
+
+def _plugin_yaml_pip_deps():
+    """Extract the quoted requirement strings from the hindsight plugin.yaml.
+
+    plugin.yaml's ``pip_dependencies`` is a plain YAML list of quoted specs;
+    a narrow regex avoids adding a PyYAML dependency to this packaging test.
+    """
+    text = (
+        REPO_ROOT / "plugins" / "memory" / "hindsight" / "plugin.yaml"
+    ).read_text(encoding="utf-8")
+    return re.findall(r'^\s*-\s*["\']([^"\']+)["\']', text, flags=re.MULTILINE)
+
+
+def _provider_pinned_client_version():
+    """Read the provider pin without importing plugin runtime dependencies."""
+    source = (
+        REPO_ROOT / "plugins" / "memory" / "hindsight" / "__init__.py"
+    ).read_text(encoding="utf-8")
+    match = re.search(
+        r"^_PINNED_CLIENT_VERSION\s*=\s*['\"]([^'\"]+)['\"]\s*$",
+        source,
+        flags=re.MULTILINE,
+    )
+    assert match, "could not find _PINNED_CLIENT_VERSION in hindsight provider"
+    return match.group(1)
+
+
+def test_hindsight_client_specifier_is_consistent_across_mirrors():
+    """Every install surface must use the same exact client requirement."""
+    pyproject_extras = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )["project"]["optional-dependencies"]
+    pyproject = _specifier_of(pyproject_extras.get("hindsight", []), _HINDSIGHT_DIST)
+    lazy = _specifier_of(
+        _lazy_deps_by_feature().get("memory.hindsight", []), _HINDSIGHT_DIST
+    )
+    plugin = _specifier_of(_plugin_yaml_pip_deps(), _HINDSIGHT_DIST)
+    provider = frozenset({f"=={_provider_pinned_client_version()}"})
+
+    assert pyproject, "hindsight-client missing from the [hindsight] extra in pyproject.toml"
+    assert lazy, "hindsight-client missing from memory.hindsight in tools/lazy_deps.py"
+    assert plugin, "hindsight-client missing from plugins/memory/hindsight/plugin.yaml"
+
+    assert len(pyproject) == 1 and next(iter(pyproject)).startswith("=="), (
+        f"hindsight-client must remain exact-pinned: {sorted(pyproject)}"
+    )
+
+    assert pyproject == lazy == plugin == provider, (
+        "hindsight-client requirement drifted across its mirrors — keep the "
+        "exact spec in lockstep:\n"
+        f"  pyproject [hindsight]: {sorted(pyproject)}\n"
+        f"  tools/lazy_deps.py:    {sorted(lazy)}\n"
+        f"  plugin.yaml:           {sorted(plugin)}\n"
+        f"  provider pin:          {sorted(provider)}"
+    )

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -140,7 +140,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client>=0.8.4,<0.9",),
+    "memory.hindsight": ("hindsight-client==0.8.5",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -140,7 +140,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client>=0.8.4,<0.9",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the

--- a/uv.lock
+++ b/uv.lock
@@ -1791,7 +1791,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = ">=0.8.4,<0.9" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.8.5" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },

--- a/uv.lock
+++ b/uv.lock
@@ -1791,7 +1791,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = ">=0.8.4,<0.9" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
@@ -1883,7 +1883,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-client"
-version = "0.6.1"
+version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1893,9 +1893,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/26/8b8efa4be21fc3ba12ade3b1353d87f9837ec0d3ec2607e8adbf85bc9c63/hindsight_client-0.6.1.tar.gz", hash = "sha256:314d0bb9e13622e15586ba1586a799726d405b27bc20d78872474b5d6d96cd51", size = 99833, upload-time = "2026-05-08T13:01:23.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/18/c74c4d7dfc181157fb9deb0f3fd17258eb83f73f8e701c8f77ed085138a7/hindsight_client-0.8.5.tar.gz", hash = "sha256:5f435a9f60e7232bb642be79c7dbe4e4e53c72720c110b8cfe28f242835ed04c", size = 118313, upload-time = "2026-07-22T12:05:33.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/4f/a1d0bc33ef933ecc52e76dc1514163594d25836a5d303c256a61bb61445d/hindsight_client-0.6.1-py3-none-any.whl", hash = "sha256:9fdda176ab50f7cec8d7339c6608c148f0cd9ad7e65d9d76192f2db730bc330a", size = 249379, upload-time = "2026-05-08T13:01:22.035Z" },
+    { url = "https://files.pythonhosted.org/packages/23/66/80f8f49e3395a97e630b25b42fda5c545a1bda7ae2be581e4c774b767e21/hindsight_client-0.8.5-py3-none-any.whl", hash = "sha256:f868a4764a9d98d84f8fdff6f50703e00d91667b55c22a6c19e2bc44bb84295f", size = 291921, upload-time = "2026-07-22T12:05:32.177Z" },
 ]
 
 [[package]]

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -430,7 +430,7 @@ hermes config set memory.provider hindsight
 echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
 ```
 
-The setup wizard installs dependencies automatically and only installs what's needed for the selected mode (`hindsight-client` for cloud, `hindsight-all` for local). Requires `hindsight-client >= 0.4.22` (auto-upgraded on session start if outdated).
+The setup wizard installs only what the selected mode needs (`hindsight-client` for cloud or local-external; `hindsight-all` plus the exact client constraint for local-embedded). Requires `hindsight-client==0.8.5` (re-pinned to that reviewed version on session start if a different version is installed).
 
 **Local mode UI:** `hindsight-embed -p hermes ui start`
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
@@ -344,7 +344,7 @@ hermes config set memory.provider hindsight
 echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
 ```
 
-安装向导会自动安装依赖，并仅安装所选模式所需的内容（云端用 `hindsight-client`，本地用 `hindsight-all`）。需要 `hindsight-client >= 0.4.22`（会话启动时若版本过旧则自动升级）。
+安装向导仅安装所选模式需要的依赖（云端或本地外部模式使用 `hindsight-client`；本地嵌入模式使用 `hindsight-all` 并同时施加精确的客户端约束）。需要 `hindsight-client==0.8.5`（会话启动时若安装了其他版本，将自动重新固定到该已审核版本）。
 
 **本地模式 UI：** `hindsight-embed -p hermes ui start`
 


### PR DESCRIPTION
Closes #61198.

Bumps `hindsight-client` from `==0.6.1` to the current stable `==0.8.5`, regenerates `uv.lock`, and makes every Hermes-managed install path converge on the same reviewed client version.

The exact requirement is kept consistent across the `[hindsight]` extra, lazy dependency map, plugin manifest, and provider constant. The provider setup/runtime paths reuse that requirement; local embedded setup constrains the client alongside `hindsight-all`, whose metadata otherwise allows `hindsight-client>=0.0.7`. A session-start gate re-pins any installed-version drift, older or newer.

The generic range guidance in `CONTRIBUTING.md` differs from the newer exact-pin supply-chain note in `pyproject.toml`. This PR follows the policy adjacent to the edited dependency and the latest review direction: new versions enter through an intentional pin bump plus lockfile regeneration.

`hindsight-client` 0.8.4 and 0.8.5 have identical `requires_dist`, and the existing Hermes API call surface remains compatible per the independent verification on this PR.

Verification: `uv lock --check`, Ruff, and the targeted packaging/project/lazy-deps/provider/lazy-install tests pass. The Windows run is 222 passed and 1 skipped after deselecting only three pre-existing Windows-only `Path.home()` cases; the unfiltered run is 222 passed, 3 failed, and 1 skipped. GitHub CI is the Linux merge gate.