### PR TITLE
fix(desktop): recover expired remote oauth sessions from boot failure

### DIFF
--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -51,7 +51,7 @@ export function BootFailureOverlay() {
       ?.getRecentLogs()
       .then(res => setLogs(res.lines ?? []))
       .catch(() => undefined)
-  }, [visible])
+  }, [boot.error, visible])
 
   // Resolve whether this boot failure is a remote-gateway reauth so we can
   // offer the actionable "Sign in" path instead of the local-only recovery
@@ -80,7 +80,7 @@ export function BootFailureOverlay() {
         return
       }
 
-      if (cancelled || !isRemoteReauthFailure(config)) {
+      if (cancelled || !isRemoteReauthFailure(config, boot.error)) {
         return
       }
 
@@ -104,7 +104,7 @@ export function BootFailureOverlay() {
     return () => {
       cancelled = true
     }
-  }, [visible])
+  }, [boot.error, visible])
 
   if (!visible || suppressed) {
     return null
@@ -129,11 +129,13 @@ export function BootFailureOverlay() {
     setBusy(null)
   }
 
-  // Open the gateway's login window (renders the username/password form for a
-  // basic gateway, or the OAuth redirect otherwise — the desktop drives both
-  // through the same window). On a successful sign-in the session cookie is
-  // re-established in the persistent partition; reload so boot re-runs and the
-  // reconnect now mints a ticket against a live session.
+  // Clear the OAuth partition first, then open the gateway's login window
+  // (renders the username/password form for a basic gateway, or the OAuth
+  // redirect otherwise — the desktop drives both through the same window).
+  // Clearing without a URL signs out the gateway AND any identity-provider
+  // cookies in this dedicated partition, so stale Nous/Portal sessions don't
+  // silently bounce us back into the same expired state. On successful sign-in
+  // the session cookie is re-established; reload so boot mints a fresh ticket.
   const signInRemote = async () => {
     if (!remoteReauth) {
       return
@@ -142,6 +144,7 @@ export function BootFailureOverlay() {
     setBusy('signin')
 
     try {
+      await window.hermesDesktop?.oauthLogoutConnectionConfig?.()
       const result = await window.hermesDesktop?.oauthLoginConnectionConfig(remoteReauth.url)
 
       if (result?.connected) {
@@ -197,7 +200,7 @@ export function BootFailureOverlay() {
               {remoteReauth ? (
                 <Button disabled={Boolean(busy)} onClick={() => void signInRemote()}>
                   {busy === 'signin' ? <Loader2 className="animate-spin" /> : <LogIn />}
-                  {label}
+                  {copy.signOutAndSignIn}
                 </Button>
               ) : (
                 <Button disabled={Boolean(busy)} onClick={() => void retry()}>
@@ -220,7 +223,9 @@ export function BootFailureOverlay() {
                 {copy.openLogs}
               </Button>
             </div>
-            <p className="text-xs text-muted-foreground">{remoteReauth ? copy.remoteSignInHint : copy.repairHint}</p>
+            <p className="text-xs text-muted-foreground">
+              {remoteReauth ? copy.remoteSignInHint(label) : copy.repairHint}
+            </p>
           </div>
 
           {logs.length > 0 ? (

--- a/apps/desktop/src/components/boot-failure-reauth.test.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { DesktopConnectionConfig } from '@/global'
 
-import { deriveProviderShape, isRemoteReauthFailure, signInLabel } from './boot-failure-reauth'
+import { deriveProviderShape, isRemoteReauthError, isRemoteReauthFailure, signInLabel } from './boot-failure-reauth'
 
 function config(overrides: Partial<DesktopConnectionConfig> = {}): DesktopConnectionConfig {
   return {
@@ -23,8 +23,17 @@ describe('isRemoteReauthFailure', () => {
     expect(isRemoteReauthFailure(config())).toBe(true)
   })
 
-  it('false when the oauth session is still connected', () => {
-    expect(isRemoteReauthFailure(config({ remoteOauthConnected: true }))).toBe(false)
+  it('false when the oauth session is still connected and the error is not auth-shaped', () => {
+    expect(isRemoteReauthFailure(config({ remoteOauthConnected: true }), 'Python exploded')).toBe(false)
+  })
+
+  it('true when the session indicator is connected but boot failed while minting a remote OAuth ticket', () => {
+    expect(
+      isRemoteReauthFailure(
+        config({ remoteOauthConnected: true }),
+        'Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.'
+      )
+    ).toBe(true)
   })
 
   it('false for a local gateway', () => {
@@ -42,6 +51,18 @@ describe('isRemoteReauthFailure', () => {
   it('false for null/undefined config', () => {
     expect(isRemoteReauthFailure(null)).toBe(false)
     expect(isRemoteReauthFailure(undefined)).toBe(false)
+  })
+})
+
+describe('isRemoteReauthError', () => {
+  it('recognizes the expired remote gateway session error', () => {
+    expect(
+      isRemoteReauthError('Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.')
+    ).toBe(true)
+  })
+
+  it('ignores non-auth boot errors', () => {
+    expect(isRemoteReauthError('Hermes background process exited during startup.')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/components/boot-failure-reauth.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.ts
@@ -26,13 +26,27 @@ const DEFAULT_SIGN_IN_COPY: SignInCopy = {
   withProvider: provider => `Sign in with ${provider}`
 }
 
-// A remote, gated (oauth-bucket), not-currently-connected gateway is a
-// remote-reauth boot failure: the access cookie lapsed (e.g. the remote
-// dashboard restarted) and the local-recovery buttons (Retry/Repair) can't
-// fix it — only re-establishing the remote session can. A connected oauth
-// session, or a token/local gateway, boots for some other reason the
-// local-recovery buttons address, so those return false here.
-export function isRemoteReauthFailure(config: DesktopConnectionConfig | null | undefined): boolean {
+// A remote, gated (oauth-bucket) gateway with an auth-shaped boot error is
+// a remote-reauth boot failure: the access cookie lapsed, the refresh token was
+// rejected, or the remote dashboard could not mint a websocket ticket. The
+// Settings indicator may still say "connected" when an RT cookie exists, so
+// the boot error text is part of the signal — otherwise Tony gets dumped into
+// local-only recovery buttons for a problem only reauth can fix.
+export function isRemoteReauthError(error: string | null | undefined): boolean {
+  const text = String(error || '').toLowerCase()
+
+  return (
+    text.includes('remote gateway session has expired') ||
+    text.includes('gateway sign-in required') ||
+    text.includes('needs oauth login') ||
+    (text.includes('oauth') && (text.includes('not signed in') || text.includes('sign in')))
+  )
+}
+
+export function isRemoteReauthFailure(
+  config: DesktopConnectionConfig | null | undefined,
+  error?: string | null
+): boolean {
   if (!config) {
     return false
   }
@@ -40,8 +54,8 @@ export function isRemoteReauthFailure(config: DesktopConnectionConfig | null | u
   return (
     config.mode === 'remote' &&
     config.remoteAuthMode === 'oauth' &&
-    !config.remoteOauthConnected &&
-    Boolean(config.remoteUrl)
+    Boolean(config.remoteUrl) &&
+    (!config.remoteOauthConnected || isRemoteReauthError(error))
   )
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -92,7 +92,9 @@ export const en: Translations = {
       useLocalGateway: 'Use local gateway',
       openLogs: 'Open logs',
       repairHint: 'Repair re-runs the installer and can take a few minutes on a fresh machine.',
-      remoteSignInHint: 'Opens the gateway login window. Use local gateway to switch to the bundled backend instead.',
+      remoteSignInHint: signInLabel =>
+        `Signs out of the saved remote/Nous browser session, then opens ${signInLabel}. Use local gateway to switch to the bundled backend instead.`,
+      signOutAndSignIn: 'Sign out & sign in',
       hideRecentLogs: 'Hide recent logs',
       showRecentLogs: 'Show recent logs',
       signedInTitle: 'Signed in',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -92,8 +92,9 @@ export const ja = defineLocale({
       useLocalGateway: 'ローカルゲートウェイを使用',
       openLogs: 'ログを開く',
       repairHint: '修復はインストーラーを再実行します。新しいマシンでは数分かかる場合があります。',
-      remoteSignInHint:
-        'ゲートウェイのログインウィンドウを開きます。代わりにバンドルされたバックエンドに切り替えるには「ローカルゲートウェイを使用」を選択してください。',
+      remoteSignInHint: signInLabel =>
+        `保存済みのリモート/Nous ブラウザーセッションからサインアウトしてから ${signInLabel} を開きます。代わりにバンドルされたバックエンドに切り替えるには「ローカルゲートウェイを使用」を選択してください。`,
+      signOutAndSignIn: 'サインアウトしてサインイン',
       hideRecentLogs: '最近のログを非表示',
       showRecentLogs: '最近のログを表示',
       signedInTitle: 'サインインしました',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -135,7 +135,8 @@ export interface Translations {
       useLocalGateway: string
       openLogs: string
       repairHint: string
-      remoteSignInHint: string
+      remoteSignInHint: (signInLabel: string) => string
+      signOutAndSignIn: string
       hideRecentLogs: string
       showRecentLogs: string
       signedInTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -90,7 +90,9 @@ export const zhHant = defineLocale({
       useLocalGateway: '使用本機閘道',
       openLogs: '開啟記錄',
       repairHint: '修復會重新執行安裝程式，在新機器上可能需要幾分鐘。',
-      remoteSignInHint: '開啟閘道登入視窗。使用本機閘道可切換至內建後端。',
+      remoteSignInHint: signInLabel =>
+        `先登出已儲存的遠端/Nous 瀏覽器工作階段，然後開啟 ${signInLabel}。使用本機閘道可切換至內建後端。`,
+      signOutAndSignIn: '登出並重新登入',
       hideRecentLogs: '隱藏最近記錄',
       showRecentLogs: '顯示最近記錄',
       signedInTitle: '已登入',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -90,7 +90,9 @@ export const zh: Translations = {
       useLocalGateway: '使用本地网关',
       openLogs: '打开日志',
       repairHint: '修复会重新运行安装器，在新机器上可能需要几分钟。',
-      remoteSignInHint: '打开网关登录窗口。也可以使用本地网关切换到随应用提供的后端。',
+      remoteSignInHint: signInLabel =>
+        `先退出已保存的远程/Nous 浏览器会话，然后打开 ${signInLabel}。也可以使用本地网关切换到随应用提供的后端。`,
+      signOutAndSignIn: '退出并重新登录',
       hideRecentLogs: '隐藏最近日志',
       showRecentLogs: '显示最近日志',
       signedInTitle: '已登录',


### PR DESCRIPTION
## Summary
- detects auth-shaped remote OAuth boot failures even when the saved cookie jar still looks connected
- adds a recovery button on the boot-failure overlay that signs out of the dedicated OAuth partition before opening the remote gateway login window
- updates boot-failure copy/locales so the action is explicit: sign out, then sign in again

## Why
When a desktop client is attached to a remote OAuth-gated backend, an expired/rejected remote session can currently land on the generic "Hermes couldn't start" recovery page. The actionable fix is buried under Settings → Gateway → sign out/sign in, and retry/repair/local gateway are the wrong recovery path.

This keeps the user on the failure page and lets them refresh the remote/Nous session directly.

## Test Plan
- [x] `npm run test:ui -- src/components/boot-failure-reauth.test.ts`
- [x] `npm run typecheck`
- [x] `npm run build`
