### PR TITLE
fix(qqbot): add return_exceptions=True to asyncio.gather in chunked upload

### DIFF
--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -599,4 +599,9 @@ async def _run_with_concurrency(
         async with sem:
             await thunk()
 
-    await asyncio.gather(*(_wrap(t) for t in tasks))
+    results = await asyncio.gather(
+        *(_wrap(t) for t in tasks), return_exceptions=True,
+    )
+    for r in results:
+        if isinstance(r, Exception):
+            raise r


### PR DESCRIPTION
## Summary

Add `return_exceptions=True` to `asyncio.gather()` in `gateway/platforms/qqbot/chunked_upload.py`'s `_run_with_concurrency()` helper.

## Problem

The `_run_with_concurrency()` function uses `asyncio.gather()` to run concurrent part uploads for chunked file transfers on QQ Bot. Without `return_exceptions=True`, if **any single part upload fails** (after exhausting retries), the gather propagates the exception and **cancels all other in-flight part uploads**. 

For a 30-part file upload, this means a transient network failure on part 15 cancels the other 29 parts that may have been successfully uploading or about to succeed.

## Fix

Add `return_exceptions=True` to the `asyncio.gather()` call and re-raise the first exception after all tasks complete. This matches the same pattern used elsewhere in the codebase (e.g. `#61244` for the trajectory compressor, `#61140` for feishu).

## Testing

- Syntax check passed (py_compile)
- Pattern matches existing conventions in `tools/mcp_tool.py`, `gateway/platforms/base.py`