### PR TITLE
feat(tools): add file type registry for structured format summarization

### DIFF
--- a/tests/tools/test_file_type_registry.py
+++ b/tests/tools/test_file_type_registry.py
@@ -1,0 +1,377 @@
+"""Tests for tools/file_type_registry.py — format detection and summarization."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.file_type_registry import (
+    _csv_handler,
+    _har_handler,
+    _json_structure_handler,
+    _log_file_handler,
+    _format_size,
+    _detect_csv_delimiter,
+    detect_and_summarize,
+    detect_format,
+    known_format_extensions,
+    register_format,
+)
+
+
+# =========================================================================
+# Format size helper
+# =========================================================================
+
+class TestFormatSize:
+    def test_bytes(self):
+        assert _format_size(500) == "500 B"
+
+    def test_kilobytes(self):
+        assert _format_size(2048) == "2.0 KB"
+
+    def test_megabytes(self):
+        assert _format_size(5_242_880) == "5.0 MB"
+
+    def test_gigabytes(self):
+        assert _format_size(2_147_483_648) == "2.0 GB"
+
+    def test_edge_zero(self):
+        assert _format_size(0) == "0 B"
+
+
+# =========================================================================
+# CSV delimiter detection
+# =========================================================================
+
+class TestDetectCsvDelimiter:
+    def test_comma(self):
+        assert _detect_csv_delimiter("a,b,c") == ","
+
+    def test_tab(self):
+        assert _detect_csv_delimiter("a\tb\tc") == "\t"
+
+    def test_semicolon(self):
+        assert _detect_csv_delimiter("a;b;c") == ";"
+
+    def test_pipe(self):
+        assert _detect_csv_delimiter("a|b|c") == "|"
+
+    def test_empty_defaults_to_comma(self):
+        assert _detect_csv_delimiter("") == ","
+
+
+# =========================================================================
+# HAR handler
+# =========================================================================
+
+class TestHarHandler:
+    def test_valid_har_with_entries(self):
+        har_content = json.dumps({
+            "log": {
+                "entries": [
+                    {
+                        "request": {
+                            "url": "https://api.example.com/users",
+                            "method": "GET",
+                        },
+                        "response": {
+                            "status": 200,
+                            "_transferSize": 1200,
+                            "content": {"size": 5000, "mimeType": "application/json"},
+                        },
+                        "startedDateTime": "2026-07-08T10:00:00Z",
+                    },
+                    {
+                        "request": {
+                            "url": "https://api.example.com/data",
+                            "method": "POST",
+                        },
+                        "response": {
+                            "status": 201,
+                            "_transferSize": 350,
+                            "content": {"size": 200, "mimeType": "text/plain"},
+                        },
+                        "startedDateTime": "2026-07-08T10:00:01Z",
+                    },
+                    {
+                        "request": {
+                            "url": "https://cdn.example.com/image.png",
+                            "method": "GET",
+                        },
+                        "response": {
+                            "status": 404,
+                            "_transferSize": 0,
+                            "content": {"size": 0, "mimeType": "text/html"},
+                        },
+                        "startedDateTime": "2026-07-08T10:00:02Z",
+                    },
+                ]
+            }
+        })
+        path = "/tmp/test.har"
+        result = _har_handler(path, har_content, 2048)
+        assert result is not None
+        assert "HAR Network Trace" in result
+        assert "3 requests" in result
+        assert "api.example.com" in result
+        assert "cdn.example.com" in result
+        assert "200" in result
+        assert "404" in result
+        assert "GET" in result
+        assert "POST" in result
+        # Error count: 1 (the 404)
+        assert "Error responses: 1" in result
+
+    def test_empty_har(self):
+        har_content = json.dumps({"log": {"entries": []}})
+        result = _har_handler("/tmp/empty.har", har_content, 100)
+        assert result is not None
+        assert "empty" in result.lower()
+
+    def test_invalid_json_har(self):
+        result = _har_handler("/tmp/bad.har", "not json", 100)
+        assert result is not None
+        assert "not valid JSON" in result
+
+    def test_har_no_log_key(self):
+        # Some HAR files use the root as the log object
+        har_content = json.dumps({
+            "entries": [{
+                "request": {"url": "https://example.com/", "method": "GET"},
+                "response": {"status": 200, "_transferSize": 100, "content": {"size": 500}},
+            }]
+        })
+        result = _har_handler("/tmp/alt.har", har_content, 500)
+        assert result is not None
+        assert "HAR Network Trace" in result
+        assert "1 requests" in result
+
+
+# =========================================================================
+# JSON handler
+# =========================================================================
+
+class TestJsonHandler:
+    def test_json_object(self):
+        content = json.dumps({"name": "Alice", "age": 30, "items": [1, 2, 3], "meta": {"key": "val"}})
+        result = _json_structure_handler("/tmp/data.json", content, 200)
+        assert result is not None
+        assert "JSON Object" in result
+        assert "4 top-level key" in result
+        assert "name" in result
+        assert "items" in result
+
+    def test_json_array(self):
+        content = json.dumps([{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}])
+        result = _json_structure_handler("/tmp/list.json", content, 300)
+        assert result is not None
+        assert "JSON Array" in result
+        assert "6 items" in result
+
+    def test_invalid_json(self):
+        result = _json_structure_handler("/tmp/bad.json", "{invalid", 100)
+        assert result is not None
+        assert "not valid" in result
+
+    def test_primitive_json(self):
+        result = _json_structure_handler("/tmp/num.json", "42", 10)
+        assert result is not None
+        assert "JSON value" in result
+
+
+# =========================================================================
+# CSV handler
+# =========================================================================
+
+class TestCsvHandler:
+    def test_basic_csv(self):
+        content = "name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,SF\n"
+        result = _csv_handler("/tmp/data.csv", content, 200)
+        assert result is not None
+        assert "CSV File" in result
+        assert "3 data rows" in result
+        assert "3 columns" in result
+        assert "name" in result
+        assert "age" in result
+        assert "city" in result
+        assert "Alice" in result
+
+    def test_empty_csv(self):
+        result = _csv_handler("/tmp/empty.csv", "", 0)
+        assert result is not None
+        assert "empty" in result.lower()
+
+    def test_tsv_detection(self):
+        content = "name\tage\tcity\nAlice\t30\tNYC\n"
+        result = _csv_handler("/tmp/data.tsv", content, 100)
+        assert result is not None
+        assert "CSV File" in result
+        assert "1 data rows" in result
+
+
+# =========================================================================
+# Log file handler
+# =========================================================================
+
+class TestLogFileHandler:
+    def test_with_severity_levels(self):
+        content = (
+            "2026-07-08 INFO  Server started\n"
+            "2026-07-08 ERROR Connection refused\n"
+            "2026-07-08 WARN  Disk space low\n"
+            "2026-07-08 INFO  Request received\n"
+            "2026-07-08 ERROR Timeout exceeded\n"
+        )
+        result = _log_file_handler("/tmp/app.log", content, 300)
+        assert result is not None
+        assert "Log File" in result
+        assert "5 lines" in result
+        assert "INFO: 2" in result
+        assert "ERROR: 2" in result
+        assert "WARN: 1" in result
+
+    def test_no_severity(self):
+        content = "line one\nline two\nline three\n"
+        result = _log_file_handler("/tmp/plain.log", content, 100)
+        assert result is not None
+        assert "Log File" in result
+        assert "3 lines" in result
+
+
+# =========================================================================
+# Registry and detection
+# =========================================================================
+
+class TestRegistry:
+    def test_detect_known_format(self):
+        assert detect_format("/path/file.har") == ".har"
+        assert detect_format("/path/file.json") == ".json"
+        assert detect_format("/path/file.csv") == ".csv"
+        assert detect_format("/path/file.log") == ".log"
+
+    def test_detect_unknown_format(self):
+        assert detect_format("/path/file.md") is None
+        assert detect_format("/path/file.py") is None
+
+    def test_known_extensions(self):
+        exts = known_format_extensions()
+        assert ".har" in exts
+        assert ".json" in exts
+        assert ".csv" in exts
+        assert ".log" in exts
+
+    def test_detect_and_summarize_happy_path(self):
+        content = json.dumps({"log": {"entries": [{
+            "request": {"url": "https://example.com/", "method": "GET"},
+            "response": {"status": 200, "_transferSize": 100, "content": {"size": 500}},
+        }]}})
+        result = detect_and_summarize("/tmp/test.har", content, 500)
+        assert result is not None
+        assert "HAR Network Trace" in result
+
+    def test_detect_and_summarize_unknown(self):
+        result = detect_and_summarize("/tmp/unknown.xyz", "some content", 100)
+        assert result is None
+
+    def test_detect_and_summarize_handler_failure_graceful(self):
+        # Handler that raises
+        def _broken(_p, _c, _s):
+            raise RuntimeError("oops")
+        register_format(".broken", _broken, "test")
+        result = detect_and_summarize("/tmp/test.broken", "content", 100)
+        assert result is None
+
+
+# =========================================================================
+# Integration test (requires ShellFileOperations)
+# =========================================================================
+
+class TestReadFileIntegration:
+    def test_har_file_reads_as_summary(self):
+        """When read_file encounters a .har file, it should return a summary."""
+        from tools.file_operations import ShellFileOperations
+        from unittest.mock import MagicMock
+
+        har_data = json.dumps({
+            "log": {
+                "entries": [
+                    {
+                        "request": {"url": "https://example.com/api", "method": "GET"},
+                        "response": {"status": 200, "_transferSize": 500, "content": {"size": 2000, "mimeType": "application/json"}},
+                        "startedDateTime": "2026-07-08T10:00:00Z",
+                    }
+                ]
+            }
+        })
+
+        mock_env = MagicMock()
+        file_size = len(har_data.encode("utf-8"))
+
+        # Mock executor for wc -c, head -c, cat
+        def mock_execute(cmd: str, cwd=None, **kwargs):
+            if "wc -c" in cmd:
+                return {"output": str(file_size), "returncode": 0}
+            if "head -c 1000" in cmd:
+                return {"output": har_data[:1000], "returncode": 0}
+            if cmd.startswith("cat "):
+                return {"output": har_data, "returncode": 0}
+            if cmd.startswith("command -v"):
+                return {"output": "yes", "returncode": 0}
+            if "wc -l" in cmd:
+                line_count = har_data.count("\n") + 1
+                return {"output": str(line_count), "returncode": 0}
+            if "echo $HOME" in cmd:
+                return {"output": "/tmp", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute = mock_execute
+        mock_env.cwd = "/tmp"
+
+        ops = ShellFileOperations(mock_env, cwd="/tmp")
+        result = ops.read_file("/tmp/test.har")
+
+        assert result.format_type == "har"
+        assert result.error is None
+        assert "HAR Network Trace" in result.content
+        assert "1 requests" in result.content
+
+    def test_json_file_reads_as_structure(self):
+        """read_file should return a JSON structure summary for .json files."""
+        from tools.file_operations import ShellFileOperations
+        from unittest.mock import MagicMock
+
+        json_data = json.dumps({"users": [1, 2, 3], "config": {"debug": True}, "name": "test"})
+
+        mock_env = MagicMock()
+        file_size = len(json_data.encode("utf-8"))
+
+        def mock_execute(cmd: str, cwd=None, **kwargs):
+            if "wc -c" in cmd:
+                return {"output": str(file_size), "returncode": 0}
+            if "head -c 1000" in cmd:
+                return {"output": json_data[:1000], "returncode": 0}
+            if cmd.startswith("cat "):
+                return {"output": json_data, "returncode": 0}
+            if cmd.startswith("command -v"):
+                return {"output": "yes", "returncode": 0}
+            if "wc -l" in cmd:
+                line_count = json_data.count("\n") + 1
+                return {"output": str(line_count), "returncode": 0}
+            if "echo $HOME" in cmd:
+                return {"output": "/tmp", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute = mock_execute
+        mock_env.cwd = "/tmp"
+
+        ops = ShellFileOperations(mock_env, cwd="/tmp")
+        result = ops.read_file("/tmp/data.json")
+
+        assert result.format_type == "json"
+        assert result.error is None
+        assert "JSON Object" in result.content
+        assert "3 top-level key" in result.content

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -33,6 +33,12 @@ from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, ClassVar
 from pathlib import Path
 from tools.binary_extensions import BINARY_EXTENSIONS
+from tools.file_type_registry import (
+    detect_and_summarize,
+    detect_format,
+    known_format_extensions,
+    max_structured_file_size,
+)
 
 from agent.file_safety import (
     build_write_denied_paths,
@@ -167,6 +173,7 @@ class ReadResult:
     dimensions: Optional[str] = None  # For images: "WIDTHxHEIGHT"
     error: Optional[str] = None
     similar_files: List[str] = field(default_factory=list)
+    format_type: Optional[str] = None  # Structured format name (e.g. "har", "json", "csv")
     
     def to_dict(self) -> dict:
         return {k: v for k, v in self.__dict__.items() if v is not None and v != []}
@@ -894,6 +901,51 @@ class ShellFileOperations(FileOperations):
         ext = os.path.splitext(path)[1].lower()
         return ext in IMAGE_EXTENSIONS
     
+    def _try_structured_read(self, path: str, file_size: int) -> Optional[ReadResult]:
+        """Check if *path* matches a known structured format and produce a summary.
+
+        Returns a ``ReadResult`` with the summary as ``content`` and
+        ``format_type`` set to the format name, or ``None`` if no format
+        handler matched or the file is too large to process.
+        """
+        ext = detect_format(path)
+        if ext is None:
+            return None
+
+        if file_size > max_structured_file_size():
+            return ReadResult(
+                format_type=ext.lstrip("."),
+                file_size=file_size,
+                hint=(
+                    f"Structured {ext} file detected ({_format_size(file_size)}), "
+                    "but it is too large to summarise automatically. "
+                    "Use the terminal tool with an appropriate parser to inspect it."
+                ),
+                is_binary=False,
+            )
+
+        # Read the full file content via cat
+        cat_cmd = f"cat {self._escape_shell_arg(path)}"
+        cat_result = self._exec(cat_cmd)
+        if cat_result.exit_code != 0:
+            return None  # Fall through to normal read
+
+        raw_content = _strip_terminal_fence_leaks(cat_result.stdout)
+        summary = detect_and_summarize(path, raw_content, file_size)
+
+        if summary is None:
+            return None  # Handler didn't produce output; fall through
+
+        return ReadResult(
+            content=summary,
+            file_size=file_size,
+            format_type=ext.lstrip("."),
+            hint=(
+                f"Structured summary for {ext} file. "
+                f"Use read_file with offset/limit to view the raw content."
+            ),
+        )
+    
     def _add_line_numbers(self, content: str, start_line: int = 1) -> str:
         """Add line numbers to content in ``LINE_NUM|CONTENT`` format.
 
