### PR TITLE
fix(gateway): scope api_server secrets under multiplex profiles

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -42,6 +42,7 @@ import re
 import sqlite3
 import time
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -809,6 +810,38 @@ def _notify_cron_provider_jobs_changed() -> None:
         _notify_provider_jobs_changed()
     except Exception:
         pass
+
+
+@contextmanager
+def _api_server_profile_secret_scope():
+    """Install the active profile's secret scope when multiplex isolation is on.
+
+    API-server agent entry does not go through ``GatewayRunner``'s
+    ``_profile_runtime_scope`` wrapper, so credential resolution via
+    ``get_secret`` (e.g. ``OPENROUTER_BASE_URL`` in ``runtime_provider``)
+    would otherwise fail-closed under ``gateway.multiplex_profiles``
+    (#61276). No-op when multiplexing is off — identical to single-profile
+    behavior. Mirrors the cron ``run_one_job`` scope install.
+    """
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        is_multiplex_active,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+
+    if not is_multiplex_active():
+        yield
+        return
+
+    from hermes_constants import get_hermes_home
+
+    token = set_secret_scope(build_profile_secret_scope(get_hermes_home()))
+    try:
+        yield
+    finally:
+        reset_secret_scope(token)
+
 
 # Defense-in-depth: mirror the agent-facing cronjob tool, which scans the
 # user-supplied prompt for exfiltration/injection payloads at create/update
@@ -4058,36 +4091,40 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id or "",
             )
             try:
