### PR TITLE
feat(kanban): safe CDP tab pruning after task completion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -294,6 +294,18 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # instead of agent-browser/Browserbase. See docs/user-guide/features/browser.md.
 # CAMOFOX_URL=http://localhost:9377
 
+# --- Safe CDP tab pruning after Kanban completion (docs/cdp-tab-pruning.md) ---
+# Auto-close only disposable about:blank / chrome://newtab tabs on the lane's
+# CDP endpoint after a task completes. Real and sensitive tabs are never closed,
+# and >=1 page is always preserved per Brave process. OFF and dry-run by default,
+# so leaving these unset changes nothing.
+# HERMES_CDP_PRUNE_ENABLED=false     # master switch (must be true to do anything)
+# HERMES_CDP_PRUNE_DRY_RUN=true      # set false to actually close (else logs only)
+# HERMES_CDP_PRUNE_SCRATCH=false     # also close data:text/html scratch tabs
+# HERMES_CDP_PRUNE_ON_BLOCK=false    # also prune on a true block (blank/newtab only)
+# HERMES_CDP_PRUNE_ENDPOINT=         # explicit host:port(s); default = connected browser
+# HERMES_CDP_PRUNE_TIMEOUT=5         # per-call HTTP timeout (s)
+
 # Externally managed Camofox sessions — when another app owns the visible
 # Camofox browser, set these so Hermes shares the same userId/profile instead
 # of creating its own isolated session.

--- a/docs/cdp-tab-pruning.md
+++ b/docs/cdp-tab-pruning.md
@@ -1,0 +1,110 @@
+# Safe CDP tab pruning after Kanban completion
+
+**Module:** `tools/cdp_prune.py` · **Wiring:** `hermes_cli/kanban_db.py`
+(`_maybe_prune_cdp_after_transition`) · **Tests:** `tests/tools/test_cdp_prune.py`,
+`tests/hermes_cli/test_kanban_cdp_prune_hook.py`
+
+Worker Brave/CDP lanes accumulate throwaway `about:blank` and
+`chrome://newtab/` tabs as tasks run. This feature closes **only** those
+clearly-disposable tabs after a Kanban task completes, and never touches a
+real page.
+
+## The cleanup rule (what future agents need to know)
+
+> After a successful `kanban_complete`, disposable tabs (`about:blank`,
+> `chrome://newtab/` and fork variants) on the lane's CDP endpoint may be
+> auto-closed. **Real URLs are never closed.** At least one page target is
+> always preserved per Brave process, so a lane's only context is never
+> terminated. Do **not** hand-roll tab-closing in worker prompts — this is
+> handled at the lifecycle layer.
+
+### What is "disposable"
+
+| Class       | Example                          | Closed by default? |
+|-------------|----------------------------------|--------------------|
+| `blank`     | `about:blank`, empty URL         | ✅ yes             |
+| `newtab`    | `chrome://newtab/`, `brave://newtab/`, `chrome://new-tab-page/`, `edge://newtab/` | ✅ yes |
+| `scratch`   | `data:text/html,...`             | ❌ no — only with `HERMES_CDP_PRUNE_SCRATCH=1` |
+| `real`      | any `http(s)://`, `file://`, non-newtab `chrome://settings` etc. | ❌ never |
+| `sensitive` | real URL matching a domain-critical hint | ❌ never (defense in depth) |
+
+Non-page CDP targets (`service_worker`, `background_page`, `worker`,
+`iframe`, `browser`) are never candidates.
+
+### Safety invariants (enforced in `plan_prune`, covered by tests)
+
+1. **Never close a real or sensitive URL.** The closable set is exactly
+   blank + newtab (+ scratch only when explicitly opted in).
+2. **Sensitive denylist as defense in depth.** Any URL whose host+path
+   matches trading / marketplace / finance-IRS / health / auth-MFA /
+   client-vendor hints is force-skipped even if a future rule widened the
+   closable set. Over-matching here is safe — it only preserves more.
+3. **Preserve ≥1 page per Brave process.** If every page target would be
+   closed (e.g. a lane holding only its intentional initial `about:blank`),
+   one disposable page is kept (preferring the `about:blank`). Coordinator
+   lanes are one Brave process each, so "per process" == "per lane".
+4. **Best-effort, non-blocking.** Any failure in the pruner is swallowed and
+   never affects the board state transition.
+
+## How it is wired
+
+`kanban_db.complete_task` (and the truly-blocked path of `block_task`) call
+`_maybe_prune_cdp_after_transition`, which delegates to
+`tools.cdp_prune.prune_after_transition`. This is the universal completion
+choke point, so it fires uniformly for CLI (`hermes kanban complete`),
+in-process `kanban_complete` tool, and MCP completions.
+
+> **Why not a plugin hook?** The `kanban_task_completed` plugin hook exists,
+> but standalone plugins are opt-in via `plugins.enabled` (currently empty)
+> and the `hermes kanban` CLI path skips plugin discovery, so a plugin would
+> not fire for CLI completions without a config change. The direct
+> dispatcher-adjacent wiring is robust across every completion path.
+
+## Configuration (all off / dry-run by default)
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `HERMES_CDP_PRUNE_ENABLED`  | `false` | Master switch for the runtime trigger. **Inert until set.** |
+| `HERMES_CDP_PRUNE_DRY_RUN`  | `true`  | When enabled, still only log sanitized counts — close nothing. Set `0`/`false` to actually close. |
+| `HERMES_CDP_PRUNE_SCRATCH`  | `false` | Also close synthetic `data:text/html` scratch tabs (completion only). |
+| `HERMES_CDP_PRUNE_ON_BLOCK` | `false` | Also prune on a true block. Always blank/newtab only (never scratch). |
+| `HERMES_CDP_PRUNE_ENDPOINT` | —       | Comma-separated explicit endpoints. Falls back to the worker's connected browser (`BROWSER_CDP_URL` / `browser.cdp_url`). |
+| `HERMES_CDP_PRUNE_TIMEOUT`  | `5`     | Per-HTTP-call timeout (seconds, clamped 1–30). |
+
+Because the default is **disabled + dry-run**, merging this code changes no
+runtime behavior. Activating live pruning is a deliberate two-step opt-in
+(`HERMES_CDP_PRUNE_ENABLED=1` and `HERMES_CDP_PRUNE_DRY_RUN=0`).
+
+### Activation note (gateway restart)
+
+CLI completions (`hermes kanban complete`) read env per-invocation, so no
+restart is needed for that path. **In-process / gateway-embedded workers**
+inherit env at process start — activating for those requires setting the env
+in the gateway's service environment and **restarting the gateway**. Per the
+Hermes ops rules, do not restart the gateway automatically; open a BLOCKED
+R3 gate with the exact restart ask.
+
+## Manual dry-run / audit (closes nothing)
+
+```bash
+# Audit the worker's own lane (uses browser.cdp_url):
+python -m tools.cdp_prune
+
+# Audit a specific lane; add --no-dry-run to actually close, --scratch for data: tabs:
+python -m tools.cdp_prune --endpoint http://127.0.0.1:18838
+```
+
+Output is sanitized — lane `host:port`, per-class counts, and close/skip
+totals only. Never URLs, titles, cookies, localStorage, tokens, page DOM,
+or screenshots.
+
+Example (real coordinator-lane audit — all dry-run, nothing closed):
+
+```
+lane=127.0.0.1:18832 would_close=4 counts=class:blank=4 class:newtab=1 ... preserved_last_page=True
+lane=127.0.0.1:18838 would_close=2 counts=class:blank=2 class:real=4  ... preserved_last_page=False
+lane=127.0.0.1:18833 would_close=0 counts=class:sensitive=1           ... preserved_last_page=False
+```
+
+`preserved_last_page=True` on 18832 shows the safety net firing: that lane
+held only disposable tabs, so one was kept to preserve the lane context.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -162,6 +162,42 @@ def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None
         _log.debug("kanban lifecycle hook %s failed: %s", event, exc)
 
 
