### PR TITLE
fix: Feishu WS reconnect on disconnect + session context recovery on auto-reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10869,12 +10869,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # so the agent knows this is a fresh conversation (not an intentional /reset).
         if _was_auto_reset:
             reset_reason = getattr(session_entry, 'auto_reset_reason', None) or 'idle'
+            prev_sid = getattr(session_entry, 'previous_session_id', None)
+            sid_hint = f" Previous session ID: {prev_sid}." if prev_sid else ""
             if reset_reason == "suspended":
-                context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
+                context_note = f"[System note: The user's previous session was stopped and suspended.{sid_hint} Use session_search(session_id='{prev_sid}') to review the last conversation, then resume naturally without re-introducing yourself.]" if prev_sid else "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
             elif reset_reason == "daily":
-                context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
+                context_note = f"[System note: The user's session was automatically reset by the daily schedule.{sid_hint} Use session_search(session_id='{prev_sid}') to review the last conversation, then resume naturally without re-introducing yourself.]" if prev_sid else "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
             else:
-                context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
+                context_note = f"[System note: The user's previous session expired due to inactivity.{sid_hint} Use session_search(session_id='{prev_sid}') to review the last conversation, then resume naturally without re-introducing yourself.]" if prev_sid else "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
             context_prompt = context_note + "\n\n" + context_prompt
 
             # Send a user-facing notification explaining the reset, unless:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -675,6 +675,10 @@ class SessionEntry:
     was_auto_reset: bool = False
     auto_reset_reason: Optional[str] = None  # "idle" or "daily"
     reset_had_activity: bool = False  # whether the expired session had any messages
+    # Set when a session was auto-reset from a previous one.  When non-None,
+    # the agent is instructed to recover context from this session before
+    # responding, preventing the "amnesia" experience on messaging platforms.
+    previous_session_id: Optional[str] = None
 
     # Set by reset_session() when the user explicitly sends /new or /reset.
     # Consumed once by _handle_message_with_agent to trigger topic/channel
@@ -1841,6 +1845,7 @@ class SessionStore:
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
+                previous_session_id=db_end_session_id if was_auto_reset else None,
             )
 
             self._entries[session_key] = entry

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1336,8 +1336,42 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     _apply_runtime_ws_overrides()
     try:
         ws_client.start()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning(
+            "[Feishu] WebSocket client exited with error (will trigger reconnect): %s",
+            exc,
+        )
+        adapter._set_fatal_error(
+            "feishu_ws_disconnect", str(exc), retryable=True
+        )
+        loop = getattr(adapter, "_loop", None)
+        if loop is not None and not loop.is_closed():
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    adapter._notify_fatal_error(), loop
+                )
+            except Exception:
+                pass
+    else:
+        # Normal exit — if adapter is still supposed to be running,
+        # this is an unexpected disconnect (e.g. server-side close).
+        if getattr(adapter, "_running", False):
+            logger.warning(
+                "[Feishu] WebSocket client exited unexpectedly (will trigger reconnect)"
+            )
+            adapter._set_fatal_error(
+                "feishu_ws_disconnect",
+                "WebSocket client exited unexpectedly",
+                retryable=True,
+            )
+            loop = getattr(adapter, "_loop", None)
+            if loop is not None and not loop.is_closed():
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        adapter._notify_fatal_error(), loop
+                    )
+                except Exception:
+                    pass
     finally:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:


### PR DESCRIPTION
## Summary

Two interrelated fixes that improve reliability and UX on Feishu messaging platform:

### 1. Feishu WebSocket disconnect → auto-reconnect

Before: _run_official_feishu_ws_client silently swallowed ALL exceptions from ws_client.start() → gateway appeared dead without recovery.

After:
- Logs the exception and triggers reconnect via _set_fatal_error(feishu_ws_disconnect, ..., retryable=True)
- Also handles unexpected clean exit (server-side close) when adapter is still _running
- Thread-safe: uses asyncio.run_coroutine_threadsafe to bridge from the WS thread to the adapter event loop

### 2. Session context recovery after auto-reset

Before: auto-reset (daily/suspended/idle) created a blank-slate session with no link to the previous conversation → agent had amnesia.

After:
- Added previous_session_id field to SessionEntry (set on auto-reset from the ended session DB id)
- Injected session_search() hint into the context note so the agent can recover context from the prior session
- Falls back to original message when previous_session_id is unavailable