### PR TITLE
fix(switch_model): drop stale non-empty base_url when provider changes

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1759,6 +1759,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     old_model = agent.model
     old_provider = agent.provider
+    old_base_url = agent.base_url
 
     # ── Snapshot all fields the swap+rebuild can mutate ──
     # If the rebuild raises (bad API key, network error, build_anthropic_client
@@ -1810,8 +1811,30 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # Without this guard the old provider's URL (e.g. Ollama's localhost
         # address) would persist silently after switching to a cloud provider
         # that returns an empty base_url string.
+        #
+        # Refinement over #52727 — the original guard only blocks the empty
+        # case. When the caller repeats the OLD provider's URL alongside a
+        # NEW provider, that bypasses the truthy check and cross-wires the
+        # agent (new provider's API key → old provider's endpoint,
+        # silent credential mis-routing). Reject the equal-and-provider-
+        # changed combination and fall back to the empty default so the new
+        # provider set_next_api_call_base_url() resolves from registry (#61296).
         if base_url:
-            agent.base_url = base_url
+            old_norm = (old_provider or "").strip().lower()
+            new_norm = (new_provider or "").strip().lower()
+            same_provider = bool(old_norm) and old_norm == new_norm
+            same_url = bool(old_base_url) and base_url == old_base_url
+            if same_url and not same_provider:
+                # Caller passed the OLD provider's URL while switching to
+                # a different provider. Treat as stale; don't trust it.
+                logger.info(
+                    "switch_model: dropping stale base_url=%r inherited from "
+                    "old provider %r while switching to %r (#61296)",
+                    base_url, old_provider, new_provider,
+                )
+                agent.base_url = ""
+            else:
+                agent.base_url = base_url
         agent.api_mode = api_mode
         # Invalidate transport cache — new api_mode may need a different transport
         if hasattr(agent, "_transport_cache"):

