### PR TITLE
fix: clear stale base_url on provider switch to prevent credential mis-routing (#61296)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1810,8 +1810,16 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # Without this guard the old provider's URL (e.g. Ollama's localhost
         # address) would persist silently after switching to a cloud provider
         # that returns an empty base_url string.
+        #
+        # When a non-empty stale base_url (e.g. https://ollama.com/v1 from a
+        # prior session) leaks across providers, the new provider's API key is
+        # silently sent to the old endpoint — credential mis-routing (#61296).
+        # Guard: if base_url is empty AND the provider changed, explicitly
+        # clear the stale URL so it doesn't contaminate the new client.
         if base_url:
             agent.base_url = base_url
+        elif old_provider != new_provider:
+            agent.base_url = ""
         agent.api_mode = api_mode
         # Invalidate transport cache — new api_mode may need a different transport
         if hasattr(agent, "_transport_cache"):


### PR DESCRIPTION
## Summary

Fixes #61296 — `switch_model()` silently cross-wires the new provider's API key with the old provider's stale `base_url`.

## Problem

When `switch_model()` in `agent/agent_runtime_helpers.py` receives an empty `base_url` for the new provider (which is correct — the new provider resolves its own endpoint), the guard at L1813 only checks truthiness:

```python
if base_url:
    agent.base_url = base_url
```

If the old provider had a non-empty `base_url` (e.g. `https://ollama.com/v1` from a prior session), it **sticks** — the agent now has `provider == minimax-cn` but `base_url == https://ollama.com/v1`. The new provider's API key is silently sent to the wrong endpoint.

## Fix

Add an `elif` branch that explicitly clears `agent.base_url` when the provider changed and the new `base_url` is empty:

```python
if base_url:
    agent.base_url = base_url
elif old_provider != new_provider:
    agent.base_url = 
```

This lets the downstream client rebuild resolve the correct endpoint for the new provider.

## Change

- `agent/agent_runtime_helpers.py`: +8 lines (comment + elif guard)

## Testing

- No existing tests for `switch_model()` internal state — verified the resolution chain: `model_switch.switch_model()` always resolves a new `base_url` from `resolve_runtime_provider()` for provider changes, so the empty-string fallback only fires when the resolver itself returns empty (native SDK providers). The stale URL is cleared in that case.