### PR TITLE
fix(dashboard): key keep-alive PTY on session, not just tab token (#61284)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15331,6 +15331,12 @@ async def pty_ws(ws: WebSocket) -> None:
 
     # --- spawn PTY ------------------------------------------------------
     resume = ws.query_params.get("resume") or None
+    # The frontend's explicit session/profile selection, captured before the
+    # active-session-file fallback below can rewrite ``resume``.  This is the
+    # PTY's identity for keep-alive keying (#61284): a per-tab attach token is
+    # NOT enough — switching sessions reuses the token but must not reuse the
+    # previous session's live PTY.
+    raw_resume = resume
     profile = ws.query_params.get("profile") or None
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
@@ -15373,6 +15379,15 @@ async def pty_ws(ws: WebSocket) -> None:
 
 
     attach_token = ws.query_params.get("attach") or None
+    # Key keep-alive PTYs on the selected session + profile as well as the tab
+    # token, so switching sessions spawns/reattaches the right PTY instead of
+    # replaying the previously-attached one (#61284).  NUL-joined so no query
+    # value can collide across fields.
+    registry_key = (
+        None
+        if attach_token is None
+        else "\0".join((attach_token, raw_resume or "", profile or ""))
+    )
 
     def _spawn():
         return PtyBridge.spawn(argv, cwd=cwd, env=env)
@@ -15395,7 +15410,7 @@ async def pty_ws(ws: WebSocket) -> None:
     # Keep-alive path: the PTY outlives this socket; reattach by token.
     try:
         session, _created = await PTY_REGISTRY.attach_or_spawn(
-            attach_token, spawn=_spawn
+            registry_key, spawn=_spawn
         )
     except PtyUnavailableError as exc:
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
@@ -15443,7 +15458,7 @@ async def pty_ws(ws: WebSocket) -> None:
     finally:
         # Detach only — the PTY keeps running for a reattach; the registry
         # reaper closes it after the TTL (or immediately on process exit).
-        PTY_REGISTRY.detach(attach_token, ws)
+        PTY_REGISTRY.detach(registry_key, ws)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pty_keepalive_ws.py
+++ b/tests/test_pty_keepalive_ws.py
@@ -51,3 +51,111 @@ async def test_attach_token_reuses_same_session(monkeypatch):
         assert len(spawned) == 1                # reattached, did not respawn
     finally:
         web_server.PTY_REGISTRY._sessions.clear()
+
+
+@pytest.mark.asyncio
+async def test_same_token_different_resume_spawns_distinct_session(monkeypatch):
+    """Switching sessions (same tab token, new ?resume=) must spawn a fresh PTY.
+
+    Regression for #61284: the registry was keyed only on the per-tab attach
+    token, so selecting a different session reattached to the previous
+    session's live PTY and the newly-requested ``resume`` was silently
+    dropped — the terminal kept showing the old session.
+    """
+    spawned = []          # (argv-resume marker) per spawn
+
+    class FakeBridge:
+        def __init__(self):
+            self.alive = True
+
+        def read(self, timeout):
+            return b""        # idle forever
+
+        def write(self, data):
+            pass
+
+        def resize(self, cols, rows):
+            pass
+
+        def close(self):
+            self.alive = False
+
+    resumes = []
+
+    def fake_spawn(argv, cwd=None, env=None):
+        b = FakeBridge()
+        spawned.append(b)
+        return b
+
+    monkeypatch.setattr(web_server.PtyBridge, "spawn", staticmethod(fake_spawn))
+    monkeypatch.setattr(web_server, "_ws_auth_reason", lambda ws: (None, "test"))
+    monkeypatch.setattr(web_server, "_ws_host_origin_reason", lambda ws: None)
+    monkeypatch.setattr(web_server, "_ws_client_reason", lambda ws: None)
+
+    async def fake_argv(**kw):
+        resumes.append(kw.get("resume"))
+        return (["x"], "/tmp", {})
+
+    monkeypatch.setattr(web_server, "_resolve_chat_argv_async", fake_argv)
+
+    from starlette.testclient import TestClient
+
+    try:
+        client = TestClient(web_server.app)
+        with client.websocket_connect("/api/pty?attach=TOK1&resume=SESS_A") as ws1:
+            ws1.send_bytes(b"hi")
+        with client.websocket_connect("/api/pty?attach=TOK1&resume=SESS_B") as ws2:
+            ws2.send_bytes(b"again")
+        assert len(spawned) == 2                 # distinct session => distinct PTY
+        assert resumes == ["SESS_A", "SESS_B"]   # second PTY honours the new resume
+    finally:
+        web_server.PTY_REGISTRY._sessions.clear()
+
+
+@pytest.mark.asyncio
+async def test_same_token_same_resume_reattaches(monkeypatch):
+    """Refreshing the SAME session (same token + same resume) reattaches."""
+    spawned = []
+
+    class FakeBridge:
+        def __init__(self):
+            self.alive = True
+
+        def read(self, timeout):
+            return b""
+
+        def write(self, data):
+            pass
+
+        def resize(self, cols, rows):
+            pass
+
+        def close(self):
+            self.alive = False
+
+    def fake_spawn(argv, cwd=None, env=None):
+        b = FakeBridge()
+        spawned.append(b)
+        return b
+
+    monkeypatch.setattr(web_server.PtyBridge, "spawn", staticmethod(fake_spawn))
+    monkeypatch.setattr(web_server, "_ws_auth_reason", lambda ws: (None, "test"))
+    monkeypatch.setattr(web_server, "_ws_host_origin_reason", lambda ws: None)
+    monkeypatch.setattr(web_server, "_ws_client_reason", lambda ws: None)
+
+    async def fake_argv(**kw):
+        return (["x"], "/tmp", {})
+
+    monkeypatch.setattr(web_server, "_resolve_chat_argv_async", fake_argv)
+
+    from starlette.testclient import TestClient
+
+    try:
+        client = TestClient(web_server.app)
+        with client.websocket_connect("/api/pty?attach=TOK1&resume=SESS_A") as ws1:
+            ws1.send_bytes(b"hi")
+        with client.websocket_connect("/api/pty?attach=TOK1&resume=SESS_A") as ws2:
+            ws2.send_bytes(b"again")
+        assert len(spawned) == 1                 # same session => reattach
+    finally:
+        web_server.PTY_REGISTRY._sessions.clear()


### PR DESCRIPTION
Fixes #61284.

## Symptom

Switching chat sessions in the dashboard shows the *previous* session's terminal instead of the selected one — "all chat sessions just re-render the same current session." REST metadata (`getSessionDetail`) is correct; only the PTY view is wrong.

## Root cause

The keep-alive PTY registry is keyed **only** on the per-tab `attach` token (`hermes.pty.token.chat`), which is stable across session switches. On a switch to `/chat?resume=B`:

- `forceFresh` is **false** (a plain switch never sets it — only "Start new session"/reconnect do), so the token does **not** rotate.
- `attach_or_spawn(attach_token, ...)` finds the still-live PTY running session **A** and reattaches, replaying A's ring buffer. The freshly-resolved argv carrying `--resume B` is never spawned.

`hermes_cli/pty_session.py`:
```python
existing = self._sessions.get(key)
if existing is not None and existing.alive:
    return existing, False          # _spawn (with the new --resume) never runs
```

Note: this is the inverse of the keep-alive-race theory floated in the issue — the token never rotates on a switch and no fresh PTY spawns; the **old** PTY is reused. The `code=1005 / messages=1` log is benign teardown of the superseded socket, not the trigger.

## Fix

Fold the frontend's explicit selection into the registry key — the raw `resume` (captured **before** the active-session-file fallback rewrites it) plus `profile`:

```python
raw_resume = resume   # before the active-file fallback mutates `resume`
registry_key = "\0".join((attach_token, raw_resume or "", profile or ""))
```

Keep-alive is preserved on every axis:

- Default chat (`/chat`, no resume) → stable key across refresh.
- Refresh while viewing B → same key → reattaches to B's live PTY.
- Switch A→B → distinct key → spawns B; A lingers to the reaper TTL, so switching back reattaches to A's live agent.

Bounded by the existing `max_sessions` + reaper, so no PTY leak. `profile` is folded in too because profile switching has the identical latent bug.

## Tests

- `test_same_token_different_resume_spawns_distinct_session` — same tab token + different `resume` spawns a **distinct** PTY, and the second spawn's argv honours the new `resume`. Fails on `main` (`assert 1 == 2`), passes with the fix.
- `test_same_token_same_resume_reattaches` — same token + same `resume` still reattaches (keep-alive on refresh preserved).
- Existing `test_attach_token_reuses_same_session` and the full `tests/hermes_cli/test_web_server.py` suite (357 tests) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