@@ -1116,6 +1168,11 @@ class ShellFileOperations(FileOperations):
                     "Use vision_analyze with this file path to inspect the image contents."
                 ),
             )
+        
+        # Check for structured formats (HAR, JSON, CSV, etc.) — produce a summary
+        structured = self._try_structured_read(path, file_size)
+        if structured is not None:
+            return structured
         
         # Read a sample to check for binary content
         sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"

--- a/tools/file_type_registry.py
+++ b/tools/file_type_registry.py
@@ -1,0 +1,429 @@
+"""
+File type registry — detects structured data formats and produces
+intelligent summaries instead of raw content injection.
+
+Provides:
+- Extension-based format detection
+- Per-format handler functions that return human-readable summaries
+- A registry for adding new format handlers
+
+Usage:
+    from tools.file_type_registry import detect_and_summarize, register_format
+    
+    summary = detect_and_summarize("/path/to/file.har", file_content, file_size)
+    if summary:
+        print(summary)  # Short, structured summary
+"""
+
+import json
+import os
+import logging
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Handler signature: (path: str, content: str, file_size: int) -> str | None
+# Returns a human-readable summary string, or None if the file can't be parsed.
+HandlerFunc = Callable[[str, str, int], Optional[str]]
+
+# Registry: extension → (handler, description)
+_FORMAT_REGISTRY: dict[str, tuple[HandlerFunc, str]] = {}
+
+
+def register_format(
+    extension: str,
+    handler: HandlerFunc,
+    description: str = "",
+) -> None:
+    """Register a handler for a specific file extension.
+
+    Args:
+        extension: File extension including the dot (e.g. '.har', '.json')
+        handler: Function that takes (path, content, file_size) and returns a summary
+        description: Human-readable description of the format
+    """
+    ext = extension.lower()
+    if not ext.startswith("."):
+        ext = f".{ext}"
+    _FORMAT_REGISTRY[ext] = (handler, description)
+
+
+def known_format_extensions() -> frozenset[str]:
+    """Return the set of registered format extensions."""
+    return frozenset(_FORMAT_REGISTRY.keys())
+
+
+def detect_format(path: str) -> Optional[str]:
+    """Detect format extension by file extension.
+
+    Returns the matching extension (e.g. '.har'), or None if no format matches.
+    """
+    ext = os.path.splitext(path)[1].lower()
+    if ext in _FORMAT_REGISTRY:
+        return ext
+    return None
+
+
+def detect_and_summarize(path: str, content: str, file_size: int) -> Optional[str]:
+    """Detect format and produce a summary for *path*.
+
+    Args:
+        path: Absolute file path (used for extension detection)
+        content: Full file content as a string
+        file_size: File size in bytes
+
+    Returns:
+        A human-readable summary string, or None if no registered format matches.
+    """
+    ext = os.path.splitext(path)[1].lower()
+    entry = _FORMAT_REGISTRY.get(ext)
+    if entry is None:
+        return None
+    handler, _ = entry
+    try:
+        return handler(path, content, file_size)
+    except Exception as exc:
+        logger.warning("Format handler for %s failed: %s", ext, exc)
+        return None
+
+
+# =========================================================================
+# Built-in format handlers
+# =========================================================================
+
+
+def _har_handler(path: str, content: str, file_size: int) -> Optional[str]:
+    """Parse HAR (HTTP Archive) file and return a network trace summary."""
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as e:
+        return f"HAR file detected but is not valid JSON: {e}"
+
+    log = data["log"] if isinstance(data, dict) and "log" in data else data
+    entries = log.get("entries", []) if isinstance(log, dict) else data
+
+    if not isinstance(entries, list):
+        return "HAR file detected but format is unrecognised (expected 'log.entries' array)"
+
+    total = len(entries)
+    if total == 0:
+        return "HAR file detected — empty (no network requests recorded)."
+
+    domains: dict[str, int] = {}
+    status_codes: dict[int, int] = {}
+    methods: dict[str, int] = {}
+    content_types: dict[str, int] = {}
+    total_transfer = 0
+    total_body = 0
+    timeline_start: Optional[float] = None
+    timeline_end: Optional[float] = None
+    errors = 0
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+
+        req = entry.get("request", {})
+        res = entry.get("response", {})
+
+        url = req.get("url", "")
+        if "//" in url:
+            domain = url.split("/")[2] if len(url.split("/")) > 2 else "unknown"
+        else:
+            domain = "unknown"
+        domains[domain] = domains.get(domain, 0) + 1
+
+        method = req.get("method", "GET")
+        methods[method] = methods.get(method, 0) + 1
+
+        status = res.get("status", 0)
+        if isinstance(status, int):
+            status_codes[status] = status_codes.get(status, 0) + 1
+            if status >= 400:
+                errors += 1
+
+        # Transfer size (wire bytes)
+        transfer = res.get("_transferSize", 0) or 0
+        total_transfer += transfer
+
+        # Body size
+        body_size = res.get("content", {}).get("size", 0) or 0
+        total_body += body_size
+
+        # Content type
+        ct = (res.get("content", {}).get("mimeType", "") or "").split(";")[0]
+        if ct:
+            content_types[ct] = content_types.get(ct, 0) + 1
+
+        # Timeline
+        started = entry.get("startedDateTime")
+        if started:
+            try:
+                from datetime import datetime
+                t = datetime.fromisoformat(started.replace("Z", "+00:00")).timestamp()
+                if timeline_start is None or t < timeline_start:
+                    timeline_start = t
+                if timeline_end is None or t > timeline_end:
+                    timeline_end = t
+            except (ValueError, TypeError):
+                pass
+
+    # Build summary
+    lines = [
+        f"HAR Network Trace: {total} requests",
+        f"  File size:       {_format_size(file_size)}",
+        f"  Transfer size:   {_format_size(total_transfer)} (wire)",
+        f"  Body size:       {_format_size(total_body)} (decompressed)",
+        f"  Unique domains:  {len(domains)}",
+        f"  Error responses: {errors}",
+    ]
+
+    if timeline_start is not None and timeline_end is not None:
+        duration = timeline_end - timeline_start
+        if duration < 120:
+            lines.append(f"  Time span:       {duration:.1f}s")
+        else:
+            lines.append(f"  Time span:       {duration / 60:.1f} min")
+
+    # Top domains
+    if domains:
+        lines.append("")
+        lines.append("Top domains by request count:")
+        for domain, count in sorted(domains.items(), key=lambda x: -x[1])[:10]:
+            lines.append(f"  {domain}: {count}")
+
+    # Methods
+    if methods:
+        lines.append("")
+        lines.append("HTTP methods:")
+        for method, count in sorted(methods.items(), key=lambda x: -x[1]):
+            lines.append(f"  {method}: {count}")
+
+    # Status code distribution (grouped)
+    if status_codes:
+        lines.append("")
+        lines.append("Status code distribution:")
+        for code in sorted(status_codes.keys()):
+            label = _status_label(code)
+            count = status_codes[code]
+            bar = "█" * min(count, 40)
+            lines.append(f"  {code} {label}: {count} {bar}")
+
+    # Top content types
+    if content_types:
+        lines.append("")
+        lines.append("Content types:")
+        for ct, count in sorted(content_types.items(), key=lambda x: -x[1])[:8]:
+            lines.append(f"  {ct}: {count}")
+
+    return "\n".join(lines)
+
+
+def _json_structure_handler(path: str, content: str, file_size: int) -> Optional[str]:
+    """Analyze JSON structure and return a summary."""
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as e:
+        return f"JSON file detected but is not valid: {e}"
+
+    if isinstance(data, dict):
+        keys = list(data.keys())
+        lines = [
+            f"JSON Object: {len(keys)} top-level key{'s' if len(keys) != 1 else ''}",
+            f"  File size: {_format_size(file_size)}",
+        ]
+        if keys:
+            lines.append("")
+            lines.append("Top-level keys:")
+            for key in keys[:20]:
+                val = data[key]
+                if isinstance(val, dict):
+                    lines.append(f"  {key}: object ({len(val)} keys)")
+                elif isinstance(val, list):
+                    lines.append(f"  {key}: array ({len(val)} items)")
+                elif isinstance(val, str):
+                    lines.append(f"  {key}: string ({len(val)} chars)")
+                elif val is None:
+                    lines.append(f"  {key}: null")
+                else:
+                    lines.append(f"  {key}: {type(val).__name__} ({val!r})")
+            if len(keys) > 20:
+                lines.append(f"  ... and {len(keys) - 20} more keys")
+        return "\n".join(lines)
+
+    elif isinstance(data, list):
+        lines = [
+            f"JSON Array: {len(data)} items",
+            f"  File size: {_format_size(file_size)}",
+        ]
+        if data:
+            lines.append("")
+            lines.append("First 5 items:")
+            for i, item in enumerate(data[:5]):
+                if isinstance(item, (dict, list)):
+                    preview = json.dumps(item, ensure_ascii=False)[:200]
+                else:
+                    preview = repr(item)[:200]
+                lines.append(f"  [{i}]: {preview}")
+            if len(data) > 5:
+                lines.append(f"  ... and {len(data) - 5} more items")
+        return "\n".join(lines)
+
+    else:
+        preview = json.dumps(data, ensure_ascii=False)[:500]
+        return f"JSON value: {preview}"
+
+
+def _csv_handler(path: str, content: str, file_size: int) -> Optional[str]:
+    """Preview CSV/TSV file with structure info."""
+    import csv as csv_module
+    import io
+
+    delimiter = _detect_csv_delimiter(content)
+    try:
+        reader = csv_module.reader(io.StringIO(content), delimiter=delimiter)
+        rows = list(reader)
+    except Exception as e:
+        return f"CSV file detected but could not parse: {e}"
+
+    if not rows:
+        return "CSV file detected — empty."
+
+    header = rows[0] if rows else []
+    data_rows = rows[1:] if len(rows) > 1 else []
+    total_rows = len(data_rows)
+
+    lines = [
+        f"CSV File: {total_rows} data rows, {len(header)} columns",
+        f"  File size: {_format_size(file_size)}",
+        f"  Delimiter: {repr(delimiter)}",
+    ]
+
+    if header:
+        lines.append("")
+        lines.append("Columns:")
+        for i, col in enumerate(header):
+            sample_vals = []
+            for row in data_rows[:5]:
+                if i < len(row) and row[i].strip():
+                    sample_vals.append(row[i][:60])
+                    break
+            sample = f' (e.g. {sample_vals[0]!r})' if sample_vals else ''
+            lines.append(f"  [{i}] {col}{sample}")
+
+        if total_rows > 0:
+            lines.append("")
+            lines.append("First 5 rows:")
+            for idx, row in enumerate(data_rows[:5]):
+                vals = [row[i] if i < len(row) else "" for i in range(min(len(header), 8))]
+                lines.append(f"  [{idx}]: {' | '.join(v[:40] for v in vals)}")
+                if len(header) > 8:
+                    lines.append(f"        ... and {len(header) - 8} more columns")
+            if total_rows > 5:
+                lines.append(f"  ... and {total_rows - 5} more rows")
+
+    return "\n".join(lines)
+
+
+def _log_file_handler(path: str, content: str, file_size: int) -> Optional[str]:
+    """Summarise a log file: count lines, detect common patterns."""
+    lines = content.splitlines()
+    total = len(lines)
+
+    # Detect severity levels
+    import re
+    severity_patterns = {
+        "ERROR": re.compile(r"\bERROR\b", re.IGNORECASE),
+        "WARN": re.compile(r"\bWARN(?:ING)?\b", re.IGNORECASE),
+        "INFO": re.compile(r"\bINFO\b", re.IGNORECASE),
+        "DEBUG": re.compile(r"\bDEBUG\b", re.IGNORECASE),
+        "TRACE": re.compile(r"\bTRACE\b", re.IGNORECASE),
+        "FATAL": re.compile(r"\bFATAL\b", re.IGNORECASE),
+        "CRITICAL": re.compile(r"\bCRITICAL\b", re.IGNORECASE),
+    }
+    severity_counts: dict[str, int] = {}
+    for line in lines:
+        for level, pattern in severity_patterns.items():
+            if pattern.search(line):
+                severity_counts[level] = severity_counts.get(level, 0) + 1
+
+    summary = [
+        f"Log File: {total} lines",
+        f"  File size: {_format_size(file_size)}",
+    ]
+    if severity_counts:
+        summary.append("")
+        summary.append("Severity distribution:")
+        for level in ["FATAL", "CRITICAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"]:
+            if level in severity_counts:
+                summary.append(f"  {level}: {severity_counts[level]}")
+    summary.append("")
+    summary.append(f"First 3 lines:")
+    summary.extend(f"  {l}" for l in lines[:3])
+    summary.append(f"Last 3 lines:")
+    summary.extend(f"  {l}" for l in lines[-3:])
+
+    return "\n".join(summary)
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+_MAX_STRUCTURED_FILE_SIZE = 50 * 1024 * 1024  # 50 MB — max file to process
+
+
+def max_structured_file_size() -> int:
+    """Return the maximum file size (bytes) allowed for structured processing."""
+    return _MAX_STRUCTURED_FILE_SIZE
+
+
+def _format_size(size_bytes: int) -> str:
+    """Format byte size for human display."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    elif size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+
+
+def _detect_csv_delimiter(content: str) -> str:
+    """Detect CSV delimiter by examining the first line."""
+    first_line = content.splitlines()[0] if content else ""
+    if not first_line:
+        return ","
+    # Count occurrences of potential delimiters
+    counts = {d: first_line.count(d) for d in ",;\t|"}
+    if not counts:
+        return ","
+    best = max(counts, key=counts.get)
+    return best if counts[best] > 0 else ","
+
+
+def _status_label(code: int) -> str:
+    """Return a short label for an HTTP status code."""
+    if 100 <= code < 200:
+        return "Informational"
+    elif 200 <= code < 300:
+        return "Success"
+    elif 300 <= code < 400:
+        return "Redirect"
+    elif 400 <= code < 500:
+        return "Client Error"
+    elif 500 <= code < 600:
+        return "Server Error"
+    return "Unknown"
+
+
+# =========================================================================
+# Register built-in handlers
+# =========================================================================
+
+register_format(".har", _har_handler, "HTTP Archive (network trace)")
+register_format(".json", _json_structure_handler, "JSON data file")
+register_format(".csv", _csv_handler, "Comma-separated values")
+register_format(".tsv", _csv_handler, "Tab-separated values")
+register_format(".log", _log_file_handler, "Log file")
+register_format(".txt", _log_file_handler, "Text log file")


### PR DESCRIPTION
## What changed

Added `tools/file_type_registry.py` — a file type detection and summarization engine that produces intelligent summaries for structured data formats instead of injecting raw content into the LLM context.

## Why

When a user drags a `.har` (or other structured data file) into the Hermes Desktop chat, the full raw content gets injected into the conversation context. For a HAR file this can be 1.6M+ tokens, causing `context injection refused` errors (#60911). The fix is to detect known structured formats and produce a concise, human-readable summary that the model can work with directly.

## How it works

1. **Format registry** — extension → handler mapping in `tools/file_type_registry.py`
2. **Built-in handlers**:
   - `.har`: network trace summary (total requests, domains, status codes, methods, content types, errors, timeline)
   - `.json`: structure-aware preview (object keys with types, array length, primitive values)
   - `.csv` / `.tsv`: column detection, row count, delimiter auto-detection, first-rows preview
   - `.log` / `.txt`: line count, severity-level distribution (ERROR/WARN/INFO/DEBUG/...)
3. **Integration** — `ShellFileOperations.read_file()` checks the registry after the image check and before the binary check. When a format matches, it reads the full file, runs the handler, and returns a `ReadResult` with `content=summary` and `format_type` set.
4. **Size guard** — files over 50 MB return a hint instead of attempting summarisation.

## How to test

```bash
pytest tests/tools/test_file_type_registry.py -v
```

31 tests covering:
- HAR parsing (valid, empty, invalid JSON, alternate structure)
- JSON structure analysis (object, array, primitive, invalid)
- CSV/TSV preview (delimiter detection, rows/columns)
- Log file severity detection
- Registry functions (detect, known_extensions, handler failure graceful handling)
- Integration with `ShellFileOperations.read_file` via mocked executor

## Tested on
- Windows 11 (git-bash) — all 31 tests pass
- Pre-existing test suite (`test_file_operations.py`) — 88/90 pass (2 pre-existing Windows-only failures)

## Related
- Closes #60911
- Related: #57486 (pass @file: path instead of injecting full content)
- Related: #47481 (auto-open right-rail preview for known file types)
