### PR TITLE
fix(delegate): keep delegation.base_url authoritative against credential-pool rotation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4474,9 +4474,82 @@ class AIAgent:
         if merged:
             self._client_kwargs["default_headers"] = merged
 
+    def _credential_entry_compatible(self, entry) -> bool:
+        """Whether a pool entry may be swapped into this agent at all.
+
+        ``_swap_credential`` applies the entry's api_key AND base_url, so a
+        cross-provider entry silently retargets the agent to a different
+        host while ``self.provider`` still names the resolved provider —
+        the ``provider=anthropic base_url=https://openrouter.ai/api/v1``
+        mismatch behind #61195 (same class as #7833/#33088/#33163).  Those
+        earlier fixes each guarded ONE caller (recover, restore); this
+        check lives at the single choke point every rotation flows
+        through, so new call sites (e.g. the delegate startup lease) are
+        covered by construction.
+
+        Entries without a usable provider string are treated as unscoped
+        and allowed — matching the pool-level guard semantics in
+        ``recover_with_credential_pool``.
+        """
+        entry_provider = getattr(entry, "provider", None)
+        if not isinstance(entry_provider, str) or not entry_provider.strip():
+            return True
+        entry_provider = entry_provider.strip().lower()
+        agent_provider = (getattr(self, "provider", "") or "").strip().lower()
+        if not agent_provider or entry_provider == agent_provider:
+            return True
+        # Custom endpoints: the agent carries the generic ``custom`` label
+        # while pool entries are keyed ``custom:<name>`` — same comparison
+        # as recover_with_credential_pool / restore_primary (#56885).
+        if agent_provider == "custom" and entry_provider.startswith("custom:"):
+            try:
+                from agent.credential_pool import get_custom_provider_pool_key
+
+                agent_key = (
+                    get_custom_provider_pool_key(getattr(self, "base_url", "") or "")
+                    or ""
+                ).strip().lower()
+                return bool(agent_key) and agent_key == entry_provider
+            except Exception:
+                return False
+        return False
+
     def _swap_credential(self, entry) -> None:
+        if not self._credential_entry_compatible(entry):
+            logger.warning(
+                "Refusing credential swap: pool entry provider %r does not "
+                "match agent provider %r — applying it would retarget "
+                "base_url away from %s (#61195)",
+                getattr(entry, "provider", None),
+                self.provider,
+                self.base_url,
+            )
+            return
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
+        # When delegation.base_url is explicitly configured, that endpoint is
+        # authoritative for this child agent: rotation may swap KEYS, but a
+        # pool entry's own base_url must not retarget the request away from
+        # the endpoint the user pinned in config (#61195).  The pin is
+        # provider-scoped so a later provider switch (fallback chain) is
+        # unaffected.
+        _pin = getattr(self, "_delegation_endpoint_pin", None)
+        if _pin:
+            _pin_provider, _pin_base = _pin
+            if (
+                _pin_base
+                and (self.provider or "") == (_pin_provider or "")
+                and isinstance(runtime_base, str)
+                and runtime_base.rstrip("/") != _pin_base.rstrip("/")
+            ):
+                logger.info(
+                    "Delegation endpoint pin: keeping explicitly configured "
+                    "base_url %s (pool entry %s carries %s); rotating key only",
+                    _pin_base,
+                    getattr(entry, "id", "?"),
+                    runtime_base,
+                )
+                runtime_base = _pin_base
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token

