### PR TITLE
fix: enforce disabled MCP toolsets in oneshot mode (#61184)

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -769,10 +769,15 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
                     f"[dim {dim}]{srv['name']}[/] [{text}]({srv['transport']})[/] "
                     f"[dim {dim}]—[/] [{text}]{srv['tools']} tool(s)[/]"
                 )
-            elif srv.get("disabled") or status == "disabled":
+            elif srv.get("disabled") or status in {"disabled", "disabled_toolsets"}:
+                label = (
+                    "disabled (disabled_toolsets)"
+                    if status == "disabled_toolsets"
+                    else "disabled"
+                )
                 right_lines.append(
                     f"[dim {dim}]{srv['name']}[/] [dim]({srv['transport']})[/] "
-                    f"[dim {dim}]— disabled[/]"
+                    f"[dim {dim}]— {label}[/]"
                 )
             elif status == "connecting":
                 right_lines.append(

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -638,11 +638,25 @@ def cmd_mcp_list(args=None):
         else:
             tools_str = "all"
 
-        # Enabled status
+        # Enabled status — also surface agent.disabled_toolsets so a
+        # configured-but-blocked MCP server is not shown as plain "enabled"
+        # (issue #61184).
         enabled = cfg.get("enabled", True)
         if isinstance(enabled, str):
             enabled = enabled.lower() in {"true", "1", "yes"}
-        status = color("✓ enabled", Colors.GREEN) if enabled else color("✗ disabled", Colors.DIM)
+        blocked_by_disabled = False
+        try:
+            from toolsets import is_mcp_server_disabled_by_toolsets
+
+            blocked_by_disabled = is_mcp_server_disabled_by_toolsets(str(name))
+        except Exception:
+            blocked_by_disabled = False
+        if not enabled:
+            status = color("✗ disabled", Colors.DIM)
+        elif blocked_by_disabled:
+            status = color("✗ blocked (disabled_toolsets)", Colors.YELLOW)
+        else:
+            status = color("✓ enabled", Colors.GREEN)
 
         print(f"  {name:<16} {transport:<30} {tools_str:<12} {status}")
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -343,9 +343,10 @@ def _run_agent(
     # MCP discovery used to race oneshot tool snapshotting (#38448 / #61184):
     # background discovery started in _prepare_agent_startup, but -z never
     # waited, so aliases (server-b → mcp-server-b) were missing when tools
-    # were resolved and disabled-toolset subtraction could no-op. Run/await
-    # discovery BEFORE building AIAgent so MCP aliases exist and
-    # disabled_toolsets can strip them.
+    # were resolved and disabled-toolset subtraction could no-op. Ensure the
+    # shared discovery owner exists, then wait only for its configured bounded
+    # interval before building AIAgent. Slow servers continue in that same
+    # background thread and are picked up by late-binding refresh.
     try:
         from hermes_cli.mcp_startup import (
             start_background_mcp_discovery,
@@ -357,11 +358,6 @@ def _run_agent(
             thread_name="oneshot-mcp-discovery",
         )
         wait_for_mcp_discovery()
-        # Idempotent: finish any servers that missed the bounded wait so the
-        # single oneshot turn sees a complete registry (or explicit failures).
-        from tools.mcp_tool import discover_mcp_tools
-
-        discover_mcp_tools()
     except Exception:
         logging.getLogger(__name__).debug(
             "oneshot MCP discovery failed (non-fatal)", exc_info=True,

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -332,6 +332,41 @@ def _run_agent(
     if toolsets_list is None and use_config_toolsets:
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
+    # agent.disabled_toolsets is a hard security boundary (issue #61184).
+    # Apply it in oneshot the same way interactive CLI / cron / gateway do —
+    # not only by subtracting names from the enabled list, but as an explicit
+    # disabled_toolsets pass to AIAgent so schema assembly AND dispatch refuse
+    # tools from disabled MCP servers (bare name or mcp-<name> alias).
+    agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+    disabled_toolsets = list(agent_cfg.get("disabled_toolsets") or []) or None
+
+    # MCP discovery used to race oneshot tool snapshotting (#38448 / #61184):
+    # background discovery started in _prepare_agent_startup, but -z never
+    # waited, so aliases (server-b → mcp-server-b) were missing when tools
+    # were resolved and disabled-toolset subtraction could no-op. Run/await
+    # discovery BEFORE building AIAgent so MCP aliases exist and
+    # disabled_toolsets can strip them.
+    try:
+        from hermes_cli.mcp_startup import (
+            start_background_mcp_discovery,
+            wait_for_mcp_discovery,
+        )
+
+        start_background_mcp_discovery(
+            logger=logging.getLogger(__name__),
+            thread_name="oneshot-mcp-discovery",
+        )
+        wait_for_mcp_discovery()
+        # Idempotent: finish any servers that missed the bounded wait so the
+        # single oneshot turn sees a complete registry (or explicit failures).
+        from tools.mcp_tool import discover_mcp_tools
+
+        discover_mcp_tools()
+    except Exception:
+        logging.getLogger(__name__).debug(
+            "oneshot MCP discovery failed (non-fatal)", exc_info=True,
+        )
+
     session_db = _create_session_db_for_oneshot()
     # Read the effective fallback chain from profile config so oneshot workers
     # honour the same merge semantics as interactive CLI and gateway sessions.
@@ -344,6 +379,7 @@ def _run_agent(
         api_mode=runtime.get("api_mode"),
         model=effective_model,
         enabled_toolsets=toolsets_list,
+        disabled_toolsets=disabled_toolsets,
         quiet_mode=True,
         platform="cli",
         session_db=session_db,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1661,10 +1661,27 @@ def _get_platform_tools(
     # globally suppress specific toolsets (e.g. "memory") across all
     # platforms without per-platform toolset configuration.  This runs
     # last so it overrides everything above.
+    #
+    # Expand MCP bare/canonical aliases so ``server-b`` and ``mcp-server-b``
+    # both remove the MCP server from the platform toolset list (#61184).
     agent_cfg = config.get("agent") or {}
     disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
     if disabled_toolsets:
-        disabled_set = {str(ts) for ts in disabled_toolsets}
+        try:
+            from toolsets import expand_disabled_toolset_names
+
+            mcp_names = {
+                str(n)
+                for n in ((config.get("mcp_servers") or {}) if isinstance(config.get("mcp_servers"), dict) else {})
+            }
+            disabled_set = set(
+                expand_disabled_toolset_names(
+                    [str(ts) for ts in disabled_toolsets],
+                    mcp_server_names=mcp_names,
+                )
+            )
+        except Exception:
+            disabled_set = {str(ts) for ts in disabled_toolsets}
         enabled_toolsets -= disabled_set
 
     # #38798: if this platform was explicitly configured but every toolset name
@@ -4194,10 +4211,22 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
     if mcp_servers:
         print()
         print("MCP servers:")
+        try:
+            from toolsets import is_mcp_server_disabled_by_toolsets
+
+            agent_disabled = is_mcp_server_disabled_by_toolsets
+        except Exception:
+            agent_disabled = lambda _name, _d=None: False  # noqa: E731
         for srv_name, srv_cfg in mcp_servers.items():
             tools_cfg = srv_cfg.get("tools") or {}
             exclude = tools_cfg.get("exclude") or []
             include = tools_cfg.get("include") or []
+            if agent_disabled(str(srv_name)):
+                _print_info(
+                    f"{srv_name}  "
+                    f"{color('disabled by agent.disabled_toolsets', Colors.YELLOW)}"
+                )
+                continue
             if include:
                 _print_info(f"{srv_name}  [include only: {', '.join(include)}]")
             elif exclude:

--- a/model_tools.py
+++ b/model_tools.py
@@ -30,7 +30,12 @@ import time
 from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import discover_builtin_tools, registry
-from toolsets import resolve_toolset, validate_toolset
+from toolsets import (
+    expand_disabled_toolset_names,
+    resolve_toolset,
+    tool_blocked_by_disabled_toolsets,
+    validate_toolset,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -396,8 +401,18 @@ def _compute_tool_definitions(
     # This ensures that even if a composite toolset (like hermes-cli)
     # is enabled, any tools belonging to a disabled toolset are strictly
     # stripped out. See issue #17309.
+    #
+    # Expand MCP bare/canonical aliases so ``server-b`` and ``mcp-server-b``
+    # both strip the same tools (#61184). Only warn for operator-supplied
+    # names (not synthetic expansions that may not exist pre-discovery).
     if disabled_toolsets:
-        for toolset_name in disabled_toolsets:
+        original_disabled = [str(n) for n in disabled_toolsets]
+        expanded_disabled = expand_disabled_toolset_names(original_disabled)
+        seen_disabled: set = set()
+        for toolset_name in expanded_disabled:
+            if toolset_name in seen_disabled:
+                continue
+            seen_disabled.add(toolset_name)
             if validate_toolset(toolset_name):
                 if toolset_name.startswith("hermes-"):
                     # Platform bundles (hermes-*) include _HERMES_CORE_TOOLS, so
@@ -429,7 +444,7 @@ def _compute_tool_definitions(
                 tools_to_include.difference_update(legacy_tools)
                 if not quiet_mode:
                     print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
-            elif not quiet_mode:
+            elif not quiet_mode and toolset_name in original_disabled:
                 print(f"⚠️  Unknown toolset: {toolset_name}")
 
     # Plugin-registered tools are now resolved through the normal toolset
@@ -1007,6 +1022,7 @@ def handle_function_call(
                 }, ensure_ascii=False)
             # Recurse with the underlying tool. All hooks fire against the
             # real tool name. The bridge is invisible to hooks by design.
+            # Disabled-toolset enforcement also runs on the recursive call.
             return handle_function_call(
                 function_name=underlying_name,
                 function_args=underlying_args,
@@ -1021,6 +1037,23 @@ def handle_function_call(
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
             )
+
+    # ── Disabled-toolset hard boundary (issue #61184) ────────────────
+    # Schema filtering should already exclude these tools, but a stale
+    # snapshot, progressive-disclosure tool_call, or direct dispatch must
+    # never execute a tool from a disabled toolset — especially a disabled
+    # MCP server that shares a local tool name with an allowed one.
+    if disabled_toolsets:
+        blocked_label = tool_blocked_by_disabled_toolsets(
+            function_name, list(disabled_toolsets),
+        )
+        if blocked_label:
+            err = (
+                f"Tool '{function_name}' belongs to disabled toolset "
+                f"{blocked_label} and cannot be executed."
+            )
+            logger.warning("Refusing disabled-toolset dispatch: %s", err)
+            return json.dumps({"error": err}, ensure_ascii=False)
 
     _tool_original_args = dict(function_args)
     if not skip_tool_request_middleware:

--- a/tests/test_disabled_mcp_toolsets_61184.py
+++ b/tests/test_disabled_mcp_toolsets_61184.py
@@ -14,6 +14,8 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -347,10 +349,7 @@ class TestOneshotDisabledMcp61184:
         from hermes_cli import oneshot as oneshot_mod
 
         captured = {}
-
-        def fake_discover():
-            captured["discovered"] = True
-            return [two_mcp_servers["tool_a"], two_mcp_servers["tool_b"]]
+        synchronous_discover = MagicMock()
 
         class FakeAgent:
             def __init__(self, **kwargs):
@@ -410,17 +409,93 @@ class TestOneshotDisabledMcp61184:
             "hermes_cli.mcp_startup.wait_for_mcp_discovery",
             lambda timeout=None: captured.__setitem__("waited", True),
         )
-        monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", fake_discover)
+        monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", synchronous_discover)
         monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
 
         response, result = oneshot_mod._run_agent("check cluster", model="test-model")
 
         assert response == "ok"
         assert captured.get("waited") is True
-        assert captured.get("discovered") is True
+        synchronous_discover.assert_not_called()
         assert captured["kwargs"].get("disabled_toolsets") == ["server-b"]
         assert two_mcp_servers["tool_b"] not in captured.get("tool_names", set())
         assert two_mcp_servers["tool_a"] in captured.get("tool_names", set())
+
+    def test_slow_discovery_is_not_duplicated_or_awaited_past_bound(self, monkeypatch):
+        from hermes_cli import mcp_startup
+        from hermes_cli import oneshot as oneshot_mod
+
+        discovery_started = threading.Event()
+        release_discovery = threading.Event()
+        attempts = 0
+
+        def slow_discover():
+            nonlocal attempts
+            attempts += 1
+            discovery_started.set()
+            release_discovery.wait(timeout=2)
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                self.suppress_status_output = False
+                self.stream_delta_callback = None
+                self.tool_gen_callback = None
+
+            def run_conversation(self, prompt):
+                return {"final_response": "ok", "completed": True}
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"default": "test-model", "provider": "test"},
+                "mcp_discovery_timeout": 0.02,
+                "mcp_servers": {"slow-server": {"url": "http://slow/mcp"}},
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda cfg, platform: {"slow-server"},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kw: {
+                "api_key": "k",
+                "base_url": "http://localhost",
+                "provider": "test",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.fallback_config.get_fallback_chain",
+            lambda cfg: None,
+        )
+        monkeypatch.setattr(oneshot_mod, "_create_session_db_for_oneshot", lambda: None)
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", False)
+        monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+        monkeypatch.setattr(mcp_startup, "_has_configured_mcp_servers", lambda: True)
+        monkeypatch.setattr(
+            mcp_startup,
+            "_discover_mcp_tools_without_interactive_oauth",
+            slow_discover,
+        )
+
+        started_at = time.monotonic()
+        try:
+            response, _ = oneshot_mod._run_agent("check cluster", model="test-model")
+            elapsed = time.monotonic() - started_at
+
+            assert discovery_started.is_set()
+            assert response == "ok"
+            assert attempts == 1
+            assert elapsed < 0.5
+            assert mcp_startup.mcp_discovery_in_flight()
+        finally:
+            release_discovery.set()
+            thread = mcp_startup._mcp_discovery_thread
+            if thread is not None:
+                thread.join(timeout=1)
 
 
 # ---------------------------------------------------------------------------
@@ -518,4 +593,3 @@ class TestPlatformAndCliDisabledMcp61184:
         assert statuses["server-b"]["disabled"] is True
         assert statuses["server-b"]["status"] == "disabled_toolsets"
         assert statuses["server-a"]["disabled"] is False
-

--- a/tests/test_disabled_mcp_toolsets_61184.py
+++ b/tests/test_disabled_mcp_toolsets_61184.py
@@ -1,0 +1,521 @@
+"""Regression tests for issue #61184.
+
+``agent.disabled_toolsets`` must be a hard security boundary for MCP servers:
+
+* bare name (``server-b``) and canonical (``mcp-server-b``) both work
+* schemas exclude disabled MCP tools after discovery
+* oneshot (-z) passes disabled_toolsets and waits for MCP discovery
+* dispatch refuses tools from disabled toolsets with an explicit error
+* tool_search / tool_describe / tool_call cannot surface or run them
+* CLI list/status surfaces the blocked state
+* unavailable intended servers do not silently fall back to a disabled peer
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.registry import registry
+from toolsets import (
+    expand_disabled_toolset_names,
+    is_mcp_server_disabled_by_toolsets,
+    tool_blocked_by_disabled_toolsets,
+)
+
+
+SHARED_LOCAL_TOOL = "cluster_status"
+
+
+def _register_fake_mcp_server(server_name: str, local_tool: str = SHARED_LOCAL_TOOL, *, result_payload: str = "ok"):
+    """Register a fake MCP-style tool: toolset mcp-<server>, alias <server>."""
+    from tools.mcp_tool import sanitize_mcp_name_component
+
+    safe_server = sanitize_mcp_name_component(server_name)
+    safe_tool = sanitize_mcp_name_component(local_tool)
+    tool_name = f"mcp_{safe_server}_{safe_tool}"
+    toolset = f"mcp-{server_name}"
+
+    def _handler(args, **kwargs):
+        return json.dumps({
+            "server": server_name,
+            "tool": local_tool,
+            "result": result_payload,
+        })
+
+    registry.register(
+        name=tool_name,
+        toolset=toolset,
+        schema={
+            "name": tool_name,
+            "description": f"{local_tool} from {server_name}",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+        handler=_handler,
+        check_fn=lambda: True,
+        description=f"{local_tool} from {server_name}",
+    )
+    registry.register_toolset_alias(server_name, toolset)
+    return tool_name, toolset
+
+
+@pytest.fixture
+def two_mcp_servers(monkeypatch):
+    """Two MCP servers exposing the same local tool name; server-b is sensitive."""
+    # Isolate registry mutations from other tests.
+    saved_tools = dict(registry._tools)
+    saved_aliases = dict(registry._toolset_aliases)
+    saved_checks = dict(registry._toolset_checks)
+    saved_gen = registry._generation
+
+    # Clear any prior MCP entries for these names (idempotent re-register).
+    for name in list(registry._tools.keys()):
+        if name.startswith("mcp_server_a_") or name.startswith("mcp_server_b_"):
+            try:
+                registry.deregister(name)
+            except Exception:
+                pass
+
+    tool_a, ts_a = _register_fake_mcp_server("server-a", result_payload="cluster-A")
+    tool_b, ts_b = _register_fake_mcp_server("server-b", result_payload="cluster-B")
+
+    mcp_servers = {
+        "server-a": {"url": "http://host-a/mcp"},
+        "server-b": {"url": "https://host-b/mcp"},
+    }
+    monkeypatch.setattr(
+        "toolsets._configured_mcp_server_names",
+        lambda: set(mcp_servers.keys()),
+    )
+
+    yield {
+        "tool_a": tool_a,
+        "tool_b": tool_b,
+        "ts_a": ts_a,
+        "ts_b": ts_b,
+        "mcp_servers": mcp_servers,
+    }
+
+    # Restore registry snapshot.
+    with registry._lock:
+        registry._tools.clear()
+        registry._tools.update(saved_tools)
+        registry._toolset_aliases.clear()
+        registry._toolset_aliases.update(saved_aliases)
+        registry._toolset_checks.clear()
+        registry._toolset_checks.update(saved_checks)
+        registry._generation = saved_gen + 1
+
+
+def _tool_names(defs):
+    return {t["function"]["name"] for t in defs}
+
+
+# ---------------------------------------------------------------------------
+# expand / alias helpers
+# ---------------------------------------------------------------------------
+
+
+class TestExpandDisabledMcpAliases61184:
+    def test_bare_and_canonical_expand_to_each_other(self, two_mcp_servers):
+        bare = expand_disabled_toolset_names(["server-b"])
+        canon = expand_disabled_toolset_names(["mcp-server-b"])
+        assert "server-b" in bare and "mcp-server-b" in bare
+        assert "server-b" in canon and "mcp-server-b" in canon
+
+    def test_is_mcp_server_disabled_accepts_both_forms(self, two_mcp_servers):
+        assert is_mcp_server_disabled_by_toolsets("server-b", ["server-b"])
+        assert is_mcp_server_disabled_by_toolsets("server-b", ["mcp-server-b"])
+        assert not is_mcp_server_disabled_by_toolsets("server-a", ["server-b"])
+
+    def test_tool_blocked_label_mentions_both_forms(self, two_mcp_servers):
+        label = tool_blocked_by_disabled_toolsets(
+            two_mcp_servers["tool_b"], ["server-b"],
+        )
+        assert label is not None
+        assert "server-b" in label
+        assert "mcp-server-b" in label
+
+
+# ---------------------------------------------------------------------------
+# get_tool_definitions schema filtering
+# ---------------------------------------------------------------------------
+
+
+class TestGetToolDefinitionsDisabledMcp61184:
+    def test_disabled_bare_name_excludes_server_b_tools(self, two_mcp_servers):
+        from model_tools import get_tool_definitions, _clear_tool_defs_cache
+
+        _clear_tool_defs_cache()
+        defs = get_tool_definitions(
+            enabled_toolsets=["server-a", "server-b"],
+            disabled_toolsets=["server-b"],
+            quiet_mode=True,
+        )
+        names = _tool_names(defs)
+        assert two_mcp_servers["tool_a"] in names
+        assert two_mcp_servers["tool_b"] not in names
+
+    def test_disabled_canonical_name_same_as_bare(self, two_mcp_servers):
+        from model_tools import get_tool_definitions, _clear_tool_defs_cache
+
+        _clear_tool_defs_cache()
+        bare = _tool_names(get_tool_definitions(
+            enabled_toolsets=["server-a", "server-b"],
+            disabled_toolsets=["server-b"],
+            quiet_mode=True,
+        ))
+        _clear_tool_defs_cache()
+        canon = _tool_names(get_tool_definitions(
+            enabled_toolsets=["server-a", "server-b"],
+            disabled_toolsets=["mcp-server-b"],
+            quiet_mode=True,
+        ))
+        assert bare == canon
+        assert two_mcp_servers["tool_b"] not in bare
+        assert two_mcp_servers["tool_a"] in bare
+
+    def test_non_mcp_disabled_toolsets_still_work(self, two_mcp_servers):
+        """Preserves existing behavior for non-MCP toolsets (#61184 constraint)."""
+        from model_tools import get_tool_definitions, _clear_tool_defs_cache
+
+        # Use a private non-MCP tool so we are not dependent on check_fn / API keys.
+        fake_name = "_61184_probe_tool"
+        if fake_name in registry._tools:
+            registry.deregister(fake_name)
+        registry.register(
+            name=fake_name,
+            toolset="probe61184",
+            schema={
+                "name": fake_name,
+                "description": "probe",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            check_fn=lambda: True,
+            description="probe",
+        )
+        try:
+            # Make probe61184 a real toolset name for validate_toolset.
+            from toolsets import TOOLSETS
+
+            TOOLSETS["probe61184"] = {
+                "description": "probe",
+                "tools": [fake_name],
+                "includes": [],
+            }
+            _clear_tool_defs_cache()
+            with_probe = _tool_names(get_tool_definitions(
+                enabled_toolsets=["probe61184", "server-a"],
+                disabled_toolsets=None,
+                quiet_mode=True,
+            ))
+            _clear_tool_defs_cache()
+            no_probe = _tool_names(get_tool_definitions(
+                enabled_toolsets=["probe61184", "server-a"],
+                disabled_toolsets=["probe61184"],
+                quiet_mode=True,
+            ))
+            assert fake_name in with_probe
+            assert fake_name not in no_probe
+            assert two_mcp_servers["tool_a"] in no_probe
+        finally:
+            try:
+                registry.deregister(fake_name)
+            except Exception:
+                pass
+            from toolsets import TOOLSETS
+            TOOLSETS.pop("probe61184", None)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-time enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchDisabledMcp61184:
+    def test_dispatch_refuses_disabled_server_b_tool(self, two_mcp_servers):
+        from model_tools import handle_function_call
+
+        raw = handle_function_call(
+            two_mcp_servers["tool_b"],
+            {},
+            disabled_toolsets=["server-b"],
+        )
+        result = json.loads(raw)
+        assert "error" in result
+        assert two_mcp_servers["tool_b"] in result["error"]
+        assert "disabled toolset" in result["error"]
+        assert "server-b" in result["error"]
+        assert "cannot be executed" in result["error"]
+
+    def test_dispatch_refuses_with_canonical_disabled_name(self, two_mcp_servers):
+        from model_tools import handle_function_call
+
+        raw = handle_function_call(
+            two_mcp_servers["tool_b"],
+            {},
+            disabled_toolsets=["mcp-server-b"],
+        )
+        result = json.loads(raw)
+        assert "error" in result
+        assert "cannot be executed" in result["error"]
+
+    def test_dispatch_allows_server_a_when_only_b_disabled(self, two_mcp_servers):
+        from model_tools import handle_function_call
+
+        raw = handle_function_call(
+            two_mcp_servers["tool_a"],
+            {},
+            disabled_toolsets=["server-b"],
+        )
+        result = json.loads(raw)
+        assert result.get("server") == "server-a"
+        assert result.get("result") == "cluster-A"
+
+    def test_no_silent_fallback_when_server_a_unavailable(self, two_mcp_servers, monkeypatch):
+        """If the intended server is down, do not execute the disabled peer."""
+        from model_tools import handle_function_call
+
+        # Simulate server-a check failing / tool deregistered from schema, but
+        # a stale direct dispatch against server-b must still be refused.
+        raw = handle_function_call(
+            two_mcp_servers["tool_b"],
+            {},
+            enabled_toolsets=["server-a"],
+            disabled_toolsets=["server-b"],
+        )
+        result = json.loads(raw)
+        assert "error" in result
+        assert result.get("server") != "server-b"
+        assert "cluster-B" not in json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# tool_search progressive disclosure
+# ---------------------------------------------------------------------------
+
+
+class TestToolSearchDisabledMcp61184:
+    def test_disabled_tools_not_in_tool_search_catalog(self, two_mcp_servers):
+        from model_tools import get_tool_definitions, _clear_tool_defs_cache
+
+        _clear_tool_defs_cache()
+        defs = get_tool_definitions(
+            enabled_toolsets=["server-a", "server-b"],
+            disabled_toolsets=["server-b"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        names = _tool_names(defs)
+        assert two_mcp_servers["tool_b"] not in names
+        assert two_mcp_servers["tool_a"] in names
+
+    def test_tool_call_bridge_cannot_execute_disabled_mcp(self, two_mcp_servers, monkeypatch):
+        from model_tools import handle_function_call
+        from tools import tool_search as ts
+
+        # Force bridge path: tool_call with underlying name of disabled tool.
+        raw = handle_function_call(
+            ts.TOOL_CALL_NAME,
+            {"name": two_mcp_servers["tool_b"], "arguments": {}},
+            enabled_toolsets=["server-a", "server-b"],
+            disabled_toolsets=["server-b"],
+        )
+        result = json.loads(raw)
+        assert "error" in result
+        # Either scoped-catalog rejection or disabled-toolset refusal.
+        err = result["error"].lower()
+        assert (
+            "not available" in err
+            or "disabled toolset" in err
+            or "cannot be executed" in err
+        )
+        assert result.get("server") != "server-b"
+
+
+# ---------------------------------------------------------------------------
+# oneshot path
+# ---------------------------------------------------------------------------
+
+
+class TestOneshotDisabledMcp61184:
+    def test_oneshot_passes_disabled_toolsets_and_awaits_mcp(self, two_mcp_servers, monkeypatch):
+        from hermes_cli import oneshot as oneshot_mod
+
+        captured = {}
+
+        def fake_discover():
+            captured["discovered"] = True
+            return [two_mcp_servers["tool_a"], two_mcp_servers["tool_b"]]
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured["kwargs"] = kwargs
+                self.suppress_status_output = False
+                self.stream_delta_callback = None
+                self.tool_gen_callback = None
+                self.tools = []
+                self.valid_tool_names = set()
+                self.enabled_toolsets = kwargs.get("enabled_toolsets")
+                self.disabled_toolsets = kwargs.get("disabled_toolsets")
+
+            def run_conversation(self, prompt):
+                from model_tools import get_tool_definitions
+
+                self.tools = get_tool_definitions(
+                    enabled_toolsets=self.enabled_toolsets,
+                    disabled_toolsets=self.disabled_toolsets,
+                    quiet_mode=True,
+                )
+                self.valid_tool_names = {t["function"]["name"] for t in self.tools}
+                captured["tool_names"] = set(self.valid_tool_names)
+                return {"final_response": "ok", "completed": True}
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"default": "test-model", "provider": "test"},
+                "agent": {"disabled_toolsets": ["server-b"]},
+                "mcp_servers": two_mcp_servers["mcp_servers"],
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools",
+            lambda cfg, platform: {"server-a", "server-b", "web"},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kw: {
+                "api_key": "k",
+                "base_url": "http://localhost",
+                "provider": "test",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.fallback_config.get_fallback_chain",
+            lambda cfg: None,
+        )
+        monkeypatch.setattr(oneshot_mod, "_create_session_db_for_oneshot", lambda: None)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_startup.start_background_mcp_discovery",
+            lambda **kw: captured.__setitem__("bg_started", True),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.mcp_startup.wait_for_mcp_discovery",
+            lambda timeout=None: captured.__setitem__("waited", True),
+        )
+        monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", fake_discover)
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+
+        response, result = oneshot_mod._run_agent("check cluster", model="test-model")
+
+        assert response == "ok"
+        assert captured.get("waited") is True
+        assert captured.get("discovered") is True
+        assert captured["kwargs"].get("disabled_toolsets") == ["server-b"]
+        assert two_mcp_servers["tool_b"] not in captured.get("tool_names", set())
+        assert two_mcp_servers["tool_a"] in captured.get("tool_names", set())
+
+
+# ---------------------------------------------------------------------------
+# Platform tools + CLI surfaces
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformAndCliDisabledMcp61184:
+    def test_get_platform_tools_removes_bare_and_canonical(self, two_mcp_servers):
+        from hermes_cli.tools_config import _get_platform_tools
+
+        config = {
+            "platform_toolsets": {"cli": ["web"]},
+            "agent": {"disabled_toolsets": ["server-b"]},
+            "mcp_servers": two_mcp_servers["mcp_servers"],
+        }
+        enabled = _get_platform_tools(config, "cli")
+        assert "server-b" not in enabled
+        assert "mcp-server-b" not in enabled
+        # server-a still present when defaults include MCP servers
+        assert "server-a" in enabled
+
+        config2 = {
+            "platform_toolsets": {"cli": ["web"]},
+            "agent": {"disabled_toolsets": ["mcp-server-b"]},
+            "mcp_servers": two_mcp_servers["mcp_servers"],
+        }
+        enabled2 = _get_platform_tools(config2, "cli")
+        assert "server-b" not in enabled2
+        assert "mcp-server-b" not in enabled2
+
+    def test_mcp_list_shows_blocked_by_disabled_toolsets(self, two_mcp_servers, monkeypatch, capsys, tmp_path):
+        from hermes_cli import mcp_config
+
+        monkeypatch.setattr(
+            mcp_config,
+            "_get_mcp_servers",
+            lambda config=None: {
+                "server-a": {"url": "http://host-a/mcp", "enabled": True},
+                "server-b": {"url": "https://host-b/mcp", "enabled": True},
+            },
+        )
+        monkeypatch.setattr(
+            "toolsets.is_mcp_server_disabled_by_toolsets",
+            lambda name, d=None: str(name) == "server-b",
+        )
+
+        mcp_config.cmd_mcp_list()
+        out = capsys.readouterr().out
+        assert "server-a" in out
+        assert "server-b" in out
+        assert "disabled_toolsets" in out or "blocked" in out.lower()
+
+    def test_tools_list_marks_disabled_mcp(self, two_mcp_servers, capsys, monkeypatch):
+        from hermes_cli.tools_config import _print_tools_list
+
+        monkeypatch.setattr(
+            "toolsets.is_mcp_server_disabled_by_toolsets",
+            lambda name, d=None: str(name) == "server-b",
+        )
+        _print_tools_list(
+            enabled_toolsets={"web", "server-a"},
+            mcp_servers=two_mcp_servers["mcp_servers"],
+            platform="cli",
+        )
+        out = capsys.readouterr().out
+        assert "server-b" in out
+        assert "disabled_toolsets" in out
+
+    def test_get_mcp_status_marks_disabled_toolsets(self, two_mcp_servers, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+
+        monkeypatch.setattr(
+            mcp_tool,
+            "_load_mcp_config",
+            lambda: {
+                "server-a": {"url": "http://a"},
+                "server-b": {"url": "https://b"},
+            },
+        )
+        monkeypatch.setattr(
+            "toolsets.is_mcp_server_disabled_by_toolsets",
+            lambda name, d=None: str(name) == "server-b",
+        )
+        with mcp_tool._lock:
+            saved = dict(mcp_tool._servers)
+            mcp_tool._servers.clear()
+        try:
+            statuses = {e["name"]: e for e in mcp_tool.get_mcp_status()}
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._servers.clear()
+                mcp_tool._servers.update(saved)
+
+        assert statuses["server-b"]["disabled"] is True
+        assert statuses["server-b"]["status"] == "disabled_toolsets"
+        assert statuses["server-a"]["disabled"] is False
+

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4490,23 +4490,21 @@ def get_mcp_status() -> List[dict]:
         connecting = set(_server_connecting)
         connect_errors = dict(_server_connect_errors)
 
+    # agent.disabled_toolsets is a hard boundary for MCP servers (#61184).
+    # Surface that in status so list/banner UIs do not show a blocked server
+    # as plain "connected/enabled".
+    try:
+        from toolsets import is_mcp_server_disabled_by_toolsets
+    except Exception:
+        def is_mcp_server_disabled_by_toolsets(_name, _d=None):  # type: ignore
+            return False
+
     for name, cfg in configured.items():
         transport = cfg.get("transport", "http") if "url" in cfg else "stdio"
         enabled = _parse_boolish(cfg.get("enabled", True), default=True)
+        blocked_by_disabled = bool(is_mcp_server_disabled_by_toolsets(str(name)))
         server = active_servers.get(name)
-        if server and server.session is not None:
-            entry = {
-                "name": name,
-                "transport": transport,
-                "tools": len(server._registered_tool_names) if hasattr(server, "_registered_tool_names") else len(server._tools),
-                "connected": True,
-                "disabled": False,
-                "status": "connected",
-            }
-            if server._sampling:
-                entry["sampling"] = dict(server._sampling.metrics)
-            result.append(entry)
-        elif not enabled:
+        if not enabled:
             # A server with enabled: false is intentionally not connected — it is
             # disabled, not failed. Surface that distinction so consumers (banner,
             # TUI) can render "disabled" rather than an alarming "failed".
@@ -4518,6 +4516,37 @@ def get_mcp_status() -> List[dict]:
                 "disabled": True,
                 "status": "disabled",
             })
+        elif blocked_by_disabled:
+            # Report as not-connected for UI consumers that key on `connected`
+            # first (banner, TUI). The process may still hold a live socket, but
+            # tools from this server are a hard deny for the active profile.
+            tool_count = 0
+            if server is not None:
+                if hasattr(server, "_registered_tool_names"):
+                    tool_count = len(server._registered_tool_names)
+                else:
+                    tool_count = len(getattr(server, "_tools", []) or [])
+            result.append({
+                "name": name,
+                "transport": transport,
+                "tools": tool_count,
+                "connected": False,
+                "disabled": True,
+                "status": "disabled_toolsets",
+                "reason": "agent.disabled_toolsets",
+            })
+        elif server and server.session is not None:
+            entry = {
+                "name": name,
+                "transport": transport,
+                "tools": len(server._registered_tool_names) if hasattr(server, "_registered_tool_names") else len(server._tools),
+                "connected": True,
+                "disabled": False,
+                "status": "connected",
+            }
+            if server._sampling:
+                entry["sampling"] = dict(server._sampling.metrics)
+            result.append(entry)
         elif name in connecting:
             result.append({
                 "name": name,

--- a/toolsets.py
+++ b/toolsets.py
@@ -879,6 +879,177 @@ def validate_toolset(name: str) -> bool:
     return name in _get_registry_toolset_aliases()
 
 
+def _configured_mcp_server_names() -> Set[str]:
+    """Return bare MCP server names from config (``mcp_servers`` keys).
+
+    Fail-soft: any config error yields an empty set so callers can still
+    expand via live registry aliases alone.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        servers = (read_raw_config() or {}).get("mcp_servers") or {}
+        if not isinstance(servers, dict):
+            return set()
+        return {str(name) for name in servers.keys() if name}
+    except Exception:
+        return set()
+
+
+def expand_disabled_toolset_names(
+    names: Optional[List[str]],
+    *,
+    mcp_server_names: Optional[Set[str]] = None,
+) -> List[str]:
+    """Expand disabled toolset names so MCP bare and ``mcp-<name>`` forms match.
+
+    Issue #61184: ``agent.disabled_toolsets: [server-b]`` must also disable
+    the canonical toolset ``mcp-server-b`` (and vice versa). Expansion also
+    follows live registry aliases (``server-b`` → ``mcp-server-b``) once MCP
+    discovery has registered them.
+
+    Non-MCP names (``memory``, ``web``, ``hermes-cli``, …) are returned
+    unchanged — only MCP bare/canonical pairs and registered aliases are
+    expanded.
+    """
+    if not names:
+        return []
+
+    known_mcp = set(mcp_server_names) if mcp_server_names is not None else _configured_mcp_server_names()
+    aliases = _get_registry_toolset_aliases()  # alias → canonical
+    reverse: Dict[str, Set[str]] = {}
+    for alias, canonical in aliases.items():
+        reverse.setdefault(canonical, set()).add(alias)
+
+    expanded: List[str] = []
+    seen: Set[str] = set()
+
+    def _add(value: str) -> None:
+        if value and value not in seen:
+            seen.add(value)
+            expanded.append(value)
+
+    for raw in names:
+        name = str(raw).strip()
+        if not name:
+            continue
+        _add(name)
+
+        # Live registry alias → canonical (and reverse).
+        target = aliases.get(name)
+        if target:
+            _add(target)
+            for alias in reverse.get(target, ()):
+                _add(alias)
+        for alias in reverse.get(name, ()):
+            _add(alias)
+
+        # MCP bare ↔ mcp-<name> for configured servers or registered aliases.
+        if name.startswith("mcp-"):
+            bare = name[4:]
+            if bare and (bare in known_mcp or name in aliases.values() or bare in aliases):
+                _add(bare)
+        else:
+            if name in known_mcp or name in aliases or f"mcp-{name}" in reverse:
+                _add(f"mcp-{name}")
+
+    return expanded
+
+
+def disabled_toolset_label(toolset_name: str, disabled_names: Optional[List[str]] = None) -> str:
+    """Human-readable label for a disabled toolset (bare + canonical when MCP)."""
+    if not toolset_name:
+        return "''"
+    if toolset_name.startswith("mcp-"):
+        bare = toolset_name[4:]
+        return f"'{bare}' / '{toolset_name}'"
+    # Dual-label bare MCP server names (configured or aliased).
+    mcp_form = f"mcp-{toolset_name}"
+    known_mcp = _configured_mcp_server_names()
+    aliases = _get_registry_toolset_aliases()
+    if (
+        toolset_name in known_mcp
+        or aliases.get(toolset_name) == mcp_form
+        or (disabled_names and mcp_form in set(expand_disabled_toolset_names(list(disabled_names))))
+    ):
+        return f"'{toolset_name}' / '{mcp_form}'"
+    return f"'{toolset_name}'"
+
+
+def tool_blocked_by_disabled_toolsets(
+    tool_name: str,
+    disabled_toolsets: Optional[List[str]],
+) -> Optional[str]:
+    """Return a label if *tool_name* belongs to a disabled toolset, else None.
+
+    Defense-in-depth for issue #61184: schema filtering should already exclude
+    these tools, but stale schemas, tool_call bridges, or direct dispatch must
+    still refuse execution.
+    """
+    if not tool_name or not disabled_toolsets:
+        return None
+
+    expanded = expand_disabled_toolset_names(list(disabled_toolsets))
+    if not expanded:
+        return None
+    expanded_set = set(expanded)
+
+    try:
+        from tools.registry import registry
+
+        toolset = registry.get_toolset_for_tool(tool_name)
+    except Exception:
+        toolset = None
+
+    if toolset and toolset in expanded_set:
+        return disabled_toolset_label(toolset, disabled_toolsets)
+
+    # Alias form: toolset is mcp-server-b, disabled listed server-b (expanded).
+    if toolset:
+        for name in expanded:
+            if name == toolset:
+                return disabled_toolset_label(toolset, disabled_toolsets)
+            try:
+                if validate_toolset(name) and tool_name in set(resolve_toolset(name)):
+                    return disabled_toolset_label(toolset or name, disabled_toolsets)
+            except Exception:
+                continue
+
+    # Fallback without toolset metadata: subtract by resolved tool names.
+    for name in expanded:
+        try:
+            if validate_toolset(name) and tool_name in set(resolve_toolset(name)):
+                return disabled_toolset_label(name, disabled_toolsets)
+        except Exception:
+            continue
+
+    return None
+
+
+def is_mcp_server_disabled_by_toolsets(
+    server_name: str,
+    disabled_toolsets: Optional[List[str]] = None,
+) -> bool:
+    """True if *server_name* is blocked by ``agent.disabled_toolsets`` (#61184)."""
+    if not server_name:
+        return False
+    if disabled_toolsets is None:
+        try:
+            from hermes_cli.config import read_raw_config
+
+            agent_cfg = (read_raw_config() or {}).get("agent") or {}
+            disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
+        except Exception:
+            disabled_toolsets = []
+    if not disabled_toolsets:
+        return False
+    expanded = set(expand_disabled_toolset_names(list(disabled_toolsets)))
+    return (
+        str(server_name) in expanded
+        or f"mcp-{server_name}" in expanded
+    )
+
+
 def create_custom_toolset(
     name: str,
     description: str,

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -685,6 +685,7 @@ agent:
   disabled_toolsets:
     - memory       # hide memory tools + MEMORY_GUIDANCE injection
     - web          # no web_search / web_extract anywhere
+    - server-b     # block an MCP server (bare name or mcp-server-b)
 ```
 
 This applies **after** per-platform tool config (`platform_toolsets` written by
@@ -692,6 +693,12 @@ This applies **after** per-platform tool config (`platform_toolsets` written by
 platform's saved config still lists it. Use this when you want a single
 switch for "turn X off everywhere" rather than editing 15+ platform rows in
 the `hermes tools` UI.
+
+MCP servers register as toolset `mcp-<name>` with bare `<name>` as an alias.
+Either form in `disabled_toolsets` is honored — including in `hermes -z`
+oneshot mode, where discovery completes before the tool snapshot and dispatch
+refuses any tool belonging to a disabled MCP server (issue #61184).
+`hermes mcp list` / `hermes tools list` surface servers blocked this way.
 
 Leaving the list empty, or omitting the key, is a no-op.
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/NousResearch/hermes-agent/issues/61184.

`agent.disabled_toolsets` is now enforced for MCP servers (including bare-name aliases) in `hermes -z` **before the tool schema snapshot** and again **at dispatch time**, so a disabled MCP backend can never silently answer when the intended server is unavailable.

### Root cause

1. **`hermes -z` never passed `disabled_toolsets` to `AIAgent`** — only enabled platform toolsets were applied. Interactive CLI / cron / gateway already layered `agent.disabled_toolsets`.
2. **Oneshot raced MCP discovery** (related to #38448): background discovery started in `_prepare_agent_startup`, but `-z` did not wait before building the agent tool snapshot, so MCP aliases (`server-b` → `mcp-server-b`) were often missing when toolsets were resolved.
3. **Alias forms were incomplete**: `disabled_toolsets: [server-b]` and `[mcp-server-b]` did not always expand to the same set, and there was **no dispatch-time hard deny** if a stale schema / `tool_call` bridge still named a disabled tool.
4. **CLI status** treated a configured-but-blocked MCP server as plain enabled/connected, so operators could not confirm the boundary was active.

### Fix

- Expand MCP bare ↔ `mcp-<name>` disabled names (config + live registry aliases) in `toolsets.expand_disabled_toolset_names`.
- Apply expanded names in `get_tool_definitions()` subtraction and in `_get_platform_tools()`.
- **Oneshot (`hermes -z`)**: await/run MCP discovery before constructing `AIAgent`, and pass `agent.disabled_toolsets` through.
- **Dispatch defense-in-depth** in `handle_function_call`: refuse tools belonging to a disabled toolset with an explicit error:
  `Tool '<tool>' belongs to disabled toolset '<server-b>' / 'mcp-server-b' and cannot be executed.`
- Surface blocked servers in `hermes mcp list`, `hermes tools list`, and `get_mcp_status()` / banner.
- Document MCP alias behavior under `agent.disabled_toolsets` in the user guide.

**Confirmation:** `agent.disabled_toolsets` is enforced both before tool schema exposure and at dispatch time (including progressive-disclosure `tool_call` via recursive dispatch).

Non-MCP disabled toolsets (`memory`, `web`, platform bundles, etc.) keep their existing subtraction semantics. MCP servers still register dynamically; filtering is session/schema + dispatch based so multi-session hosts remain valid.

## Test plan

- [x] Added `tests/test_disabled_mcp_toolsets_61184.py` with two fake MCP servers sharing a local tool name:
  - schema exclusion for bare + canonical disabled names
  - oneshot passes `disabled_toolsets` and awaits MCP discovery
  - direct dispatch refused for disabled server tools
  - no silent fallback to disabled peer
  - tool_search / tool_call bridge cannot execute disabled MCP tools
  - CLI list / `get_mcp_status` surfaces `disabled_toolsets` state
  - non-MCP disabled toolsets still work
- [x] Ran: `scripts/run_tests.sh tests/test_disabled_mcp_toolsets_61184.py tests/test_model_tools.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_mcp_config.py tests/tools/test_mcp_tool.py tests/hermes_cli/test_banner.py tests/test_toolsets.py` → **454 passed**