### PR TITLE
fix(managed-uv): add timeout to all subprocess.run calls

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -117,6 +117,7 @@ def _ensure_uv_path() -> Optional[str]:
             capture_output=True,
             text=True,
             check=False,
+            timeout=10,
         ).stdout.strip()
         print(f"  ✓ Managed uv installed ({version})")
     else:
@@ -172,6 +173,7 @@ def update_managed_uv() -> Optional[str]:
         capture_output=True,
         text=True,
         check=False,
+        timeout=120,
     )
     if result.returncode == 0:
         version = subprocess.run(
@@ -179,6 +181,7 @@ def update_managed_uv() -> Optional[str]:
             capture_output=True,
             text=True,
             check=False,
+            timeout=10,
         ).stdout.strip()
         print(f"  ✓ Managed uv updated ({version})")
     else:
@@ -224,12 +227,14 @@ def _install_uv_posix(env: dict[str, str]) -> None:
             ["curl", "-LsSf", "https://astral.sh/uv/install.sh", "-o", installer_path],
             check=True,
             capture_output=True,
+            timeout=60,
         )
         subprocess.run(
             ["sh", installer_path],
             env=env,
             check=True,
             capture_output=True,
+            timeout=120,
         )
     finally:
         try:
@@ -248,6 +253,7 @@ def _install_uv_windows(env: dict[str, str]) -> None:
         env=env,
         check=True,
         capture_output=True,
+        timeout=120,
     )
 
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:


### PR DESCRIPTION
## Summary

Added `timeout` to all `subprocess.run()` calls in `hermes_cli/managed_uv.py` to prevent indefinite hangs during uv installer downloads and self-updates.

## Problem

Six `subprocess.run()` calls in `managed_uv.py` lacked `timeout`:

1. **curl download** — downloads the uv installer from astral.sh; a stalled network connection blocks the entire agent turn indefinitely.
2. **sh installer** — runs the downloaded installer script; a hung installer blocks indefinitely.
3. **powershell installer** — Windows equivalent; same risk.
4. **uv --version verify** (2 calls) — version probe after install/update; a frozen binary blocks indefinitely.
5. **uv self update** — network-dependent self-update; can hang on slow connections.

None of these calls are wrapped in timeout-aware try/except blocks, so any of them can permanently block the process.

## Fix

Added appropriate timeouts:
- `timeout=10` for lightweight `--version` probes
- `timeout=60` for the curl download of the small install script
- `timeout=120` for the installer execution and `self update` (both are network-dependent and may need to download binaries)

## Testing
- Syntax check passed (py_compile)
- Behavior verified