### PR TITLE
fix(desktop): include pywin32 paths for Windows backend

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -6,6 +6,7 @@ import {
   appendUniquePathEntries,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
+  getWindowsVenvPythonPathEntries,
   normalizeHermesHomeRoot,
   pathEnvKey,
   POSIX_SANE_PATH_ENTRIES
@@ -98,6 +99,45 @@ test('Windows PATH casing and delimiter are preserved without POSIX sane entries
   assert.ok(env.Path.includes('\\venv\\Scripts;'))
   assert.ok(env.Path.includes(';C:\\Windows\\System32;C:\\Windows'))
   assert.equal(env.Path.includes('/opt/homebrew/bin'), false)
+})
+
+test('Windows venv PYTHONPATH includes pywin32 extension directories for base pythonw', () => {
+  const venvRoot = 'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv'
+  const sitePackages = path.win32.join(venvRoot, 'Lib', 'site-packages')
+  const pywin32System32 = path.win32.join(sitePackages, 'pywin32_system32')
+  const win32 = path.win32.join(sitePackages, 'win32')
+  const win32Lib = path.win32.join(win32, 'lib')
+  const existingDirs = new Set([sitePackages, pywin32System32, win32, win32Lib])
+  const pythonPathEntries = getWindowsVenvPythonPathEntries(venvRoot, {
+    directoryExists: (entry: string) => existingDirs.has(entry),
+    pathModule: path.win32
+  })
+
+  assert.deepEqual(pythonPathEntries, [sitePackages, pywin32System32, win32, win32Lib])
+
+  const env = buildDesktopBackendEnv({
+    hermesHome: 'C:\\Users\\test\\AppData\\Local\\hermes',
+    pythonPathEntries: ['C:\\repo\\hermes-agent', ...pythonPathEntries],
+    venvRoot,
+    currentEnv: {
+      Path: 'C:\\Windows\\System32',
+      PYTHONPATH: 'C:\\existing\\pythonpath'
+    },
+    platform: 'win32',
+    pathModule: path.win32
+  })
+
+  assert.equal(
+    env.PYTHONPATH,
+    [
+      'C:\\repo\\hermes-agent',
+      sitePackages,
+      pywin32System32,
+      win32,
+      win32Lib,
+      'C:\\existing\\pythonpath'
+    ].join(';')
+  )
 })
 
 test('appendUniquePathEntries drops empty entries and keeps first occurrence', () => {

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 // Match the POSIX fallback surface used by the Python terminal environment.
@@ -73,6 +74,39 @@ function buildDesktopBackendPath({
   return appendUniquePathEntries([hermesNodeBin, venvBin, currentPath, saneEntries], { delimiter })
 }
 
+function defaultDirectoryExists(target: string): boolean {
+  try {
+    return fs.statSync(target).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function getWindowsVenvPythonPathEntries(
+  venvRoot: string | null | undefined,
+  {
+    directoryExists = defaultDirectoryExists,
+    pathModule = path.win32
+  }: {
+    directoryExists?: (target: string) => boolean
+    pathModule?: typeof path.win32
+  } = {}
+): string[] {
+  if (!venvRoot) {
+    return []
+  }
+
+  const sitePackages = pathModule.join(venvRoot, 'Lib', 'site-packages')
+  const entries = [
+    sitePackages,
+    pathModule.join(sitePackages, 'pywin32_system32'),
+    pathModule.join(sitePackages, 'win32'),
+    pathModule.join(sitePackages, 'win32', 'lib')
+  ]
+
+  return entries.filter(entry => directoryExists(entry))
+}
+
 function normalizeHermesHomeRoot(hermesHome, { pathModule = pathModuleForPlatform(process.platform) }: any = {}) {
   if (!hermesHome) {
     return hermesHome
@@ -116,6 +150,7 @@ export {
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
   delimiterForPlatform,
+  getWindowsVenvPythonPathEntries,
   normalizeHermesHomeRoot,
   pathEnvKey,
   POSIX_SANE_PATH_ENTRIES

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,7 +31,7 @@ import {
 import nodePty from 'node-pty'
 
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
-import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
+import { buildDesktopBackendEnv, getWindowsVenvPythonPathEntries, normalizeHermesHomeRoot } from './backend-env'
 import { canImportHermesCli, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
@@ -1857,13 +1857,7 @@ function getVenvSitePackagesEntries(venvRoot) {
   }
 
   if (IS_WINDOWS) {
-    const sitePackages = path.join(venvRoot, 'Lib', 'site-packages')
-
-    if (directoryExists(sitePackages)) {
-      entries.push(sitePackages)
-    }
-
-    return entries
+    return getWindowsVenvPythonPathEntries(venvRoot, { directoryExists, pathModule: path.win32 })
   }
 
   const version = (() => {

--- a/apps/desktop/electron/windows-child-process.test.ts
+++ b/apps/desktop/electron/windows-child-process.test.ts
@@ -42,7 +42,7 @@ test('desktop background child processes opt into hidden Windows consoles', () =
 
   assert.match(source, /function unwrapWindowsVenvHermesCommand\(command, backendArgs\)/)
   assert.match(source, /function getVenvSitePackagesEntries\(venvRoot\)/)
-  assert.match(source, /path\.join\(venvRoot, 'Lib', 'site-packages'\)/)
+  assert.match(source, /getWindowsVenvPythonPathEntries\(venvRoot/)
   assert.match(source, /args: \['-m', 'hermes_cli\.main', \.\.\.backendArgs\]/)
 })
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -157,6 +157,24 @@ _GATEWAY_SECRET_PATTERNS = (
 )
 
 
+def _windows_venv_pythonpath_entries(venv_dir: Path) -> list[Path]:
+    site_packages = venv_dir / "Lib" / "site-packages"
+    if not site_packages.exists():
+        return []
+
+    entries = [site_packages]
+    for relative in (
+        Path("pywin32_system32"),
+        Path("win32"),
+        Path("win32") / "lib",
+    ):
+        candidate = site_packages / relative
+        if candidate.exists():
+            entries.append(candidate)
+
+    return entries
+
+
 def _ensure_windows_gateway_venv_imports() -> None:
     """Make detached Windows gateway runs see the Hermes venv packages.
 
@@ -187,10 +205,11 @@ def _ensure_windows_gateway_venv_imports() -> None:
             continue
         seen.add(venv_key)
 
-        site_packages = resolved_venv / "Lib" / "site-packages"
-        if not site_packages.exists():
+        pythonpath_entries = _windows_venv_pythonpath_entries(resolved_venv)
+        if not pythonpath_entries:
             continue
 
+        site_packages = pythonpath_entries[0]
         project_entry = str(project_root)
         site_entry = str(site_packages)
         if project_entry not in sys.path:
@@ -202,9 +221,14 @@ def _ensure_windows_gateway_venv_imports() -> None:
             sys.path.remove(site_entry)
         insert_at = 1 if sys.path and sys.path[0] == project_entry else 0
         sys.path.insert(insert_at, site_entry)
+        for entry in reversed(pythonpath_entries[1:]):
+            extra_entry = str(entry)
+            if extra_entry in sys.path:
+                sys.path.remove(extra_entry)
+            sys.path.insert(insert_at + 1, extra_entry)
 
         os.environ["VIRTUAL_ENV"] = str(resolved_venv)
-        pythonpath = [project_entry, site_entry]
+        pythonpath = [project_entry, *[str(entry) for entry in pythonpath_entries]]
         if os.environ.get("PYTHONPATH"):
             pythonpath.append(os.environ["PYTHONPATH"])
         os.environ["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
@@ -6248,10 +6272,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 watcher_python = sys.executable
             venv_dir = Path(watcher_env.get("VIRTUAL_ENV") or project_root / "venv")
-            site_packages = venv_dir / "Lib" / "site-packages"
-            if site_packages.exists():
+            pythonpath_entries = _windows_venv_pythonpath_entries(venv_dir)
+            if pythonpath_entries:
                 watcher_env["VIRTUAL_ENV"] = str(venv_dir)
-                pythonpath = [str(project_root), str(site_packages)]
+                pythonpath = [str(project_root), *[str(entry) for entry in pythonpath_entries]]
                 if watcher_env.get("PYTHONPATH"):
                     pythonpath.append(watcher_env["PYTHONPATH"])
                 watcher_env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -731,6 +731,24 @@ def _read_pyvenv_cfg(venv_dir: Path) -> dict[str, str]:
     return parsed
 
 
+def _windows_venv_pythonpath_entries(venv_dir: Path) -> list[str]:
+    site_packages = venv_dir / "Lib" / "site-packages"
+    if not site_packages.exists():
+        return []
+
+    entries = [site_packages]
+    for relative in (
+        Path("pywin32_system32"),
+        Path("win32"),
+        Path("win32") / "lib",
+    ):
+        candidate = site_packages / relative
+        if candidate.exists():
+            entries.append(candidate)
+
+    return [str(entry) for entry in entries]
+
+
 def _resolve_detached_python(python_exe: str) -> tuple[str, Path, list[str]]:
     """Return (windowed_python, venv_dir, extra_pythonpath) for detached runs.
 
@@ -749,9 +767,9 @@ def _resolve_detached_python(python_exe: str) -> tuple[str, Path, list[str]]:
     home = cfg.get("home", "")
     if "uv" in cfg and home:
         base_pythonw = Path(home) / "pythonw.exe"
-        site_packages = venv_dir / "Lib" / "site-packages"
-        if base_pythonw.exists() and site_packages.exists():
-            return (str(base_pythonw), venv_dir, [str(site_packages)])
+        pythonpath_entries = _windows_venv_pythonpath_entries(venv_dir)
+        if base_pythonw.exists() and pythonpath_entries:
+            return (str(base_pythonw), venv_dir, pythonpath_entries)
 
     return (windowed, venv_dir, [])
 

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -293,8 +293,13 @@ async def test_detached_restart_helper_is_idempotent(monkeypatch):
 def test_windows_gateway_venv_imports_add_site_packages(monkeypatch, tmp_path):
     venv_dir = tmp_path / "venv"
     site_packages = venv_dir / "Lib" / "site-packages"
-    pth_extra = tmp_path / "pywin32_system32"
+    pywin32_system32 = site_packages / "pywin32_system32"
+    win32 = site_packages / "win32"
+    win32_lib = win32 / "lib"
+    pth_extra = tmp_path / "pywin32_extra"
     site_packages.mkdir(parents=True)
+    pywin32_system32.mkdir()
+    win32_lib.mkdir(parents=True)
     pth_extra.mkdir()
     (site_packages / "pywin32.pth").write_text(str(pth_extra), encoding="utf-8")
     project_root = str(gateway_run.Path(gateway_run.__file__).resolve().parent.parent)
@@ -310,7 +315,8 @@ def test_windows_gateway_venv_imports_add_site_packages(monkeypatch, tmp_path):
     assert str(pth_extra) in gateway_run.sys.path
     assert gateway_run.os.environ["VIRTUAL_ENV"] == str(venv_dir.resolve())
     pythonpath = gateway_run.os.environ["PYTHONPATH"].split(gateway_run.os.pathsep)
-    assert pythonpath[:3] == [project_root, str(site_packages), "already-there"]
+    assert pythonpath[:5] == [project_root, str(site_packages), str(pywin32_system32), str(win32), str(win32_lib)]
+    assert pythonpath[-1] == "already-there"
 
 
 @pytest.mark.asyncio
@@ -319,7 +325,12 @@ async def test_windows_detached_restart_scrubs_gateway_marker(monkeypatch, tmp_p
     popen_calls = []
     venv_dir = tmp_path / "venv"
     site_packages = venv_dir / "Lib" / "site-packages"
+    pywin32_system32 = site_packages / "pywin32_system32"
+    win32 = site_packages / "win32"
+    win32_lib = win32 / "lib"
     site_packages.mkdir(parents=True)
+    pywin32_system32.mkdir()
+    win32_lib.mkdir(parents=True)
 
     monkeypatch.setattr(gateway_run.sys, "platform", "win32")
     monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["hermes"])
@@ -348,7 +359,11 @@ async def test_windows_detached_restart_scrubs_gateway_marker(monkeypatch, tmp_p
     assert cmd[-3:] == ["hermes", "gateway", "restart"]
     assert kwargs["env"].get("_HERMES_GATEWAY") is None
     assert kwargs["env"]["VIRTUAL_ENV"] == str(venv_dir)
-    assert str(site_packages) in kwargs["env"]["PYTHONPATH"].split(gateway_run.os.pathsep)
+    pythonpath = kwargs["env"]["PYTHONPATH"].split(gateway_run.os.pathsep)
+    assert str(site_packages) in pythonpath
+    assert str(pywin32_system32) in pythonpath
+    assert str(win32) in pythonpath
+    assert str(win32_lib) in pythonpath
     assert kwargs["stdout"] is subprocess.DEVNULL
     assert kwargs["stderr"] is subprocess.DEVNULL
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -78,10 +78,15 @@ def test_build_gateway_argv_uses_base_pythonw_for_uv_venv_launcher(monkeypatch, 
     project = tmp_path / "project"
     scripts = project / "venv" / "Scripts"
     site_packages = project / "venv" / "Lib" / "site-packages"
+    pywin32_system32 = site_packages / "pywin32_system32"
+    win32 = site_packages / "win32"
+    win32_lib = win32 / "lib"
     hermes_home = tmp_path / "hermes-home"
     base = tmp_path / "uv" / "python" / "cpython-3.11-windows-x86_64-none"
     scripts.mkdir(parents=True)
     site_packages.mkdir(parents=True)
+    pywin32_system32.mkdir()
+    win32_lib.mkdir(parents=True)
     hermes_home.mkdir()
     base.mkdir(parents=True)
 
@@ -108,8 +113,12 @@ def test_build_gateway_argv_uses_base_pythonw_for_uv_venv_launcher(monkeypatch, 
     assert argv[:3] == [str(base_pythonw), "-m", "hermes_cli.main"]
     assert cwd == str(hermes_home.resolve())
     assert env_overlay["VIRTUAL_ENV"] == str(project / "venv")
-    assert str(project) in env_overlay["PYTHONPATH"].split(gateway_windows.os.pathsep)
-    assert str(site_packages) in env_overlay["PYTHONPATH"].split(gateway_windows.os.pathsep)
+    pythonpath = env_overlay["PYTHONPATH"].split(gateway_windows.os.pathsep)
+    assert str(project) in pythonpath
+    assert str(site_packages) in pythonpath
+    assert str(pywin32_system32) in pythonpath
+    assert str(win32) in pythonpath
+    assert str(win32_lib) in pythonpath
 
 
 class TestStableWindowsGatewayWorkingDir:
@@ -215,10 +224,15 @@ def test_gateway_cmd_script_uses_uv_safe_base_pythonw(monkeypatch, tmp_path):
     project = tmp_path / "project"
     scripts = project / "venv" / "Scripts"
     site_packages = project / "venv" / "Lib" / "site-packages"
+    pywin32_system32 = site_packages / "pywin32_system32"
+    win32 = site_packages / "win32"
+    win32_lib = win32 / "lib"
     hermes_home = tmp_path / "hermes-home"
     base = tmp_path / "uv" / "python" / "cpython-3.11-windows-x86_64-none"
     scripts.mkdir(parents=True)
     site_packages.mkdir(parents=True)
+    pywin32_system32.mkdir()
+    win32_lib.mkdir(parents=True)
     hermes_home.mkdir()
     base.mkdir(parents=True)
 
@@ -242,6 +256,9 @@ def test_gateway_cmd_script_uses_uv_safe_base_pythonw(monkeypatch, tmp_path):
     assert str(base_pythonw) in content
     assert f'set "VIRTUAL_ENV={project / "venv"}"' in content
     assert str(site_packages) in content
+    assert str(pywin32_system32) in content
+    assert str(win32) in content
+    assert str(win32_lib) in content
     assert str(venv_pythonw) not in content
 
 


### PR DESCRIPTION
## Summary
- include pywin32 extension directories in the Windows desktop backend PYTHONPATH when using a uv base pythonw.exe
- mirror the same venv PYTHONPATH entries for Windows gateway launchers and restart watchers
- add regression coverage for desktop backend env, gateway launch scripts, and gateway restart env propagation

## Root Cause
Windows uv venv launchers can hand off to the base pythonw.exe. That interpreter can import packages from venv/Lib/site-packages when PYTHONPATH is set, but it does not process the venv pywin32 .pth file. As a result, pywintypes/win32api can be missing even though cua-driver doctor succeeds.

## Validation
- node --import .../tsx/dist/loader.mjs --test electron/backend-env.test.ts electron/windows-child-process.test.ts
- python3 -m pytest -s tests/hermes_cli/test_gateway_windows.py -q
- python3 -m pytest -s tests/gateway/test_restart_drain.py::test_windows_gateway_venv_imports_add_site_packages tests/gateway/test_restart_drain.py::test_windows_detached_restart_scrubs_gateway_marker tests/gateway/test_restart_drain.py::test_windows_detached_restart_uses_pythonw_for_watcher -q
- python3 -m py_compile hermes_cli/gateway_windows.py gateway/run.py
- local smoke: uv base python.exe imports pywintypes, win32api, and mcp with the expanded PYTHONPATH