+def _maybe_prune_cdp_after_transition(
+    event: str,
+    task_id: str,
+    *,
+    board: Optional[str] = None,
+    assignee: Optional[str] = None,
+    run_id: Optional[int] = None,
+) -> None:
+    """Safely prune disposable CDP tabs after a completion/block, best-effort.
+
+    Fires from the same lifecycle choke point as the plugin hooks (so it runs
+    for CLI, in-process-tool, and MCP completions alike) but is entirely
+    self-contained rather than plugin-gated, since standalone plugins are
+    opt-in via ``plugins.enabled`` and the CLI complete path skips plugin
+    discovery. Fully gated + inert by default: does nothing unless
+    ``HERMES_CDP_PRUNE_ENABLED`` is set, and only ever closes clearly
+    disposable tabs (about:blank / newtab). See :mod:`tools.cdp_prune` and
+    docs/cdp-tab-pruning.md. Any failure is swallowed — cleanup must never
+    affect a board state transition.
+    """
+    try:
+        from tools.cdp_prune import is_enabled, prune_after_transition
+
+        if not is_enabled():
+            return
+        prune_after_transition(
+            event=event,
+            task_id=task_id,
+            board=board,
+            assignee=assignee,
+            run_id=run_id,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        _log.debug("cdp-prune after %s failed: %s", event, exc)
+
+
 # A running task's claim is valid for 15 minutes by default; after that the
 # next dispatcher tick reclaims it. Workers that outlive this window should
 # call ``heartbeat_claim(task_id)`` periodically. In practice most kanban
@@ -4167,6 +4203,13 @@ def complete_task(
         run_id=run_id,
         summary=(summary if summary is not None else result),
     )
+    _maybe_prune_cdp_after_transition(
+        "completed",
+        task_id,
+        board=get_current_board(),
+        assignee=_done_task.assignee if _done_task else None,
+        run_id=run_id,
+    )
     return True
 
 
@@ -4749,6 +4792,15 @@ def block_task(
         assignee=_blocked_task.assignee if _blocked_task else None,
         run_id=run_id,
         reason=reason,
+    )
+    # Optional, opt-in, and strictly-disposable-only (see HERMES_CDP_PRUNE_ON_BLOCK).
+    # Skipped for the dependency_wait routing above, which resumes the task.
+    _maybe_prune_cdp_after_transition(
+        "blocked",
+        task_id,
+        board=get_current_board(),
+        assignee=_blocked_task.assignee if _blocked_task else None,
+        run_id=run_id,
     )
     return True
 

--- a/tests/hermes_cli/test_kanban_cdp_prune_hook.py
+++ b/tests/hermes_cli/test_kanban_cdp_prune_hook.py
@@ -1,0 +1,77 @@
+"""Integration smoke: kanban complete/block wire into the CDP pruner.
+
+Proves the dispatcher-adjacent wiring in ``kanban_db._maybe_prune_cdp_after_transition``
+actually fires ``tools.cdp_prune.prune_after_transition`` on completion (and only
+when enabled), without opening any socket — the pruner call itself is stubbed.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from tools import cdp_prune as cp
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _clean_prune_env(monkeypatch):
+    for var in (
+        "HERMES_CDP_PRUNE_ENABLED",
+        "HERMES_CDP_PRUNE_ON_BLOCK",
+        "HERMES_CDP_PRUNE_ENDPOINT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def _capture_calls(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        cp, "prune_after_transition", lambda **kw: calls.append(kw) or {"ok": True}
+    )
+    return calls
+
+
+def test_completion_fires_pruner_when_enabled(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_CDP_PRUNE_ENABLED", "1")
+    calls = _capture_calls(monkeypatch)
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="prune me", assignee="claude-code")
+        kb.complete_task(conn, tid, result="done")
+    assert len(calls) == 1
+    assert calls[0]["event"] == "completed"
+    assert calls[0]["task_id"] == tid
+
+
+def test_completion_inert_when_disabled(kanban_home, monkeypatch):
+    # default: HERMES_CDP_PRUNE_ENABLED unset -> pruner never invoked
+    calls = _capture_calls(monkeypatch)
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="leave tabs alone")
+        kb.complete_task(conn, tid, result="done")
+    assert calls == []
+
+
+def test_pruner_failure_never_breaks_completion(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_CDP_PRUNE_ENABLED", "1")
+
+    def _boom(**kw):
+        raise RuntimeError("pruner exploded")
+
+    monkeypatch.setattr(cp, "prune_after_transition", _boom)
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="must still complete")
+        # completion must succeed despite the pruner raising
+        assert kb.complete_task(conn, tid, result="done") is True
+        assert kb.get_task(conn, tid).status == "done"

--- a/tests/tools/test_cdp_prune.py
+++ b/tests/tools/test_cdp_prune.py
@@ -1,0 +1,470 @@
+"""Tests for tools.cdp_prune — safe CDP tab pruning.
+
+All coverage is driven by mocked CDP target lists and an injected fake client;
+no test opens a socket or touches a real browser. The focus is the safety
+contract: only disposable about:blank/newtab tabs are ever closed, real and
+sensitive tabs are always preserved, and at least one page target survives.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from tools import cdp_prune as cp
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _page(target_id: str, url: str, *, ttype: str = "page", title: str = "") -> Dict[str, Any]:
+    return {"id": target_id, "type": ttype, "url": url, "title": title}
+
+
+class FakeCdpClient:
+    """Injectable CDP client that records close() calls and never does I/O."""
+
+    def __init__(self, targets: List[Dict[str, Any]], *, fail_ids=None, raise_on_list=False):
+        self._targets = targets
+        self.closed: List[str] = []
+        self._fail_ids = set(fail_ids or ())
+        self._raise_on_list = raise_on_list
+
+    def list_targets(self) -> List[Dict[str, Any]]:
+        if self._raise_on_list:
+            raise ConnectionError("boom")
+        return list(self._targets)
+
+    def close_target(self, target_id: str) -> bool:
+        self.closed.append(target_id)
+        return target_id not in self._fail_ids
+
+
+@pytest.fixture(autouse=True)
+def _clear_prune_env(monkeypatch):
+    """Ensure a clean env so gating defaults are deterministic."""
+    for var in (
+        "HERMES_CDP_PRUNE_ENABLED",
+        "HERMES_CDP_PRUNE_DRY_RUN",
+        "HERMES_CDP_PRUNE_SCRATCH",
+        "HERMES_CDP_PRUNE_ON_BLOCK",
+        "HERMES_CDP_PRUNE_ENDPOINT",
+        "HERMES_CDP_PRUNE_TIMEOUT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# classify_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("about:blank", cp.CLASS_BLANK),
+        ("", cp.CLASS_BLANK),
+        ("about:blank#blocked", cp.CLASS_BLANK),
+        ("chrome://newtab/", cp.CLASS_NEWTAB),
+        ("chrome://newtab", cp.CLASS_NEWTAB),
+        ("brave://newtab/", cp.CLASS_NEWTAB),
+        ("chrome://new-tab-page/", cp.CLASS_NEWTAB),
+        ("edge://newtab/", cp.CLASS_NEWTAB),
+        ("data:text/html,<h1>scratch</h1>", cp.CLASS_SCRATCH),
+        ("https://example.com/article", cp.CLASS_REAL),
+        ("http://localhost:3000/app", cp.CLASS_REAL),
+        ("file:///Users/x/report.html", cp.CLASS_REAL),
+        # non-newtab internal pages are real (preserve intentional settings tabs)
+        ("chrome://settings/", cp.CLASS_REAL),
+        ("chrome://extensions/", cp.CLASS_REAL),
+    ],
+)
+def test_classify_url_basic(url, expected):
+    assert cp.classify_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.chase.com/dashboard",
+        "https://sellercentral.amazon.com/orders",
+        "https://mychart.example.org/patient",
+        "https://accounts.google.com/signin",
+        "https://www.irs.gov/payments",
+        "https://app.coinbase.com/trade",
+        "https://vendor-portal.acme.com/login",
+    ],
+)
+def test_classify_url_sensitive(url):
+    assert cp.classify_url(url) == cp.CLASS_SENSITIVE
+    assert cp.is_sensitive(url) is True
+
+
+def test_blank_and_newtab_are_not_sensitive():
+    assert cp.is_sensitive("about:blank") is False
+    assert cp.is_sensitive("chrome://newtab/") is False
+
+
+# ---------------------------------------------------------------------------
+# plan_prune — the core safety contract
+# ---------------------------------------------------------------------------
+
+
+def test_plan_closes_disposable_keeps_real():
+    targets = [
+        _page("t-real", "https://news.example.com"),
+        _page("t-blank", "about:blank"),
+        _page("t-newtab", "chrome://newtab/"),
+    ]
+    plan = cp.plan_prune(targets)
+    assert set(plan.to_close) == {"t-blank", "t-newtab"}
+    # real page keeps the lane alive -> no forced preservation
+    assert plan.preserved_safety_target is None
+    real = next(d for d in plan.decisions if d.target_id == "t-real")
+    assert real.action == "skip" and real.url_class == cp.CLASS_REAL
+
+
+def test_plan_never_closes_real_or_sensitive():
+    targets = [
+        _page("t-blank", "about:blank"),
+        _page("t-bank", "https://chase.com/account"),
+        _page("t-shop", "https://sellercentral.amazon.com"),
+        _page("t-doc", "https://docs.example.com/page"),
+    ]
+    plan = cp.plan_prune(targets)
+    assert plan.to_close == ["t-blank"]
+    for tid in ("t-bank", "t-shop", "t-doc"):
+        d = next(d for d in plan.decisions if d.target_id == tid)
+        assert d.action == "skip"
+
+
+def test_plan_preserves_one_page_when_all_disposable():
+    """Coordinator lane with only its intentional about:blank must keep it."""
+    targets = [
+        _page("t-blank", "about:blank"),
+        _page("t-nt1", "chrome://newtab/"),
+        _page("t-nt2", "chrome://newtab/"),
+    ]
+    plan = cp.plan_prune(targets)
+    # exactly one page survives, and it's the about:blank (preferred)
+    assert plan.preserved_safety_target == "t-blank"
+    assert set(plan.to_close) == {"t-nt1", "t-nt2"}
+    kept = next(d for d in plan.decisions if d.target_id == "t-blank")
+    assert kept.action == "skip" and kept.reason == "preserve-last-page"
+
+
+def test_plan_preserves_newtab_when_no_blank():
+    targets = [
+        _page("t-nt1", "chrome://newtab/"),
+        _page("t-nt2", "chrome://newtab/"),
+    ]
+    plan = cp.plan_prune(targets)
+    assert plan.preserved_safety_target == "t-nt1"
+    assert plan.to_close == ["t-nt2"]
+
+
+def test_plan_single_blank_is_preserved_not_closed():
+    targets = [_page("t-only", "about:blank")]
+    plan = cp.plan_prune(targets)
+    assert plan.to_close == []
+    assert plan.preserved_safety_target == "t-only"
+
+
+def test_plan_scratch_gated_off_by_default():
+    targets = [
+        _page("t-real", "https://x.example.com"),
+        _page("t-scratch", "data:text/html,<b>hi</b>"),
+    ]
+    plan = cp.plan_prune(targets)
+    assert plan.to_close == []  # scratch not closed by default
+    d = next(d for d in plan.decisions if d.target_id == "t-scratch")
+    assert d.url_class == cp.CLASS_SCRATCH and d.action == "skip"
+
+
+def test_plan_scratch_closed_when_allowed():
+    targets = [
+        _page("t-real", "https://x.example.com"),
+        _page("t-scratch", "data:text/html,<b>hi</b>"),
+    ]
+    plan = cp.plan_prune(targets, allow_scratch=True)
+    assert plan.to_close == ["t-scratch"]
+
+
+def test_plan_ignores_non_page_targets():
+    targets = [
+        _page("sw", "https://x.example.com/sw.js", ttype="service_worker"),
+        _page("bg", "chrome-extension://abc/bg", ttype="background_page"),
+        _page("wk", "about:blank", ttype="worker"),
+        _page("t-blank", "about:blank", ttype="page"),
+        _page("t-real", "https://x.example.com", ttype="page"),
+    ]
+    plan = cp.plan_prune(targets)
+    # only the page-type about:blank is closed; workers/bg never touched
+    assert plan.to_close == ["t-blank"]
+    for tid in ("sw", "bg", "wk"):
+        d = next(d for d in plan.decisions if d.target_id == tid)
+        assert d.action == "skip" and d.url_class == "non_page"
+
+
+def test_plan_handles_missing_target_id():
+    targets = [{"type": "page", "url": "about:blank"}]  # no id
+    plan = cp.plan_prune(targets)
+    assert plan.to_close == []
+    assert plan.decisions[0].reason == "no-target-id"
+
+
+def test_plan_accepts_target_getTargets_shape():
+    """Normalizer handles the CDP Target.getTargets 'targetId' key too."""
+    targets = [
+        {"targetId": "t1", "type": "page", "url": "about:blank"},
+        {"targetId": "t2", "type": "page", "url": "https://real.example.com"},
+    ]
+    plan = cp.plan_prune(targets)
+    assert plan.to_close == ["t1"]
+
+
+def test_plan_counts_are_sanitized():
+    targets = [
+        _page("t-blank", "about:blank", title="Secret Bank Statement"),
+        _page("t-real", "https://chase.com/acct?token=abcd", title="My Balance"),
+    ]
+    plan = cp.plan_prune(targets)
+    blob = repr(plan.counts)
+    # counts expose classes + numbers only, never URLs/titles/tokens
+    assert "chase.com" not in blob
+    assert "token" not in blob
+    assert "Secret" not in blob
+    assert plan.counts["class:blank"] == 1
+    assert plan.counts["class:sensitive"] == 1
+
+
+# ---------------------------------------------------------------------------
+# prune_endpoint — I/O orchestration via injected fake client
+# ---------------------------------------------------------------------------
+
+
+def test_prune_endpoint_dry_run_closes_nothing():
+    client = FakeCdpClient(
+        [_page("t-blank", "about:blank"), _page("t-real", "https://x.example.com")]
+    )
+    summary = cp.prune_endpoint("http://127.0.0.1:18838", dry_run=True, client=client)
+    assert client.closed == []  # nothing closed in dry-run
+    assert summary["would_close"] == 1
+    assert summary["dry_run"] is True
+    assert summary["lane"] == "127.0.0.1:18838"
+
+
+def test_prune_endpoint_live_closes_disposable_only():
+    client = FakeCdpClient(
+        [
+            _page("t-blank", "about:blank"),
+            _page("t-newtab", "chrome://newtab/"),
+            _page("t-real", "https://x.example.com"),
+            _page("t-bank", "https://chase.com/acct"),
+        ]
+    )
+    summary = cp.prune_endpoint("http://127.0.0.1:18838", dry_run=False, client=client)
+    assert set(client.closed) == {"t-blank", "t-newtab"}
+    assert summary["closed"] == 2
+    assert summary["close_failed"] == 0
+
+
+def test_prune_endpoint_live_preserves_last_page():
+    client = FakeCdpClient(
+        [_page("t-blank", "about:blank"), _page("t-nt", "chrome://newtab/")]
+    )
+    summary = cp.prune_endpoint("http://127.0.0.1:18838", dry_run=False, client=client)
+    # one page preserved; only one newtab actually closed
+    assert client.closed == ["t-nt"]
+    assert summary["preserved_last_page"] is True
+    assert summary["closed"] == 1
+
+
+def test_prune_endpoint_counts_close_failures():
+    client = FakeCdpClient(
+        [
+            _page("t-blank", "about:blank"),
+            _page("t-nt", "chrome://newtab/"),
+            _page("t-real", "https://x.example.com"),
+        ],
+        fail_ids={"t-nt"},
+    )
+    summary = cp.prune_endpoint("http://127.0.0.1:18838", dry_run=False, client=client)
+    assert summary["closed"] == 1
+    assert summary["close_failed"] == 1
+
+
+def test_prune_endpoint_unreachable_is_soft_error():
+    client = FakeCdpClient([], raise_on_list=True)
+    summary = cp.prune_endpoint("http://127.0.0.1:19999", dry_run=False, client=client)
+    assert "error" in summary
+    assert summary["closed"] == 0
+    assert client.closed == []
+
+
+# ---------------------------------------------------------------------------
+# normalize_base_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "endpoint,expected",
+    [
+        ("http://127.0.0.1:18838", "http://127.0.0.1:18838"),
+        ("http://127.0.0.1:18838/json/version", "http://127.0.0.1:18838"),
+        ("ws://127.0.0.1:18838/devtools/browser/abc", "http://127.0.0.1:18838"),
+        ("wss://host:9222/devtools/browser/x", "https://host:9222"),
+        ("127.0.0.1:18838", "http://127.0.0.1:18838"),
+        ("", ""),
+    ],
+)
+def test_normalize_base_url(endpoint, expected):
+    assert cp.normalize_base_url(endpoint) == expected
+
+
+# ---------------------------------------------------------------------------
+# prune_after_transition — gating
+# ---------------------------------------------------------------------------
+
+
+def test_transition_disabled_by_default(monkeypatch):
+    called = []
+    monkeypatch.setattr(cp, "prune_endpoint", lambda *a, **k: called.append(1))
+    assert cp.prune_after_transition(event="completed", task_id="t1") is None
+    assert called == []
+
+
+def test_transition_enabled_no_endpoint_is_noop(monkeypatch):
+    monkeypatch.setenv("HERMES_CDP_PRUNE_ENABLED", "1")
+    monkeypatch.setattr(cp, "resolve_endpoints", lambda: [])
+    called = []
+    monkeypatch.setattr(cp, "prune_endpoint", lambda *a, **k: called.append(1))
+    assert cp.prune_after_transition(event="completed", task_id="t1") is None
+    assert called == []
+
+
+def test_transition_completed_runs_dry_by_default(monkeypatch):
+    monkeypatch.setenv("HERMES_CDP_PRUNE_ENABLED", "1")
+    monkeypatch.setattr(cp, "resolve_endpoints", lambda: ["http://127.0.0.1:18838"])
+    seen = {}
+
+    def _fake_prune(endpoint, *, dry_run, allow_scratch, timeout):
+        seen["dry_run"] = dry_run
+        seen["allow_scratch"] = allow_scratch
+        return {"lane": "127.0.0.1:18838", "would_close": 3, "closed": 0}
+
+    monkeypatch.setattr(cp, "prune_endpoint", _fake_prune)
+    agg = cp.prune_after_transition(event="completed", task_id="t1")
+    assert agg is not None
+    assert agg["dry_run"] is True  # dry-run default even when enabled
+    assert seen["dry_run"] is True
+    assert seen["allow_scratch"] is False
+    assert agg["would_close"] == 3
+    assert agg["lanes"] == 1
+
+
+def test_transition_live_when_dry_run_disabled(monkeypatch):
+    monkeypatch.setenv("HERMES_CDP_PRUNE_ENABLED", "1")
+    monkeypatch.setenv("HERMES_CDP_PRUNE_DRY_RUN", "0")
+    monkeypatch.setenv("HERMES_CDP_PRUNE_SCRATCH", "1")
+    monkeypatch.setattr(cp, "resolve_endpoints", lambda: ["http://127.0.0.1:18838"])
+    seen = {}
+
+    def _fake_prune(endpoint, *, dry_run, allow_scratch, timeout):
+        seen["dry_run"] = dry_run
+        seen["allow_scratch"] = allow_scratch
+        return {"closed": 2}
+
+    monkeypatch.setattr(cp, "prune_endpoint", _fake_prune)
+    agg = cp.prune_after_transition(event="completed", task_id="t1")
+    assert seen["dry_run"] is False
+    assert seen["allow_scratch"] is True
+    assert agg["closed"] == 2
+
+
+def test_transition_block_requires_opt_in(monkeypatch):
+    monkeypatch.setenv("HERMES_CDP_PRUNE_ENABLED", "1")
+    monkeypatch.setattr(cp, "resolve_endpoints", lambda: ["http://127.0.0.1:18838"])
+    called = []
+    monkeypatch.setattr(cp, "prune_endpoint", lambda *a, **k: called.append(1) or {})
+    # block without opt-in -> no-op
+    assert cp.prune_after_transition(event="blocked", task_id="t1") is None
+    assert called == []
+
+
+def test_transition_block_never_closes_scratch(monkeypatch):
+    monkeypatch.setenv("HERMES_CDP_PRUNE_ENABLED", "1")
+    monkeypatch.setenv("HERMES_CDP_PRUNE_ON_BLOCK", "1")
+    monkeypatch.setenv("HERMES_CDP_PRUNE_SCRATCH", "1")  # even with scratch on...
+    monkeypatch.setattr(cp, "resolve_endpoints", lambda: ["http://127.0.0.1:18838"])
+    seen = {}
+
+    def _fake_prune(endpoint, *, dry_run, allow_scratch, timeout):
+        seen["allow_scratch"] = allow_scratch
+        return {}
+
+    monkeypatch.setattr(cp, "prune_endpoint", _fake_prune)
+    cp.prune_after_transition(event="blocked", task_id="t1")
+    # ...block path forces scratch off
+    assert seen["allow_scratch"] is False
+
+
+def test_transition_never_raises(monkeypatch):
+    monkeypatch.setenv("HERMES_CDP_PRUNE_ENABLED", "1")
+
+    def _boom():
+        raise RuntimeError("resolve failed")
+
+    monkeypatch.setattr(cp, "resolve_endpoints", _boom)
+    # swallowed -> None, not an exception
+    assert cp.prune_after_transition(event="completed", task_id="t1") is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_endpoints_explicit_env(monkeypatch):
+    monkeypatch.setenv(
+        "HERMES_CDP_PRUNE_ENDPOINT",
+        "http://127.0.0.1:18838, ws://127.0.0.1:18830/devtools/browser/x",
+    )
+    eps = cp.resolve_endpoints()
+    assert eps == ["http://127.0.0.1:18838", "http://127.0.0.1:18830"]
+
+
+def test_resolve_endpoints_dedupes(monkeypatch):
+    monkeypatch.setenv(
+        "HERMES_CDP_PRUNE_ENDPOINT",
+        "http://127.0.0.1:18838,http://127.0.0.1:18838/json/version",
+    )
+    assert cp.resolve_endpoints() == ["http://127.0.0.1:18838"]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_no_endpoint_returns_2(monkeypatch, capsys):
+    monkeypatch.setattr(cp, "resolve_endpoints", lambda: [])
+    rc = cp.main([])
+    assert rc == 2
+    assert "no endpoint" in capsys.readouterr().out
+
+
+def test_cli_dry_run_default(monkeypatch, capsys):
+    seen = {}
+
+    def _fake_prune(endpoint, *, dry_run, allow_scratch, timeout):
+        seen["dry_run"] = dry_run
+        return {"lane": "127.0.0.1:18838", "would_close": 0}
+
+    monkeypatch.setattr(cp, "prune_endpoint", _fake_prune)
+    rc = cp.main(["--endpoint", "http://127.0.0.1:18838"])
+    assert rc == 0
+    assert seen["dry_run"] is True  # CLI defaults to dry-run