-                agent = self._create_agent(
-                    ephemeral_system_prompt=ephemeral_system_prompt,
-                    session_id=session_id,
-                    stream_delta_callback=stream_delta_callback,
-                    tool_progress_callback=tool_progress_callback,
-                    tool_start_callback=tool_start_callback,
-                    tool_complete_callback=tool_complete_callback,
-                    gateway_session_key=gateway_session_key,
-                    route=route,
-                )
-                if agent_ref is not None:
-                    agent_ref[0] = agent
-                effective_task_id = session_id or str(uuid.uuid4())
-                result = agent.run_conversation(
-                    user_message=user_message,
-                    conversation_history=conversation_history,
-                    task_id=effective_task_id,
-                )
-                usage = {
-                    "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
-                    "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
-                    "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
-                }
-                # Include the effective session ID in the result so callers
-                # (e.g. X-Hermes-Session-Id header) can track compression-
-                # triggered session rotations. (#16938)
-                _eff_sid = getattr(agent, "session_id", session_id)
-                if isinstance(_eff_sid, str) and _eff_sid:
-                    result["session_id"] = _eff_sid
-                return result, usage
+                # Must run inside the executor thread: secret scope is a
+                # ContextVar and bare run_in_executor does not copy the
+                # caller's context (#61276).
+                with _api_server_profile_secret_scope():
+                    agent = self._create_agent(
+                        ephemeral_system_prompt=ephemeral_system_prompt,
+                        session_id=session_id,
+                        stream_delta_callback=stream_delta_callback,
+                        tool_progress_callback=tool_progress_callback,
+                        tool_start_callback=tool_start_callback,
+                        tool_complete_callback=tool_complete_callback,
+                        gateway_session_key=gateway_session_key,
+                        route=route,
+                    )
+                    if agent_ref is not None:
+                        agent_ref[0] = agent
+                    effective_task_id = session_id or str(uuid.uuid4())
+                    result = agent.run_conversation(
+                        user_message=user_message,
+                        conversation_history=conversation_history,
+                        task_id=effective_task_id,
+                    )
+                    usage = {
+                        "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                        "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+                        "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                    }
+                    # Include the effective session ID in the result so callers
+                    # (e.g. X-Hermes-Session-Id header) can track compression-
+                    # triggered session rotations. (#16938)
+                    _eff_sid = getattr(agent, "session_id", session_id)
+                    if isinstance(_eff_sid, str) and _eff_sid:
+                        result["session_id"] = _eff_sid
+                    return result, usage
             finally:
                 clear_session_vars(tokens)
 
@@ -4288,14 +4325,17 @@ class APIServerAdapter(BasePlatformAdapter):
         async def _run_and_close():
             try:
                 self._set_run_status(run_id, "running")
-                agent = self._create_agent(
-                    ephemeral_system_prompt=ephemeral_system_prompt,
-                    session_id=session_id,
-                    stream_delta_callback=_text_cb,
-                    tool_progress_callback=event_cb,
-                    gateway_session_key=gateway_session_key,
-                    route=route,
-                )
+                # Credential resolution during agent construction must run under
+                # the profile secret scope when multiplexing is on (#61276).
+                with _api_server_profile_secret_scope():
+                    agent = self._create_agent(
+                        ephemeral_system_prompt=ephemeral_system_prompt,
+                        session_id=session_id,
+                        stream_delta_callback=_text_cb,
+                        tool_progress_callback=event_cb,
+                        gateway_session_key=gateway_session_key,
+                        route=route,
+                    )
                 self._active_run_agents[run_id] = agent
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
@@ -4336,40 +4376,43 @@ class APIServerAdapter(BasePlatformAdapter):
                     effective_task_id = session_id or run_id
                     approval_token = None
                     session_tokens = []
-                    try:
-                        # Bind approval/session identity for this API run via
-                        # contextvars so concurrent runs do not share process
-                        # environment state.
-                        approval_token = set_current_session_key(approval_session_key)
-                        session_tokens = self._bind_api_server_session(
-                            session_key=approval_session_key,
-                        )
-                        register_gateway_notify(approval_session_key, _approval_notify)
-                        r = agent.run_conversation(
-                            user_message=user_message,
-                            conversation_history=conversation_history,
-                            task_id=effective_task_id,
-                        )
-                    finally:
+                    # Re-install scope in the executor thread (ContextVar does
+                    # not cross bare run_in_executor; #61276).
+                    with _api_server_profile_secret_scope():
                         try:
-                            unregister_gateway_notify(approval_session_key)
+                            # Bind approval/session identity for this API run via
+                            # contextvars so concurrent runs do not share process
+                            # environment state.
+                            approval_token = set_current_session_key(approval_session_key)
+                            session_tokens = self._bind_api_server_session(
+                                session_key=approval_session_key,
+                            )
+                            register_gateway_notify(approval_session_key, _approval_notify)
+                            r = agent.run_conversation(
+                                user_message=user_message,
+                                conversation_history=conversation_history,
+                                task_id=effective_task_id,
+                            )
                         finally:
-                            if approval_token is not None:
-                                try:
-                                    reset_current_session_key(approval_token)
-                                except Exception:
-                                    pass
-                            if session_tokens:
-                                try:
-                                    clear_session_vars(session_tokens)
-                                except Exception:
-                                    pass
-                    u = {
-                        "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
-                        "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
-                        "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
-                    }
-                    return r, u
+                            try:
+                                unregister_gateway_notify(approval_session_key)
+                            finally:
+                                if approval_token is not None:
+                                    try:
+                                        reset_current_session_key(approval_token)
+                                    except Exception:
+                                        pass
+                                if session_tokens:
+                                    try:
+                                        clear_session_vars(session_tokens)
+                                    except Exception:
+                                        pass
+                        u = {
+                            "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                            "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+                            "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                        }
+                        return r, u
 
                 result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
                 # Check for structured failure (non-retryable client errors like

--- a/tests/gateway/test_api_server_multiplex_secret_scope.py
+++ b/tests/gateway/test_api_server_multiplex_secret_scope.py
@@ -1,0 +1,123 @@
+"""Regression for #61276: api_server agent entry under multiplex isolation.
+
+When gateway.multiplex_profiles is on, get_secret fails closed without a
+profile secret scope. Messaging platforms install scope via
+GatewayRunner._profile_runtime_scope; api_server did not, so SSE chat
+completions crashed on OPENROUTER_BASE_URL (and any other credential)
+resolution.
+
+These tests code-simulate the bug class — no live gateway or network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent import secret_scope as ss
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _api_server_profile_secret_scope,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_multiplex():
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+    # Ensure no leaked scope from a failed test.
+    if ss.current_secret_scope() is not None:
+        # best-effort: cannot reset without token; flag off is enough for
+        # subsequent tests that check is_multiplex_active.
+        pass
+
+
+@pytest.fixture
+def adapter():
+    return APIServerAdapter(PlatformConfig(enabled=True))
+
+
+class TestApiServerProfileSecretScope:
+    def test_noop_when_multiplex_off(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_BASE_URL", "https://from-environ.example/v1")
+        with _api_server_profile_secret_scope():
+            # Legacy path: unscoped get_secret reads os.environ.
+            assert ss.get_secret("OPENROUTER_BASE_URL") == "https://from-environ.example/v1"
+        assert ss.current_secret_scope() is None
+
+    def test_installs_and_tears_down_under_multiplex(self, tmp_path, monkeypatch):
+        (tmp_path / ".env").write_text(
+            "OPENROUTER_BASE_URL=https://openrouter.ai/api/v1\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home",
+            lambda: tmp_path,
+        )
+        monkeypatch.setenv("OPENROUTER_BASE_URL", "https://leak.example/v1")
+        ss.set_multiplex_active(True)
+
+        with _api_server_profile_secret_scope():
+            assert ss.current_secret_scope() is not None
+            # Profile .env wins; process env must not leak through.
+            assert ss.get_secret("OPENROUTER_BASE_URL") == "https://openrouter.ai/api/v1"
+
+        assert ss.current_secret_scope() is None
+        with pytest.raises(ss.UnscopedSecretError):
+            ss.get_secret("OPENROUTER_BASE_URL")
+
+
+@pytest.mark.asyncio
+async def test_run_agent_scopes_secret_reads_under_multiplex(
+    adapter, tmp_path, monkeypatch,
+):
+    """Code-sim repro of #61276: _create_agent path reads OPENROUTER_BASE_URL.
+
+    Without the scope install inside the executor thread, this raises
+    UnscopedSecretError during SSE agent setup.
+    """
+    (tmp_path / ".env").write_text(
+        "OPENROUTER_BASE_URL=https://openrouter.ai/api/v1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    observed: dict = {}
+
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def __init__(self, session_id: str):
+            self.session_id = session_id
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            # Mid-run credential reads (tool/MCP/provider) must also see scope.
+            observed["during_run"] = ss.get_secret("OPENROUTER_BASE_URL")
+            return {"final_response": "ok"}
+
+    def fake_create_agent(**kwargs):
+        # Mirrors _resolve_runtime_agent_kwargs -> runtime_provider._getenv
+        # which is where the reporter's UnscopedSecretError fired.
+        observed["during_create"] = ss.get_secret("OPENROUTER_BASE_URL")
+        observed["scope_during_create"] = ss.current_secret_scope() is not None
+        return FakeAgent(kwargs.get("session_id") or "s")
+
+    monkeypatch.setattr(adapter, "_create_agent", fake_create_agent)
+    ss.set_multiplex_active(True)
+
+    result, usage = await adapter._run_agent(
+        user_message="hi",
+        conversation_history=[],
+        session_id="chatcmpl-repro-61276",
+    )
+
+    assert result["final_response"] == "ok"
+    assert usage["total_tokens"] == 0
+    assert observed["scope_during_create"] is True
+    assert observed["during_create"] == "https://openrouter.ai/api/v1"
+    assert observed["during_run"] == "https://openrouter.ai/api/v1"
+    # Scope must not leak after the turn.
+    assert ss.current_secret_scope() is None

--- a/tests/gateway/test_api_server_multiplex_secret_scope.py
+++ b/tests/gateway/test_api_server_multiplex_secret_scope.py
@@ -11,6 +11,9 @@ These tests code-simulate the bug class — no live gateway or network.
 
 from __future__ import annotations
 
+import asyncio
+import json
+
 import pytest
 
 from agent import secret_scope as ss
@@ -120,4 +123,61 @@ async def test_run_agent_scopes_secret_reads_under_multiplex(
     assert observed["during_create"] == "https://openrouter.ai/api/v1"
     assert observed["during_run"] == "https://openrouter.ai/api/v1"
     # Scope must not leak after the turn.
+    assert ss.current_secret_scope() is None
+
+
+@pytest.mark.asyncio
+async def test_v1_runs_scopes_agent_creation_and_executor_run(
+    adapter, tmp_path, monkeypatch,
+):
+    """The independent /v1/runs path scopes both of its execution regions."""
+    (tmp_path / ".env").write_text(
+        "OPENROUTER_BASE_URL=https://openrouter.ai/api/v1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    observed: dict = {}
+
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def run_conversation(self, user_message, conversation_history, task_id):
+            observed["during_run"] = ss.get_secret("OPENROUTER_BASE_URL")
+            observed["scope_during_run"] = ss.current_secret_scope() is not None
+            return {"final_response": "ok"}
+
+    def fake_create_agent(**kwargs):
+        observed["during_create"] = ss.get_secret("OPENROUTER_BASE_URL")
+        observed["scope_during_create"] = ss.current_secret_scope() is not None
+        return FakeAgent()
+
+    monkeypatch.setattr(adapter, "_create_agent", fake_create_agent)
+    ss.set_multiplex_active(True)
+
+    class FakeRequest:
+        headers = {}
+
+        async def json(self):
+            return {"input": "hi"}
+
+    response = await adapter._handle_runs(FakeRequest())
+    assert response.status == 202
+    run_id = json.loads(response.text)["run_id"]
+
+    for _ in range(20):
+        status = adapter._run_statuses[run_id]
+        if status["status"] in {"completed", "failed"}:
+            break
+        await asyncio.sleep(0.05)
+
+    assert status["status"] == "completed"
+    assert observed == {
+        "during_create": "https://openrouter.ai/api/v1",
+        "scope_during_create": True,
+        "during_run": "https://openrouter.ai/api/v1",
+        "scope_during_run": True,
+    }
     assert ss.current_secret_scope() is None


### PR DESCRIPTION
## Summary

- When `gateway.multiplex_profiles` is on, credential reads go through `get_secret` and fail closed unless a profile secret scope is installed.
- Messaging platforms already wrap turns in `_profile_runtime_scope`; **api_server** (`/v1/chat/completions` SSE and `/v1/runs`) did not, so agent setup raised `UnscopedSecretError` on `OPENROUTER_BASE_URL` (and any other scoped credential).
- Install the same profile secret scope on api_server agent entry (create + run), inside the executor thread where ContextVars actually apply. No-op when multiplexing is off.

Fixes #61276

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_api_server_multiplex_secret_scope.py`
- [x] Existing `test_run_agent_binds_api_session_context_for_tool_env` still passes
- [ ] Optional live check: `gateway.multiplex_profiles: true` + api_server streaming chat completion with OpenRouter