### PR TITLE
fix(api): interrupt session SSE runs on disconnect

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1979,6 +1979,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 event_name = event_type.replace("tool.", "tool.")
                 _enqueue(event_name, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
 
+        agent_ref: list = [None]
+
         async def _run_and_signal() -> None:
             try:
                 await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": user_message}}))
@@ -1992,6 +1994,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
                     gateway_session_key=gateway_session_key,
+                    agent_ref=agent_ref,
                 )
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
@@ -2017,6 +2020,21 @@ class APIServerAdapter(BasePlatformAdapter):
             finally:
                 await queue.put(_event_payload("done", {}))
                 await queue.put(None)
+
+        async def _interrupt_stream_task(reason: str) -> None:
+            """Stop the agent run cleanly when the SSE client goes away."""
+            agent = agent_ref[0]
+            if agent is not None:
+                try:
+                    agent.interrupt(reason)
+                except Exception:
+                    pass
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
 
         task = asyncio.create_task(_run_and_signal())
         try:
@@ -2051,10 +2069,21 @@ class APIServerAdapter(BasePlatformAdapter):
                 data = json.dumps(payload, ensure_ascii=False)
                 await response.write(f"event: {name}\ndata: {data}\n\n".encode("utf-8"))
                 last_write = time.monotonic()
-        except (asyncio.CancelledError, ConnectionResetError):
-            task.cancel()
+        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError) as exc:
+            # Client closed the SSE stream mid-run. Interrupt the agent so it
+            # stops LLM/tool work instead of writing to a dead transport.
+            await _interrupt_stream_task("SSE client disconnected")
+            logger.info(
+                "[api_server] session SSE client disconnected for %s (%s); agent interrupted",
+                session_id,
+                type(exc).__name__,
+            )
+        except asyncio.CancelledError:
+            await _interrupt_stream_task("SSE task cancelled")
+            logger.info("[api_server] session SSE task cancelled for %s", session_id)
             raise
         except Exception as exc:
+            await _interrupt_stream_task(f"SSE stream error: {type(exc).__name__}")
             logger.debug("[api_server] session SSE stream error: %s", exc)
         return response
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,6 +1,7 @@
 """Focused tests for API server session-control endpoints."""
 
-from unittest.mock import AsyncMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -338,6 +339,46 @@ async def test_session_chat_stream_emits_lifecycle_events_and_keepalive_safe_sha
     assert "event: assistant.completed" in body
     assert "event: run.completed" in body
     assert "event: done" in body
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_client_disconnect_interrupts_agent(adapter, session_db):
+    """A client closing the session SSE stream should stop the active agent run."""
+    session_id = session_db.create_session("disconnect-session", "api_server")
+    fake_agent = MagicMock()
+    write_count = {"n": 0}
+
+    class DisconnectingStreamResponse:
+        def __init__(self, *args, **kwargs):
+            self.headers = kwargs.get("headers", {})
+
+        async def prepare(self, request):
+            return None
+
+        async def write(self, payload):
+            write_count["n"] += 1
+            if write_count["n"] >= 3:
+                raise ConnectionResetError("simulated client disconnect")
+
+    async def fake_run(**kwargs):
+        if "agent_ref" in kwargs:
+            kwargs["agent_ref"][0] = fake_agent
+        kwargs["stream_delta_callback"]("partial response")
+        await asyncio.sleep(60)
+        return {"final_response": "should not complete", "session_id": session_id}, {"total_tokens": 1}
+
+    request = MagicMock()
+    request.headers = {}
+    request.match_info = {"session_id": session_id}
+    request.json = AsyncMock(return_value={"message": "start then disconnect"})
+
+    import gateway.platforms.api_server as api_mod
+
+    with patch.object(api_mod.web, "StreamResponse", DisconnectingStreamResponse):
+        with patch.object(adapter, "_run_agent", side_effect=fake_run):
+            await adapter._handle_session_chat_stream(request)
+
+    fake_agent.interrupt.assert_called_once_with("SSE client disconnected")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- interrupt active session SSE agent runs when the client disconnects
- handle normal transport disconnects without re-raising as stream failures
- add a regression test that simulates a client disconnect during streaming

## Test Plan
- python -m pytest tests/gateway/test_session_api.py::test_session_chat_stream_client_disconnect_interrupts_agent -q -o 'addopts='
- python -m pytest tests/gateway/test_session_api.py -q -o 'addopts='
- python -m pytest tests/gateway/test_api_server.py -q -o 'addopts='

## Notes
The regression test fails on current upstream with ConnectionResetError before this fix.