### PR TITLE
fix(qqbot): add missing is_reconnect parameter to connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
Fixes QQAdapter.connect() crashing with TypeError: got an unexpected keyword argument 'is_reconnect' on gateway reconnect.

The base class BasePlatformAdapter.connect() signature includes *, is_reconnect: bool = False but QQAdapter's override omitted it.

Closes #60635, #58646, #53443