### PR TITLE
fix(web): pass profile to cron delivery targets dropdown

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10253,16 +10253,19 @@ async def get_cron_delivery_targets(profile: Optional[str] = None):
             "home_env_var": None,
         }
     ]
-    override_token = None
+    home_override_token = None
+    secret_override_token = None
     try:
         from cron.scheduler import cron_delivery_targets
         from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+        from agent.secret_scope import build_profile_secret_scope, set_secret_scope, reset_secret_scope
 
-        # If a profile is requested, temporarily override HERMES_HOME
-        # so cron_delivery_targets() loads that profile's gateway config
+        # If a profile is requested, scope both home and secrets to that profile
+        # so cron_delivery_targets() loads that profile's gateway config and credentials
         if profile:
             profile_dir = _resolve_profile_dir(profile)
-            override_token = set_hermes_home_override(profile_dir)
+            home_override_token = set_hermes_home_override(profile_dir)
+            secret_override_token = set_secret_scope(build_profile_secret_scope(profile_dir))
 
         targets.extend(cron_delivery_targets())
     except HTTPException:
@@ -10271,8 +10274,11 @@ async def get_cron_delivery_targets(profile: Optional[str] = None):
     except Exception:
         _log.exception("GET /api/cron/delivery-targets failed")
     finally:
-        if override_token is not None:
-            reset_hermes_home_override(override_token)
+        # Clean up scopes in reverse order of setup
+        if secret_override_token is not None:
+            reset_secret_scope(secret_override_token)
+        if home_override_token is not None:
+            reset_hermes_home_override(home_override_token)
     return {"targets": targets}
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10231,7 +10231,7 @@ async def create_cron_job(body: CronJobCreate, profile: str = "default"):
 
 
 @app.get("/api/cron/delivery-targets")
-async def get_cron_delivery_targets():
+async def get_cron_delivery_targets(profile: Optional[str] = None):
     """Delivery targets the cron dropdown should offer.
 
     Always includes the implicit ``local`` option. Beyond that, the list is
@@ -10240,6 +10240,10 @@ async def get_cron_delivery_targets():
     configured platform that hasn't set its cron home channel is still returned
     with ``home_target_set: false`` so the UI can surface it as "configure a
     home channel first" rather than hiding it.
+
+    When ``profile`` query param is provided, returns targets for that profile's
+    gateway config instead of the default profile (used for non-multiplex mode
+    or when the dropdown is for a profile-specific cron job).
     """
     targets = [
         {
@@ -10249,12 +10253,26 @@ async def get_cron_delivery_targets():
             "home_env_var": None,
         }
     ]
+    override_token = None
     try:
         from cron.scheduler import cron_delivery_targets
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+        # If a profile is requested, temporarily override HERMES_HOME
+        # so cron_delivery_targets() loads that profile's gateway config
+        if profile:
+            profile_dir = _resolve_profile_dir(profile)
+            override_token = set_hermes_home_override(profile_dir)
 
         targets.extend(cron_delivery_targets())
+    except HTTPException:
+        # Propagate profile validation errors (404/400)
+        raise
     except Exception:
         _log.exception("GET /api/cron/delivery-targets failed")
+    finally:
+        if override_token is not None:
+            reset_hermes_home_override(override_token)
     return {"targets": targets}
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1856,6 +1856,38 @@ class TestWebServerEndpoints:
         # No hardcoded telegram/discord/slack/email when they aren't configured.
         assert "telegram" not in targets
 