--- a/tests/tools/test_delegation_base_url_routing.py
+++ b/tests/tools/test_delegation_base_url_routing.py
@@ -1,0 +1,264 @@
+"""Regression tests for #61195 — delegation.base_url must stay authoritative.
+
+Bug shape: ``delegation.base_url: https://api.anthropic.com`` with a primary
+``model.provider: openrouter``.  The child's ``provider``/``base_url`` resolve
+correctly through ``_resolve_delegation_credentials() -> _build_child_agent()
+-> init_agent()``, but the startup credential lease in ``_run_single_child()``
+called ``_swap_credential()`` with whatever pool entry it found — and
+``_swap_credential`` applies the entry's ``base_url`` unconditionally.  A pool
+entry carrying the parent's endpoint retargets the child's outbound HTTP to
+``https://openrouter.ai/api/v1`` while ``agent.provider`` still says
+``anthropic`` — the exact mismatched pair from the issue's errors.log, failing
+with 401 "Missing Authentication header".
+
+The fix is structural, at the choke point every rotation flows through:
+
+* ``_swap_credential`` refuses cross-provider entries outright
+  (``_credential_entry_compatible``), mirroring the caller-side guards from
+  #33088 / #56885 that previously had to be re-added one call site at a time.
+* An explicit ``delegation.base_url`` is pinned (``_delegation_endpoint_pin``):
+  same-provider rotation swaps keys but keeps the configured endpoint.
+* ``_resolve_delegation_credentials`` prefers the user's own Anthropic
+  credential for a direct api.anthropic.com endpoint instead of inheriting
+  the parent's (foreign-provider) key.
+"""
+
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agent.credential_pool import CredentialPool, PooledCredential
+from tools.delegate_tool import (
+    _build_child_agent,
+    _resolve_delegation_credentials,
+)
+
+ANTHROPIC_URL = "https://api.anthropic.com"
+OPENROUTER_URL = "https://openrouter.ai/api/v1"
+
+DELEGATION_CFG = {"base_url": ANTHROPIC_URL, "model": "claude-sonnet-4-5"}
+
+
+def _entry(provider, token, base_url):
+    return PooledCredential(
+        provider=provider,
+        id=f"{provider}-{token[-6:]}",
+        label=f"{provider} entry",
+        auth_type="api_key",
+        priority=0,
+        source=f"env:{provider.upper()}_API_KEY",
+        access_token=token,
+        base_url=base_url,
+    )
+
+
+def _make_parent():
+    parent = MagicMock()
+    parent.base_url = OPENROUTER_URL
+    parent.api_key = "sk-or-v1-parent-key"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "moonshotai/kimi-k2.7-code"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent.openrouter_min_coding_score = None
+    parent._session_db = None
+    parent._delegate_depth = 0
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._credential_pool = CredentialPool(
+        "openrouter", [_entry("openrouter", "sk-or-v1-pool-key", OPENROUTER_URL)]
+    )
+    parent._fallback_chain = None
+    parent.reasoning_config = None
+    parent.prefill_messages = None
+    parent.max_tokens = None
+    parent.acp_command = None
+    parent.acp_args = []
+    parent.session_id = "parent-session"
+    parent._current_turn_id = "turn-1"
+    return parent
+
+
+def _build_delegated_child(child_pool):
+    """Build a real child through the production path with a controlled pool."""
+    parent = _make_parent()
+    with patch(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        return_value="sk-ant-native-key",
+    ):
+        creds = _resolve_delegation_credentials(DELEGATION_CFG, parent)
+        with patch(
+            "tools.delegate_tool._resolve_child_credential_pool",
+            return_value=child_pool,
+        ):
+            child = _build_child_agent(
+                task_index=0,
+                goal="regression",
+                context=None,
+                toolsets=None,
+                model=creds["model"],
+                max_iterations=5,
+                task_count=1,
+                parent_agent=parent,
+                override_provider=creds["provider"],
+                override_base_url=creds["base_url"],
+                override_api_key=creds["api_key"],
+                override_api_mode=creds["api_mode"],
+                pin_base_url=bool(creds.get("base_url_pinned")),
+                role="leaf",
+            )
+    return child
+
+
+def _lease_like_run_single_child(child):
+    """Verbatim startup-lease logic from delegate_tool._run_single_child."""
+    child_pool = getattr(child, "_credential_pool", None)
+    if child_pool is not None:
+        leased = child_pool.acquire_lease()
+        if leased is not None:
+            entry = child_pool.current()
+            if entry is not None and hasattr(child, "_swap_credential"):
+                child._swap_credential(entry)
+
+
+class TestDelegationCredentialResolution(unittest.TestCase):
+    def test_direct_anthropic_endpoint_resolves_native_key(self):
+        """delegation.base_url=api.anthropic.com must not inherit the parent's
+        foreign-provider key when the user has an Anthropic credential."""
+        parent = _make_parent()
+        with patch(
+            "agent.anthropic_adapter.resolve_anthropic_token",
+            return_value="sk-ant-native-key",
+        ):
+            creds = _resolve_delegation_credentials(DELEGATION_CFG, parent)
+        self.assertEqual(creds["provider"], "anthropic")
+        self.assertEqual(creds["base_url"], ANTHROPIC_URL)
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+        self.assertEqual(creds["api_key"], "sk-ant-native-key")
+        self.assertTrue(creds["base_url_pinned"])
+
+    def test_no_native_key_falls_back_to_parent_inheritance(self):
+        """Without an Anthropic credential the pre-existing behavior stands:
+        api_key=None -> _build_child_agent inherits the parent's key."""
+        parent = _make_parent()
+        with patch(
+            "agent.anthropic_adapter.resolve_anthropic_token", return_value=None
+        ):
+            creds = _resolve_delegation_credentials(DELEGATION_CFG, parent)
+        self.assertIsNone(creds["api_key"])
+
+    def test_explicit_delegation_api_key_still_wins(self):
+        parent = _make_parent()
+        cfg = dict(DELEGATION_CFG, api_key="sk-ant-explicit")
+        with patch(
+            "agent.anthropic_adapter.resolve_anthropic_token",
+            return_value="sk-ant-native-key",
+        ):
+            creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_key"], "sk-ant-explicit")
+
+
+class TestStartupLeaseCannotRetargetChild(unittest.TestCase):
+    """The #61195 shapes, end-to-end through real AIAgent construction."""
+
+    def test_cross_provider_pool_entry_is_refused(self):
+        """A pool holding the parent-provider's entries (the contamination
+        shape behind the reported ``provider=anthropic
+        base_url=https://openrouter.ai/api/v1`` log line) must not be able to
+        retarget the child."""
+        pool = CredentialPool(
+            "openrouter", [_entry("openrouter", "sk-or-v1-pool-key", OPENROUTER_URL)]
+        )
+        child = _build_delegated_child(pool)
+        _lease_like_run_single_child(child)
+
+        self.assertEqual(child.provider, "anthropic")
+        self.assertEqual(child.base_url, ANTHROPIC_URL)
+        self.assertEqual(child._anthropic_base_url, ANTHROPIC_URL)
+        # The foreign key must not have been applied either.
+        self.assertNotEqual(child.api_key, "sk-or-v1-pool-key")
+
+    def test_same_provider_entry_with_foreign_base_url_keeps_pinned_endpoint(self):
+        """Same-provider entry whose base_url points elsewhere: rotate the
+        key, keep the explicitly configured delegation endpoint."""
+        pool = CredentialPool(
+            "anthropic", [_entry("anthropic", "sk-ant-pool-key", OPENROUTER_URL)]
+        )
+        child = _build_delegated_child(pool)
+        _lease_like_run_single_child(child)
+
+        self.assertEqual(child.api_key, "sk-ant-pool-key")
+        self.assertEqual(child.base_url, ANTHROPIC_URL)
+        self.assertEqual(child._anthropic_base_url, ANTHROPIC_URL)
+
+    def test_same_provider_rotation_still_works(self):
+        """Pool rotation for delegated children must keep working — the fix
+        must not pin children to a single key (pool sharing exists so
+        subagents can rotate on rate limits)."""
+        pool = CredentialPool(
+            "anthropic", [_entry("anthropic", "sk-ant-pool-key", ANTHROPIC_URL)]
+        )
+        child = _build_delegated_child(pool)
+        _lease_like_run_single_child(child)
+
+        self.assertEqual(child.api_key, "sk-ant-pool-key")
+        self.assertEqual(child.base_url, ANTHROPIC_URL)
+
+    def test_unscoped_entry_keeps_legacy_swap_behavior(self):
+        """Entries without a provider string are unscoped (legacy pools) and
+        still swap — matching recover_with_credential_pool's semantics."""
+        entry = _entry("", "sk-legacy-key", None)
+        pool = CredentialPool("anthropic", [entry])
+        child = _build_delegated_child(pool)
+        _lease_like_run_single_child(child)
+
+        self.assertEqual(child.api_key, "sk-legacy-key")
+        self.assertEqual(child.base_url, ANTHROPIC_URL)
+
+
+class TestPinScopedToProvider(unittest.TestCase):
+    def test_pin_released_after_provider_switch(self):
+        """The endpoint pin is scoped to the delegated provider: after a
+        provider switch (fallback chain), rotation for the new provider must
+        follow the new provider's entries, not the stale pin."""
+        child = _build_delegated_child(None)
+        # Simulate what the fallback path does on a provider switch.
+        child.provider = "openrouter"
+        child.api_mode = "chat_completions"
+        child.base_url = OPENROUTER_URL
+        child._client_kwargs = {"api_key": "sk-or-v1-old", "base_url": OPENROUTER_URL}
+        with patch.object(child, "_replace_primary_openai_client", return_value=True):
+            child._swap_credential(
+                _entry("openrouter", "sk-or-v1-rotated", OPENROUTER_URL)
+            )
+        self.assertEqual(child.api_key, "sk-or-v1-rotated")
+        self.assertEqual(child.base_url, OPENROUTER_URL)
+
+
+class TestNonDelegationSwapUnchanged(unittest.TestCase):
+    def test_same_provider_entry_endpoint_still_follows_entry(self):
+        """Primary (non-delegated) agents keep the existing semantics: a
+        same-provider entry that carries its own base_url (per-key proxy)
+        retargets the client as before — no pin applies."""
+        child = _build_delegated_child(None)
+        del child._delegation_endpoint_pin
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(),
+        ):
+            child._swap_credential(
+                _entry("anthropic", "sk-ant-proxy-key", "https://my-proxy.example/v1")
+            )
+        self.assertEqual(child.api_key, "sk-ant-proxy-key")
+        self.assertEqual(child.base_url, "https://my-proxy.example/v1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1058,6 +1058,10 @@ def _build_child_agent(
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # True when override_base_url came from an explicit delegation.base_url
+    # config entry — the endpoint is then authoritative for this child and
+    # credential-pool rotation must not retarget it (#61195).
+    pin_base_url: bool = False,
     # Per-call role controlling whether the child can further delegate.
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
@@ -1352,6 +1356,14 @@ def _build_child_agent(
     parent_sid = getattr(parent_agent, "session_id", None)
     if parent_sid and getattr(child, "_session_init_model_config", None) is not None:
         child._session_init_model_config["_delegate_from"] = parent_sid
+
+    # When delegation.base_url is explicitly configured it is authoritative
+    # for this child: _swap_credential rotates keys but keeps this endpoint,
+    # instead of letting a pool entry's base_url retarget the request back
+    # to the parent's provider (#61195).  Scoped to the resolved provider so
+    # a later fallback-chain provider switch is unaffected.
+    if pin_base_url and override_base_url:
+        child._delegation_endpoint_pin = (effective_provider, effective_base_url)
 
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
@@ -2502,6 +2514,7 @@ def delegate_task(
                 override_api_mode=creds["api_mode"],
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
+                pin_base_url=bool(creds.get("base_url_pinned")),
                 role=effective_role,
             )
             # Override with correct parent tool names (before child construction mutated global)
@@ -3070,12 +3083,30 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         if configured_api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
             api_mode = configured_api_mode
 
+        if api_key is None and provider == "anthropic":
+            # Direct api.anthropic.com endpoint with no delegation.api_key:
+            # the parent may run a different provider (e.g. openrouter), and
+            # inheriting its key is a guaranteed 401 here.  Prefer the user's
+            # own Anthropic credential — the same resolver init_agent uses
+            # for native Anthropic — and only fall back to parent inheritance
+            # when none exists (#61195).
+            try:
+                from agent.anthropic_adapter import resolve_anthropic_token
+
+                api_key = resolve_anthropic_token() or None
+            except Exception:
+                api_key = None
+
         return {
             "model": configured_model,
             "provider": provider,
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
+            # An explicit delegation.base_url is authoritative for the child:
+            # credential-pool rotation may swap keys but must not retarget
+            # the endpoint (#61195).  Consumed by _build_child_agent.
+            "base_url_pinned": True,
         }
 
     if not configured_provider:


### PR DESCRIPTION
Closes #61195.

## Problem

With `delegation.base_url: https://api.anthropic.com` and a primary
`model.provider: openrouter`, the subagent's `provider`/`base_url`/`api_mode`
resolve correctly to the Anthropic values through
`_resolve_delegation_credentials() → _build_child_agent() → init_agent()`, as
the issue reports. But the child's first outbound request still went to
`https://openrouter.ai/api/v1`, producing the mismatched pair from the log —
`provider=anthropic base_url=https://openrouter.ai/api/v1` — and a 401.

## Root cause

The divergence happens **after** `init_agent()`, in the startup credential
lease in `_run_single_child()`:

```python
child_pool = getattr(child, "_credential_pool", None)
if child_pool is not None:
    leased_cred_id = child_pool.acquire_lease()
    if leased_cred_id is not None:
        leased_entry = child_pool.current()
        if leased_entry is not None and hasattr(child, "_swap_credential"):
            child._swap_credential(leased_entry)   # ← applies entry.base_url
```

`_swap_credential()` applies the pool entry's **`base_url` as well as its
api_key**, unconditionally. So a pool entry that carries the parent provider's
endpoint silently retargets the correctly-resolved child back to
`openrouter.ai` while `child.provider` still says `anthropic`. I reproduced
this end-to-end (real `AIAgent` build + the verbatim lease block): a child
resolved to `api.anthropic.com` whose `_credential_pool` contained an
`openrouter` entry ends up with `provider=anthropic base_url=openrouter.ai/api/v1`
— the exact failure in the report.

This is the same class as the recurring regressions the issue lists
(#10653/#16816/#26482/#34318). Each earlier fix guarded **one** caller of the
rotation path (`recover_with_credential_pool`, `restore_primary`). The delegate
startup lease is simply another caller that was never guarded — hence the
recurrence. Rather than add a fourth caller-side guard, this fixes it at the
**single choke point every rotation flows through**.

## Fix (structural)

1. **`_swap_credential` refuses cross-provider entries**
   (`_credential_entry_compatible`). A pool entry whose provider doesn't match
   the agent's is never applied — so `base_url`/api_key can't be retargeted to
   a foreign host. This subsumes the ad-hoc guards in
   `recover_with_credential_pool`/`restore_primary` and, crucially, covers any
   future call site (like this lease) by construction. Entries with no provider
   string stay "unscoped" and are still applied (legacy pools); `custom:<name>`
   endpoints use the same key comparison as the existing guards (#56885).

2. **An explicit `delegation.base_url` is pinned** (`_delegation_endpoint_pin`).
   When the user configures a literal endpoint, same-provider rotation may swap
   the **key** but must not change the endpoint. The pin is provider-scoped, so
   a later fallback-chain provider switch is unaffected.

3. **A direct `api.anthropic.com` delegation endpoint resolves the user's own
   Anthropic credential** (via `resolve_anthropic_token()`, the same resolver
   `init_agent` uses for native Anthropic) instead of inheriting the parent's
   foreign-provider key — which was a guaranteed 401 on that endpoint even once
   the routing is correct. Falls back to parent inheritance when no Anthropic
   credential exists; an explicit `delegation.api_key` still wins.

## Tests

New `tests/tools/test_delegation_base_url_routing.py` (9 cases) drives the real
`_build_child_agent` + the verbatim `_run_single_child` lease block:

- cross-provider pool entry is refused (the reported shape) — child stays on
  `api.anthropic.com`, foreign key not applied;
- same-provider entry carrying a foreign `base_url` → key rotates, pinned
  endpoint kept;
- same-provider rotation still works (children must still rotate on rate limits);
- unscoped/legacy entries keep swapping;
- pin is released after a provider switch;
- non-delegation swaps still follow the entry's base_url (per-key proxy case);
- credential resolution prefers the native Anthropic key / falls back / honors
  explicit `delegation.api_key`.

Existing delegation + credential-pool + swap suites pass unchanged (245 tests
across `test_delegate`, `test_async_delegation`, `test_credential_pool_*`,
`test_fallback_credential_isolation`, `test_primary_runtime_restore`,
`test_restore_primary_pool_reselect`, `test_anthropic_third_party_oauth_guard`).

## Note / possible follow-up

I did not change `_swap_credential` to *refuse* a same-provider entry whose own
`base_url` differs (the per-key proxy case in test 9) — that's a legitimate
existing behavior for primary agents, so the endpoint authority is expressed via
the delegation pin rather than a blanket base_url lock. Happy to adjust the
shape if you'd prefer the pin implemented differently (e.g. storing the pinned
endpoint on the pool entry instead of the agent).