--- a/tools/cdp_prune.py
+++ b/tools/cdp_prune.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""Safe CDP tab pruning for coordinator Brave/CDP lanes.
+
+After a Kanban task completes, worker lanes tend to accumulate throwaway
+``about:blank`` and ``chrome://newtab/`` tabs. This module closes *only*
+those clearly-disposable tabs on a lane's Chrome DevTools Protocol (CDP)
+endpoint, and never touches a real page.
+
+Design goals (see docs/cdp-tab-pruning.md):
+
+* **Conservative by construction.** The default disposable set is exactly
+  ``about:blank`` + new-tab pages. Every real URL — http(s), file, and
+  even non-newtab ``chrome://``/``brave://`` pages — is preserved. Synthetic
+  ``data:text/html,...`` scratch tabs are only closable when explicitly
+  opted in (``allow_scratch``), and a broad domain-critical denylist
+  (trading, marketplace, finance/IRS, health, auth/MFA, client/vendor)
+  force-skips anything that even *looks* sensitive, as defense in depth.
+* **Never orphan a lane.** At least one ``page`` target is preserved per
+  browser process, so pruning can never terminate the lane's only usable
+  context — this matches the coordinator-lane model where each Brave lane
+  is one process launched with an intentional initial ``about:blank``.
+* **Sanitized.** Logs carry lane host:port, per-class counts, and URL
+  *classes* only — never page bodies, cookies, localStorage, tokens, full
+  URLs, or titles.
+* **Inert until opted in.** The runtime trigger is gated behind
+  ``HERMES_CDP_PRUNE_ENABLED`` (default off) and dry-run
+  (``HERMES_CDP_PRUNE_DRY_RUN`` default on), so importing/merging this
+  changes no behavior until an operator activates it.
+
+The pure ``classify_url`` / ``plan_prune`` functions carry all the safety
+logic and are exercised directly by the test suite with mocked CDP target
+lists; the thin :class:`HttpCdpClient` seam is the only part that touches a
+real browser and is injectable so tests never open a socket.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol, Sequence
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+# URL "classes" a target can fall into. Only ``blank`` / ``newtab`` (and
+# optionally ``scratch``) are ever closable; ``real`` and ``sensitive`` are
+# always preserved.
+CLASS_BLANK = "blank"
+CLASS_NEWTAB = "newtab"
+CLASS_SCRATCH = "scratch"
+CLASS_REAL = "real"
+CLASS_SENSITIVE = "sensitive"
+
+# CDP target ``type`` values we treat as user-facing tabs. Everything else
+# (service_worker, background_page, worker, iframe, browser, ...) is never a
+# prune candidate.
+PAGE_TYPE = "page"
+
+# New-tab landing pages across Chromium forks. Compared against the URL with a
+# trailing slash stripped and lowercased.
+_NEWTAB_URLS = frozenset(
+    {
+        "chrome://newtab",
+        "chrome://new-tab-page",
+        "chrome://new-tab-page-third-party",
+        "brave://newtab",
+        "edge://newtab",
+        "about:newtab",
+        "about:home",
+    }
+)
+
+# ``about:blank`` variants. ``about:blank#blocked`` shows up when a popup is
+# blocked; still disposable.
+_BLANK_URLS = frozenset({"", "about:blank", "about:blank#blocked"})
+
+# Defense-in-depth denylist. If a URL matches any of these substrings we mark
+# it ``sensitive`` and force-skip, regardless of any other rule. Over-matching
+# here is *safe* (it only preserves more tabs); the goal is to make it
+# essentially impossible for the pruner to ever close a human/domain-critical
+# tab even if a future rule change widened the closable set. Matched against a
+# lowercased ``host + path`` string.
+_SENSITIVE_HINTS: tuple[str, ...] = (
+    # finance / trading / IRS / taxes
+    "bank", "chase", "wellsfargo", "wells-fargo", "citi", "capitalone",
+    "fidelity", "schwab", "vanguard", "robinhood", "etrade", "e-trade",
+    "coinbase", "kraken", "binance", "gemini", "trading", "broker",
+    "irs.gov", "turbotax", "hrblock", "tax", "paypal", "venmo", "stripe",
+    "wise.com", "invoice", "billing", "payroll", "quickbooks",
+    # marketplace / seller / commerce
+    "amazon", "seller", "sellercentral", "ebay", "etsy", "shopify",
+    "marketplace", "mercari", "poshmark", "stockx", "walmart", "alibaba",
+    "storefront", "checkout", "cart",
+    # health
+    "health", "mychart", "patient", "medical", "clinic", "hospital",
+    "pharmacy", "cvs", "walgreens", "insurance", "medicare", "medicaid",
+    # account / security / login / MFA
+    "login", "signin", "sign-in", "sign_in", "logout", "account", "accounts",
+    "auth", "oauth", "openid", "sso", "saml", "mfa", "2fa", "otp", "verify",
+    "verification", "password", "credential", "security", "okta", "duo",
+    "authy", "onelogin", "recovery",
+    # client / vendor / work portals
+    "client", "vendor", "portal", "admin", "dashboard", "console",
+)
+
+
+def _url_host_path(url: str) -> str:
+    """Return a lowercased ``host + path`` string for hint matching.
+
+    Best-effort: parse errors fall back to the raw lowercased URL so a weird
+    URL still gets screened by the sensitive denylist.
+    """
+    low = (url or "").strip().lower()
+    try:
+        parsed = urlparse(low)
+        host = parsed.netloc or ""
+        path = parsed.path or ""
+        combined = f"{host}{path}".strip()
+        return combined or low
+    except Exception:  # pragma: no cover - defensive
+        return low
+
+
+def is_sensitive(url: str) -> bool:
+    """True when *url* matches a domain-critical hint (always preserve).
+
+    Only meaningful for real navigable URLs — ``about:``/``data:``/newtab
+    URLs never contain a matchable host and return False.
+    """
+    low = (url or "").strip().lower()
+    if not low or low in _BLANK_URLS:
+        return False
+    if low.startswith(("about:", "data:", "chrome:", "brave:", "edge:")):
+        # Internal pages are handled by their own class; the denylist is for
+        # navigable web content only.
+        return False
+    hay = _url_host_path(url)
+    return any(hint in hay for hint in _SENSITIVE_HINTS)
+
+
+def classify_url(url: str) -> str:
+    """Classify a target URL into one of the ``CLASS_*`` buckets.
+
+    * ``about:blank`` (and empty)                 -> ``blank``
+    * ``chrome://newtab/`` and fork variants      -> ``newtab``
+    * navigable URL matching the sensitive list   -> ``sensitive``
+    * ``data:text/html,...``                      -> ``scratch``
+    * anything else (http/https/file/chrome://…)  -> ``real``
+    """
+    low = (url or "").strip().lower()
+    if low in _BLANK_URLS:
+        return CLASS_BLANK
+    if low.rstrip("/") in _NEWTAB_URLS:
+        return CLASS_NEWTAB
+    if is_sensitive(url):
+        return CLASS_SENSITIVE
+    if low.startswith("data:text/html"):
+        return CLASS_SCRATCH
+    return CLASS_REAL
+
+
+# ---------------------------------------------------------------------------
+# Planning
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TargetDecision:
+    """A per-target close/skip decision. ``url_class`` is safe to log."""
+
+    target_id: str
+    type: str
+    url_class: str
+    action: str  # "close" | "skip"
+    reason: str
+
+
+@dataclass
+class PrunePlan:
+    """Result of :func:`plan_prune` — pure, no I/O performed yet."""
+
+    decisions: List[TargetDecision] = field(default_factory=list)
+    to_close: List[str] = field(default_factory=list)
+    preserved_safety_target: Optional[str] = None
+
+    @property
+    def counts(self) -> Dict[str, int]:
+        """Sanitized counts safe to emit in logs (no URLs, no titles)."""
+        c: Dict[str, int] = {
+            "total": len(self.decisions),
+            "close": len(self.to_close),
+            "skip": sum(1 for d in self.decisions if d.action == "skip"),
+        }
+        for d in self.decisions:
+            c[f"class:{d.url_class}"] = c.get(f"class:{d.url_class}", 0) + 1
+        return c
+
+
+def _normalize_target(raw: Dict[str, Any]) -> Dict[str, str]:
+    """Normalize a CDP target dict from either HTTP ``/json`` or
+    ``Target.getTargets`` shape into ``{target_id, type, url, title}``.
+    """
+    target_id = str(raw.get("id") or raw.get("targetId") or "")
+    return {
+        "target_id": target_id,
+        "type": str(raw.get("type") or ""),
+        "url": str(raw.get("url") or ""),
+        "title": str(raw.get("title") or ""),
+    }
+
+
+def _pick_preserve(candidates: Sequence[TargetDecision]) -> TargetDecision:
+    """Choose which disposable page to keep when all pages are disposable.
+
+    Prefer the lane's intentional initial ``about:blank``, then a new-tab
+    page, then anything else — deterministic given input order.
+    """
+    for cls in (CLASS_BLANK, CLASS_NEWTAB, CLASS_SCRATCH):
+        for d in candidates:
+            if d.url_class == cls:
+                return d
+    return candidates[0]
+
+
+def plan_prune(
+    targets: Sequence[Dict[str, Any]],
+    *,
+    allow_scratch: bool = False,
+) -> PrunePlan:
+    """Decide which targets to close, purely (no network).
+
+    Rules:
+      1. Only ``type == "page"`` targets are ever considered.
+      2. Closable classes are ``blank`` + ``newtab`` (plus ``scratch`` when
+         ``allow_scratch``). ``real`` and ``sensitive`` are always skipped.
+      3. At least one ``page`` target survives per call — if every page would
+         be closed, one disposable page is preserved.
+    """
+    decisions: List[TargetDecision] = []
+    closable = {CLASS_BLANK, CLASS_NEWTAB}
+    if allow_scratch:
+        closable.add(CLASS_SCRATCH)
+
+    for raw in targets:
+        t = _normalize_target(raw)
+        if not t["target_id"]:
+            # Can't act on a target with no id; record and skip.
+            decisions.append(
+                TargetDecision("", t["type"], "unknown", "skip", "no-target-id")
+            )
+            continue
+        if t["type"] != PAGE_TYPE:
+            decisions.append(
+                TargetDecision(
+                    t["target_id"], t["type"], "non_page", "skip", "not-a-page-target"
+                )
+            )
+            continue
+        cls = classify_url(t["url"])
+        if cls == CLASS_SENSITIVE:
+            decisions.append(
+                TargetDecision(t["target_id"], t["type"], cls, "skip", "sensitive")
+            )
+        elif cls in closable:
+            decisions.append(
+                TargetDecision(
+                    t["target_id"], t["type"], cls, "close", f"disposable:{cls}"
+                )
+            )
+        else:
+            reason = "real" if cls == CLASS_REAL else f"preserve:{cls}"
+            decisions.append(
+                TargetDecision(t["target_id"], t["type"], cls, "skip", reason)
+            )
+
+    # --- One-page preservation (per browser process) -----------------------
+    page_decisions = [d for d in decisions if d.type == PAGE_TYPE]
+    surviving = [d for d in page_decisions if d.action == "skip"]
+    closing = [d for d in page_decisions if d.action == "close"]
+    preserved: Optional[str] = None
+    if page_decisions and not surviving and closing:
+        keep = _pick_preserve(closing)
+        keep.action = "skip"
+        keep.reason = "preserve-last-page"
+        preserved = keep.target_id
+
+    to_close = [d.target_id for d in decisions if d.action == "close"]
+    return PrunePlan(
+        decisions=decisions, to_close=to_close, preserved_safety_target=preserved
+    )
+
+
+# ---------------------------------------------------------------------------
+# I/O seam
+# ---------------------------------------------------------------------------
+
+
+class CdpClient(Protocol):
+    """Minimal CDP target list/close surface. Injectable for tests."""
+
+    def list_targets(self) -> List[Dict[str, Any]]:
+        ...
+
+    def close_target(self, target_id: str) -> bool:
+        ...
+
+
+class HttpCdpClient:
+    """Default client using the DevTools HTTP JSON endpoints.
+
+    * ``GET {base}/json``               -> list targets
+    * ``GET {base}/json/close/{id}``    -> close a target
+
+    These endpoints are exposed by Chromium-family browsers (Brave included)
+    started with ``--remote-debugging-port`` bound to a literal loopback
+    address, which is exactly how the coordinator lanes launch. Uses stdlib
+    ``urllib`` so the module stays import-light on the kanban lifecycle path.
+    """
+
+    def __init__(self, base_url: str, *, timeout: float = 5.0) -> None:
+        self.base_url = normalize_base_url(base_url)
+        self.timeout = timeout
+
+    def _get(self, path: str) -> tuple[int, str]:
+        import urllib.request
+
+        url = f"{self.base_url}{path}"
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:  # noqa: S310
+            body = resp.read().decode("utf-8", "replace")
+            return resp.status, body
+
+    def list_targets(self) -> List[Dict[str, Any]]:
+        status, body = self._get("/json")
+        if status != 200:
+            raise RuntimeError(f"/json returned HTTP {status}")
+        data = json.loads(body)
+        if not isinstance(data, list):
+            raise RuntimeError("/json did not return a list")
+        return data
+
+    def close_target(self, target_id: str) -> bool:
+        try:
+            status, _ = self._get(f"/json/close/{target_id}")
+            return status == 200
+        except Exception as exc:
+            logger.debug("close_target %s failed: %s", target_id[:8], exc)
+            return False
+
+
+def normalize_base_url(endpoint: str) -> str:
+    """Coerce any accepted CDP endpoint form into an ``http://host:port`` base.
+
+    Accepts ``http(s)://host:port[/...]``, ``ws(s)://host:port/devtools/...``,
+    and bare ``host:port``. Strips any path so ``/json`` can be appended.
+    """
+    raw = (endpoint or "").strip()
+    if not raw:
+        return ""
+    low = raw.lower()
+    if low.startswith(("ws://", "wss://")):
+        raw = ("https://" if low.startswith("wss://") else "http://") + raw.split("://", 1)[1]
+    elif not low.startswith(("http://", "https://")):
+        raw = "http://" + raw
+    parsed = urlparse(raw)
+    scheme = parsed.scheme or "http"
+    netloc = parsed.netloc or parsed.path  # bare host:port lands in .path
+    return f"{scheme}://{netloc}".rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Endpoint pruning
+# ---------------------------------------------------------------------------
+
+
+def _sanitized_lane(base_url: str) -> str:
+    """Return just ``host:port`` for logging (never any path/query)."""
+    try:
+        parsed = urlparse(base_url)
+        return parsed.netloc or base_url
+    except Exception:  # pragma: no cover - defensive
+        return base_url
+
+
+def prune_endpoint(
+    endpoint: str,
+    *,
+    dry_run: bool = True,
+    allow_scratch: bool = False,
+    client: Optional[CdpClient] = None,
+    timeout: float = 5.0,
+) -> Dict[str, Any]:
+    """List, classify, and (unless *dry_run*) close disposable tabs on one lane.
+
+    Returns a sanitized summary dict — ``lane`` (host:port), ``dry_run``,
+    per-class ``counts``, ``closed`` / ``close_failed`` counts, and
+    ``preserved_last_page`` — containing no URLs, titles, or page data.
+    Never raises; connection/parse failures are reported via an ``error`` key.
+    """
+    lane = _sanitized_lane(normalize_base_url(endpoint))
+    summary: Dict[str, Any] = {
+        "lane": lane,
+        "dry_run": dry_run,
+        "allow_scratch": allow_scratch,
+        "counts": {},
+        "closed": 0,
+        "close_failed": 0,
+        "preserved_last_page": False,
+    }
+    try:
+        cdp = client or HttpCdpClient(endpoint, timeout=timeout)
+        targets = cdp.list_targets()
+    except Exception as exc:
+        summary["error"] = f"{type(exc).__name__}: {exc}"
+        logger.info("cdp-prune lane=%s unreachable: %s", lane, summary["error"])
+        return summary
+
+    plan = plan_prune(targets, allow_scratch=allow_scratch)
+    summary["counts"] = plan.counts
+    summary["preserved_last_page"] = plan.preserved_safety_target is not None
+
+    if dry_run:
+        logger.info(
+            "cdp-prune DRY-RUN lane=%s would_close=%d counts=%s preserved_last_page=%s",
+            lane,
+            len(plan.to_close),
+            _fmt_counts(plan.counts),
+            summary["preserved_last_page"],
+        )
+        summary["would_close"] = len(plan.to_close)
+        return summary
+
+    closed = 0
+    failed = 0
+    for target_id in plan.to_close:
+        if cdp.close_target(target_id):
+            closed += 1
+        else:
+            failed += 1
+    summary["closed"] = closed
+    summary["close_failed"] = failed
+    logger.info(
+        "cdp-prune lane=%s closed=%d failed=%d counts=%s preserved_last_page=%s",
+        lane,
+        closed,
+        failed,
+        _fmt_counts(plan.counts),
+        summary["preserved_last_page"],
+    )
+    return summary
+
+
+def _fmt_counts(counts: Dict[str, int]) -> str:
+    """Compact ``k=v`` rendering of the sanitized counts for a log line."""
+    return " ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+
+
+# ---------------------------------------------------------------------------
+# Runtime gating + resolution (kanban lifecycle entrypoint)
+# ---------------------------------------------------------------------------
+
+
+def _env_true(name: str, default: bool) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def is_enabled() -> bool:
+    """Master switch for the runtime trigger. Off unless explicitly enabled."""
+    return _env_true("HERMES_CDP_PRUNE_ENABLED", False)
+
+
+def is_dry_run() -> bool:
+    """Dry-run unless explicitly disabled — safe default even once enabled."""
+    return _env_true("HERMES_CDP_PRUNE_DRY_RUN", True)
+
+
+def allow_scratch() -> bool:
+    return _env_true("HERMES_CDP_PRUNE_SCRATCH", False)
+
+
+def _prune_timeout() -> float:
+    try:
+        return max(1.0, min(float(os.environ.get("HERMES_CDP_PRUNE_TIMEOUT", "5")), 30.0))
+    except (TypeError, ValueError):
+        return 5.0
+
+
+def resolve_endpoints() -> List[str]:
+    """Resolve which CDP endpoint(s) to prune.
+
+    Precedence:
+      1. ``HERMES_CDP_PRUNE_ENDPOINT`` — comma-separated explicit endpoints.
+      2. The worker's connected browser via ``BROWSER_CDP_URL`` /
+         ``browser.cdp_url`` (the lane this worker was actually driving).
+
+    Returns a de-duplicated list of ``http://host:port`` bases; empty when
+    nothing resolves (pruner then no-ops safely).
+    """
+    explicit = os.environ.get("HERMES_CDP_PRUNE_ENDPOINT", "").strip()
+    raw_endpoints: List[str] = []
+    if explicit:
+        raw_endpoints.extend(part for part in explicit.split(",") if part.strip())
+    else:
+        try:
+            from tools.browser_tool import _get_cdp_override
+
+            override = (_get_cdp_override() or "").strip()
+            if override:
+                raw_endpoints.append(override)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("cdp-prune endpoint resolution failed: %s", exc)
+
+    seen: Dict[str, None] = {}
+    for ep in raw_endpoints:
+        base = normalize_base_url(ep)
+        if base:
+            seen.setdefault(base, None)
+    return list(seen.keys())
+
+
+def prune_after_transition(
+    *,
+    event: str,
+    task_id: str = "",
+    board: Optional[str] = None,
+    assignee: Optional[str] = None,
+    run_id: Optional[int] = None,
+    profile_name: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Gated, best-effort entrypoint fired from the kanban lifecycle.
+
+    Returns a sanitized aggregate summary, or ``None`` when the feature is
+    disabled or no endpoint resolves. Never raises — a misbehaving pruner
+    must never affect a board state transition.
+
+    ``event`` is ``"completed"`` or ``"blocked"``. Blocking only prunes when
+    ``HERMES_CDP_PRUNE_ON_BLOCK`` is set, and then only ever the strictly
+    disposable blank/newtab set (scratch is never closed on block).
+    """
+    try:
+        if not is_enabled():
+            return None
+        if event == "blocked" and not _env_true("HERMES_CDP_PRUNE_ON_BLOCK", False):
+            return None
+
+        endpoints = resolve_endpoints()
+        if not endpoints:
+            logger.debug("cdp-prune: enabled but no endpoint resolved; skipping")
+            return None
+
+        # On block, force the most conservative rule set regardless of the
+        # scratch flag; completion honors the operator's scratch preference.
+        scratch_ok = allow_scratch() if event == "completed" else False
+        dry = is_dry_run()
+        timeout = _prune_timeout()
+
+        results: List[Dict[str, Any]] = []
+        for endpoint in endpoints:
+            results.append(
+                prune_endpoint(
+                    endpoint,
+                    dry_run=dry,
+                    allow_scratch=scratch_ok,
+                    timeout=timeout,
+                )
+            )
+
+        agg = {
+            "event": event,
+            "task_id": task_id,
+            "dry_run": dry,
+            "lanes": len(results),
+            "closed": sum(r.get("closed", 0) for r in results),
+            "would_close": sum(r.get("would_close", 0) for r in results),
+            "results": results,
+        }
+        logger.info(
+            "cdp-prune event=%s task=%s lanes=%d dry_run=%s closed=%d would_close=%d",
+            event,
+            task_id or "?",
+            agg["lanes"],
+            dry,
+            agg["closed"],
+            agg["would_close"],
+        )
+        return agg
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("cdp-prune prune_after_transition swallowed error: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CLI (dry-run by default)
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser():
+    import argparse
+
+    p = argparse.ArgumentParser(
+        prog="python -m tools.cdp_prune",
+        description=(
+            "Safely prune disposable (about:blank / newtab) tabs on a CDP lane. "
+            "Dry-run by default: prints sanitized counts and closes nothing."
+        ),
+    )
+    p.add_argument(
+        "--endpoint",
+        action="append",
+        default=None,
+        help=(
+            "CDP endpoint (http://host:port, ws://host:port/devtools/..., or "
+            "host:port). Repeatable. Defaults to resolve_endpoints() "
+            "(HERMES_CDP_PRUNE_ENDPOINT or the connected browser)."
+        ),
+    )
+    p.add_argument(
+        "--no-dry-run",
+        dest="dry_run",
+        action="store_false",
+        help="Actually close disposable tabs (default is dry-run).",
+    )
+    p.add_argument(
+        "--scratch",
+        action="store_true",
+        help="Also close synthetic data:text/html scratch tabs (conservative off by default).",
+    )
+    p.add_argument("--timeout", type=float, default=5.0, help="Per-call HTTP timeout (s).")
+    p.set_defaults(dry_run=True)
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = _build_arg_parser().parse_args(argv)
+    endpoints = args.endpoint or resolve_endpoints()
+    if not endpoints:
+        print(
+            json.dumps(
+                {
+                    "error": "no endpoint (pass --endpoint or set "
+                    "HERMES_CDP_PRUNE_ENDPOINT / browser.cdp_url)"
+                }
+            )
+        )
+        return 2
+    results = [
+        prune_endpoint(
+            ep,
+            dry_run=args.dry_run,
+            allow_scratch=args.scratch,
+            timeout=args.timeout,
+        )
+        for ep in endpoints
+    ]
+    print(json.dumps({"dry_run": args.dry_run, "results": results}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements safe automatic pruning of disposable Brave/CDP tabs after Kanban tasks complete (Kanban task **t_62ed2d2e**). After a successful completion, only clearly-disposable `about:blank` / `chrome://newtab/` tabs on the lane's CDP endpoint are closed; every real or sensitive tab is preserved, and at least one page target is always kept per Brave process so a lane's only usable context is never terminated.

## What's here

- **`tools/cdp_prune.py`** — the mechanism:
  - Pure `classify_url` / `plan_prune` carrying all safety logic (blank+newtab disposable by default; `data:` scratch gated behind opt-in; **real & sensitive always preserved**), plus **one-page-per-process preservation**.
  - Injectable I/O seam (`HttpCdpClient`, default: HTTP `/json` list + `/json/close/<id>`), so tests never open a socket.
  - **Sanitized logging** — lane `host:port` + URL-*class* counts only. Never page bodies, cookies, localStorage, tokens, full URLs, or titles.
  - A `python -m tools.cdp_prune` CLI that is **dry-run by default**.
- **`hermes_cli/kanban_db.py`** — a gated, best-effort call from the completion choke point (`complete_task`, plus the truly-blocked path of `block_task`; the dependency-wait path is intentionally skipped). Fires uniformly for CLI, in-process-tool, and MCP completions. Chosen over a plugin hook because standalone plugins are opt-in via `plugins.enabled` (empty) and the `hermes kanban` CLI path skips plugin discovery — a plugin would not fire for CLI completions.
- **Tests** — `tests/tools/test_cdp_prune.py` (55, mocked CDP inventories: safe close/skip, one-page preservation, sanitization, gating, endpoint normalization, CLI) + `tests/hermes_cli/test_kanban_cdp_prune_hook.py` (3 lifecycle-wiring smokes incl. "pruner failure never breaks completion").
- **Docs** — `docs/cdp-tab-pruning.md` + `.env.example` entries.

## Safety posture

**Ships inert.** `HERMES_CDP_PRUNE_ENABLED` defaults off and `HERMES_CDP_PRUNE_DRY_RUN` defaults on, so merging changes no runtime behavior. Activating live pruning is a deliberate two-step opt-in (`ENABLED=1` + `DRY_RUN=0`).

During implementation nothing real was touched: tests use mocked clients, and validation against live local lanes was **dry-run only** (`GET /json` + in-memory classify; closed nothing; read no cookies/localStorage/DOM/screenshots).

### Live dry-run evidence (nothing closed)
```
lane=127.0.0.1:18832 would_close=4 counts=class:blank=4 class:newtab=1 ... preserved_last_page=True
lane=127.0.0.1:18838 would_close=2 counts=class:blank=2 class:real=4  ... preserved_last_page=False
lane=127.0.0.1:18833 would_close=0 counts=class:sensitive=1           ... preserved_last_page=False
```
`preserved_last_page=True` on 18832 is the safety net firing — an all-disposable lane keeps one page.

## Activation note
CLI completions read env per-invocation (no restart). In-process/gateway workers inherit env at start, so live activation there needs the gateway env set + a **gateway restart** — to be requested via a BLOCKED R3 gate, not done automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)