+    def test_cron_delivery_targets_with_profile_param(self, monkeypatch):
+        """Accepts profile query parameter and validates input."""
+        import gateway.config as gateway_config
+
+        class _Platform:
+            def __init__(self, value):
+                self.value = value
+
+        class _GatewayConfig:
+            def get_connected_platforms(self):
+                return [_Platform("matrix")]
+
+        # Mock to avoid real gateway config loading
+        monkeypatch.setattr(gateway_config, "load_gateway_config", lambda: _GatewayConfig())
+        monkeypatch.setenv("MATRIX_HOME_ROOM", "!room:matrix.org")
+
+        # Test without profile parameter (existing behavior)
+        resp = self.client.get("/api/cron/delivery-targets")
+        assert resp.status_code == 200
+        targets = {t["id"]: t for t in resp.json()["targets"]}
+        assert "local" in targets
+        assert "matrix" in targets
+
+        # Test with profile parameter (new behavior)
+        # Since we can't easily mock profile resolution in this test context,
+        # we verify the parameter is accepted and returns appropriate status code.
+        # Profile resolution and HERMES_HOME override are covered by the
+        # existing cron delivery targets integration logic.
+        resp = self.client.get("/api/cron/delivery-targets?profile=nonexistent_profile")
+        # Should return 404 for non-existent profile (via _resolve_profile_dir)
+        assert resp.status_code == 404
+
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")
         assert resp.status_code == 200

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -568,8 +568,12 @@ export const api = {
   // Cron jobs
   getCronJobs: (profile = "all") =>
     fetchJSON<CronJob[]>(`/api/cron/jobs?profile=${encodeURIComponent(profile)}`),
-  getCronDeliveryTargets: () =>
-    fetchJSON<{ targets: CronDeliveryTarget[] }>("/api/cron/delivery-targets"),
+  getCronDeliveryTargets: (profile?: string) =>
+    fetchJSON<{ targets: CronDeliveryTarget[] }>(
+      profile
+        ? `/api/cron/delivery-targets?profile=${encodeURIComponent(profile)}`
+        : "/api/cron/delivery-targets"
+    ),
   createCronJob: (job: CronJobMutation, profile = "default") =>
     fetchJSON<CronJob>(`/api/cron/jobs?profile=${encodeURIComponent(profile)}`, {
       method: "POST",

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -593,7 +593,7 @@ export default function CronPage() {
 
   useEffect(() => {
     api
-      .getCronDeliveryTargets()
+      .getCronDeliveryTargets(resourceProfile)
       .then((res) => setDeliveryTargets(res.targets))
       .catch(() =>
         // Fall back to local-only so the modal still works if the endpoint fails.
@@ -601,7 +601,7 @@ export default function CronPage() {
           { id: "local", name: "Local", home_target_set: true, home_env_var: null },
         ]),
       );
-  }, []);
+  }, [resourceProfile]);
 
   useEffect(() => {
     loadJobs();


### PR DESCRIPTION
## What does this PR do?

Fixes the cron delivery targets dropdown in the Dashboard WebUI to respect the selected profile. Previously, when creating a cron job, selecting a non-default profile (e.g., wx1) in the Profile dropdown did not update the Deliver to dropdown — it always showed channels from the default profile only.

The fix is a front-end + back-end double omission correction:
- Back-end: Accept an optional profile query parameter on /api/cron/delivery-targets and temporarily override HERMES_HOME so cron_delivery_targets() loads the requested profile's gateway config
- Frontend: Pass the selected resourceProfile to getCronDeliveryTargets() and re-fetch when profile changes

## Related Issue

Fixes #61272

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- hermes_cli/web_server.py: Add optional profile parameter to get_cron_delivery_targets() endpoint. When provided, temporarily set HERMES_HOME override via set_hermes_home_override() before calling cron_delivery_targets(), ensuring the profile's gateway config is loaded. Override is reset in finally block.
- web/src/lib/api.ts: Accept optional profile parameter in getCronDeliveryTargets() and append it as ?profile= query parameter when present.
- web/src/pages/CronPage.tsx: Update useEffect dependency from [] to [resourceProfile] so delivery targets re-fetch when the selected profile changes.
- tests/hermes_cli/test_web_server.py: Add regression test verifying that /api/cron/delivery-targets accepts the optional profile query parameter and validates profile existence (returns 404 for non-existent profiles).

## How to Test

1. Configure Hermes with multiple profiles (e.g., default and wx1), where wx1 has a weixin gateway channel configured
2. Start the Dashboard WebUI and navigate to the Cron page
3. Click "New Job" to open the cron job creation modal
4. In the Profile dropdown, select default, and verify Deliver to dropdown contains default profile's channels. Observed result: Deliver to dropdown shows local, matrix (from default profile).
5. In the Profile dropdown, select wx1 (non-default profile), and verify Deliver to dropdown updates to show wx1's channels. Observed result: Deliver to dropdown shows local, weixin (from wx1 profile).
6. Switch back to the default profile in the Profile dropdown and verify the Deliver to dropdown now shows the default profile's channels. Observed result: Deliver to dropdown reverts to local, matrix (from default profile).

Expected result: The Deliver to dropdown updates to show channels from the selected profile, not always the default profile. Verified locally using macOS Hermes Agent with two configured profiles.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A