--- a/tests/run_agent/test_switch_model_stale_base_url_61296.py
+++ b/tests/run_agent/test_switch_model_stale_base_url_61296.py
@@ -1,0 +1,234 @@
+"""Regression tests for #61296: switch_model() must not trust a stale non-empty
+base_url when the caller is switching to a different provider.
+
+The empty-string guard (#52727) prevents an Ollama localhost URL from leaking
+into a cloud provider that returns "" for base_url. But it does not catch a
+truthy *stale* URL: when ``switch_model(new_provider='minimax-cn',
+base_url='https://ollama.com/v1', ...)`` lands, the truthy check passes and
+the agent ends up with the new provider's API key paired against the old
+provider's endpoint — silent credential mis-routing.
+
+The fix detects ``base_url == old_base_url`` AND a provider change, then drops
+the stale URL so the new provider's ``set_next_api_call_base_url()`` resolves
+from registry.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.agent_runtime_helpers import switch_model
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(
+    current_provider,
+    current_model,
+    current_base_url,
+    current_pool=None,
+):
+    """Bare agent object with the minimum attributes switch_model touches.
+
+    ``current_pool`` defaults to None so the helper mirrors a real boot
+    state; the same-provider tests construct an agent WITH a pool to
+    pin down the no-reload contract from #52727.
+    """
+    agent = MagicMock(name=f"Agent[{current_provider}]")
+    agent.provider = current_provider
+    agent.model = current_model
+    agent.base_url = current_base_url
+    agent.api_key = f"{current_provider}-key"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock(name="Client")
+    agent._client_kwargs = {
+        "api_key": "***",
+        "base_url": current_base_url,
+    }
+    agent._anthropic_client = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._is_anthropic_oauth = False
+    agent._config_context_length = None
+    agent._transport_cache = {}
+    agent._cached_system_prompt = "cached-system-prompt"
+    agent.context_compressor = None
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent._primary_runtime = {}
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._credential_pool = current_pool
+    agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
+    agent._ensure_lmstudio_runtime_loaded = MagicMock()
+    return agent
+
+
+def _make_pool(provider):
+    pool = MagicMock(name=f"Pool[{provider}]")
+    pool.provider = provider
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# the fix
+# ---------------------------------------------------------------------------
+
+
+class TestSwitchModelStaleBaseUrl:
+    """Issue #61296: switch_model must reject a non-empty stale base_url when
+    the provider is changing. Pre-fix the truthy `if base_url:` guard trusted
+    it and produced cross-wired agents (new provider key → old provider URL).
+    """
+
+    def test_old_provider_url_rejected_on_provider_change(self):
+        """Caller repeats the OLD provider's URL alongside a NEW provider.
+
+        Before the fix: agent.base_url == 'https://ollama.com/v1' after the
+        switch — agent now serves minimax-cn traffic through ollama.com.
+        After the fix: agent.base_url is reset to '' so the new
+        provider's registry provides a fresh endpoint.
+        """
+        agent = _make_agent(
+            current_provider="ollama-cloud",
+            current_model="qwen3:32b",
+            current_base_url="https://ollama.com/v1",
+        )
+
+        with patch(
+            "agent.credential_pool.load_pool",
+            return_value=MagicMock(provider="minimax-cn"),
+        ):
+            switch_model(
+                agent,
+                new_model="MiniMax-M3",
+                new_provider="minimax-cn",
+                api_key="minimax-secret-key",
+                base_url="https://ollama.com/v1",  # stale, truthy
+                api_mode="chat_completions",
+            )
+
+        assert agent.provider == "minimax-cn"
+        # The whole point: base_url must NOT be the old provider's URL.
+        assert agent.base_url != "https://ollama.com/v1", (
+            f"switch_model cross-wired agent: provider={agent.provider!r} "
+            f"but base_url={agent.base_url!r} is still the old provider's "
+            "endpoint (#61296)"
+        )
+        # And the new provider's key was applied.
+        assert agent.api_key == "minimax-secret-key"
+
+    def test_same_provider_same_url_kept(self):
+        """A same-provider re-selection with the same URL is NOT stale.
+
+        The caller is re-affirming the current URL, possibly with a
+        different model. Nothing has gone stale. The fix's guard must
+        NOT fire and base_url must stay verbatim.
+        """
+        agent = _make_agent(
+            current_provider="groq",
+            current_model="llama-3.3-70b",
+            current_base_url="https://api.groq.com/openai/v1",
+            current_pool=_make_pool("groq"),
+        )
+
+        with patch("agent.credential_pool.load_pool") as load_pool_mock:
+            switch_model(
+                agent,
+                new_model="llama-3.1-8b",
+                new_provider="groq",  # SAME
+                api_key="groq-key-new",
+                base_url="https://api.groq.com/openai/v1",  # SAME
+                api_mode="chat_completions",
+            )
+
+        assert agent.base_url == "https://api.groq.com/openai/v1"
+        # Same-provider switches do not reload the pool (#52727).
+        load_pool_mock.assert_not_called()
+
+    def test_same_provider_different_url_accepted(self):
+        """Caller switches within the same provider to a different endpoint.
+
+        E.g. user re-points groq at a regional proxy or self-hosted mirror.
+        base_url differs from the old URL → not the stale pattern.
+        """
+        agent = _make_agent(
+            current_provider="groq",
+            current_model="llama-3.3-70b",
+            current_base_url="https://api.groq.com/openai/v1",
+            current_pool=_make_pool("groq"),
+        )
+
+        with patch("agent.credential_pool.load_pool") as load_pool_mock:
+            switch_model(
+                agent,
+                new_model="llama-3.3-70b",
+                new_provider="groq",
+                api_key="groq-key-new",
+                base_url="https://groq-proxy.internal/v1",  # different
+                api_mode="chat_completions",
+            )
+
+        assert agent.base_url == "https://groq-proxy.internal/v1"
+        load_pool_mock.assert_not_called()
+
+    def test_different_provider_different_url_accepted(self):
+        """Caller passes a brand new URL alongside a brand new provider.
+
+        Healthy case — neither side matches the old agent state. Not stale.
+        """
+        agent = _make_agent(
+            current_provider="ollama-cloud",
+            current_model="qwen3:32b",
+            current_base_url="https://ollama.com/v1",
+        )
+
+        with patch(
+            "agent.credential_pool.load_pool",
+            return_value=MagicMock(provider="minimax-cn"),
+        ):
+            switch_model(
+                agent,
+                new_model="MiniMax-M3",
+                new_provider="minimax-cn",
+                api_key="minimax-secret-key",
+                base_url="https://api.minimax.com/v1",  # different from old
+                api_mode="chat_completions",
+            )
+
+        assert agent.base_url == "https://api.minimax.com/v1"
+        assert agent.provider == "minimax-cn"
+
+    def test_agent_without_existing_base_url_not_triggered(self):
+        """An agent with no previous base_url never matches the stale-guard.
+
+        Covers boot-time switches where the agent started blank. Almost
+        all of those also change providers, but the guard must be a no-op
+        rather than spuriously reset a URL the caller just typed.
+        """
+        agent = _make_agent(
+            current_provider="",
+            current_model="",
+            current_base_url="",
+        )
+
+        with patch(
+            "agent.credential_pool.load_pool",
+            return_value=MagicMock(provider="minimax-cn"),
+        ):
+            switch_model(
+                agent,
+                new_model="MiniMax-M3",
+                new_provider="minimax-cn",
+                api_key="minimax-secret-key",
+                base_url="https://api.minimax.com/v1",
+                api_mode="chat_completions",
+            )
+
+        # Caller-provided URL is kept verbatim on the boot path.
+        assert agent.base_url == "https://api.minimax.com/v1"


### PR DESCRIPTION
## Summary

`agent/agent_runtime_helpers.switch_model()` had a guard on the agent's `base_url` only when the supplied value was empty (the Ollama localhost vs cloud-empty case from #52727). A non-empty *stale* `base_url` slipped through: if a caller passes `new_provider='minimax-cn', base_url='https://ollama.com/v1'` while the agent previously ran Ollama, the truthy guard passes and the swap ends up serving the new provider's API key through the old provider's endpoint — silent credential mis-routing. Issue #61296 lays out the symptom and supplies a function-level reproduction.

## Fix

Capture `old_base_url = agent.base_url` at function entry (alongside the existing `old_provider`). When the supplied `base_url` equals old_base_url AND the new provider differs from the old one, drop the stale value by emptying `agent.base_url` so the new provider resolves a fresh endpoint via `set_next_api_call_base_url()` from its registry. Same-provider re-selections and same-URL-with-different-URL flows are unaffected. The fix logs an info-level trace so operators see when a stale URL was filtered out.

## Changes

- `agent/agent_runtime_helpers.py`: tighten the existing `if base_url:` block in `switch_model()` with an equality + provider-change check; the change is local to that guard and keeps the `#52727` empty-string case intact.

- `tests/run_agent/test_switch_model_stale_base_url_61296.py`: 5 regression tests pinning the new behavior — the cross-wire case (old URL + new provider), same provider + same URL (kept), same provider + different URL (kept), different provider + different URL (kept), and an agent with no previous base_url (never triggers the guard).

## How to Test

```
pytest tests/run_agent/test_switch_model_stale_base_url_61296.py -xvs  # 5/5
pytest tests/run_agent/test_switch_model_pool_reload_52727.py tests/run_agent/test_switch_model_fallback_prune.py tests/run_agent/test_switch_model_context.py tests/run_agent/test_switch_model_rollback.py  # 15/15 sibling suites green
```

## Checklist

- [x] Tests pass — 5/5 new + 15/15 in sibling switch_model suites.
- [x] Follows Conventional Commits (`fix(switch_model): …`).
- [x] Cross-platform impact: pure Python module behavior, no platform-sensitive code.
- [x] profile-safe paths used (no path involvement).
- [x] .env not used (provider/URL state is in-memory on the agent).

## Risk & Impact

Low. The fix is a stricter form of the existing truthy guard — it only activates on a previously-unintended combination (`base_url == old_base_url` AND provider changes), and even then sets `agent.base_url = ''` so a downstream resolution continues to run. All four sibling suites in `tests/run_agent/` for switch_model pass unchanged.

Type: Bug fix (security-adjacent: credential mis-routing).
Closes: #61296